### PR TITLE
Limit DuckDB threads during parallel test execution

### DIFF
--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -726,7 +726,7 @@ def validate_parquet_extension(output_file: str, any_extension: bool = False) ->
         )
 
 
-def get_duckdb_connection(load_spatial=True, load_httpfs=None, use_s3_auth=False):
+def get_duckdb_connection(load_spatial=True, load_httpfs=None, use_s3_auth=False, threads=None):
     """
     Create a DuckDB connection with necessary extensions loaded.
 
@@ -742,11 +742,17 @@ def get_duckdb_connection(load_spatial=True, load_httpfs=None, use_s3_auth=False
                     If None (default), auto-detects based on usage.
         use_s3_auth: Whether to configure AWS credential chain for S3 (default: False).
                     Only needed for private buckets.
+        threads: Number of threads for DuckDB to use (default: None = all cores).
+                Limiting threads is useful for parallel test execution to prevent
+                CPU saturation when multiple pytest workers create connections.
 
     Returns:
         duckdb.DuckDBPyConnection: Configured connection with extensions loaded
     """
-    con = duckdb.connect()
+    config = {}
+    if threads is not None:
+        config["threads"] = threads
+    con = duckdb.connect(config=config) if config else duckdb.connect()
 
     # Enable large buffer size for Arrow export to handle datasets with >2GB of
     # string/binary data (e.g., large WKB geometry columns). Without this,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,52 @@
 """
 Pytest configuration and shared fixtures for geoparquet-io tests.
+
+DuckDB Thread Limiting for Parallel Test Execution
+--------------------------------------------------
+Problem: DuckDB uses all CPU cores by default. With pytest-xdist running
+multiple workers (e.g., -n 4), each worker creates multiple DuckDB connections,
+leading to thread explosion: 4 workers × N connections × 16 threads = CPU saturation.
+
+Solution: Monkeypatch duckdb.connect() BEFORE any modules import duckdb.
+conftest.py is loaded before test collection, so we patch immediately at import.
+With 4 workers and 2 threads per connection, max threads = 4 × 2 = 8.
 """
 
-import json
-import os
-import shutil
-import tempfile
-import time
-from contextlib import contextmanager
-from pathlib import Path
-
+# ---------------------------------------------------------------------------
+# CRITICAL: Patch duckdb.connect BEFORE any other imports
+# This must happen before geoparquet_io modules are imported during collection
+# ---------------------------------------------------------------------------
 import duckdb
-import pyarrow.parquet as pq
-import pytest
+
+_DUCKDB_TEST_THREADS = 2  # Threads per DuckDB connection during tests
+_original_duckdb_connect = duckdb.connect
+
+
+def _thread_limited_connect(*args, **kwargs):
+    """Wrapper around duckdb.connect that limits threads for test performance."""
+    config = kwargs.pop("config", {}) or {}
+    if "threads" not in config:
+        config["threads"] = _DUCKDB_TEST_THREADS
+    return _original_duckdb_connect(*args, config=config, **kwargs)
+
+
+# Apply the monkeypatch globally at import time - BEFORE other imports
+duckdb.connect = _thread_limited_connect
+
+# ---------------------------------------------------------------------------
+# Now import everything else (they'll get the patched duckdb.connect)
+# noqa: E402 - Intentionally importing after duckdb patch
+# ---------------------------------------------------------------------------
+import json  # noqa: E402
+import os  # noqa: E402
+import shutil  # noqa: E402
+import tempfile  # noqa: E402
+import time  # noqa: E402
+from contextlib import contextmanager  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import pyarrow.parquet as pq  # noqa: E402
+import pytest  # noqa: E402
 
 # Test data directory
 TEST_DATA_DIR = Path(__file__).parent / "data"


### PR DESCRIPTION
## Description
Monkeypatch duckdb.connect() in conftest.py to limit threads per connection to 2 during tests. This prevents CPU saturation when pytest-xdist runs multiple workers, each creating multiple DuckDB connections.

- Add thread limiting wrapper in conftest.py (applied before any imports)
- Add optional threads parameter to get_duckdb_connection() for explicit control
- With 4 workers × 2 threads = max 8 threads vs previous 4 × N × 16

## Checklist
- [x] Code is formatted
- [ ] Tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to limit DuckDB threads during connection setup for better resource control and test parallelism.

* **Tests**
  * Enhanced test configuration to automatically cap DuckDB threads (default 2), improving stability during parallel test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->