### PR TITLE
Fix benchmark workflow permissions for PR comments

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,6 +29,10 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-trigger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to the benchmark workflow so it can post results as comments on PRs
- Fixes "HttpError: Resource not accessible by integration" error

## Technical Details
The `pull_request` event with `labeled` type has read-only permissions by default. The `actions/github-script` step was failing when trying to call `github.rest.issues.createComment()`.

## Related Issue(s)
Discovered during benchmark workflow testing on PR #187

## Checklist
- [x] Code formatted with `ruff format .` and `ruff check --fix .`
- [x] All tests pass (`pytest`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow permissions for improved security and reliability of automated processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->