### PR TITLE
Document release process and add version consistency check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,22 @@ jobs:
       - name: Validate CLAUDE.md
         run: uv run python scripts/validate_claude_md.py
 
+      - name: Check version consistency
+        run: |
+          python3 << 'PYEOF'
+          import tomllib, re, sys
+          with open("pyproject.toml", "rb") as f:
+              pyproject_ver = tomllib.load(f)["project"]["version"]
+          with open("geoparquet_io/cli/main.py") as f:
+              m = re.search(r'^__version__\s*=\s*["\x27](.*?)["\x27]', f.read(), re.MULTILINE)
+              cli_ver = m.group(1) if m else "NOT FOUND"
+          if pyproject_ver != cli_ver:
+              print(f"::error::Version mismatch: pyproject.toml={pyproject_ver}, cli/main.py={cli_ver}")
+              print("Run 'uv run cz bump' to update all version files, or manually sync them.")
+              sys.exit(1)
+          print(f"Versions match: {pyproject_ver}")
+          PYEOF
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ Complexity guidance: guard clauses, dictionary dispatch, max 30-40 lines/functio
 
 **Commits**: Enforced by commitizen hook. Format: `type(scope): message`
 **PRs**: Update `docs/guide/` and `docs/api/python-api.md` if API changed.
+**Releases**: Use `uv run cz bump` to update version in `pyproject.toml` + `cli/main.py`, changelog, and tag. CI enforces version consistency.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,13 +64,43 @@ New CLI commands need corresponding Python API:
 
 See `CLAUDE.md` for full architecture details.
 
-## Publishing
+## Releasing
 
 (Maintainers only)
 
-1. Update version in `pyproject.toml`
-2. Update `CHANGELOG.md`
-3. Create tag: `git tag v0.x.0 && git push origin v0.x.0`
+### Using `cz bump` (recommended)
+
+[Commitizen](https://commitizen-tools.github.io/commitizen/) automates version bumps, changelog updates, and tagging:
+
+```bash
+uv run cz bump              # Auto-determine version from commit history
+uv run cz bump --increment PATCH  # Force a patch bump (1.0.0 → 1.0.1)
+uv run cz bump --increment MINOR  # Force a minor bump (1.0.0 → 1.1.0)
+uv run cz bump --increment MAJOR  # Force a major bump (1.0.0 → 2.0.0)
+uv run cz bump --prerelease beta  # Pre-release (1.0.0 → 1.1.0b0)
+uv run cz bump --dry-run          # Preview without making changes
+```
+
+This will:
+
+1. Bump the version in `pyproject.toml` and `geoparquet_io/cli/main.py`
+2. Update `CHANGELOG.md` from conventional commit messages
+3. Create a commit and git tag (e.g., `v1.1.0`)
+
+After bumping:
+
+```bash
+git push origin main --tags
+```
+
+Then create a [GitHub Release](https://github.com/geoparquet/geoparquet-io/releases/new) from the new tag. The `publish.yml` workflow will automatically build and publish to PyPI.
+
+### Version files
+
+Version is maintained in two places (kept in sync by `cz bump` and enforced by CI):
+
+- `pyproject.toml` — `version = "x.y.z"` (package metadata)
+- `geoparquet_io/cli/main.py` — `__version__ = "x.y.z"` (CLI `--version` output)
 
 ## License
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -78,7 +78,7 @@ from geoparquet_io.core.upload import check_credentials
 from geoparquet_io.core.upload import upload as upload_impl
 
 # Version info
-__version__ = "1.1.0b1"
+__version__ = "1.0.0"
 
 
 class OptionalIntCommand(GlobAwareCommand):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,10 @@ skips = [
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "1.0.0"
-version_files = ["pyproject.toml:^version"]
+version_files = [
+    "pyproject.toml:^version",
+    "geoparquet_io/cli/main.py:^__version__",
+]
 tag_format = "v$version"
 update_changelog_on_bump = true
 changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
## Summary

- **Fix `__version__` drift**: Resets `cli/main.py` from `1.1.0b1` back to `1.0.0` to match `pyproject.toml`
- **Add `cli/main.py` to commitizen `version_files`**: `cz bump` now updates both `pyproject.toml` and `cli/main.py` automatically
- **Add CI version consistency check**: The `lint` job now fails if the two version strings diverge
- **Replace outdated "Publishing" docs**: `docs/contributing.md` now documents the full `cz bump` workflow with examples, and `CLAUDE.md` adds a one-line release reference

## Test plan

- [ ] Verify `uv run cz bump --dry-run` shows both `pyproject.toml` and `cli/main.py` in files to update
- [ ] Verify CI lint job passes (version check step shows "Versions match: 1.0.0")
- [ ] Temporarily desync versions and confirm CI fails with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.0.0 (stable release).
  * Improved release process with automated version management across multiple configuration sources.
  * Enhanced release documentation with clearer instructions for version updates and changelog generation.
  * Added CI validation to ensure version consistency across project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->