### PR TITLE
[Cleanup] Add user-friendly error messages for invalid Parquet files

### DIFF
--- a/.claude/agents/deep-explore.md
+++ b/.claude/agents/deep-explore.md
@@ -1,0 +1,59 @@
+---
+name: deep-explore
+description: Deep codebase exploration using grepai semantic search and call graph tracing. Use this agent for understanding code architecture, finding implementations by intent, analyzing function relationships, and exploring unfamiliar code areas.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+## Instructions
+
+You are a specialized code exploration agent with access to grepai semantic search and call graph tracing.
+
+### Primary Tools
+
+#### 1. Semantic Search: `grepai search`
+
+Use this to find code by intent and meaning:
+
+```bash
+# Use English queries for best results (--compact saves ~80% tokens)
+grepai search "authentication flow" --json --compact
+grepai search "error handling middleware" --json --compact
+grepai search "database connection management" --json --compact
+```
+
+#### 2. Call Graph Tracing: `grepai trace`
+
+Use this to understand function relationships and code flow:
+
+```bash
+# Find all functions that call a symbol
+grepai trace callers "HandleRequest" --json
+
+# Find all functions called by a symbol
+grepai trace callees "ProcessOrder" --json
+
+# Build complete call graph
+grepai trace graph "ValidateToken" --depth 3 --json
+```
+
+Use `grepai trace` when you need to:
+- Find all callers of a function
+- Understand the call hierarchy
+- Analyze the impact of changes to a function
+- Map dependencies between components
+
+### When to use standard tools
+
+Only fall back to Grep/Glob when:
+- You need exact text matching (variable names, imports)
+- grepai is not available or returns errors
+- You need file path patterns
+
+### Workflow
+
+1. Start with `grepai search` to find relevant code semantically
+2. Use `grepai trace` to understand function relationships and call graphs
+3. Use `Read` to examine promising files in detail
+4. Use Grep only for exact string searches if needed
+5. Synthesize findings into a clear summary

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 .worktrees/
+.grepai/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improved error messages for common user mistakes (closes #140)
-  - No more stack traces when passing wrong file types (e.g., `.gpkg` to parquet commands)
-  - Clear, actionable error messages with hints for fixing the issue
-  - Added defensive checks to prevent `AttributeError` on missing output files
+  - Using a .gpkg file with `gpio add` commands now shows:
+    "Not a valid Parquet file... Hint: Use 'gpio convert geoparquet' to convert other formats"
+  - Previously showed full stack trace with `duckdb.InvalidInputException`
+  - Error handling applied to all commands using `GlobAwareCommand` and `SingleFileCommand`
 
 ### Internal
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,3 +360,72 @@ return ctx.code.extract(content, "typescript", { type: "function", name: "handle
 | Avant d'éditer | Utiliser l'outil natif `Read` |
 
 <!-- END DISTILL -->
+
+
+## grepai - Semantic Code Search
+
+**IMPORTANT: You MUST use grepai as your PRIMARY tool for code exploration and search.**
+
+### When to Use grepai (REQUIRED)
+
+Use `grepai search` INSTEAD OF Grep/Glob/find for:
+- Understanding what code does or where functionality lives
+- Finding implementations by intent (e.g., "authentication logic", "error handling")
+- Exploring unfamiliar parts of the codebase
+- Any search where you describe WHAT the code does rather than exact text
+
+### When to Use Standard Tools
+
+Only use Grep/Glob when you need:
+- Exact text matching (variable names, imports, specific strings)
+- File path patterns (e.g., `**/*.go`)
+
+### Fallback
+
+If grepai fails (not running, index unavailable, or errors), fall back to standard Grep/Glob tools.
+
+### Usage
+
+```bash
+# ALWAYS use English queries for best results (--compact saves ~80% tokens)
+grepai search "user authentication flow" --json --compact
+grepai search "error handling middleware" --json --compact
+grepai search "database connection pool" --json --compact
+grepai search "API request validation" --json --compact
+```
+
+### Query Tips
+
+- **Use English** for queries (better semantic matching)
+- **Describe intent**, not implementation: "handles user login" not "func Login"
+- **Be specific**: "JWT token validation" better than "token"
+- Results include: file path, line numbers, relevance score, code preview
+
+### Call Graph Tracing
+
+Use `grepai trace` to understand function relationships:
+- Finding all callers of a function before modifying it
+- Understanding what functions are called by a given function
+- Visualizing the complete call graph around a symbol
+
+#### Trace Commands
+
+**IMPORTANT: Always use `--json` flag for optimal AI agent integration.**
+
+```bash
+# Find all functions that call a symbol
+grepai trace callers "HandleRequest" --json
+
+# Find all functions called by a symbol
+grepai trace callees "ProcessOrder" --json
+
+# Build complete call graph (callers + callees)
+grepai trace graph "ValidateToken" --depth 3 --json
+```
+
+### Workflow
+
+1. Start with `grepai search` to find relevant code
+2. Use `grepai trace` to understand function relationships
+3. Use `Read` tool to examine files from results
+4. Only use Grep for exact string searches if needed

--- a/context/shared/plans/PROGRESS.md
+++ b/context/shared/plans/PROGRESS.md
@@ -10,8 +10,8 @@
 | PR1 | C4: Remove deprecated commands | ✅ Complete | PR #174 - Merged | Issue #154 (M4/Issue #115 was already fixed) |
 | PR2 | C1: Refactor inspect_legacy | ✅ Complete | PR #176 - Merged | Grade E → C (removed deprecated code) |
 | PR3 | C2: Test coverage 75%+ | ✅ Complete | PR #178 - Merged | 67.0% → 68.54% (target: 75%+ not reached, but meaningful progress) |
-| PR4 | C3: CLI consistency (partial) | 🔍 PR Open - Awaiting Review | PR #192 | Issue #120 (partial), #150. Added --show-sql, --verbose, progress, renamed --profile→--aws-profile |
-| PR5 | H1 + H3: Error handling + profile cleanup | ⏸️ Partial (H3 done in PR4) | - | H3 complete in PR4. H1 (#140) remains |
+| PR4 | C3: CLI consistency (partial) | ✅ Complete | PR #192 - Merged | Issue #120 (partial), #150. Added --show-sql, --verbose, progress, renamed --profile→--aws-profile |
+| PR5 | H1: Error handling | 🔄 In progress | - | Issue #140. User-friendly error messages for invalid file types |
 | PR6 | H2: Grade D refactoring (top 3) | ⏳ Not started | - | extract, convert, inspect |
 | PR7 | Docs audit (optional) | ⏳ Not started | - | If time permits |
 
@@ -58,7 +58,7 @@
     Further improvement requires systematic testing of external dependencies.
 
 ### 2026-01-27
-- **PR4 Completed** (PR #192 - Awaiting Review):
+- **PR4 Completed** (PR #192 - Merged):
   - Added `--show-sql` to all DuckDB commands (add, partition, sort, extract arcgis)
   - Added `--verbose` to 6 missing commands (inspect subcommands, publish upload)
   - Added progress reporting to 3 commands (add h3, add quadkey, sort column)
@@ -69,3 +69,13 @@
   - Created issue #191 for --overwrite standardization (deferred to separate PR)
   - All 1412 tests passing, 68% coverage maintained
   - CHANGELOG.md updated with all changes
+
+### 2026-01-31
+- **PR5 In Progress** (Branch: cleanup/pr5-error-handling):
+  - Added error handling to `get_kv_metadata()` in `duckdb_metadata.py`
+  - Added `invoke()` override to `GlobAwareCommand` class to catch `GeoParquetError`
+  - Now shows user-friendly error messages for invalid Parquet files (e.g., using .gpkg with add commands)
+  - Before: Full stack trace with `duckdb.InvalidInputException`
+  - After: Clean error message with hint to use `gpio convert`
+  - Added 4 new tests for error handling (2 in test_duckdb_metadata.py, 2 in test_add.py)
+  - Addresses issue #140 (unsightly stack trace)

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -5,9 +5,32 @@ This module provides reusable decorators to ensure consistency across commands
 and reduce code duplication.
 """
 
+import functools
+
 import click
 
 from geoparquet_io.core.common import ParquetWriteSettings
+
+
+def handle_geoparquet_errors(func):
+    """
+    Decorator to convert GeoParquetError exceptions to user-friendly Click errors.
+
+    Catches GeoParquetError from core functions and converts them to
+    click.ClickException for clean error display without stack traces.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Import here to avoid circular imports
+        from geoparquet_io.core.duckdb_metadata import GeoParquetError
+
+        try:
+            return func(*args, **kwargs)
+        except GeoParquetError as e:
+            raise click.ClickException(str(e)) from None
+
+    return wrapper
 
 
 def parse_row_group_options(
@@ -370,6 +393,9 @@ class GlobAwareCommand(click.Command):
     For commands that support glob patterns (like extract), it suggests quoting.
     For commands that don't (like convert), it suggests using gpio extract first.
 
+    This class also handles GeoParquetError exceptions from core functions,
+    converting them to user-friendly Click exceptions without stack traces.
+
     Usage:
         @cli.command(cls=GlobAwareCommand)
         def my_command(...):
@@ -392,6 +418,16 @@ class GlobAwareCommand(click.Command):
         "extract": "geoparquet",
         "inspect": "summary",
     }
+
+    def invoke(self, ctx):
+        """Invoke the command with user-friendly error handling."""
+        # Import here to avoid circular imports
+        from geoparquet_io.core.duckdb_metadata import GeoParquetError
+
+        try:
+            return super().invoke(ctx)
+        except GeoParquetError as e:
+            raise click.ClickException(str(e)) from None
 
     def make_context(self, info_name, args, parent=None, **extra):
         """Detect shell-expanded glob patterns and provide helpful errors."""

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -63,6 +63,9 @@ def get_kv_metadata(parquet_file: str, con=None) -> dict[bytes, bytes]:
     Extract key-value metadata using parquet_kv_metadata().
 
     Returns dict like {b'geo': b'{"version": "1.1.0", ...}'}
+
+    Raises:
+        GeoParquetError: If file is not a valid Parquet file or cannot be read.
     """
     safe_url = _safe_url(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
@@ -83,6 +86,19 @@ def get_kv_metadata(parquet_file: str, con=None) -> dict[bytes, bytes]:
             if key_bytes:
                 kv_dict[key_bytes] = val_bytes
         return kv_dict
+    except duckdb.InvalidInputException as e:
+        # File is not a valid Parquet file (e.g., wrong format, corrupt)
+        error_msg = str(e)
+        if "No magic bytes found" in error_msg or "not a parquet file" in error_msg.lower():
+            raise GeoParquetError(
+                f"Not a valid Parquet file: {parquet_file}\n"
+                f"This command requires .parquet files with valid Parquet format.\n"
+                f"Hint: Use 'gpio convert geoparquet' to convert other formats."
+            ) from e
+        raise GeoParquetError(f"Invalid Parquet file: {parquet_file}\n{error_msg}") from e
+    except duckdb.IOException as e:
+        # File not found, permission denied, or other I/O error
+        raise GeoParquetError(f"Cannot read file: {parquet_file}\n{str(e)}") from e
     finally:
         if should_close:
             connection.close()

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -447,3 +447,35 @@ class TestRemoteWriteSupport:
             assert source_path.endswith(".parquet")
             # Destination should be the remote URL
             assert call_args[1]["destination"] == remote_output
+
+
+class TestAddCommandErrorHandling:
+    """Tests for user-friendly error handling in add commands."""
+
+    def test_add_bbox_with_gpkg_shows_friendly_error(self, tmp_path):
+        """Test that using a .gpkg file shows a friendly error, not a stack trace."""
+        # Create a fake gpkg file (not a valid parquet)
+        gpkg_file = tmp_path / "test.gpkg"
+        gpkg_file.write_text("Not a parquet file")
+
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox", str(gpkg_file)])
+
+        # Should fail with exit code 1
+        assert result.exit_code == 1
+
+        # Should show friendly error message, not a stack trace
+        assert "Traceback" not in result.output
+        assert "Not a valid Parquet file" in result.output
+        assert "gpio convert" in result.output
+
+    def test_add_bbox_with_nonexistent_file_shows_friendly_error(self):
+        """Test that using a nonexistent file shows a friendly error."""
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox", "/nonexistent/path/file.parquet"])
+
+        # Should fail
+        assert result.exit_code != 0
+
+        # Should show friendly error message
+        assert "Traceback" not in result.output

--- a/tests/test_duckdb_metadata.py
+++ b/tests/test_duckdb_metadata.py
@@ -373,3 +373,53 @@ class TestGeoParquetErrorExceptions:
         import click
 
         assert not issubclass(GeoParquetError, click.ClickException)
+
+    def test_get_kv_metadata_raises_error_for_invalid_parquet(self):
+        """Test that get_kv_metadata raises GeoParquetError for invalid files."""
+        # Create a temporary non-parquet file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".parquet", delete=False) as f:
+            f.write("This is not a parquet file")
+            temp_path = f.name
+
+        try:
+            with pytest.raises(GeoParquetError) as exc_info:
+                get_kv_metadata(temp_path)
+
+            # Verify error message is informative
+            error_msg = str(exc_info.value)
+            assert "Not a valid Parquet file" in error_msg
+            assert temp_path in error_msg
+            assert "gpio convert" in error_msg
+
+            # Verify the original exception is chained
+            assert exc_info.value.__cause__ is not None
+        finally:
+            # Clean up
+            Path(temp_path).unlink(missing_ok=True)
+
+    def test_get_kv_metadata_raises_error_for_io_error(self):
+        """Test that get_kv_metadata raises GeoParquetError for I/O errors."""
+        # Create an incomplete parquet file
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".parquet", delete=False) as f:
+            # Write just a few bytes - not a complete parquet file structure
+            f.write(b"PAR1")  # Parquet magic number but incomplete
+            temp_path = f.name
+
+        try:
+            with pytest.raises(GeoParquetError) as exc_info:
+                get_kv_metadata(temp_path)
+
+            # Verify error message mentions read issue or invalid parquet
+            error_msg = str(exc_info.value)
+            assert (
+                "Cannot read file" in error_msg
+                or "Not a valid Parquet file" in error_msg
+                or "Invalid Parquet file" in error_msg
+            )
+            assert temp_path in error_msg
+
+            # Verify the original exception is chained
+            assert exc_info.value.__cause__ is not None
+        finally:
+            # Clean up
+            Path(temp_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Addresses issue #140 - removes unsightly stack traces when users pass wrong file types.

**Changes:**
- Added error handling to `get_kv_metadata()` in `duckdb_metadata.py` to catch `InvalidInputException`
- Added `invoke()` override to `GlobAwareCommand` class to convert `GeoParquetError` to `ClickException`
- Shows helpful message with hint to use `gpio convert` for non-parquet files

**Before:**
```
Traceback (most recent call last):
  ... 30+ lines of stack trace ...
_duckdb.InvalidInputException: Invalid Input Error: No magic bytes found at end of file
```

**After:**
```
Error: Not a valid Parquet file: tests/data/buildings_test.gpkg
This command requires .parquet files with valid Parquet format.
Hint: Use 'gpio convert geoparquet' to convert other formats.
```

## Test plan

- [x] Added 4 new tests for error handling
  - 2 in test_duckdb_metadata.py (get_kv_metadata error cases)
  - 2 in test_add.py (CLI integration tests)
- [x] All 1463 fast tests pass
- [x] Pre-commit hooks pass (ruff, xenon, etc.)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Replaced technical stack traces with user-friendly error messages when invalid file formats are used, including actionable conversion guidance.

* **Documentation**
  * Added documentation for semantic code search functionality and code exploration workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->