### PR TITLE
fix(tests): resolve CI failures for pip-audit CVE and wfs import

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -65,9 +65,28 @@ class TestSecurityScanResults:
 
     @pytest.mark.network
     def test_pip_audit_passes(self):
-        """Verify no known vulnerabilities in dependencies."""
+        """Verify no known vulnerabilities in dependencies.
+
+        Self-expiring CVE ignores: remove once fixed versions are released.
+        """
+        # Check pip version to see if CVE-2026-3219 ignore is still needed
+        pip_version_result = subprocess.run(
+            ["uv", "run", "pip", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            cwd=_PROJECT_ROOT,
+        )
+        pip_version = pip_version_result.stdout.split()[1]
+        major_minor = ".".join(pip_version.split(".")[:2])
+
+        # CVE-2026-3219: pip tar/ZIP handling (CVSS 4.6). Fix expected in pip 26.1+.
+        cmd = ["uv", "run", "pip-audit"]
+        if major_minor < "26.1":
+            cmd.extend(["--ignore-vuln", "CVE-2026-3219"])
+
         result = subprocess.run(
-            ["uv", "run", "pip-audit"],
+            cmd,
             capture_output=True,
             text=True,
             timeout=_SUBPROCESS_TIMEOUT,

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -78,11 +78,12 @@ class TestSecurityScanResults:
             cwd=_PROJECT_ROOT,
         )
         pip_version = pip_version_result.stdout.split()[1]
-        major_minor = ".".join(pip_version.split(".")[:2])
+        version_parts = pip_version.split(".")[:2]
+        major_minor = (int(version_parts[0]), int(version_parts[1]))
 
         # CVE-2026-3219: pip tar/ZIP handling (CVSS 4.6). Fix expected in pip 26.1+.
         cmd = ["uv", "run", "pip-audit"]
-        if major_minor < "26.1":
+        if major_minor < (26, 1):
             cmd.extend(["--ignore-vuln", "CVE-2026-3219"])
 
         result = subprocess.run(

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1839,9 +1839,9 @@ class TestTypeInferenceIntegration:
         """Real WFS data should have numeric columns properly typed."""
         import pyarrow as pa
 
-        from geoparquet_io import wfs_to_table
+        from geoparquet_io.api import ops
 
-        table = wfs_to_table(
+        table = ops.from_wfs(
             self.BELGIUM_WFS,
             self.BELGIUM_LAYER,
             limit=50,


### PR DESCRIPTION
## Summary
- Add self-expiring CVE-2026-3219 ignore to `test_pip_audit_passes` (matches CI workflow logic)
- Fix `test_wfs_type_inference_real_server` to use public API `ops.from_wfs()` instead of non-exported `wfs_to_table`

## Details

**pip-audit fix:** The test now checks pip version and only ignores CVE-2026-3219 when pip < 26.1. This matches the CI workflow's self-expiring ignore pattern - when pip 26.1+ ships with the fix, the ignore automatically drops.

**WFS import fix:** The test was importing `wfs_to_table` directly from `geoparquet_io`, but that function was never exported. The correct public API is `ops.from_wfs()`.

## Test plan
- [x] `test_pip_audit_passes` passes locally with ignore
- [x] `ops.from_wfs` import verified working

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved security test robustness by dynamically handling different pip versions
  * Refactored tests to utilize stable public APIs for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->