### PR TITLE
feat(wfs): WFS 2.0 support, axis order fix, CRS validation

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -189,10 +189,11 @@ from geoparquet_io.api import Table
 table = Table.from_wfs(
     'https://geo.example.com/wfs',
     'cities',
-    version='1.1.0',      # WFS version (1.0.0 or 1.1.0)
+    version='auto',       # WFS version (auto, 2.0.0, 1.1.0, 1.0.0)
     bbox=(-122.5, 37.5, -122.0, 38.0),  # Optional filter
     limit=1000,           # Max features
     max_workers=2,        # Parallel requests
+    axis_order='auto',    # Bbox axis order (auto, xy, latlon)
 )
 ```
 
@@ -212,11 +213,13 @@ table = ops.from_wfs('https://geo.example.com/wfs', 'cities', limit=100)
 |-----------|------|-------------|
 | `service_url` | str | WFS service URL |
 | `typename` | str | Layer name to extract |
-| `version` | str | WFS version: `1.0.0` or `1.1.0` (default) |
+| `version` | str | WFS version: `auto` (default), `2.0.0`, `1.1.0`, `1.0.0`. Auto tries 2.0.0 first. |
 | `bbox` | tuple | Bounding box filter (xmin, ymin, xmax, ymax) |
 | `limit` | int | Maximum number of features |
 | `max_workers` | int | Number of parallel fetch workers (default: 1) |
 | `page_size` | int | Features per WFS request page (default: 10000) |
+| `axis_order` | str | Bbox axis order: `auto` (default), `xy`, `latlon`. Auto detects from CRS format. |
+| `strict_crs` | bool | Fail on CRS mismatch (default: False, warns instead) |
 
 !!! note "No automatic Hilbert sorting"
     Like other Python API extraction methods, `from_wfs()` does NOT apply Hilbert sorting by default. Chain `.sort_hilbert()` explicitly if needed.
@@ -1068,7 +1071,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.convert_to_flatgeobuf(table, output)` | Convert to FlatGeobuf |
 | `ops.convert_to_csv(table, output, include_wkt=True, include_bbox=True)` | Convert to CSV |
 | `ops.convert_to_shapefile(table, output, encoding='UTF-8', overwrite=False)` | Convert to Shapefile |
-| `ops.from_wfs(service_url, typename, version='1.1.0', bbox=None, limit=None, max_workers=1, page_size=10000)` | Fetch from WFS service |
+| `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=10000, axis_order='auto', strict_crs=False)` | Fetch from WFS service |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |
 | `ops.explain_analyze(file_path, query=None)` | DuckDB EXPLAIN ANALYZE query plan |

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1116,6 +1116,34 @@ gpio extract wfs https://geo.example.com/wfs cities output.parquet \
     --compression-level 6
 ```
 
+### WFS Version
+
+gpio supports WFS 1.0.0, 1.1.0, and 2.0.0. By default, auto-negotiation tries the newest version first:
+
+```bash
+# Auto-negotiate (default) - tries 2.0.0, then 1.1.0, then 1.0.0
+gpio extract wfs https://geo.example.com/wfs cities output.parquet
+
+# Force specific version
+gpio extract wfs https://geo.example.com/wfs cities output.parquet \
+    --wfs-version 1.1.0
+```
+
+### Axis Order
+
+WFS 1.1.0+ with URN-format CRS (e.g., `urn:ogc:def:crs:EPSG::4326`) uses lat,lon axis order per OGC spec. gpio auto-detects this, but you can override:
+
+```bash
+# Force lon,lat (XY) axis order
+gpio extract wfs https://geo.example.com/wfs cities output.parquet \
+    --bbox 4.82,50.44,4.92,50.48 \
+    --axis-order xy
+
+# Force lat,lon axis order
+gpio extract wfs https://geo.example.com/wfs cities output.parquet \
+    --axis-order latlon
+```
+
 ### CRS Handling
 
 gpio automatically negotiates the coordinate reference system with the WFS server:
@@ -1124,6 +1152,14 @@ gpio automatically negotiates the coordinate reference system with the WFS serve
 # Request specific CRS from server
 gpio extract wfs https://geo.example.com/wfs cities output.parquet \
     --output-crs EPSG:3857
+```
+
+Some servers ignore `srsName` and return data in their native CRS. gpio detects this and warns:
+
+```bash
+# Fail instead of warn on CRS mismatch
+gpio extract wfs https://geo.example.com/wfs cities output.parquet \
+    --strict-crs
 ```
 
 ### Common Public WFS Services

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -756,11 +756,13 @@ def from_arcgis(
 def from_wfs(
     service_url: str,
     typename: str,
-    version: str = "1.1.0",
+    version: str = "auto",
     bbox: tuple[float, float, float, float] | None = None,
     limit: int | None = None,
     max_workers: int = 1,
     page_size: int = 10000,
+    axis_order: str = "auto",
+    strict_crs: bool = False,
 ) -> pa.Table:
     """
     Fetch WFS layer as PyArrow Table.
@@ -771,11 +773,16 @@ def from_wfs(
     Args:
         service_url: WFS service URL
         typename: Feature type name (e.g., 'cities' or 'ns:cities')
-        version: WFS version (1.0.0 or 1.1.0)
+        version: WFS version ('auto', '2.0.0', '1.1.0', '1.0.0'). Default 'auto'
+            tries 2.0.0, then 1.1.0, then 1.0.0.
         bbox: Optional bounding box filter (xmin, ymin, xmax, ymax)
         limit: Maximum features to fetch
         max_workers: Parallel requests for large datasets (default: 1)
         page_size: Features per page when using parallel mode (default: 10000)
+        axis_order: Bbox axis order ('auto', 'xy', 'latlon'). 'auto' detects from
+            CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
+        strict_crs: If True, fail when server returns coordinates that don't match
+            requested CRS. If False (default), warn and use detected CRS.
 
     Returns:
         PyArrow Table with geometry column
@@ -785,6 +792,8 @@ def from_wfs(
         >>> table = ops.from_wfs('https://geo.example.com/wfs', 'cities', limit=100)
         >>> # For large datasets:
         >>> table = ops.from_wfs('https://geo.example.com/wfs', 'parcels', max_workers=4)
+        >>> # Force axis order for problematic servers:
+        >>> table = ops.from_wfs(url, layer, axis_order='latlon')
     """
     from geoparquet_io.core.wfs import wfs_to_table
 
@@ -796,6 +805,8 @@ def from_wfs(
         limit=limit,
         max_workers=max_workers,
         page_size=page_size,
+        axis_order=axis_order,
+        strict_crs=strict_crs,
     )
 
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -539,11 +539,13 @@ class Table:
         cls,
         service_url: str,
         typename: str,
-        version: str = "1.1.0",
+        version: str = "auto",
         bbox: tuple[float, float, float, float] | None = None,
         limit: int | None = None,
         max_workers: int = 1,
         page_size: int = 10000,
+        axis_order: str = "auto",
+        strict_crs: bool = False,
     ) -> Table:
         """
         Create Table from WFS layer.
@@ -554,11 +556,16 @@ class Table:
         Args:
             service_url: WFS service URL
             typename: Feature type name (e.g., 'cities' or 'ns:cities')
-            version: WFS version (1.0.0 or 1.1.0)
+            version: WFS version ('auto', '2.0.0', '1.1.0', '1.0.0'). Default 'auto'
+                tries 2.0.0, then 1.1.0, then 1.0.0.
             bbox: Optional bounding box filter (xmin, ymin, xmax, ymax)
             limit: Maximum features to fetch
             max_workers: Parallel requests for large datasets (default: 1)
             page_size: Features per page when using parallel mode (default: 10000)
+            axis_order: Bbox axis order ('auto', 'xy', 'latlon'). 'auto' detects from
+                CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
+            strict_crs: If True, fail when server returns coordinates that don't match
+                requested CRS. If False (default), warn and use detected CRS.
 
         Returns:
             Table for chaining operations
@@ -568,6 +575,8 @@ class Table:
             >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'cities').add_bbox().write('cities.parquet')
             >>> # For large datasets:
             >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'parcels', max_workers=4)
+            >>> # Force axis order for problematic servers:
+            >>> gpio.Table.from_wfs(url, layer, axis_order='latlon')
         """
         from geoparquet_io.core.wfs import wfs_to_table
 
@@ -579,6 +588,8 @@ class Table:
             limit=limit,
             max_workers=max_workers,
             page_size=page_size,
+            axis_order=axis_order,
+            strict_crs=strict_crs,
         )
         return cls(table)
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2756,17 +2756,52 @@ def extract_bigquery_cmd(
     )
 
 
+def _deprecated_version_callback(ctx, param, value):
+    """Callback to warn about deprecated --version flag."""
+    if value is not None:
+        import click
+
+        click.echo(
+            "Warning: --version is deprecated, use --wfs-version instead",
+            err=True,
+        )
+    return value
+
+
 @extract.command(name="wfs")
 @handle_geoparquet_errors
 @click.argument("service_url")
 @click.argument("typename", required=False)
 @click.argument("output_file", required=False, type=click.Path())
 @click.option(
-    "--version",
+    "--wfs-version",
     "wfs_version",
     default="1.1.0",
-    type=click.Choice(["1.0.0", "1.1.0"]),
-    help="WFS protocol version",
+    type=click.Choice(["auto", "2.0.0", "1.1.0", "1.0.0"]),
+    help="WFS protocol version. 'auto' tries 2.0.0, then 1.1.0, then 1.0.0. Default: 1.1.0",
+)
+@click.option(
+    "--version",
+    "deprecated_version",
+    type=click.Choice(["auto", "2.0.0", "1.1.0", "1.0.0"]),
+    hidden=True,
+    callback=_deprecated_version_callback,
+    expose_value=True,
+    is_eager=True,
+    help="Deprecated: use --wfs-version instead",
+)
+@click.option(
+    "--axis-order",
+    type=click.Choice(["auto", "xy", "latlon"]),
+    default="auto",
+    help="Bbox axis order. 'auto' (default) detects from CRS format. "
+    "'xy' forces lon,lat order. 'latlon' forces lat,lon order.",
+)
+@click.option(
+    "--strict-crs",
+    is_flag=True,
+    help="Fail if server returns coordinates that don't match requested CRS. "
+    "Without this flag, a warning is shown and detected CRS is used.",
 )
 @click.option(
     "--bbox",
@@ -2822,6 +2857,9 @@ def extract_wfs_cmd(
     typename,
     output_file,
     wfs_version,
+    deprecated_version,
+    axis_order,
+    strict_crs,
     bbox,
     bbox_mode,
     limit,
@@ -2879,12 +2917,22 @@ def extract_wfs_cmd(
         WFSError,
         convert_wfs_to_geoparquet,
         list_available_layers,
+        negotiate_wfs_version,
     )
+
+    # Handle deprecated --version flag
+    if deprecated_version is not None:
+        wfs_version = deprecated_version
 
     # If no typename, list available layers
     if typename is None:
         try:
-            layers = list_available_layers(service_url, version=wfs_version)
+            # Handle auto version negotiation for listing
+            if wfs_version == "auto":
+                negotiated_version, _ = negotiate_wfs_version(service_url)
+                layers = list_available_layers(service_url, version=negotiated_version)
+            else:
+                layers = list_available_layers(service_url, version=wfs_version)
         except WFSError as e:
             raise click.ClickException(str(e)) from None
 
@@ -2948,6 +2996,8 @@ def extract_wfs_cmd(
             limit=limit,
             max_workers=workers,
             page_size=page_size,
+            axis_order=axis_order,
+            strict_crs=strict_crs,
             skip_hilbert=skip_hilbert,
             skip_bbox=skip_bbox,
             compression=compression.upper(),

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -439,27 +439,44 @@ def _validate_crs_coordinates(
         finally:
             con.close()
 
-        # Check if coordinates look like WGS84 when WGS84 was requested
+        # Validate coordinates match requested CRS
         normalized_crs = _normalize_crs(requested_crs)
+        xmin, ymin, xmax, ymax = bbox
+        detected = _estimate_crs_from_bbox(bbox)
+
+        # Check for mismatch between requested and detected CRS
+        mismatch = False
         if normalized_crs == "EPSG:4326":
-            xmin, ymin, xmax, ymax = bbox
             # WGS84 coordinates should be in valid range
             if abs(xmin) > 180 or abs(xmax) > 180 or abs(ymin) > 90 or abs(ymax) > 90:
-                detected = _estimate_crs_from_bbox(bbox)
-                msg = (
-                    f"Coordinate mismatch: requested {requested_crs} but got bbox "
-                    f"[{xmin:.2f}, {ymin:.2f}, {xmax:.2f}, {ymax:.2f}]. "
-                )
-                if detected:
-                    msg += f"Coordinates look like {detected}. Server may have ignored srsName."
-                else:
-                    msg += "Server may have returned data in a different CRS."
+                mismatch = True
+        elif normalized_crs == "EPSG:3857":
+            # Web Mercator should have large meter values, not small degree values
+            if abs(xmin) < 1000 and abs(xmax) < 1000 and abs(ymin) < 1000 and abs(ymax) < 1000:
+                mismatch = True
+        elif normalized_crs == "EPSG:3035":
+            # LAEA Europe should be in specific range
+            if not (2_000_000 < xmin < 7_500_000 and 1_000_000 < ymin < 5_500_000):
+                mismatch = True
+        elif detected and detected != normalized_crs:
+            # Generic check: if we detected a CRS and it differs from requested
+            mismatch = True
 
-                if strict:
-                    raise WFSError(msg)
-                else:
-                    warn(msg)
-                    return False, detected
+        if mismatch:
+            msg = (
+                f"Coordinate mismatch: requested {requested_crs} but got bbox "
+                f"[{xmin:.2f}, {ymin:.2f}, {xmax:.2f}, {ymax:.2f}]. "
+            )
+            if detected:
+                msg += f"Coordinates look like {detected}. Server may have ignored srsName."
+            else:
+                msg += "Server may have returned data in a different CRS."
+
+            if strict:
+                raise WFSError(msg)
+            else:
+                warn(msg)
+                return False, detected
 
         return True, None
 
@@ -899,7 +916,7 @@ def _get_feature_count(
         "service": "WFS",
         "version": version,
         "request": "GetFeature",
-        "typeName" if version == "1.0.0" else "typeNames": typename,
+        "typeNames" if version == "2.0.0" else "typeName": typename,
         "resultType": "hits",
     }
 
@@ -1024,11 +1041,11 @@ def _build_wfs_url(
         "service": "WFS",
         "version": version,
         "request": "GetFeature",
-        "typeName" if version == "1.0.0" else "typeNames": typename,
+        "typeNames" if version == "2.0.0" else "typeName": typename,
         "outputFormat": "application/json",
     }
 
-    if max_features:
+    if max_features is not None:
         # WFS 2.0 uses count, WFS 1.x uses maxFeatures
         if version == "2.0.0":
             params["count"] = str(max_features)

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -2,7 +2,7 @@
 WFS (Web Feature Service) to GeoParquet conversion.
 
 This module provides functionality to download features from OGC WFS services
-and convert them to GeoParquet format. Supports WFS 1.0.0 and 1.1.0.
+and convert them to GeoParquet format. Supports WFS 1.0.0, 1.1.0, and 2.0.0.
 
 Key features:
 - DuckDB-native HTTP streaming for fast extraction (10x+ faster than Python HTTP)
@@ -26,10 +26,12 @@ import pyarrow as pa
 __all__ = [
     "WFSError",
     "WFSLayerInfo",
+    "WFS_VERSIONS",
     "convert_wfs_to_geoparquet",
     "get_layer_info",
     "get_wfs_capabilities",
     "list_available_layers",
+    "negotiate_wfs_version",
     "wfs_to_table",
 ]
 
@@ -271,6 +273,50 @@ def get_wfs_capabilities(service_url: str, version: str = "1.1.0"):
             raise WFSError(f"Failed to get WFS capabilities: {e}") from e
 
 
+# WFS versions in preference order (newest first)
+WFS_VERSIONS = ["2.0.0", "1.1.0", "1.0.0"]
+
+
+def negotiate_wfs_version(service_url: str, preferred_version: str = "auto"):
+    """
+    Negotiate the best WFS version to use with the server.
+
+    Args:
+        service_url: WFS service URL
+        preferred_version: "auto" to try all versions, or specific version
+
+    Returns:
+        Tuple of (negotiated_version, wfs_capabilities_object)
+
+    Raises:
+        WFSError: If no supported version works
+    """
+    if preferred_version != "auto":
+        # User specified version, use it directly
+        wfs = get_wfs_capabilities(service_url, preferred_version)
+        return preferred_version, wfs
+
+    # Auto-negotiate: try versions in preference order
+    errors = []
+    for version in WFS_VERSIONS:
+        try:
+            debug(f"Trying WFS version {version}...")
+            wfs = get_wfs_capabilities(service_url, version)
+            info(f"Using WFS version {version}")
+            return version, wfs
+        except WFSError as e:
+            errors.append(f"  {version}: {e}")
+            continue
+
+    # All versions failed
+    error_details = "\n".join(errors)
+    raise WFSError(
+        f"Could not connect to WFS service with any supported version.\n"
+        f"Tried: {', '.join(WFS_VERSIONS)}\n"
+        f"Errors:\n{error_details}"
+    )
+
+
 def _normalize_crs(crs: str) -> str:
     """
     Normalize CRS string to consistent EPSG format.
@@ -310,6 +356,118 @@ def _normalize_crs(crs: str) -> str:
 def _crs_matches(crs1: str, crs2: str) -> bool:
     """Check if two CRS strings represent the same coordinate system."""
     return _normalize_crs(crs1) == _normalize_crs(crs2)
+
+
+def _estimate_crs_from_bbox(
+    bbox: tuple[float, float, float, float],
+) -> str | None:
+    """
+    Estimate CRS from coordinate ranges (rough heuristic).
+
+    This is a best-effort detection for common mismatches.
+    Returns None if unable to determine.
+
+    Args:
+        bbox: (xmin, ymin, xmax, ymax)
+
+    Returns:
+        Estimated EPSG code or None
+    """
+    xmin, ymin, xmax, ymax = bbox
+
+    # WGS84 / EPSG:4326: lon in [-180, 180], lat in [-90, 90]
+    if -180 <= xmin <= 180 and -180 <= xmax <= 180 and -90 <= ymin <= 90 and -90 <= ymax <= 90:
+        return "EPSG:4326"
+
+    # ETRS89-LAEA / EPSG:3035: European extent roughly 2M-7M x 1M-5.5M
+    # Check this BEFORE Web Mercator since it's more specific
+    if 2_000_000 < xmin < 7_500_000 and 2_000_000 < xmax < 7_500_000:
+        if 1_000_000 < ymin < 5_500_000 and 1_000_000 < ymax < 5_500_000:
+            return "EPSG:3035"
+
+    # Web Mercator / EPSG:3857: typically ±20M meters, centered at 0,0
+    # Uses wider ranges than EPSG:3035
+    if abs(xmin) > 1_000_000 or abs(xmax) > 1_000_000:
+        if abs(xmin) < 21_000_000 and abs(xmax) < 21_000_000:
+            if abs(ymin) < 21_000_000 and abs(ymax) < 21_000_000:
+                return "EPSG:3857"
+
+    return None
+
+
+def _validate_crs_coordinates(
+    table: pa.Table,
+    requested_crs: str,
+    strict: bool = False,
+) -> tuple[bool, str | None]:
+    """
+    Validate that table coordinates match the requested CRS.
+
+    Computes bbox from geometries and checks if coordinates are in expected range.
+
+    Args:
+        table: PyArrow table with geometry column
+        requested_crs: CRS that was requested from WFS
+        strict: If True, raise error on mismatch; if False, warn and return detected CRS
+
+    Returns:
+        Tuple of (is_valid, detected_crs_if_mismatch)
+    """
+    if table.num_rows == 0:
+        return True, None
+
+    try:
+        # Extract bbox from geometry column using DuckDB
+        # Geometry is stored as WKB, so we need ST_GeomFromWKB to convert
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            con.register("data", table)
+            result = con.execute("""
+                SELECT
+                    MIN(ST_XMin(ST_GeomFromWKB(geometry))) as xmin,
+                    MIN(ST_YMin(ST_GeomFromWKB(geometry))) as ymin,
+                    MAX(ST_XMax(ST_GeomFromWKB(geometry))) as xmax,
+                    MAX(ST_YMax(ST_GeomFromWKB(geometry))) as ymax
+                FROM data
+                WHERE geometry IS NOT NULL
+            """).fetchone()
+
+            if result is None or result[0] is None:
+                return True, None
+
+            bbox = (result[0], result[1], result[2], result[3])
+        finally:
+            con.close()
+
+        # Check if coordinates look like WGS84 when WGS84 was requested
+        normalized_crs = _normalize_crs(requested_crs)
+        if normalized_crs == "EPSG:4326":
+            xmin, ymin, xmax, ymax = bbox
+            # WGS84 coordinates should be in valid range
+            if abs(xmin) > 180 or abs(xmax) > 180 or abs(ymin) > 90 or abs(ymax) > 90:
+                detected = _estimate_crs_from_bbox(bbox)
+                msg = (
+                    f"Coordinate mismatch: requested {requested_crs} but got bbox "
+                    f"[{xmin:.2f}, {ymin:.2f}, {xmax:.2f}, {ymax:.2f}]. "
+                )
+                if detected:
+                    msg += f"Coordinates look like {detected}. Server may have ignored srsName."
+                else:
+                    msg += "Server may have returned data in a different CRS."
+
+                if strict:
+                    raise WFSError(msg)
+                else:
+                    warn(msg)
+                    return False, detected
+
+        return True, None
+
+    except WFSError:
+        raise
+    except Exception as e:
+        debug(f"CRS validation skipped due to error: {e}")
+        return True, None
 
 
 def _detect_geometry_column(wfs, typename: str) -> str:
@@ -571,31 +729,98 @@ def _determine_bbox_strategy(
     return True
 
 
+def _is_urn_crs(crs: str) -> bool:
+    """Check if CRS string is in URN format (urn:ogc:def:crs:EPSG::4326)."""
+    return crs.lower().startswith("urn:")
+
+
+def _is_geographic_crs(crs: str) -> bool:
+    """Check if CRS is a geographic coordinate system (lat/lon, not projected)."""
+    normalized = _normalize_crs(crs)
+    # Common geographic CRS codes
+    geographic_codes = {
+        "EPSG:4326",  # WGS84
+        "EPSG:4269",  # NAD83
+        "EPSG:4267",  # NAD27
+        "EPSG:4258",  # ETRS89
+    }
+    return normalized in geographic_codes or "CRS84" in crs.upper()
+
+
+def _needs_axis_swap(crs: str, version: str, axis_order: str = "auto") -> bool:
+    """
+    Determine if bbox coordinates need axis order swap (lat,lon instead of lon,lat).
+
+    Per OGC spec:
+    - WFS 1.0.0: Always lon,lat (XY)
+    - WFS 1.1.0+: Depends on CRS definition
+      - EPSG:4326 (simple): lon,lat (common practice, though spec says lat,lon)
+      - urn:ogc:def:crs:EPSG::4326: lat,lon per spec (YX)
+      - CRS:84: Always lon,lat (XY) by definition
+
+    Args:
+        crs: Coordinate reference system string
+        version: WFS version
+        axis_order: "auto" (detect), "xy" (force lon,lat), "latlon" (force lat,lon)
+
+    Returns:
+        True if bbox needs to be swapped to lat,lon order
+    """
+    if axis_order == "xy":
+        return False
+    if axis_order == "latlon":
+        return True
+
+    # WFS 1.0.0 always uses XY order
+    if version == "1.0.0":
+        return False
+
+    # CRS:84 is explicitly XY ordered
+    if "CRS84" in crs.upper() or "CRS:84" in crs.upper():
+        return False
+
+    # For WFS 1.1.0+: URN format with geographic CRS uses lat,lon
+    if _is_urn_crs(crs) and _is_geographic_crs(crs):
+        return True
+
+    return False
+
+
 def _build_bbox_param(
     bbox: tuple[float, float, float, float],
     crs: str,
     version: str = "1.1.0",
+    axis_order: str = "auto",
 ) -> str:
     """
-    Build WFS bbox parameter string.
+    Build WFS bbox parameter string with correct axis order.
 
-    WFS 1.0.0: xmin,ymin,xmax,ymax
-    WFS 1.1.0: xmin,ymin,xmax,ymax,crs
+    WFS 1.0.0: xmin,ymin,xmax,ymax (always XY)
+    WFS 1.1.0+: Axis order depends on CRS format
+      - EPSG:4326 (simple): xmin,ymin,xmax,ymax,crs
+      - urn:ogc:def:crs:EPSG::4326: ymin,xmin,ymax,xmax,crs (lat,lon per spec)
 
     Args:
-        bbox: Bounding box tuple (xmin, ymin, xmax, ymax)
+        bbox: Bounding box tuple (xmin, ymin, xmax, ymax) in lon,lat order
         crs: Coordinate reference system
         version: WFS version
+        axis_order: "auto" (detect from CRS), "xy" (force lon,lat), "latlon" (force lat,lon)
 
     Returns:
-        Bbox parameter string
+        Bbox parameter string with correct axis order for the CRS
     """
     xmin, ymin, xmax, ymax = bbox
 
     if version == "1.0.0":
         return f"{xmin},{ymin},{xmax},{ymax}"
+
+    # Check if we need to swap axis order for this CRS
+    if _needs_axis_swap(crs, version, axis_order):
+        # Swap to lat,lon order (ymin,xmin,ymax,xmax)
+        debug(f"Using lat,lon axis order for URN CRS: {crs}")
+        return f"{ymin},{xmin},{ymax},{xmax},{crs}"
     else:
-        # WFS 1.1.0+ includes CRS
+        # Standard lon,lat order (xmin,ymin,xmax,ymax)
         return f"{xmin},{ymin},{xmax},{ymax},{crs}"
 
 
@@ -788,6 +1013,7 @@ def _build_wfs_url(
     start_index: int | None = None,
     bbox: tuple[float, float, float, float] | None = None,
     crs: str | None = None,
+    axis_order: str = "auto",
 ) -> str:
     """Build a WFS GetFeature URL with pagination support."""
     from urllib.parse import urlencode
@@ -803,14 +1029,17 @@ def _build_wfs_url(
     }
 
     if max_features:
-        # WFS 1.0.0 uses maxFeatures, WFS 1.1.0+ uses count (but maxFeatures often works)
-        params["maxFeatures"] = str(max_features)
+        # WFS 2.0 uses count, WFS 1.x uses maxFeatures
+        if version == "2.0.0":
+            params["count"] = str(max_features)
+        else:
+            params["maxFeatures"] = str(max_features)
 
     if start_index is not None and start_index > 0 and version != "1.0.0":
         params["startIndex"] = str(start_index)
 
     if bbox and crs:
-        params["bbox"] = _build_bbox_param(bbox, crs, version)
+        params["bbox"] = _build_bbox_param(bbox, crs, version, axis_order)
 
     return f"{clean_url}?{urlencode(params)}"
 
@@ -824,6 +1053,7 @@ def fetch_all_features_duckdb(
     crs: str | None = None,
     max_workers: int = 1,
     page_size: int = 10000,
+    axis_order: str = "auto",
 ) -> pa.Table:
     """
     Fetch WFS features using DuckDB's native HTTP streaming.
@@ -842,6 +1072,7 @@ def fetch_all_features_duckdb(
         crs: CRS for bbox parameter
         max_workers: Number of parallel requests (1 = single streaming request)
         page_size: Features per page when using parallel mode (default: 10000)
+        axis_order: Bbox axis order ("auto", "xy", "latlon")
 
     Returns:
         PyArrow Table with geometry (WKB) and all properties
@@ -861,7 +1092,13 @@ def fetch_all_features_duckdb(
             progress("Streaming features via DuckDB...")
 
         url = _build_wfs_url(
-            service_url, typename, version, max_features=max_features, bbox=bbox, crs=crs
+            service_url,
+            typename,
+            version,
+            max_features=max_features,
+            bbox=bbox,
+            crs=crs,
+            axis_order=axis_order,
         )
         return _fetch_wfs_page_duckdb(url)
 
@@ -869,7 +1106,13 @@ def fetch_all_features_duckdb(
     if total_count is None:
         warn("Cannot determine feature count; falling back to single request mode.")
         url = _build_wfs_url(
-            service_url, typename, version, max_features=max_features, bbox=bbox, crs=crs
+            service_url,
+            typename,
+            version,
+            max_features=max_features,
+            bbox=bbox,
+            crs=crs,
+            axis_order=axis_order,
         )
         return _fetch_wfs_page_duckdb(url)
 
@@ -898,6 +1141,7 @@ def fetch_all_features_duckdb(
             start_index=start,
             bbox=bbox,
             crs=crs,
+            axis_order=axis_order,
         )
         pages.append((i, start, url))
 
@@ -939,6 +1183,8 @@ def wfs_to_table(
     limit: int | None = None,
     max_workers: int = 1,
     page_size: int = 10000,
+    axis_order: str = "auto",
+    strict_crs: bool = False,
     verbose: bool = False,
 ) -> pa.Table:
     """
@@ -955,19 +1201,25 @@ def wfs_to_table(
     Args:
         service_url: WFS service URL
         typename: Layer typename
-        version: WFS version (1.0.0 or 1.1.0)
+        version: WFS version (1.0.0, 1.1.0, or 2.0.0)
         bbox: Bounding box filter (xmin, ymin, xmax, ymax)
         bbox_mode: Bbox strategy ("auto", "server", "local")
         output_crs: Request specific CRS (e.g., "EPSG:4326")
         limit: Maximum features to fetch
         max_workers: Parallel requests for large datasets (default: 1 = single request)
         page_size: Features per page when using parallel mode (default: 10000)
+        axis_order: Bbox axis order ("auto", "xy", "latlon")
+        strict_crs: If True, fail on CRS mismatch; if False, warn and use detected CRS
         verbose: Enable debug output
 
     Returns:
         PyArrow Table with GeoParquet-compatible geometry
     """
     configure_verbose(verbose)
+
+    # Handle auto version negotiation
+    if version == "auto":
+        version, _ = negotiate_wfs_version(service_url)
 
     # Get layer info
     info("Connecting to WFS service...")
@@ -1002,6 +1254,7 @@ def wfs_to_table(
         crs=crs,
         max_workers=max_workers,
         page_size=page_size,
+        axis_order=axis_order,
     )
 
     if table.num_rows == 0:
@@ -1027,6 +1280,13 @@ def wfs_to_table(
             debug(f"After local filter: {table.num_rows:,} features")
         finally:
             con.close()
+
+    # Validate CRS - check if coordinates match requested CRS
+    crs_valid, detected_crs = _validate_crs_coordinates(table, crs, strict=strict_crs)
+    if not crs_valid and detected_crs:
+        # Server returned data in different CRS - use detected CRS for metadata
+        info(f"Using detected CRS {detected_crs} for output metadata")
+        crs = detected_crs
 
     # Add CRS metadata to schema
     projjson = parse_crs_string_to_projjson(_normalize_crs(crs))
@@ -1060,6 +1320,8 @@ def convert_wfs_to_geoparquet(
     limit: int | None = None,
     max_workers: int = 1,
     page_size: int = 10000,
+    axis_order: str = "auto",
+    strict_crs: bool = False,
     skip_hilbert: bool = False,
     skip_bbox: bool = False,
     compression: str = "ZSTD",
@@ -1084,6 +1346,8 @@ def convert_wfs_to_geoparquet(
         limit: Maximum features
         max_workers: Parallel requests for large datasets (default: 1)
         page_size: Features per page when using parallel mode (default: 10000)
+        axis_order: Bbox axis order ("auto", "xy", "latlon")
+        strict_crs: If True, fail on CRS mismatch
         skip_hilbert: Skip Hilbert curve sorting
         skip_bbox: Skip adding bbox column
         compression: Compression algorithm
@@ -1112,6 +1376,8 @@ def convert_wfs_to_geoparquet(
         limit=limit,
         max_workers=max_workers,
         page_size=page_size,
+        axis_order=axis_order,
+        strict_crs=strict_crs,
         verbose=verbose,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,7 +271,7 @@ verbose = false
 
 [tool.codespell]
 skip = ".git,*.lock,*.parquet,*.json,tests/data/*,.venv,uv.lock"
-ignore-words-list = "nd,ot,crs,inout"
+ignore-words-list = "nd,ot,crs,inout,hel"
 check-filenames = true
 
 [tool.coverage.run]

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1145,3 +1145,322 @@ class TestDuckDBNativeWFS:
 
         geom_type = table.schema.field("geometry").type
         assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type)
+
+
+# =============================================================================
+# Axis Order Tests (Issue #397)
+# =============================================================================
+
+
+class TestAxisOrder:
+    """Test axis order detection and bbox parameter building.
+
+    WFS 1.1.0+ with URN format CRS uses lat,lon (YX) axis order per OGC spec,
+    while simple EPSG:4326 format uses lon,lat (XY).
+    """
+
+    def test_is_urn_crs_detects_urn_format(self):
+        """Should correctly identify URN format CRS strings."""
+        from geoparquet_io.core.wfs import _is_urn_crs
+
+        assert _is_urn_crs("urn:ogc:def:crs:EPSG::4326") is True
+        assert _is_urn_crs("urn:x-ogc:def:crs:EPSG::4326") is True
+        assert _is_urn_crs("URN:OGC:DEF:CRS:EPSG::3857") is True
+        assert _is_urn_crs("EPSG:4326") is False
+        assert _is_urn_crs("http://www.opengis.net/def/crs/EPSG/0/4326") is False
+
+    def test_is_geographic_crs_detects_geographic_systems(self):
+        """Should correctly identify geographic (lat/lon) CRS."""
+        from geoparquet_io.core.wfs import _is_geographic_crs
+
+        assert _is_geographic_crs("EPSG:4326") is True
+        assert _is_geographic_crs("urn:ogc:def:crs:EPSG::4326") is True
+        assert _is_geographic_crs("EPSG:4269") is True  # NAD83
+        assert _is_geographic_crs("CRS:84") is True
+        assert _is_geographic_crs("EPSG:3857") is False  # Web Mercator (projected)
+        assert _is_geographic_crs("EPSG:3035") is False  # LAEA (projected)
+
+    @pytest.mark.parametrize(
+        "crs,version,axis_order,expected_swap",
+        [
+            # WFS 1.0.0 always uses XY
+            ("EPSG:4326", "1.0.0", "auto", False),
+            ("urn:ogc:def:crs:EPSG::4326", "1.0.0", "auto", False),
+            # WFS 1.1.0+ with simple EPSG format uses XY
+            ("EPSG:4326", "1.1.0", "auto", False),
+            ("EPSG:4326", "2.0.0", "auto", False),
+            # WFS 1.1.0+ with URN format uses YX (lat,lon)
+            ("urn:ogc:def:crs:EPSG::4326", "1.1.0", "auto", True),
+            ("urn:ogc:def:crs:EPSG::4326", "2.0.0", "auto", True),
+            ("urn:x-ogc:def:crs:EPSG::4326", "1.1.0", "auto", True),
+            # CRS:84 is always XY by definition
+            ("CRS:84", "1.1.0", "auto", False),
+            ("urn:ogc:def:crs:OGC:1.3:CRS84", "2.0.0", "auto", False),
+            # Projected CRS never swaps
+            ("urn:ogc:def:crs:EPSG::3857", "1.1.0", "auto", False),
+            # Forced axis order overrides auto-detection
+            ("urn:ogc:def:crs:EPSG::4326", "1.1.0", "xy", False),
+            ("EPSG:4326", "1.1.0", "latlon", True),
+        ],
+    )
+    def test_needs_axis_swap(self, crs, version, axis_order, expected_swap):
+        """Axis swap decision based on CRS format, version, and override."""
+        from geoparquet_io.core.wfs import _needs_axis_swap
+
+        result = _needs_axis_swap(crs, version, axis_order)
+        assert result is expected_swap
+
+    @pytest.mark.parametrize(
+        "bbox,crs,version,axis_order,expected",
+        [
+            # WFS 1.0.0: no CRS suffix
+            ((-122.5, 37.5, -122.0, 38.0), "EPSG:4326", "1.0.0", "auto", "-122.5,37.5,-122.0,38.0"),
+            # WFS 1.1.0 with simple CRS: XY order with CRS suffix
+            (
+                (-122.5, 37.5, -122.0, 38.0),
+                "EPSG:4326",
+                "1.1.0",
+                "auto",
+                "-122.5,37.5,-122.0,38.0,EPSG:4326",
+            ),
+            # WFS 1.1.0 with URN CRS: YX order (lat,lon) with CRS suffix
+            (
+                (-122.5, 37.5, -122.0, 38.0),
+                "urn:ogc:def:crs:EPSG::4326",
+                "1.1.0",
+                "auto",
+                "37.5,-122.5,38.0,-122.0,urn:ogc:def:crs:EPSG::4326",
+            ),
+            # WFS 2.0.0 with URN CRS: YX order
+            (
+                (4.82, 50.44, 4.92, 50.48),
+                "urn:ogc:def:crs:EPSG::4326",
+                "2.0.0",
+                "auto",
+                "50.44,4.82,50.48,4.92,urn:ogc:def:crs:EPSG::4326",
+            ),
+            # Forced XY order ignores URN format
+            (
+                (-122.5, 37.5, -122.0, 38.0),
+                "urn:ogc:def:crs:EPSG::4326",
+                "1.1.0",
+                "xy",
+                "-122.5,37.5,-122.0,38.0,urn:ogc:def:crs:EPSG::4326",
+            ),
+        ],
+    )
+    def test_build_bbox_param_axis_order(self, bbox, crs, version, axis_order, expected):
+        """Bbox parameter string should have correct axis order."""
+        from geoparquet_io.core.wfs import _build_bbox_param
+
+        result = _build_bbox_param(bbox, crs, version, axis_order)
+        assert result == expected
+
+
+# =============================================================================
+# Version Negotiation Tests (Issue #312)
+# =============================================================================
+
+
+class TestVersionNegotiation:
+    """Test WFS version negotiation and WFS 2.0 support."""
+
+    def test_wfs_versions_list(self):
+        """WFS_VERSIONS should be in preference order (newest first)."""
+        from geoparquet_io.core.wfs import WFS_VERSIONS
+
+        assert WFS_VERSIONS == ["2.0.0", "1.1.0", "1.0.0"]
+
+    def test_build_wfs_url_uses_count_for_wfs_2(self):
+        """WFS 2.0 should use 'count' parameter instead of 'maxFeatures'."""
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs",
+            "test:layer",
+            version="2.0.0",
+            max_features=100,
+        )
+        assert "count=100" in url
+        assert "maxFeatures" not in url
+
+    def test_build_wfs_url_uses_maxfeatures_for_wfs_1(self):
+        """WFS 1.x should use 'maxFeatures' parameter."""
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs",
+            "test:layer",
+            version="1.1.0",
+            max_features=100,
+        )
+        assert "maxFeatures=100" in url
+        assert "count=" not in url
+
+    def test_build_wfs_url_uses_typenames_for_wfs_11_plus(self):
+        """WFS 1.1.0+ should use 'typeNames' (plural)."""
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        for version in ["1.1.0", "2.0.0"]:
+            url = _build_wfs_url(
+                "https://example.com/wfs",
+                "test:layer",
+                version=version,
+            )
+            assert "typeNames=test%3Alayer" in url or "typeNames=test:layer" in url
+
+    def test_build_wfs_url_uses_typename_for_wfs_10(self):
+        """WFS 1.0.0 should use 'typeName' (singular)."""
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs",
+            "test:layer",
+            version="1.0.0",
+        )
+        assert "typeName=test" in url
+        assert "typeNames=" not in url
+
+
+# =============================================================================
+# CRS Validation Tests (Issue #398)
+# =============================================================================
+
+
+class TestCRSValidation:
+    """Test CRS coordinate validation and mismatch detection."""
+
+    def test_estimate_crs_from_bbox_detects_wgs84(self):
+        """Should detect WGS84 coordinates."""
+        from geoparquet_io.core.wfs import _estimate_crs_from_bbox
+
+        # Valid WGS84 bbox
+        assert _estimate_crs_from_bbox((-122.5, 37.5, -122.0, 38.0)) == "EPSG:4326"
+        assert _estimate_crs_from_bbox((-180, -90, 180, 90)) == "EPSG:4326"
+        assert _estimate_crs_from_bbox((4.82, 50.44, 4.92, 50.48)) == "EPSG:4326"
+
+    def test_estimate_crs_from_bbox_detects_laea_europe(self):
+        """Should detect EPSG:3035 (LAEA Europe) coordinates."""
+        from geoparquet_io.core.wfs import _estimate_crs_from_bbox
+
+        # Typical EPSG:3035 bbox (Belgian buildings in meters)
+        bbox = (3817324.31, 2942224.42, 4063861.36, 3100245.97)
+        assert _estimate_crs_from_bbox(bbox) == "EPSG:3035"
+
+    def test_estimate_crs_from_bbox_detects_web_mercator(self):
+        """Should detect EPSG:3857 (Web Mercator) coordinates."""
+        from geoparquet_io.core.wfs import _estimate_crs_from_bbox
+
+        # Web Mercator coordinates (world extent)
+        bbox = (-20037508.34, -20037508.34, 20037508.34, 20037508.34)
+        assert _estimate_crs_from_bbox(bbox) == "EPSG:3857"
+
+    def test_validate_crs_coordinates_passes_for_valid_wgs84(self):
+        """Should pass when coordinates match requested WGS84 CRS."""
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.wfs import _validate_crs_coordinates
+
+        # Create a table with valid WGS84 geometry
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            result = con.execute("""
+                SELECT ST_AsWKB(ST_Point(-122.4, 37.8)) as geometry
+            """).arrow()
+            table = result.read_all()
+        finally:
+            con.close()
+
+        is_valid, detected = _validate_crs_coordinates(table, "EPSG:4326")
+        assert is_valid is True
+        assert detected is None
+
+    def test_validate_crs_coordinates_detects_mismatch(self):
+        """Should detect when coordinates don't match requested CRS."""
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.wfs import _validate_crs_coordinates
+
+        # Create a table with EPSG:3035 coordinates (not WGS84)
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            result = con.execute("""
+                SELECT ST_AsWKB(ST_Point(3900000, 3000000)) as geometry
+            """).arrow()
+            table = result.read_all()
+        finally:
+            con.close()
+
+        # Request WGS84 but coordinates are clearly projected
+        is_valid, detected = _validate_crs_coordinates(table, "EPSG:4326", strict=False)
+        assert is_valid is False
+        assert detected == "EPSG:3035"
+
+    def test_validate_crs_coordinates_raises_on_strict_mismatch(self):
+        """Should raise error in strict mode when CRS doesn't match."""
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.wfs import WFSError, _validate_crs_coordinates
+
+        # Create a table with projected coordinates
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            result = con.execute("""
+                SELECT ST_AsWKB(ST_Point(3900000, 3000000)) as geometry
+            """).arrow()
+            table = result.read_all()
+        finally:
+            con.close()
+
+        with pytest.raises(WFSError, match="Coordinate mismatch"):
+            _validate_crs_coordinates(table, "EPSG:4326", strict=True)
+
+    def test_validate_crs_coordinates_skips_empty_table(self):
+        """Should pass for empty tables without checking."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _validate_crs_coordinates
+
+        # Empty table
+        table = pa.table({"geometry": pa.array([], type=pa.binary())})
+
+        is_valid, detected = _validate_crs_coordinates(table, "EPSG:4326")
+        assert is_valid is True
+        assert detected is None
+
+
+# =============================================================================
+# Integration Tests for WFS 2.0 (Issue #312)
+# =============================================================================
+
+
+@pytest.mark.network
+@pytest.mark.slow
+class TestWFS20Integration:
+    """Integration tests against real WFS 2.0 servers.
+
+    Uses Helsinki WFS (kartta.hel.fi) which reliably supports WFS 2.0.0.
+    """
+
+    HELSINKI_WFS = "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"
+    HELSINKI_LAYER = "avoindata:Ajoneuvoliikenne_liikennemaarat_viiva"
+
+    @pytest.mark.xfail(reason="External WFS service may be unavailable")
+    def test_version_negotiation_finds_wfs_2(self):
+        """Auto negotiation should find WFS 2.0.0 when available."""
+        from geoparquet_io.core.wfs import negotiate_wfs_version
+
+        version, wfs = negotiate_wfs_version(self.HELSINKI_WFS)
+        assert version in ["2.0.0", "1.1.0", "1.0.0"]
+
+    @pytest.mark.xfail(reason="External WFS service may be unavailable")
+    def test_extract_with_wfs_2_version(self):
+        """Should successfully extract features using WFS 2.0.0."""
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        table = wfs_to_table(
+            self.HELSINKI_WFS,
+            self.HELSINKI_LAYER,
+            version="2.0.0",
+            limit=10,
+        )
+
+        assert table.num_rows <= 10
+        assert "geometry" in table.column_names

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1297,17 +1297,29 @@ class TestVersionNegotiation:
         assert "maxFeatures=100" in url
         assert "count=" not in url
 
-    def test_build_wfs_url_uses_typenames_for_wfs_11_plus(self):
-        """WFS 1.1.0+ should use 'typeNames' (plural)."""
+    def test_build_wfs_url_uses_typenames_for_wfs_20(self):
+        """WFS 2.0.0 should use 'typeNames' (plural)."""
         from geoparquet_io.core.wfs import _build_wfs_url
 
-        for version in ["1.1.0", "2.0.0"]:
-            url = _build_wfs_url(
-                "https://example.com/wfs",
-                "test:layer",
-                version=version,
-            )
-            assert "typeNames=test%3Alayer" in url or "typeNames=test:layer" in url
+        url = _build_wfs_url(
+            "https://example.com/wfs",
+            "test:layer",
+            version="2.0.0",
+        )
+        assert "typeNames=test%3Alayer" in url or "typeNames=test:layer" in url
+        assert "typeName=" not in url
+
+    def test_build_wfs_url_uses_typename_for_wfs_11(self):
+        """WFS 1.1.0 should use 'typeName' (singular) per OGC spec."""
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs",
+            "test:layer",
+            version="1.1.0",
+        )
+        assert "typeName=test%3Alayer" in url or "typeName=test:layer" in url
+        assert "typeNames=" not in url
 
     def test_build_wfs_url_uses_typename_for_wfs_10(self):
         """WFS 1.0.0 should use 'typeName' (singular)."""
@@ -1431,6 +1443,7 @@ class TestCRSValidation:
 # =============================================================================
 
 
+@pytest.mark.integration
 @pytest.mark.network
 @pytest.mark.slow
 class TestWFS20Integration:


### PR DESCRIPTION
## Summary
- **WFS 2.0 Support** (#312): Version negotiation, `count` pagination param
- **Axis Order Fix** (#397): Auto-detect lat,lon order for URN CRS in WFS 1.1.0+
- **CRS Validation** (#398): Detect and warn when server ignores `srsName`

Fixes #312, #397, #398

## Changes

### Core (`geoparquet_io/core/wfs.py`)
- `negotiate_wfs_version()`: Auto-negotiate best WFS version
- `_needs_axis_swap()`: Detect axis order from CRS format + version
- `_build_bbox_param()`: Handle lat,lon ordering for URN CRS
- `_validate_crs_coordinates()`: Check if response coords match requested CRS
- `_estimate_crs_from_bbox()`: Estimate CRS from coordinate ranges
- Updated pagination: `count` for WFS 2.0, `maxFeatures` for 1.x

### CLI (`geoparquet_io/cli/main.py`)
- `--wfs-version auto|2.0.0|1.1.0|1.0.0` (deprecates `--version`)
- `--axis-order auto|xy|latlon` for manual override
- `--strict-crs` flag to fail on CRS mismatch

### Tests (`tests/test_wfs.py`)
- 31 new unit tests for axis order, version negotiation, CRS validation
- Integration tests for WFS 2.0 against Helsinki WFS

## Test plan
- [x] All 91 WFS tests pass
- [x] New axis order tests verify correct bbox parameter format
- [x] CRS validation tests verify mismatch detection
- [x] CLI help shows new flags correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WFS 2.0.0 support now available with automatic version negotiation
  * New `--wfs-version` flag for WFS extraction (includes `auto` mode for automatic detection)
  * Added `axis_order` and `strict_crs` parameters for improved bbox coordinate handling

* **Improvements**
  * Enhanced CRS coordinate validation with automatic mismatch detection

* **Tests**
  * Expanded WFS test coverage for version negotiation and CRS handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->