### PR TITLE
Fix H3 partitioning to use full cell IDs instead of prefix

### DIFF
--- a/geoparquet_io/core/partition_by_h3.py
+++ b/geoparquet_io/core/partition_by_h3.py
@@ -120,7 +120,7 @@ def partition_by_h3(
                 analyze_partition_strategy(
                     input_parquet=input_parquet,
                     column_name=h3_column_name,
-                    column_prefix_length=resolution,
+                    column_prefix_length=None,
                     verbose=True,
                 )
             except PartitionAnalysisError:
@@ -135,7 +135,7 @@ def partition_by_h3(
             preview_partition(
                 input_parquet=input_parquet,
                 column_name=h3_column_name,
-                column_prefix_length=resolution,
+                column_prefix_length=None,
                 limit=preview_limit,
                 verbose=verbose,
             )
@@ -149,12 +149,14 @@ def partition_by_h3(
     click.echo(f"Partitioning by H3 cells at resolution {resolution} (column: '{h3_column_name}')")
 
     try:
-        # Use common partition function with H3 resolution as prefix length
+        # Use common partition function with full H3 cell IDs
+        # Note: resolution is used when generating the H3 column, not as a prefix length
+        # Each H3 cell at the specified resolution becomes a separate partition
         num_partitions = partition_by_column(
             input_parquet=input_parquet,
             output_folder=output_folder,
             column_name=h3_column_name,
-            column_prefix_length=resolution,
+            column_prefix_length=None,
             hive=hive,
             overwrite=overwrite,
             verbose=verbose,


### PR DESCRIPTION
## Description
Fixes H3 partitioning to use complete 15-character H3 cell IDs instead of truncating them to the resolution length. Previously, partitioning at resolution 9 would only use the first 9 characters of the cell ID, which could group different cells together incorrectly. 

This does make the partition names much longer, but seems like h3 doesn't work like quadkey -  you need the whole hex string there, you can't just lop stuff off and have it work at lower resolutions.

## Technical Details
- Changed `column_prefix_length` from `resolution` to `None` in `partition_by_h3()` function
- This affects the main partition operation as well as `analyze_partition_strategy()` and `preview_partition()` calls
- H3 cell IDs are always 15 characters regardless of resolution; the resolution parameter is used when generating the H3 column, not for truncating it
- Updated tests to expect 15-character cell IDs in output filenames

## Related Issue(s)
- #95 

## Checklist
- [x] Code is formatted
- [x] Tests pass