### PR TITLE
Fix slow test coverage failure by setting fail-under to 0 [test-slow]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Run slow and network tests (parallel)
         run: |
-          uv run pytest -n auto -m "slow or network" -v --tb=short --cov=geoparquet_io --cov-report=xml
+          uv run pytest -n auto -m "slow or network" -v --tb=short --cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0
 
       - name: Upload slow test coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Description

Fixes the failing slow test CI jobs for Ubuntu and Windows with Python 3.11.

## Problem

The slow-tests job was failing with:
```
FAIL Required test coverage of 67% not reached. Total coverage: 28.50%
```

Slow tests only exercise specific operations (format conversions, streaming, reprojection, network access) which results in ~29% code coverage. The pytest configuration requires 67% minimum coverage, causing the build to fail even though all tests passed.

## Solution

Added `--cov-fail-under=0` flag to the slow test command. This:
- ✅ Still collects coverage data (generates coverage.xml)
- ✅ Still uploads coverage to Codecov with `slowtests` flag
- ✅ Allows tests to pass without hitting coverage threshold
- ✅ Maintains coverage enforcement for fast tests (67% minimum)

## Test Plan

- [x] Reproduced issue locally: slow tests with default settings failed at 29% coverage
- [x] Verified fix: slow tests with `--cov-fail-under=0` pass and generate coverage.xml
- [x] Confirmed fast tests still enforce 67% threshold

[test-slow]

## Checklist
- [x] Code is formatted
- [ ] Tests pass (waiting for CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test coverage reporting to include terminal output displaying missing test coverage lines and adjusted coverage threshold configuration for more reliable test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->