### PR TITLE
Support PMTile creation with layer metadata based on a column name

### DIFF
--- a/docs/guide/geojson.md
+++ b/docs/guide/geojson.md
@@ -60,6 +60,9 @@ For a simpler PMTiles workflow, use the built-in `gpio pmtiles` command. It prov
 
     # With CRS override (for incorrect metadata)
     gpio pmtiles create data.parquet tiles.pmtiles --src-crs EPSG:3857
+
+    # Add layer metadata to the output PMTiles based on the values of column 'owner'
+    gpio pmtiles create --layer-by-column owner data.parquet tiles.pmtiles
     ```
 
 === "Python"

--- a/docs/guide/geojson.md
+++ b/docs/guide/geojson.md
@@ -91,6 +91,13 @@ For a simpler PMTiles workflow, use the built-in `gpio pmtiles` command. It prov
         output_path="tiles.pmtiles",
         src_crs="EPSG:3857"
     )
+
+    # Add layer metadata to the output PMTiles based on the values of column 'owner'
+    ops.create_pmtiles(
+        input_path="data.parquet",
+        output_path="tiles.pmtiles",
+        layer_by_column="owner"
+    )
     ```
 
 The command handles the entire pipeline internally (reprojection → filtering → conversion → tippecanoe) with optimal settings.

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -941,6 +941,7 @@ def create_pmtiles(
     profile: str | None = None,
     src_crs: str | None = None,
     attribution: str | None = None,
+    layer_by_column: str | None = None,
 ) -> None:
     """
     Create PMTiles from a GeoParquet file using tippecanoe.
@@ -962,6 +963,7 @@ def create_pmtiles(
         profile: AWS profile name for S3 files
         src_crs: Source CRS for reprojection to WGS84
         attribution: Attribution HTML for the tiles
+        layer_by_column: Split tiles into layers grouped by the values of this column
 
     Raises:
         TippecanoeNotFoundError: If tippecanoe is not in PATH
@@ -996,4 +998,5 @@ def create_pmtiles(
         profile=profile,
         src_crs=src_crs,
         attribution=attribution,
+        layer_by_column=layer_by_column,
     )

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -6152,6 +6152,12 @@ def pmtiles(ctx):
 )
 @click.option("--src-crs", help="Source CRS for reprojection to WGS84")
 @click.option("--attribution", help="Custom attribution HTML for tiles")
+@click.option(
+    "--layer-by-column",
+    type=str,
+    default=None,
+    help="In the generated PMTiles, split tiles into layers based on the value of this column",
+)
 @verbose_option
 @aws_profile_option
 def pmtiles_create(
@@ -6168,6 +6174,7 @@ def pmtiles_create(
     attribution,
     verbose,
     aws_profile,
+    layer_by_column,
 ):
     """Create PMTiles from a GeoParquet file.
 
@@ -6183,6 +6190,8 @@ def pmtiles_create(
         gpio pmtiles create data.parquet tiles.pmtiles --bbox "-122.5,37.5,-122.0,38.0"
 
         gpio pmtiles create data.parquet tiles.pmtiles --where "population > 10000"
+
+        gpio pmtiles create data.parquet tiles.pmtiles --layer-by-column owner
     """
     from geoparquet_io.core.pmtiles import create_pmtiles_from_geoparquet
 
@@ -6201,6 +6210,7 @@ def pmtiles_create(
             profile=aws_profile,
             src_crs=src_crs,
             attribution=attribution,
+            layer_by_column=layer_by_column,
         )
         click.echo(click.style(f"✓ Created {output_file}", fg="green"))
     except Exception as e:

--- a/geoparquet_io/core/pmtiles.py
+++ b/geoparquet_io/core/pmtiles.py
@@ -270,7 +270,7 @@ def _run_pipeline(
             cmd_str = " | ".join(" ".join(cmd) for cmd in gpio_commands)
             debug(f"Running: {cmd_str} | {' '.join(tippecanoe_cmd)}")
         if layer_by_column:
-            debug(f"Add layer metadata into PMTiles from column '{layer_by_column}'")
+            debug(f"Adding layer metadata into PMTiles from column '{layer_by_column}'")
 
     processes: list[subprocess.Popen] = []
 

--- a/geoparquet_io/core/pmtiles.py
+++ b/geoparquet_io/core/pmtiles.py
@@ -272,7 +272,7 @@ def _run_pipeline(
         if layer_by_column:
             debug(f"Add layer metadata into PMTiles from column '{layer_by_column}'")
 
-    processes: list[subprocess.Popen[bytes]] = []
+    processes: list[subprocess.Popen] = []
 
     try:
         for i, cmd in enumerate(gpio_commands):
@@ -379,7 +379,7 @@ def _run_pipeline(
                 stdin=processes[-1].stdout if processes else None,
                 stdout=None if verbose else subprocess.PIPE,
                 stderr=None,
-            )
+            )  # type: ignore
             processes.append(tippecanoe_proc)
             if len(processes) > 1 and processes[-2].stdout:
                 processes[-2].stdout.close()
@@ -391,7 +391,7 @@ def _run_pipeline(
             # truncated input), and the upstream stderr is the real diagnostic —
             # we must not short-circuit on tippecanoe's exit code before
             # collecting it.
-            upstream_errors: list[str] = []
+            upstream_gpio_errors: list[str] = []
             for proc in processes[:-1]:
                 stderr_bytes = b""
                 if proc.stderr:
@@ -399,16 +399,16 @@ def _run_pipeline(
                     proc.stderr.close()
                 proc.wait()
                 if proc.returncode != 0:
-                    upstream_errors.append(_format_proc_error(proc, stderr_bytes))
+                    upstream_gpio_errors.append(_format_proc_error(proc, stderr_bytes))
 
             if tippecanoe_proc.returncode != 0:
                 msg = f"tippecanoe failed with exit code {tippecanoe_proc.returncode}"
-                if upstream_errors:
-                    msg = f"{msg}\nUpstream errors:\n" + "\n\n".join(upstream_errors)
+                if upstream_gpio_errors:
+                    msg = f"{msg}\nUpstream errors:\n" + "\n\n".join(upstream_gpio_errors)
                 raise RuntimeError(msg)
 
-            if upstream_errors:
-                raise RuntimeError("\n\n".join(upstream_errors))
+            if upstream_gpio_errors:
+                raise RuntimeError("\n\n".join(upstream_gpio_errors))
 
     except KeyboardInterrupt:
         for proc in processes:
@@ -479,6 +479,7 @@ def create_pmtiles_from_geoparquet(
         raise TippecanoeNotFoundError()
 
     # If layer_by_column is set, ensure that the group by column is always included
+    include_cols_with_layer_by_column: str | None
     if layer_by_column and include_cols:
         cols = [c.strip() for c in include_cols.split(",")]
         if layer_by_column not in cols:

--- a/geoparquet_io/core/pmtiles.py
+++ b/geoparquet_io/core/pmtiles.py
@@ -4,10 +4,14 @@ Orchestrates a streaming pipeline: GeoParquet → gpio commands → tippecanoe �
 Requires tippecanoe to be installed and available in PATH.
 """
 
+import io
+import json
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
+from typing import IO
 
 from geoparquet_io.core.logging_config import debug, success
 
@@ -146,6 +150,34 @@ def _build_gpio_commands(
     return [convert_cmd]
 
 
+def _add_layer_info(geojson_stream: IO[str], layer_by_column: str) -> Iterator[str]:
+    """
+    Read newline-delimited GeoJSON features from a stream and re-emit them
+    with a `tippecanoe.layer` property injected on each feature.
+
+    gpio outputs one bare Feature JSON object per line (not a FeatureCollection).
+    Tippecanoe accepts this format directly when passed via stdin.
+    """
+
+    for line in geojson_stream:
+        line = line.strip()
+        if not line:
+            continue
+
+        feature = json.loads(line)
+        props = feature.get("properties") or {}
+        raw_value = props.get(layer_by_column)
+
+        # fall back to _unknown if layer_by_column is not found
+        if raw_value is None or str(raw_value).strip() == "":
+            layer_name = "_unknown"
+        else:
+            layer_name = str(raw_value).strip()
+
+        feature["tippecanoe"] = {"layer": layer_name}
+        yield json.dumps(feature, separators=(",", ":")) + "\n"
+
+
 def _build_tippecanoe_command(
     output_path: str,
     layer: str | None,
@@ -153,11 +185,16 @@ def _build_tippecanoe_command(
     max_zoom: int | None,
     verbose: bool,
     attribution: str | None = None,
+    layer_by_column: str | None = None,
 ) -> list[str]:
     """Build the tippecanoe command with production-quality settings."""
     cmd = ["tippecanoe", "-P", "-o", output_path]
 
-    if layer:
+    if layer_by_column:
+        # Let tippecanoe read layer names from the `tippecanoe.layer` property
+        # on each feature — do NOT pass -l at all.
+        pass
+    elif layer:
         cmd.extend(["-l", layer])
     else:
         layer_name = Path(output_path).stem
@@ -217,8 +254,14 @@ def _run_pipeline(
     gpio_commands: list[list[str]],
     tippecanoe_cmd: list[str],
     verbose: bool,
+    layer_by_column: str | None = None,
 ) -> None:
-    """Execute the pipeline of commands."""
+    """Execute the gpio to tippecanoe pipeline.
+
+    If layer_by_column is given, the gpio output is intercepted and each
+    feature is annotated with a `tippecanoe.layer` value derived from
+    that column before being forwarded to tippecanoe.
+    """
     if verbose:
         if len(gpio_commands) == 1:
             cmd_str = " ".join(gpio_commands[0])
@@ -226,6 +269,8 @@ def _run_pipeline(
         else:
             cmd_str = " | ".join(" ".join(cmd) for cmd in gpio_commands)
             debug(f"Running: {cmd_str} | {' '.join(tippecanoe_cmd)}")
+        if layer_by_column:
+            debug(f"Add layer metadata into PMTiles from column '{layer_by_column}'")
 
     processes: list[subprocess.Popen[bytes]] = []
 
@@ -244,42 +289,126 @@ def _run_pipeline(
             if i > 0 and processes[-2].stdout:
                 processes[-2].stdout.close()
 
-        tippecanoe_proc = subprocess.Popen(
-            tippecanoe_cmd,
-            stdin=processes[-1].stdout if processes else None,
-            stdout=None if verbose else subprocess.PIPE,
-            stderr=None,
-        )
-        processes.append(tippecanoe_proc)
+        if layer_by_column:
+            # Intercept: stream gpio output → inject layers → stream into tippecanoe
+            last_proc = processes[-1]
 
-        if len(processes) > 1 and processes[-2].stdout:
-            processes[-2].stdout.close()
+            tippecanoe_proc = subprocess.Popen(
+                tippecanoe_cmd,
+                stdin=subprocess.PIPE,
+                stdout=None,
+                stderr=None,
+                text=True,  # work with strings instead of bytes
+            )
 
-        tippecanoe_proc.communicate()
+            if last_proc.stdout is None:
+                raise RuntimeError("last process has no stdout")
+            if tippecanoe_proc.stdin is None:
+                raise RuntimeError("tippecanoe has no stdin")
 
-        # Drain stderr and wait for upstream procs FIRST. If an upstream gpio
-        # process crashed, tippecanoe almost always exits non-zero too (read
-        # truncated input), and the upstream stderr is the real diagnostic —
-        # we must not short-circuit on tippecanoe's exit code before
-        # collecting it.
-        upstream_errors: list[str] = []
-        for proc in processes[:-1]:
-            stderr_bytes = b""
-            if proc.stderr:
-                stderr_bytes = proc.stderr.read()
-                proc.stderr.close()
-            proc.wait()
-            if proc.returncode != 0:
-                upstream_errors.append(_format_proc_error(proc, stderr_bytes))
+            geojson_stream = io.TextIOWrapper(last_proc.stdout, encoding="utf-8")
 
-        if tippecanoe_proc.returncode != 0:
-            msg = f"tippecanoe failed with exit code {tippecanoe_proc.returncode}"
+            wrote_any = False
+
+            try:
+                for line in _add_layer_info(geojson_stream, layer_by_column):
+                    # Detect if tippecanoe already exited (e.g., file exists, bad args, etc.)
+                    if tippecanoe_proc.poll() is not None:
+                        raise RuntimeError(
+                            f"tippecanoe failed with code {tippecanoe_proc.returncode}"
+                        )
+
+                    tippecanoe_proc.stdin.write(line)
+                    wrote_any = True
+
+                # Signal EOF to tippecanoe
+                tippecanoe_proc.stdin.close()
+
+                # Wait for upstream gpio process to finish
+                last_stderr = b""
+                if last_proc.stderr:
+                    last_stderr = last_proc.stderr.read()
+                    last_proc.stderr.close()
+
+                last_proc.wait()
+
+                # Collect upstream errors
+                upstream_errors: list[str] = []
+
+                for proc in processes[:-1]:
+                    stderr_bytes = b""
+                    if proc.stderr:
+                        stderr_bytes = proc.stderr.read()
+                        proc.stderr.close()
+                    proc.wait()
+                    if proc.returncode != 0:
+                        upstream_errors.append(_format_proc_error(proc, stderr_bytes))
+
+                if last_proc.returncode != 0:
+                    upstream_errors.append(_format_proc_error(last_proc, last_stderr or b""))
+
+                if upstream_errors:
+                    tippecanoe_proc.wait()
+                    raise RuntimeError("\n\n".join(upstream_errors))
+
+                if not wrote_any:
+                    tippecanoe_proc.wait()
+                    raise RuntimeError(
+                        "gpio pipeline produced no output — check input path, "
+                        "filters, and that the column exists in the file"
+                    )
+
+                # Wait for tippecanoe to finish
+                tippecanoe_proc.wait()
+
+                if tippecanoe_proc.returncode != 0:
+                    raise RuntimeError(
+                        f"tippecanoe failed with exit code {tippecanoe_proc.returncode}"
+                    )
+
+            except Exception:
+                # Ensure processes are cleaned up on failure
+                if tippecanoe_proc.poll() is None:
+                    tippecanoe_proc.terminate()
+                if last_proc.poll() is None:
+                    last_proc.terminate()
+                raise
+        else:
+            tippecanoe_proc = subprocess.Popen(
+                tippecanoe_cmd,
+                stdin=processes[-1].stdout if processes else None,
+                stdout=None if verbose else subprocess.PIPE,
+                stderr=None,
+            )
+            processes.append(tippecanoe_proc)
+            if len(processes) > 1 and processes[-2].stdout:
+                processes[-2].stdout.close()
+
+            tippecanoe_proc.communicate()
+
+            # Drain stderr and wait for upstream procs FIRST. If an upstream gpio
+            # process crashed, tippecanoe almost always exits non-zero too (read
+            # truncated input), and the upstream stderr is the real diagnostic —
+            # we must not short-circuit on tippecanoe's exit code before
+            # collecting it.
+            upstream_errors: list[str] = []
+            for proc in processes[:-1]:
+                stderr_bytes = b""
+                if proc.stderr:
+                    stderr_bytes = proc.stderr.read()
+                    proc.stderr.close()
+                proc.wait()
+                if proc.returncode != 0:
+                    upstream_errors.append(_format_proc_error(proc, stderr_bytes))
+
+            if tippecanoe_proc.returncode != 0:
+                msg = f"tippecanoe failed with exit code {tippecanoe_proc.returncode}"
+                if upstream_errors:
+                    msg = f"{msg}\nUpstream errors:\n" + "\n\n".join(upstream_errors)
+                raise RuntimeError(msg)
+
             if upstream_errors:
-                msg = f"{msg}\nUpstream errors:\n" + "\n\n".join(upstream_errors)
-            raise RuntimeError(msg)
-
-        if upstream_errors:
-            raise RuntimeError("\n\n".join(upstream_errors))
+                raise RuntimeError("\n\n".join(upstream_errors))
 
     except KeyboardInterrupt:
         for proc in processes:
@@ -307,6 +436,7 @@ def create_pmtiles_from_geoparquet(
     profile: str | None = None,
     src_crs: str | None = None,
     attribution: str | None = None,
+    layer_by_column: str | None = None,
 ) -> None:
     """
     Create PMTiles using gpio streaming + tippecanoe subprocess.
@@ -331,27 +461,53 @@ def create_pmtiles_from_geoparquet(
         profile: AWS profile name for S3 files
         src_crs: Source CRS for reprojection to WGS84
         attribution: Attribution HTML for the tiles
+        layer_by_column: Split tiles into layers grouped by values of this column
 
     Raises:
         TippecanoeNotFoundError: If tippecanoe is not in PATH
-        ValueError: If paths contain shell metacharacters
+        ValueError: If paths contain shell metacharacters or the user supplied an invalid layer_by_column
         RuntimeError: If any subprocess fails
     """
     _validate_path(input_path)
     _validate_path(output_path)
-
+    if layer and layer_by_column:
+        raise ValueError(
+            "When creating pmtiles, you cannot specify both 'layer' which defines one layer name "
+            "and 'layer_by_column' which defines multiple layer names based on the values of a column"
+        )
     if not _check_tippecanoe():
         raise TippecanoeNotFoundError()
 
+    # If layer_by_column is set, ensure that the group by column is always included
+    if layer_by_column and include_cols:
+        cols = [c.strip() for c in include_cols.split(",")]
+        if layer_by_column not in cols:
+            cols.append(layer_by_column)
+        include_cols_with_layer_by_column = ",".join(cols)
+    else:
+        include_cols_with_layer_by_column = include_cols
+
     gpio_commands = _build_gpio_commands(
-        input_path, bbox, where, include_cols, precision, verbose, profile, src_crs
+        input_path,
+        bbox,
+        where,
+        include_cols_with_layer_by_column,
+        precision,
+        verbose,
+        profile,
+        src_crs,
     )
-
     tippecanoe_cmd = _build_tippecanoe_command(
-        output_path, layer, min_zoom, max_zoom, verbose, attribution
+        output_path,
+        layer,
+        min_zoom,
+        max_zoom,
+        verbose,
+        attribution,
+        layer_by_column,
     )
 
-    _run_pipeline(gpio_commands, tippecanoe_cmd, verbose)
+    _run_pipeline(gpio_commands, tippecanoe_cmd, verbose, layer_by_column)
 
     if verbose:
         success(f"Created {output_path}")

--- a/tests/test_pmtiles.py
+++ b/tests/test_pmtiles.py
@@ -456,6 +456,46 @@ class TestPMTilesIntegration:
         assert output_file.exists()
         assert output_file.stat().st_size > 0
 
+    @skip_windows
+    @pytest.mark.skipif(not has_gpio(), reason="gpio not installed")
+    @pytest.mark.skipif(not has_tippecanoe(), reason="tippecanoe not installed")
+    @pytest.mark.slow
+    def test_layer_by_column(self, tmp_path):
+        """Test PMTiles creation with multiple layers based on a column name"""
+        test_data_dir = Path(__file__).parent / "data"
+        input_file = test_data_dir / "places_test.parquet"
+
+        if not input_file.exists():
+            pytest.skip(f"Test file not found: {input_file}")
+
+        output_file = tmp_path / "layer_by_column.pmtiles"
+
+        from geoparquet_io.core.pmtiles import create_pmtiles_from_geoparquet
+
+        create_pmtiles_from_geoparquet(
+            input_path=str(input_file),
+            output_path=str(output_file),
+            min_zoom=0,
+            max_zoom=10,
+            verbose=True,
+            layer_by_column="address",
+        )
+
+        assert output_file.exists()
+        assert output_file.stat().st_size > 0
+
+        with pytest.raises(ValueError):
+            # ensure that both a layer by column
+            # and a single layer name cannot be specified
+            # since these are mutually exclusive
+            create_pmtiles_from_geoparquet(
+                input_path=str(input_file),
+                output_path=str(output_file),
+                verbose=True,
+                layer_by_column="address",
+                layer="DUMMY",
+            )
+
 
 class TestRunPipelineErrorSurfacing:
     """Pipeline errors must surface upstream stderr.


### PR DESCRIPTION
## Support PMTile creation with layer metadata based on a column name

Add a `--layer-by-column` argument to the `pmtiles create` subcommand for the purpose of adding layer metadata to PMTiles output. 

## Description
<!-- Concise summary of what changed and why. This may be used in release notes. -->

Example
```
 gpio pmtiles create --layer-by-column owner parcels.parquet output.pmtiles
```

## Technical Details

This edits the gpio to tippecanoe pipeline to add layer metadata to each geojson. This is essentially just another streaming operation in the middle.

## Breaking Changes
**Does this PR introduce breaking changes?** No 

<!-- If yes, describe what breaks and how users should migrate -->

## Related Info

Example generated pmtiles ends up looking something like this in the pmtiles.io viewer

<img width="2268" height="873" alt="image" src="https://github.com/user-attachments/assets/68438ee7-01ed-4ffb-bcae-54598446faf9" />


## Checklist
- [x] Tests added/updated
- [x] All tests pass (`uv run pytest`)
- [x] Documentation updated (README, guides, CLI reference)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--layer-by-column` flag to `gpio pmtiles create` command, allowing automatic layer splitting based on values from a specified GeoParquet column.
  * Updated API to support layer-by-column workflows with built-in validation against conflicting parameters.

* **Documentation**
  * Added CLI examples demonstrating the new layer-by-column feature.

* **Tests**
  * Added integration tests for layer-by-column functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->