### PR TITLE
fix(inspect): show geo_bbox stats in row group tables and --geo-stats

### DIFF
--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2027,8 +2027,8 @@ def inspect_stats(parquet_file, json_output, markdown_output, verbose):
     "--row-groups",
     "meta_row_groups",
     type=int,
-    default=1,
-    help="Number of row groups to display (default: 1)",
+    default=None,
+    help="Number of row groups to display (default: 1, or all with --geo-stats)",
 )
 @click.option(
     "--geo-stats",

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2028,7 +2028,7 @@ def inspect_stats(parquet_file, json_output, markdown_output, verbose):
     "meta_row_groups",
     type=int,
     default=None,
-    help="Number of row groups to display (default: 1, or all with --geo-stats)",
+    help="Number of row groups to display (default: 1)",
 )
 @click.option(
     "--geo-stats",

--- a/geoparquet_io/core/inspect.py
+++ b/geoparquet_io/core/inspect.py
@@ -396,7 +396,7 @@ def display_metadata(
     parquet: bool = False,
     geoparquet: bool = False,
     parquet_geo: bool = False,
-    row_groups: int = 1,
+    row_groups: int | None = None,
     json_output: bool = False,
     geo_stats: bool = False,
 ) -> None:
@@ -407,7 +407,7 @@ def display_metadata(
         parquet: Show only Parquet file metadata
         geoparquet: Show only GeoParquet 'geo' metadata
         parquet_geo: Show only Parquet geospatial metadata
-        row_groups: Number of row groups to display
+        row_groups: Number of row groups to display (None = 1 for metadata, all for --geo-stats)
         json_output: Output as JSON
         geo_stats: Show per-row-group geo_bbox statistics
     """
@@ -420,31 +420,39 @@ def display_metadata(
     )
 
     if geo_stats:
+        # --geo-stats: show all row groups by default, unless --row-groups was explicit
         format_row_group_geo_stats(parquet_file, json_output, row_groups)
         return
+
+    # For regular metadata display, default to showing 1 row group
+    effective_row_groups = row_groups if row_groups is not None else 1
 
     # Count how many specific flags were set
     specific_flags = sum([parquet, geoparquet, parquet_geo])
 
     if specific_flags == 0:
         # Show all sections
-        format_all_metadata(parquet_file, json_output, row_groups)
+        format_all_metadata(parquet_file, json_output, effective_row_groups)
     elif specific_flags > 1:
         # Multiple specific flags - show each requested section
         primary_col = get_primary_geometry_column(parquet_file)
 
         if parquet:
-            format_parquet_metadata_enhanced(parquet_file, json_output, row_groups, primary_col)
+            format_parquet_metadata_enhanced(
+                parquet_file, json_output, effective_row_groups, primary_col
+            )
         if parquet_geo:
-            format_parquet_geo_metadata(parquet_file, json_output, row_groups)
+            format_parquet_geo_metadata(parquet_file, json_output, effective_row_groups)
         if geoparquet:
             format_geoparquet_metadata(parquet_file, json_output)
     else:
         # Single specific flag
         if parquet:
             primary_col = get_primary_geometry_column(parquet_file)
-            format_parquet_metadata_enhanced(parquet_file, json_output, row_groups, primary_col)
+            format_parquet_metadata_enhanced(
+                parquet_file, json_output, effective_row_groups, primary_col
+            )
         elif geoparquet:
             format_geoparquet_metadata(parquet_file, json_output)
         elif parquet_geo:
-            format_parquet_geo_metadata(parquet_file, json_output, row_groups)
+            format_parquet_geo_metadata(parquet_file, json_output, effective_row_groups)

--- a/geoparquet_io/core/inspect.py
+++ b/geoparquet_io/core/inspect.py
@@ -420,7 +420,6 @@ def display_metadata(
     )
 
     if geo_stats:
-        # --geo-stats: show all row groups by default, unless --row-groups was explicit
         format_row_group_geo_stats(parquet_file, json_output, row_groups)
         return
 

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -566,6 +566,15 @@ def _format_parquet_metadata_json(
     print(json.dumps(metadata_dict, indent=2))
 
 
+def _format_bbox_corner(x: float, y: float) -> str:
+    """Format a bbox corner as (x, y), adapting precision to fit."""
+    for fmt in (".2f", ".1f", ".0f"):
+        result = f"({x:{fmt}}, {y:{fmt}})"
+        if len(result) <= 24:
+            return result
+    return f"({x:.0f}, {y:.0f})"
+
+
 def _print_row_group_table(console: Console, cols_in_rg: list, geo_columns: dict) -> None:
     """Print a table of columns for a row group."""
     table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
@@ -593,8 +602,8 @@ def _print_row_group_table(console: Console, cols_in_rg: list, geo_columns: dict
         if is_geo and min_val == "-" and col.get("geo_bbox"):
             geo_bbox = col["geo_bbox"]
             if geo_bbox.get("xmin") is not None:
-                min_val = f"({geo_bbox['xmin']:.2f}, {geo_bbox['ymin']:.2f})"
-                max_val = f"({geo_bbox['xmax']:.2f}, {geo_bbox['ymax']:.2f})"
+                min_val = _format_bbox_corner(geo_bbox["xmin"], geo_bbox["ymin"])
+                max_val = _format_bbox_corner(geo_bbox["xmax"], geo_bbox["ymax"])
 
         table.add_row(
             col_name_display,

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -951,9 +951,9 @@ def format_parquet_geo_metadata(
                     }
                 )
     else:
-        native_stats = get_per_row_group_native_geo_stats(safe_url)
-        if native_stats:
-            for col_name in geo_columns_info:
+        for col_name in geo_columns_info:
+            native_stats = get_per_row_group_native_geo_stats(safe_url, geometry_column=col_name)
+            if native_stats:
                 for rg_stat in native_stats:
                     geo_columns_info[col_name]["row_group_stats"].append(
                         {

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -507,6 +507,14 @@ def _build_row_group_json(rg_id: int, cols_in_rg: list, geo_columns: dict) -> di
                 "min": str(col.get("stats_min")),
                 "max": str(col.get("stats_max")),
             }
+        elif is_geo and col.get("geo_bbox"):
+            geo_bbox = col["geo_bbox"]
+            if geo_bbox.get("xmin") is not None:
+                col_dict["statistics"] = {
+                    "min": f"({geo_bbox['xmin']}, {geo_bbox['ymin']})",
+                    "max": f"({geo_bbox['xmax']}, {geo_bbox['ymax']})",
+                    "source": "geo_bbox",
+                }
         rg_dict["columns"].append(col_dict)
 
     return rg_dict
@@ -581,6 +589,12 @@ def _print_row_group_table(console: Console, cols_in_rg: list, geo_columns: dict
 
         min_val = str(col.get("stats_min", "-"))[:20] if col.get("stats_min") else "-"
         max_val = str(col.get("stats_max", "-"))[:20] if col.get("stats_max") else "-"
+
+        if is_geo and min_val == "-" and col.get("geo_bbox"):
+            geo_bbox = col["geo_bbox"]
+            if geo_bbox.get("xmin") is not None:
+                min_val = f"({geo_bbox['xmin']:.4f}, {geo_bbox['ymin']:.4f})"[:20]
+                max_val = f"({geo_bbox['xmax']:.4f}, {geo_bbox['ymax']:.4f})"[:20]
 
         table.add_row(
             col_name_display,
@@ -897,6 +911,7 @@ def format_parquet_geo_metadata(
         detect_geometry_columns,
         get_file_metadata,
         get_per_row_group_bbox_stats,
+        get_per_row_group_native_geo_stats,
         get_schema_info,
         has_bbox_column,
     )
@@ -912,7 +927,7 @@ def format_parquet_geo_metadata(
 
     geo_columns_info = _build_geo_columns_info(schema_info, geo_columns)
 
-    # Add bbox row group stats if bbox column exists
+    # Add row group stats: try bbox column first, then native geo_bbox
     if has_bbox and bbox_col_name:
         rg_bbox_stats = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
         for col_name in geo_columns_info:
@@ -926,6 +941,20 @@ def format_parquet_geo_metadata(
                         "ymax": rg_stat["ymax"],
                     }
                 )
+    else:
+        native_stats = get_per_row_group_native_geo_stats(safe_url)
+        if native_stats:
+            for col_name in geo_columns_info:
+                for rg_stat in native_stats:
+                    geo_columns_info[col_name]["row_group_stats"].append(
+                        {
+                            "row_group": rg_stat["row_group_id"],
+                            "xmin": rg_stat["xmin"],
+                            "ymin": rg_stat["ymin"],
+                            "xmax": rg_stat["xmax"],
+                            "ymax": rg_stat["ymax"],
+                        }
+                    )
 
     num_rg_to_show = num_row_groups
     if row_groups_limit is not None:

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -593,8 +593,8 @@ def _print_row_group_table(console: Console, cols_in_rg: list, geo_columns: dict
         if is_geo and min_val == "-" and col.get("geo_bbox"):
             geo_bbox = col["geo_bbox"]
             if geo_bbox.get("xmin") is not None:
-                min_val = f"({geo_bbox['xmin']:.4f}, {geo_bbox['ymin']:.4f})"[:20]
-                max_val = f"({geo_bbox['xmax']:.4f}, {geo_bbox['ymax']:.4f})"[:20]
+                min_val = f"({geo_bbox['xmin']:.2f}, {geo_bbox['ymin']:.2f})"
+                max_val = f"({geo_bbox['xmax']:.2f}, {geo_bbox['ymax']:.2f})"
 
         table.add_row(
             col_name_display,

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -1235,14 +1235,14 @@ def format_row_group_geo_stats(
     # Merge num_rows into stats
     stats_with_rows = _merge_row_counts(rg_stats, num_rows_per_rg)
 
-    # Apply row_groups limit if specified
-    if row_groups is not None:
-        stats_with_rows = stats_with_rows[:row_groups]
+    total_row_groups = len(stats_with_rows)
+    effective_limit = row_groups if row_groups is not None else 1
+    stats_with_rows = stats_with_rows[:effective_limit]
 
     if json_output:
         print(json.dumps({"row_group_geo_stats": stats_with_rows}, indent=2))
     else:
-        _format_geo_stats_terminal(stats_with_rows)
+        _format_geo_stats_terminal(stats_with_rows, total_row_groups)
 
 
 def _get_num_rows_per_row_group(safe_url: str, file_meta: dict) -> dict[int, int]:
@@ -1284,7 +1284,7 @@ def _merge_row_counts(rg_stats: list[dict], num_rows_per_rg: dict[int, int]) -> 
     return merged
 
 
-def _format_geo_stats_terminal(stats: list[dict]) -> None:
+def _format_geo_stats_terminal(stats: list[dict], total_row_groups: int) -> None:
     """Render per-row-group geo_bbox stats as a Rich table."""
     console = Console()
     console.print()
@@ -1315,5 +1315,11 @@ def _format_geo_stats_terminal(stats: list[dict]) -> None:
         )
 
     console.print(table)
-    console.print(f"\n[dim]{len(stats)} row group(s) with geo_bbox statistics[/dim]")
+
+    shown = len(stats)
+    remaining = total_row_groups - shown
+    if remaining > 0:
+        console.print(f"\n  [dim]... and {remaining} more row group(s)[/dim]")
+        console.print(f"  [dim]Use --row-groups {total_row_groups} to see all row groups[/dim]")
+
     console.print()

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1048,6 +1048,152 @@ class TestInspectSubcommands:
         stats = get_row_group_geo_stats(no_bbox_file)
         assert stats == []
 
+    # --- V2 multi-row-group geo_bbox display tests ---
+
+    @pytest.fixture
+    def v2_multi_rg_file(self, tmp_path):
+        """Create a GeoParquet 2.0 file with multiple row groups and native geo_bbox."""
+        import duckdb
+
+        output = str(tmp_path / "v2_multi_rg.parquet")
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+        con.execute(
+            """
+            COPY (
+                SELECT
+                    ST_Point(i % 360 - 180, (i % 180) - 90) AS geometry,
+                    i AS id
+                FROM range(500000) t(i)
+            )
+            TO '{}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V2', ROW_GROUP_SIZE 100000)
+        """.format(output.replace("'", "''"))
+        )
+        con.close()
+        return output
+
+    @pytest.fixture
+    def v11_multi_rg_file(self, tmp_path):
+        """Create a GeoParquet 1.1 file with multiple row groups and a bbox column."""
+        # First create a V2 file with multiple RGs, then convert to 1.1 with bbox
+        import duckdb
+
+        from geoparquet_io.core.convert import convert_to_geoparquet
+
+        v2_path = str(tmp_path / "v2_source.parquet")
+        output = str(tmp_path / "v11_multi_rg.parquet")
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+        con.execute(
+            """
+            COPY (
+                SELECT
+                    ST_Point(i % 360 - 180, (i % 180) - 90) AS geometry,
+                    i AS id
+                FROM range(500000) t(i)
+            )
+            TO '{}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V1', ROW_GROUP_SIZE 100000)
+        """.format(v2_path.replace("'", "''"))
+        )
+        con.close()
+
+        convert_to_geoparquet(
+            v2_path,
+            output,
+            skip_hilbert=True,
+            verbose=False,
+            geoparquet_version="1.1",
+        )
+        return output
+
+    def test_geo_stats_shows_all_row_groups_by_default(self, runner, v2_multi_rg_file):
+        """--geo-stats should show ALL row groups by default, not just 1."""
+        result = runner.invoke(cli, ["inspect", "meta", v2_multi_rg_file, "--geo-stats"])
+
+        assert result.exit_code == 0
+        assert "5 row group(s)" in result.output
+
+    def test_geo_stats_respects_row_groups_limit(self, runner, v2_multi_rg_file):
+        """--geo-stats with --row-groups N should show only N row groups."""
+        result = runner.invoke(
+            cli, ["inspect", "meta", v2_multi_rg_file, "--geo-stats", "--row-groups", "2"]
+        )
+
+        assert result.exit_code == 0
+        assert "2 row group(s)" in result.output
+
+    def test_inspect_meta_geometry_shows_geo_bbox_minmax(self, runner, v2_multi_rg_file):
+        """V2 geometry column should show geo_bbox coords as MinValue/MaxValue, not '-'."""
+        result = runner.invoke(cli, ["inspect", "meta", v2_multi_rg_file, "--row-groups", "1"])
+
+        assert result.exit_code == 0
+        # The geometry row in the row group table should have geo_bbox coordinates
+        # Rich may wrap the 🌍 emoji and column name across lines, so check the
+        # BYTE_ARRAY(Geometry) line which contains the min/max values
+        lines = result.output.split("\n")
+        geo_line = next(
+            (line for line in lines if "BYTE_ARRAY" in line and "Geometry" in line),
+            None,
+        )
+        assert geo_line is not None, "Could not find geometry column in row group output"
+        # Should contain coordinate values (parenthesized) instead of bare dashes
+        assert "(" in geo_line, (
+            f"Geometry MinValue/MaxValue should show geo_bbox coordinates, got: {geo_line}"
+        )
+
+    def test_parquet_geo_section_shows_native_row_group_stats(self, runner, v2_multi_rg_file):
+        """Parquet Geo section should show per-RG bbox stats from native geo_bbox for V2."""
+        result = runner.invoke(
+            cli, ["inspect", "meta", v2_multi_rg_file, "--parquet-geo", "--row-groups", "2"]
+        )
+
+        assert result.exit_code == 0
+        # Should show row group stats section
+        assert "Row Group" in result.output
+        assert "Bbox:" in result.output or "xmin" in result.output.lower()
+
+    # --- V1.1 regression tests ---
+
+    def test_v11_geo_stats_shows_all_row_groups_by_default(self, runner, v11_multi_rg_file):
+        """--geo-stats should show all row groups for V1.1 files with bbox columns too."""
+        result = runner.invoke(cli, ["inspect", "meta", v11_multi_rg_file, "--geo-stats"])
+
+        assert result.exit_code == 0
+        # Should show more than 1 row group
+        assert "1 row group(s)" not in result.output
+        assert "row group(s)" in result.output
+
+    def test_v11_geo_stats_respects_row_groups_limit(self, runner, v11_multi_rg_file):
+        """--geo-stats with --row-groups N should work for V1.1 bbox column files."""
+        result = runner.invoke(
+            cli, ["inspect", "meta", v11_multi_rg_file, "--geo-stats", "--row-groups", "2"]
+        )
+
+        assert result.exit_code == 0
+        assert "2 row group(s)" in result.output
+
+    def test_v11_inspect_meta_unchanged(self, runner):
+        """V1.1 file inspect meta should continue working (no regression)."""
+        v11_file = os.path.join(os.path.dirname(__file__), "data", "places_test.parquet")
+        result = runner.invoke(cli, ["inspect", "meta", v11_file])
+
+        assert result.exit_code == 0
+        assert "GeoParquet Metadata" in result.output
+        assert "Parquet File Metadata" in result.output
+
+    def test_v11_inspect_meta_row_groups_default_still_1(self, runner):
+        """Default row groups display (without --geo-stats) should still be 1."""
+        v11_file = os.path.join(os.path.dirname(__file__), "data", "places_test.parquet")
+        result = runner.invoke(cli, ["inspect", "meta", v11_file])
+
+        assert result.exit_code == 0
+        # Should show "showing 1 of N" for the parquet section
+        assert "Row Group 0:" in result.output
+
     def test_inspect_stats_subcommand_markdown(self, runner, test_file):
         """Test stats subcommand with markdown output."""
         result = runner.invoke(cli, ["inspect", "stats", test_file, "--markdown"])

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1110,12 +1110,22 @@ class TestInspectSubcommands:
         )
         return output
 
-    def test_geo_stats_shows_all_row_groups_by_default(self, runner, v2_multi_rg_file):
-        """--geo-stats should show ALL row groups by default, not just 1."""
+    def test_geo_stats_defaults_to_one_row_group_with_hint(self, runner, v2_multi_rg_file):
+        """--geo-stats should show 1 row group by default with '... and N more' hint."""
         result = runner.invoke(cli, ["inspect", "meta", v2_multi_rg_file, "--geo-stats"])
 
         assert result.exit_code == 0
-        assert "5 row group(s)" in result.output
+        assert "4 more row group(s)" in result.output
+        assert "--row-groups 5" in result.output
+
+    def test_geo_stats_shows_all_with_row_groups_flag(self, runner, v2_multi_rg_file):
+        """--geo-stats with --row-groups 5 should show all 5 row groups."""
+        result = runner.invoke(
+            cli, ["inspect", "meta", v2_multi_rg_file, "--geo-stats", "--row-groups", "5"]
+        )
+
+        assert result.exit_code == 0
+        assert "more row group(s)" not in result.output
 
     def test_geo_stats_respects_row_groups_limit(self, runner, v2_multi_rg_file):
         """--geo-stats with --row-groups N should show only N row groups."""
@@ -1124,7 +1134,8 @@ class TestInspectSubcommands:
         )
 
         assert result.exit_code == 0
-        assert "2 row group(s)" in result.output
+        assert "3 more row group(s)" in result.output
+        assert "--row-groups 5" in result.output
 
     def test_inspect_meta_geometry_shows_geo_bbox_minmax(self, runner, v2_multi_rg_file):
         """V2 geometry column should show geo_bbox coords as MinValue/MaxValue, not '-'."""
@@ -1158,14 +1169,13 @@ class TestInspectSubcommands:
 
     # --- V1.1 regression tests ---
 
-    def test_v11_geo_stats_shows_all_row_groups_by_default(self, runner, v11_multi_rg_file):
-        """--geo-stats should show all row groups for V1.1 files with bbox columns too."""
+    def test_v11_geo_stats_defaults_to_one_with_hint(self, runner, v11_multi_rg_file):
+        """--geo-stats should show 1 row group by default with hint for V1.1 files."""
         result = runner.invoke(cli, ["inspect", "meta", v11_multi_rg_file, "--geo-stats"])
 
         assert result.exit_code == 0
-        # Should show more than 1 row group
-        assert "1 row group(s)" not in result.output
-        assert "row group(s)" in result.output
+        assert "more row group(s)" in result.output
+        assert "--row-groups" in result.output
 
     def test_v11_geo_stats_respects_row_groups_limit(self, runner, v11_multi_rg_file):
         """--geo-stats with --row-groups N should work for V1.1 bbox column files."""
@@ -1174,7 +1184,7 @@ class TestInspectSubcommands:
         )
 
         assert result.exit_code == 0
-        assert "2 row group(s)" in result.output
+        assert "more row group(s)" in result.output
 
     def test_v11_inspect_meta_unchanged(self, runner):
         """V1.1 file inspect meta should continue working (no regression)."""

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -930,6 +930,94 @@ class TestCRSComparison:
         assert _crs_are_equivalent(crs1, crs2) is False
 
 
+@pytest.fixture(scope="module")
+def v2_multi_rg_file(tmp_path_factory):
+    """Create a GeoParquet 2.0 file with multiple row groups and native geo_bbox."""
+    import duckdb
+
+    output = str(tmp_path_factory.mktemp("v2") / "v2_multi_rg.parquet")
+    con = duckdb.connect()
+    con.install_extension("spatial")
+    con.load_extension("spatial")
+    con.execute(
+        """
+        COPY (
+            SELECT
+                ST_Point(i % 360 - 180, (i % 180) - 90) AS geometry,
+                i AS id
+            FROM range(500000) t(i)
+        )
+        TO '{}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V2', ROW_GROUP_SIZE 100000)
+    """.format(output.replace("'", "''"))
+    )
+    con.close()
+    return output
+
+
+@pytest.fixture(scope="module")
+def v11_multi_rg_file(tmp_path_factory):
+    """Create a GeoParquet 1.1 file with multiple row groups and a bbox column."""
+    import duckdb
+
+    from geoparquet_io.core.convert import convert_to_geoparquet
+
+    tmpdir = tmp_path_factory.mktemp("v11")
+    v2_path = str(tmpdir / "v2_source.parquet")
+    output = str(tmpdir / "v11_multi_rg.parquet")
+    con = duckdb.connect()
+    con.install_extension("spatial")
+    con.load_extension("spatial")
+    con.execute(
+        """
+        COPY (
+            SELECT
+                ST_Point(i % 360 - 180, (i % 180) - 90) AS geometry,
+                i AS id
+            FROM range(500000) t(i)
+        )
+        TO '{}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V1', ROW_GROUP_SIZE 100000)
+    """.format(v2_path.replace("'", "''"))
+    )
+    con.close()
+
+    convert_to_geoparquet(
+        v2_path,
+        output,
+        skip_hilbert=True,
+        verbose=False,
+        geoparquet_version="1.1",
+    )
+    return output
+
+
+@pytest.fixture(scope="module")
+def v2_multi_geom_file(tmp_path_factory):
+    """Create a GeoParquet 2.0 file with two geometry columns."""
+    import duckdb
+
+    output = str(tmp_path_factory.mktemp("v2mg") / "v2_multi_geom.parquet")
+    con = duckdb.connect()
+    con.install_extension("spatial")
+    con.load_extension("spatial")
+    con.execute(
+        """
+        COPY (
+            SELECT
+                ST_Point(i % 360 - 180, (i % 180) - 90) AS geometry,
+                ST_Point((i + 100) % 360 - 180, ((i + 50) % 180) - 90) AS geometry2,
+                i AS id
+            FROM range(500000) t(i)
+        )
+        TO '{}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V2', ROW_GROUP_SIZE 100000)
+    """.format(output.replace("'", "''"))
+    )
+    con.close()
+    return output
+
+
 # Tests for new subcommand structure
 class TestInspectSubcommands:
     """Tests for the new inspect subcommand structure."""
@@ -1050,66 +1138,8 @@ class TestInspectSubcommands:
 
     # --- V2 multi-row-group geo_bbox display tests ---
 
-    @pytest.fixture
-    def v2_multi_rg_file(self, tmp_path):
-        """Create a GeoParquet 2.0 file with multiple row groups and native geo_bbox."""
-        import duckdb
-
-        output = str(tmp_path / "v2_multi_rg.parquet")
-        con = duckdb.connect()
-        con.install_extension("spatial")
-        con.load_extension("spatial")
-        con.execute(
-            """
-            COPY (
-                SELECT
-                    ST_Point(i % 360 - 180, (i % 180) - 90) AS geometry,
-                    i AS id
-                FROM range(500000) t(i)
-            )
-            TO '{}'
-            (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V2', ROW_GROUP_SIZE 100000)
-        """.format(output.replace("'", "''"))
-        )
-        con.close()
-        return output
-
-    @pytest.fixture
-    def v11_multi_rg_file(self, tmp_path):
-        """Create a GeoParquet 1.1 file with multiple row groups and a bbox column."""
-        # First create a V2 file with multiple RGs, then convert to 1.1 with bbox
-        import duckdb
-
-        from geoparquet_io.core.convert import convert_to_geoparquet
-
-        v2_path = str(tmp_path / "v2_source.parquet")
-        output = str(tmp_path / "v11_multi_rg.parquet")
-        con = duckdb.connect()
-        con.install_extension("spatial")
-        con.load_extension("spatial")
-        con.execute(
-            """
-            COPY (
-                SELECT
-                    ST_Point(i % 360 - 180, (i % 180) - 90) AS geometry,
-                    i AS id
-                FROM range(500000) t(i)
-            )
-            TO '{}'
-            (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V1', ROW_GROUP_SIZE 100000)
-        """.format(v2_path.replace("'", "''"))
-        )
-        con.close()
-
-        convert_to_geoparquet(
-            v2_path,
-            output,
-            skip_hilbert=True,
-            verbose=False,
-            geoparquet_version="1.1",
-        )
-        return output
-
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_geo_stats_defaults_to_one_row_group_with_hint(self, runner, v2_multi_rg_file):
         """--geo-stats should show 1 row group by default with '... and N more' hint."""
         result = runner.invoke(cli, ["inspect", "meta", v2_multi_rg_file, "--geo-stats"])
@@ -1118,6 +1148,8 @@ class TestInspectSubcommands:
         assert "4 more row group(s)" in result.output
         assert "--row-groups 5" in result.output
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_geo_stats_shows_all_with_row_groups_flag(self, runner, v2_multi_rg_file):
         """--geo-stats with --row-groups 5 should show all 5 row groups."""
         result = runner.invoke(
@@ -1127,6 +1159,8 @@ class TestInspectSubcommands:
         assert result.exit_code == 0
         assert "more row group(s)" not in result.output
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_geo_stats_respects_row_groups_limit(self, runner, v2_multi_rg_file):
         """--geo-stats with --row-groups N should show only N row groups."""
         result = runner.invoke(
@@ -1137,25 +1171,25 @@ class TestInspectSubcommands:
         assert "3 more row group(s)" in result.output
         assert "--row-groups 5" in result.output
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_inspect_meta_geometry_shows_geo_bbox_minmax(self, runner, v2_multi_rg_file):
         """V2 geometry column should show geo_bbox coords as MinValue/MaxValue, not '-'."""
         result = runner.invoke(cli, ["inspect", "meta", v2_multi_rg_file, "--row-groups", "1"])
 
         assert result.exit_code == 0
-        # The geometry row in the row group table should have geo_bbox coordinates
-        # Rich may wrap the 🌍 emoji and column name across lines, so check the
-        # BYTE_ARRAY(Geometry) line which contains the min/max values
         lines = result.output.split("\n")
         geo_line = next(
             (line for line in lines if "BYTE_ARRAY" in line and "Geometry" in line),
             None,
         )
         assert geo_line is not None, "Could not find geometry column in row group output"
-        # Should contain coordinate values (parenthesized) instead of bare dashes
         assert "(" in geo_line, (
             f"Geometry MinValue/MaxValue should show geo_bbox coordinates, got: {geo_line}"
         )
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_parquet_geo_section_shows_native_row_group_stats(self, runner, v2_multi_rg_file):
         """Parquet Geo section should show per-RG bbox stats from native geo_bbox for V2."""
         result = runner.invoke(
@@ -1163,12 +1197,13 @@ class TestInspectSubcommands:
         )
 
         assert result.exit_code == 0
-        # Should show row group stats section
         assert "Row Group" in result.output
         assert "Bbox:" in result.output or "xmin" in result.output.lower()
 
     # --- V1.1 regression tests ---
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_v11_geo_stats_defaults_to_one_with_hint(self, runner, v11_multi_rg_file):
         """--geo-stats should show 1 row group by default with hint for V1.1 files."""
         result = runner.invoke(cli, ["inspect", "meta", v11_multi_rg_file, "--geo-stats"])
@@ -1177,6 +1212,8 @@ class TestInspectSubcommands:
         assert "more row group(s)" in result.output
         assert "--row-groups" in result.output
 
+    @pytest.mark.slow
+    @pytest.mark.integration
     def test_v11_geo_stats_respects_row_groups_limit(self, runner, v11_multi_rg_file):
         """--geo-stats with --row-groups N should work for V1.1 bbox column files."""
         result = runner.invoke(
@@ -1203,6 +1240,23 @@ class TestInspectSubcommands:
         assert result.exit_code == 0
         # Should show "showing 1 of N" for the parquet section
         assert "Row Group 0:" in result.output
+
+    # --- Multi-geometry tests ---
+
+    @pytest.mark.slow
+    @pytest.mark.integration
+    def test_multi_geom_parquet_geo_shows_per_column_stats(self, runner, v2_multi_geom_file):
+        """Each geometry column should get its own native geo_bbox stats."""
+        result = runner.invoke(
+            cli,
+            ["inspect", "meta", v2_multi_geom_file, "--parquet-geo", "--row-groups", "5"],
+        )
+
+        assert result.exit_code == 0
+        assert "geometry" in result.output
+        assert "geometry2" in result.output
+        output_lower = result.output.lower()
+        assert output_lower.count("xmin") >= 2 or result.output.count("Bbox:") >= 2
 
     def test_inspect_stats_subcommand_markdown(self, runner, test_file):
         """Test stats subcommand with markdown output."""


### PR DESCRIPTION
## Summary

Three display bugs prevented per-row-group geo_bbox statistics from showing for GeoParquet 2.0 and parquet-geo-only files:

- **Row group table shows geo_bbox coordinates** for geometry MinValue/MaxValue instead of `-` / `-`. Uses `(xmin, ymin)` / `(xmax, ymax)` format with adaptive precision (fewer decimals for large projected coordinates).
- **`--geo-stats` should show "... and N more" hint** when row groups are truncated, though the `--row-groups` flag to see all.  Need to add the same hint.
- **Parquet Geo Metadata section shows native geo stats** for GeoParquet 2.0 files (which lack bbox covering columns) should work by falling back to `get_per_row_group_native_geo_stats()`.

Fixes #411

## Test plan

- [x] `test_geo_stats_defaults_to_one_row_group_with_hint` — shows 1 row group with "... and 4 more" hint
- [x] `test_geo_stats_shows_all_with_row_groups_flag` — `--row-groups 5` shows all 5, no hint
- [x] `test_geo_stats_respects_row_groups_limit` — `--row-groups 2` shows 2 with "3 more" hint
- [x] `test_inspect_meta_geometry_shows_geo_bbox_minmax` — geometry column shows coordinates, not `-`
- [x] `test_parquet_geo_section_shows_native_row_group_stats` — `--parquet-geo` shows per-RG bbox data
- [x] `test_v11_geo_stats_defaults_to_one_with_hint` — V1.1 regression: default 1 with hint
- [x] `test_v11_geo_stats_respects_row_groups_limit` — V1.1 regression: `--row-groups` limit works
- [x] `test_v11_inspect_meta_unchanged` — V1.1 regression: `inspect meta` output unchanged
- [x] `test_v11_inspect_meta_row_groups_default_still_1` — V1.1 regression: default row groups still 1
- [x] Full test suite: 79/79 in test_inspect.py pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)