### PR TITLE
fix(deps): bump pytest to 9.0.3 for CVE-2025-71176

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ gpio = "geoparquet_io:cli"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
+    "pytest>=9.0.3",  # CVE-2025-71176 fix
     "pytest-cov>=4.0.0",
     "pytest-xdist>=3.5.0",
     "nbmake>=1.5.0",
@@ -319,7 +319,7 @@ forbidden_modules = ["geoparquet_io.cli"]
 dev = [
     "import-linter>=2.11",
     "pygments>=2.20.0",  # CVE-2026-4539 fix
-    "pytest>=9.0.1",
+    "pytest>=9.0.3",  # CVE-2025-71176 fix
     "pytest-cov>=7.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1280,7 +1280,7 @@ requires-dist = [
     { name = "pyogrio", marker = "extra == 'benchmark'", specifier = ">=0.7.0" },
     { name = "pyproj", specifier = ">=3.0.0" },
     { name = "pystac", specifier = ">=1.9.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
@@ -1299,7 +1299,7 @@ provides-extras = ["dev", "docs", "benchmark"]
 dev = [
     { name = "import-linter", specifier = ">=2.11" },
     { name = "pygments", specifier = ">=2.20.0" },
-    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
@@ -3458,7 +3458,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.1"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -3469,9 +3469,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps pytest from >=7.0.0/>=9.0.1 to >=9.0.3 to fix CVE-2025-71176
- Updates both `[project.optional-dependencies].dev` and `[dependency-groups].dev`

## Test plan
- [ ] CI passes (pip-audit should no longer flag pytest)
- [ ] Tests run successfully with pytest 9.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum pytest version to 9.0.3 across development dependencies to ensure consistent testing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->