### PR TITLE
Fix regression to print WKT for geometries in inspect

### DIFF
--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -323,7 +323,9 @@ def test_wkb_to_wkt_preview_with_valid_wkb():
     result = wkb_to_wkt_preview(point_wkb)
     assert "POINT" in result
     # Should contain actual coordinates, not just type
-    assert "1" in result or "<POINT>" in result  # WKT or fallback
+    # Verify it's actual WKT, not the fallback format
+    assert "<POINT>" not in result, "Expected WKT output, got fallback"
+    assert "1" in result  # Should contain the x-coordinate
 
 
 def test_wkb_to_wkt_preview_fallback():


### PR DESCRIPTION
## Summary

- Fixes a regression where `gpio inspect` was showing `<GEOMETRY>` instead of actual WKT geometry strings
- Geometry columns now display truncated WKT previews (e.g., `POLYGON ((-122.5 37.5, ...))`)
- Bbox struct columns now display nicely formatted as `[xmin, ymin, xmax, ymax]`

## Technical Details

- Added `wkb_to_wkt_preview()` function that uses DuckDB's spatial extension to convert WKB to WKT
- Handles both standard ISO WKB format and DuckDB's internal GEOMETRY format (prefix 0x02)
- `get_preview_data()` now converts geometry columns to WKT using `ST_AsText()` in the SQL query
- Added helper functions for bbox struct detection and formatting
- All previews truncate to configurable max length (default 60 chars)

## Related Issue(s)

Fixes geometry display regression in inspect command.

## Checklist

- [x] Code is formatted with Ruff (`pre-commit run --all-files`)
- [x] Tests pass locally (`pytest`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geometry columns in data previews now render as readable, truncated text with consistent preview lengths across formats.
  * Bounding box values are displayed compactly and consistently.
  * Automatic detection of geometry columns improves preview formatting without manual configuration; previews for both start/end rows are handled correctly.

* **Tests**
  * Added comprehensive tests covering geometry previews, bbox formatting, detection, and output formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->