### PR TITLE
Fix crash on non-numeric CRS codes like IGNF:LAMB93

### DIFF
--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -146,7 +146,10 @@ def _extract_crs_identifier(crs_info: Any) -> tuple[str, int] | None:
                 authority = crs_id.get("authority", "").upper()
                 code = crs_id.get("code")
                 if authority and code:
-                    return (authority, int(code))
+                    try:
+                        return (authority, int(code))
+                    except (ValueError, TypeError):
+                        pass  # Non-numeric code like "LAMB93"
         return None
 
     if isinstance(crs_info, str):


### PR DESCRIPTION
## Summary
- Fixes `gpio inspect` crash when file has a non-numeric CRS code (e.g., `IGNF:LAMB93`)
- Adds try/except to handle `ValueError` when parsing PROJJSON CRS codes

## Technical Details
The `_extract_crs_identifier()` function in `inspect_utils.py` assumed CRS codes in PROJJSON format would always be numeric EPSG codes. French CRS like LAMB93 use string identifiers, causing `int("LAMB93")` to fail.

The fix adds exception handling consistent with other CRS parsing branches in the same function.

## Test plan
- [x] Tested with `france.parquet` file that has `IGNF:LAMB93` CRS
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for non-numeric Coordinate Reference System (CRS) codes in GeoParquet inspection. The system now gracefully processes non-numeric identifiers (such as "LAMB93") instead of raising exceptions, making CRS parsing more robust.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->