### PR TITLE
Add --force flag to gpio add bbox command

### DIFF
--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -15,11 +15,30 @@ gpio add bbox s3://bucket/input.parquet s3://bucket/output.parquet --profile pro
 
 Creates a struct column with `{xmin, ymin, xmax, ymax}` for each feature. Bbox covering metadata is automatically added to comply with GeoParquet 1.1 spec.
 
+### Existing Bbox Detection
+
+The command automatically checks for existing bbox columns:
+
+- **If bbox exists with metadata**: Informs you and exits successfully (no action needed)
+- **If bbox exists without metadata**: Suggests using `gpio add bbox-metadata` instead
+- **Use `--force`**: Replace existing bbox column with a freshly computed one
+
+```bash
+# Check and skip if bbox already exists
+gpio add bbox input.parquet output.parquet
+
+# Force replace existing bbox
+gpio add bbox input.parquet output.parquet --force
+```
+
 **Options:**
 
 ```bash
 # Custom column name
 gpio add bbox input.parquet output.parquet --bbox-name bounds
+
+# Force replace existing bbox
+gpio add bbox input.parquet output.parquet --force
 
 # With compression settings
 gpio add bbox input.parquet output.parquet --compression ZSTD --compression-level 15

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1147,6 +1147,11 @@ def add_country_codes(
 @click.argument("input_parquet")
 @click.argument("output_parquet")
 @click.option("--bbox-name", default="bbox", help="Name for the bbox column (default: bbox)")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Replace existing bbox column instead of skipping",
+)
 @click.option("--profile", help="AWS profile name (for S3 remote outputs)")
 @output_format_options
 @dry_run_option
@@ -1155,6 +1160,7 @@ def add_bbox(
     input_parquet,
     output_parquet,
     bbox_name,
+    force,
     profile,
     compression,
     compression_level,
@@ -1170,10 +1176,11 @@ def add_bbox(
     GeoParquet file (GeoParquet 1.1 spec). The bbox column improves spatial query
     performance.
 
-    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
+    If the file already has a bbox column with covering metadata, the command will
+    inform you and exit successfully (no action needed). Use --force to replace an
+    existing bbox column.
 
-    If your file already has a bbox column but lacks metadata, use 'add bbox-metadata'
-    instead.
+    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
 
     Examples:
 
@@ -1184,6 +1191,10 @@ def add_bbox(
         \b
         # Remote to remote
         gpio add bbox s3://bucket/in.parquet s3://bucket/out.parquet --profile my-aws
+
+        \b
+        # Force replace existing bbox
+        gpio add bbox input.parquet output.parquet --force
     """
     # Validate mutually exclusive options
     if row_group_size and row_group_size_mb:
@@ -1211,6 +1222,7 @@ def add_bbox(
         row_group_mb,
         row_group_size,
         profile,
+        force,
     )
 
 


### PR DESCRIPTION
## Description
Adds `--force` flag to `gpio add bbox` command to control behavior when a bbox column already exists. Without `--force`, the command now skips files that already have a bbox column. With `--force`, it replaces the existing bbox column with newly computed values.

## Technical Details
- Modified `add_bbox_column.py` to check for existing bbox column before processing
- Added `--force` flag to CLI in `main.py`
- Updated `common.py` with helper for bbox column detection
- Default behavior changed: files with existing bbox are now skipped (non-breaking since previous behavior would error)

## Related Issue(s)
- N/A

## Checklist
- [x] Code is formatted
- [x] Tests pass