### PR TITLE
feat(cli): add ability to pass custom basename for partition output file

### DIFF
--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -131,6 +131,7 @@ All partition commands support:
 --preview-limit 15     # Number of partitions to show (default: 15)
 --force                # Override analysis warnings
 --skip-analysis        # Skip analysis (performance-sensitive cases)
+--prefix PREFIX        # Custom filename prefix (e.g., 'fields' → fields_USA.parquet)
 ```
 
 ## Output Structures
@@ -154,6 +155,18 @@ output/
 │   └── data.parquet
 └── column=value3/
     └── data.parquet
+```
+
+### Custom Filename Prefix
+
+Add `--prefix NAME` to prepend a custom prefix to partition filenames:
+
+```bash
+# Standard: fields_USA.parquet, fields_Kenya.parquet
+gpio partition admin input.parquet output/ --dataset gaul --levels country --prefix fields
+
+# Hive: country=USA/fields_USA.parquet, country=Kenya/fields_Kenya.parquet
+gpio partition admin input.parquet output/ --dataset gaul --levels country --prefix fields --hive
 ```
 
 ## Partition Analysis

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -102,6 +102,19 @@ def bbox_option(func):
     )(func)
 
 
+def prefix_option(func):
+    """
+    Add --prefix option to a partitioning command.
+
+    Allows users to add a custom prefix to partition filenames.
+    Example: --prefix fields → fields_USA.parquet
+    """
+    return click.option(
+        "--prefix",
+        help="Custom prefix for partition filenames (e.g., 'fields' → fields_USA.parquet)",
+    )(func)
+
+
 def partition_options(func):
     """
     Add standard partitioning options to a command.
@@ -113,6 +126,7 @@ def partition_options(func):
     - --skip-analysis: Skip partition strategy analysis
     - --hive: Use Hive-style partitioning
     - --overwrite: Overwrite existing partition files
+    - --prefix: Custom filename prefix
     """
     func = click.option(
         "--hive", is_flag=True, help="Use Hive-style partitioning in output folder structure"
@@ -141,4 +155,5 @@ def partition_options(func):
         is_flag=True,
         help="Skip partition strategy analysis (for performance-sensitive cases)",
     )(func)
+    func = prefix_option(func)
     return func

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -953,6 +953,7 @@ def partition_admin(
     preview_limit,
     force,
     skip_analysis,
+    prefix,
     verbose,
 ):
     """Partition by administrative boundaries via spatial join with remote datasets.
@@ -1011,6 +1012,7 @@ def partition_admin(
         verbose=verbose,
         force=force,
         skip_analysis=skip_analysis,
+        filename_prefix=prefix,
     )
 
 
@@ -1032,6 +1034,7 @@ def partition_string(
     preview_limit,
     force,
     skip_analysis,
+    prefix,
     verbose,
 ):
     """Partition a GeoParquet file by string column values.
@@ -1071,6 +1074,7 @@ def partition_string(
         verbose,
         force,
         skip_analysis,
+        prefix,
     )
 
 
@@ -1107,6 +1111,7 @@ def partition_h3(
     preview_limit,
     force,
     skip_analysis,
+    prefix,
     verbose,
 ):
     """Partition a GeoParquet file by H3 cells at specified resolution.
@@ -1157,6 +1162,7 @@ def partition_h3(
         keep_h3_col,
         force,
         skip_analysis,
+        prefix,
     )
 
 
@@ -1213,6 +1219,7 @@ def partition_kdtree(
     preview_limit,
     force,
     skip_analysis,
+    prefix,
     verbose,
 ):
     """Partition a GeoParquet file by KD-tree cells.
@@ -1298,6 +1305,7 @@ def partition_kdtree(
         skip_analysis,
         sample_size,
         auto_target,
+        prefix,
     )
 
 

--- a/geoparquet_io/core/partition_admin_hierarchical.py
+++ b/geoparquet_io/core/partition_admin_hierarchical.py
@@ -39,6 +39,7 @@ def partition_by_admin_hierarchical(
     verbose: bool = False,
     force: bool = False,
     skip_analysis: bool = False,
+    filename_prefix: Optional[str] = None,
 ) -> int:
     """
     Partition a GeoParquet file by administrative boundaries.
@@ -329,7 +330,12 @@ def partition_by_admin_hierarchical(
         os.makedirs(partition_folder, exist_ok=True)
 
         # Generate output filename
-        filename = f"{sanitize_filename(str(combination[-1]))}.parquet"
+        safe_last_value = sanitize_filename(str(combination[-1]))
+        filename = (
+            f"{filename_prefix}_{safe_last_value}.parquet"
+            if filename_prefix
+            else f"{safe_last_value}.parquet"
+        )
         output_file = os.path.join(partition_folder, filename)
 
         # Skip if exists and not overwriting

--- a/geoparquet_io/core/partition_by_h3.py
+++ b/geoparquet_io/core/partition_by_h3.py
@@ -25,6 +25,7 @@ def partition_by_h3(
     keep_h3_column: bool = None,
     force: bool = False,
     skip_analysis: bool = False,
+    filename_prefix: str = None,
 ):
     """
     Partition a GeoParquet file by H3 cells at specified resolution.
@@ -158,6 +159,7 @@ def partition_by_h3(
             keep_partition_column=keep_h3_column,
             force=force,
             skip_analysis=skip_analysis,
+            filename_prefix=filename_prefix,
         )
 
         if verbose:

--- a/geoparquet_io/core/partition_by_kdtree.py
+++ b/geoparquet_io/core/partition_by_kdtree.py
@@ -27,6 +27,7 @@ def partition_by_kdtree(
     skip_analysis: bool = False,
     sample_size: int = 100000,
     auto_target_rows: tuple = None,
+    filename_prefix: str = None,
 ):
     """
     Partition a GeoParquet file by KD-tree cells.
@@ -182,6 +183,7 @@ def partition_by_kdtree(
             keep_partition_column=keep_kdtree_column,
             force=force,
             skip_analysis=skip_analysis,
+            filename_prefix=filename_prefix,
         )
 
         if verbose:

--- a/geoparquet_io/core/partition_by_string.py
+++ b/geoparquet_io/core/partition_by_string.py
@@ -52,6 +52,7 @@ def partition_by_string(
     verbose: bool = False,
     force: bool = False,
     skip_analysis: bool = False,
+    filename_prefix: str = None,
 ):
     """
     Partition a GeoParquet file by string column values or prefixes.
@@ -130,6 +131,7 @@ def partition_by_string(
         verbose=verbose,
         force=force,
         skip_analysis=skip_analysis,
+        filename_prefix=filename_prefix,
     )
 
     click.echo(f"Successfully created {num_partitions} partition file(s)")

--- a/geoparquet_io/core/partition_common.py
+++ b/geoparquet_io/core/partition_common.py
@@ -495,6 +495,7 @@ def partition_by_column(
     keep_partition_column: bool = True,
     force: bool = False,
     skip_analysis: bool = False,
+    filename_prefix: Optional[str] = None,
 ) -> int:
     """
     Common function to partition a GeoParquet file by column values.
@@ -510,6 +511,7 @@ def partition_by_column(
         keep_partition_column: Whether to keep the partition column in output files (default: True)
         force: Force partitioning even if analysis detects issues
         skip_analysis: Skip partition strategy analysis (for performance)
+        filename_prefix: Optional prefix for partition filenames (e.g., 'fields' → fields_USA.parquet)
 
     Returns:
         Number of partitions created
@@ -589,6 +591,13 @@ def partition_by_column(
         safe_value = sanitize_filename(str(partition_value))
 
         # Determine output path
+        # Build filename with optional prefix
+        filename = (
+            f"{filename_prefix}_{safe_value}.parquet"
+            if filename_prefix
+            else f"{safe_value}.parquet"
+        )
+
         if hive:
             # Hive-style: folder named "column=value"
             if column_prefix_length is not None:
@@ -598,10 +607,10 @@ def partition_by_column(
                 folder_name = f"{column_name}={safe_value}"
             write_folder = os.path.join(output_folder, folder_name)
             os.makedirs(write_folder, exist_ok=True)
-            output_filename = os.path.join(write_folder, f"{safe_value}.parquet")
+            output_filename = os.path.join(write_folder, filename)
         else:
             write_folder = output_folder
-            output_filename = os.path.join(write_folder, f"{safe_value}.parquet")
+            output_filename = os.path.join(write_folder, filename)
 
         # Skip if file exists and not overwriting
         if os.path.exists(output_filename) and not overwrite:

--- a/geoparquet_io/core/split_by_country.py
+++ b/geoparquet_io/core/split_by_country.py
@@ -110,6 +110,7 @@ def split_by_country(
     preview_limit=15,
     force=False,
     skip_analysis=False,
+    filename_prefix=None,
 ):
     """
     Split a GeoParquet file into separate files by country code.
@@ -185,6 +186,7 @@ def split_by_country(
         verbose=verbose,
         force=force,
         skip_analysis=skip_analysis,
+        filename_prefix=filename_prefix,
     )
 
     click.echo(f"Successfully split file into {num_partitions} country file(s)")


### PR DESCRIPTION
## Description
Adds simple functionality to pass an optional filename prefix when partitioning geoparquet files, e.g., "fields", so the filename becomes "fields_NL.parquet" instead of "NL.parquet".

## Related Issue(s)
- #33 

## Checklist
- [x] Code is formatted
- [x] Tests pass
