### PR TITLE
Fix BigQuery extract by removing invalid bq_project_id setting

### DIFF
--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -198,10 +198,8 @@ class BigQueryConnection:
             if self.geography_as_geometry:
                 self._con.execute("SET bq_geography_as_geometry=true;")
 
-            # Set project if provided (validated)
-            if self.project:
-                validated_project = _validate_project_id(self.project)
-                self._con.execute(f"SET bq_project_id='{validated_project}';")
+            # Note: project ID is specified in the fully-qualified table name
+            # (project.dataset.table) passed to bigquery_scan(), not as a SET parameter
 
             return self._con
 
@@ -259,10 +257,8 @@ def get_bigquery_connection(
     if geography_as_geometry:
         con.execute("SET bq_geography_as_geometry=true;")
 
-    # Set project if provided (validated)
-    if project:
-        validated_project = _validate_project_id(project)
-        con.execute(f"SET bq_project_id='{validated_project}';")
+    # Note: project ID is specified in the fully-qualified table name
+    # (project.dataset.table) passed to bigquery_scan(), not as a SET parameter
 
     return con
 


### PR DESCRIPTION
## Summary

- Remove invalid `SET bq_project_id` configuration from BigQuery connection setup
- The DuckDB BigQuery extension does not have this setting; project ID is passed in the fully-qualified table name to `bigquery_scan()`

## Technical Details

The error occurred because the code was trying to set a non-existent DuckDB configuration parameter:
```
Catalog Error: unrecognized configuration parameter "bq_project_id"
```

Per the [DuckDB BigQuery extension documentation](https://duckdb.org/community_extensions/extensions/bigquery.html), there is no `bq_project_id` setting. The project ID is specified directly in the table identifier passed to `bigquery_scan('project.dataset.table')`.

The `_normalize_table_id()` function already ensures the table ID is in fully-qualified `project.dataset.table` format before calling `bigquery_scan()`, so no separate setting is needed.

## Test plan

- [ ] Run `gpio extract bigquery project.dataset.table output.parquet` with a valid BigQuery table
- [ ] Verify extraction completes without "unrecognized configuration parameter" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated BigQuery project specification to require fully-qualified table names (project.dataset.table) instead of relying on a SET parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->