### PR TITLE
fix(arcgis): add adaptive batch size and --batch-size flag

### DIFF
--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2406,6 +2406,12 @@ def extract_geoparquet(
     default=1,
     help="Number of concurrent requests (1-10). Default: 1 (sequential). Values 2-3 recommended for speedup. Higher values may trigger rate limits.",
 )
+@click.option(
+    "--batch-size",
+    type=click.IntRange(min=1, max=5000),
+    default=None,
+    help="Features per request. Default: server's maxRecordCount. Auto-reduces on server errors. Use smaller values for layers with complex geometries.",
+)
 @geoparquet_version_option
 @overwrite_option
 @verbose_option
@@ -2430,6 +2436,7 @@ def extract_arcgis(
     skip_hilbert,
     skip_bbox,
     workers,
+    batch_size,
     geoparquet_version,
     overwrite,
     verbose,
@@ -2535,6 +2542,7 @@ def extract_arcgis(
         skip_hilbert=skip_hilbert,
         skip_bbox=skip_bbox,
         max_workers=workers,
+        batch_size=batch_size,
         compression=compression.upper(),
         compression_level=compression_level,
         verbose=verbose,

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -511,9 +511,12 @@ def fetch_all_features(
             f"Recommended range: 1-10 (2-3 for best balance)"
         )
 
+    # Sanitize and validate batch_size
+    sanitized_batch = batch_size if batch_size and batch_size > 0 else DEFAULT_PAGE_SIZE
+
     # Determine batch size (respect server limit)
     max_batch = min(
-        batch_size or DEFAULT_PAGE_SIZE,
+        sanitized_batch,
         layer_info.max_record_count or DEFAULT_PAGE_SIZE,
     )
 
@@ -629,8 +632,9 @@ def fetch_all_features(
                 results = []
                 batch_too_large = False
                 failed_batch_size = None
+                failed_at_index = None
 
-                for offset, req_batch_size, future in futures:
+                for idx, (offset, req_batch_size, future) in enumerate(futures):
                     try:
                         page = future.result()
                         results.append((offset, page))
@@ -638,6 +642,7 @@ def fetch_all_features(
                         # Mark for retry with smaller batch
                         batch_too_large = True
                         failed_batch_size = req_batch_size
+                        failed_at_index = idx
                         break
                     except Exception as e:
                         # If one request fails, propagate the error (fail-fast)
@@ -646,6 +651,22 @@ def fetch_all_features(
                         ) from e
 
                 if batch_too_large:
+                    # Cancel/drain remaining futures to avoid duplicate requests
+                    from concurrent.futures import CancelledError
+
+                    for remaining_idx in range(failed_at_index + 1, len(futures)):
+                        _, _, remaining_future = futures[remaining_idx]
+                        remaining_future.cancel()
+                        # Drain any that couldn't be cancelled
+                        try:
+                            remaining_future.result(timeout=0.1)
+                        except (CancelledError, BatchTooLargeError, Exception):
+                            pass  # Expected - just draining
+
+                    # Clear for retry
+                    futures.clear()
+                    results.clear()
+
                     # Reduce batch size and restart from batch_start
                     new_batch = _get_reduced_batch_size(failed_batch_size or effective_batch)
                     if new_batch is None:

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-import time
 import uuid
 from collections.abc import Generator
 from dataclasses import dataclass
@@ -23,9 +22,13 @@ from geoparquet_io.core.common import write_geoparquet_table
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 from geoparquet_io.core.exceptions import (
+    BatchTooLargeError,
     GeoParquetError,
     InvalidParameterError,
     RemoteAccessError,
+)
+from geoparquet_io.core.http_retry import (
+    make_request_with_retry,
 )
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success, warn
 from geoparquet_io.core.remote import setup_aws_profile_if_needed
@@ -75,65 +78,30 @@ class ArcGISLayerInfo:
     total_count: int
 
 
-# Module-level HTTP client for connection pooling
-_shared_http_client = None
+# Adaptive batch size fallback sequence
+BATCH_SIZE_FALLBACKS = [1000, 500, 100, 50, 10, 1]
 
 
-def _get_shared_http_client():
+def _get_reduced_batch_size(current_batch: int) -> int | None:
     """
-    Get or create a shared HTTP client for connection pooling.
+    Get the next smaller batch size from the fallback sequence.
 
-    This reuses TCP connections across requests, saving ~100-200ms per request
-    on TLS handshakes. HTTP/2 is DISABLED due to compatibility issues with
-    ArcGIS servers (they disconnect after sustained use).
+    Args:
+        current_batch: Current batch size that failed
 
     Returns:
-        httpx.Client: Shared client instance with connection pooling enabled
+        Next smaller batch size, or None if already at minimum (1)
     """
-    global _shared_http_client
+    if current_batch <= 1:
+        return None
 
-    if _shared_http_client is None:
-        try:
-            import httpx
+    # Find the first fallback smaller than current batch
+    for fallback in BATCH_SIZE_FALLBACKS:
+        if fallback < current_batch:
+            return fallback
 
-            _shared_http_client = httpx.Client(
-                timeout=60.0,
-                follow_redirects=True,
-                http2=False,  # Disabled - causes RemoteProtocolError with ArcGIS
-                limits=httpx.Limits(
-                    max_connections=20,  # Allow more connections for parallel workers
-                    max_keepalive_connections=20,
-                ),
-            )
-        except ImportError as e:
-            raise GeoParquetError(
-                "httpx is required for ArcGIS conversion. Install with: pip install httpx"
-            ) from e
-
-    return _shared_http_client
-
-
-def _reset_http_client():
-    """
-    Reset the shared HTTP client (for testing or cleanup).
-
-    This closes the existing client and allows a new one to be created.
-    """
-    global _shared_http_client
-
-    if _shared_http_client is not None:
-        _shared_http_client.close()
-        _shared_http_client = None
-
-
-def _get_http_client():
-    """
-    Get HTTP client for making requests.
-
-    Deprecated: Use _get_shared_http_client() for connection pooling.
-    Kept for backward compatibility.
-    """
-    return _get_shared_http_client()
+    # current_batch is very small but > 1, try 1
+    return 1
 
 
 def _make_request(
@@ -143,72 +111,39 @@ def _make_request(
     data: dict | None = None,
     max_retries: int = 3,
     retry_delay: float = 1.0,
+    batch_size: int | None = None,
 ) -> dict:
     """
     Make HTTP request with retry logic.
 
-    Uses shared HTTP client for connection pooling and enables gzip compression
-    to reduce bandwidth usage by 60-80%.
+    Delegates to shared http_retry module for connection pooling and error handling.
+
+    Args:
+        method: HTTP method ("GET" or "POST")
+        url: Request URL
+        params: Query parameters
+        data: POST data
+        max_retries: Number of retry attempts
+        retry_delay: Base delay between retries
+        batch_size: Current batch size (for BatchTooLargeError context)
+
+    Returns:
+        Parsed JSON response
+
+    Raises:
+        RemoteAccessError: For HTTP errors
+        BatchTooLargeError: When server returns non-JSON (batch too large)
     """
-    import httpx
-
-    last_exception = None
-
-    # Headers for compression support (60-80% bandwidth reduction)
-    headers = {
-        "Accept-Encoding": "gzip, deflate",
-    }
-
-    for attempt in range(max_retries):
-        try:
-            client = _get_shared_http_client()
-            if method == "GET":
-                response = client.get(url, params=params, headers=headers)
-            else:
-                response = client.post(url, data=data, headers=headers)
-            response.raise_for_status()
-            return response.json()
-        except httpx.RemoteProtocolError as e:
-            # Server disconnected - reset connection pool and retry
-            last_exception = e
-            if attempt < max_retries - 1:
-                _reset_http_client()  # Force fresh connection
-                time.sleep(retry_delay * (attempt + 1))
-        except httpx.TimeoutException as e:
-            last_exception = e
-            if attempt < max_retries - 1:
-                time.sleep(retry_delay * (attempt + 1))
-        except httpx.NetworkError as e:
-            last_exception = e
-            if attempt < max_retries - 1:
-                time.sleep(retry_delay * (attempt + 1))
-        except httpx.HTTPStatusError as e:
-            status = e.response.status_code
-            # Retry on 429 (rate limited) or 5xx (server errors)
-            if status == 429 or (500 <= status < 600):
-                last_exception = e
-                if attempt < max_retries - 1:
-                    # Honor Retry-After header if present
-                    retry_after = e.response.headers.get("Retry-After")
-                    if retry_after and retry_after.isdigit():
-                        delay = float(retry_after)
-                    else:
-                        delay = retry_delay * (attempt + 1)
-                    time.sleep(delay)
-                    continue
-            elif status == 401:
-                raise RemoteAccessError(
-                    url, "Authentication required. Use --token or --username/--password."
-                ) from None
-            elif status == 403:
-                raise RemoteAccessError(
-                    url, "Access denied. Check your credentials and service permissions."
-                ) from None
-            elif status == 404:
-                raise RemoteAccessError(url, "Service not found (404). Check the URL.") from None
-            raise RemoteAccessError(url, f"HTTP error {status}: {e}") from e
-
-    raise RemoteAccessError(url, f"Request failed after {max_retries} attempts: {last_exception}")
+    return make_request_with_retry(
+        method=method,
+        url=url,
+        params=params,
+        data=data,
+        max_retries=max_retries,
+        retry_delay=retry_delay,
+        parse_json=True,
+        batch_size=batch_size,
+    )
 
 
 def _handle_arcgis_response(data: dict, context: str) -> dict:
@@ -525,7 +460,7 @@ def fetch_features_page(
 
     params = _add_token_to_params(params, token)
 
-    data = _make_request("GET", query_url, params=params)
+    data = _make_request("GET", query_url, params=params, batch_size=limit)
 
     # GeoJSON responses don't have the standard error format
     # Check if we got features or an error
@@ -588,28 +523,48 @@ def fetch_all_features(
         total = min(total, max_features)
 
     if max_workers == 1:
-        # Sequential fetching (original behavior)
+        # Sequential fetching with adaptive batch size
         offset = 0
         fetched = 0
+        effective_batch = max_batch  # May be reduced on BatchTooLargeError
 
         while offset < total:
             # Adjust batch size for last page if limit applies
             remaining = total - offset
-            current_batch = min(max_batch, remaining)
+            current_batch = min(effective_batch, remaining)
 
             end = min(offset + current_batch, total)
             progress(f"Fetching features {offset + 1}-{end} of {total}...")
 
-            page = fetch_features_page(
-                service_url,
-                offset,
-                current_batch,
-                where,
-                bbox=bbox,
-                out_fields=out_fields,
-                token=token,
-                verbose=verbose,
-            )
+            try:
+                page = fetch_features_page(
+                    service_url,
+                    offset,
+                    current_batch,
+                    where,
+                    bbox=bbox,
+                    out_fields=out_fields,
+                    token=token,
+                    verbose=verbose,
+                )
+            except BatchTooLargeError as e:
+                # Server couldn't handle batch size - reduce and retry
+                new_batch = _get_reduced_batch_size(current_batch)
+                if new_batch is None:
+                    # Already at minimum batch size, can't reduce further
+                    raise GeoParquetError(
+                        f"Server cannot handle even batch_size=1. "
+                        f"This layer may have geometry too complex to download. "
+                        f"Original error: {e.reason}"
+                    ) from e
+
+                warn(
+                    f"Server returned error for batch_size={current_batch}. "
+                    f"Reducing to {new_batch} and retrying..."
+                )
+                effective_batch = new_batch
+                # Don't increment offset - retry same position with smaller batch
+                continue
 
             features = page.get("features", [])
             if not features:
@@ -637,6 +592,7 @@ def fetch_all_features(
 
         fetched = 0
         batch_start = 0
+        effective_batch = max_batch  # May be reduced on BatchTooLargeError
 
         # Reuse a single thread pool for all batches (more efficient)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -645,12 +601,12 @@ def fetch_all_features(
                 futures = []
 
                 for i in range(max_workers):
-                    offset = batch_start + (i * max_batch)
+                    offset = batch_start + (i * effective_batch)
                     if offset >= total:
                         break
 
                     remaining = total - offset
-                    current_batch = min(max_batch, remaining)
+                    current_batch = min(effective_batch, remaining)
                     end = min(offset + current_batch, total)
 
                     # Print progress message synchronously (avoid race condition)
@@ -667,20 +623,43 @@ def fetch_all_features(
                         token=token,
                         verbose=False,  # Disable per-request verbose to avoid race conditions
                     )
-                    futures.append((offset, future))
+                    futures.append((offset, current_batch, future))
 
                 # Collect results in order
                 results = []
-                for offset, future in futures:
+                batch_too_large = False
+                failed_batch_size = None
+
+                for offset, req_batch_size, future in futures:
                     try:
                         page = future.result()
                         results.append((offset, page))
+                    except BatchTooLargeError:
+                        # Mark for retry with smaller batch
+                        batch_too_large = True
+                        failed_batch_size = req_batch_size
+                        break
                     except Exception as e:
                         # If one request fails, propagate the error (fail-fast)
-                        # Retries can be added later if needed
                         raise RemoteAccessError(
                             service_url, f"Failed to fetch features at offset {offset}: {e}"
                         ) from e
+
+                if batch_too_large:
+                    # Reduce batch size and restart from batch_start
+                    new_batch = _get_reduced_batch_size(failed_batch_size or effective_batch)
+                    if new_batch is None:
+                        raise GeoParquetError(
+                            "Server cannot handle even batch_size=1. "
+                            "This layer may have geometry too complex to download."
+                        )
+                    warn(
+                        f"Server returned error for batch_size={failed_batch_size}. "
+                        f"Reducing to {new_batch} and retrying..."
+                    )
+                    effective_batch = new_batch
+                    # Don't increment batch_start - retry from same position
+                    continue
 
                 # Sort by offset to maintain order
                 results.sort(key=lambda x: x[0])
@@ -699,7 +678,7 @@ def fetch_all_features(
                     fetched += len(features)
 
                 # Move to next batch
-                batch_start += max_workers * max_batch
+                batch_start += max_workers * effective_batch
 
                 # Stop if we've hit the user limit
                 if max_features is not None and fetched >= max_features:
@@ -1153,6 +1132,7 @@ def convert_arcgis_to_geoparquet(
     skip_hilbert: bool = False,
     skip_bbox: bool = False,
     max_workers: int = 1,
+    batch_size: int | None = None,
     compression: str = "ZSTD",
     compression_level: int = 15,
     verbose: bool = False,
@@ -1189,6 +1169,7 @@ def convert_arcgis_to_geoparquet(
         skip_hilbert: Skip Hilbert spatial ordering
         skip_bbox: Skip adding bbox column for spatial query optimization
         max_workers: Number of concurrent requests (1 = sequential, 2-3 recommended)
+        batch_size: Features per request (default: server's maxRecordCount, auto-reduces on error)
         compression: Compression codec (ZSTD, GZIP, etc.)
         compression_level: Compression level
         verbose: Whether to print verbose output
@@ -1228,6 +1209,7 @@ def convert_arcgis_to_geoparquet(
         include_cols=include_cols,
         exclude_cols=exclude_cols,
         limit=limit,
+        batch_size=batch_size,
         max_workers=max_workers,
         verbose=verbose,
     )

--- a/geoparquet_io/core/exceptions.py
+++ b/geoparquet_io/core/exceptions.py
@@ -112,3 +112,17 @@ class ValidationError(GeoParquetError):
     """Raised when GeoParquet validation fails."""
 
     pass
+
+
+class BatchTooLargeError(GeoParquetError):
+    """Raised when server returns non-JSON response due to batch size limits.
+
+    This typically happens when a server's actual payload limit is lower than
+    its advertised maxRecordCount. The caller should retry with a smaller batch.
+    """
+
+    def __init__(self, url: str, batch_size: int, reason: str) -> None:
+        self.url = sanitize_url_for_logging(url)
+        self.batch_size = batch_size
+        self.reason = reason
+        super().__init__(f"Batch size {batch_size} too large for {self.url}: {reason}")

--- a/geoparquet_io/core/http_retry.py
+++ b/geoparquet_io/core/http_retry.py
@@ -13,6 +13,7 @@ Used by: arcgis.py, wfs.py
 from __future__ import annotations
 
 import json
+import threading
 import time
 from typing import TYPE_CHECKING, Any, cast
 
@@ -22,8 +23,9 @@ from geoparquet_io.core.logging_config import warn
 if TYPE_CHECKING:
     import httpx
 
-# Module-level HTTP client for connection pooling
+# Module-level HTTP client for connection pooling with thread safety
 _shared_http_client: httpx.Client | None = None
+_http_client_lock = threading.Lock()
 
 # Default timeout and retry settings
 DEFAULT_TIMEOUT = 60.0
@@ -39,6 +41,9 @@ def get_shared_http_client(
     """
     Get or create a shared HTTP client for connection pooling.
 
+    Thread-safe: uses a lock to prevent race conditions when multiple
+    threads try to create or access the client simultaneously.
+
     Reuses TCP connections across requests, saving ~100-200ms per request
     on TLS handshakes.
 
@@ -53,31 +58,34 @@ def get_shared_http_client(
     global _shared_http_client
     import httpx
 
-    if _shared_http_client is None:
-        _shared_http_client = httpx.Client(
-            timeout=timeout,
-            follow_redirects=True,
-            http2=http2,
-            limits=httpx.Limits(
-                max_connections=max_connections,
-                max_keepalive_connections=max_connections,
-            ),
-        )
-
-    return _shared_http_client
+    with _http_client_lock:
+        if _shared_http_client is None:
+            _shared_http_client = httpx.Client(
+                timeout=timeout,
+                follow_redirects=True,
+                http2=http2,
+                limits=httpx.Limits(
+                    max_connections=max_connections,
+                    max_keepalive_connections=max_connections,
+                ),
+            )
+        return _shared_http_client
 
 
 def reset_http_client() -> None:
     """
     Reset the shared HTTP client (for connection errors or cleanup).
 
+    Thread-safe: acquires lock before closing/clearing the client.
     Closes the existing client and allows a new one to be created.
     """
     global _shared_http_client
 
-    if _shared_http_client is not None:
-        _shared_http_client.close()
-        _shared_http_client = None
+    with _http_client_lock:
+        if _shared_http_client is not None:
+            client_to_close = _shared_http_client
+            _shared_http_client = None
+            client_to_close.close()
 
 
 def make_request_with_retry(
@@ -141,11 +149,11 @@ def make_request_with_retry(
                 except json.JSONDecodeError as e:
                     # Server returned non-JSON (likely HTML error page)
                     # This is NOT retryable with same params - batch is too large
-                    content_preview = response.text[:200] if response.text else "(empty)"
+                    # Don't include response content in error - may contain sensitive tokens
                     raise BatchTooLargeError(
                         url=url,
                         batch_size=batch_size or 0,
-                        reason=f"Server returned non-JSON response: {content_preview}...",
+                        reason="Server returned non-JSON response (likely HTML error page)",
                     ) from e
             else:
                 return bytes(response.content)

--- a/geoparquet_io/core/http_retry.py
+++ b/geoparquet_io/core/http_retry.py
@@ -1,0 +1,208 @@
+"""
+Shared HTTP request utilities with retry logic.
+
+This module provides reusable HTTP request functions with:
+- Exponential backoff retry on transient errors
+- Connection pooling via shared httpx client
+- Gzip compression support
+- Proper error classification (retryable vs. fatal)
+
+Used by: arcgis.py, wfs.py
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+from geoparquet_io.core.exceptions import BatchTooLargeError, RemoteAccessError
+from geoparquet_io.core.logging_config import warn
+
+if TYPE_CHECKING:
+    import httpx
+
+# Module-level HTTP client for connection pooling
+_shared_http_client: httpx.Client | None = None
+
+# Default timeout and retry settings
+DEFAULT_TIMEOUT = 60.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RETRY_DELAY = 1.0
+
+
+def get_shared_http_client(
+    timeout: float = DEFAULT_TIMEOUT,
+    http2: bool = False,
+    max_connections: int = 20,
+) -> httpx.Client:
+    """
+    Get or create a shared HTTP client for connection pooling.
+
+    Reuses TCP connections across requests, saving ~100-200ms per request
+    on TLS handshakes.
+
+    Args:
+        timeout: Request timeout in seconds
+        http2: Enable HTTP/2 (disabled by default for ArcGIS compatibility)
+        max_connections: Maximum number of connections in pool
+
+    Returns:
+        Shared httpx.Client instance
+    """
+    global _shared_http_client
+    import httpx
+
+    if _shared_http_client is None:
+        _shared_http_client = httpx.Client(
+            timeout=timeout,
+            follow_redirects=True,
+            http2=http2,
+            limits=httpx.Limits(
+                max_connections=max_connections,
+                max_keepalive_connections=max_connections,
+            ),
+        )
+
+    return _shared_http_client
+
+
+def reset_http_client() -> None:
+    """
+    Reset the shared HTTP client (for connection errors or cleanup).
+
+    Closes the existing client and allows a new one to be created.
+    """
+    global _shared_http_client
+
+    if _shared_http_client is not None:
+        _shared_http_client.close()
+        _shared_http_client = None
+
+
+def make_request_with_retry(
+    method: str,
+    url: str,
+    params: dict | None = None,
+    data: dict | None = None,
+    headers: dict | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_delay: float = DEFAULT_RETRY_DELAY,
+    timeout: float = DEFAULT_TIMEOUT,
+    parse_json: bool = True,
+    batch_size: int | None = None,
+) -> dict[str, Any] | bytes:
+    """
+    Make HTTP request with retry logic and proper error handling.
+
+    Args:
+        method: HTTP method ("GET" or "POST")
+        url: Request URL
+        params: Query parameters (for GET)
+        data: Form data (for POST)
+        headers: Additional headers (Accept-Encoding: gzip added automatically)
+        max_retries: Number of retry attempts
+        retry_delay: Base delay between retries (exponential backoff)
+        timeout: Request timeout in seconds
+        parse_json: If True, parse response as JSON and raise BatchTooLargeError
+            on parse failure. If False, return raw bytes.
+        batch_size: Current batch size (used for BatchTooLargeError context)
+
+    Returns:
+        Parsed JSON dict if parse_json=True, otherwise raw bytes
+
+    Raises:
+        RemoteAccessError: For fatal HTTP errors (401, 403, 404) or exhausted retries
+        BatchTooLargeError: When JSON parsing fails (server returned HTML error)
+    """
+    import httpx
+
+    last_exception: Exception | None = None
+
+    # Build headers with compression support
+    request_headers = {"Accept-Encoding": "gzip, deflate"}
+    if headers:
+        request_headers.update(headers)
+
+    for attempt in range(max_retries):
+        try:
+            client = get_shared_http_client(timeout=timeout)
+
+            if method == "GET":
+                response = client.get(url, params=params, headers=request_headers)
+            else:
+                response = client.post(url, data=data, headers=request_headers)
+
+            response.raise_for_status()
+
+            if parse_json:
+                try:
+                    return cast(dict[str, Any], response.json())
+                except json.JSONDecodeError as e:
+                    # Server returned non-JSON (likely HTML error page)
+                    # This is NOT retryable with same params - batch is too large
+                    content_preview = response.text[:200] if response.text else "(empty)"
+                    raise BatchTooLargeError(
+                        url=url,
+                        batch_size=batch_size or 0,
+                        reason=f"Server returned non-JSON response: {content_preview}...",
+                    ) from e
+            else:
+                return bytes(response.content)
+
+        except httpx.RemoteProtocolError as e:
+            # Server disconnected - reset connection pool and retry
+            last_exception = e
+            warn(f"HTTP protocol error (attempt {attempt + 1}/{max_retries}): {e}")
+            if attempt < max_retries - 1:
+                reset_http_client()
+                time.sleep(retry_delay * (attempt + 1))
+
+        except httpx.TimeoutException as e:
+            last_exception = e
+            warn(f"HTTP timeout after {timeout}s (attempt {attempt + 1}/{max_retries})")
+            if attempt < max_retries - 1:
+                time.sleep(retry_delay * (attempt + 1))
+
+        except httpx.NetworkError as e:
+            last_exception = e
+            warn(f"HTTP network error (attempt {attempt + 1}/{max_retries}): {e}")
+            if attempt < max_retries - 1:
+                time.sleep(retry_delay * (attempt + 1))
+
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+
+            # Retry on rate limit or server errors
+            if status == 429 or (500 <= status < 600):
+                last_exception = e
+                warn(f"HTTP {status} (attempt {attempt + 1}/{max_retries})")
+                if attempt < max_retries - 1:
+                    retry_after = e.response.headers.get("Retry-After")
+                    delay = (
+                        float(retry_after)
+                        if retry_after and retry_after.isdigit()
+                        else retry_delay * (attempt + 1)
+                    )
+                    time.sleep(delay)
+                    continue
+
+            # Fatal errors - don't retry
+            if status == 401:
+                raise RemoteAccessError(
+                    url, "Authentication required. Use --token or --username/--password."
+                ) from None
+            if status == 403:
+                raise RemoteAccessError(
+                    url, "Access denied. Check your credentials and service permissions."
+                ) from None
+            if status == 404:
+                raise RemoteAccessError(url, "Service not found (404). Check the URL.") from None
+
+            raise RemoteAccessError(url, f"HTTP error {status}: {e}") from e
+
+        except BatchTooLargeError:
+            # Don't retry BatchTooLargeError - caller needs to reduce batch size
+            raise
+
+    raise RemoteAccessError(url, f"Request failed after {max_retries} attempts: {last_exception}")

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -13,10 +13,8 @@ Key features:
 
 from __future__ import annotations
 
-import atexit
 import json
 import re
-import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +36,12 @@ __all__ = [
 from geoparquet_io.core.common import write_geoparquet_table
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
 from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection
+from geoparquet_io.core.http_retry import (
+    get_shared_http_client as _get_shared_http_client_base,
+)
+from geoparquet_io.core.http_retry import (
+    reset_http_client as _reset_http_client_base,
+)
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,
@@ -88,66 +92,18 @@ class WFSLayerInfo:
     available_formats: list[str]
 
 
-# Module-level HTTP client for connection pooling with thread safety
-_shared_http_client = None
-_http_client_lock = threading.Lock()
-
 # Default timeout for HTTP requests (seconds)
 DEFAULT_TIMEOUT = 60.0
 
 
 def _get_shared_http_client(timeout: float = DEFAULT_TIMEOUT):
-    """
-    Get or create a shared HTTP client for connection pooling.
-
-    Thread-safe: uses a lock to prevent race conditions when
-    multiple threads try to create the client simultaneously.
-
-    Reuses TCP connections across requests, saving ~100-200ms per request
-    on TLS handshakes.
-
-    Args:
-        timeout: Request timeout in seconds (default: 60.0)
-
-    Returns:
-        httpx.Client: Shared client with connection pooling enabled
-    """
-    global _shared_http_client
-
-    with _http_client_lock:
-        if _shared_http_client is None:
-            try:
-                import httpx
-
-                _shared_http_client = httpx.Client(
-                    timeout=timeout,
-                    follow_redirects=True,
-                    http2=False,  # Disabled for compatibility with older WFS servers
-                    limits=httpx.Limits(
-                        max_connections=20,
-                        max_keepalive_connections=20,
-                    ),
-                )
-            except ImportError as e:
-                raise WFSError(
-                    "httpx is required for WFS extraction. Install with: pip install httpx"
-                ) from e
-
-    return _shared_http_client
+    """Get shared HTTP client from http_retry module."""
+    return _get_shared_http_client_base(timeout=timeout)
 
 
 def _reset_http_client():
-    """Reset the shared HTTP client (for testing or cleanup)."""
-    global _shared_http_client
-
-    with _http_client_lock:
-        if _shared_http_client is not None:
-            _shared_http_client.close()
-            _shared_http_client = None
-
-
-# Register cleanup on interpreter exit to prevent resource leak
-atexit.register(_reset_http_client)
+    """Reset shared HTTP client from http_retry module."""
+    _reset_http_client_base()
 
 
 def _make_request(

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1282,3 +1282,221 @@ class TestRealWorldSchemaMismatch:
         # Verify the schema is consistent (no schema mismatch error occurred)
         # If we got here without error, the fix is working
         assert table.schema is not None
+
+
+class TestBatchSizeReduction:
+    """Unit tests for adaptive batch size functionality."""
+
+    def test_get_reduced_batch_size_from_large(self):
+        """Test batch size reduction from large value."""
+        from geoparquet_io.core.arcgis import _get_reduced_batch_size
+
+        # From 2000, should reduce to 1000
+        assert _get_reduced_batch_size(2000) == 1000
+        # From 1500, should reduce to 1000
+        assert _get_reduced_batch_size(1500) == 1000
+
+    def test_get_reduced_batch_size_from_medium(self):
+        """Test batch size reduction from medium values."""
+        from geoparquet_io.core.arcgis import _get_reduced_batch_size
+
+        # From 1000, should reduce to 500
+        assert _get_reduced_batch_size(1000) == 500
+        # From 500, should reduce to 100
+        assert _get_reduced_batch_size(500) == 100
+
+    def test_get_reduced_batch_size_from_small(self):
+        """Test batch size reduction from small values."""
+        from geoparquet_io.core.arcgis import _get_reduced_batch_size
+
+        # From 100, should reduce to 50
+        assert _get_reduced_batch_size(100) == 50
+        # From 50, should reduce to 10
+        assert _get_reduced_batch_size(50) == 10
+        # From 10, should reduce to 1
+        assert _get_reduced_batch_size(10) == 1
+
+    def test_get_reduced_batch_size_at_minimum(self):
+        """Test batch size reduction at minimum returns None."""
+        from geoparquet_io.core.arcgis import _get_reduced_batch_size
+
+        # At 1, can't reduce further
+        assert _get_reduced_batch_size(1) is None
+        # At 0 (edge case), can't reduce
+        assert _get_reduced_batch_size(0) is None
+
+    def test_get_reduced_batch_size_unusual_values(self):
+        """Test batch size reduction with unusual values."""
+        from geoparquet_io.core.arcgis import _get_reduced_batch_size
+
+        # Value between fallbacks should get next lower
+        assert _get_reduced_batch_size(750) == 500
+        assert _get_reduced_batch_size(5) == 1
+        assert _get_reduced_batch_size(2) == 1
+
+
+class TestBatchTooLargeError:
+    """Unit tests for BatchTooLargeError exception."""
+
+    def test_error_attributes(self):
+        """Test BatchTooLargeError stores correct attributes."""
+        from geoparquet_io.core.exceptions import BatchTooLargeError
+
+        error = BatchTooLargeError(
+            url="https://example.com/arcgis/rest/services/test/FeatureServer/0/query",
+            batch_size=500,
+            reason="Server returned HTML error page",
+        )
+
+        assert error.batch_size == 500
+        assert "500" in str(error)
+        assert "HTML error page" in str(error)
+
+    def test_error_sanitizes_url(self):
+        """Test BatchTooLargeError sanitizes sensitive URL params."""
+        from geoparquet_io.core.exceptions import BatchTooLargeError
+
+        # URL with query params that might contain credentials
+        error = BatchTooLargeError(
+            url="https://example.com/arcgis?token=secret123&other=param",
+            batch_size=100,
+            reason="test",
+        )
+
+        # Query params should be stripped
+        assert "secret123" not in error.url
+
+
+class TestAdaptiveBatchWithMock:
+    """Tests for adaptive batch size behavior using mocks."""
+
+    def test_batch_reduces_on_json_error(self):
+        """Test that batch size reduces when server returns non-JSON."""
+        from unittest.mock import patch
+
+        from geoparquet_io.core.arcgis import (
+            ArcGISLayerInfo,
+            fetch_all_features,
+        )
+        from geoparquet_io.core.exceptions import BatchTooLargeError
+
+        # Mock layer info
+        layer_info = ArcGISLayerInfo(
+            name="Test",
+            geometry_type="esriGeometryPoint",
+            spatial_reference={"wkid": 4326},
+            fields=[],
+            max_record_count=1000,
+            total_count=100,
+        )
+
+        call_count = 0
+        batch_sizes_used = []
+
+        def mock_fetch_page(service_url, offset, limit, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            batch_sizes_used.append(limit)
+
+            # First call with large batch fails
+            if limit > 50:
+                raise BatchTooLargeError(
+                    url=service_url,
+                    batch_size=limit,
+                    reason="Simulated server error",
+                )
+
+            # Smaller batches succeed
+            return {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [0, 0]},
+                        "properties": {"id": i},
+                    }
+                    for i in range(offset, min(offset + limit, 100))
+                ],
+            }
+
+        with patch(
+            "geoparquet_io.core.arcgis.fetch_features_page",
+            side_effect=mock_fetch_page,
+        ):
+            pages = list(
+                fetch_all_features(
+                    "https://example.com/FeatureServer/0",
+                    layer_info,
+                    batch_size=100,
+                )
+            )
+
+        # Should have reduced batch size and succeeded
+        assert len(pages) > 0
+        # First attempt was 100, then reduced to 50
+        assert 100 in batch_sizes_used
+        assert 50 in batch_sizes_used
+
+
+@pytest.mark.network
+class TestAdaptiveBatchNetworkIntegration:
+    """Network integration tests for adaptive batch size (issue #382)."""
+
+    # Mozambique Admin 3 layer that triggers batch-too-large errors
+    MOZ_ADMIN3_SERVICE = (
+        "https://www.mozgis.gov.mz/server/rest/services/Data/"
+        "UnidadesAdministrativasCenso2017/FeatureServer/3"
+    )
+
+    @pytest.fixture
+    def output_file(self, tmp_path):
+        """Create a temporary output file path."""
+        output = tmp_path / f"moz_admin3_{uuid.uuid4()}.parquet"
+        yield str(output)
+        safe_unlink(output)
+
+    def test_mozambique_admin3_adaptive_batch_issue_382(self, output_file):
+        """Test extraction from Mozambique Admin 3 that triggers issue #382.
+
+        This layer has 458 features with complex polygons. The server's
+        maxRecordCount is 2000, but it returns HTML errors for batches
+        larger than ~100 features due to payload size limits.
+
+        The adaptive batch size should automatically reduce and succeed.
+        """
+        from geoparquet_io.core.arcgis import convert_arcgis_to_geoparquet
+
+        # This should succeed with adaptive batch reduction
+        convert_arcgis_to_geoparquet(
+            self.MOZ_ADMIN3_SERVICE,
+            output_file,
+            skip_hilbert=True,  # Skip for speed
+            verbose=True,
+        )
+
+        assert Path(output_file).exists()
+        pf = pq.ParquetFile(output_file)
+        # Should have all 458 features
+        assert pf.metadata.num_rows == 458
+
+    def test_cli_batch_size_option(self, output_file):
+        """Test --batch-size CLI option works."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "extract",
+                "arcgis",
+                self.MOZ_ADMIN3_SERVICE,
+                output_file,
+                "--batch-size",
+                "50",  # Start with small batch to avoid errors
+                "--skip-hilbert",
+                "-v",
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert Path(output_file).exists()
+        pf = pq.ParquetFile(output_file)
+        assert pf.metadata.num_rows == 458

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1439,6 +1439,8 @@ class TestAdaptiveBatchWithMock:
 
 
 @pytest.mark.network
+@pytest.mark.slow
+@pytest.mark.integration
 class TestAdaptiveBatchNetworkIntegration:
     """Network integration tests for adaptive batch size (issue #382)."""
 
@@ -1455,12 +1457,19 @@ class TestAdaptiveBatchNetworkIntegration:
         yield str(output)
         safe_unlink(output)
 
-    def test_mozambique_admin3_adaptive_batch_issue_382(self, output_file):
+    @pytest.fixture
+    def expected_feature_count(self):
+        """Fetch current feature count from the service dynamically."""
+        from geoparquet_io.core.arcgis import get_feature_count
+
+        return get_feature_count(self.MOZ_ADMIN3_SERVICE)
+
+    def test_mozambique_admin3_adaptive_batch_issue_382(self, output_file, expected_feature_count):
         """Test extraction from Mozambique Admin 3 that triggers issue #382.
 
-        This layer has 458 features with complex polygons. The server's
-        maxRecordCount is 2000, but it returns HTML errors for batches
-        larger than ~100 features due to payload size limits.
+        This layer has complex polygons. The server's maxRecordCount is 2000,
+        but it returns HTML errors for batches larger than ~100 features due
+        to payload size limits.
 
         The adaptive batch size should automatically reduce and succeed.
         """
@@ -1476,10 +1485,10 @@ class TestAdaptiveBatchNetworkIntegration:
 
         assert Path(output_file).exists()
         pf = pq.ParquetFile(output_file)
-        # Should have all 458 features
-        assert pf.metadata.num_rows == 458
+        # Should have all features (count fetched dynamically from service)
+        assert pf.metadata.num_rows == expected_feature_count
 
-    def test_cli_batch_size_option(self, output_file):
+    def test_cli_batch_size_option(self, output_file, expected_feature_count):
         """Test --batch-size CLI option works."""
         runner = CliRunner()
         result = runner.invoke(
@@ -1499,4 +1508,4 @@ class TestAdaptiveBatchNetworkIntegration:
         assert result.exit_code == 0, f"CLI failed: {result.output}"
         assert Path(output_file).exists()
         pf = pq.ParquetFile(output_file)
-        assert pf.metadata.num_rows == 458
+        assert pf.metadata.num_rows == expected_feature_count

--- a/tests/test_arcgis_http_optimization.py
+++ b/tests/test_arcgis_http_optimization.py
@@ -17,10 +17,11 @@ class TestConnectionPooling:
         This is a performance optimization to avoid creating new TCP/TLS
         connections for every request.
         """
-        from geoparquet_io.core.arcgis import _make_request, _reset_http_client
+        from geoparquet_io.core.arcgis import _make_request
+        from geoparquet_io.core.http_retry import reset_http_client
 
         # Reset to ensure clean state
-        _reset_http_client()
+        reset_http_client()
 
         mock_client = MagicMock()
         mock_response = Mock()
@@ -28,7 +29,7 @@ class TestConnectionPooling:
         mock_response.raise_for_status = Mock()
         mock_client.get.return_value = mock_response
 
-        with patch("geoparquet_io.core.arcgis._get_shared_http_client") as mock_get_client:
+        with patch("geoparquet_io.core.http_retry.get_shared_http_client") as mock_get_client:
             mock_get_client.return_value = mock_client
 
             # Make multiple requests
@@ -39,9 +40,6 @@ class TestConnectionPooling:
             # Client should be retrieved 3 times (function called 3 times)
             assert mock_get_client.call_count == 3
 
-            # Verify the mock returned the same client each time
-            assert all(call[1] == {} for call in mock_get_client.call_args_list)  # No args passed
-
     def test_http_client_has_connection_pooling_enabled(self):
         """
         Test that HTTP client has connection pooling properly configured.
@@ -49,12 +47,12 @@ class TestConnectionPooling:
         Connection pooling allows reusing TCP connections across requests,
         which saves ~100-200ms per request on TLS handshake.
         """
-        from geoparquet_io.core.arcgis import _get_shared_http_client, _reset_http_client
+        from geoparquet_io.core.http_retry import get_shared_http_client, reset_http_client
 
         # Reset to ensure clean state
-        _reset_http_client()
+        reset_http_client()
 
-        client = _get_shared_http_client()
+        client = get_shared_http_client()
 
         # Verify client is an httpx.Client instance with expected config
         import httpx
@@ -67,15 +65,15 @@ class TestConnectionPooling:
 
     def test_http_client_is_singleton(self):
         """
-        Test that _get_shared_http_client returns the same instance.
+        Test that get_shared_http_client returns the same instance.
 
         This ensures connection pooling works across the entire module,
         not just within a single function.
         """
-        from geoparquet_io.core.arcgis import _get_shared_http_client
+        from geoparquet_io.core.http_retry import get_shared_http_client
 
-        client1 = _get_shared_http_client()
-        client2 = _get_shared_http_client()
+        client1 = get_shared_http_client()
+        client2 = get_shared_http_client()
 
         # Should be the exact same object
         assert client1 is client2
@@ -86,11 +84,11 @@ class TestConnectionPooling:
 
         This is useful for tests that need to verify client creation logic.
         """
-        from geoparquet_io.core.arcgis import _get_shared_http_client, _reset_http_client
+        from geoparquet_io.core.http_retry import get_shared_http_client, reset_http_client
 
-        client1 = _get_shared_http_client()
-        _reset_http_client()
-        client2 = _get_shared_http_client()
+        client1 = get_shared_http_client()
+        reset_http_client()
+        client2 = get_shared_http_client()
 
         # After reset, should get a different instance
         assert client1 is not client2
@@ -102,12 +100,12 @@ class TestConnectionPooling:
         HTTP/2 causes RemoteProtocolError with ArcGIS servers after sustained use.
         Connection pooling and gzip compression still provide performance benefits.
         """
-        from geoparquet_io.core.arcgis import _get_shared_http_client, _reset_http_client
+        from geoparquet_io.core.http_retry import get_shared_http_client, reset_http_client
 
         # Reset to ensure clean state
-        _reset_http_client()
+        reset_http_client()
 
-        client = _get_shared_http_client()
+        client = get_shared_http_client()
 
         # Verify client exists and has transport
         assert hasattr(client, "_transport")
@@ -132,7 +130,7 @@ class TestGzipCompression:
         mock_response.raise_for_status = Mock()
         mock_client.get.return_value = mock_response
 
-        with patch("geoparquet_io.core.arcgis._get_shared_http_client") as mock_get_client:
+        with patch("geoparquet_io.core.http_retry.get_shared_http_client") as mock_get_client:
             mock_get_client.return_value = mock_client
 
             _make_request("GET", "https://example.com/test", params={"f": "json"})


### PR DESCRIPTION
## Summary

- Fixes JSONDecodeError when ArcGIS server returns HTML error for large batches (#382)
- Adds adaptive batch size that auto-reduces on server errors (2000 → 1000 → 500 → 100 → 50 → 10 → 1)
- Adds `--batch-size` CLI flag for manual control
- Extracts shared HTTP retry logic to `core/http_retry.py` (DRY refactor)

## Test plan

- [x] Unit tests for `_get_reduced_batch_size` helper
- [x] Unit tests for `BatchTooLargeError` exception  
- [x] Mock integration test for adaptive retry behavior
- [x] Network integration test with Mozambique Admin 3 layer (issue reproduction)
- [x] All existing ArcGIS tests pass (48/48)
- [x] All WFS tests pass (64/64)
- [x] Pre-commit hooks pass

## Reproduction

Before this fix:
```bash
gpio extract arcgis \
  https://www.mozgis.gov.mz/server/rest/services/Data/UnidadesAdministrativasCenso2017/FeatureServer/3 \
  moz_admin3.parquet
# JSONDecodeError: Expecting value...
```

After this fix:
```bash
gpio extract arcgis \
  https://www.mozgis.gov.mz/server/rest/services/Data/UnidadesAdministrativasCenso2017/FeatureServer/3 \
  moz_admin3.parquet
# Server returned error for batch_size=458. Reducing to 100 and retrying...
# Converted 458 features to moz_admin3.parquet
```

Fixes #382

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--batch-size` option to `extract arcgis` command to control request size (range 1–5000).
  * Implemented automatic batch-size reduction on server errors for improved robustness.

* **Refactor**
  * Consolidated HTTP client pooling logic into shared module for better maintainability.

* **Tests**
  * Added comprehensive test coverage for batch-size adaptation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->