### PR TITLE
Update docs URL to geoparquet.io and repo to geoparquet org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # geoparquet-io
 
-[![Tests](https://github.com/cholmes/geoparquet-io/actions/workflows/tests.yml/badge.svg)](https://github.com/cholmes/geoparquet-io/actions/workflows/tests.yml)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://github.com/cholmes/geoparquet-io)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/cholmes/geoparquet-io/blob/main/LICENSE)
+[![Tests](https://github.com/geoparquet/geoparquet-io/actions/workflows/tests.yml/badge.svg)](https://github.com/geoparquet/geoparquet-io/actions/workflows/tests.yml)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://github.com/geoparquet/geoparquet-io)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/geoparquet/geoparquet-io/blob/main/LICENSE)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 
 Fast I/O and transformation tools for GeoParquet files using PyArrow and DuckDB.
 
-**📚 [Full Documentation](https://geoparquet.org/geoparquet-io/)** | **[Quick Start Tutorial](https://geoparquet.org/geoparquet-io/getting-started/quickstart/)**
+**📚 [Full Documentation](https://geoparquet.io/)** | **[Quick Start Tutorial](https://geoparquet.io/getting-started/quickstart/)**
 
 ## Features
 
@@ -27,7 +27,7 @@ Fast I/O and transformation tools for GeoParquet files using PyArrow and DuckDB.
 pip install geoparquet-io
 ```
 
-See the [Installation Guide](https://geoparquet.org/geoparquet-io/getting-started/installation/) for other options (uv, from source) and requirements.
+See the [Installation Guide](https://geoparquet.io/getting-started/installation/) for other options (uv, from source) and requirements.
 
 ## Quick Start
 
@@ -56,7 +56,7 @@ gpio sort hilbert https://example.com/data.parquet s3://bucket/sorted.parquet
 gpio extract --bbox "-122.5,37.5,-122.0,38.0" input.parquet | gpio add bbox - | gpio sort hilbert - output.parquet
 ```
 
-For more examples and detailed usage, see the [Quick Start Tutorial](https://geoparquet.org/geoparquet-io/getting-started/quickstart/) and [User Guide](https://geoparquet.org/geoparquet-io/guide/inspect/).
+For more examples and detailed usage, see the [Quick Start Tutorial](https://geoparquet.io/getting-started/quickstart/) and [User Guide](https://geoparquet.io/guide/inspect/).
 
 ## Python API
 
@@ -83,7 +83,7 @@ gpio.read('data.parquet') \
     .upload('s3://bucket/filtered.parquet')
 ```
 
-The Python API keeps data in memory as Arrow tables, providing up to 5x better performance than CLI operations. See the [Python API documentation](https://geoparquet.org/geoparquet-io/api/python-api/) for full details.
+The Python API keeps data in memory as Arrow tables, providing up to 5x better performance than CLI operations. See the [Python API documentation](https://geoparquet.io/api/python-api/) for full details.
 
 ## Claude Code Integration
 
@@ -102,9 +102,9 @@ Contributions are welcome! See [CONTRIBUTING.md](docs/contributing.md) for devel
 
 ## Links
 
-- **Documentation**: [https://geoparquet.org/geoparquet-io/](https://geoparquet.org/geoparquet-io/)
+- **Documentation**: [https://geoparquet.io/](https://geoparquet.io/)
 - **PyPI**: [https://pypi.org/project/geoparquet-io/](https://pypi.org/project/geoparquet-io/)
-- **Issues**: [https://github.com/cholmes/geoparquet-io/issues](https://github.com/cholmes/geoparquet-io/issues)
+- **Issues**: [https://github.com/geoparquet/geoparquet-io/issues](https://github.com/geoparquet/geoparquet-io/issues)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ We take the security of geoparquet-io seriously. If you believe you have found a
 ### Please DO:
 
 1. **Report via GitHub Security Advisories** (preferred):
-   - Go to the [Security tab](https://github.com/cholmes/geoparquet-io/security/advisories)
+   - Go to the [Security tab](https://github.com/geoparquet/geoparquet-io/security/advisories)
    - Click "Report a vulnerability"
    - Fill in the details
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,35 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2025-11-17
 
 ### Added
-- `gpio convert` command for optimized GeoParquet conversion from vector formats (Shapefile, GeoJSON, GeoPackage, GDB, CSV/TSV) ([#56](https://github.com/cholmes/geoparquet-io/pull/56))
-- `gpio stac` command for STAC Item and Collection generation ([#57](https://github.com/cholmes/geoparquet-io/pull/57))
-- `gpio check stac` command for STAC validation ([#57](https://github.com/cholmes/geoparquet-io/pull/57))
-- `--prefix` option for partition commands to customize output filenames ([#62](https://github.com/cholmes/geoparquet-io/pull/62))
+- `gpio convert` command for optimized GeoParquet conversion from vector formats (Shapefile, GeoJSON, GeoPackage, GDB, CSV/TSV) ([#56](https://github.com/geoparquet/geoparquet-io/pull/56))
+- `gpio stac` command for STAC Item and Collection generation ([#57](https://github.com/geoparquet/geoparquet-io/pull/57))
+- `gpio check stac` command for STAC validation ([#57](https://github.com/geoparquet/geoparquet-io/pull/57))
+- `--prefix` option for partition commands to customize output filenames ([#62](https://github.com/geoparquet/geoparquet-io/pull/62))
 
 ### Changed
-- Documentation consolidated with snippets system ([#55](https://github.com/cholmes/geoparquet-io/pull/55))
+- Documentation consolidated with snippets system ([#55](https://github.com/geoparquet/geoparquet-io/pull/55))
 
 ## [0.3.0] - 2025-11-06
 
 ### Added
-- `gpio meta` command for deep inspection of Parquet and GeoParquet metadata ([#46](https://github.com/cholmes/geoparquet-io/pull/46))
-- Multi-level admin boundary partitioning with GAUL and Overture Maps datasets ([#38](https://github.com/cholmes/geoparquet-io/pull/38))
-- Code quality checks with vulture and xenon to CI workflow ([#48](https://github.com/cholmes/geoparquet-io/pull/48), [#49](https://github.com/cholmes/geoparquet-io/pull/49), [#50](https://github.com/cholmes/geoparquet-io/pull/50))
+- `gpio meta` command for deep inspection of Parquet and GeoParquet metadata ([#46](https://github.com/geoparquet/geoparquet-io/pull/46))
+- Multi-level admin boundary partitioning with GAUL and Overture Maps datasets ([#38](https://github.com/geoparquet/geoparquet-io/pull/38))
+- Code quality checks with vulture and xenon to CI workflow ([#48](https://github.com/geoparquet/geoparquet-io/pull/48), [#49](https://github.com/geoparquet/geoparquet-io/pull/49), [#50](https://github.com/geoparquet/geoparquet-io/pull/50))
 
 ### Changed
-- GitHub Actions dependency updates ([#39](https://github.com/cholmes/geoparquet-io/pull/39), [#40](https://github.com/cholmes/geoparquet-io/pull/40), [#41](https://github.com/cholmes/geoparquet-io/pull/41), [#42](https://github.com/cholmes/geoparquet-io/pull/42))
+- GitHub Actions dependency updates ([#39](https://github.com/geoparquet/geoparquet-io/pull/39), [#40](https://github.com/geoparquet/geoparquet-io/pull/40), [#41](https://github.com/geoparquet/geoparquet-io/pull/41), [#42](https://github.com/geoparquet/geoparquet-io/pull/42))
 
 ## [0.2.0] - 2025-10-24
 
 ### Added
-- MkDocs documentation site with GitHub Pages deployment ([#35](https://github.com/cholmes/geoparquet-io/pull/35))
+- MkDocs documentation site with GitHub Pages deployment ([#35](https://github.com/geoparquet/geoparquet-io/pull/35))
   - Comprehensive user guide and CLI reference
   - API documentation
   - Real-world examples
-  - Published at https://cholmes.github.io/geoparquet-io/
+  - Published at https://geoparquet.io/
 
 ### Changed
-- Consolidated 177 lines of duplicated CLI option definitions into reusable decorators ([#36](https://github.com/cholmes/geoparquet-io/pull/36))
+- Consolidated 177 lines of duplicated CLI option definitions into reusable decorators ([#36](https://github.com/geoparquet/geoparquet-io/pull/36))
 
 ## [0.1.0] - 2025-10-19
 
@@ -69,15 +69,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Core Features
 - **Spatial Sorting**: Hilbert curve ordering for optimal spatial locality
 - **Bbox Operations**: Add bbox columns and metadata for query performance
-- **H3 Support**: H3 hexagonal cell ID support via DuckDB H3 extension ([#23](https://github.com/cholmes/geoparquet-io/pull/23))
+- **H3 Support**: H3 hexagonal cell ID support via DuckDB H3 extension ([#23](https://github.com/geoparquet/geoparquet-io/pull/23))
   - `gpio add h3` and `gpio partition h3` commands
   - H3 columns excluded from partition output by default (configurable)
   - Enhanced metadata system for custom covering metadata (bbox + H3) in GeoParquet 1.1 spec
-- **KD-tree Partitioning**: Balanced spatial partitioning support ([#30](https://github.com/cholmes/geoparquet-io/pull/30))
+- **KD-tree Partitioning**: Balanced spatial partitioning support ([#30](https://github.com/geoparquet/geoparquet-io/pull/30))
   - `gpio add kdtree` and `gpio partition kdtree` commands
   - Auto-select partitions targeting ~120k rows using approximate mode
   - Exact computation mode available for deterministic results
-- **Inspect Command**: Fast metadata inspection ([#31](https://github.com/cholmes/geoparquet-io/pull/31))
+- **Inspect Command**: Fast metadata inspection ([#31](https://github.com/geoparquet/geoparquet-io/pull/31))
   - Optional data preview with `--head`/`--tail` flags
   - Column statistics with `--stats` flag
   - JSON output support with `--json` flag
@@ -130,9 +130,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release as `geoparquet-tools` with basic functionality.
 
-[Unreleased]: https://github.com/cholmes/geoparquet-io/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/cholmes/geoparquet-io/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/cholmes/geoparquet-io/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/cholmes/geoparquet-io/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/cholmes/geoparquet-io/releases/tag/v0.1.0
+[Unreleased]: https://github.com/geoparquet/geoparquet-io/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/geoparquet/geoparquet-io/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/geoparquet/geoparquet-io/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/geoparquet/geoparquet-io/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/geoparquet/geoparquet-io/releases/tag/v0.1.0
 [0.0.1]: https://github.com/cholmes/geoparquet-tools/releases/tag/v0.0.1

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+geoparquet.io

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to geoparquet-io! This document prov
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/cholmes/geoparquet-io.git
+   git clone https://github.com/geoparquet/geoparquet-io.git
    cd geoparquet-io
    ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,7 @@
 uv pip install geoparquet-io
 
 # Or install from source
-git clone https://github.com/cholmes/geoparquet-io.git
+git clone https://github.com/geoparquet/geoparquet-io.git
 cd geoparquet-io
 uv sync --all-extras
 ```
@@ -27,7 +27,7 @@ pip install geoparquet-io
 For the latest development version:
 
 ```bash
-git clone https://github.com/cholmes/geoparquet-io.git
+git clone https://github.com/geoparquet/geoparquet-io.git
 cd geoparquet-io
 uv sync  # recommended
 # or

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # geoparquet-io
 
-[![Tests](https://github.com/cholmes/geoparquet-io/actions/workflows/tests.yml/badge.svg)](https://github.com/cholmes/geoparquet-io/actions/workflows/tests.yml)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://github.com/cholmes/geoparquet-io)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/cholmes/geoparquet-io/blob/main/LICENSE)
+[![Tests](https://github.com/geoparquet/geoparquet-io/actions/workflows/tests.yml/badge.svg)](https://github.com/geoparquet/geoparquet-io/actions/workflows/tests.yml)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://github.com/geoparquet/geoparquet-io)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/geoparquet/geoparquet-io/blob/main/LICENSE)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 
 Fast I/O and transformation tools for GeoParquet files using PyArrow and DuckDB.
@@ -105,10 +105,10 @@ gpio.read('input.parquet') \
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/cholmes/geoparquet-io/issues)
-- **Source Code**: [GitHub Repository](https://github.com/cholmes/geoparquet-io)
+- **Issues**: [GitHub Issues](https://github.com/geoparquet/geoparquet-io/issues)
+- **Source Code**: [GitHub Repository](https://github.com/geoparquet/geoparquet-io)
 - **Contributing**: See our [Contributing Guide](contributing.md)
 
 ## License
 
-Apache 2.0 - See [LICENSE](https://github.com/cholmes/geoparquet-io/blob/main/LICENSE) for details.
+Apache 2.0 - See [LICENSE](https://github.com/geoparquet/geoparquet-io/blob/main/LICENSE) for details.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -222,4 +222,4 @@ When reporting issues, include:
 4. Python version: `python --version`
 5. Operating system
 
-File issues at: [GitHub Issues](https://github.com/cholmes/geoparquet-io/issues)
+File issues at: [GitHub Issues](https://github.com/geoparquet/geoparquet-io/issues)

--- a/examples/01_getting_started.ipynb
+++ b/examples/01_getting_started.ipynb
@@ -248,13 +248,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Next Steps\n",
-    "\n",
-    "- [02_python_api_chaining.ipynb](02_python_api_chaining.ipynb) - Advanced chaining and pipelines\n",
-    "- [03_spatial_indices.ipynb](03_spatial_indices.ipynb) - Spatial index options\n",
-    "- [Python API Reference](https://geoparquet.org/geoparquet-io/api/python-api/) - Full documentation"
-   ]
+   "source": "## Next Steps\n\n- [02_python_api_chaining.ipynb](02_python_api_chaining.ipynb) - Advanced chaining and pipelines\n- [03_spatial_indices.ipynb](03_spatial_indices.ipynb) - Spatial index options\n- [Python API Reference](https://geoparquet.io/api/python-api/) - Full documentation"
   }
  ],
  "metadata": {

--- a/examples/03_spatial_indices.ipynb
+++ b/examples/03_spatial_indices.ipynb
@@ -222,12 +222,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Next Steps\n",
-    "\n",
-    "- [04_partitioning.ipynb](04_partitioning.ipynb) - Splitting data into multiple files\n",
-    "- [Spatial Performance Guide](https://geoparquet.org/geoparquet-io/concepts/spatial-indices/) - Detailed explanation"
-   ]
+   "source": "## Next Steps\n\n- [04_partitioning.ipynb](04_partitioning.ipynb) - Splitting data into multiple files\n- [Spatial Performance Guide](https://geoparquet.io/concepts/spatial-indices/) - Detailed explanation"
   }
  ],
  "metadata": {

--- a/examples/04_partitioning.ipynb
+++ b/examples/04_partitioning.ipynb
@@ -208,12 +208,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Next Steps\n",
-    "\n",
-    "- [05_cloud_workflows.ipynb](05_cloud_workflows.ipynb) - Cloud storage integration\n",
-    "- [Partition Guide](https://geoparquet.org/geoparquet-io/guide/partition/) - CLI partitioning options"
-   ]
+   "source": "## Next Steps\n\n- [05_cloud_workflows.ipynb](05_cloud_workflows.ipynb) - Cloud storage integration\n- [Partition Guide](https://geoparquet.io/guide/partition/) - CLI partitioning options"
   }
  ],
  "metadata": {

--- a/examples/05_cloud_workflows.ipynb
+++ b/examples/05_cloud_workflows.ipynb
@@ -262,12 +262,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## More Resources\n",
-    "\n",
-    "- [Remote Files Guide](https://geoparquet.org/geoparquet-io/guide/remote-files/) - CLI remote file support\n",
-    "- [Upload Guide](https://geoparquet.org/geoparquet-io/cli/upload/) - CLI upload options"
-   ]
+   "source": "## More Resources\n\n- [Remote Files Guide](https://geoparquet.io/guide/remote-files/) - CLI remote file support\n- [Upload Guide](https://geoparquet.io/cli/upload/) - CLI upload options"
   }
  ],
  "metadata": {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: geoparquet-io
 site_description: Fast I/O and transformation tools for GeoParquet files
 site_author: Chris Holmes
-site_url: https://cholmes.github.io/geoparquet-io/
-repo_name: cholmes/geoparquet-io
-repo_url: https://github.com/cholmes/geoparquet-io
+site_url: https://geoparquet.io/
+repo_name: geoparquet/geoparquet-io
+repo_url: https://github.com/geoparquet/geoparquet-io
 edit_uri: edit/main/docs/
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,10 @@ gpio = "geoparquet_io:cli"
 gt = "geoparquet_io:cli"  # Legacy alias for backwards compatibility
 
 [project.urls]
-"Homepage" = "https://github.com/cholmes/geoparquet-io"
-"Bug Tracker" = "https://github.com/cholmes/geoparquet-io/issues"
-"Documentation" = "https://github.com/cholmes/geoparquet-io#readme"
-"Source" = "https://github.com/cholmes/geoparquet-io"
+"Homepage" = "https://github.com/geoparquet/geoparquet-io"
+"Bug Tracker" = "https://github.com/geoparquet/geoparquet-io/issues"
+"Documentation" = "https://geoparquet.io/"
+"Source" = "https://github.com/geoparquet/geoparquet-io"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- Updates all documentation URLs from `geoparquet.org/geoparquet-io` to `https://geoparquet.io/`
- Updates all GitHub repository URLs from `cholmes/geoparquet-io` to `geoparquet/geoparquet-io`
- Adds CNAME file for GitHub Pages custom domain

## Technical Details
Updated files:
- `mkdocs.yml` - site_url and repo configuration
- `README.md` - badges, doc links, and issue links
- `pyproject.toml` - project URLs
- `docs/index.md`, `docs/CHANGELOG.md`, `docs/contributing.md`, `docs/troubleshooting.md`, `docs/getting-started/installation.md` - various GitHub and doc links
- `SECURITY.md` - security advisories link
- `examples/*.ipynb` - doc reference links in 4 notebooks
- `docs/CNAME` - new file for custom domain

## Test plan
- [ ] Verify docs build successfully with `mkdocs serve`
- [ ] Confirm CNAME is included in built docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation URLs from geoparquet.org to geoparquet.io across all guides and API references.
  * Updated project repository and support links throughout documentation files and configuration.
  * Configured new domain hosting settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->