### PR TITLE
bump: version 1.0.1 → 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,41 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - Plugin system documentation
 - Dependency updates (actions/checkout v6, astral-sh/setup-uv v7, etc.)
 
+## v1.1.0 (2026-04-29)
+
+### Feat
+
+- integrate gpio-pmtiles into core
+- **api**: expose axis_order and strict_crs in Python API
+- **wfs**: add WFS 2.0 support, axis order fix, and CRS validation
+
+### Fix
+
+- **wfs**: address adversarial review findings for --output-crs
+- **wfs**: honor --output-crs by reprojecting when server returns different CRS
+- skip non-GeoParquet files early in check --pmtiles (#408)
+- address PR #417 adversarial review findings
+- PMTiles pipeline bugs found in adversarial review
+- extend bbox fixes to streaming code paths
+- GeoParquet 2.0 bbox handling for reproject, check, and add commands
+- **tests**: use tuple comparison for pip version check
+- **tests**: resolve CI failures for pip-audit CVE and wfs import
+- **inspect**: scope fixtures to module, add markers, fix multi-geometry stats
+- **inspect**: default --geo-stats to 1 row group with "... and N more" hint
+- **inspect**: adapt geo_bbox precision to fit large projected coordinates
+- **inspect**: use 2 decimal places for geo_bbox display and remove truncation
+- **inspect**: show geo_bbox stats in row group tables and --geo-stats
+- **wfs**: add version guard for srsName and improve test coverage
+- **wfs**: include srsName parameter without bbox filter
+- **test**: correct import path for list_layers module
+- **convert**: apply gc.collect() on all platforms for multi-layer reads
+- **wfs**: move type inference after concat, fix resource leak
+- **wfs**: infer column types from string values
+- **wfs**: address review findings
+- **deps**: bump lxml>=6.1.0 for CVE-2026-41066 (#395)
+- **deps**: remove pyarrow version cap
+- **ci**: rename release.yml back to publish.yml for PyPI trusted publisher
+
 ## v1.0.1 (2026-04-20)
 
 ### Fix

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,41 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - Plugin system documentation
 - Dependency updates (actions/checkout v6, astral-sh/setup-uv v7, etc.)
 
+## v1.1.0 (2026-04-29)
+
+### Feat
+
+- integrate gpio-pmtiles into core
+- **api**: expose axis_order and strict_crs in Python API
+- **wfs**: add WFS 2.0 support, axis order fix, and CRS validation
+
+### Fix
+
+- **wfs**: address adversarial review findings for --output-crs
+- **wfs**: honor --output-crs by reprojecting when server returns different CRS
+- skip non-GeoParquet files early in check --pmtiles (#408)
+- address PR #417 adversarial review findings
+- PMTiles pipeline bugs found in adversarial review
+- extend bbox fixes to streaming code paths
+- GeoParquet 2.0 bbox handling for reproject, check, and add commands
+- **tests**: use tuple comparison for pip version check
+- **tests**: resolve CI failures for pip-audit CVE and wfs import
+- **inspect**: scope fixtures to module, add markers, fix multi-geometry stats
+- **inspect**: default --geo-stats to 1 row group with "... and N more" hint
+- **inspect**: adapt geo_bbox precision to fit large projected coordinates
+- **inspect**: use 2 decimal places for geo_bbox display and remove truncation
+- **inspect**: show geo_bbox stats in row group tables and --geo-stats
+- **wfs**: add version guard for srsName and improve test coverage
+- **wfs**: include srsName parameter without bbox filter
+- **test**: correct import path for list_layers module
+- **convert**: apply gc.collect() on all platforms for multi-layer reads
+- **wfs**: move type inference after concat, fix resource leak
+- **wfs**: infer column types from string values
+- **wfs**: address review findings
+- **deps**: bump lxml>=6.1.0 for CVE-2026-41066 (#395)
+- **deps**: remove pyarrow version cap
+- **ci**: rename release.yml back to publish.yml for PyPI trusted publisher
+
 ## v1.0.1 (2026-04-20)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geoparquet-io"
-version = "1.0.1"
+version = "1.1.0"
 description = "Fast I/O and transformation tools for GeoParquet files"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -256,7 +256,7 @@ skips = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.0.1"
+version = "1.1.0"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 update_changelog_on_bump = true

--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Release v1.1.0 with:

- **PMTiles integration**: `gpio pmtiles create` now built-in (no plugin needed)
- **WFS 2.0 support**: axis order fix, CRS validation, `--output-crs` reprojection guarantee
- **Python API**: `axis_order` and `strict_crs` parameters exposed
- **GeoParquet 2.0**: bbox handling fixes across reproject, check, and add commands
- **Security**: lxml bump for CVE-2026-41066

See [CHANGELOG.md](./CHANGELOG.md#v110-2026-04-29) for full details.

## Release process

After merge, publish.yml will:
1. Detect `bump:` commit message
2. Create git tag `v1.1.0`
3. Build and publish to PyPI
4. Create GitHub release

🤖 Generated with [Claude Code](https://claude.ai/code)