### PR TITLE
fix(wfs): auto-paginate large datasets and fix parallel worker crash

### DIFF
--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1133,6 +1133,15 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
 
 
+class WFSStartIndexLimitError(WFSError):
+    """Raised when server rejects a startIndex beyond its limit."""
+
+    def __init__(self, limit: int, total_count: int, message: str):
+        self.limit = limit
+        self.total_count = total_count
+        super().__init__(message)
+
+
 def _fetch_wfs_page_via_http(url: str) -> pa.Table:
     """
     Fetch a WFS GeoJSON page using Python HTTP, parse with DuckDB from disk.
@@ -1144,12 +1153,23 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
     """
     import tempfile
 
+    import httpx
+
     start_time = time.time()
     debug(f"HTTP fetch: {url[:80]}...")
 
     client = _get_shared_http_client(timeout=600)
     response = client.get(url, headers={"Accept-Encoding": "gzip, deflate"})
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 400:
+            body = e.response.text
+            if "startindex" in body.lower():
+                raise WFSError(
+                    f"Server rejected paginated request (startIndex limit): {body.strip()}"
+                ) from e
+        raise
 
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
         tmp.write(response.content)
@@ -1195,6 +1215,56 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
     finally:
         Path(tmp_path).unlink(missing_ok=True)
+
+
+def _probe_startindex_limit(
+    service_url: str,
+    typename: str,
+    version: str,
+    crs: str | None = None,
+    axis_order: str = "auto",
+) -> int | None:
+    """
+    Probe a WFS server to discover any startIndex limit.
+
+    Some servers (e.g., PDOK) reject requests with startIndex above a
+    threshold (e.g., 50,000). This sends a lightweight probe request
+    to detect that limit before attempting full pagination.
+
+    Returns the limit value if detected, or None if no limit found.
+    """
+    import httpx
+
+    probe_offset = 50001
+    url = _build_wfs_url(
+        service_url,
+        typename,
+        version,
+        max_features=1,
+        start_index=probe_offset,
+        crs=crs,
+        axis_order=axis_order,
+    )
+
+    try:
+        client = _get_shared_http_client(timeout=30)
+        response = client.get(url, headers={"Accept-Encoding": "gzip, deflate"})
+        if response.status_code == 400:
+            body = response.text.lower()
+            if "startindex" in body:
+                import re as _re
+
+                match = _re.search(r"startindex.*?(\d[\d.,]+)", body)
+                if match:
+                    limit_str = match.group(1).replace(",", "").replace(".", "")
+                    try:
+                        return int(limit_str)
+                    except ValueError:
+                        pass
+                return 50000
+        return None
+    except httpx.HTTPError:
+        return None
 
 
 def _build_wfs_url(
@@ -1307,6 +1377,23 @@ def fetch_all_features_duckdb(
 
     # Paginated mode — sequential (max_workers=1) or parallel
     effective_total = max_features if max_features else total_count
+
+    # Probe for server-side startIndex limit before building all pages
+    startindex_limit = _probe_startindex_limit(
+        service_url, typename, version, crs=crs, axis_order=axis_order
+    )
+    if startindex_limit is not None:
+        max_reachable = startindex_limit + page_size
+        if effective_total > max_reachable:
+            raise WFSError(
+                f"Server limits startIndex to {startindex_limit:,}, so only "
+                f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
+                f"Options:\n"
+                f"  1. Use --limit {max_reachable} to fetch only what's reachable\n"
+                f"  2. Use --bbox to spatially filter to a smaller region\n"
+                f"  3. Download the dataset directly from the provider's bulk download service"
+            )
+
     num_pages = (effective_total + page_size - 1) // page_size
     actual_workers = min(max_workers, num_pages)
 

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1133,6 +1133,70 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
 
 
+def _fetch_wfs_page_via_http(url: str) -> pa.Table:
+    """
+    Fetch a WFS GeoJSON page using Python HTTP, parse with DuckDB from disk.
+
+    Thread-safe alternative to _fetch_wfs_page_duckdb for parallel fetching.
+    DuckDB's httpfs extension crashes when multiple connections make concurrent
+    HTTP requests (libc++abi: terminating). This downloads via Python's
+    thread-safe httpx client, writes to a temp file, and parses locally.
+    """
+    import tempfile
+
+    start_time = time.time()
+    debug(f"HTTP fetch: {url[:80]}...")
+
+    client = _get_shared_http_client(timeout=600)
+    response = client.get(url, headers={"Accept-Encoding": "gzip, deflate"})
+    response.raise_for_status()
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        tmp.write(response.content)
+        tmp_path = tmp.name
+
+    try:
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        safe_path = _escape_sql_string(tmp_path)
+
+        count_result = con.execute(f"""
+            SELECT len(features) AS cnt
+            FROM read_json_auto('{safe_path}', maximum_object_size=536870912)
+        """).fetchone()
+        feature_count = count_result[0] if count_result else 0
+
+        if feature_count == 0:
+            debug("Empty response, returning empty table")
+            return pa.table({"geometry": pa.array([], type=pa.binary())})
+
+        query = f"""
+            WITH features AS (
+                SELECT unnest(features) AS feature
+                FROM read_json_auto('{safe_path}', maximum_object_size=536870912)
+            ),
+            extracted AS (
+                SELECT
+                    ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
+                    feature.properties AS props
+                FROM features
+            )
+            SELECT geometry, unnest(props) FROM extracted
+        """
+        result = con.execute(query)
+        table = result.arrow().read_all()
+
+        elapsed = time.time() - start_time
+        debug(f"HTTP+DuckDB OK: {table.num_rows:,} rows in {elapsed:.1f}s")
+        return table
+    except Exception as e:
+        error_msg = str(e)
+        if "HTTP" in error_msg or "Could not" in error_msg:
+            raise WFSError(f"Failed to fetch WFS data: {e}") from e
+        raise WFSError(f"Failed to parse WFS response: {e}") from e
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
 def _build_wfs_url(
     service_url: str,
     typename: str,
@@ -1218,8 +1282,12 @@ def fetch_all_features_duckdb(
     if max_features and total_count:
         total_count = min(total_count, max_features)
 
-    # Single request mode (default) - fastest for most cases
-    if max_workers == 1 or version == "1.0.0":
+    # Single request for small datasets or when count is unknown
+    needs_pagination = (
+        total_count is not None and version != "1.0.0" and (max_features or total_count) > page_size
+    )
+
+    if not needs_pagination:
         if total_count:
             progress(f"Streaming {total_count:,} features via DuckDB...")
         else:
@@ -1237,28 +1305,14 @@ def fetch_all_features_duckdb(
         table = _fetch_wfs_page_duckdb(url)
         return _infer_column_types(table)
 
-    # Parallel pagination mode for large datasets
-    if total_count is None:
-        warn("Cannot determine feature count; falling back to single request mode.")
-        url = _build_wfs_url(
-            service_url,
-            typename,
-            version,
-            max_features=max_features,
-            bbox=bbox,
-            crs=crs,
-            axis_order=axis_order,
-        )
-        table = _fetch_wfs_page_duckdb(url)
-        return _infer_column_types(table)
-
-    # Calculate page ranges
+    # Paginated mode — sequential (max_workers=1) or parallel
     effective_total = max_features if max_features else total_count
     num_pages = (effective_total + page_size - 1) // page_size
     actual_workers = min(max_workers, num_pages)
 
     progress(
-        f"Fetching {effective_total:,} features in {num_pages} pages using {actual_workers} workers..."
+        f"Fetching {effective_total:,} features in {num_pages} pages "
+        f"using {actual_workers} {'worker' if actual_workers == 1 else 'workers'}..."
     )
 
     # Build page URLs
@@ -1281,22 +1335,33 @@ def fetch_all_features_duckdb(
         )
         pages.append((i, start, url))
 
-    # Fetch pages in parallel
+    # Fetch pages (sequentially if 1 worker, parallel otherwise)
     results = {}
-    with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-        future_to_page = {
-            executor.submit(_fetch_wfs_page_duckdb, url): (page_num, start)
-            for page_num, start, url in pages
-        }
-
-        for future in as_completed(future_to_page):
-            page_num, start = future_to_page[future]
+    if actual_workers == 1:
+        for page_num, start, url in pages:
             try:
-                table = future.result()
+                table = _fetch_wfs_page_duckdb(url)
                 results[page_num] = table
                 debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
             except Exception as e:
                 raise WFSError(f"Failed to fetch page {page_num + 1} (offset {start}): {e}") from e
+    else:
+        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+            future_to_page = {
+                executor.submit(_fetch_wfs_page_via_http, url): (page_num, start)
+                for page_num, start, url in pages
+            }
+
+            for future in as_completed(future_to_page):
+                page_num, start = future_to_page[future]
+                try:
+                    table = future.result()
+                    results[page_num] = table
+                    debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
+                except Exception as e:
+                    raise WFSError(
+                        f"Failed to fetch page {page_num + 1} (offset {start}): {e}"
+                    ) from e
 
     # Combine tables in order
     if not results:

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1308,6 +1308,76 @@ class TestAutoPageSingleWorker:
         assert mock_http.call_count == 2
         mock_duckdb.assert_not_called()
 
+    def test_startindex_limit_raises_clear_error(self):
+        """When server has startIndex limit, should raise with actionable guidance."""
+        from geoparquet_io.core.wfs import WFSError, fetch_all_features_duckdb
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=11000000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=50000),
+        ):
+            with pytest.raises(WFSError, match="startIndex.*50,000"):
+                fetch_all_features_duckdb(
+                    "https://mock.wfs/wfs",
+                    "layer",
+                    max_workers=1,
+                    page_size=10000,
+                )
+
+    def test_startindex_limit_allows_small_datasets(self):
+        """When total features fit within the startIndex limit, should proceed."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=30000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=50000),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page),
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        assert result.num_rows > 0
+
+    def test_no_startindex_limit_proceeds_normally(self):
+        """When server has no startIndex limit, pagination should proceed."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page),
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        assert result.num_rows > 0
+
 
 # =============================================================================
 # Axis Order Tests (Issue #397)

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1147,6 +1147,168 @@ class TestDuckDBNativeWFS:
         assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type)
 
 
+class TestAutoPageSingleWorker:
+    """Test that single-worker mode auto-paginates for large datasets."""
+
+    def test_single_worker_paginates_when_count_exceeds_page_size(self):
+        """With max_workers=1 and total > page_size, should paginate sequentially."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page1 = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+        page2 = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x03"], type=pa.binary()),
+                "name": pa.array(["b"]),
+            }
+        )
+
+        call_count = 0
+
+        def mock_fetch(url):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return page1
+            return page2
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", side_effect=mock_fetch),
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        assert call_count == 2
+        assert result.num_rows == 2
+
+    def test_single_worker_no_pagination_when_count_within_page_size(self):
+        """With max_workers=1 and total <= page_size, should use single request."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=5000),
+            patch(
+                "geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=mock_table
+            ) as mock_fetch,
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        mock_fetch.assert_called_once()
+        assert result.num_rows == 1
+
+    def test_single_worker_no_pagination_when_count_unknown(self):
+        """With max_workers=1 and unknown count, should use single request."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=None),
+            patch(
+                "geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=mock_table
+            ) as mock_fetch,
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        mock_fetch.assert_called_once()
+        assert result.num_rows == 1
+
+    def test_single_worker_pagination_respects_max_features(self):
+        """Auto-pagination should respect max_features limit."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=100000),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page) as mock_fetch,
+        ):
+            fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                max_features=15000,
+                page_size=10000,
+            )
+
+        # 15000 features / 10000 page_size = 2 pages
+        assert mock_fetch.call_count == 2
+
+    def test_parallel_workers_use_http_fetcher(self):
+        """Parallel mode should use _fetch_wfs_page_via_http, not httpfs."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch(
+                "geoparquet_io.core.wfs._fetch_wfs_page_via_http", return_value=page
+            ) as mock_http,
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb") as mock_duckdb,
+        ):
+            fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=2,
+                page_size=10000,
+            )
+
+        assert mock_http.call_count == 2
+        mock_duckdb.assert_not_called()
+
+
 # =============================================================================
 # Axis Order Tests (Issue #397)
 # =============================================================================


### PR DESCRIPTION
## Summary

- **Auto-paginate in single-worker mode**: When the feature count exceeds the page size (default 10,000), `fetch_all_features_duckdb` now paginates sequentially even with `--workers 1` (the default). Previously it tried to fetch all features in a single HTTP request, which caused WFS servers to truncate large responses (e.g. 11M features from PDOK), producing malformed JSON that DuckDB couldn't parse.
- **Fix parallel worker crash**: `--workers >1` crashed with `libc++abi: terminating` because DuckDB's httpfs extension isn't thread-safe for concurrent HTTP requests from multiple connections. Parallel workers now download via Python's thread-safe httpx client to temp files, then parse locally with DuckDB (no httpfs needed).
- **Detect server startIndex limits**: Some WFS servers (e.g., PDOK) cap `startIndex` at 50,000, making full pagination impossible for very large datasets. Now probes the server for this limit before attempting pagination and raises a clear error with actionable options (`--limit`, `--bbox`, or bulk download).

Reproducer (before fix):
```
gpio extract wfs https://service.pdok.nl/kadaster/bu/wfs/v1_0 bu:building buildings.parquet
# Error: Failed to parse WFS response: Invalid Input Error: Malformed JSON...

gpio extract wfs ... --workers 4
# libc++abi: terminating
```

After fix:
```
gpio extract wfs https://service.pdok.nl/kadaster/bu/wfs/v1_0 bu:building buildings.parquet
# Error: Server limits startIndex to 50,000, so only 60,000 of 11,349,540
# features are reachable via pagination.
#
# Options:
#   1. Use --limit 60000 to fetch only what's reachable
#   2. Use --bbox to spatially filter to a smaller region
#   3. Download the dataset directly from the provider's bulk download service
```

## Test plan

- [x] New `TestAutoPageSingleWorker` test class with 8 tests covering:
  - Single-worker auto-pagination when count exceeds page size
  - No pagination when count fits in one page
  - No pagination when count is unknown (falls back to single request)
  - `max_features` limit respected during auto-pagination
  - Parallel workers use HTTP-based fetcher (not httpfs)
  - Server startIndex limit detected and raises clear error
  - Small datasets proceed normally when within startIndex limit
  - No startIndex limit detected proceeds normally
- [x] All 126 existing WFS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)