### PR TITLE
feat(wfs): add --auto-tile to bypass server startIndex limits

### DIFF
--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -763,6 +763,7 @@ def from_wfs(
     page_size: int = 10000,
     axis_order: str = "auto",
     strict_crs: bool = False,
+    auto_tile: bool = False,
 ) -> pa.Table:
     """
     Fetch WFS layer as PyArrow Table.
@@ -783,6 +784,8 @@ def from_wfs(
             CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
         strict_crs: If True, fail when server returns coordinates that don't match
             requested CRS. If False (default), warn and use detected CRS.
+        auto_tile: Automatically subdivide into spatial tiles for servers with
+            startIndex limits (default: False)
 
     Returns:
         PyArrow Table with geometry column
@@ -790,10 +793,8 @@ def from_wfs(
     Example:
         >>> from geoparquet_io.api import ops
         >>> table = ops.from_wfs('https://geo.example.com/wfs', 'cities', limit=100)
-        >>> # For large datasets:
-        >>> table = ops.from_wfs('https://geo.example.com/wfs', 'parcels', max_workers=4)
-        >>> # Force axis order for problematic servers:
-        >>> table = ops.from_wfs(url, layer, axis_order='latlon')
+        >>> # For large datasets on servers with startIndex limits:
+        >>> table = ops.from_wfs('https://geo.example.com/wfs', 'parcels', auto_tile=True)
     """
     from geoparquet_io.core.wfs import wfs_to_table
 
@@ -807,6 +808,7 @@ def from_wfs(
         page_size=page_size,
         axis_order=axis_order,
         strict_crs=strict_crs,
+        auto_tile=auto_tile,
     )
 
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -554,6 +554,7 @@ class Table:
         page_size: int = 10000,
         axis_order: str = "auto",
         strict_crs: bool = False,
+        auto_tile: bool = False,
     ) -> Table:
         """
         Create Table from WFS layer.
@@ -574,6 +575,8 @@ class Table:
                 CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
             strict_crs: If True, fail when server returns coordinates that don't match
                 requested CRS. If False (default), warn and use detected CRS.
+            auto_tile: Automatically subdivide into spatial tiles for servers with
+                startIndex limits (default: False)
 
         Returns:
             Table for chaining operations
@@ -581,10 +584,8 @@ class Table:
         Example:
             >>> import geoparquet_io as gpio
             >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'cities').add_bbox().write('cities.parquet')
-            >>> # For large datasets:
-            >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'parcels', max_workers=4)
-            >>> # Force axis order for problematic servers:
-            >>> gpio.Table.from_wfs(url, layer, axis_order='latlon')
+            >>> # For large datasets on servers with startIndex limits:
+            >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'parcels', auto_tile=True)
         """
         from geoparquet_io.core.wfs import wfs_to_table
 
@@ -598,6 +599,7 @@ class Table:
             page_size=page_size,
             axis_order=axis_order,
             strict_crs=strict_crs,
+            auto_tile=auto_tile,
         )
         return cls(table)
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2894,6 +2894,12 @@ def _deprecated_version_callback(ctx, param, value):
     help="Features per page when using --workers > 1. Default: 10000.",
 )
 @click.option(
+    "--auto-tile",
+    is_flag=True,
+    help="Automatically subdivide into spatial tiles to work around server "
+    "startIndex limits. Use for large datasets on servers that cap pagination.",
+)
+@click.option(
     "--skip-hilbert",
     is_flag=True,
     help="Skip Hilbert curve sorting (faster, but no spatial clustering)",
@@ -2923,6 +2929,7 @@ def extract_wfs_cmd(
     output_crs,
     workers,
     page_size,
+    auto_tile,
     skip_hilbert,
     skip_bbox,
     compression,
@@ -3064,6 +3071,7 @@ def extract_wfs_cmd(
             geoparquet_version=geoparquet_version,
             overwrite=overwrite,
             verbose=verbose,
+            auto_tile=auto_tile,
         )
     except WFSError as e:
         raise click.ClickException(str(e)) from None

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -895,6 +895,9 @@ def _get_feature_count(
     service_url: str,
     typename: str,
     version: str = "1.1.0",
+    bbox: tuple[float, float, float, float] | None = None,
+    crs: str | None = None,
+    axis_order: str = "auto",
 ) -> int | None:
     """
     Try to get feature count using resultType=hits.
@@ -905,6 +908,9 @@ def _get_feature_count(
         service_url: WFS service URL
         typename: Layer typename
         version: WFS version
+        bbox: Optional bounding box filter (xmin, ymin, xmax, ymax)
+        crs: CRS for bbox parameter
+        axis_order: Bbox axis order ("auto", "xy", "latlon")
 
     Returns:
         Feature count or None if not supported
@@ -920,6 +926,9 @@ def _get_feature_count(
         "typeNames" if version == "2.0.0" else "typeName": typename,
         "resultType": "hits",
     }
+
+    if bbox and crs:
+        params["bbox"] = _build_bbox_param(bbox, crs, version, axis_order)
 
     try:
         content = _make_request(clean_url, params=params)
@@ -1051,7 +1060,7 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
         con.close()
 
 
-def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
+def _fetch_wfs_page_duckdb(url: str, extract_fid: bool = False) -> pa.Table:
     """
     Fetch a WFS GeoJSON page directly using DuckDB's httpfs.
 
@@ -1103,6 +1112,8 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
             return pa.table({"geometry": pa.array([], type=pa.binary())})
 
         # Full query to extract features
+        fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
+        fid_select = "_wfs_fid," if extract_fid else ""
         query = f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
@@ -1110,11 +1121,13 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
             ),
             extracted AS (
                 SELECT
+                    {fid_col}
                     ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
                     feature.properties AS props
                 FROM features
             )
             SELECT
+                {fid_select}
                 geometry,
                 unnest(props)
             FROM extracted
@@ -1142,7 +1155,7 @@ class WFSStartIndexLimitError(WFSError):
         super().__init__(message)
 
 
-def _fetch_wfs_page_via_http(url: str) -> pa.Table:
+def _fetch_wfs_page_via_http(url: str, extract_fid: bool = False) -> pa.Table:
     """
     Fetch a WFS GeoJSON page using Python HTTP, parse with DuckDB from disk.
 
@@ -1189,6 +1202,8 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
             debug("Empty response, returning empty table")
             return pa.table({"geometry": pa.array([], type=pa.binary())})
 
+        fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
+        fid_select = "_wfs_fid," if extract_fid else ""
         query = f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
@@ -1196,11 +1211,12 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
             ),
             extracted AS (
                 SELECT
+                    {fid_col}
                     ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
                     feature.properties AS props
                 FROM features
             )
-            SELECT geometry, unnest(props) FROM extracted
+            SELECT {fid_select} geometry, unnest(props) FROM extracted
         """
         result = con.execute(query)
         table = result.arrow().read_all()
@@ -1215,6 +1231,235 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
     finally:
         Path(tmp_path).unlink(missing_ok=True)
+
+
+def _generate_tile_grid(
+    bbox: tuple[float, float, float, float],
+    num_tiles: int,
+) -> list[tuple[float, float, float, float]]:
+    """
+    Generate a grid of tile bboxes covering the given bbox.
+
+    Uses aspect-ratio-aware layout so tiles are roughly square in
+    geographic coordinates.
+    """
+    import math
+
+    if num_tiles <= 1:
+        return [bbox]
+
+    xmin, ymin, xmax, ymax = bbox
+    width = xmax - xmin
+    height = ymax - ymin
+
+    if width <= 0 or height <= 0:
+        return [bbox]
+
+    aspect = width / height
+    cols = max(1, round(math.sqrt(num_tiles * aspect)))
+    rows = max(1, math.ceil(num_tiles / cols))
+
+    dx = width / cols
+    dy = height / rows
+
+    tiles = []
+    for r in range(rows):
+        for c in range(cols):
+            tiles.append(
+                (
+                    xmin + c * dx,
+                    ymin + r * dy,
+                    xmin + (c + 1) * dx,
+                    ymin + (r + 1) * dy,
+                )
+            )
+
+    return tiles
+
+
+def _refine_tiles_adaptive(
+    tiles: list[tuple[float, float, float, float]],
+    service_url: str,
+    typename: str,
+    version: str,
+    crs: str,
+    axis_order: str,
+    max_per_tile: int,
+    max_depth: int = 8,
+) -> list[tuple[float, float, float, float]]:
+    """
+    Recursively subdivide tiles that exceed the feature count limit.
+
+    For each tile, probes the server with resultType=hits + bbox to check
+    the feature count. Tiles over max_per_tile are split into 4 quadrants.
+    """
+
+    def _subdivide(
+        bbox: tuple[float, float, float, float], depth: int
+    ) -> list[tuple[float, float, float, float]]:
+        if depth >= max_depth:
+            return [bbox]
+
+        count = _get_feature_count(
+            service_url,
+            typename,
+            version,
+            bbox=bbox,
+            crs=crs,
+            axis_order=axis_order,
+        )
+
+        if count is None or count <= max_per_tile:
+            return [bbox]
+
+        xmin, ymin, xmax, ymax = bbox
+        mx = (xmin + xmax) / 2
+        my = (ymin + ymax) / 2
+
+        quadrants = [
+            (xmin, ymin, mx, my),
+            (mx, ymin, xmax, my),
+            (xmin, my, mx, ymax),
+            (mx, my, xmax, ymax),
+        ]
+
+        result = []
+        for q in quadrants:
+            result.extend(_subdivide(q, depth + 1))
+        return result
+
+    refined = []
+    for tile in tiles:
+        refined.extend(_subdivide(tile, 0))
+    return refined
+
+
+def _deduplicate_tiles(table: pa.Table) -> pa.Table:
+    """
+    Deduplicate features that appear in multiple tiles.
+
+    Uses _wfs_fid column if present (from GeoJSON feature.id).
+    Falls back to geometry bytes deduplication.
+    Always drops the _wfs_fid column from output.
+    """
+    if table.num_rows == 0:
+        if "_wfs_fid" in table.column_names:
+            return table.drop(["_wfs_fid"])
+        return table
+
+    con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+
+    try:
+        con.register("tile_data", table)
+
+        if "_wfs_fid" in table.column_names:
+            all_cols = [c for c in table.column_names if c != "_wfs_fid"]
+            col_list = ", ".join(f'"{c}"' for c in all_cols)
+            query = f"""
+                SELECT {col_list}
+                FROM (
+                    SELECT *, ROW_NUMBER() OVER (PARTITION BY "_wfs_fid") AS _rn
+                    FROM tile_data
+                    WHERE "_wfs_fid" IS NOT NULL
+                ) WHERE _rn = 1
+                UNION ALL
+                SELECT {col_list}
+                FROM tile_data
+                WHERE "_wfs_fid" IS NULL
+            """
+        else:
+            all_cols = table.column_names
+            col_list = ", ".join(f'"{c}"' for c in all_cols)
+            query = f"""
+                SELECT {col_list}
+                FROM (
+                    SELECT *, ROW_NUMBER() OVER (PARTITION BY geometry) AS _rn
+                    FROM tile_data
+                ) WHERE _rn = 1
+            """
+
+        result = con.execute(query)
+        return result.arrow().read_all()
+    finally:
+        con.close()
+
+
+def _fetch_with_spatial_tiles(
+    service_url: str,
+    typename: str,
+    version: str,
+    total_count: int,
+    startindex_limit: int,
+    layer_bbox: tuple[float, float, float, float],
+    crs: str,
+    max_workers: int = 1,
+    page_size: int = 10000,
+    axis_order: str = "auto",
+    max_features: int | None = None,
+) -> pa.Table:
+    """
+    Fetch a large WFS dataset by subdividing into spatial tiles.
+
+    Used when the server caps startIndex, making full pagination impossible.
+    Subdivides the layer bbox into tiles, fetches each tile separately,
+    deduplicates features on tile boundaries, and combines results.
+    """
+    import math
+
+    max_per_tile = startindex_limit
+    num_tiles = max(2, math.ceil(total_count / (max_per_tile * 0.8)))
+
+    progress(f"Auto-tiling: splitting {total_count:,} features into ~{num_tiles} spatial tiles...")
+
+    tiles = _generate_tile_grid(layer_bbox, num_tiles)
+
+    progress(f"Refining {len(tiles)} tiles (checking feature counts per tile)...")
+    tiles = _refine_tiles_adaptive(
+        tiles,
+        service_url,
+        typename,
+        version,
+        crs=crs,
+        axis_order=axis_order,
+        max_per_tile=max_per_tile,
+    )
+
+    progress(f"Fetching {len(tiles)} tiles...")
+
+    all_tables = []
+    for i, tile_bbox in enumerate(tiles):
+        debug(f"Tile {i + 1}/{len(tiles)}: bbox={tile_bbox}")
+        tile_table = fetch_all_features_duckdb(
+            service_url,
+            typename,
+            version,
+            max_features=max_features,
+            bbox=tile_bbox,
+            crs=crs,
+            max_workers=max_workers,
+            page_size=page_size,
+            axis_order=axis_order,
+            extract_fid=True,
+        )
+        if tile_table.num_rows > 0:
+            all_tables.append(tile_table)
+        progress(f"Tile {i + 1}/{len(tiles)}: {tile_table.num_rows:,} features")
+
+    if not all_tables:
+        raise WFSError("No features returned from any spatial tile.")
+
+    combined = pa.concat_tables(all_tables, promote_options="default")
+    before_dedup = combined.num_rows
+
+    combined = _deduplicate_tiles(combined)
+    after_dedup = combined.num_rows
+
+    if before_dedup != after_dedup:
+        debug(
+            f"Deduplicated: {before_dedup:,} → {after_dedup:,} ({before_dedup - after_dedup:,} duplicates)"
+        )
+
+    return _infer_column_types(combined)
 
 
 def _probe_startindex_limit(
@@ -1322,6 +1567,7 @@ def fetch_all_features_duckdb(
     max_workers: int = 1,
     page_size: int = 10000,
     axis_order: str = "auto",
+    extract_fid: bool = False,
 ) -> pa.Table:
     """
     Fetch WFS features using DuckDB's native HTTP streaming.
@@ -1372,7 +1618,7 @@ def fetch_all_features_duckdb(
             crs=crs,
             axis_order=axis_order,
         )
-        table = _fetch_wfs_page_duckdb(url)
+        table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
         return _infer_column_types(table)
 
     # Paginated mode — sequential (max_workers=1) or parallel
@@ -1389,9 +1635,10 @@ def fetch_all_features_duckdb(
                 f"Server limits startIndex to {startindex_limit:,}, so only "
                 f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
                 f"Options:\n"
-                f"  1. Use --limit {max_reachable} to fetch only what's reachable\n"
-                f"  2. Use --bbox to spatially filter to a smaller region\n"
-                f"  3. Download the dataset directly from the provider's bulk download service"
+                f"  1. Use --auto-tile to automatically subdivide into spatial tiles\n"
+                f"  2. Use --limit {max_reachable} to fetch only what's reachable\n"
+                f"  3. Use --bbox to spatially filter to a smaller region\n"
+                f"  4. Download the dataset directly from the provider's bulk download service"
             )
 
     num_pages = (effective_total + page_size - 1) // page_size
@@ -1427,7 +1674,7 @@ def fetch_all_features_duckdb(
     if actual_workers == 1:
         for page_num, start, url in pages:
             try:
-                table = _fetch_wfs_page_duckdb(url)
+                table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
                 results[page_num] = table
                 debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
             except Exception as e:
@@ -1435,7 +1682,7 @@ def fetch_all_features_duckdb(
     else:
         with ThreadPoolExecutor(max_workers=actual_workers) as executor:
             future_to_page = {
-                executor.submit(_fetch_wfs_page_via_http, url): (page_num, start)
+                executor.submit(_fetch_wfs_page_via_http, url, extract_fid): (page_num, start)
                 for page_num, start, url in pages
             }
 
@@ -1475,6 +1722,7 @@ def wfs_to_table(
     axis_order: str = "auto",
     strict_crs: bool = False,
     verbose: bool = False,
+    auto_tile: bool = False,
 ) -> pa.Table:
     """
     Fetch WFS layer as PyArrow Table.
@@ -1533,20 +1781,49 @@ def wfs_to_table(
     if bbox:
         use_server_bbox = _determine_bbox_strategy(bbox_mode, layer_info)
 
-    # Use DuckDB-native streaming for fast extraction
-    # Single request mode is 10x+ faster than Python HTTP
-    # Parallel mode is useful for very large datasets (1M+ features)
-    table = fetch_all_features_duckdb(
-        service_url=service_url,
-        typename=layer_info.typename,
-        version=version,
-        max_features=limit,
-        bbox=bbox if use_server_bbox else None,
-        crs=crs,
-        max_workers=max_workers,
-        page_size=page_size,
-        axis_order=axis_order,
-    )
+    # Check if auto-tiling is needed (server has startIndex limit + dataset exceeds it)
+    use_tiling = False
+    if auto_tile and version != "1.0.0":
+        total_count = _get_feature_count(service_url, layer_info.typename, version)
+        startindex_limit = _probe_startindex_limit(
+            service_url, layer_info.typename, version, crs=crs, axis_order=axis_order
+        )
+        if startindex_limit and total_count:
+            effective = min(limit, total_count) if limit else total_count
+            if effective > startindex_limit + page_size:
+                if not layer_info.bbox:
+                    raise WFSError(
+                        "Auto-tiling requires a layer bounding box from capabilities, "
+                        "but this layer has none. Use --bbox to specify one manually."
+                    )
+                use_tiling = True
+
+    if use_tiling:
+        table = _fetch_with_spatial_tiles(
+            service_url=service_url,
+            typename=layer_info.typename,
+            version=version,
+            total_count=effective,
+            startindex_limit=startindex_limit,
+            layer_bbox=layer_info.bbox,
+            crs=crs,
+            max_workers=max_workers,
+            page_size=page_size,
+            axis_order=axis_order,
+            max_features=limit,
+        )
+    else:
+        table = fetch_all_features_duckdb(
+            service_url=service_url,
+            typename=layer_info.typename,
+            version=version,
+            max_features=limit,
+            bbox=bbox if use_server_bbox else None,
+            crs=crs,
+            max_workers=max_workers,
+            page_size=page_size,
+            axis_order=axis_order,
+        )
 
     if table.num_rows == 0:
         if bbox:
@@ -1633,6 +1910,7 @@ def convert_wfs_to_geoparquet(
     geoparquet_version: str | None = None,
     overwrite: bool = False,
     verbose: bool = False,
+    auto_tile: bool = False,
 ) -> None:
     """
     Extract WFS layer and save as optimized GeoParquet.
@@ -1660,6 +1938,7 @@ def convert_wfs_to_geoparquet(
         geoparquet_version: GeoParquet version
         overwrite: Overwrite existing file
         verbose: Enable debug output
+        auto_tile: Automatically subdivide into spatial tiles for servers with startIndex limits
     """
     configure_verbose(verbose)
 
@@ -1682,6 +1961,7 @@ def convert_wfs_to_geoparquet(
         axis_order=axis_order,
         strict_crs=strict_crs,
         verbose=verbose,
+        auto_tile=auto_tile,
     )
 
     # Apply Hilbert ordering (unless skipped)

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1309,6 +1309,9 @@ def _refine_tiles_adaptive(
             axis_order=axis_order,
         )
 
+        if count is not None and count == 0:
+            return []
+
         if count is None or count <= max_per_tile:
             return [bbox]
 
@@ -1594,7 +1597,9 @@ def fetch_all_features_duckdb(
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     # Get expected count for progress and pagination
-    total_count = _get_feature_count(service_url, typename, version)
+    total_count = _get_feature_count(
+        service_url, typename, version, bbox=bbox, crs=crs, axis_order=axis_order
+    )
     if max_features and total_count:
         total_count = min(total_count, max_features)
 
@@ -1618,28 +1623,39 @@ def fetch_all_features_duckdb(
             crs=crs,
             axis_order=axis_order,
         )
-        table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
-        return _infer_column_types(table)
+        fetcher = _fetch_wfs_page_via_http if extract_fid else _fetch_wfs_page_duckdb
+        table = fetcher(url, extract_fid=extract_fid)
+        expected = max_features or total_count
+        if expected and table.num_rows < expected and version != "1.0.0":
+            # Server returned fewer than expected — likely has a maxFeatures cap.
+            # Fall through to adaptive pagination to fetch the rest.
+            needs_pagination = True
+            page_size = table.num_rows or page_size
+        else:
+            return table if extract_fid else _infer_column_types(table)
 
     # Paginated mode — sequential (max_workers=1) or parallel
     effective_total = max_features if max_features else total_count
 
-    # Probe for server-side startIndex limit before building all pages
-    startindex_limit = _probe_startindex_limit(
-        service_url, typename, version, crs=crs, axis_order=axis_order
-    )
-    if startindex_limit is not None:
-        max_reachable = startindex_limit + page_size
-        if effective_total > max_reachable:
-            raise WFSError(
-                f"Server limits startIndex to {startindex_limit:,}, so only "
-                f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
-                f"Options:\n"
-                f"  1. Use --auto-tile to automatically subdivide into spatial tiles\n"
-                f"  2. Use --limit {max_reachable} to fetch only what's reachable\n"
-                f"  3. Use --bbox to spatially filter to a smaller region\n"
-                f"  4. Download the dataset directly from the provider's bulk download service"
-            )
+    # Probe for server-side startIndex limit before building all pages.
+    # Skip the probe when fetching a spatial tile (extract_fid=True) since
+    # the tiling orchestrator already ensured each tile fits within the limit.
+    if not extract_fid:
+        startindex_limit = _probe_startindex_limit(
+            service_url, typename, version, crs=crs, axis_order=axis_order
+        )
+        if startindex_limit is not None:
+            max_reachable = startindex_limit + page_size
+            if effective_total > max_reachable:
+                raise WFSError(
+                    f"Server limits startIndex to {startindex_limit:,}, so only "
+                    f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
+                    f"Options:\n"
+                    f"  1. Use --auto-tile to automatically subdivide into spatial tiles\n"
+                    f"  2. Use --limit {max_reachable} to fetch only what's reachable\n"
+                    f"  3. Use --bbox to spatially filter to a smaller region\n"
+                    f"  4. Download the dataset directly from the provider's bulk download service"
+                )
 
     num_pages = (effective_total + page_size - 1) // page_size
     actual_workers = min(max_workers, num_pages)
@@ -1649,37 +1665,65 @@ def fetch_all_features_duckdb(
         f"using {actual_workers} {'worker' if actual_workers == 1 else 'workers'}..."
     )
 
-    # Build page URLs
-    pages = []
-    for i in range(num_pages):
-        start = i * page_size
-        remaining = effective_total - start
-        count = min(page_size, remaining)
-        if count <= 0:
-            break
-        url = _build_wfs_url(
-            service_url,
-            typename,
-            version,
-            max_features=count,
-            start_index=start,
-            bbox=bbox,
-            crs=crs,
-            axis_order=axis_order,
-        )
-        pages.append((i, start, url))
+    fetcher = _fetch_wfs_page_via_http if extract_fid else _fetch_wfs_page_duckdb
 
-    # Fetch pages (sequentially if 1 worker, parallel otherwise)
+    # Sequential adaptive pagination — adjusts page size if server caps maxFeatures
     results = {}
     if actual_workers == 1:
-        for page_num, start, url in pages:
+        offset = 0
+        page_num = 0
+        server_page_size = page_size
+        while offset < effective_total:
+            remaining = effective_total - offset
+            count = min(server_page_size, remaining)
+            url = _build_wfs_url(
+                service_url,
+                typename,
+                version,
+                max_features=count,
+                start_index=offset,
+                bbox=bbox,
+                crs=crs,
+                axis_order=axis_order,
+            )
             try:
-                table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
-                results[page_num] = table
-                debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
+                table = fetcher(url, extract_fid=extract_fid)
             except Exception as e:
-                raise WFSError(f"Failed to fetch page {page_num + 1} (offset {start}): {e}") from e
+                raise WFSError(f"Failed to fetch page {page_num + 1} (offset {offset}): {e}") from e
+            if table.num_rows == 0:
+                break
+            results[page_num] = table
+            # Detect server-side maxFeatures cap: if the server returned fewer
+            # than requested but we haven't reached the end, adapt page_size
+            if table.num_rows < count and server_page_size > table.num_rows:
+                server_page_size = table.num_rows
+                debug(f"Server caps response to {server_page_size} features per request")
+            offset += table.num_rows
+            page_num += 1
+            debug(
+                f"Page {page_num}: {table.num_rows:,} features (offset {offset:,}/{effective_total:,})"
+            )
     else:
+        # Parallel mode — pre-build pages (cannot adapt dynamically)
+        pages = []
+        for i in range(num_pages):
+            start = i * page_size
+            remaining = effective_total - start
+            count = min(page_size, remaining)
+            if count <= 0:
+                break
+            url = _build_wfs_url(
+                service_url,
+                typename,
+                version,
+                max_features=count,
+                start_index=start,
+                bbox=bbox,
+                crs=crs,
+                axis_order=axis_order,
+            )
+            pages.append((i, start, url))
+
         with ThreadPoolExecutor(max_workers=actual_workers) as executor:
             future_to_page = {
                 executor.submit(_fetch_wfs_page_via_http, url, extract_fid): (page_num, start)
@@ -1702,10 +1746,12 @@ def fetch_all_features_duckdb(
         raise WFSError("No features returned from WFS service.")
 
     tables = [results[i] for i in sorted(results.keys())]
-    combined = pa.concat_tables(tables)
+    combined = pa.concat_tables(tables, promote_options="default")
     debug(f"Combined {len(tables)} pages: {combined.num_rows:,} total features")
 
-    # Infer types AFTER concat to ensure consistent schema (issue #400)
+    # Skip type inference for tile fetches — the tiling orchestrator handles it
+    if extract_fid:
+        return combined
     return _infer_column_types(combined)
 
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1171,7 +1171,7 @@ class TestAutoPageSingleWorker:
 
         call_count = 0
 
-        def mock_fetch(url):
+        def mock_fetch(url, extract_fid=False):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -2302,3 +2302,367 @@ class TestSrsNameWithoutBbox:
         # More specific check for Belgium
         assert 2.5 <= x <= 6.5, f"X coord {x} not in Belgium longitude range"
         assert 49.0 <= y <= 52.0, f"Y coord {y} not in Belgium latitude range"
+
+
+# =============================================================================
+# Spatial Tiling Tests (startIndex limit workaround)
+# =============================================================================
+
+
+class TestGenerateTileGrid:
+    """Test grid generation for spatial tiling."""
+
+    def test_correct_count(self):
+        """Grid should produce at least the requested number of tiles."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        bbox = (3.0, 50.0, 7.0, 54.0)
+        tiles = _generate_tile_grid(bbox, 4)
+        assert len(tiles) >= 4
+
+    def test_covers_full_bbox(self):
+        """Union of tile bboxes should cover the original bbox."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        bbox = (3.0, 50.0, 7.0, 54.0)
+        tiles = _generate_tile_grid(bbox, 6)
+
+        all_xmin = min(t[0] for t in tiles)
+        all_ymin = min(t[1] for t in tiles)
+        all_xmax = max(t[2] for t in tiles)
+        all_ymax = max(t[3] for t in tiles)
+
+        assert all_xmin == pytest.approx(bbox[0])
+        assert all_ymin == pytest.approx(bbox[1])
+        assert all_xmax == pytest.approx(bbox[2])
+        assert all_ymax == pytest.approx(bbox[3])
+
+    def test_single_tile(self):
+        """Requesting 1 tile should return the original bbox."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        bbox = (3.0, 50.0, 7.0, 54.0)
+        tiles = _generate_tile_grid(bbox, 1)
+        assert len(tiles) == 1
+        assert tiles[0] == pytest.approx(bbox)
+
+    def test_respects_aspect_ratio(self):
+        """Wide bbox should produce more columns than rows."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        wide_bbox = (0.0, 0.0, 10.0, 2.0)
+        tiles = _generate_tile_grid(wide_bbox, 10)
+
+        xs = sorted({t[0] for t in tiles} | {t[2] for t in tiles})
+        ys = sorted({t[1] for t in tiles} | {t[3] for t in tiles})
+        cols = len(xs) - 1
+        rows = len(ys) - 1
+        assert cols > rows
+
+
+class TestRefineTilesAdaptive:
+    """Test adaptive quadtree refinement of tile grid."""
+
+    def test_splits_oversized_tile(self):
+        """Tile with count > limit should be subdivided into 4."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        def mock_count(service_url, typename, version, bbox=None, crs=None, axis_order="auto"):
+            if bbox == (0.0, 0.0, 1.0, 1.0):
+                return 100000
+            return 20000
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", side_effect=mock_count):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+            )
+
+        assert len(result) == 4
+
+    def test_leaves_small_tiles_alone(self):
+        """Tile with count < limit should not be subdivided."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", return_value=10000):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+            )
+
+        assert len(result) == 1
+        assert result[0] == tiles[0]
+
+    def test_max_depth_prevents_infinite_recursion(self):
+        """Recursion should stop at max_depth even if tiles are still too large."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", return_value=999999):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+                max_depth=2,
+            )
+
+        # depth 0: 1 tile -> 4 (depth 1) -> 16 (depth 2, max)
+        assert len(result) == 16
+
+    def test_handles_none_count_gracefully(self):
+        """If _get_feature_count returns None, tile should be kept as-is."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", return_value=None):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+            )
+
+        assert len(result) == 1
+
+
+class TestGetFeatureCountWithBbox:
+    """Test _get_feature_count extended with bbox parameter."""
+
+    def test_bbox_included_in_request(self):
+        """When bbox provided, it should appear in the hits request."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with patch("geoparquet_io.core.wfs._make_request") as mock_req:
+            mock_req.return_value = b'numberOfFeatures="42"'
+            result = _get_feature_count(
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                bbox=(4.0, 52.0, 5.0, 53.0),
+                crs="EPSG:4326",
+            )
+
+        assert result == 42
+        call_params = mock_req.call_args[1]["params"]
+        assert "bbox" in call_params
+
+    def test_no_bbox_backward_compatible(self):
+        """Without bbox, request should not include bbox param."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with patch("geoparquet_io.core.wfs._make_request") as mock_req:
+            mock_req.return_value = b'numberOfFeatures="100"'
+            result = _get_feature_count("http://mock/wfs", "layer", "1.1.0")
+
+        assert result == 100
+        call_params = mock_req.call_args[1]["params"]
+        assert "bbox" not in call_params
+
+
+class TestDeduplicateTiles:
+    """Test deduplication of features across tile boundaries."""
+
+    def test_removes_duplicates_by_fid(self):
+        """Features with same _wfs_fid should be deduplicated."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        table = pa.table(
+            {
+                "_wfs_fid": pa.array(["a", "b", "a", "c"]),
+                "geometry": pa.array([b"\x01", b"\x02", b"\x01", b"\x03"], type=pa.binary()),
+                "name": pa.array(["x", "y", "x", "z"]),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        assert result.num_rows == 3
+
+    def test_drops_fid_column(self):
+        """_wfs_fid column should be removed from output."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        table = pa.table(
+            {
+                "_wfs_fid": pa.array(["a", "b"]),
+                "geometry": pa.array([b"\x01", b"\x02"], type=pa.binary()),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        assert "_wfs_fid" not in result.column_names
+
+    def test_fallback_geometry_dedup_when_no_fid(self):
+        """When _wfs_fid is absent, deduplicate by geometry bytes."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        table = pa.table(
+            {
+                "geometry": pa.array([b"\x01", b"\x02", b"\x01"], type=pa.binary()),
+                "name": pa.array(["x", "y", "x"]),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        assert result.num_rows == 2
+
+
+class TestFetchWithSpatialTiles:
+    """Test the spatial tiling orchestrator."""
+
+    def test_combines_tile_results(self):
+        """Should fetch each tile and combine results."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_with_spatial_tiles
+
+        tile1 = pa.table(
+            {
+                "_wfs_fid": pa.array(["a"]),
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["x"]),
+            }
+        )
+        tile2 = pa.table(
+            {
+                "_wfs_fid": pa.array(["b"]),
+                "geometry": pa.array([b"\x01\x03"], type=pa.binary()),
+                "name": pa.array(["y"]),
+            }
+        )
+
+        call_count = 0
+
+        def mock_fetch(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return tile1 if call_count == 1 else tile2
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs._generate_tile_grid",
+                return_value=[
+                    (0.0, 0.0, 0.5, 0.5),
+                    (0.5, 0.0, 1.0, 0.5),
+                ],
+            ),
+            patch(
+                "geoparquet_io.core.wfs._refine_tiles_adaptive",
+                side_effect=lambda tiles, *a, **kw: tiles,
+            ),
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", side_effect=mock_fetch),
+        ):
+            result = _fetch_with_spatial_tiles(
+                service_url="http://mock/wfs",
+                typename="layer",
+                version="1.1.0",
+                total_count=100000,
+                startindex_limit=50000,
+                layer_bbox=(0.0, 0.0, 1.0, 0.5),
+                crs="EPSG:4326",
+            )
+
+        assert result.num_rows == 2
+        assert "_wfs_fid" not in result.column_names
+
+    def test_auto_tile_triggers_tiling(self):
+        """wfs_to_table with auto_tile=True should invoke tiling when limit detected."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs.negotiate_wfs_version", return_value=("1.1.0", MagicMock())
+            ),
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_info,
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=11000000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=50000),
+            patch(
+                "geoparquet_io.core.wfs._fetch_with_spatial_tiles", return_value=mock_table
+            ) as mock_tile,
+        ):
+            mock_info.return_value = MagicMock(
+                typename="layer",
+                title="Layer",
+                crs_list=["EPSG:4326"],
+                default_crs="EPSG:4326",
+                available_formats=["application/json"],
+                bbox=(3.0, 50.0, 7.0, 54.0),
+            )
+            wfs_to_table("http://mock/wfs", "layer", auto_tile=True)
+
+        mock_tile.assert_called_once()
+
+    def test_auto_tile_noop_when_no_limit(self):
+        """When server has no startIndex limit, should use normal fetch path."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs.negotiate_wfs_version", return_value=("1.1.0", MagicMock())
+            ),
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_info,
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
+            patch(
+                "geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=mock_table
+            ) as mock_fetch,
+            patch("geoparquet_io.core.wfs._fetch_with_spatial_tiles") as mock_tile,
+        ):
+            mock_info.return_value = MagicMock(
+                typename="layer",
+                title="Layer",
+                crs_list=["EPSG:4326"],
+                default_crs="EPSG:4326",
+                available_formats=["application/json"],
+                bbox=(3.0, 50.0, 7.0, 54.0),
+            )
+            wfs_to_table("http://mock/wfs", "layer", auto_tile=True)
+
+        mock_fetch.assert_called_once()
+        mock_tile.assert_not_called()

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1156,16 +1156,18 @@ class TestAutoPageSingleWorker:
 
         from geoparquet_io.core.wfs import fetch_all_features_duckdb
 
+        # Each page must have page_size rows so adaptive pagination doesn't
+        # mistake 1-row results for a server-side maxFeatures cap.
         page1 = pa.table(
             {
-                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
-                "name": pa.array(["a"]),
+                "geometry": pa.array([b"\x01\x02"] * 10000, type=pa.binary()),
+                "name": pa.array(["a"] * 10000),
             }
         )
         page2 = pa.table(
             {
-                "geometry": pa.array([b"\x01\x03"], type=pa.binary()),
-                "name": pa.array(["b"]),
+                "geometry": pa.array([b"\x01\x03"] * 10000, type=pa.binary()),
+                "name": pa.array(["b"] * 10000),
             }
         )
 
@@ -1190,7 +1192,7 @@ class TestAutoPageSingleWorker:
             )
 
         assert call_count == 2
-        assert result.num_rows == 2
+        assert result.num_rows == 20000
 
     def test_single_worker_no_pagination_when_count_within_page_size(self):
         """With max_workers=1 and total <= page_size, should use single request."""
@@ -1200,8 +1202,8 @@ class TestAutoPageSingleWorker:
 
         mock_table = pa.table(
             {
-                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
-                "name": pa.array(["a"]),
+                "geometry": pa.array([b"\x01\x02"] * 5000, type=pa.binary()),
+                "name": pa.array(["a"] * 5000),
             }
         )
 
@@ -1219,7 +1221,7 @@ class TestAutoPageSingleWorker:
             )
 
         mock_fetch.assert_called_once()
-        assert result.num_rows == 1
+        assert result.num_rows == 5000
 
     def test_single_worker_no_pagination_when_count_unknown(self):
         """With max_workers=1 and unknown count, should use single request."""
@@ -1256,18 +1258,24 @@ class TestAutoPageSingleWorker:
 
         from geoparquet_io.core.wfs import fetch_all_features_duckdb
 
-        page = pa.table(
-            {
-                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
-                "name": pa.array(["a"]),
-            }
-        )
+        call_count = 0
+
+        def mock_fetch(url, extract_fid=False):
+            nonlocal call_count
+            call_count += 1
+            n = 10000 if call_count == 1 else 5000
+            return pa.table(
+                {
+                    "geometry": pa.array([b"\x01\x02"] * n, type=pa.binary()),
+                    "name": pa.array(["a"] * n),
+                }
+            )
 
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=100000),
-            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page) as mock_fetch,
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", side_effect=mock_fetch),
         ):
-            fetch_all_features_duckdb(
+            result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
                 "layer",
                 max_workers=1,
@@ -1275,8 +1283,8 @@ class TestAutoPageSingleWorker:
                 page_size=10000,
             )
 
-        # 15000 features / 10000 page_size = 2 pages
-        assert mock_fetch.call_count == 2
+        assert call_count == 2
+        assert result.num_rows == 15000
 
     def test_parallel_workers_use_http_fetcher(self):
         """Parallel mode should use _fetch_wfs_page_via_http, not httpfs."""


### PR DESCRIPTION
## Summary

- Adds `--auto-tile` flag to `gpio extract wfs` that automatically subdivides a layer's bounding box into spatial tiles when a server caps `startIndex` (e.g., PDOK at 50,000)
- Adaptively refines tiles using `resultType=hits` bbox probes — dense areas get subdivided into quadrants (max depth 8), sparse areas stay as single tiles
- Deduplicates boundary features by WFS feature ID (`feature.id`), with fallback to geometry bytes hash
- Exposes `auto_tile` parameter through CLI (`--auto-tile`), `Table.from_wfs()`, and `ops.from_wfs()`

## How it works

1. Detects startIndex limit via probe request
2. Gets layer WGS84 bbox from capabilities
3. Generates aspect-ratio-aware initial grid: `ceil(total / (limit * 0.8))` tiles
4. Probes each tile's feature count; subdivides any tile exceeding the limit
5. Fetches each tile via existing `fetch_all_features_duckdb(bbox=tile_bbox)`
6. Combines tiles, deduplicates by `_wfs_fid`, drops the ID column

## Test plan

- [x] 16 new unit tests covering grid generation, adaptive refinement, deduplication, and end-to-end tiling
- [x] All 142 offline WFS tests pass
- [ ] Manual test with PDOK: `gpio extract wfs https://service.pdok.nl/kadaster/bu/wfs/v1_0 bu:building buildings.parquet --auto-tile --limit 100000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)