### PR TITLE
fix: GeoParquet 2.0 bbox handling (#409, #410, #412)

### DIFF
--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -344,6 +344,18 @@ def _add_bbox_file_based(
         ymax := ST_YMax({geom_col})
     )"""
 
+    # Build covering metadata for the bbox column (GeoParquet 1.1+ spec)
+    covering_metadata = {
+        "covering": {
+            "bbox": {
+                "xmin": [bbox_column_name, "xmin"],
+                "ymin": [bbox_column_name, "ymin"],
+                "xmax": [bbox_column_name, "xmax"],
+                "ymax": [bbox_column_name, "ymax"],
+            }
+        }
+    }
+
     # Use the generic helper for all boilerplate
     add_computed_column(
         input_parquet=input_parquet,
@@ -361,6 +373,7 @@ def _add_bbox_file_based(
         profile=profile,
         replace_column=replace_column,
         geoparquet_version=geoparquet_version,
+        custom_metadata=covering_metadata,
     )
 
     if not dry_run:

--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -260,6 +260,18 @@ def _add_bbox_streaming(
 
         return _make_add_bbox_query(source, geom_col, bbox_column_name, replace_existing=force)
 
+    # Build covering metadata for the bbox column (GeoParquet 1.1+ spec)
+    covering_metadata = {
+        "covering": {
+            "bbox": {
+                "xmin": [bbox_column_name, "xmin"],
+                "ymin": [bbox_column_name, "ymin"],
+                "xmax": [bbox_column_name, "xmax"],
+                "ymax": [bbox_column_name, "ymax"],
+            }
+        }
+    }
+
     execute_transform(
         input_path,
         output_path,
@@ -270,6 +282,7 @@ def _add_bbox_streaming(
         row_group_size_mb=row_group_size_mb,
         row_group_rows=row_group_rows,
         profile=profile,
+        custom_metadata=covering_metadata,
         geoparquet_version=geoparquet_version,
     )
 

--- a/geoparquet_io/core/check_spatial_order.py
+++ b/geoparquet_io/core/check_spatial_order.py
@@ -262,6 +262,72 @@ def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=F
     return ratio
 
 
+def _check_spatial_order_from_row_group_bboxes(
+    row_group_bboxes, parquet_file, verbose=False, return_results=False, quiet=False
+):
+    """Check spatial ordering from row group bboxes (native geo_bbox stats).
+
+    Shared logic for checking spatial order from pre-fetched row group bboxes.
+    Used by both bbox column method and native geo_bbox stats method.
+
+    Args:
+        row_group_bboxes: List of dicts with row_group_id, xmin, ymin, xmax, ymax
+        parquet_file: Path to parquet file (for logging)
+        verbose: Print additional information
+        return_results: If True, return structured results dict
+        quiet: If True, suppress all output
+
+    Returns:
+        ratio (float) if return_results=False, or dict if return_results=True
+    """
+    if len(row_group_bboxes) <= 1:
+        if verbose:
+            debug("Only one or zero row groups - assuming well ordered")
+        ratio = 0.0
+        overlap_count = 0
+        total_pairs = 0
+    else:
+        overlap_count = 0
+        for i in range(len(row_group_bboxes) - 1):
+            bbox1 = row_group_bboxes[i]
+            bbox2 = row_group_bboxes[i + 1]
+            if _bboxes_overlap(bbox1, bbox2):
+                overlap_count += 1
+                if verbose:
+                    debug(f"Row groups {bbox1['row_group_id']} and {bbox2['row_group_id']} overlap")
+
+        total_pairs = len(row_group_bboxes) - 1
+        ratio = overlap_count / total_pairs if total_pairs > 0 else 0.0
+
+        if verbose:
+            debug(f"Overlapping pairs: {overlap_count}/{total_pairs}")
+
+    passed = ratio < 0.3
+
+    issues = []
+    recommendations = []
+    if not passed:
+        issues.append(f"Poor spatial ordering (overlap ratio: {ratio:.2f})")
+        recommendations.append("Apply Hilbert spatial ordering for better query performance")
+
+    if not quiet and not return_results and not verbose:
+        _print_bbox_stats_results(ratio, overlap_count, total_pairs)
+
+    if return_results:
+        return {
+            "passed": passed,
+            "ratio": ratio,
+            "overlap_count": overlap_count,
+            "total_pairs": total_pairs,
+            "method": "native_geo_bbox",
+            "issues": issues,
+            "recommendations": recommendations,
+            "fix_available": not passed,
+        }
+
+    return ratio
+
+
 def check_spatial_order(
     parquet_file, random_sample_size, limit_rows, verbose, return_results=False, quiet=False
 ):
@@ -281,7 +347,10 @@ def check_spatial_order(
     Returns:
         ratio (float) if return_results=False, or dict if return_results=True
     """
-    from geoparquet_io.core.duckdb_metadata import has_bbox_column
+    from geoparquet_io.core.duckdb_metadata import (
+        get_per_row_group_native_geo_stats,
+        has_bbox_column,
+    )
     from geoparquet_io.core.logging_config import warn
 
     safe_url = safe_file_url(parquet_file, verbose)
@@ -301,13 +370,28 @@ def check_spatial_order(
             # IndexError: Empty or malformed row group stats
             if verbose:
                 warn(f"Bbox-stats method failed: {e}, falling back to sampling")
+            # Fall through to try native geo_bbox stats
+
+    # Try native geo_bbox stats (GeoParquet 2.0 / parquet-geo-only)
+    geometry_column = find_primary_geometry_column(parquet_file, verbose)
+    native_geo_stats = get_per_row_group_native_geo_stats(safe_url, geometry_column)
+    if native_geo_stats:
+        if verbose:
+            debug(f"Using native geo_bbox stats ({len(native_geo_stats)} row groups)")
+        try:
+            return _check_spatial_order_from_row_group_bboxes(
+                native_geo_stats, parquet_file, verbose, return_results, quiet
+            )
+        except (ValueError, KeyError, IndexError) as e:
+            if verbose:
+                warn(f"Native geo_bbox method failed: {e}, falling back to sampling")
             # Fall through to sampling method
 
     # Fall back to sampling method
     if verbose or not quiet:
         warn(
-            "Bbox column not found - using slower sampling method. "
-            "For faster checks, add bbox column with 'gpio add bbox'."
+            "No bbox column or native geo_bbox stats found - using slower sampling method. "
+            "For faster checks, add bbox column with 'gpio add bbox' or use GeoParquet 2.0."
         )
 
     geometry_column = find_primary_geometry_column(parquet_file, verbose)

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1538,6 +1538,13 @@ def write_parquet_with_metadata(
     # Check if we need to add/rewrite geo metadata
     rewrite_needed = needs_metadata_rewrite(effective_version, original_metadata)
 
+    # Force rewrite if custom_metadata contains covering (e.g., bbox, H3, S2)
+    # This ensures covering metadata is written even for 2.0→2.0 operations
+    if custom_metadata and "covering" in custom_metadata:
+        rewrite_needed = True
+        if verbose:
+            debug("Forcing metadata rewrite for covering metadata")
+
     if show_sql:
         info("\n-- Query:")
         progress(query)

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -534,7 +534,7 @@ def _reproject_streaming(
             detected_crs = _detect_source_crs(working_url, verbose=False)
             effective_source_crs = source_crs if source_crs else detected_crs
 
-            # Check for existing bbox column to exclude
+            # Check for existing bbox column to exclude (will be regenerated)
             bbox_col = _get_bbox_column_name(working_url, verbose=False)
             exclude_cols = [geom_col]
             if bbox_col:
@@ -542,17 +542,41 @@ def _reproject_streaming(
             # Quote column names to handle special characters (colons, spaces, etc.)
             exclude_clause = ", ".join(f'"{c}"' for c in exclude_cols)
 
-            # Build reprojection query
-            query = f"""
-                SELECT
-                    * EXCLUDE ({exclude_clause}),
-                    ST_Transform(
-                        "{geom_col}",
-                        '{effective_source_crs}',
-                        '{target_crs}'
-                    ) AS "{geom_col}"
-                FROM '{working_url}'
-            """
+            # Build reprojection query with bbox regeneration if input had bbox
+            if bbox_col:
+                # Use CTE to compute reprojected geometry once, then regenerate bbox
+                query = f"""
+                    WITH reprojected AS (
+                        SELECT
+                            * EXCLUDE ({exclude_clause}),
+                            ST_Transform(
+                                "{geom_col}",
+                                '{effective_source_crs}',
+                                '{target_crs}'
+                            ) AS "{geom_col}"
+                        FROM '{working_url}'
+                    )
+                    SELECT
+                        *,
+                        STRUCT_PACK(
+                            xmin := ST_XMin("{geom_col}"),
+                            ymin := ST_YMin("{geom_col}"),
+                            xmax := ST_XMax("{geom_col}"),
+                            ymax := ST_YMax("{geom_col}")
+                        ) AS "{bbox_col}"
+                    FROM reprojected
+                """
+            else:
+                query = f"""
+                    SELECT
+                        * EXCLUDE ({exclude_clause}),
+                        ST_Transform(
+                            "{geom_col}",
+                            '{effective_source_crs}',
+                            '{target_crs}'
+                        ) AS "{geom_col}"
+                    FROM '{working_url}'
+                """
 
             # Get original metadata for preservation
             from geoparquet_io.core.common import get_parquet_metadata

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -350,16 +350,44 @@ def reproject_impl(
         # Build SQL query with ST_Transform
         # geometry_always_xy is set at connection level (DuckDB 1.5+)
         log("Reprojecting...")
-        query = f"""
-            SELECT
-                * EXCLUDE ({exclude_clause}),
-                ST_Transform(
-                    "{geom_col}",
-                    '{effective_source_crs}',
-                    '{target_crs}'
-                ) AS "{geom_col}"
-            FROM '{input_url}'
-        """
+
+        # Build bbox regeneration clause if input had bbox column
+        if bbox_col:
+            # Use CTE to avoid computing ST_Transform multiple times
+            query = f"""
+                WITH reprojected AS (
+                    SELECT
+                        * EXCLUDE ({exclude_clause}),
+                        ST_Transform(
+                            "{geom_col}",
+                            '{effective_source_crs}',
+                            '{target_crs}'
+                        ) AS "{geom_col}"
+                    FROM '{input_url}'
+                )
+                SELECT
+                    *,
+                    STRUCT_PACK(
+                        xmin := ST_XMin("{geom_col}"),
+                        ymin := ST_YMin("{geom_col}"),
+                        xmax := ST_XMax("{geom_col}"),
+                        ymax := ST_YMax("{geom_col}")
+                    ) AS "{bbox_col}"
+                FROM reprojected
+            """
+            if verbose:
+                debug(f"Regenerating bbox column '{bbox_col}' with reprojected coordinates")
+        else:
+            query = f"""
+                SELECT
+                    * EXCLUDE ({exclude_clause}),
+                    ST_Transform(
+                        "{geom_col}",
+                        '{effective_source_crs}',
+                        '{target_crs}'
+                    ) AS "{geom_col}"
+                FROM '{input_url}'
+            """
 
         # Determine output path
         if output_parquet:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -478,3 +478,66 @@ class TestAddCommandErrorHandling:
 
         # Should show friendly error message
         assert "Traceback" not in result.output
+
+
+class TestAddBboxCoveringMetadata:
+    """Tests for bbox covering metadata (fixes #412)."""
+
+    def test_add_bbox_includes_covering_metadata_for_v2(
+        self, buildings_test_file, temp_output_file
+    ):
+        """Test that add bbox includes covering metadata for GeoParquet 2.0."""
+        import json
+
+        import pyarrow.parquet as pq
+
+        runner = CliRunner()
+        result = runner.invoke(
+            add,
+            ["bbox", buildings_test_file, temp_output_file, "--geoparquet-version", "2.0"],
+        )
+        assert result.exit_code == 0
+        assert os.path.exists(temp_output_file)
+
+        # Check covering metadata in geo metadata
+        pf = pq.ParquetFile(temp_output_file)
+        geo_meta = json.loads(pf.schema_arrow.metadata.get(b"geo", b"{}"))
+
+        # Find the geometry column's covering metadata
+        primary_col = geo_meta.get("primary_column", "geometry")
+        col_meta = geo_meta.get("columns", {}).get(primary_col, {})
+        covering = col_meta.get("covering", {})
+
+        # Verify bbox covering exists with correct structure
+        assert "bbox" in covering, "covering.bbox should exist in geo metadata"
+        bbox_covering = covering["bbox"]
+        assert bbox_covering.get("xmin") == ["bbox", "xmin"]
+        assert bbox_covering.get("ymin") == ["bbox", "ymin"]
+        assert bbox_covering.get("xmax") == ["bbox", "xmax"]
+        assert bbox_covering.get("ymax") == ["bbox", "ymax"]
+
+    def test_add_bbox_includes_covering_metadata_for_v1_1(
+        self, buildings_test_file, temp_output_file
+    ):
+        """Test that add bbox includes covering metadata for GeoParquet 1.1."""
+        import json
+
+        import pyarrow.parquet as pq
+
+        runner = CliRunner()
+        result = runner.invoke(
+            add,
+            ["bbox", buildings_test_file, temp_output_file, "--geoparquet-version", "1.1"],
+        )
+        assert result.exit_code == 0
+        assert os.path.exists(temp_output_file)
+
+        # Check covering metadata
+        pf = pq.ParquetFile(temp_output_file)
+        geo_meta = json.loads(pf.schema_arrow.metadata.get(b"geo", b"{}"))
+
+        primary_col = geo_meta.get("primary_column", "geometry")
+        col_meta = geo_meta.get("columns", {}).get(primary_col, {})
+        covering = col_meta.get("covering", {})
+
+        assert "bbox" in covering, "covering.bbox should exist for GeoParquet 1.1"

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -541,3 +541,43 @@ class TestAddBboxCoveringMetadata:
         covering = col_meta.get("covering", {})
 
         assert "bbox" in covering, "covering.bbox should exist for GeoParquet 1.1"
+
+    def test_add_bbox_streaming_includes_covering_metadata(self, buildings_test_file, tmp_path):
+        """Test that streaming add bbox also includes covering metadata via internal function."""
+        import json
+
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.add.bbox import _add_bbox_streaming
+
+        output_file = str(tmp_path / "streaming_bbox.parquet")
+
+        # Test the internal streaming function directly (simulates stdin->file path)
+        _add_bbox_streaming(
+            input_path=buildings_test_file,  # File as source (simulates stdin materialized)
+            output_path=output_file,
+            bbox_column_name="bbox",
+            verbose=False,
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=None,
+            profile=None,
+            force=False,
+            geoparquet_version="2.0",
+        )
+
+        assert os.path.exists(output_file)
+
+        # Check covering metadata exists in streaming output
+        pf = pq.ParquetFile(output_file)
+        geo_meta = json.loads(pf.schema_arrow.metadata.get(b"geo", b"{}"))
+
+        primary_col = geo_meta.get("primary_column", "geometry")
+        col_meta = geo_meta.get("columns", {}).get(primary_col, {})
+        covering = col_meta.get("covering", {})
+
+        assert "bbox" in covering, "covering.bbox should exist in streaming output"
+        bbox_covering = covering["bbox"]
+        assert bbox_covering.get("xmin") == ["bbox", "xmin"]
+        assert bbox_covering.get("ymax") == ["bbox", "ymax"]

--- a/tests/test_check_spatial_order.py
+++ b/tests/test_check_spatial_order.py
@@ -333,6 +333,7 @@ class TestNativeGeoBboxDetection:
     def test_check_spatial_order_with_native_geo_bbox(self, tmp_path):
         """Test that check_spatial_order detects native geo_bbox stats from GeoParquet 2.0."""
         import duckdb
+        import pytest
 
         # Create a GeoParquet 2.0 file (without separate bbox column, but with native geo_bbox)
         output_file = str(tmp_path / "test_v2.parquet")
@@ -355,7 +356,7 @@ class TestNativeGeoBboxDetection:
         column_names = [col[0] for col in columns]
         assert "bbox" not in column_names, "Test file should not have bbox column"
 
-        # Check for native geo_bbox stats
+        # Check for native geo_bbox stats - skip if DuckDB version doesn't support them
         geo_bbox_result = conn.execute(f"""
             SELECT geo_bbox
             FROM parquet_metadata('{output_file}')
@@ -364,22 +365,26 @@ class TestNativeGeoBboxDetection:
             LIMIT 1
         """).fetchone()
 
-        # If native geo_bbox stats exist, check_spatial_order should use them
-        if geo_bbox_result:
-            from geoparquet_io.core.check_spatial_order import check_spatial_order
-
-            result = check_spatial_order(
-                output_file,
-                random_sample_size=50,
-                limit_rows=500,
-                verbose=False,
-                return_results=True,
+        if not geo_bbox_result:
+            pytest.skip(
+                "DuckDB version does not populate geo_bbox stats for GeoParquet V2 - "
+                "cannot test native geo_bbox detection"
             )
 
-            # Should use native_geo_bbox method, not sampling
-            assert result["method"] in ("native_geo_bbox", "bbox_stats"), (
-                f"Expected native_geo_bbox or bbox_stats method, got {result['method']}"
-            )
+        from geoparquet_io.core.check_spatial_order import check_spatial_order
+
+        result = check_spatial_order(
+            output_file,
+            random_sample_size=50,
+            limit_rows=500,
+            verbose=False,
+            return_results=True,
+        )
+
+        # Should use native_geo_bbox method, not sampling
+        assert result["method"] in ("native_geo_bbox", "bbox_stats"), (
+            f"Expected native_geo_bbox or bbox_stats method, got {result['method']}"
+        )
 
     def test_helper_function_returns_correct_structure(self):
         """Test that _check_spatial_order_from_row_group_bboxes returns correct structure."""

--- a/tests/test_check_spatial_order.py
+++ b/tests/test_check_spatial_order.py
@@ -325,3 +325,87 @@ class TestAutoDetectionAndFallback:
         for field in ["passed", "ratio", "issues", "recommendations", "fix_available", "method"]:
             assert field in bbox_result
             assert field in sampling_result
+
+
+class TestNativeGeoBboxDetection:
+    """Tests for native geo_bbox stats detection (fixes #410)."""
+
+    def test_check_spatial_order_with_native_geo_bbox(self, tmp_path):
+        """Test that check_spatial_order detects native geo_bbox stats from GeoParquet 2.0."""
+        import duckdb
+
+        # Create a GeoParquet 2.0 file (without separate bbox column, but with native geo_bbox)
+        output_file = str(tmp_path / "test_v2.parquet")
+        conn = duckdb.connect()
+        conn.execute("INSTALL spatial; LOAD spatial;")
+
+        # Create test data with geometry
+        conn.execute(f"""
+            COPY (
+                SELECT
+                    ST_Point(i * 0.01, i * 0.01) as geometry,
+                    i as id
+                FROM range(100) t(i)
+            ) TO '{output_file}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, GEOPARQUET_VERSION 'V2')
+        """)
+
+        # Verify no bbox column exists
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{output_file}"').fetchall()
+        column_names = [col[0] for col in columns]
+        assert "bbox" not in column_names, "Test file should not have bbox column"
+
+        # Check for native geo_bbox stats
+        geo_bbox_result = conn.execute(f"""
+            SELECT geo_bbox
+            FROM parquet_metadata('{output_file}')
+            WHERE path_in_schema = 'geometry'
+              AND geo_bbox IS NOT NULL
+            LIMIT 1
+        """).fetchone()
+
+        # If native geo_bbox stats exist, check_spatial_order should use them
+        if geo_bbox_result:
+            from geoparquet_io.core.check_spatial_order import check_spatial_order
+
+            result = check_spatial_order(
+                output_file,
+                random_sample_size=50,
+                limit_rows=500,
+                verbose=False,
+                return_results=True,
+            )
+
+            # Should use native_geo_bbox method, not sampling
+            assert result["method"] in ("native_geo_bbox", "bbox_stats"), (
+                f"Expected native_geo_bbox or bbox_stats method, got {result['method']}"
+            )
+
+    def test_helper_function_returns_correct_structure(self):
+        """Test that _check_spatial_order_from_row_group_bboxes returns correct structure."""
+        from geoparquet_io.core.check_spatial_order import (
+            _check_spatial_order_from_row_group_bboxes,
+        )
+
+        # Mock row group bboxes
+        row_group_bboxes = [
+            {"row_group_id": 0, "xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0},
+            {"row_group_id": 1, "xmin": 0.5, "ymin": 0.5, "xmax": 1.5, "ymax": 1.5},
+            {"row_group_id": 2, "xmin": 1.0, "ymin": 1.0, "xmax": 2.0, "ymax": 2.0},
+        ]
+
+        result = _check_spatial_order_from_row_group_bboxes(
+            row_group_bboxes,
+            parquet_file="test.parquet",
+            verbose=False,
+            return_results=True,
+            quiet=True,
+        )
+
+        # Verify structure
+        assert "passed" in result
+        assert "ratio" in result
+        assert "method" in result
+        assert result["method"] == "native_geo_bbox"
+        assert "overlap_count" in result
+        assert "total_pairs" in result

--- a/tests/test_crs_conversion.py
+++ b/tests/test_crs_conversion.py
@@ -828,3 +828,68 @@ class TestCRSDetectionHelpers:
         crs = _detect_source_crs(test_file, verbose=False)
         assert crs != "EPSG:4326", "Should not fall back to 4326 when valid PROJJSON exists"
         assert "32145" in crs or crs.startswith("{")
+
+
+class TestReprojectBboxPreservation:
+    """Tests for bbox column preservation during reproject (fixes #409)."""
+
+    def test_reproject_preserves_bbox_column(self, runner, temp_output_file, places_test_file):
+        """Test that reproject regenerates bbox column with transformed coordinates."""
+        import duckdb
+
+        # places_test_file has bbox column, reproject it
+        result = runner.invoke(
+            cli,
+            ["convert", "reproject", places_test_file, temp_output_file, "-d", "EPSG:3857"],
+        )
+        assert result.exit_code == 0
+
+        # Verify bbox column exists in output
+        conn = duckdb.connect()
+        conn.execute("INSTALL spatial; LOAD spatial;")
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
+        column_names = [col[0] for col in columns]
+        assert "bbox" in column_names, "bbox column should be preserved after reproject"
+
+        # Verify bbox structure has xmin, ymin, xmax, ymax
+        bbox_struct = conn.execute(f'SELECT bbox FROM "{temp_output_file}" LIMIT 1').fetchone()[0]
+        assert "xmin" in bbox_struct
+        assert "ymin" in bbox_struct
+        assert "xmax" in bbox_struct
+        assert "ymax" in bbox_struct
+
+        # Verify bbox values are in Web Mercator range (not WGS84)
+        bbox_stats = conn.execute(f"""
+            SELECT
+                MIN(bbox.xmin) as min_x,
+                MAX(bbox.xmax) as max_x,
+                MIN(bbox.ymin) as min_y,
+                MAX(bbox.ymax) as max_y
+            FROM "{temp_output_file}"
+        """).fetchone()
+
+        # Web Mercator coordinates are typically in meters, much larger than WGS84 degrees
+        # WGS84: -180 to 180, Web Mercator: ~-20M to ~20M
+        min_x, max_x, min_y, max_y = bbox_stats
+        assert abs(min_x) > 1000 or abs(max_x) > 1000, (
+            f"bbox x values {min_x}, {max_x} look like WGS84 degrees, not Web Mercator"
+        )
+
+    def test_reproject_without_bbox_does_not_add_bbox(
+        self, runner, temp_output_file, buildings_test_file
+    ):
+        """Test that reproject doesn't add bbox if input didn't have one."""
+        import duckdb
+
+        # buildings_test_file doesn't have bbox column
+        result = runner.invoke(
+            cli,
+            ["convert", "reproject", buildings_test_file, temp_output_file, "-d", "EPSG:3857"],
+        )
+        assert result.exit_code == 0
+
+        # Verify no bbox column in output
+        conn = duckdb.connect()
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
+        column_names = [col[0] for col in columns]
+        assert "bbox" not in column_names, "bbox should not be added if input didn't have one"

--- a/tests/test_crs_conversion.py
+++ b/tests/test_crs_conversion.py
@@ -893,3 +893,35 @@ class TestReprojectBboxPreservation:
         columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
         column_names = [col[0] for col in columns]
         assert "bbox" not in column_names, "bbox should not be added if input didn't have one"
+
+    def test_reproject_streaming_preserves_bbox_column(self, tmp_path, places_test_file):
+        """Test that streaming reproject also regenerates bbox column via internal function."""
+        import duckdb
+
+        from geoparquet_io.core.reproject import _reproject_streaming
+
+        output_file = str(tmp_path / "streaming_output.parquet")
+
+        # Test the internal streaming function directly (simulates stdin->file path)
+        _reproject_streaming(
+            input_path=places_test_file,  # File as source (simulates stdin materialized)
+            output_path=output_file,
+            target_crs="EPSG:3857",
+            source_crs=None,
+            compression="ZSTD",
+            compression_level=None,
+            verbose=False,
+            profile=None,
+            geoparquet_version=None,
+        )
+
+        # Verify bbox column exists in output
+        conn = duckdb.connect()
+        conn.execute("INSTALL spatial; LOAD spatial;")
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{output_file}"').fetchall()
+        column_names = [col[0] for col in columns]
+        assert "bbox" in column_names, "bbox column should be preserved in streaming reproject"
+
+        # Verify bbox has correct structure
+        bbox_struct = conn.execute(f'SELECT bbox FROM "{output_file}" LIMIT 1').fetchone()[0]
+        assert "xmin" in bbox_struct and "ymax" in bbox_struct


### PR DESCRIPTION
## Summary

Fixes three related issues with bbox handling in GeoParquet 2.0:

- **#409**: `gpio convert reproject` now regenerates the bbox column with transformed coordinates instead of dropping it
- **#410**: `gpio check` now detects native `geo_bbox` row group statistics for GeoParquet 2.0 files, avoiding false "bbox not found" warnings
- **#412**: `gpio add bbox` now includes covering metadata for all GeoParquet versions including 2.0

## Changes

### #409 - Reproject bbox preservation (`reproject.py`)
- When input has bbox column, use CTE to compute reprojected geometry once
- Add new bbox struct with coordinates from the reprojected geometry
- If input has no bbox, output also has no bbox (no change)

### #410 - Native geo_bbox detection (`check_spatial_order.py`)
- Added check for native `geo_bbox` row group stats via `get_per_row_group_native_geo_stats()`
- New helper `_check_spatial_order_from_row_group_bboxes()` for shared logic
- Falls back to sampling only when neither bbox column nor native geo_bbox exists

### #412 - Bbox covering metadata for 2.0 (`bbox.py`, `common.py`)
- `_add_bbox_file_based()` now passes `custom_metadata` with covering info
- `write_parquet_with_metadata()` forces metadata rewrite when `custom_metadata` contains covering
- Ensures covering metadata is written even for 2.0→2.0 operations

## Test plan

- [x] `test_add_bbox_includes_covering_metadata_for_v2` - verifies covering metadata for 2.0
- [x] `test_add_bbox_includes_covering_metadata_for_v1_1` - verifies covering metadata for 1.1
- [x] `test_reproject_preserves_bbox_column` - verifies bbox regeneration after reproject
- [x] `test_reproject_without_bbox_does_not_add_bbox` - verifies no bbox added if input lacks one
- [x] `test_check_spatial_order_with_native_geo_bbox` - verifies native geo_bbox detection
- [x] `test_helper_function_returns_correct_structure` - verifies helper returns correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)