### PR TITLE
Fix CSV import failure for large WKT geometries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,8 @@ geoparquet_io/
 | `common.py` |  | 4036 |
 | `validate.py` | GeoParquet file validation against specification r... | 2854 |
 | `inspect_utils.py` | Utilities for inspecting GeoParquet files. | 1548 |
+| `convert.py` |  | 1300 |
 | `duckdb_metadata.py` | DuckDB-based Parquet metadata extraction. | 1277 |
-| `convert.py` |  | 1270 |
 | `arcgis.py` | ArcGIS Feature Service to GeoParquet conversion. | 1226 |
 | `extract.py` | Extract columns and rows from GeoParquet files. | 1225 |
 | `metadata_utils.py` | Utilities for extracting and formatting GeoParquet... | 1077 |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -292,6 +292,29 @@ gpio inspect file.parquet --stats
 gpio convert data.csv output.parquet --skip-invalid
 ```
 
+### CSV "Maximum line size exceeded" Error
+
+**Symptom**: `Maximum line size of X bytes exceeded` when converting CSV with large WKT geometries.
+
+**Cause**: WKT geometries (complex polygons, coastlines) can exceed line size limits.
+
+**Solutions**:
+
+1. **Use `--csv-max-line-size`** to increase the limit:
+```bash
+gpio convert data.csv output.parquet --csv-max-line-size 100000000  # 100MB
+```
+
+2. **Set environment variable** for persistent override:
+```bash
+export GPIO_CSV_MAX_LINE_SIZE=100000000
+gpio convert data.csv output.parquet
+```
+
+Default is 50MB. Increase if your WKT geometries are larger.
+
+**Note**: Large values increase memory usage during CSV parsing. On memory-constrained systems, avoid setting excessively high limits.
+
 ## Getting Help
 
 ### Debug Information

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1095,6 +1095,12 @@ def convert(ctx):
     help="CSV/TSV: Skip rows with invalid geometries instead of failing",
 )
 @click.option(
+    "--csv-max-line-size",
+    type=int,
+    default=None,
+    help="CSV/TSV: Maximum line size in bytes (default: 50MB). Increase for very large WKT geometries.",
+)
+@click.option(
     "--allow-no-geometry",
     is_flag=True,
     help="Allow conversion to plain Parquet when no geometry column is detected (default: error)",
@@ -1115,6 +1121,7 @@ def convert_to_geoparquet_cmd(
     delimiter,
     crs,
     skip_invalid,
+    csv_max_line_size,
     allow_no_geometry,
     geoparquet_version,
     verbose,
@@ -1143,11 +1150,16 @@ def convert_to_geoparquet_cmd(
       # Pipe to another command (auto-streams when piped)
       gpio convert input.gpkg | gpio add bbox - | gpio upload - s3://bucket/data.parquet
     """
+    from geoparquet_io.core.convert import set_csv_max_line_size
     from geoparquet_io.core.streaming import (
         StreamingError,
         should_stream_output,
         validate_output,
     )
+
+    # Set CSV max line size if specified
+    if csv_max_line_size is not None:
+        set_csv_max_line_size(csv_max_line_size)
 
     # Validate output early - provides helpful error if no output and not piping
     try:

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -105,17 +105,47 @@ def _is_parquet_file(input_file):
 # with complex polygons (coastlines, admin boundaries) that exceed this.
 # 50MB should handle virtually any reasonable geospatial data.
 # See: https://github.com/geoparquet/geoparquet-io/issues/301
-CSV_MAX_LINE_SIZE = 50 * 1024 * 1024  # 50 MB
+CSV_MAX_LINE_SIZE_DEFAULT = 50 * 1024 * 1024  # 50 MB
+
+# Module-level override (set by CLI --csv-max-line-size option)
+_csv_max_line_size_override = None
+
+
+def get_csv_max_line_size():
+    """Get effective CSV max line size, checking override and env var."""
+    import os
+
+    # 1. Module-level override (from CLI)
+    if _csv_max_line_size_override is not None:
+        return _csv_max_line_size_override
+
+    # 2. Environment variable (power-user escape hatch)
+    env_val = os.environ.get("GPIO_CSV_MAX_LINE_SIZE")
+    if env_val:
+        try:
+            return int(env_val)
+        except ValueError:
+            pass  # Fall through to default
+
+    # 3. Default
+    return CSV_MAX_LINE_SIZE_DEFAULT
+
+
+def set_csv_max_line_size(value):
+    """Set the CSV max line size override. Pass None to reset to default."""
+    global _csv_max_line_size_override
+    _csv_max_line_size_override = value
 
 
 def _build_csv_read_expr(input_file, delimiter):
     """Build DuckDB CSV read expression with geospatial-appropriate max_line_size."""
+    max_line_size = get_csv_max_line_size()
     if delimiter:
         return (
             f"read_csv('{input_file}', delim='{delimiter}', header=true, "
-            f"AUTO_DETECT=TRUE, max_line_size={CSV_MAX_LINE_SIZE})"
+            f"AUTO_DETECT=TRUE, max_line_size={max_line_size})"
         )
-    return f"read_csv_auto('{input_file}', max_line_size={CSV_MAX_LINE_SIZE})"
+    return f"read_csv_auto('{input_file}', max_line_size={max_line_size})"
 
 
 def _get_csv_columns(con, csv_read):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -115,6 +115,8 @@ def csv_large_wkt_input(tmp_path):
     This tests that gpio can handle geospatial CSVs with very large WKT strings,
     such as complex polygons with many vertices (coastlines, administrative boundaries).
     """
+    import math
+
     # Generate a polygon with enough vertices to exceed 2MB
     # Each coordinate pair like "0.123456 0.654321," is ~20 bytes
     # Need ~100,000 coordinate pairs to reach 2MB
@@ -123,8 +125,6 @@ def csv_large_wkt_input(tmp_path):
     coords = []
     for i in range(num_vertices):
         # Create a circle-ish polygon
-        import math
-
         angle = 2 * math.pi * i / num_vertices
         x = round(4.9 + 0.1 * math.cos(angle), 7)
         y = round(52.3 + 0.1 * math.sin(angle), 7)
@@ -657,6 +657,85 @@ class TestConvertCSVCore:
         assert "POLYGON" in result[0]
         assert result[1] > 100_000  # Should have many vertices
         con.close()
+
+    def test_convert_csv_large_wkt_with_explicit_delimiter(self, tmp_path, temp_output_file):
+        """Test large WKT with explicit delimiter (tests both branches of _build_csv_read_expr).
+
+        Verifies that max_line_size is applied to both read_csv (explicit delimiter)
+        and read_csv_auto (auto-detect) branches.
+        """
+        import math
+
+        # Create a moderately large WKT (just over default 2MB limit)
+        num_vertices = 110_000
+        coords = []
+        for i in range(num_vertices):
+            angle = 2 * math.pi * i / num_vertices
+            x = round(4.9 + 0.1 * math.cos(angle), 7)
+            y = round(52.3 + 0.1 * math.sin(angle), 7)
+            coords.append(f"{x} {y}")
+        coords.append(coords[0])  # Close polygon
+        wkt = f"POLYGON(({','.join(coords)}))"
+
+        # Create CSV with semicolon delimiter (forces explicit delimiter path)
+        csv_path = tmp_path / "large_wkt_semicolon.csv"
+        csv_path.write_text(f'id;name;wkt\n1;Large Polygon;"{wkt}"\n')
+
+        # Convert with explicit delimiter
+        convert_to_geoparquet(str(csv_path), temp_output_file, delimiter=";", verbose=False)
+
+        assert os.path.exists(temp_output_file)
+        con = duckdb.connect()
+        con.execute("INSTALL spatial;")
+        con.execute("LOAD spatial;")
+        result = con.execute(
+            f"SELECT ST_GeometryType(geometry), ST_NPoints(geometry) FROM '{temp_output_file}'"
+        ).fetchone()
+        assert "POLYGON" in result[0]
+        assert result[1] > 100_000
+        con.close()
+
+    def test_convert_csv_custom_max_line_size_env_var(
+        self, tmp_path, temp_output_file, monkeypatch
+    ):
+        """Test that GPIO_CSV_MAX_LINE_SIZE env var is respected."""
+        from geoparquet_io.core.convert import get_csv_max_line_size, set_csv_max_line_size
+
+        # Reset any override from previous tests
+        set_csv_max_line_size(None)
+
+        # Set custom value via env var
+        custom_size = 100 * 1024 * 1024  # 100MB
+        monkeypatch.setenv("GPIO_CSV_MAX_LINE_SIZE", str(custom_size))
+
+        assert get_csv_max_line_size() == custom_size
+
+        # Reset
+        monkeypatch.delenv("GPIO_CSV_MAX_LINE_SIZE", raising=False)
+        set_csv_max_line_size(None)
+
+    def test_convert_csv_large_wkt_fails_with_small_limit(
+        self, csv_large_wkt_input, temp_output_file
+    ):
+        """Verify that large WKT would fail with DuckDB's default 2MB limit.
+
+        This boundary test proves the fix is necessary by showing the old behavior
+        would have failed. We temporarily set max_line_size to 2MB (DuckDB's default).
+        """
+        from geoparquet_io.core.convert import set_csv_max_line_size
+
+        try:
+            # Set to DuckDB's default 2MB limit
+            set_csv_max_line_size(2 * 1024 * 1024)
+
+            # This should fail with "Maximum line size exceeded"
+            with pytest.raises(Exception) as exc_info:
+                convert_to_geoparquet(csv_large_wkt_input, temp_output_file, verbose=False)
+
+            assert "maximum line size" in str(exc_info.value).lower()
+        finally:
+            # Reset to default
+            set_csv_max_line_size(None)
 
 
 class TestConvertCSVValidation:


### PR DESCRIPTION
## Summary

- Fixes #301: CSV import fails with "Maximum line size of 2000000 bytes exceeded" for files containing large WKT geometries
- DuckDB's `read_csv_auto()` defaults to 2MB `max_line_size`, but geospatial CSVs often contain WKT geometries (complex polygons, coastlines, administrative boundaries) that exceed this limit
- Added `CSV_MAX_LINE_SIZE` constant (50MB) and applied it to CSV reading expressions

## Test plan

- [x] Added regression test `test_convert_csv_large_wkt_exceeding_2mb` that creates a 2.5MB WKT polygon
- [x] Verified original UNESCO.csv from issue #301 now converts successfully
- [x] All 18 CSV tests pass
- [x] 1962 tests pass overall (quick suite)
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to set the CSV/TSV maximum line size at conversion time and an override mechanism for runtime configuration.

* **Bug Fixes**
  * CSV conversion now supports much larger WKT geometries (default max line size increased to 50MB), preventing failures on very long lines.

* **Tests**
  * Added tests covering conversions of very large WKT polygon geometries, explicit-delimiter handling, env-var overrides, and failure on small limits.

* **Documentation**
  * New troubleshooting guidance for "maximum line size" errors and remedies (CLI flag, env var, default and memory note).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->