### PR TITLE
Fix stale CLI examples across guide docs

### DIFF
--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -223,8 +223,8 @@ gpio also includes built-in benchmark commands:
 # Run benchmark suite on specific files
 gpio benchmark suite --files path/to/file.parquet --operations core
 
-# Run quick benchmark (single operation, timing only)
-gpio benchmark run inspect path/to/file.parquet
+# Compare converter performance on a single file
+gpio benchmark compare path/to/file.parquet
 ```
 
 ## Profiling Integration

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -491,7 +491,7 @@ DuckDB also uses significantly less memory than alternatives (near-zero vs 600MB
 To run your own benchmarks:
 
 ```bash
-gpio benchmark input.geojson --iterations 3
+gpio benchmark compare input.geojson --iterations 3
 ```
 
 See [`gpio benchmark`](../cli/benchmark.md) for details.

--- a/docs/guide/inspect.md
+++ b/docs/guide/inspect.md
@@ -1,9 +1,9 @@
 # Inspecting Files
 
-The `inspect` command provides quick, human-readable summaries of GeoParquet files.
+The `inspect` command provides quick, human-readable summaries of GeoParquet files. `gpio inspect` is a shortcut for `gpio inspect summary` — both show the same output.
 
 !!! tip "Need more detail?"
-    For comprehensive metadata analysis including row group details and full schema information, use `gpio inspect --meta`.
+    For comprehensive metadata analysis including row group details and full schema information, use `gpio inspect meta`.
 
 ## Basic Usage
 
@@ -40,17 +40,17 @@ Shows:
 === "CLI"
 
     ```bash
-    # First 10 rows (default when no value given)
-    gpio inspect data.parquet --head
+    # First 10 rows (default)
+    gpio inspect head data.parquet
 
     # First 20 rows
-    gpio inspect data.parquet --head 20
+    gpio inspect head data.parquet 20
 
-    # Last 10 rows (default when no value given)
-    gpio inspect data.parquet --tail
+    # Last 10 rows (default)
+    gpio inspect tail data.parquet
 
     # Last 5 rows
-    gpio inspect data.parquet --tail 5
+    gpio inspect tail data.parquet 5
     ```
 
 === "Python"
@@ -83,9 +83,6 @@ Shows:
     ```bash
     # Column statistics (nulls, min/max, unique counts)
     gpio inspect stats data.parquet
-
-    # Combine with preview
-    gpio inspect data.parquet --head --stats
     ```
 
 === "Python"
@@ -138,10 +135,10 @@ Output includes a "Compression Ratios" table showing which columns benefit most 
 
     ```bash
     # Human-readable format
-    gpio inspect data.parquet --geo-metadata
+    gpio inspect meta data.parquet --geo
 
     # JSON format (exact metadata content)
-    gpio inspect data.parquet --geo-metadata --json
+    gpio inspect meta data.parquet --geo --json
     ```
 
 === "Python"
@@ -181,10 +178,10 @@ View the complete Parquet file metadata (low-level details):
 
 ```bash
 # Human-readable format
-gpio inspect data.parquet --parquet-metadata
+gpio inspect meta data.parquet --parquet
 
 # JSON format (detailed metadata)
-gpio inspect data.parquet --parquet-metadata --json
+gpio inspect meta data.parquet --parquet --json
 ```
 
 The metadata includes:
@@ -199,10 +196,10 @@ View geospatial metadata from the Parquet footer (column-level statistics and lo
 
 ```bash
 # Human-readable format
-gpio inspect data.parquet --parquet-geo-metadata
+gpio inspect meta data.parquet --parquet-geo
 
 # JSON format
-gpio inspect data.parquet --parquet-geo-metadata --json
+gpio inspect meta data.parquet --parquet-geo --json
 ```
 
 This shows metadata from the Parquet specification for geospatial types:
@@ -211,7 +208,7 @@ This shows metadata from the Parquet specification for geospatial types:
 - Geospatial types (WKB integer codes)
 - Custom geospatial key-value metadata
 
-**Note:** This is different from `--geo-metadata` which shows GeoParquet metadata from the 'geo' key.
+**Note:** This is different from `--geo` which shows GeoParquet metadata from the 'geo' key.
 
 ## Bloom Filter Information
 
@@ -300,11 +297,14 @@ Returns layer names for files with 2+ layers. Single-layer files return nothing.
 ## JSON Output
 
 ```bash
-# Machine-readable output
+# Machine-readable summary
 gpio inspect data.parquet --json
 
 # Use with jq
 gpio inspect data.parquet --json | jq '.file_info.rows'
+
+# Metadata as JSON
+gpio inspect meta data.parquet --json
 ```
 
 ## Inspecting Partitioned Data
@@ -355,9 +355,6 @@ gpio inspect partitions/ --check-all --json
 # Markdown output for documentation
 gpio inspect partitions/ --check-all --markdown
 ```
-
-!!! note "Preview options not available with --check-all"
-    The `--head`, `--tail`, and `--stats` options cannot be combined with `--check-all` since they apply to individual files.
 
 ## See Also
 

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -73,15 +73,11 @@ uv tool install geoparquet-io --with gpio-pmtiles
 **Commands**:
 ```bash
 # Convert GeoParquet to PMTiles
-gpio pmtiles write input.parquet output.pmtiles
-
-# Convert PMTiles to GeoParquet
-gpio pmtiles read input.pmtiles output.parquet
+gpio pmtiles create input.parquet output.pmtiles
 ```
 
 **Use Cases**:
 - Generating tilesets from GeoParquet for web mapping
-- Converting PMTiles archives to GeoParquet for analysis
 - Building vector tile pipelines
 
 ## How Plugins Work


### PR DESCRIPTION
## Summary

Got some reports on errors on [linkedin](https://www.linkedin.com/feed/update/urn:li:ugcPost:7450553644611084290/?dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287452688068878397441%2Curn%3Ali%3AugcPost%3A7450553644611084290%29&dashReplyUrn=urn%3Ali%3Afsd_comment%3A%287452693337934917633%2Curn%3Ali%3AugcPost%3A7450553644611084290%29) so had claude fix those. And then also had claude scan for other divergences. It found stuff in benchmark and also in pmtiles.

- **inspect.md**: Updated all CLI examples from old flat-flag syntax (`gpio inspect data.parquet --head`, `--geo-metadata`, `--parquet-geo-metadata`) to current subcommand syntax (`gpio inspect head`, `gpio inspect meta --geo`, `gpio inspect meta --parquet-geo`). Added note that `gpio inspect` is a shortcut for `gpio inspect summary`.
- **benchmarks.md**: Fixed `gpio benchmark run` → `gpio benchmark compare` (the `run` subcommand doesn't exist)
- **convert.md**: Fixed `gpio benchmark input.geojson` → `gpio benchmark compare input.geojson`
- **plugins.md**: Fixed `gpio pmtiles write/read` → `gpio pmtiles create` (the only subcommand the plugin provides)

## Test plan

- [ ] Verify each CLI example in the changed docs runs without error
- [ ] Review rendered docs on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `gpio inspect` command structure—now features `summary` as default subcommand with `head` and `tail` options, plus reorganized `meta` subcommand with `--geo`, `--parquet`, and `--parquet-geo` flags.
  * Clarified `gpio benchmark` examples to use the `compare` subcommand.
  * Simplified `gpio pmtiles` plugin documentation to show `create` command only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->