### PR TITLE
Bump version to 1.1.0b1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0-beta] - 2026-03-05
+
+Minor version bump for ongoing beta improvements.
+
 ## [1.0.0-beta] - 2026-02-10
 
 This is the first beta release of geoparquet-io 1.0, featuring major new spatial indexing systems, auto-resolution partitioning, comprehensive `--overwrite` support, and significant performance improvements.

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -75,7 +75,7 @@ from geoparquet_io.core.upload import check_credentials
 from geoparquet_io.core.upload import upload as upload_impl
 
 # Version info
-__version__ = "1.0.0b1"
+__version__ = "1.1.0b1"
 
 
 class OptionalIntCommand(GlobAwareCommand):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geoparquet-io"
-version = "1.0.0b1"
+version = "1.1.0b1"
 description = "Fast I/O and transformation tools for GeoParquet files"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "1.0.0b1"
+version = "1.1.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0b1 to 1.1.0b1 (v1.1-beta)
- Update version in `pyproject.toml` and `geoparquet_io/cli/main.py`
- Add changelog entry for 1.1.0-beta

## Test plan
- [x] Version updated in pyproject.toml
- [x] Version updated in cli/main.py
- [x] Changelog updated
- [x] Tag v1.1.0b1 pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.1.0-beta
* **Documentation**
  * Updated changelog with version 1.1.0-beta entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->