### PR TITLE
Quote column names in SQL to handle special characters

### DIFF
--- a/geoparquet_io/core/add_bbox_column.py
+++ b/geoparquet_io/core/add_bbox_column.py
@@ -71,7 +71,8 @@ def add_bbox_table(
 
         if geom_is_blob and geom_col in table.column_names:
             # Create view with geometry conversion
-            other_cols = [c for c in table.column_names if c != geom_col]
+            # Quote column names to handle special characters (colons, spaces, etc.)
+            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
             col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"

--- a/geoparquet_io/core/add_quadkey_column.py
+++ b/geoparquet_io/core/add_quadkey_column.py
@@ -234,7 +234,8 @@ def add_quadkey_table(
         geom_is_blob = any(col[0] == geom_col and "BLOB" in col[1].upper() for col in columns_info)
 
         if geom_is_blob and geom_col in table.column_names:
-            other_cols = [c for c in table.column_names if c != geom_col]
+            # Quote column names to handle special characters (colons, spaces, etc.)
+            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
             col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -736,7 +736,8 @@ def extract_table(
 
         if geom_is_blob and geom_col in table.column_names:
             # Create view with geometry conversion
-            other_cols = [c for c in table.column_names if c != geom_col]
+            # Quote column names to handle special characters (colons, spaces, etc.)
+            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
             col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -65,7 +65,8 @@ def hilbert_order_table(
         geom_is_blob = any(col[0] == geom_col and "BLOB" in col[1].upper() for col in columns_info)
 
         if geom_is_blob and geom_col in table.column_names:
-            other_cols = [c for c in table.column_names if c != geom_col]
+            # Quote column names to handle special characters (colons, spaces, etc.)
+            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
             col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"


### PR DESCRIPTION
## Summary

Column names containing special characters like colons (e.g., `hcat:name_en`) were not being quoted in SQL queries, causing DuckDB `BinderException` errors.

## Changes

- Quote all column names with double quotes when building SQL queries in:
  - `reproject.py` - reproject_table(), reproject_impl(), _reproject_streaming()
  - `add_bbox_column.py`
  - `extract.py`
  - `hilbert_order.py`
  - `add_quadkey_column.py`

- Wrap ST_Transform output in `ST_AsWKB()` in `reproject_table()` to ensure the geometry is in proper WKB format for GeoParquet compatibility (DuckDB ST_Transform returns geometry in internal format, not WKB)

## Test plan

- [x] Tested with GeoParquet file containing column names with colons
- [x] Verified reprojection produces valid WKB output
- [x] All pre-commit checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of column names with special characters (spaces, colons, etc.) across geometry operations. The library now properly quotes column identifiers in SQL queries to ensure compatibility with non-standard column names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->