### PR TITLE
fix(windows): release file handles before replace in bbox_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - Plugin system documentation
 - Dependency updates (actions/checkout v6, astral-sh/setup-uv v7, etc.)
 
+## v1.1.1 (2026-04-29)
+
+### Fix
+
+- **windows**: release file handles before replace in bbox_metadata
+
 ## v1.1.0 (2026-04-29)
 
 ### Feat

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,6 +92,12 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - Plugin system documentation
 - Dependency updates (actions/checkout v6, astral-sh/setup-uv v7, etc.)
 
+## v1.1.1 (2026-04-29)
+
+### Fix
+
+- **windows**: release file handles before replace in bbox_metadata
+
 ## v1.1.0 (2026-04-29)
 
 ### Feat

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import gc
 import json
 import os
 
@@ -109,6 +110,10 @@ def add_bbox_metadata(parquet_file, verbose=False):
             version="2.6",
             write_page_index=False,
         )
+
+        # Release references before file replace (Windows file locking)
+        del table, new_table
+        gc.collect()
 
         # Replace original file
         os.replace(temp_file, parquet_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geoparquet-io"
-version = "1.1.0"
+version = "1.1.1"
 description = "Fast I/O and transformation tools for GeoParquet files"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -256,7 +256,7 @@ skips = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.1.0"
+version = "1.1.1"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 update_changelog_on_bump = true

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -169,7 +169,9 @@ class TestAddCommands:
 
         runner = CliRunner()
         result = runner.invoke(add, ["bbox-metadata", temp_file])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, (
+            f"Command failed: {result.output}\nException: {result.exception}"
+        )
         # Should either add metadata or report it already exists
         assert "Added bbox covering metadata" in result.output or "already exists" in result.output
 

--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Add `gc.collect()` and explicit `del` before `os.replace()` to release PyArrow file handles on Windows
- Improve test error messages for better CI debugging

Fixes Windows CI failure in `test_add_bbox_metadata_to_existing_bbox`.

## Test plan

- [x] Local test passes
- [ ] Windows CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)