### PR TITLE
Replace leftover fetch_arrow_table() with .arrow().read_all()

### DIFF
--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -904,7 +904,7 @@ def read_spatial_to_arrow(
             else:
                 # Spatial formats (GeoJSON, Shapefile, GeoPackage, etc.)
                 table_expr = f"ST_Read('{input_url}')"
-            arrow_table = con.execute(f"SELECT * FROM {table_expr}").fetch_arrow_table()
+            arrow_table = con.execute(f"SELECT * FROM {table_expr}").arrow().read_all()
             return arrow_table, None, None
 
         return arrow_table, detected_crs, geometry_column


### PR DESCRIPTION
## Summary
- Replace one leftover `fetch_arrow_table()` call in `convert.py:907` with `.arrow().read_all()`
- This was missed in PR #283 (DuckDB 1.5 upgrade) — the no-geometry fallback path still used the old method

## Context
`fetch_arrow_table()` crashes in DuckDB 1.5 with `TransactionContext::ActiveTransaction` when the result contains geometry columns from parquet sources. PR #283 replaced 20 call sites but missed this one.

## Test plan
- [x] All 53 convert tests pass
- [x] Lint/format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Updated the spatial data retrieval mechanism used in read operations to employ an enhanced method for converting non-geometry table results to the proper data format. This internal refinement improves data handling consistency and strengthens the overall robustness of spatial data transformation processes throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->