### PR TITLE
Restore A5 and S2 documentation from PR #256

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -86,6 +86,8 @@ See [Python API Reference - Pipeline Composition](python-api.md#pipeline-composi
 |--------|-------------|
 | `.add_bbox()` | Add bounding box column |
 | `.add_h3(resolution)` | Add H3 hexagonal cell column |
+| `.add_a5(resolution)` | Add A5 cell column |
+| `.add_s2(level)` | Add S2 cell column |
 | `.add_quadkey(resolution)` | Add quadkey tile column |
 | `.add_kdtree()` | Add KD-tree partition column |
 | `.sort_hilbert()` | Sort by Hilbert space-filling curve |

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -356,6 +356,21 @@ table = gpio.read('input.parquet').add_s2(level=10)
 table = gpio.read('input.parquet').add_s2(column_name='s2_index', level=15)
 ```
 
+#### `add_a5(column_name='a5_cell', resolution=15)`
+
+Add an A5 cell column based on geometry location.
+
+```python
+# Default resolution (15)
+table = gpio.read('input.parquet').add_a5()
+
+# Lower resolution for larger cells
+table = gpio.read('input.parquet').add_a5(resolution=10)
+
+# Custom column name
+table = gpio.read('input.parquet').add_a5(column_name='a5_index', resolution=12)
+```
+
 #### `add_kdtree(column_name='kdtree_cell', iterations=9, sample_size=100000)`
 
 Add a KD-tree cell column for data-adaptive spatial partitioning.
@@ -532,7 +547,7 @@ print(f"Created {stats['file_count']} files")
 
 #### `partition_by_a5(output_dir, resolution=15, compression='ZSTD', hive=True, overwrite=False)`
 
-Partition the table into a Hive-partitioned directory by A5 (S2-based) cell.
+Partition the table into a Hive-partitioned directory by A5 cell.
 
 ```python
 # Partition by A5
@@ -648,7 +663,7 @@ result = sub_partition_directory(
 
 **Parameters:**
 - `directory` (str): Directory containing parquet files
-- `partition_type` (str): Type of partition ("h3", "s2", "quadkey")
+- `partition_type` (str): Type of partition ("h3", "a5", "s2", "quadkey")
 - `min_size_bytes` (int): Minimum file size to process
 - `resolution` (int | None): Resolution for H3/quadkey (0-15 for H3)
 - `level` (int | None): Level for S2 (alias for resolution)
@@ -948,6 +963,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.add_bbox(table, column_name='bbox', geometry_column=None)` | Add bounding box column |
 | `ops.add_quadkey(table, column_name='quadkey', resolution=13, use_centroid=False, geometry_column=None)` | Add quadkey column |
 | `ops.add_h3(table, column_name='h3_cell', resolution=9, geometry_column=None)` | Add H3 cell column |
+| `ops.add_a5(table, column_name='a5_cell', resolution=15, geometry_column=None)` | Add A5 cell column |
 | `ops.add_s2(table, column_name='s2_cell', level=13, geometry_column=None)` | Add S2 cell column |
 | `ops.add_kdtree(table, column_name='kdtree_cell', iterations=9, sample_size=100000, geometry_column=None)` | Add KD-tree cell column |
 | `ops.sort_hilbert(table, geometry_column=None)` | Reorder by Hilbert curve |

--- a/docs/concepts/spatial-indices.md
+++ b/docs/concepts/spatial-indices.md
@@ -214,7 +214,7 @@ gpio.read('input.parquet').add_kdtree().write('output.parquet')
 | Column | Cell Shape | Resolution Range | Best For |
 |--------|------------|------------------|----------|
 | **H3** | Hexagon | 0-15 | Aggregations, joins, uniform coverage |
-| **A5** | Pentagon | 0-30 | Equal-area aggregations, joins & analysis |
+| **A5** | Pentagon | 0-31 | Equal-area aggregations, joins & analysis |
 | **S2** | Quad | 0-30 | Global datasets, hierarchical indexing |
 | **Quadkey** | Square | 0-23 | Web mapping, tile workflows |
 | **KD-tree** | Varies | 1-20 | Clustered data, balanced partitions |
@@ -321,7 +321,7 @@ gpio.read('input.parquet') \
 # Add H3/A5 for aggregation, S2 for spherical analysis, quadkey for mapping
 gpio add bbox input.parquet | \
     gpio add h3 --resolution 9 - | \
-    gpio add a5 --resolution 13 - | \
+    gpio add a5 --level 13 - | \
     gpio add s2 --level 13 - | \
     gpio add quadkey --resolution 12 - | \
     gpio sort hilbert - enriched.parquet

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -64,6 +64,16 @@ gpio.read('input.parquet') \
     .add_h3(resolution=9) \
     .write('with_h3.parquet')
 
+# Add A5 cells
+gpio.read('input.parquet') \
+    .add_a5(resolution=15) \
+    .write('with_a5.parquet')
+
+# Add S2 spherical cells
+gpio.read('input.parquet') \
+    .add_s2(level=13) \
+    .write('with_s2.parquet')
+
 # Add quadkey tiles
 gpio.read('input.parquet') \
     .add_quadkey(resolution=12) \
@@ -73,6 +83,7 @@ gpio.read('input.parquet') \
 gpio.read('input.parquet') \
     .add_bbox() \
     .add_h3(resolution=9) \
+    .add_a5(resolution=13) \
     .add_quadkey(resolution=12) \
     .sort_hilbert() \
     .write('enriched.parquet')

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -97,6 +97,12 @@ Enhance your data with additional spatial indexing:
 # Add H3 hexagonal cell IDs (resolution 9 ≈ 105m² cells)
 gpio add h3 input.parquet output_h3.parquet --resolution 9
 
+# Add A5 cell IDs
+gpio add a5 input.parquet output_a5.parquet --resolution 15
+
+# Add S2 spherical cell IDs
+gpio add s2 input.parquet output_s2.parquet --level 13
+
 # Add KD-tree partition IDs (auto-selects optimal partition count)
 gpio add kdtree input.parquet output_kdtree.parquet
 

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -194,6 +194,43 @@ s2_cell_token(
 Cell IDs are stored as hex strings (e.g., `"89c25901"`) rather than integers for
 maximum portability across systems.
 
+## A5 Cells
+
+Add [A5](https://a5geo.org/) spatial cell IDs based on geometry centroids.
+
+=== "CLI"
+
+    ```bash
+    gpio add a5 input.parquet output.parquet --resolution 15
+
+    # From HTTPS to S3
+    gpio add a5 https://example.com/data.parquet s3://bucket/indexed.parquet --resolution 15
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    gpio.read('input.parquet').add_a5(resolution=15).write('output.parquet')
+
+    # Custom column name
+    gpio.read('input.parquet').add_a5(column_name='a5_index', resolution=12).write('output.parquet')
+    ```
+
+**Options:**
+
+```bash
+# Custom column name
+gpio add a5 input.parquet output.parquet --a5-name a5_index
+
+# Different resolution
+gpio add a5 input.parquet output.parquet --resolution 12
+
+# With row group sizing
+gpio add a5 input.parquet output.parquet --row-group-size-mb 256MB
+```
+
 ## KD-Tree Partitions
 
 Add balanced spatial partition IDs using KD-tree:

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -49,7 +49,7 @@ The auto-resolution calculation uses these cell count formulas:
 |-------|---------|-------|
 | **H3** | `cells ≈ 122 × 7^resolution` | Hexagonal cells |
 | **S2** | `cells = 6 × 4^level` | Spherical cells |
-| **A5** | `cells = 6 × 4^resolution` | S2-based |
+| **A5** | `cells = 6 × 4^resolution` | Equal-area cells |
 | **Quadkey** | `tiles = 4^zoom` | Square tiles |
 
 ## By String Column
@@ -259,7 +259,7 @@ Auto-resolution calculates the optimal S2 level using the formula: `cells = 6 ×
 
 ## By A5 Cells
 
-Partition by A5 (S2-based) spatial cells:
+Partition by A5 spatial cells:
 
 === "CLI"
 

--- a/docs/guide/piping.md
+++ b/docs/guide/piping.md
@@ -31,6 +31,8 @@ All transformation commands support Arrow IPC piping:
 | `add quadkey` | Yes | Yes |
 | `add h3` | Yes | Yes |
 | `add kdtree` | Yes | Yes |
+| `add a5` | Yes | Yes |
+| `add s2` | Yes | Yes |
 | `add admin-divisions` | Yes | Yes |
 | `sort hilbert` | Yes | Yes |
 | `sort quadkey` | Yes | Yes |
@@ -40,6 +42,8 @@ All transformation commands support Arrow IPC piping:
 | `partition string` | Yes | No (writes to directory) |
 | `partition quadkey` | Yes | No (writes to directory) |
 | `partition h3` | Yes | No (writes to directory) |
+| `partition a5` | Yes | No (writes to directory) |
+| `partition s2` | Yes | No (writes to directory) |
 | `partition kdtree` | Yes | No (writes to directory) |
 | `partition admin` | Yes | No (writes to directory) |
 
@@ -215,7 +219,7 @@ See [Python API Reference](../api/python-api.md) for full documentation.
 
 - [Python API](../api/python-api.md) - For programmatic access with even better performance
 - [Extract Command](extract.md) - Filtering and column selection
-- [Add Command](../cli/add.md) - Add bbox, H3, quadkey, KD-tree, and admin division columns
+- [Add Command](../cli/add.md) - Add bbox, H3, A5, S2, quadkey, KD-tree, and admin division columns
 - [Sort Command](sort.md) - Hilbert, quadkey, and column sorting
 - [Reproject Guide](../cli/convert.md) - Reprojection options
 - [Partition Command](partition.md) - Partitioning strategies

--- a/docs/guide/sub-partitioning.md
+++ b/docs/guide/sub-partitioning.md
@@ -54,6 +54,12 @@ by_country/
     gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place
     ```
 
+=== "A5"
+
+    ```bash
+    gpio partition a5 by_country/ --min-size 100MB --resolution 12 --in-place
+    ```
+
 === "S2"
 
     ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Fast I/O and transformation tools for GeoParquet files using PyArrow and DuckDB.
 - **Pipeable**: Chain commands with Unix pipes using Arrow IPC streaming - no intermediate files
 - **Comprehensive**: Sort, extract, partition, enhance, validate, and upload GeoParquet files
 - **Cloud-Native**: Read from and write to S3, GCS, Azure, and HTTPS sources
-- **Spatial Indexing**: Add bbox, H3 hexagonal cells, KD-tree partitions, and admin divisions
+- **Spatial Indexing**: Add bbox, H3 hexagonal cells, A5 equal-area cells, S2 spherical cells, KD-tree partitions, and admin divisions
 - **Best Practices**: Automatic optimization following GeoParquet 1.1 and 2.0 specs
 - **Parquet Geo Types support**: Read and write Parquet geometry and geography types
 - **Flexible**: CLI and Python API for any workflow


### PR DESCRIPTION
## Problem

PR #269 (codespell) accidentally reverted all the A5 and S2 documentation that @felixthoemmes added in PR #256.

## Solution

This PR restores all those changes by applying the diff from PR #256.

## Changes Restored

- **A5 cells section** in `docs/guide/add.md` (37 new lines)
- **A5 partition documentation** in `docs/guide/partition.md`
- **S2 examples and corrections** throughout documentation
- **Resolution/level parameter updates** for consistency
- **Python API examples** for A5

## Files Changed

- `docs/api/overview.md`
- `docs/api/python-api.md`
- `docs/concepts/spatial-indices.md`
- `docs/examples/basic.md`
- `docs/getting-started/quickstart.md`
- `docs/guide/add.md`
- `docs/guide/partition.md`
- `docs/guide/piping.md`
- `docs/guide/sub-partitioning.md`
- `docs/index.md`

**10 files changed, 90 insertions(+), 8 deletions(-)**

Fixes: https://github.com/geoparquet/geoparquet-io/pull/269#issuecomment-4064032828
Related: #256, #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for two new spatial indices: A5 equal-area cells and S2 spherical cells.
  * Documented new API methods `add_a5()` and `add_s2()` with code examples and CLI commands.
  * Updated getting-started, API reference, and guide sections to reflect new spatial indexing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->