### PR TITLE
fix(pmtiles): handle BrokenPipe and surface upstream stderr (#421)

### DIFF
--- a/geoparquet_io/core/geojson_stream.py
+++ b/geoparquet_io/core/geojson_stream.py
@@ -234,30 +234,39 @@ def _stream_to_stdout(
         Number of features written
     """
     import json
+    import os
 
     result = con.execute(query)
     count = 0
     output = sys.stdout
 
-    while True:
-        row = result.fetchone()
-        if row is None:
-            break
+    try:
+        while True:
+            row = result.fetchone()
+            if row is None:
+                break
 
-        if rs:
-            output.write(RS)
+            if rs:
+                output.write(RS)
 
-        if pretty:
-            # Parse and re-serialize with indentation
-            feature = json.loads(row[0])
-            output.write(json.dumps(feature, indent=2))
-        else:
-            output.write(row[0])
+            if pretty:
+                # Parse and re-serialize with indentation
+                feature = json.loads(row[0])
+                output.write(json.dumps(feature, indent=2))
+            else:
+                output.write(row[0])
 
-        output.write("\n")
-        count += 1
+            output.write("\n")
+            count += 1
 
-    output.flush()
+        output.flush()
+    except BrokenPipeError:
+        # Downstream consumer closed the pipe early (e.g. `| head`, tippecanoe
+        # finished reading). Redirect stdout to devnull so interpreter-shutdown
+        # flush does not re-raise. Standard Unix pipe-tool behavior.
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull_fd, sys.stdout.fileno())
+
     return count
 
 

--- a/geoparquet_io/core/geojson_stream.py
+++ b/geoparquet_io/core/geojson_stream.py
@@ -264,8 +264,15 @@ def _stream_to_stdout(
         # Downstream consumer closed the pipe early (e.g. `| head`, tippecanoe
         # finished reading). Redirect stdout to devnull so interpreter-shutdown
         # flush does not re-raise. Standard Unix pipe-tool behavior.
+        try:
+            stdout_fd = sys.stdout.fileno()
+        except (OSError, ValueError):
+            return count
         devnull_fd = os.open(os.devnull, os.O_WRONLY)
-        os.dup2(devnull_fd, sys.stdout.fileno())
+        try:
+            os.dup2(devnull_fd, stdout_fd)
+        finally:
+            os.close(devnull_fd)
 
     return count
 

--- a/geoparquet_io/core/pmtiles.py
+++ b/geoparquet_io/core/pmtiles.py
@@ -187,6 +187,32 @@ def _build_tippecanoe_command(
     return cmd
 
 
+def _format_proc_error(proc: "subprocess.Popen[bytes]", stderr_bytes: bytes) -> str:
+    """Build a diagnostic message for a failed pipeline process.
+
+    Picks an informative `cmd_name` — for `python -m geoparquet_io …`
+    invocations, surfaces the module + subcommand rather than the
+    interpreter path.
+    """
+    args = proc.args if isinstance(proc.args, list) else [str(proc.args)]
+    cmd_name = "command"
+    if args:
+        if "-m" in args:
+            m_idx = args.index("-m")
+            tail = args[m_idx + 1 : m_idx + 4]
+            if tail:
+                cmd_name = " ".join(tail)
+        else:
+            binary = Path(args[0]).name
+            rest = next((a for a in args[1:] if not a.startswith("-")), "")
+            cmd_name = f"{binary} {rest}".strip() or binary
+    stderr_text = stderr_bytes.decode(errors="replace").strip()
+    msg = f"{cmd_name} failed with exit code {proc.returncode}"
+    if stderr_text:
+        msg = f"{msg}\nstderr:\n{stderr_text}"
+    return msg
+
+
 def _run_pipeline(
     gpio_commands: list[list[str]],
     tippecanoe_cmd: list[str],
@@ -231,11 +257,12 @@ def _run_pipeline(
 
         tippecanoe_proc.communicate()
 
-        if tippecanoe_proc.returncode != 0:
-            raise RuntimeError(f"tippecanoe failed with exit code {tippecanoe_proc.returncode}")
-
-        # Drain stderr and wait for earlier processes
-        # Note: stdout is already closed for piping, so we only drain stderr
+        # Drain stderr and wait for upstream procs FIRST. If an upstream gpio
+        # process crashed, tippecanoe almost always exits non-zero too (read
+        # truncated input), and the upstream stderr is the real diagnostic —
+        # we must not short-circuit on tippecanoe's exit code before
+        # collecting it.
+        upstream_errors: list[str] = []
         for proc in processes[:-1]:
             stderr_bytes = b""
             if proc.stderr:
@@ -243,12 +270,16 @@ def _run_pipeline(
                 proc.stderr.close()
             proc.wait()
             if proc.returncode != 0:
-                cmd_name = proc.args[0] if isinstance(proc.args, list) else "command"
-                stderr_text = stderr_bytes.decode(errors="replace").strip()
-                msg = f"{cmd_name} failed with exit code {proc.returncode}"
-                if stderr_text:
-                    msg = f"{msg}\nstderr:\n{stderr_text}"
-                raise RuntimeError(msg)
+                upstream_errors.append(_format_proc_error(proc, stderr_bytes))
+
+        if tippecanoe_proc.returncode != 0:
+            msg = f"tippecanoe failed with exit code {tippecanoe_proc.returncode}"
+            if upstream_errors:
+                msg = f"{msg}\nUpstream errors:\n" + "\n\n".join(upstream_errors)
+            raise RuntimeError(msg)
+
+        if upstream_errors:
+            raise RuntimeError("\n\n".join(upstream_errors))
 
     except KeyboardInterrupt:
         for proc in processes:

--- a/geoparquet_io/core/pmtiles.py
+++ b/geoparquet_io/core/pmtiles.py
@@ -237,13 +237,18 @@ def _run_pipeline(
         # Drain stderr and wait for earlier processes
         # Note: stdout is already closed for piping, so we only drain stderr
         for proc in processes[:-1]:
+            stderr_bytes = b""
             if proc.stderr:
-                proc.stderr.read()
+                stderr_bytes = proc.stderr.read()
                 proc.stderr.close()
             proc.wait()
             if proc.returncode != 0:
                 cmd_name = proc.args[0] if isinstance(proc.args, list) else "command"
-                raise RuntimeError(f"{cmd_name} failed with exit code {proc.returncode}")
+                stderr_text = stderr_bytes.decode(errors="replace").strip()
+                msg = f"{cmd_name} failed with exit code {proc.returncode}"
+                if stderr_text:
+                    msg = f"{msg}\nstderr:\n{stderr_text}"
+                raise RuntimeError(msg)
 
     except KeyboardInterrupt:
         for proc in processes:

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -341,6 +341,7 @@ class TestPipelineIntegration:
             if output_path.exists():
                 output_path.unlink()
 
+    @pytest.mark.integration
     @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
     @pytest.mark.skipif(
         sys.platform == "win32" or shutil.which("head") is None,

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -11,6 +11,7 @@ Tests verify that gpio convert geojson:
 """
 
 import json
+import shutil
 import sys
 import tempfile
 import uuid
@@ -341,7 +342,7 @@ class TestPipelineIntegration:
                 output_path.unlink()
 
     @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX `head` not available")
+    @pytest.mark.skipif(shutil.which("head") is None, reason="POSIX `head` binary not available")
     def test_streaming_handles_broken_pipe(self):
         """Stream survives downstream closing pipe early (e.g. tippecanoe done).
 
@@ -350,7 +351,6 @@ class TestPipelineIntegration:
         users as `gpio failed with exit code 1` with no logs.
         """
         import subprocess
-        import sys
 
         producer = subprocess.Popen(
             [

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -11,6 +11,7 @@ Tests verify that gpio convert geojson:
 """
 
 import json
+import sys
 import tempfile
 import uuid
 from pathlib import Path
@@ -340,6 +341,7 @@ class TestPipelineIntegration:
                 output_path.unlink()
 
     @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX `head` not available")
     def test_streaming_handles_broken_pipe(self):
         """Stream survives downstream closing pipe early (e.g. tippecanoe done).
 

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -339,6 +339,45 @@ class TestPipelineIntegration:
             if output_path.exists():
                 output_path.unlink()
 
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_streaming_handles_broken_pipe(self):
+        """Stream survives downstream closing pipe early (e.g. tippecanoe done).
+
+        Regression for issue #421: piping `gpio convert geojson` to a consumer
+        that closes early caused a silent BrokenPipeError exit 1, surfaced to
+        users as `gpio failed with exit code 1` with no logs.
+        """
+        import subprocess
+        import sys
+
+        producer = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "from geoparquet_io.cli.main import cli; cli()",
+                "convert",
+                "geojson",
+                str(PLACES_PARQUET),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        consumer = subprocess.Popen(
+            ["head", "-n", "1"],
+            stdin=producer.stdout,
+            stdout=subprocess.DEVNULL,
+        )
+        producer.stdout.close()
+        consumer.wait(timeout=30)
+        stderr = producer.stderr.read()
+        producer.stderr.close()
+        producer.wait(timeout=30)
+
+        assert producer.returncode == 0, (
+            f"gpio convert geojson exited {producer.returncode} after downstream "
+            f"closed pipe. stderr: {stderr.decode(errors='replace')!r}"
+        )
+
 
 @pytest.mark.skipif(not BUILDINGS_PARQUET.exists(), reason="Test data not available")
 class TestPolygonGeometries:

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -342,7 +342,10 @@ class TestPipelineIntegration:
                 output_path.unlink()
 
     @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
-    @pytest.mark.skipif(shutil.which("head") is None, reason="POSIX `head` binary not available")
+    @pytest.mark.skipif(
+        sys.platform == "win32" or shutil.which("head") is None,
+        reason="needs POSIX platform with `head` binary (Git-for-Windows head triggers cp1252 encoding bug, unrelated to #421)",
+    )
     def test_streaming_handles_broken_pipe(self):
         """Stream survives downstream closing pipe early (e.g. tippecanoe done).
 

--- a/tests/test_pmtiles.py
+++ b/tests/test_pmtiles.py
@@ -455,3 +455,29 @@ class TestPMTilesIntegration:
 
         assert output_file.exists()
         assert output_file.stat().st_size > 0
+
+
+class TestRunPipelineErrorSurfacing:
+    """Pipeline errors must surface upstream stderr.
+
+    Regression for issue #421: a failing upstream gpio process had its stderr
+    captured to PIPE, drained, then discarded — the raised RuntimeError only
+    contained the exit code, leaving users debugging blind.
+    """
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="needs POSIX shell")
+    def test_pipeline_error_includes_upstream_stderr(self):
+        from geoparquet_io.core.pmtiles import _run_pipeline
+
+        sentinel = "GPIO_UPSTREAM_BOOM_a3f9"
+        with pytest.raises(RuntimeError) as exc_info:
+            _run_pipeline(
+                gpio_commands=[
+                    ["sh", "-c", f"echo {sentinel} >&2; exit 7"],
+                ],
+                tippecanoe_cmd=["cat"],
+                verbose=False,
+            )
+        msg = str(exc_info.value)
+        assert "exit code 7" in msg
+        assert sentinel in msg, f"upstream stderr '{sentinel}' not surfaced in error: {msg!r}"

--- a/tests/test_pmtiles.py
+++ b/tests/test_pmtiles.py
@@ -481,3 +481,30 @@ class TestRunPipelineErrorSurfacing:
         msg = str(exc_info.value)
         assert "exit code 7" in msg
         assert sentinel in msg, f"upstream stderr '{sentinel}' not surfaced in error: {msg!r}"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="needs POSIX shell")
+    def test_tippecanoe_failure_still_surfaces_upstream_stderr(self):
+        """When tippecanoe also exits non-zero, upstream stderr must still surface.
+
+        Real-world failure mode: upstream gpio crashes, tippecanoe sees a
+        truncated stream and also exits non-zero. The previous implementation
+        short-circuited on tippecanoe's exit code, hiding the real cause.
+        """
+        from geoparquet_io.core.pmtiles import _run_pipeline
+
+        sentinel = "GPIO_UPSTREAM_TIPPECANOE_DUAL_b7c4"
+        with pytest.raises(RuntimeError) as exc_info:
+            _run_pipeline(
+                gpio_commands=[
+                    ["sh", "-c", f"echo {sentinel} >&2; exit 5"],
+                ],
+                tippecanoe_cmd=["sh", "-c", "exit 9"],
+                verbose=False,
+            )
+        msg = str(exc_info.value)
+        assert "tippecanoe failed" in msg
+        assert "exit code 9" in msg
+        assert sentinel in msg, (
+            f"upstream stderr '{sentinel}' lost behind tippecanoe error: {msg!r}"
+        )
+        assert "exit code 5" in msg


### PR DESCRIPTION
Closes #421.

## Summary
- `gpio pmtiles create` exited 1 silently after tippecanoe finished. Upstream `gpio convert geojson` hit `BrokenPipeError` once tippecanoe closed stdin; the pipeline wrapper raised a generic "exit code 1" with the captured stderr discarded.
- `_stream_to_stdout` now catches `BrokenPipeError` and `dup2`s stdout to `/dev/null`, matching standard Unix pipe-tool behavior — interpreter-shutdown flush no longer re-raises.
- `_run_pipeline` now appends captured upstream stderr to the raised `RuntimeError` so real failures are diagnosable.

## Diagnosis trail
1. Reproduced via `gpio convert geojson fields_pgo_crs84_bbox_snappy.parquet | head -1` → exit 1, silent stderr.
2. Reproduced stderr-swallowing in `_run_pipeline` with `sh -c 'echo BOOM >&2; exit 7'` → raised `sh failed with exit code 7`, sentinel discarded.
3. Both reproductions encoded as failing pytest regressions before fixing.

## Test plan
- [x] `tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe` — pipes CLI output to `head -n 1`, asserts exit 0.
- [x] `tests/test_pmtiles.py::TestRunPipelineErrorSurfacing::test_pipeline_error_includes_upstream_stderr` — feeds a failing upstream into `_run_pipeline`, asserts stderr sentinel surfaces in the `RuntimeError`.
- [x] Full `tests/test_geojson_stream.py` + `tests/test_pmtiles.py` — 58 passed, no regressions.
- [x] Manual sanity: original repro `uv run gpio convert geojson … | head -1` now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of terminated downstream connections during GeoJSON streaming to avoid crashes on early consumer exit
  * Improved pipeline error reporting so failures include diagnostic output from upstream processes

* **Tests**
  * Added regression tests covering streaming resilience and pipeline error-message correctness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->