### PR TITLE
fix(upload): add proper error handling

### DIFF
--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1953,17 +1953,20 @@ def upload(
       # Stop on first error instead of continuing
       gpio upload output/ s3://bucket/dataset/ --fail-fast
     """
-    upload_impl(
-        source=source,
-        destination=destination,
-        profile=profile,
-        pattern=pattern,
-        max_files=max_files,
-        chunk_concurrency=chunk_concurrency,
-        chunk_size=chunk_size,
-        fail_fast=fail_fast,
-        dry_run=dry_run,
-    )
+    try:
+        upload_impl(
+            source=source,
+            destination=destination,
+            profile=profile,
+            pattern=pattern,
+            max_files=max_files,
+            chunk_concurrency=chunk_concurrency,
+            chunk_size=chunk_size,
+            fail_fast=fail_fast,
+            dry_run=dry_run,
+        )
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Add proper CLI error handling for upload command - converts ValueError to ClickException for better error messages. This was part of the bigger `upload` PR but I forgot to check it in. 

## Checklist
- [x] Code is formatted
- [x] Tests pass
