### PR TITLE
feat: Add missing partition_by_a5() API method and fix documentation drift

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -590,7 +590,7 @@ stats = table.partition_by_s2('output/', level=10)
 print(f"Created {stats['file_count']} files")
 ```
 
-#### `partition_by_a5(output_dir, resolution=15, compression='ZSTD', hive=True, overwrite=False, force=False, skip_analysis=False)`
+#### `partition_by_a5(output_dir, resolution=15, compression='ZSTD', hive=True, overwrite=False)`
 
 Partition the table into a Hive-partitioned directory by A5 cell.
 
@@ -598,9 +598,6 @@ Partition the table into a Hive-partitioned directory by A5 cell.
 # Partition by A5
 stats = table.partition_by_a5('output/', resolution=12)
 print(f"Created {stats['file_count']} files")
-
-# Force partition even if analysis suggests issues
-stats = table.partition_by_a5('output/', resolution=12, force=True)
 ```
 
 #### `partition_by_string(output_dir, column, chars=None, hive=True, overwrite=False)`

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -590,7 +590,7 @@ stats = table.partition_by_s2('output/', level=10)
 print(f"Created {stats['file_count']} files")
 ```
 
-#### `partition_by_a5(output_dir, resolution=15, compression='ZSTD', hive=True, overwrite=False)`
+#### `partition_by_a5(output_dir, resolution=15, compression='ZSTD', hive=True, overwrite=False, force=False, skip_analysis=False)`
 
 Partition the table into a Hive-partitioned directory by A5 cell.
 
@@ -598,6 +598,9 @@ Partition the table into a Hive-partitioned directory by A5 cell.
 # Partition by A5
 stats = table.partition_by_a5('output/', resolution=12)
 print(f"Created {stats['file_count']} files")
+
+# Force partition even if analysis suggests issues
+stats = table.partition_by_a5('output/', resolution=12, force=True)
 ```
 
 #### `partition_by_string(output_dir, column, chars=None, hive=True, overwrite=False)`

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -229,7 +229,7 @@ Reports which columns have bloom filters, coverage percentages, and total bloom 
 === "Python"
 
     ```python
-    result = table.check_spec()
+    result = table.validate()
     if result.passed():
         print("Valid GeoParquet!")
     ```

--- a/docs/guide/meta.md
+++ b/docs/guide/meta.md
@@ -20,16 +20,15 @@ The `gpio inspect meta` command shows comprehensive metadata from GeoParquet fil
 === "Python"
 
     ```python
-    from geoparquet_io import Table
+    import geoparquet_io as gpio
 
-    table = Table("data.parquet")
+    table = gpio.read("data.parquet")
 
     # Get all metadata
     metadata = table.metadata()
 
-    # Access specific metadata
-    geo_metadata = table.geo_metadata()
-    parquet_metadata = table.parquet_metadata()
+    # Include parquet metadata
+    metadata = table.metadata(include_parquet_metadata=True)
     ```
 
 ## Metadata Types

--- a/docs/guide/stac.md
+++ b/docs/guide/stac.md
@@ -17,12 +17,14 @@ The `gpio publish stac` command generates [STAC (SpatioTemporal Asset Catalog)](
 === "Python"
 
     ```python
-    from geoparquet_io import Table
-
-    table = Table("data.parquet")
+    from geoparquet_io.api.stac import generate_stac
 
     # Generate STAC Item
-    table.to_stac("output.json", bucket="s3://my-bucket/data/")
+    generate_stac(
+        "data.parquet",
+        "output.json",
+        bucket="s3://my-bucket/data/"
+    )
     ```
 
 ## Output Modes

--- a/docs/guide/upload.md
+++ b/docs/guide/upload.md
@@ -20,12 +20,12 @@ The `gpio publish upload` command uploads files and directories to cloud object 
 === "Python"
 
     ```python
-    from geoparquet_io import Table
+    import geoparquet_io as gpio
 
-    table = Table("data.parquet")
+    table = gpio.read("data.parquet")
 
     # Upload to S3
-    table.upload("s3://bucket/path/data.parquet", aws_profile="my-profile")
+    table.upload("s3://bucket/path/data.parquet", profile="my-profile")
     ```
 
 ## Supported Destinations

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1530,8 +1530,6 @@ class Table:
         compression: str = "ZSTD",
         hive: bool = True,
         overwrite: bool = False,
-        force: bool = False,
-        skip_analysis: bool = False,
     ) -> dict:
         """
         Partition the table into Hive-partitioned directory by A5 cell.
@@ -1545,8 +1543,6 @@ class Table:
             compression: Compression codec (default: ZSTD)
             hive: Use Hive-style partitioning (default: True)
             overwrite: Overwrite existing output directory
-            force: Force partitioning even if analysis suggests issues
-            skip_analysis: Skip partition analysis checks
 
         Returns:
             dict with partition statistics (file_count, etc.)
@@ -1568,8 +1564,6 @@ class Table:
                 "resolution": resolution,
                 "hive": hive,
                 "overwrite": overwrite,
-                "force": force,
-                "skip_analysis": skip_analysis,
             },
             compression=compression,
             collect_stats=True,

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1522,6 +1522,59 @@ class Table:
             collect_stats=True,
         )
 
+    def partition_by_a5(
+        self,
+        output_dir: str | Path,
+        *,
+        resolution: int = 15,
+        compression: str = "ZSTD",
+        hive: bool = True,
+        overwrite: bool = False,
+        force: bool = False,
+        skip_analysis: bool = False,
+    ) -> dict:
+        """
+        Partition the table into Hive-partitioned directory by A5 cell.
+
+        A5 is a hierarchical grid system similar to H3 but with different
+        properties. Uses fixed precision levels from 0-30.
+
+        Args:
+            output_dir: Output directory path
+            resolution: A5 resolution level 0-30 (default: 15)
+            compression: Compression codec (default: ZSTD)
+            hive: Use Hive-style partitioning (default: True)
+            overwrite: Overwrite existing output directory
+            force: Force partitioning even if analysis suggests issues
+            skip_analysis: Skip partition analysis checks
+
+        Returns:
+            dict with partition statistics (file_count, etc.)
+
+        Example:
+            >>> table = gpio.read('data.parquet')
+            >>> stats = table.partition_by_a5('output/', resolution=12)
+            >>> print(f"Created {stats['file_count']} files")
+        """
+        from geoparquet_io.core.partition_by_a5 import partition_by_a5
+
+        return _run_partition_with_temp_file(
+            self._table,
+            self._geometry_column,
+            partition_by_a5,
+            output_dir,
+            temp_prefix="gpio_part_a5",
+            core_kwargs={
+                "resolution": resolution,
+                "hive": hive,
+                "overwrite": overwrite,
+                "force": force,
+                "skip_analysis": skip_analysis,
+            },
+            compression=compression,
+            collect_stats=True,
+        )
+
     def upload(
         self,
         destination: str,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -586,7 +586,6 @@ class TestOpsNewFunctions:
         assert result.num_rows == 766
 
 
-@pytest.mark.network
 class TestTablePartitionByA5:
     """Tests for Table.partition_by_a5() method."""
 
@@ -610,7 +609,9 @@ class TestTablePartitionByA5:
 
     def test_partition_by_a5_basic(self, sample_table, output_dir):
         """Test basic A5 partitioning."""
-        result = sample_table.partition_by_a5(output_dir, resolution=10, overwrite=True, force=True)
+        # Use low resolution (4) to ensure partitions have enough rows
+        # Higher resolutions create too many tiny partitions with test data
+        result = sample_table.partition_by_a5(output_dir, resolution=4, overwrite=True)
 
         assert isinstance(result, dict)
         assert "file_count" in result
@@ -621,9 +622,8 @@ class TestTablePartitionByA5:
 
     def test_partition_by_a5_hive_style(self, sample_table, output_dir):
         """Test Hive-style A5 partitioning."""
-        result = sample_table.partition_by_a5(
-            output_dir, resolution=10, hive=True, overwrite=True, force=True
-        )
+        # Use low resolution (4) to ensure partitions have enough rows
+        result = sample_table.partition_by_a5(output_dir, resolution=4, hive=True, overwrite=True)
 
         assert result["file_count"] > 0
         # Check for Hive-style directories

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -586,6 +586,52 @@ class TestOpsNewFunctions:
         assert result.num_rows == 766
 
 
+@pytest.mark.network
+class TestTablePartitionByA5:
+    """Tests for Table.partition_by_a5() method."""
+
+    @pytest.fixture
+    def sample_table(self):
+        """Create a sample Table from test data."""
+        if not PLACES_PARQUET.exists():
+            pytest.skip("Test data not available")
+        return read(PLACES_PARQUET)
+
+    @pytest.fixture
+    def output_dir(self):
+        """Create a temporary output directory."""
+        tmp_dir = Path(tempfile.gettempdir()) / f"test_part_a5_{uuid.uuid4()}"
+        yield tmp_dir
+        # Cleanup
+        if tmp_dir.exists():
+            import shutil
+
+            shutil.rmtree(tmp_dir)
+
+    def test_partition_by_a5_basic(self, sample_table, output_dir):
+        """Test basic A5 partitioning."""
+        result = sample_table.partition_by_a5(output_dir, resolution=10, overwrite=True, force=True)
+
+        assert isinstance(result, dict)
+        assert "file_count" in result
+        assert result["file_count"] > 0
+        assert output_dir.exists()
+        parquet_files = list(output_dir.rglob("*.parquet"))
+        assert len(parquet_files) > 0
+
+    def test_partition_by_a5_hive_style(self, sample_table, output_dir):
+        """Test Hive-style A5 partitioning."""
+        result = sample_table.partition_by_a5(
+            output_dir, resolution=10, hive=True, overwrite=True, force=True
+        )
+
+        assert result["file_count"] > 0
+        # Check for Hive-style directories
+        subdirs = [d for d in output_dir.iterdir() if d.is_dir()]
+        assert len(subdirs) > 0
+        assert any("a5_cell=" in d.name for d in subdirs)
+
+
 class TestReadPartition:
     """Tests for the read_partition() function."""
 


### PR DESCRIPTION
## Summary
- Add `partition_by_a5()` method to the `Table` class in `api/table.py`, following the pattern of other partition methods (`partition_by_h3`, `partition_by_s2`, `partition_by_quadkey`)
- Fix documentation drift in multiple guide files where Python examples showed incorrect API usage

## Documentation Fixes
| File | Was | Now |
|------|-----|-----|
| `docs/guide/stac.md` | `Table("path").to_stac()` | `generate_stac()` from `geoparquet_io.api.stac` |
| `docs/guide/upload.md` | `Table("path")`, `aws_profile` | `gpio.read("path")`, `profile` |
| `docs/guide/meta.md` | `Table("path")`, `geo_metadata()`, `parquet_metadata()` | `gpio.read("path")`, `metadata(include_parquet_metadata=True)` |
| `docs/guide/check.md` | `table.check_spec()` | `table.validate()` |

## Test plan
- [x] Added unit tests for `Table.partition_by_a5()` in `tests/test_api.py`
- [x] All 226 partition-related tests pass
- [x] Pre-commit hooks pass

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `partition_by_a5()` method to partition spatial data with configurable resolution and output formats.

* **Documentation**
  * Updated usage examples across multiple guides to reflect latest API patterns and method signatures.

* **Tests**
  * Added comprehensive test coverage for the new partitioning functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->