### PR TITLE
fix: add wkb conversion to read partition

### DIFF
--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -213,7 +213,10 @@ def read_partition(
         >>> table = gpio.read_partition('partitioned_output/')
         >>> table = gpio.read_partition('data/quadkey=*/*.parquet')
     """
-    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.duckdb_utils import (
+        _wrap_query_with_wkb_conversion,
+        get_duckdb_connection,
+    )
     from geoparquet_io.core.partition.reader import build_read_parquet_expr
     from geoparquet_io.core.remote import needs_httpfs
     from geoparquet_io.core.streaming import find_geometry_column_from_table
@@ -227,7 +230,12 @@ def read_partition(
 
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(path_str))
     try:
-        arrow_table = con.execute(f"SELECT * FROM {expr}").arrow().read_all()
+        query = f"SELECT * FROM {expr}"
+        for row in con.execute(f"DESCRIBE ({query})").fetchall():
+            if row[1] and row[1].upper() == "GEOMETRY":
+                query = _wrap_query_with_wkb_conversion(query, row[0], con=con)
+
+        arrow_table = con.execute(query).arrow().read_all()
     finally:
         con.close()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -673,6 +673,15 @@ class TestReadPartition:
         assert table.num_rows > 0
         assert table.geometry_column == "geometry"
 
+    def test_read_partition_then_sort_hilbert(self, partition_dir):
+        """Test reading a partitioned directory and then sorting it by Hilbert curve."""
+        from geoparquet_io import read_partition
+
+        sorted_table = read_partition(partition_dir).sort_hilbert()
+        assert sorted_table.num_rows > 0
+        assert sorted_table.geometry_column == "geometry"
+        assert sorted_table.check_spatial().passed()
+
 
 class TestTableHeadTail:
     """Tests for head() and tail() methods."""


### PR DESCRIPTION
## Description
In `read_partition` DuckDB converts GeoParquet WKB columns to native GEOMETRY type. Exporting directly via ``.arrow()`` serializes DuckDB's geometry format (not standard WKB), so downstream ``ST_GeomFromWKB`` calls fail with "WKB type 'UNKNOWN' is not supported". This PR checks if there is GEOMETRY type in the DuckDB schema and if yes casts GEOMETRY columns back to WKB via `_wrap_query_with_wkb_conversion` helper before returning the Table.

This bug was encountered when trying to read a partition and then apply Hilbert sort:
```
gpio.read_partition('s3://bucket/data/year=2026/month=02/day=*/*.parquet').sort_hilbert()
```
Resulting in this error:
```
Error: Could not parse WKB input:WKB type 'UNKNOWN' is not supported! (type id: 0, SRID: 0)
(You can use TRY_CAST instead to replace unsupported geometries with NULL)
```

## Breaking Changes
No

## Related Issue(s)
- #

## Checklist
- [x] Tests added/updated
- [x] All tests pass (`uv run pytest`)
- [ ] Documentation updated (README, guides, CLI reference)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of geometry columns when reading partitioned GeoParquet datasets so spatial columns are correctly converted on read.

* **Tests**
  * Added an end-to-end test ensuring partitioned reads followed by a Hilbert-curve sort preserve row counts, geometry column presence, and spatial validity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->