### PR TITLE
Fix false-positive CRS mismatch warnings for GeoParquet 2.0

### DIFF
--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -17,7 +17,7 @@ from rich.table import Table
 from rich.text import Text
 
 from geoparquet_io.core.common import format_size
-from geoparquet_io.core.crs_utils import _extract_crs_identifier
+from geoparquet_io.core.crs_utils import _extract_crs_identifier, is_default_crs
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.metadata_utils import (
     extract_bbox_from_row_group_stats,
@@ -136,6 +136,7 @@ def _crs_are_equivalent(crs1: Any, crs2: Any) -> bool:
     Check if two CRS values are equivalent.
 
     Compares by extracting authority and code from both values.
+    Falls back to pyproj semantic comparison for PROJJSON without authority ids.
     Handles PROJJSON dicts, "EPSG:31287" strings, and URN formats.
 
     Returns:
@@ -144,10 +145,18 @@ def _crs_are_equivalent(crs1: Any, crs2: Any) -> bool:
     id1 = _extract_crs_identifier(crs1)
     id2 = _extract_crs_identifier(crs2)
 
-    if id1 is None or id2 is None:
-        return False
+    if id1 is not None and id2 is not None:
+        return id1 == id2
 
-    return id1 == id2
+    if isinstance(crs1, dict) and isinstance(crs2, dict):
+        try:
+            from pyproj import CRS
+
+            return CRS.from_json_dict(crs1).equals(CRS.from_json_dict(crs2))
+        except Exception:
+            return False
+
+    return False
 
 
 def _detect_metadata_mismatches(
@@ -176,10 +185,11 @@ def _detect_metadata_mismatches(
                 f"but GeoParquet metadata has '{geoparquet_crs_display}'"
             )
     elif parquet_crs and not geoparquet_crs:
-        parquet_crs_display = _extract_crs_string(parquet_crs) or str(parquet_crs)
-        warnings.append(
-            f"CRS in Parquet geo type ('{parquet_crs_display}') but missing in GeoParquet metadata"
-        )
+        if not is_default_crs(parquet_crs):
+            parquet_crs_display = _extract_crs_string(parquet_crs) or str(parquet_crs)
+            warnings.append(
+                f"CRS in Parquet geo type ('{parquet_crs_display}') but missing in GeoParquet metadata"
+            )
     elif geoparquet_crs and not parquet_crs:
         # GeoParquet has CRS but Parquet type doesn't - might be expected
         pass

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -790,6 +790,145 @@ class TestCRSComparison:
 
         assert _format_crs_for_display("EPSG:4326") == "EPSG:4326"
 
+    def test_no_warning_when_parquet_has_default_crs_and_geoparquet_omits(self):
+        """Missing CRS in GeoParquet metadata means OGC:CRS84 — no warning if Parquet agrees."""
+        from geoparquet_io.core.inspect_utils import _detect_metadata_mismatches
+
+        parquet_geo_info = {
+            "crs": {
+                "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+                "type": "GeographicCRS",
+                "name": "WGS 84 (CRS84)",
+                "id": {"authority": "OGC", "code": "CRS84"},
+            }
+        }
+        geoparquet_info = {}
+
+        warnings = _detect_metadata_mismatches(parquet_geo_info, geoparquet_info)
+        assert len(warnings) == 0
+
+    def test_no_warning_when_parquet_has_epsg4326_and_geoparquet_omits(self):
+        """EPSG:4326 is also a default CRS — no warning if GeoParquet metadata omits CRS."""
+        from geoparquet_io.core.inspect_utils import _detect_metadata_mismatches
+
+        parquet_geo_info = {
+            "crs": {
+                "type": "GeographicCRS",
+                "name": "WGS 84",
+                "id": {"authority": "EPSG", "code": 4326},
+            }
+        }
+        geoparquet_info = {}
+
+        warnings = _detect_metadata_mismatches(parquet_geo_info, geoparquet_info)
+        assert len(warnings) == 0
+
+    def test_warning_when_parquet_has_non_default_crs_and_geoparquet_omits(self):
+        """Non-default CRS in Parquet but missing in GeoParquet should still warn."""
+        from geoparquet_io.core.inspect_utils import _detect_metadata_mismatches
+
+        parquet_geo_info = {
+            "crs": {
+                "type": "ProjectedCRS",
+                "name": "NAD83 / Conus Albers",
+                "id": {"authority": "EPSG", "code": 5070},
+            }
+        }
+        geoparquet_info = {}
+
+        warnings = _detect_metadata_mismatches(parquet_geo_info, geoparquet_info)
+        assert len(warnings) == 1
+        assert "missing in GeoParquet metadata" in warnings[0]
+
+    def test_crs_are_equivalent_projjson_without_id(self):
+        """PROJJSON dicts without id fields should use pyproj semantic comparison."""
+        from geoparquet_io.core.inspect_utils import _crs_are_equivalent
+
+        crs1 = {
+            "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+            "type": "GeographicCRS",
+            "name": "WGS 84",
+            "datum": {
+                "type": "GeodeticReferenceFrame",
+                "name": "World Geodetic System 1984",
+                "ellipsoid": {
+                    "name": "WGS 84",
+                    "semi_major_axis": 6378137,
+                    "inverse_flattening": 298.257223563,
+                },
+            },
+            "coordinate_system": {
+                "subtype": "ellipsoidal",
+                "axis": [
+                    {
+                        "name": "Geodetic latitude",
+                        "abbreviation": "Lat",
+                        "direction": "north",
+                        "unit": "degree",
+                    },
+                    {
+                        "name": "Geodetic longitude",
+                        "abbreviation": "Lon",
+                        "direction": "east",
+                        "unit": "degree",
+                    },
+                ],
+            },
+        }
+        crs2 = dict(crs1)
+
+        assert _crs_are_equivalent(crs1, crs2) is True
+
+    def test_crs_are_equivalent_projjson_without_id_different(self):
+        """Different PROJJSON dicts without id fields should not be equivalent."""
+        from geoparquet_io.core.inspect_utils import _crs_are_equivalent
+
+        crs1 = {
+            "type": "GeographicCRS",
+            "name": "WGS 84",
+            "datum": {
+                "type": "GeodeticReferenceFrame",
+                "name": "World Geodetic System 1984",
+                "ellipsoid": {
+                    "name": "WGS 84",
+                    "semi_major_axis": 6378137,
+                    "inverse_flattening": 298.257223563,
+                },
+            },
+            "coordinate_system": {
+                "subtype": "ellipsoidal",
+                "axis": [
+                    {
+                        "name": "Geodetic latitude",
+                        "abbreviation": "Lat",
+                        "direction": "north",
+                        "unit": "degree",
+                    },
+                    {
+                        "name": "Geodetic longitude",
+                        "abbreviation": "Lon",
+                        "direction": "east",
+                        "unit": "degree",
+                    },
+                ],
+            },
+        }
+        crs2 = {
+            "type": "ProjectedCRS",
+            "name": "NAD83 / Conus Albers",
+            "datum": {
+                "type": "GeodeticReferenceFrame",
+                "name": "North American Datum 1983",
+                "ellipsoid": {
+                    "name": "GRS 1980",
+                    "semi_major_axis": 6378137,
+                    "inverse_flattening": 298.257222101,
+                },
+            },
+        }
+
+        assert _crs_are_equivalent(crs1, crs2) is False
+
 
 # Tests for new subcommand structure
 class TestInspectSubcommands:


### PR DESCRIPTION
## Summary

- Skip CRS mismatch warning when the Parquet geo type uses the default CRS (OGC:CRS84 or EPSG:4326) and GeoParquet metadata omits `crs` — omitted CRS means OGC:CRS84 per the spec
- Fall back to `pyproj.CRS.equals()` for semantic CRS comparison when PROJJSON dicts lack authority `id` fields, instead of always returning "not equivalent"

Fixes #384

## Test plan

- [x] New test: no warning when Parquet has OGC:CRS84 and GeoParquet metadata omits CRS
- [x] New test: no warning when Parquet has EPSG:4326 and GeoParquet metadata omits CRS
- [x] New test: warning still fires for non-default CRS (e.g. EPSG:5070) missing from metadata
- [x] New test: PROJJSON without `id` fields compared as equivalent via pyproj
- [x] New test: different PROJJSON without `id` fields correctly detected as non-equivalent
- [x] All 70 existing inspect tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)