### PR TITLE
fix for inspect to print properties properly

### DIFF
--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -590,7 +590,7 @@ def inspect(parquet_file, head, tail, stats, json_output, markdown_output, profi
         setup_aws_profile_if_needed,
         validate_profile_for_urls,
     )
-    from geoparquet_io.core.duckdb_metadata import get_schema_info
+    from geoparquet_io.core.duckdb_metadata import get_usable_columns
 
     # Validate mutually exclusive options
     if head and tail:
@@ -610,41 +610,19 @@ def inspect(parquet_file, head, tail, stats, json_output, markdown_output, profi
         file_info = extract_file_info(parquet_file)
         geo_info = extract_geo_info(parquet_file)
 
-        # Get schema for column info using DuckDB (handles remote files natively)
-        schema_info = get_schema_info(parquet_file)
+        # Get usable columns using DESCRIBE (handles nested struct wrappers correctly)
+        usable_columns = get_usable_columns(parquet_file)
         primary_geom_col = geo_info.get("primary_column")
 
-        # Filter to top-level columns only:
-        # - Skip root element (duckdb_schema) which has type=None
-        # - Skip struct children by tracking which indices are children
-        columns_info = []
-        skip_count = 0  # Number of children to skip
-        for col in schema_info:
-            if skip_count > 0:
-                # This is a child of a struct, skip it
-                skip_count -= 1
-                continue
-
-            name = col.get("name", "")
-            col_type = col.get("type")
-            num_children = col.get("num_children")
-
-            # Skip root element (no type, has children)
-            if col_type is None and num_children and name == "duckdb_schema":
-                continue
-
-            # Track struct columns - their children follow immediately
-            if num_children:
-                skip_count = num_children
-
-            if name:
-                columns_info.append(
-                    {
-                        "name": name,
-                        "type": col.get("duckdb_type") or col_type or "struct",
-                        "is_geometry": name == primary_geom_col,
-                    }
-                )
+        # Build column info with geometry marking
+        columns_info = [
+            {
+                "name": col["name"],
+                "type": col["type"],
+                "is_geometry": col["name"] == primary_geom_col,
+            }
+            for col in usable_columns
+        ]
 
         # Get preview data if requested
         preview_table = None

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Old: 

```
 % gpio inspect https://object-arbutus.cloud.computecanada.ca/bq-io/vectors-cloud/wdpa/wdpa.parquet

📄 wdpa.parquet (N/A (remote))
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Rows: 296,046
Row Groups: 3
Compression: ZSTD
Parquet Type: No Parquet geo logical type
GeoParquet Version: 1.1.0
CRS: OGC:CRS84 (default)
Geometry Types: MultiPolygon
Bbox: [-180.000000, -85.411887, 180.000000, 86.453711]

Columns (5):
┏━━━━━━━━┳━━━━━━━━┓
┃ Name   ┃ Type   ┃
┡━━━━━━━━╇━━━━━━━━┩
│ schema │ struct │
│ xmin   │ DOUBLE │
│ ymin   │ DOUBLE │
│ xmax   │ DOUBLE │
│ ymax   │ DOUBLE │

```

new:
```
📄 wdpa.parquet (N/A (remote))
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Rows: 296,046
Row Groups: 3
Compression: ZSTD
Parquet Type: No Parquet geo logical type
GeoParquet Version: 1.1.0
CRS: OGC:CRS84 (default)
Geometry Types: MultiPolygon
Bbox: [-180.000000, -85.411887, 180.000000, 86.453711]

Columns (35):
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name        ┃ Type                                                       ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ SITE_ID     │ INTEGER                                                    │
│ SITE_PID    │ VARCHAR                                                    │
│ SITE_TYPE   │ VARCHAR                                                    │
│ NAME_ENG    │ VARCHAR                                                    │
│ NAME        │ VARCHAR                                                    │
│ DESIG       │ VARCHAR                                                    │
│ DESIG_ENG   │ VARCHAR                                                    │
│ DESIG_TYPE  │ VARCHAR                                                    │
│ IUCN_CAT    │ VARCHAR                                                    │
│ INT_CRIT    │ VARCHAR                                                    │
│ REALM       │ VARCHAR                                                    │
│ REP_M_AREA  │ DOUBLE                                                     │
│ GIS_M_AREA  │ DOUBLE                                                     │
│ REP_AREA    │ DOUBLE                                                     │
│ GIS_AREA    │ DOUBLE                                                     │
│ NO_TAKE     │ VARCHAR                                                    │
│ NO_TK_AREA  │ DOUBLE                                                     │
│ STATUS      │ VARCHAR                                                    │
│ STATUS_YR   │ INTEGER                                                    │
│ GOV_TYPE    │ VARCHAR                                                    │
│ GOVSUBTYPE  │ VARCHAR                                                    │
│ OWN_TYPE    │ VARCHAR                                                    │
│ OWNSUBTYPE  │ VARCHAR                                                    │
│ MANG_AUTH   │ VARCHAR                                                    │
│ MANG_PLAN   │ VARCHAR                                                    │
│ VERIF       │ VARCHAR                                                    │
│ METADATAID  │ INTEGER                                                    │
│ PRNT_ISO3   │ VARCHAR                                                    │
│ ISO3        │ VARCHAR                                                    │
│ SUPP_INFO   │ VARCHAR                                                    │
│ CONS_OBJ    │ VARCHAR                                                    │
│ INLND_WTRS  │ VARCHAR                                                    │
│ OECM_ASMT   │ VARCHAR                                                    │
│ geometry 🌍 │ GEOMETRY                                                   │
│ bbox        │ STRUCT(xmin DOUBLE, ymin DOUBLE, xmax DOUBLE, ymax DOUBLE) │
└─────────────┴────────────────────────────────────────────────────────────┘
```
## Checklist
- [x] Code is formatted
- [x] Tests pass
