### PR TITLE
bump: version 1.0.0 → 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-## [1.1.0-beta] - 2026-03-05
-
-Minor version bump for ongoing beta improvements.
-
-## [1.0.0-beta] - 2026-02-10
 
 This is the first beta release of geoparquet-io 1.0, featuring major new spatial indexing systems, auto-resolution partitioning, comprehensive `--overwrite` support, and significant performance improvements.
 
@@ -98,3 +91,178 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - Comprehensive test coverage improvements
 - Plugin system documentation
 - Dependency updates (actions/checkout v6, astral-sh/setup-uv v7, etc.)
+
+## v1.0.1 (2026-04-20)
+
+### Fix
+
+- **arcgis**: address code review feedback for adaptive batch
+- **arcgis**: add adaptive batch size and --batch-size flag (#382)
+- **reproject**: use PROJJSON for ST_Transform when CRS lacks authority id
+- **inspect**: eliminate false-positive CRS mismatch warnings for GeoParquet 2.0
+- **deps**: bump pytest to 9.0.3 for CVE-2025-71176
+
+### Refactor
+
+- **release**: adopt portolan-cli release workflow
+
+## v1.0.0 (2026-04-13)
+
+### BREAKING CHANGE
+
+- `geography_as_geometry` parameter no longer accepted.
+BREAKING CHANGE: `gt` CLI alias removed, use `gpio` instead.
+
+### Feat
+
+- **core**: add framework-agnostic exception classes and CLI handler
+- **api**: add partition_by_a5() and fix documentation drift
+- **convert**: support multiple geometry columns in GeoParquet files
+- **skills**: Package skill with gpio for all LLM users
+- **docs**: Add menard documentation anti-drift system
+
+### Fix
+
+- **release**: use PyPI menard instead of git dependency
+- **test**: align slow test assertions with core exception types
+- **test**: handle Windows path separators in test_file_utils
+- **security**: address adversarial review findings for v1.0
+- **imports**: update disk_rewrite.py to import compute_bbox_via_sql from geo_metadata
+- **cli**: unify exception handling across all CLI commands
+- **exceptions**: unify GeoParquetError and update tests for new exception types
+- **docs**: update mkdocstrings paths for reorganized modules
+- **security**: sanitize URLs in logs to prevent credential leakage
+- **security**: escape single quotes in SQL to prevent injection
+- import-linter config and broken test monkeypatch
+- **imports**: update all imports for partition/ and add/ module reorganization
+- Remove inconsistent force/skip_analysis params and fix test marker
+- **tests**: Relax performance threshold for macOS CI runners
+- **tests**: Mark all transportforcairo WFS integration tests as xfail
+- **tests**: Narrow WFS xfail to only catch WFSError exceptions
+- **tests**: mark unreliable transportforcairo WFS tests as xfail
+- update remaining tests to use dynamic geometry column detection
+- geometry column detection and SQL identifier quoting
+- **convert**: preserve original geometry column names and fix multi-geometry for all write strategies
+- **core**: address CodeRabbit findings and centralize geometry detection
+- **bigquery**: Address PR review findings
+- **arcgis**: handle schema mismatch between paginated batches
+- **benchmark**: use shared DuckDB connection helper and add test markers
+- address CodeRabbit review feedback
+- support native geo stats and honor row_groups limit
+- **test**: update assertion to avoid conflict with v1.1 warning
+- **docs**: Fix README badges, mkdocs build, and add changelog sync
+- **docs**: Fix stale documentation and menard links
+- **bigquery**: Add Python API parity and fix edges semantic bug
+- **deps**: resolve security audit failures
+- **deps**: resolve security audit failures
+- **wfs**: switch integration tests from offline USGS to Cairo WFS
+- address review issues in mutmut PR
+- **test**: improve commitizen test robustness and coverage
+
+### Refactor
+
+- **core**: remove duplicate functions from common.py
+- **core/partition**: replace click exceptions with core exceptions
+- **core/add**: replace click exceptions with core exceptions
+- **core**: replace click exceptions with core exceptions
+- **core**: remove duplicated code from common.py, add re-exports
+- **core**: extract modules from common.py monolith
+- **core**: extract remote, geometry_detection, file_utils from common.py
+- **docs**: Compress contributing.md and add auto-sync
+- **docs**: Compress CLAUDE.md and add deterministic enforcement
+- **scripts**: Consolidate doc generators and pre-commit hooks
+- **wfs**: remove ~900 lines of dead code, fix SQL injection, add parallel pagination
+
+## v1.0.0b2 (2026-03-06)
+
+### Feat
+
+- allow specifying --profile web for web specific parquet structure checks
+
+### Fix
+
+- Address code review issues for FileGDB CRS detection
+- Add FileGDB CRS detection workaround
+
+## v1.0-beta (2026-02-10)
+
+### Feat
+
+- add directory input support with --min-size to partition s2 and quadkey commands
+- add directory input support with --min-size to partition h3 command
+- add sub_partition_directory function for batch sub-partitioning
+- add find_large_files function for directory scanning
+- add --min-size and --in-place options to partition_options decorator
+
+### Fix
+
+- add min_size and in_place params to all partition function signatures
+
+## v0.9.0 (2026-01-17)
+
+## v0.8.0 (2026-01-04)
+
+## v0.7.0 (2025-12-28)
+
+## v0.6.1 (2025-12-11)
+
+## v0.6.0 (2025-12-06)
+
+### Feat
+
+- enhance inspect command with geometry types and WKT preview
+
+## v0.5.1 (2025-12-04)
+
+## v0.5.0 (2025-12-02)
+
+### Feat
+
+- **io**: add remote-to-remote support with consolidated write infrastructure
+- **auth**: add automatic AWS credential discovery for S3
+- **io**: add remote-to-remote operations and automatic AWS auth
+- **remote**: handle edge cases for remote file operations                                                                                                                             │ │                                                                                                                                                                                                         │ │   Edge case improvements:                                                                                                                                                                               │ │   - fix(convert): support remote parquet files via read_parquet() instead of ST_Read()                                                                                                                  │ │   - fix(convert): validate only local files, allow remote URLs to pass through                                                                                                                          │ │   - feat(stac): block remote files with clear error message and TODO for future                                                                                                                         │ │   - feat(common): add progress indicator for remote operations (shows protocol)                                                                                                                         │ │   - feat(common): add get_remote_error_hint() for better error messages                                                                                                                                 │ │   - docs: update limitations section with what works vs doesn't work                                                                                                                                    │ │                                                                                                                                                                                                         │ │   Closes edge cases for remote reads before tests/docs phase.
+- **upload**: add upload command to remote buckets using obstore - Upload command with obstore, supporting parallelism and progress tracking - Single file and directory uploads - Support for s3, GCS, Azure, HTTP - Pattern filtering - Dry run mode
+- **check**: add --fix flag to automatically correct issues detected by check command - add --fix, --fix-output, and --no-backup flags to all check commands - refactor check functions to return structured results enabling fixes via new core/check_fixes.py module.
+- **cli**: add benchmark command for conversion performance testing
+
+### Fix
+
+- **check**: remove format command group - remove format command group; consolidate under check - move add-bbox-metadata to add command group - simplify add-bbox command - update + reorg tests
+
+## v0.4.0 (2025-11-17)
+
+### Feat
+
+- **cli**: add ability to pass custom basename for partition output file, e.g., fields_NL.parquet instead of NL.parquet
+- **stac**: add STAC Item and Collection generation
+- **cli**: Add convert command for optimized GeoParquet conversion
+
+### Fix
+
+- **tests**: correct issue with failing test on windows
+
+## v0.3.0 (2025-11-06)
+
+## v0.2.0 (2025-10-24)
+
+### Refactor
+
+- **cli**: consolidate repetitive option decorators
+
+## v0.1.0 (2025-10-24)
+
+### Feat
+
+- **cli**: add inspect command for fast file examination
+- **partition**: add KD-tree spatial partitioning
+- Add intelligent partition analysis with recommendations and H3 column exclusion
+- **partition**: add H3 partitioning with auto-column creation
+- **add**: add H3 support with computed column abstraction
+
+### Fix
+
+- Add Windows compatibility for hive partition tests
+- Resolve Windows file locking issues in tests
+- **tests**: Ensure DuckDB connections are closed before file cleanup
+- Update test_partition_format.py import to use geoparquet_io

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,13 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-## [1.1.0-beta] - 2026-03-05
-
-Minor version bump for ongoing beta improvements.
-
-## [1.0.0-beta] - 2026-02-10
 
 This is the first beta release of geoparquet-io 1.0, featuring major new spatial indexing systems, auto-resolution partitioning, comprehensive `--overwrite` support, and significant performance improvements.
 
@@ -98,3 +91,178 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - Comprehensive test coverage improvements
 - Plugin system documentation
 - Dependency updates (actions/checkout v6, astral-sh/setup-uv v7, etc.)
+
+## v1.0.1 (2026-04-20)
+
+### Fix
+
+- **arcgis**: address code review feedback for adaptive batch
+- **arcgis**: add adaptive batch size and --batch-size flag (#382)
+- **reproject**: use PROJJSON for ST_Transform when CRS lacks authority id
+- **inspect**: eliminate false-positive CRS mismatch warnings for GeoParquet 2.0
+- **deps**: bump pytest to 9.0.3 for CVE-2025-71176
+
+### Refactor
+
+- **release**: adopt portolan-cli release workflow
+
+## v1.0.0 (2026-04-13)
+
+### BREAKING CHANGE
+
+- `geography_as_geometry` parameter no longer accepted.
+BREAKING CHANGE: `gt` CLI alias removed, use `gpio` instead.
+
+### Feat
+
+- **core**: add framework-agnostic exception classes and CLI handler
+- **api**: add partition_by_a5() and fix documentation drift
+- **convert**: support multiple geometry columns in GeoParquet files
+- **skills**: Package skill with gpio for all LLM users
+- **docs**: Add menard documentation anti-drift system
+
+### Fix
+
+- **release**: use PyPI menard instead of git dependency
+- **test**: align slow test assertions with core exception types
+- **test**: handle Windows path separators in test_file_utils
+- **security**: address adversarial review findings for v1.0
+- **imports**: update disk_rewrite.py to import compute_bbox_via_sql from geo_metadata
+- **cli**: unify exception handling across all CLI commands
+- **exceptions**: unify GeoParquetError and update tests for new exception types
+- **docs**: update mkdocstrings paths for reorganized modules
+- **security**: sanitize URLs in logs to prevent credential leakage
+- **security**: escape single quotes in SQL to prevent injection
+- import-linter config and broken test monkeypatch
+- **imports**: update all imports for partition/ and add/ module reorganization
+- Remove inconsistent force/skip_analysis params and fix test marker
+- **tests**: Relax performance threshold for macOS CI runners
+- **tests**: Mark all transportforcairo WFS integration tests as xfail
+- **tests**: Narrow WFS xfail to only catch WFSError exceptions
+- **tests**: mark unreliable transportforcairo WFS tests as xfail
+- update remaining tests to use dynamic geometry column detection
+- geometry column detection and SQL identifier quoting
+- **convert**: preserve original geometry column names and fix multi-geometry for all write strategies
+- **core**: address CodeRabbit findings and centralize geometry detection
+- **bigquery**: Address PR review findings
+- **arcgis**: handle schema mismatch between paginated batches
+- **benchmark**: use shared DuckDB connection helper and add test markers
+- address CodeRabbit review feedback
+- support native geo stats and honor row_groups limit
+- **test**: update assertion to avoid conflict with v1.1 warning
+- **docs**: Fix README badges, mkdocs build, and add changelog sync
+- **docs**: Fix stale documentation and menard links
+- **bigquery**: Add Python API parity and fix edges semantic bug
+- **deps**: resolve security audit failures
+- **deps**: resolve security audit failures
+- **wfs**: switch integration tests from offline USGS to Cairo WFS
+- address review issues in mutmut PR
+- **test**: improve commitizen test robustness and coverage
+
+### Refactor
+
+- **core**: remove duplicate functions from common.py
+- **core/partition**: replace click exceptions with core exceptions
+- **core/add**: replace click exceptions with core exceptions
+- **core**: replace click exceptions with core exceptions
+- **core**: remove duplicated code from common.py, add re-exports
+- **core**: extract modules from common.py monolith
+- **core**: extract remote, geometry_detection, file_utils from common.py
+- **docs**: Compress contributing.md and add auto-sync
+- **docs**: Compress CLAUDE.md and add deterministic enforcement
+- **scripts**: Consolidate doc generators and pre-commit hooks
+- **wfs**: remove ~900 lines of dead code, fix SQL injection, add parallel pagination
+
+## v1.0.0b2 (2026-03-06)
+
+### Feat
+
+- allow specifying --profile web for web specific parquet structure checks
+
+### Fix
+
+- Address code review issues for FileGDB CRS detection
+- Add FileGDB CRS detection workaround
+
+## v1.0-beta (2026-02-10)
+
+### Feat
+
+- add directory input support with --min-size to partition s2 and quadkey commands
+- add directory input support with --min-size to partition h3 command
+- add sub_partition_directory function for batch sub-partitioning
+- add find_large_files function for directory scanning
+- add --min-size and --in-place options to partition_options decorator
+
+### Fix
+
+- add min_size and in_place params to all partition function signatures
+
+## v0.9.0 (2026-01-17)
+
+## v0.8.0 (2026-01-04)
+
+## v0.7.0 (2025-12-28)
+
+## v0.6.1 (2025-12-11)
+
+## v0.6.0 (2025-12-06)
+
+### Feat
+
+- enhance inspect command with geometry types and WKT preview
+
+## v0.5.1 (2025-12-04)
+
+## v0.5.0 (2025-12-02)
+
+### Feat
+
+- **io**: add remote-to-remote support with consolidated write infrastructure
+- **auth**: add automatic AWS credential discovery for S3
+- **io**: add remote-to-remote operations and automatic AWS auth
+- **remote**: handle edge cases for remote file operations                                                                                                                             │ │                                                                                                                                                                                                         │ │   Edge case improvements:                                                                                                                                                                               │ │   - fix(convert): support remote parquet files via read_parquet() instead of ST_Read()                                                                                                                  │ │   - fix(convert): validate only local files, allow remote URLs to pass through                                                                                                                          │ │   - feat(stac): block remote files with clear error message and TODO for future                                                                                                                         │ │   - feat(common): add progress indicator for remote operations (shows protocol)                                                                                                                         │ │   - feat(common): add get_remote_error_hint() for better error messages                                                                                                                                 │ │   - docs: update limitations section with what works vs doesn't work                                                                                                                                    │ │                                                                                                                                                                                                         │ │   Closes edge cases for remote reads before tests/docs phase.
+- **upload**: add upload command to remote buckets using obstore - Upload command with obstore, supporting parallelism and progress tracking - Single file and directory uploads - Support for s3, GCS, Azure, HTTP - Pattern filtering - Dry run mode
+- **check**: add --fix flag to automatically correct issues detected by check command - add --fix, --fix-output, and --no-backup flags to all check commands - refactor check functions to return structured results enabling fixes via new core/check_fixes.py module.
+- **cli**: add benchmark command for conversion performance testing
+
+### Fix
+
+- **check**: remove format command group - remove format command group; consolidate under check - move add-bbox-metadata to add command group - simplify add-bbox command - update + reorg tests
+
+## v0.4.0 (2025-11-17)
+
+### Feat
+
+- **cli**: add ability to pass custom basename for partition output file, e.g., fields_NL.parquet instead of NL.parquet
+- **stac**: add STAC Item and Collection generation
+- **cli**: Add convert command for optimized GeoParquet conversion
+
+### Fix
+
+- **tests**: correct issue with failing test on windows
+
+## v0.3.0 (2025-11-06)
+
+## v0.2.0 (2025-10-24)
+
+### Refactor
+
+- **cli**: consolidate repetitive option decorators
+
+## v0.1.0 (2025-10-24)
+
+### Feat
+
+- **cli**: add inspect command for fast file examination
+- **partition**: add KD-tree spatial partitioning
+- Add intelligent partition analysis with recommendations and H3 column exclusion
+- **partition**: add H3 partitioning with auto-column creation
+- **add**: add H3 support with computed column abstraction
+
+### Fix
+
+- Add Windows compatibility for hive partition tests
+- Resolve Windows file locking issues in tests
+- **tests**: Ensure DuckDB connections are closed before file cleanup
+- Update test_partition_format.py import to use geoparquet_io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geoparquet-io"
-version = "1.0.0"
+version = "1.0.1"
 description = "Fast I/O and transformation tools for GeoParquet files"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -255,7 +255,7 @@ skips = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.0.0"
+version = "1.0.1"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 update_changelog_on_bump = true

--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release v1.0.1 with patch fixes since v1.0.0.

## Changes

- **arcgis**: adaptive batch size and --batch-size flag
- **reproject**: use PROJJSON for ST_Transform when CRS lacks authority id
- **inspect**: eliminate false-positive CRS mismatch warnings for GeoParquet 2.0
- **deps**: bump pytest to 9.0.3 for CVE-2025-71176
- **release**: adopt portolan-cli release workflow

## Post-merge

CI will automatically create tag v1.0.1, publish to PyPI, and create GitHub Release.