### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+**Related Issue(s):**
+
+- #
+
+
+**Description:**
+
+
+**PR Checklist:**
+
+- [ ] Code is formatted
+- [ ] Tests pass
+- [ ] Changes are added to CHANGELOG.md


### PR DESCRIPTION
Adds a simple PR template borrowed from `pystac-client`. Should close #21.