### PR TITLE
Fix reproject silent data corruption with PROJJSON lacking authority id

### DIFF
--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -68,6 +68,36 @@ def _detect_geometry_column_from_table(table: pa.Table) -> str:
     return "geometry"
 
 
+def _resolve_crs_to_string(crs_info) -> str | None:
+    """Resolve CRS info (PROJJSON dict or string) to a CRS string for ST_Transform.
+
+    Tries authority identifier first, then pyproj resolution, then raw PROJJSON.
+
+    Returns:
+        CRS string like "EPSG:4326" or PROJJSON string, or None if unresolvable
+    """
+    if not crs_info:
+        return None
+
+    identifier = _extract_crs_identifier(crs_info)
+    if identifier:
+        authority, code = identifier
+        return f"{authority}:{code}"
+
+    if isinstance(crs_info, dict):
+        try:
+            from pyproj import CRS
+
+            authority = CRS.from_json_dict(crs_info).to_authority()
+            if authority:
+                return f"{authority[0]}:{authority[1]}"
+        except Exception:
+            pass
+        return json.dumps(crs_info)
+
+    return None
+
+
 def _detect_crs_from_table(table: pa.Table, geom_col: str) -> str:
     """Detect CRS from table metadata.
 
@@ -76,7 +106,7 @@ def _detect_crs_from_table(table: pa.Table, geom_col: str) -> str:
         geom_col: Geometry column name
 
     Returns:
-        CRS string like "EPSG:4326"
+        CRS string like "EPSG:4326" or PROJJSON string for ST_Transform
     """
     if table.schema.metadata and b"geo" in table.schema.metadata:
         try:
@@ -84,11 +114,9 @@ def _detect_crs_from_table(table: pa.Table, geom_col: str) -> str:
             columns = geo_meta.get("columns", {})
             if geom_col in columns:
                 crs_info = columns[geom_col].get("crs")
-                if crs_info:
-                    identifier = _extract_crs_identifier(crs_info)
-                    if identifier:
-                        authority, code = identifier
-                        return f"{authority}:{code}"
+                resolved = _resolve_crs_to_string(crs_info)
+                if resolved:
+                    return resolved
         except (json.JSONDecodeError, KeyError):
             pass
     # Default to WGS84 per GeoParquet spec
@@ -191,16 +219,13 @@ def _detect_source_crs(input_url: str, verbose: bool) -> str:
         verbose: Whether to print verbose output
 
     Returns:
-        CRS string like "EPSG:4326"
+        CRS string like "EPSG:4326" or PROJJSON string for ST_Transform
     """
-    # Try to get CRS from GeoParquet metadata
     crs_info = extract_crs_from_parquet(input_url, verbose=verbose)
 
-    if crs_info:
-        identifier = _extract_crs_identifier(crs_info)
-        if identifier:
-            authority, code = identifier
-            return f"{authority}:{code}"
+    resolved = _resolve_crs_to_string(crs_info)
+    if resolved:
+        return resolved
 
     # Default to WGS84 per GeoParquet spec (missing CRS = WGS84)
     if verbose:

--- a/tests/test_crs_conversion.py
+++ b/tests/test_crs_conversion.py
@@ -36,6 +36,7 @@ from geoparquet_io.core.metadata_utils import parse_geometry_type_from_schema
 from geoparquet_io.core.reproject import (
     _detect_crs_from_table,
     _detect_geometry_column_from_table,
+    _detect_source_crs,
 )
 
 # Helper functions for CRS testing
@@ -768,3 +769,62 @@ class TestCRSDetectionHelpers:
 
         crs = _detect_crs_from_table(table, "geometry")
         assert crs == "EPSG:4326"
+
+    def test_detect_crs_from_table_projjson_without_id(self):
+        """PROJJSON without id field should use pyproj to resolve, not fall back to 4326."""
+        import pyarrow as pa
+        from pyproj import CRS as PyprojCRS
+
+        # Full PROJJSON for Vermont State Plane (EPSG:32145) but without the id field
+        full_projjson = PyprojCRS.from_authority("EPSG", 32145).to_json_dict()
+        del full_projjson["id"]
+
+        geo_meta = {
+            "version": "1.0.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "crs": full_projjson,
+                }
+            },
+        }
+        schema = pa.schema([pa.field("geometry", pa.binary())]).with_metadata(
+            {b"geo": json.dumps(geo_meta).encode("utf-8")}
+        )
+        table = pa.table({"geometry": [b""]}, schema=schema)
+
+        crs = _detect_crs_from_table(table, "geometry")
+        assert crs != "EPSG:4326", "Should not fall back to 4326 when valid PROJJSON exists"
+        # Should resolve to EPSG:32145 via pyproj, or be a PROJJSON string DuckDB can use
+        assert "32145" in crs or crs.startswith("{")
+
+    def test_detect_source_crs_projjson_without_id(self, tmp_path):
+        """_detect_source_crs should not fall back to 4326 when PROJJSON lacks id field."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        from pyproj import CRS as PyprojCRS
+
+        full_projjson = PyprojCRS.from_authority("EPSG", 32145).to_json_dict()
+        del full_projjson["id"]
+
+        geo_meta = {
+            "version": "1.0.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "crs": full_projjson,
+                }
+            },
+        }
+        schema = pa.schema([pa.field("geometry", pa.binary())]).with_metadata(
+            {b"geo": json.dumps(geo_meta).encode("utf-8")}
+        )
+        table = pa.table({"geometry": [b"\x01\x01\x00\x00\x00" + b"\x00" * 16]}, schema=schema)
+        test_file = str(tmp_path / "test.parquet")
+        pq.write_table(table, test_file)
+
+        crs = _detect_source_crs(test_file, verbose=False)
+        assert crs != "EPSG:4326", "Should not fall back to 4326 when valid PROJJSON exists"
+        assert "32145" in crs or crs.startswith("{")


### PR DESCRIPTION
## Summary

- Extract a new `_resolve_crs_to_string()` helper that tries: authority id extraction → pyproj resolution → raw PROJJSON JSON string
- Fix `_detect_source_crs()` and `_detect_crs_from_table()` to use it instead of falling back to "EPSG:4326" when valid PROJJSON exists but has no root `id` field
- DuckDB's `ST_Transform` accepts PROJJSON strings directly, so passing the raw JSON works correctly

Previously, files like the Vermont State Plane dataset (valid PROJJSON, no top-level authority tag) would be reprojected from "EPSG:4326" instead of the actual CRS, scrambling all coordinates.

Fixes #383

## Test plan

- [x] New test: `_detect_crs_from_table` resolves PROJJSON without `id` via pyproj (not 4326 fallback)
- [x] New test: `_detect_source_crs` resolves PROJJSON without `id` from a real Parquet file
- [x] All 30 existing CRS conversion tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)