### PR TITLE
feat(wfs): unified WFS improvements with 10x faster extraction

### DIFF
--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -763,6 +763,7 @@ def from_wfs(
     page_size: int = 10000,
     axis_order: str = "auto",
     strict_crs: bool = False,
+    auto_tile: bool = False,
 ) -> pa.Table:
     """
     Fetch WFS layer as PyArrow Table.
@@ -783,6 +784,8 @@ def from_wfs(
             CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
         strict_crs: If True, fail when server returns coordinates that don't match
             requested CRS. If False (default), warn and use detected CRS.
+        auto_tile: Automatically subdivide into spatial tiles for servers with
+            startIndex limits (default: False)
 
     Returns:
         PyArrow Table with geometry column
@@ -790,10 +793,8 @@ def from_wfs(
     Example:
         >>> from geoparquet_io.api import ops
         >>> table = ops.from_wfs('https://geo.example.com/wfs', 'cities', limit=100)
-        >>> # For large datasets:
-        >>> table = ops.from_wfs('https://geo.example.com/wfs', 'parcels', max_workers=4)
-        >>> # Force axis order for problematic servers:
-        >>> table = ops.from_wfs(url, layer, axis_order='latlon')
+        >>> # For large datasets on servers with startIndex limits:
+        >>> table = ops.from_wfs('https://geo.example.com/wfs', 'parcels', auto_tile=True)
     """
     from geoparquet_io.core.wfs import wfs_to_table
 
@@ -807,6 +808,7 @@ def from_wfs(
         page_size=page_size,
         axis_order=axis_order,
         strict_crs=strict_crs,
+        auto_tile=auto_tile,
     )
 
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -554,6 +554,7 @@ class Table:
         page_size: int = 10000,
         axis_order: str = "auto",
         strict_crs: bool = False,
+        auto_tile: bool = False,
     ) -> Table:
         """
         Create Table from WFS layer.
@@ -574,6 +575,8 @@ class Table:
                 CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
             strict_crs: If True, fail when server returns coordinates that don't match
                 requested CRS. If False (default), warn and use detected CRS.
+            auto_tile: Automatically subdivide into spatial tiles for servers with
+                startIndex limits (default: False)
 
         Returns:
             Table for chaining operations
@@ -581,10 +584,8 @@ class Table:
         Example:
             >>> import geoparquet_io as gpio
             >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'cities').add_bbox().write('cities.parquet')
-            >>> # For large datasets:
-            >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'parcels', max_workers=4)
-            >>> # Force axis order for problematic servers:
-            >>> gpio.Table.from_wfs(url, layer, axis_order='latlon')
+            >>> # For large datasets on servers with startIndex limits:
+            >>> gpio.Table.from_wfs('https://geo.example.com/wfs', 'parcels', auto_tile=True)
         """
         from geoparquet_io.core.wfs import wfs_to_table
 
@@ -598,6 +599,7 @@ class Table:
             page_size=page_size,
             axis_order=axis_order,
             strict_crs=strict_crs,
+            auto_tile=auto_tile,
         )
         return cls(table)
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2894,6 +2894,12 @@ def _deprecated_version_callback(ctx, param, value):
     help="Features per page when using --workers > 1. Default: 10000.",
 )
 @click.option(
+    "--auto-tile",
+    is_flag=True,
+    help="Automatically subdivide into spatial tiles to work around server "
+    "startIndex limits. Use for large datasets on servers that cap pagination.",
+)
+@click.option(
     "--skip-hilbert",
     is_flag=True,
     help="Skip Hilbert curve sorting (faster, but no spatial clustering)",
@@ -2923,6 +2929,7 @@ def extract_wfs_cmd(
     output_crs,
     workers,
     page_size,
+    auto_tile,
     skip_hilbert,
     skip_bbox,
     compression,
@@ -3064,6 +3071,7 @@ def extract_wfs_cmd(
             geoparquet_version=geoparquet_version,
             overwrite=overwrite,
             verbose=verbose,
+            auto_tile=auto_tile,
         )
     except WFSError as e:
         raise click.ClickException(str(e)) from None

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -895,6 +895,9 @@ def _get_feature_count(
     service_url: str,
     typename: str,
     version: str = "1.1.0",
+    bbox: tuple[float, float, float, float] | None = None,
+    crs: str | None = None,
+    axis_order: str = "auto",
 ) -> int | None:
     """
     Try to get feature count using resultType=hits.
@@ -905,6 +908,9 @@ def _get_feature_count(
         service_url: WFS service URL
         typename: Layer typename
         version: WFS version
+        bbox: Optional bounding box filter (xmin, ymin, xmax, ymax)
+        crs: CRS for bbox parameter
+        axis_order: Bbox axis order ("auto", "xy", "latlon")
 
     Returns:
         Feature count or None if not supported
@@ -920,6 +926,9 @@ def _get_feature_count(
         "typeNames" if version == "2.0.0" else "typeName": typename,
         "resultType": "hits",
     }
+
+    if bbox and crs:
+        params["bbox"] = _build_bbox_param(bbox, crs, version, axis_order)
 
     try:
         content = _make_request(clean_url, params=params)
@@ -1051,7 +1060,7 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
         con.close()
 
 
-def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
+def _fetch_wfs_page_duckdb(url: str, extract_fid: bool = False) -> pa.Table:
     """
     Fetch a WFS GeoJSON page directly using DuckDB's httpfs.
 
@@ -1103,6 +1112,8 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
             return pa.table({"geometry": pa.array([], type=pa.binary())})
 
         # Full query to extract features
+        fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
+        fid_select = "_wfs_fid," if extract_fid else ""
         query = f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
@@ -1110,11 +1121,13 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
             ),
             extracted AS (
                 SELECT
+                    {fid_col}
                     ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
                     feature.properties AS props
                 FROM features
             )
             SELECT
+                {fid_select}
                 geometry,
                 unnest(props)
             FROM extracted
@@ -1142,7 +1155,7 @@ class WFSStartIndexLimitError(WFSError):
         super().__init__(message)
 
 
-def _fetch_wfs_page_via_http(url: str) -> pa.Table:
+def _fetch_wfs_page_via_http(url: str, extract_fid: bool = False) -> pa.Table:
     """
     Fetch a WFS GeoJSON page using Python HTTP, parse with DuckDB from disk.
 
@@ -1189,6 +1202,8 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
             debug("Empty response, returning empty table")
             return pa.table({"geometry": pa.array([], type=pa.binary())})
 
+        fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
+        fid_select = "_wfs_fid," if extract_fid else ""
         query = f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
@@ -1196,11 +1211,12 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
             ),
             extracted AS (
                 SELECT
+                    {fid_col}
                     ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
                     feature.properties AS props
                 FROM features
             )
-            SELECT geometry, unnest(props) FROM extracted
+            SELECT {fid_select} geometry, unnest(props) FROM extracted
         """
         result = con.execute(query)
         table = result.arrow().read_all()
@@ -1215,6 +1231,235 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
     finally:
         Path(tmp_path).unlink(missing_ok=True)
+
+
+def _generate_tile_grid(
+    bbox: tuple[float, float, float, float],
+    num_tiles: int,
+) -> list[tuple[float, float, float, float]]:
+    """
+    Generate a grid of tile bboxes covering the given bbox.
+
+    Uses aspect-ratio-aware layout so tiles are roughly square in
+    geographic coordinates.
+    """
+    import math
+
+    if num_tiles <= 1:
+        return [bbox]
+
+    xmin, ymin, xmax, ymax = bbox
+    width = xmax - xmin
+    height = ymax - ymin
+
+    if width <= 0 or height <= 0:
+        return [bbox]
+
+    aspect = width / height
+    cols = max(1, round(math.sqrt(num_tiles * aspect)))
+    rows = max(1, math.ceil(num_tiles / cols))
+
+    dx = width / cols
+    dy = height / rows
+
+    tiles = []
+    for r in range(rows):
+        for c in range(cols):
+            tiles.append(
+                (
+                    xmin + c * dx,
+                    ymin + r * dy,
+                    xmin + (c + 1) * dx,
+                    ymin + (r + 1) * dy,
+                )
+            )
+
+    return tiles
+
+
+def _refine_tiles_adaptive(
+    tiles: list[tuple[float, float, float, float]],
+    service_url: str,
+    typename: str,
+    version: str,
+    crs: str,
+    axis_order: str,
+    max_per_tile: int,
+    max_depth: int = 8,
+) -> list[tuple[float, float, float, float]]:
+    """
+    Recursively subdivide tiles that exceed the feature count limit.
+
+    For each tile, probes the server with resultType=hits + bbox to check
+    the feature count. Tiles over max_per_tile are split into 4 quadrants.
+    """
+
+    def _subdivide(
+        bbox: tuple[float, float, float, float], depth: int
+    ) -> list[tuple[float, float, float, float]]:
+        if depth >= max_depth:
+            return [bbox]
+
+        count = _get_feature_count(
+            service_url,
+            typename,
+            version,
+            bbox=bbox,
+            crs=crs,
+            axis_order=axis_order,
+        )
+
+        if count is None or count <= max_per_tile:
+            return [bbox]
+
+        xmin, ymin, xmax, ymax = bbox
+        mx = (xmin + xmax) / 2
+        my = (ymin + ymax) / 2
+
+        quadrants = [
+            (xmin, ymin, mx, my),
+            (mx, ymin, xmax, my),
+            (xmin, my, mx, ymax),
+            (mx, my, xmax, ymax),
+        ]
+
+        result = []
+        for q in quadrants:
+            result.extend(_subdivide(q, depth + 1))
+        return result
+
+    refined = []
+    for tile in tiles:
+        refined.extend(_subdivide(tile, 0))
+    return refined
+
+
+def _deduplicate_tiles(table: pa.Table) -> pa.Table:
+    """
+    Deduplicate features that appear in multiple tiles.
+
+    Uses _wfs_fid column if present (from GeoJSON feature.id).
+    Falls back to geometry bytes deduplication.
+    Always drops the _wfs_fid column from output.
+    """
+    if table.num_rows == 0:
+        if "_wfs_fid" in table.column_names:
+            return table.drop(["_wfs_fid"])
+        return table
+
+    con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+
+    try:
+        con.register("tile_data", table)
+
+        if "_wfs_fid" in table.column_names:
+            all_cols = [c for c in table.column_names if c != "_wfs_fid"]
+            col_list = ", ".join(f'"{c}"' for c in all_cols)
+            query = f"""
+                SELECT {col_list}
+                FROM (
+                    SELECT *, ROW_NUMBER() OVER (PARTITION BY "_wfs_fid") AS _rn
+                    FROM tile_data
+                    WHERE "_wfs_fid" IS NOT NULL
+                ) WHERE _rn = 1
+                UNION ALL
+                SELECT {col_list}
+                FROM tile_data
+                WHERE "_wfs_fid" IS NULL
+            """
+        else:
+            all_cols = table.column_names
+            col_list = ", ".join(f'"{c}"' for c in all_cols)
+            query = f"""
+                SELECT {col_list}
+                FROM (
+                    SELECT *, ROW_NUMBER() OVER (PARTITION BY geometry) AS _rn
+                    FROM tile_data
+                ) WHERE _rn = 1
+            """
+
+        result = con.execute(query)
+        return result.arrow().read_all()
+    finally:
+        con.close()
+
+
+def _fetch_with_spatial_tiles(
+    service_url: str,
+    typename: str,
+    version: str,
+    total_count: int,
+    startindex_limit: int,
+    layer_bbox: tuple[float, float, float, float],
+    crs: str,
+    max_workers: int = 1,
+    page_size: int = 10000,
+    axis_order: str = "auto",
+    max_features: int | None = None,
+) -> pa.Table:
+    """
+    Fetch a large WFS dataset by subdividing into spatial tiles.
+
+    Used when the server caps startIndex, making full pagination impossible.
+    Subdivides the layer bbox into tiles, fetches each tile separately,
+    deduplicates features on tile boundaries, and combines results.
+    """
+    import math
+
+    max_per_tile = startindex_limit
+    num_tiles = max(2, math.ceil(total_count / (max_per_tile * 0.8)))
+
+    progress(f"Auto-tiling: splitting {total_count:,} features into ~{num_tiles} spatial tiles...")
+
+    tiles = _generate_tile_grid(layer_bbox, num_tiles)
+
+    progress(f"Refining {len(tiles)} tiles (checking feature counts per tile)...")
+    tiles = _refine_tiles_adaptive(
+        tiles,
+        service_url,
+        typename,
+        version,
+        crs=crs,
+        axis_order=axis_order,
+        max_per_tile=max_per_tile,
+    )
+
+    progress(f"Fetching {len(tiles)} tiles...")
+
+    all_tables = []
+    for i, tile_bbox in enumerate(tiles):
+        debug(f"Tile {i + 1}/{len(tiles)}: bbox={tile_bbox}")
+        tile_table = fetch_all_features_duckdb(
+            service_url,
+            typename,
+            version,
+            max_features=max_features,
+            bbox=tile_bbox,
+            crs=crs,
+            max_workers=max_workers,
+            page_size=page_size,
+            axis_order=axis_order,
+            extract_fid=True,
+        )
+        if tile_table.num_rows > 0:
+            all_tables.append(tile_table)
+        progress(f"Tile {i + 1}/{len(tiles)}: {tile_table.num_rows:,} features")
+
+    if not all_tables:
+        raise WFSError("No features returned from any spatial tile.")
+
+    combined = pa.concat_tables(all_tables, promote_options="default")
+    before_dedup = combined.num_rows
+
+    combined = _deduplicate_tiles(combined)
+    after_dedup = combined.num_rows
+
+    if before_dedup != after_dedup:
+        debug(
+            f"Deduplicated: {before_dedup:,} → {after_dedup:,} ({before_dedup - after_dedup:,} duplicates)"
+        )
+
+    return _infer_column_types(combined)
 
 
 def _probe_startindex_limit(
@@ -1322,6 +1567,7 @@ def fetch_all_features_duckdb(
     max_workers: int = 1,
     page_size: int = 10000,
     axis_order: str = "auto",
+    extract_fid: bool = False,
 ) -> pa.Table:
     """
     Fetch WFS features using DuckDB's native HTTP streaming.
@@ -1372,7 +1618,7 @@ def fetch_all_features_duckdb(
             crs=crs,
             axis_order=axis_order,
         )
-        table = _fetch_wfs_page_duckdb(url)
+        table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
         return _infer_column_types(table)
 
     # Paginated mode — sequential (max_workers=1) or parallel
@@ -1389,9 +1635,10 @@ def fetch_all_features_duckdb(
                 f"Server limits startIndex to {startindex_limit:,}, so only "
                 f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
                 f"Options:\n"
-                f"  1. Use --limit {max_reachable} to fetch only what's reachable\n"
-                f"  2. Use --bbox to spatially filter to a smaller region\n"
-                f"  3. Download the dataset directly from the provider's bulk download service"
+                f"  1. Use --auto-tile to automatically subdivide into spatial tiles\n"
+                f"  2. Use --limit {max_reachable} to fetch only what's reachable\n"
+                f"  3. Use --bbox to spatially filter to a smaller region\n"
+                f"  4. Download the dataset directly from the provider's bulk download service"
             )
 
     num_pages = (effective_total + page_size - 1) // page_size
@@ -1427,7 +1674,7 @@ def fetch_all_features_duckdb(
     if actual_workers == 1:
         for page_num, start, url in pages:
             try:
-                table = _fetch_wfs_page_duckdb(url)
+                table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
                 results[page_num] = table
                 debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
             except Exception as e:
@@ -1435,7 +1682,7 @@ def fetch_all_features_duckdb(
     else:
         with ThreadPoolExecutor(max_workers=actual_workers) as executor:
             future_to_page = {
-                executor.submit(_fetch_wfs_page_via_http, url): (page_num, start)
+                executor.submit(_fetch_wfs_page_via_http, url, extract_fid): (page_num, start)
                 for page_num, start, url in pages
             }
 
@@ -1475,6 +1722,7 @@ def wfs_to_table(
     axis_order: str = "auto",
     strict_crs: bool = False,
     verbose: bool = False,
+    auto_tile: bool = False,
 ) -> pa.Table:
     """
     Fetch WFS layer as PyArrow Table.
@@ -1533,20 +1781,49 @@ def wfs_to_table(
     if bbox:
         use_server_bbox = _determine_bbox_strategy(bbox_mode, layer_info)
 
-    # Use DuckDB-native streaming for fast extraction
-    # Single request mode is 10x+ faster than Python HTTP
-    # Parallel mode is useful for very large datasets (1M+ features)
-    table = fetch_all_features_duckdb(
-        service_url=service_url,
-        typename=layer_info.typename,
-        version=version,
-        max_features=limit,
-        bbox=bbox if use_server_bbox else None,
-        crs=crs,
-        max_workers=max_workers,
-        page_size=page_size,
-        axis_order=axis_order,
-    )
+    # Check if auto-tiling is needed (server has startIndex limit + dataset exceeds it)
+    use_tiling = False
+    if auto_tile and version != "1.0.0":
+        total_count = _get_feature_count(service_url, layer_info.typename, version)
+        startindex_limit = _probe_startindex_limit(
+            service_url, layer_info.typename, version, crs=crs, axis_order=axis_order
+        )
+        if startindex_limit and total_count:
+            effective = min(limit, total_count) if limit else total_count
+            if effective > startindex_limit + page_size:
+                if not layer_info.bbox:
+                    raise WFSError(
+                        "Auto-tiling requires a layer bounding box from capabilities, "
+                        "but this layer has none. Use --bbox to specify one manually."
+                    )
+                use_tiling = True
+
+    if use_tiling:
+        table = _fetch_with_spatial_tiles(
+            service_url=service_url,
+            typename=layer_info.typename,
+            version=version,
+            total_count=effective,
+            startindex_limit=startindex_limit,
+            layer_bbox=layer_info.bbox,
+            crs=crs,
+            max_workers=max_workers,
+            page_size=page_size,
+            axis_order=axis_order,
+            max_features=limit,
+        )
+    else:
+        table = fetch_all_features_duckdb(
+            service_url=service_url,
+            typename=layer_info.typename,
+            version=version,
+            max_features=limit,
+            bbox=bbox if use_server_bbox else None,
+            crs=crs,
+            max_workers=max_workers,
+            page_size=page_size,
+            axis_order=axis_order,
+        )
 
     if table.num_rows == 0:
         if bbox:
@@ -1633,6 +1910,7 @@ def convert_wfs_to_geoparquet(
     geoparquet_version: str | None = None,
     overwrite: bool = False,
     verbose: bool = False,
+    auto_tile: bool = False,
 ) -> None:
     """
     Extract WFS layer and save as optimized GeoParquet.
@@ -1660,6 +1938,7 @@ def convert_wfs_to_geoparquet(
         geoparquet_version: GeoParquet version
         overwrite: Overwrite existing file
         verbose: Enable debug output
+        auto_tile: Automatically subdivide into spatial tiles for servers with startIndex limits
     """
     configure_verbose(verbose)
 
@@ -1682,6 +1961,7 @@ def convert_wfs_to_geoparquet(
         axis_order=axis_order,
         strict_crs=strict_crs,
         verbose=verbose,
+        auto_tile=auto_tile,
     )
 
     # Apply Hilbert ordering (unless skipped)

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1309,6 +1309,9 @@ def _refine_tiles_adaptive(
             axis_order=axis_order,
         )
 
+        if count is not None and count == 0:
+            return []
+
         if count is None or count <= max_per_tile:
             return [bbox]
 
@@ -1594,7 +1597,9 @@ def fetch_all_features_duckdb(
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
     # Get expected count for progress and pagination
-    total_count = _get_feature_count(service_url, typename, version)
+    total_count = _get_feature_count(
+        service_url, typename, version, bbox=bbox, crs=crs, axis_order=axis_order
+    )
     if max_features and total_count:
         total_count = min(total_count, max_features)
 
@@ -1618,28 +1623,39 @@ def fetch_all_features_duckdb(
             crs=crs,
             axis_order=axis_order,
         )
-        table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
-        return _infer_column_types(table)
+        fetcher = _fetch_wfs_page_via_http if extract_fid else _fetch_wfs_page_duckdb
+        table = fetcher(url, extract_fid=extract_fid)
+        expected = max_features or total_count
+        if expected and table.num_rows < expected and version != "1.0.0":
+            # Server returned fewer than expected — likely has a maxFeatures cap.
+            # Fall through to adaptive pagination to fetch the rest.
+            needs_pagination = True
+            page_size = table.num_rows or page_size
+        else:
+            return table if extract_fid else _infer_column_types(table)
 
     # Paginated mode — sequential (max_workers=1) or parallel
     effective_total = max_features if max_features else total_count
 
-    # Probe for server-side startIndex limit before building all pages
-    startindex_limit = _probe_startindex_limit(
-        service_url, typename, version, crs=crs, axis_order=axis_order
-    )
-    if startindex_limit is not None:
-        max_reachable = startindex_limit + page_size
-        if effective_total > max_reachable:
-            raise WFSError(
-                f"Server limits startIndex to {startindex_limit:,}, so only "
-                f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
-                f"Options:\n"
-                f"  1. Use --auto-tile to automatically subdivide into spatial tiles\n"
-                f"  2. Use --limit {max_reachable} to fetch only what's reachable\n"
-                f"  3. Use --bbox to spatially filter to a smaller region\n"
-                f"  4. Download the dataset directly from the provider's bulk download service"
-            )
+    # Probe for server-side startIndex limit before building all pages.
+    # Skip the probe when fetching a spatial tile (extract_fid=True) since
+    # the tiling orchestrator already ensured each tile fits within the limit.
+    if not extract_fid:
+        startindex_limit = _probe_startindex_limit(
+            service_url, typename, version, crs=crs, axis_order=axis_order
+        )
+        if startindex_limit is not None:
+            max_reachable = startindex_limit + page_size
+            if effective_total > max_reachable:
+                raise WFSError(
+                    f"Server limits startIndex to {startindex_limit:,}, so only "
+                    f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
+                    f"Options:\n"
+                    f"  1. Use --auto-tile to automatically subdivide into spatial tiles\n"
+                    f"  2. Use --limit {max_reachable} to fetch only what's reachable\n"
+                    f"  3. Use --bbox to spatially filter to a smaller region\n"
+                    f"  4. Download the dataset directly from the provider's bulk download service"
+                )
 
     num_pages = (effective_total + page_size - 1) // page_size
     actual_workers = min(max_workers, num_pages)
@@ -1649,37 +1665,65 @@ def fetch_all_features_duckdb(
         f"using {actual_workers} {'worker' if actual_workers == 1 else 'workers'}..."
     )
 
-    # Build page URLs
-    pages = []
-    for i in range(num_pages):
-        start = i * page_size
-        remaining = effective_total - start
-        count = min(page_size, remaining)
-        if count <= 0:
-            break
-        url = _build_wfs_url(
-            service_url,
-            typename,
-            version,
-            max_features=count,
-            start_index=start,
-            bbox=bbox,
-            crs=crs,
-            axis_order=axis_order,
-        )
-        pages.append((i, start, url))
+    fetcher = _fetch_wfs_page_via_http if extract_fid else _fetch_wfs_page_duckdb
 
-    # Fetch pages (sequentially if 1 worker, parallel otherwise)
+    # Sequential adaptive pagination — adjusts page size if server caps maxFeatures
     results = {}
     if actual_workers == 1:
-        for page_num, start, url in pages:
+        offset = 0
+        page_num = 0
+        server_page_size = page_size
+        while offset < effective_total:
+            remaining = effective_total - offset
+            count = min(server_page_size, remaining)
+            url = _build_wfs_url(
+                service_url,
+                typename,
+                version,
+                max_features=count,
+                start_index=offset,
+                bbox=bbox,
+                crs=crs,
+                axis_order=axis_order,
+            )
             try:
-                table = _fetch_wfs_page_duckdb(url, extract_fid=extract_fid)
-                results[page_num] = table
-                debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
+                table = fetcher(url, extract_fid=extract_fid)
             except Exception as e:
-                raise WFSError(f"Failed to fetch page {page_num + 1} (offset {start}): {e}") from e
+                raise WFSError(f"Failed to fetch page {page_num + 1} (offset {offset}): {e}") from e
+            if table.num_rows == 0:
+                break
+            results[page_num] = table
+            # Detect server-side maxFeatures cap: if the server returned fewer
+            # than requested but we haven't reached the end, adapt page_size
+            if table.num_rows < count and server_page_size > table.num_rows:
+                server_page_size = table.num_rows
+                debug(f"Server caps response to {server_page_size} features per request")
+            offset += table.num_rows
+            page_num += 1
+            debug(
+                f"Page {page_num}: {table.num_rows:,} features (offset {offset:,}/{effective_total:,})"
+            )
     else:
+        # Parallel mode — pre-build pages (cannot adapt dynamically)
+        pages = []
+        for i in range(num_pages):
+            start = i * page_size
+            remaining = effective_total - start
+            count = min(page_size, remaining)
+            if count <= 0:
+                break
+            url = _build_wfs_url(
+                service_url,
+                typename,
+                version,
+                max_features=count,
+                start_index=start,
+                bbox=bbox,
+                crs=crs,
+                axis_order=axis_order,
+            )
+            pages.append((i, start, url))
+
         with ThreadPoolExecutor(max_workers=actual_workers) as executor:
             future_to_page = {
                 executor.submit(_fetch_wfs_page_via_http, url, extract_fid): (page_num, start)
@@ -1702,10 +1746,12 @@ def fetch_all_features_duckdb(
         raise WFSError("No features returned from WFS service.")
 
     tables = [results[i] for i in sorted(results.keys())]
-    combined = pa.concat_tables(tables)
+    combined = pa.concat_tables(tables, promote_options="default")
     debug(f"Combined {len(tables)} pages: {combined.num_rows:,} total features")
 
-    # Infer types AFTER concat to ensure consistent schema (issue #400)
+    # Skip type inference for tile fetches — the tiling orchestrator handles it
+    if extract_fid:
+        return combined
     return _infer_column_types(combined)
 
 

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1133,6 +1133,15 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
 
 
+class WFSStartIndexLimitError(WFSError):
+    """Raised when server rejects a startIndex beyond its limit."""
+
+    def __init__(self, limit: int, total_count: int, message: str):
+        self.limit = limit
+        self.total_count = total_count
+        super().__init__(message)
+
+
 def _fetch_wfs_page_via_http(url: str) -> pa.Table:
     """
     Fetch a WFS GeoJSON page using Python HTTP, parse with DuckDB from disk.
@@ -1144,12 +1153,23 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
     """
     import tempfile
 
+    import httpx
+
     start_time = time.time()
     debug(f"HTTP fetch: {url[:80]}...")
 
     client = _get_shared_http_client(timeout=600)
     response = client.get(url, headers={"Accept-Encoding": "gzip, deflate"})
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 400:
+            body = e.response.text
+            if "startindex" in body.lower():
+                raise WFSError(
+                    f"Server rejected paginated request (startIndex limit): {body.strip()}"
+                ) from e
+        raise
 
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
         tmp.write(response.content)
@@ -1195,6 +1215,56 @@ def _fetch_wfs_page_via_http(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
     finally:
         Path(tmp_path).unlink(missing_ok=True)
+
+
+def _probe_startindex_limit(
+    service_url: str,
+    typename: str,
+    version: str,
+    crs: str | None = None,
+    axis_order: str = "auto",
+) -> int | None:
+    """
+    Probe a WFS server to discover any startIndex limit.
+
+    Some servers (e.g., PDOK) reject requests with startIndex above a
+    threshold (e.g., 50,000). This sends a lightweight probe request
+    to detect that limit before attempting full pagination.
+
+    Returns the limit value if detected, or None if no limit found.
+    """
+    import httpx
+
+    probe_offset = 50001
+    url = _build_wfs_url(
+        service_url,
+        typename,
+        version,
+        max_features=1,
+        start_index=probe_offset,
+        crs=crs,
+        axis_order=axis_order,
+    )
+
+    try:
+        client = _get_shared_http_client(timeout=30)
+        response = client.get(url, headers={"Accept-Encoding": "gzip, deflate"})
+        if response.status_code == 400:
+            body = response.text.lower()
+            if "startindex" in body:
+                import re as _re
+
+                match = _re.search(r"startindex.*?(\d[\d.,]+)", body)
+                if match:
+                    limit_str = match.group(1).replace(",", "").replace(".", "")
+                    try:
+                        return int(limit_str)
+                    except ValueError:
+                        pass
+                return 50000
+        return None
+    except httpx.HTTPError:
+        return None
 
 
 def _build_wfs_url(
@@ -1307,6 +1377,23 @@ def fetch_all_features_duckdb(
 
     # Paginated mode — sequential (max_workers=1) or parallel
     effective_total = max_features if max_features else total_count
+
+    # Probe for server-side startIndex limit before building all pages
+    startindex_limit = _probe_startindex_limit(
+        service_url, typename, version, crs=crs, axis_order=axis_order
+    )
+    if startindex_limit is not None:
+        max_reachable = startindex_limit + page_size
+        if effective_total > max_reachable:
+            raise WFSError(
+                f"Server limits startIndex to {startindex_limit:,}, so only "
+                f"{max_reachable:,} of {effective_total:,} features are reachable via pagination.\n\n"
+                f"Options:\n"
+                f"  1. Use --limit {max_reachable} to fetch only what's reachable\n"
+                f"  2. Use --bbox to spatially filter to a smaller region\n"
+                f"  3. Download the dataset directly from the provider's bulk download service"
+            )
+
     num_pages = (effective_total + page_size - 1) // page_size
     actual_workers = min(max_workers, num_pages)
 

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1133,6 +1133,70 @@ def _fetch_wfs_page_duckdb(url: str) -> pa.Table:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
 
 
+def _fetch_wfs_page_via_http(url: str) -> pa.Table:
+    """
+    Fetch a WFS GeoJSON page using Python HTTP, parse with DuckDB from disk.
+
+    Thread-safe alternative to _fetch_wfs_page_duckdb for parallel fetching.
+    DuckDB's httpfs extension crashes when multiple connections make concurrent
+    HTTP requests (libc++abi: terminating). This downloads via Python's
+    thread-safe httpx client, writes to a temp file, and parses locally.
+    """
+    import tempfile
+
+    start_time = time.time()
+    debug(f"HTTP fetch: {url[:80]}...")
+
+    client = _get_shared_http_client(timeout=600)
+    response = client.get(url, headers={"Accept-Encoding": "gzip, deflate"})
+    response.raise_for_status()
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        tmp.write(response.content)
+        tmp_path = tmp.name
+
+    try:
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        safe_path = _escape_sql_string(tmp_path)
+
+        count_result = con.execute(f"""
+            SELECT len(features) AS cnt
+            FROM read_json_auto('{safe_path}', maximum_object_size=536870912)
+        """).fetchone()
+        feature_count = count_result[0] if count_result else 0
+
+        if feature_count == 0:
+            debug("Empty response, returning empty table")
+            return pa.table({"geometry": pa.array([], type=pa.binary())})
+
+        query = f"""
+            WITH features AS (
+                SELECT unnest(features) AS feature
+                FROM read_json_auto('{safe_path}', maximum_object_size=536870912)
+            ),
+            extracted AS (
+                SELECT
+                    ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
+                    feature.properties AS props
+                FROM features
+            )
+            SELECT geometry, unnest(props) FROM extracted
+        """
+        result = con.execute(query)
+        table = result.arrow().read_all()
+
+        elapsed = time.time() - start_time
+        debug(f"HTTP+DuckDB OK: {table.num_rows:,} rows in {elapsed:.1f}s")
+        return table
+    except Exception as e:
+        error_msg = str(e)
+        if "HTTP" in error_msg or "Could not" in error_msg:
+            raise WFSError(f"Failed to fetch WFS data: {e}") from e
+        raise WFSError(f"Failed to parse WFS response: {e}") from e
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
 def _build_wfs_url(
     service_url: str,
     typename: str,
@@ -1218,8 +1282,12 @@ def fetch_all_features_duckdb(
     if max_features and total_count:
         total_count = min(total_count, max_features)
 
-    # Single request mode (default) - fastest for most cases
-    if max_workers == 1 or version == "1.0.0":
+    # Single request for small datasets or when count is unknown
+    needs_pagination = (
+        total_count is not None and version != "1.0.0" and (max_features or total_count) > page_size
+    )
+
+    if not needs_pagination:
         if total_count:
             progress(f"Streaming {total_count:,} features via DuckDB...")
         else:
@@ -1237,28 +1305,14 @@ def fetch_all_features_duckdb(
         table = _fetch_wfs_page_duckdb(url)
         return _infer_column_types(table)
 
-    # Parallel pagination mode for large datasets
-    if total_count is None:
-        warn("Cannot determine feature count; falling back to single request mode.")
-        url = _build_wfs_url(
-            service_url,
-            typename,
-            version,
-            max_features=max_features,
-            bbox=bbox,
-            crs=crs,
-            axis_order=axis_order,
-        )
-        table = _fetch_wfs_page_duckdb(url)
-        return _infer_column_types(table)
-
-    # Calculate page ranges
+    # Paginated mode — sequential (max_workers=1) or parallel
     effective_total = max_features if max_features else total_count
     num_pages = (effective_total + page_size - 1) // page_size
     actual_workers = min(max_workers, num_pages)
 
     progress(
-        f"Fetching {effective_total:,} features in {num_pages} pages using {actual_workers} workers..."
+        f"Fetching {effective_total:,} features in {num_pages} pages "
+        f"using {actual_workers} {'worker' if actual_workers == 1 else 'workers'}..."
     )
 
     # Build page URLs
@@ -1281,22 +1335,33 @@ def fetch_all_features_duckdb(
         )
         pages.append((i, start, url))
 
-    # Fetch pages in parallel
+    # Fetch pages (sequentially if 1 worker, parallel otherwise)
     results = {}
-    with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-        future_to_page = {
-            executor.submit(_fetch_wfs_page_duckdb, url): (page_num, start)
-            for page_num, start, url in pages
-        }
-
-        for future in as_completed(future_to_page):
-            page_num, start = future_to_page[future]
+    if actual_workers == 1:
+        for page_num, start, url in pages:
             try:
-                table = future.result()
+                table = _fetch_wfs_page_duckdb(url)
                 results[page_num] = table
                 debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
             except Exception as e:
                 raise WFSError(f"Failed to fetch page {page_num + 1} (offset {start}): {e}") from e
+    else:
+        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+            future_to_page = {
+                executor.submit(_fetch_wfs_page_via_http, url): (page_num, start)
+                for page_num, start, url in pages
+            }
+
+            for future in as_completed(future_to_page):
+                page_num, start = future_to_page[future]
+                try:
+                    table = future.result()
+                    results[page_num] = table
+                    debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
+                except Exception as e:
+                    raise WFSError(
+                        f"Failed to fetch page {page_num + 1} (offset {start}): {e}"
+                    ) from e
 
     # Combine tables in order
     if not results:

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1066,81 +1066,109 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
         con.close()
 
 
-def _fetch_wfs_page(url: str, extract_fid: bool = False) -> pa.Table:
+def _fetch_wfs_page(
+    url: str, extract_fid: bool = False, max_retries: int = 3, retry_delay: float = 2.0
+) -> pa.Table:
     """
     Fetch a WFS GeoJSON page via httpx and parse with DuckDB locally.
 
     Downloads GeoJSON using Python httpx (thread-safe, ~10x faster than DuckDB
     httpfs for JSON), streams to a temp file, then parses with DuckDB's spatial
-    extension.
+    extension. Includes automatic retry for transient network errors.
 
     Args:
         url: Full WFS GetFeature URL with all parameters
         extract_fid: If True, extract feature.id as _wfs_fid column (for dedup)
+        max_retries: Number of retry attempts for transient errors
+        retry_delay: Base delay between retries (exponential backoff)
 
     Returns:
         PyArrow Table with geometry column (WKB) and all properties
     """
     import httpx
 
-    start_time = time.time()
-    debug(f"Fetching: {url[:100]}...")
+    last_exception: Exception | None = None
 
-    # Stream response to temp file to avoid memory exhaustion on large responses
-    tmp_path = None
-    total_bytes = 0
-    try:
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".json", delete=False) as tmp_file:
-            tmp_path = tmp_file.name
-            client = _get_shared_http_client(timeout=600)
+    for attempt in range(max_retries):
+        start_time = time.time()
+        if attempt > 0:
+            debug(f"Retry {attempt}/{max_retries - 1}: {url[:80]}...")
+        else:
+            debug(f"Fetching: {url[:100]}...")
 
-            with client.stream(
-                "GET",
-                url,
-                headers={"Accept": "application/json", "Accept-Encoding": "gzip, deflate"},
-            ) as response:
-                # Check HTTP status
-                if response.status_code == 400:
-                    body = response.read().decode("utf-8", errors="replace")
-                    if "startindex" in body.lower():
-                        raise WFSError(
-                            f"Server rejected paginated request (startIndex limit): {body.strip()}"
-                        )
-                    raise WFSError(f"WFS request failed with HTTP 400: {body[:500]}")
-                response.raise_for_status()
+        # Stream response to temp file to avoid memory exhaustion on large responses
+        tmp_path = None
+        total_bytes = 0
+        try:
+            with tempfile.NamedTemporaryFile(mode="wb", suffix=".json", delete=False) as tmp_file:
+                tmp_path = tmp_file.name
+                client = _get_shared_http_client(timeout=600)
 
-                # Validate content-type (servers may return HTML errors with 200 OK)
-                content_type = response.headers.get("content-type", "").lower()
-                if content_type and "json" not in content_type and "javascript" not in content_type:
-                    # Reject HTML, XML, or text/plain (often error pages)
-                    if any(t in content_type for t in ("html", "xml", "text/plain")):
-                        preview = response.read().decode("utf-8", errors="replace")[:500]
-                        raise WFSError(
-                            f"Expected JSON response but got {content_type}. "
-                            f"Server may have returned an error page:\n{preview}"
-                        )
+                with client.stream(
+                    "GET",
+                    url,
+                    headers={"Accept": "application/json", "Accept-Encoding": "gzip, deflate"},
+                ) as response:
+                    # Check HTTP status
+                    if response.status_code == 400:
+                        body = response.read().decode("utf-8", errors="replace")
+                        if "startindex" in body.lower():
+                            raise WFSError(
+                                f"Server rejected paginated request (startIndex limit): {body.strip()}"
+                            )
+                        raise WFSError(f"WFS request failed with HTTP 400: {body[:500]}")
+                    response.raise_for_status()
 
-                # Stream content to file
-                for chunk in response.iter_bytes(chunk_size=65536):
-                    tmp_file.write(chunk)
-                    total_bytes += len(chunk)
+                    # Validate content-type (servers may return HTML errors with 200 OK)
+                    content_type = response.headers.get("content-type", "").lower()
+                    if (
+                        content_type
+                        and "json" not in content_type
+                        and "javascript" not in content_type
+                    ):
+                        # Reject HTML, XML, or text/plain (often error pages)
+                        if any(t in content_type for t in ("html", "xml", "text/plain")):
+                            preview = response.read().decode("utf-8", errors="replace")[:500]
+                            raise WFSError(
+                                f"Expected JSON response but got {content_type}. "
+                                f"Server may have returned an error page:\n{preview}"
+                            )
 
-    except httpx.HTTPStatusError as e:
-        if tmp_path:
-            Path(tmp_path).unlink(missing_ok=True)
-        raise WFSError(f"WFS request failed with HTTP {e.response.status_code}") from e
-    except httpx.RequestError as e:
-        if tmp_path:
-            Path(tmp_path).unlink(missing_ok=True)
-        raise WFSError(f"Failed to fetch WFS data: {e}") from e
-    except WFSError:
-        if tmp_path:
-            Path(tmp_path).unlink(missing_ok=True)
-        raise
+                    # Stream content to file
+                    for chunk in response.iter_bytes(chunk_size=65536):
+                        tmp_file.write(chunk)
+                        total_bytes += len(chunk)
 
-    download_time = time.time() - start_time
-    size_mb = total_bytes / (1024 * 1024)
-    debug(f"Downloaded {size_mb:.1f} MB in {download_time:.1f}s")
+            # Success - break out of retry loop
+            download_time = time.time() - start_time
+            size_mb = total_bytes / (1024 * 1024)
+            debug(f"Downloaded {size_mb:.1f} MB in {download_time:.1f}s")
+            break
+
+        except httpx.HTTPStatusError as e:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
+            raise WFSError(f"WFS request failed with HTTP {e.response.status_code}") from e
+        except (httpx.RequestError, httpx.RemoteProtocolError) as e:
+            # Transient network error - retry
+            last_exception = e
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
+            if attempt < max_retries - 1:
+                delay = retry_delay * (attempt + 1)
+                warn(f"Network error (attempt {attempt + 1}/{max_retries}): {e}")
+                warn(f"Retrying in {delay:.1f}s...")
+                _reset_http_client()
+                time.sleep(delay)
+                continue
+            raise WFSError(f"Failed to fetch WFS data after {max_retries} attempts: {e}") from e
+        except WFSError:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
+            raise
+    else:
+        # Exhausted retries without success
+        raise WFSError(f"Failed to fetch WFS data after {max_retries} attempts: {last_exception}")
 
     con = None
     try:

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -57,6 +57,9 @@ from geoparquet_io.core.logging_config import (
 )
 from geoparquet_io.core.reproject import reproject_table
 
+# Maximum JSON object size for DuckDB parsing (1GB)
+_MAX_JSON_OBJECT_SIZE = 1073741824
+
 
 class WFSError(Exception):
     """Exception raised for WFS-related errors."""
@@ -1063,21 +1066,12 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
         con.close()
 
 
-class WFSStartIndexLimitError(WFSError):
-    """Raised when server rejects a startIndex beyond its limit."""
-
-    def __init__(self, limit: int, total_count: int, message: str):
-        self.limit = limit
-        self.total_count = total_count
-        super().__init__(message)
-
-
 def _fetch_wfs_page(url: str, extract_fid: bool = False) -> pa.Table:
     """
     Fetch a WFS GeoJSON page via httpx and parse with DuckDB locally.
 
     Downloads GeoJSON using Python httpx (thread-safe, ~10x faster than DuckDB
-    httpfs for JSON), writes to a temp file, then parses with DuckDB's spatial
+    httpfs for JSON), streams to a temp file, then parses with DuckDB's spatial
     extension.
 
     Args:
@@ -1092,47 +1086,63 @@ def _fetch_wfs_page(url: str, extract_fid: bool = False) -> pa.Table:
     start_time = time.time()
     debug(f"Fetching: {url[:100]}...")
 
-    # Download via httpx (much faster than DuckDB httpfs for JSON)
-    client = _get_shared_http_client(timeout=600)
+    # Stream response to temp file to avoid memory exhaustion on large responses
+    tmp_path = None
+    total_bytes = 0
     try:
-        response = client.get(
-            url,
-            headers={"Accept": "application/json", "Accept-Encoding": "gzip, deflate"},
-        )
-        response.raise_for_status()
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".json", delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+            client = _get_shared_http_client(timeout=600)
+
+            with client.stream(
+                "GET",
+                url,
+                headers={"Accept": "application/json", "Accept-Encoding": "gzip, deflate"},
+            ) as response:
+                # Check HTTP status
+                if response.status_code == 400:
+                    body = response.read().decode("utf-8", errors="replace")
+                    if "startindex" in body.lower():
+                        raise WFSError(
+                            f"Server rejected paginated request (startIndex limit): {body.strip()}"
+                        )
+                    raise WFSError(f"WFS request failed with HTTP 400: {body[:500]}")
+                response.raise_for_status()
+
+                # Validate content-type (servers may return HTML errors with 200 OK)
+                content_type = response.headers.get("content-type", "").lower()
+                if content_type and "json" not in content_type and "javascript" not in content_type:
+                    # Reject HTML, XML, or text/plain (often error pages)
+                    if any(t in content_type for t in ("html", "xml", "text/plain")):
+                        preview = response.read().decode("utf-8", errors="replace")[:500]
+                        raise WFSError(
+                            f"Expected JSON response but got {content_type}. "
+                            f"Server may have returned an error page:\n{preview}"
+                        )
+
+                # Stream content to file
+                for chunk in response.iter_bytes(chunk_size=65536):
+                    tmp_file.write(chunk)
+                    total_bytes += len(chunk)
+
     except httpx.HTTPStatusError as e:
-        if e.response.status_code == 400:
-            body = e.response.text
-            if "startindex" in body.lower():
-                raise WFSError(
-                    f"Server rejected paginated request (startIndex limit): {body.strip()}"
-                ) from e
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
         raise WFSError(f"WFS request failed with HTTP {e.response.status_code}") from e
     except httpx.RequestError as e:
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
         raise WFSError(f"Failed to fetch WFS data: {e}") from e
-
-    # Validate content-type is JSON (servers may return HTML errors with 200 OK)
-    content_type = response.headers.get("content-type", "").lower()
-    if "json" not in content_type and "javascript" not in content_type:
-        # Some servers use text/javascript or omit content-type entirely
-        # Only reject if it's clearly HTML/XML
-        if "html" in content_type or "xml" in content_type:
-            preview = response.text[:500]
-            raise WFSError(
-                f"Expected JSON response but got {content_type}. "
-                f"Server may have returned an error page:\n{preview}"
-            )
+    except WFSError:
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+        raise
 
     download_time = time.time() - start_time
-    content = response.content
-    size_mb = len(content) / (1024 * 1024)
+    size_mb = total_bytes / (1024 * 1024)
     debug(f"Downloaded {size_mb:.1f} MB in {download_time:.1f}s")
 
-    # Write to temp file for DuckDB local parsing
-    with tempfile.NamedTemporaryFile(mode="wb", suffix=".json", delete=False) as tmp_file:
-        tmp_file.write(content)
-        tmp_path = tmp_file.name
-
+    con = None
     try:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         safe_path = _escape_sql_string(tmp_path)
@@ -1140,7 +1150,7 @@ def _fetch_wfs_page(url: str, extract_fid: bool = False) -> pa.Table:
         # Check feature count first (DuckDB can't UNNEST empty JSON arrays)
         count_result = con.execute(f"""
             SELECT len(features) AS cnt
-            FROM read_json_auto('{safe_path}', maximum_object_size=1073741824)
+            FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
         """).fetchone()
         feature_count = count_result[0] if count_result else 0
 
@@ -1155,7 +1165,7 @@ def _fetch_wfs_page(url: str, extract_fid: bool = False) -> pa.Table:
         query = f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_path}', maximum_object_size=1073741824)
+                FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
             ),
             extracted AS (
                 SELECT
@@ -1173,9 +1183,13 @@ def _fetch_wfs_page(url: str, extract_fid: bool = False) -> pa.Table:
         total_time = time.time() - start_time
         debug(f"Parsed {table.num_rows:,} rows in {parse_time:.1f}s (total: {total_time:.1f}s)")
         return table
+    except WFSError:
+        raise
     except Exception as e:
         raise WFSError(f"Failed to parse WFS response: {e}") from e
     finally:
+        if con:
+            con.close()
         Path(tmp_path).unlink(missing_ok=True)
 
 
@@ -1288,7 +1302,7 @@ def _deduplicate_tiles(table: pa.Table) -> pa.Table:
     Deduplicate features that appear in multiple tiles.
 
     Uses _wfs_fid column if present (from GeoJSON feature.id).
-    Falls back to geometry bytes deduplication.
+    For features with NULL fid, falls back to geometry bytes deduplication.
     Always drops the _wfs_fid column from output.
     """
     if table.num_rows == 0:
@@ -1304,6 +1318,7 @@ def _deduplicate_tiles(table: pa.Table) -> pa.Table:
         if "_wfs_fid" in table.column_names:
             all_cols = [c for c in table.column_names if c != "_wfs_fid"]
             col_list = ", ".join(f'"{c}"' for c in all_cols)
+            # Deduplicate by fid when present, fall back to geometry for NULL fids
             query = f"""
                 SELECT {col_list}
                 FROM (
@@ -1313,8 +1328,11 @@ def _deduplicate_tiles(table: pa.Table) -> pa.Table:
                 ) WHERE _rn = 1
                 UNION ALL
                 SELECT {col_list}
-                FROM tile_data
-                WHERE "_wfs_fid" IS NULL
+                FROM (
+                    SELECT *, ROW_NUMBER() OVER (PARTITION BY geometry) AS _rn
+                    FROM tile_data
+                    WHERE "_wfs_fid" IS NULL
+                ) WHERE _rn = 1
             """
         else:
             all_cols = table.column_names
@@ -1397,7 +1415,7 @@ def _fetch_with_spatial_tiles(
     if not all_tables:
         raise WFSError("No features returned from any spatial tile.")
 
-    combined = pa.concat_tables(all_tables, promote_options="default")
+    combined = pa.concat_tables(all_tables, promote=True)
     before_dedup = combined.num_rows
 
     combined = _deduplicate_tiles(combined)
@@ -1506,6 +1524,152 @@ def _build_wfs_url(
     return f"{clean_url}?{urlencode(params)}"
 
 
+def _single_fetch_mode(
+    service_url: str,
+    typename: str,
+    version: str,
+    max_features: int | None,
+    bbox: tuple[float, float, float, float] | None,
+    crs: str | None,
+    axis_order: str,
+    extract_fid: bool,
+) -> pa.Table:
+    """
+    Fetch all features in a single request.
+
+    Used when the dataset is small enough to fit in one request.
+    """
+    url = _build_wfs_url(
+        service_url,
+        typename,
+        version,
+        max_features=max_features,
+        bbox=bbox,
+        crs=crs,
+        axis_order=axis_order,
+    )
+    table = _fetch_wfs_page(url, extract_fid=extract_fid)
+    return table if extract_fid else _infer_column_types(table)
+
+
+def _sequential_pagination_mode(
+    service_url: str,
+    typename: str,
+    version: str,
+    effective_total: int,
+    page_size: int,
+    bbox: tuple[float, float, float, float] | None,
+    crs: str | None,
+    axis_order: str,
+    extract_fid: bool,
+) -> dict[int, pa.Table]:
+    """
+    Fetch features using sequential adaptive pagination.
+
+    Adapts page size dynamically if server caps maxFeatures.
+    """
+    results: dict[int, pa.Table] = {}
+    offset = 0
+    page_num = 0
+    server_page_size = page_size
+
+    while offset < effective_total:
+        remaining = effective_total - offset
+        count = min(server_page_size, remaining)
+        url = _build_wfs_url(
+            service_url,
+            typename,
+            version,
+            max_features=count,
+            start_index=offset,
+            bbox=bbox,
+            crs=crs,
+            axis_order=axis_order,
+        )
+        try:
+            table = _fetch_wfs_page(url, extract_fid=extract_fid)
+        except Exception as e:
+            raise WFSError(f"Failed to fetch page {page_num + 1} (offset {offset}): {e}") from e
+
+        if table.num_rows == 0:
+            break
+
+        results[page_num] = table
+
+        # Detect server-side maxFeatures cap
+        if table.num_rows < count and server_page_size > table.num_rows:
+            server_page_size = table.num_rows
+            debug(f"Server caps response to {server_page_size} features per request")
+
+        offset += table.num_rows
+        page_num += 1
+        debug(
+            f"Page {page_num}: {table.num_rows:,} features (offset {offset:,}/{effective_total:,})"
+        )
+
+    return results
+
+
+def _parallel_pagination_mode(
+    service_url: str,
+    typename: str,
+    version: str,
+    effective_total: int,
+    page_size: int,
+    num_pages: int,
+    max_workers: int,
+    bbox: tuple[float, float, float, float] | None,
+    crs: str | None,
+    axis_order: str,
+    extract_fid: bool,
+) -> dict[int, pa.Table]:
+    """
+    Fetch features using parallel pagination.
+
+    Pre-builds page URLs and fetches concurrently using ThreadPoolExecutor.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    # Build page URLs
+    pages: list[tuple[int, int, str]] = []
+    for i in range(num_pages):
+        start = i * page_size
+        remaining = effective_total - start
+        count = min(page_size, remaining)
+        if count <= 0:
+            break
+        url = _build_wfs_url(
+            service_url,
+            typename,
+            version,
+            max_features=count,
+            start_index=start,
+            bbox=bbox,
+            crs=crs,
+            axis_order=axis_order,
+        )
+        pages.append((i, start, url))
+
+    # Fetch pages in parallel
+    results: dict[int, pa.Table] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_page = {
+            executor.submit(_fetch_wfs_page, url, extract_fid): (page_num, start)
+            for page_num, start, url in pages
+        }
+
+        for future in as_completed(future_to_page):
+            page_num, start = future_to_page[future]
+            try:
+                table = future.result()
+                results[page_num] = table
+                debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
+            except Exception as e:
+                raise WFSError(f"Failed to fetch page {page_num + 1} (offset {start}): {e}") from e
+
+    return results
+
+
 def fetch_all_features_duckdb(
     service_url: str,
     typename: str,
@@ -1545,8 +1709,6 @@ def fetch_all_features_duckdb(
     Returns:
         PyArrow Table with geometry (WKB) and all properties
     """
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
     # Get expected count for progress and pagination
     total_count = _get_feature_count(
         service_url, typename, version, bbox=bbox, crs=crs, axis_order=axis_order
@@ -1565,16 +1727,9 @@ def fetch_all_features_duckdb(
         else:
             progress("Fetching features...")
 
-        url = _build_wfs_url(
-            service_url,
-            typename,
-            version,
-            max_features=max_features,
-            bbox=bbox,
-            crs=crs,
-            axis_order=axis_order,
+        table = _single_fetch_mode(
+            service_url, typename, version, max_features, bbox, crs, axis_order, extract_fid
         )
-        table = _fetch_wfs_page(url, extract_fid=extract_fid)
         expected = max_features or total_count
         if expected and table.num_rows < expected and version != "1.0.0":
             # Server returned fewer than expected — likely has a maxFeatures cap.
@@ -1582,14 +1737,19 @@ def fetch_all_features_duckdb(
             needs_pagination = True
             page_size = table.num_rows or page_size
         else:
-            return table if extract_fid else _infer_column_types(table)
+            return table
 
     # Paginated mode — sequential (max_workers=1) or parallel
     effective_total = max_features if max_features else total_count
 
-    # Probe for server-side startIndex limit before building all pages.
-    # Skip the probe when fetching a spatial tile (extract_fid=True) since
-    # the tiling orchestrator already ensured each tile fits within the limit.
+    # Guard: pagination requires a known count
+    if effective_total is None:
+        warn("Cannot determine feature count; falling back to single request mode.")
+        return _single_fetch_mode(
+            service_url, typename, version, max_features, bbox, crs, axis_order, extract_fid
+        )
+
+    # Probe for server-side startIndex limit (skip for tile fetches)
     if not extract_fid:
         startindex_limit = _probe_startindex_limit(
             service_url, typename, version, crs=crs, axis_order=axis_order
@@ -1615,86 +1775,40 @@ def fetch_all_features_duckdb(
         f"using {actual_workers} {'worker' if actual_workers == 1 else 'workers'}..."
     )
 
-    # Sequential adaptive pagination — adjusts page size if server caps maxFeatures
-    results = {}
+    # Fetch pages using appropriate mode
     if actual_workers == 1:
-        offset = 0
-        page_num = 0
-        server_page_size = page_size
-        while offset < effective_total:
-            remaining = effective_total - offset
-            count = min(server_page_size, remaining)
-            url = _build_wfs_url(
-                service_url,
-                typename,
-                version,
-                max_features=count,
-                start_index=offset,
-                bbox=bbox,
-                crs=crs,
-                axis_order=axis_order,
-            )
-            try:
-                table = _fetch_wfs_page(url, extract_fid=extract_fid)
-            except Exception as e:
-                raise WFSError(f"Failed to fetch page {page_num + 1} (offset {offset}): {e}") from e
-            if table.num_rows == 0:
-                break
-            results[page_num] = table
-            # Detect server-side maxFeatures cap: if the server returned fewer
-            # than requested but we haven't reached the end, adapt page_size
-            if table.num_rows < count and server_page_size > table.num_rows:
-                server_page_size = table.num_rows
-                debug(f"Server caps response to {server_page_size} features per request")
-            offset += table.num_rows
-            page_num += 1
-            debug(
-                f"Page {page_num}: {table.num_rows:,} features (offset {offset:,}/{effective_total:,})"
-            )
+        results = _sequential_pagination_mode(
+            service_url,
+            typename,
+            version,
+            effective_total,
+            page_size,
+            bbox,
+            crs,
+            axis_order,
+            extract_fid,
+        )
     else:
-        # Parallel mode — pre-build pages (cannot adapt dynamically)
-        pages = []
-        for i in range(num_pages):
-            start = i * page_size
-            remaining = effective_total - start
-            count = min(page_size, remaining)
-            if count <= 0:
-                break
-            url = _build_wfs_url(
-                service_url,
-                typename,
-                version,
-                max_features=count,
-                start_index=start,
-                bbox=bbox,
-                crs=crs,
-                axis_order=axis_order,
-            )
-            pages.append((i, start, url))
-
-        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-            future_to_page = {
-                executor.submit(_fetch_wfs_page, url, extract_fid): (page_num, start)
-                for page_num, start, url in pages
-            }
-
-            for future in as_completed(future_to_page):
-                page_num, start = future_to_page[future]
-                try:
-                    table = future.result()
-                    results[page_num] = table
-                    debug(f"Page {page_num + 1}/{num_pages}: {table.num_rows:,} features")
-                except Exception as e:
-                    raise WFSError(
-                        f"Failed to fetch page {page_num + 1} (offset {start}): {e}"
-                    ) from e
+        results = _parallel_pagination_mode(
+            service_url,
+            typename,
+            version,
+            effective_total,
+            page_size,
+            num_pages,
+            actual_workers,
+            bbox,
+            crs,
+            axis_order,
+            extract_fid,
+        )
 
     # Combine tables in order
     if not results:
         raise WFSError("No features returned from WFS service.")
 
     tables = [results[i] for i in sorted(results.keys())]
-    combined = pa.concat_tables(tables, promote_options="default")
+    combined = pa.concat_tables(tables, promote=True)
     debug(f"Combined {len(tables)} pages: {combined.num_rows:,} total features")
 
     # Skip type inference for tile fetches — the tiling orchestrator handles it
@@ -1777,6 +1891,9 @@ def wfs_to_table(
 
     # Check if auto-tiling is needed (server has startIndex limit + dataset exceeds it)
     use_tiling = False
+    tiling_bbox: tuple[float, float, float, float] | None = None
+    tiling_total = 0
+    tiling_limit = 0
     if auto_tile and version != "1.0.0":
         total_count = _get_feature_count(service_url, layer_info.typename, version)
         startindex_limit = _probe_startindex_limit(
@@ -1785,21 +1902,29 @@ def wfs_to_table(
         if startindex_limit and total_count:
             effective = min(limit, total_count) if limit else total_count
             if effective > startindex_limit + page_size:
-                if not layer_info.bbox:
+                # Determine bbox for tiling: use caller bbox if provided, else layer bbox
+                if bbox and use_server_bbox:
+                    tiling_bbox = bbox
+                elif layer_info.bbox:
+                    tiling_bbox = layer_info.bbox
+                else:
                     raise WFSError(
-                        "Auto-tiling requires a layer bounding box from capabilities, "
-                        "but this layer has none. Use --bbox to specify one manually."
+                        "Auto-tiling requires a bounding box. Either:\n"
+                        "  1. Use --bbox to specify a region\n"
+                        "  2. Ensure the layer has a bbox in capabilities"
                     )
                 use_tiling = True
+                tiling_total = effective
+                tiling_limit = startindex_limit
 
-    if use_tiling:
+    if use_tiling and tiling_bbox is not None:
         table = _fetch_with_spatial_tiles(
             service_url=service_url,
             typename=layer_info.typename,
             version=version,
-            total_count=effective,
-            startindex_limit=startindex_limit,
-            layer_bbox=layer_info.bbox,
+            total_count=tiling_total,
+            startindex_limit=tiling_limit,
+            layer_bbox=tiling_bbox,
             crs=crs,
             max_workers=max_workers,
             page_size=page_size,

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -5,16 +5,19 @@ This module provides functionality to download features from OGC WFS services
 and convert them to GeoParquet format. Supports WFS 1.0.0, 1.1.0, and 2.0.0.
 
 Key features:
-- DuckDB-native HTTP streaming for fast extraction (10x+ faster than Python HTTP)
+- Fast extraction via Python httpx download + DuckDB local parsing (~10x faster)
 - Server-side bbox filtering
 - CRS negotiation with EPSG variant handling
 - Hilbert curve sorting and bbox column generation
+- Auto-pagination and parallel workers for large datasets
+- Auto-tile mode to bypass server startIndex limits
 """
 
 from __future__ import annotations
 
 import json
 import re
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -1060,92 +1063,6 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
         con.close()
 
 
-def _fetch_wfs_page_duckdb(url: str, extract_fid: bool = False) -> pa.Table:
-    """
-    Fetch a WFS GeoJSON page directly using DuckDB's httpfs.
-
-    This is MUCH faster than Python HTTP because:
-    - DuckDB streams the HTTP response (no Python memory buffering)
-    - JSON parsing happens in C++ (faster than Python json)
-    - Geometry conversion happens in-database (no temp files)
-
-    Args:
-        url: Full WFS GetFeature URL with all parameters
-
-    Returns:
-        PyArrow Table with geometry column (WKB) and all properties
-    """
-    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
-
-    # Configure longer HTTP timeout for slow WFS servers (10 minutes)
-    # Large datasets like 309k features can take 2-3 minutes to stream
-    con.execute("SET http_timeout=600000")
-
-    # Escape single quotes in URL to prevent SQL injection
-    safe_url = _escape_sql_string(url)
-
-    # Use DuckDB to fetch and parse the WFS GeoJSON in one query
-    # This streams the HTTP response and parses JSON directly
-    # Step 1: Check for empty features array (DuckDB can't UNNEST empty JSON arrays)
-    # Step 2: Unnest features and extract geometry + properties struct
-    # Step 3: Expand properties struct into individual columns
-    #
-    # Note: When features is [] (empty), read_json_auto infers it as JSON type
-    # rather than a list, causing UNNEST to fail. We handle this by first
-    # checking the feature count.
-    count_query = f"""
-        SELECT len(features) AS cnt
-        FROM read_json_auto('{safe_url}', maximum_object_size=536870912)
-    """
-
-    try:
-        debug(f"DuckDB fetch: {url[:80]}...")
-        start_time = time.time()
-
-        # Check if response has any features
-        count_result = con.execute(count_query).fetchone()
-        feature_count = count_result[0] if count_result else 0
-
-        if feature_count == 0:
-            # Return empty table with just geometry column
-            debug("Empty response, returning empty table")
-            return pa.table({"geometry": pa.array([], type=pa.binary())})
-
-        # Full query to extract features
-        fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
-        fid_select = "_wfs_fid," if extract_fid else ""
-        query = f"""
-            WITH features AS (
-                SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_url}', maximum_object_size=536870912)
-            ),
-            extracted AS (
-                SELECT
-                    {fid_col}
-                    ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
-                    feature.properties AS props
-                FROM features
-            )
-            SELECT
-                {fid_select}
-                geometry,
-                unnest(props)
-            FROM extracted
-        """
-
-        result = con.execute(query)
-        table = result.arrow().read_all()
-
-        elapsed = time.time() - start_time
-        debug(f"DuckDB OK: {table.num_rows:,} rows in {elapsed:.1f}s")
-        return table
-    except Exception as e:
-        error_msg = str(e)
-        if "HTTP" in error_msg or "Could not" in error_msg:
-            raise WFSError(f"Failed to fetch WFS data: {e}") from e
-        raise WFSError(f"Failed to parse WFS response: {e}") from e
-
-
 class WFSStartIndexLimitError(WFSError):
     """Raised when server rejects a startIndex beyond its limit."""
 
@@ -1155,25 +1072,33 @@ class WFSStartIndexLimitError(WFSError):
         super().__init__(message)
 
 
-def _fetch_wfs_page_via_http(url: str, extract_fid: bool = False) -> pa.Table:
+def _fetch_wfs_page(url: str, extract_fid: bool = False) -> pa.Table:
     """
-    Fetch a WFS GeoJSON page using Python HTTP, parse with DuckDB from disk.
+    Fetch a WFS GeoJSON page via httpx and parse with DuckDB locally.
 
-    Thread-safe alternative to _fetch_wfs_page_duckdb for parallel fetching.
-    DuckDB's httpfs extension crashes when multiple connections make concurrent
-    HTTP requests (libc++abi: terminating). This downloads via Python's
-    thread-safe httpx client, writes to a temp file, and parses locally.
+    Downloads GeoJSON using Python httpx (thread-safe, ~10x faster than DuckDB
+    httpfs for JSON), writes to a temp file, then parses with DuckDB's spatial
+    extension.
+
+    Args:
+        url: Full WFS GetFeature URL with all parameters
+        extract_fid: If True, extract feature.id as _wfs_fid column (for dedup)
+
+    Returns:
+        PyArrow Table with geometry column (WKB) and all properties
     """
-    import tempfile
-
     import httpx
 
     start_time = time.time()
-    debug(f"HTTP fetch: {url[:80]}...")
+    debug(f"Fetching: {url[:100]}...")
 
+    # Download via httpx (much faster than DuckDB httpfs for JSON)
     client = _get_shared_http_client(timeout=600)
-    response = client.get(url, headers={"Accept-Encoding": "gzip, deflate"})
     try:
+        response = client.get(
+            url,
+            headers={"Accept": "application/json", "Accept-Encoding": "gzip, deflate"},
+        )
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 400:
@@ -1182,19 +1107,40 @@ def _fetch_wfs_page_via_http(url: str, extract_fid: bool = False) -> pa.Table:
                 raise WFSError(
                     f"Server rejected paginated request (startIndex limit): {body.strip()}"
                 ) from e
-        raise
+        raise WFSError(f"WFS request failed with HTTP {e.response.status_code}") from e
+    except httpx.RequestError as e:
+        raise WFSError(f"Failed to fetch WFS data: {e}") from e
 
-    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
-        tmp.write(response.content)
-        tmp_path = tmp.name
+    # Validate content-type is JSON (servers may return HTML errors with 200 OK)
+    content_type = response.headers.get("content-type", "").lower()
+    if "json" not in content_type and "javascript" not in content_type:
+        # Some servers use text/javascript or omit content-type entirely
+        # Only reject if it's clearly HTML/XML
+        if "html" in content_type or "xml" in content_type:
+            preview = response.text[:500]
+            raise WFSError(
+                f"Expected JSON response but got {content_type}. "
+                f"Server may have returned an error page:\n{preview}"
+            )
+
+    download_time = time.time() - start_time
+    content = response.content
+    size_mb = len(content) / (1024 * 1024)
+    debug(f"Downloaded {size_mb:.1f} MB in {download_time:.1f}s")
+
+    # Write to temp file for DuckDB local parsing
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".json", delete=False) as tmp_file:
+        tmp_file.write(content)
+        tmp_path = tmp_file.name
 
     try:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         safe_path = _escape_sql_string(tmp_path)
 
+        # Check feature count first (DuckDB can't UNNEST empty JSON arrays)
         count_result = con.execute(f"""
             SELECT len(features) AS cnt
-            FROM read_json_auto('{safe_path}', maximum_object_size=536870912)
+            FROM read_json_auto('{safe_path}', maximum_object_size=1073741824)
         """).fetchone()
         feature_count = count_result[0] if count_result else 0
 
@@ -1202,12 +1148,14 @@ def _fetch_wfs_page_via_http(url: str, extract_fid: bool = False) -> pa.Table:
             debug("Empty response, returning empty table")
             return pa.table({"geometry": pa.array([], type=pa.binary())})
 
+        # Extract features with geometry conversion
         fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
         fid_select = "_wfs_fid," if extract_fid else ""
+        parse_start = time.time()
         query = f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_path}', maximum_object_size=536870912)
+                FROM read_json_auto('{safe_path}', maximum_object_size=1073741824)
             ),
             extracted AS (
                 SELECT
@@ -1221,13 +1169,11 @@ def _fetch_wfs_page_via_http(url: str, extract_fid: bool = False) -> pa.Table:
         result = con.execute(query)
         table = result.arrow().read_all()
 
-        elapsed = time.time() - start_time
-        debug(f"HTTP+DuckDB OK: {table.num_rows:,} rows in {elapsed:.1f}s")
+        parse_time = time.time() - parse_start
+        total_time = time.time() - start_time
+        debug(f"Parsed {table.num_rows:,} rows in {parse_time:.1f}s (total: {total_time:.1f}s)")
         return table
     except Exception as e:
-        error_msg = str(e)
-        if "HTTP" in error_msg or "Could not" in error_msg:
-            raise WFSError(f"Failed to fetch WFS data: {e}") from e
         raise WFSError(f"Failed to parse WFS response: {e}") from e
     finally:
         Path(tmp_path).unlink(missing_ok=True)
@@ -1573,12 +1519,16 @@ def fetch_all_features_duckdb(
     extract_fid: bool = False,
 ) -> pa.Table:
     """
-    Fetch WFS features using DuckDB's native HTTP streaming.
+    Fetch WFS features via Python httpx download and DuckDB local parsing.
 
-    Supports two modes:
-    - Single request (max_workers=1): Streams all features in one request. Fast for most cases.
-    - Parallel pagination (max_workers>1): Splits into paginated requests for very large
-      datasets (1M+ features) where a single request might timeout.
+    Downloads GeoJSON with Python httpx (~10x faster than DuckDB httpfs), then
+    parses locally with DuckDB's spatial extension.
+
+    Supports multiple modes:
+    - Single request (max_workers=1, small dataset): One request for all features
+    - Sequential pagination (max_workers=1, large dataset): Paginated requests
+    - Parallel pagination (max_workers>1): Concurrent paginated requests,
+      recommended for large datasets (100k+ features) — typically 5-6x faster
 
     Args:
         service_url: WFS service URL
@@ -1587,9 +1537,10 @@ def fetch_all_features_duckdb(
         max_features: Maximum features to fetch (None = all)
         bbox: Optional bounding box filter
         crs: CRS for bbox parameter
-        max_workers: Number of parallel requests (1 = single streaming request)
-        page_size: Features per page when using parallel mode (default: 10000)
+        max_workers: Number of parallel requests (1-10). Use 4-8 for large datasets.
+        page_size: Features per page when paginating (default: 10000)
         axis_order: Bbox axis order ("auto", "xy", "latlon")
+        extract_fid: If True, extract WFS feature IDs for deduplication
 
     Returns:
         PyArrow Table with geometry (WKB) and all properties
@@ -1610,9 +1561,9 @@ def fetch_all_features_duckdb(
 
     if not needs_pagination:
         if total_count:
-            progress(f"Streaming {total_count:,} features via DuckDB...")
+            progress(f"Fetching {total_count:,} features...")
         else:
-            progress("Streaming features via DuckDB...")
+            progress("Fetching features...")
 
         url = _build_wfs_url(
             service_url,
@@ -1623,8 +1574,7 @@ def fetch_all_features_duckdb(
             crs=crs,
             axis_order=axis_order,
         )
-        fetcher = _fetch_wfs_page_via_http if extract_fid else _fetch_wfs_page_duckdb
-        table = fetcher(url, extract_fid=extract_fid)
+        table = _fetch_wfs_page(url, extract_fid=extract_fid)
         expected = max_features or total_count
         if expected and table.num_rows < expected and version != "1.0.0":
             # Server returned fewer than expected — likely has a maxFeatures cap.
@@ -1665,8 +1615,6 @@ def fetch_all_features_duckdb(
         f"using {actual_workers} {'worker' if actual_workers == 1 else 'workers'}..."
     )
 
-    fetcher = _fetch_wfs_page_via_http if extract_fid else _fetch_wfs_page_duckdb
-
     # Sequential adaptive pagination — adjusts page size if server caps maxFeatures
     results = {}
     if actual_workers == 1:
@@ -1687,7 +1635,7 @@ def fetch_all_features_duckdb(
                 axis_order=axis_order,
             )
             try:
-                table = fetcher(url, extract_fid=extract_fid)
+                table = _fetch_wfs_page(url, extract_fid=extract_fid)
             except Exception as e:
                 raise WFSError(f"Failed to fetch page {page_num + 1} (offset {offset}): {e}") from e
             if table.num_rows == 0:
@@ -1726,7 +1674,7 @@ def fetch_all_features_duckdb(
 
         with ThreadPoolExecutor(max_workers=actual_workers) as executor:
             future_to_page = {
-                executor.submit(_fetch_wfs_page_via_http, url, extract_fid): (page_num, start)
+                executor.submit(_fetch_wfs_page, url, extract_fid): (page_num, start)
                 for page_num, start, url in pages
             }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "codespell>=2.2",
     "import-linter>=2.0",
     "bandit>=1.7",
+    "pip>=26.1",  # CVE-2026-6357
     "pip-audit>=2.7",
     "menard>=0.4.0",
     "deptry>=0.25.0",

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1118,11 +1118,11 @@ class TestDuckDBNativeWFS:
         "&maxFeatures=10"
     )
 
-    def test_fetch_wfs_page_duckdb_returns_arrow_table(self):
+    def test_fetch_wfs_page_returns_arrow_table(self):
         """DuckDB-native fetch should return an Arrow table with geometry."""
-        from geoparquet_io.core.wfs import _fetch_wfs_page_duckdb
+        from geoparquet_io.core.wfs import _fetch_wfs_page
 
-        table = _fetch_wfs_page_duckdb(self.WFS_URL)
+        table = _fetch_wfs_page(self.WFS_URL)
 
         # Should return Arrow table
         import pyarrow as pa
@@ -1134,11 +1134,11 @@ class TestDuckDBNativeWFS:
         assert table.num_rows > 0
         assert table.num_rows <= 10
 
-    def test_fetch_wfs_page_duckdb_geometry_is_wkb(self):
+    def test_fetch_wfs_page_geometry_is_wkb(self):
         """Geometry should be WKB binary format."""
-        from geoparquet_io.core.wfs import _fetch_wfs_page_duckdb
+        from geoparquet_io.core.wfs import _fetch_wfs_page
 
-        table = _fetch_wfs_page_duckdb(self.WFS_URL)
+        table = _fetch_wfs_page(self.WFS_URL)
 
         # Geometry should be binary (WKB)
         import pyarrow as pa
@@ -1182,7 +1182,7 @@ class TestAutoPageSingleWorker:
 
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
-            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", side_effect=mock_fetch),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", side_effect=mock_fetch),
         ):
             result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
@@ -1209,9 +1209,7 @@ class TestAutoPageSingleWorker:
 
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=5000),
-            patch(
-                "geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=mock_table
-            ) as mock_fetch,
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", return_value=mock_table) as mock_fetch,
         ):
             result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
@@ -1238,9 +1236,7 @@ class TestAutoPageSingleWorker:
 
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=None),
-            patch(
-                "geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=mock_table
-            ) as mock_fetch,
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", return_value=mock_table) as mock_fetch,
         ):
             result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
@@ -1273,7 +1269,7 @@ class TestAutoPageSingleWorker:
 
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=100000),
-            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", side_effect=mock_fetch),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", side_effect=mock_fetch),
         ):
             result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
@@ -1286,8 +1282,8 @@ class TestAutoPageSingleWorker:
         assert call_count == 2
         assert result.num_rows == 15000
 
-    def test_parallel_workers_use_http_fetcher(self):
-        """Parallel mode should use _fetch_wfs_page_via_http, not httpfs."""
+    def test_parallel_workers_use_httpx_fetcher(self):
+        """Parallel mode should use _fetch_wfs_page (httpx-based)."""
         import pyarrow as pa
 
         from geoparquet_io.core.wfs import fetch_all_features_duckdb
@@ -1301,10 +1297,7 @@ class TestAutoPageSingleWorker:
 
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
-            patch(
-                "geoparquet_io.core.wfs._fetch_wfs_page_via_http", return_value=page
-            ) as mock_http,
-            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb") as mock_duckdb,
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", return_value=page) as mock_fetch,
         ):
             fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
@@ -1313,8 +1306,7 @@ class TestAutoPageSingleWorker:
                 page_size=10000,
             )
 
-        assert mock_http.call_count == 2
-        mock_duckdb.assert_not_called()
+        assert mock_fetch.call_count == 2
 
     def test_startindex_limit_raises_clear_error(self):
         """When server has startIndex limit, should raise with actionable guidance."""
@@ -1348,7 +1340,7 @@ class TestAutoPageSingleWorker:
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=30000),
             patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=50000),
-            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", return_value=page),
         ):
             result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
@@ -1375,7 +1367,7 @@ class TestAutoPageSingleWorker:
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
             patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
-            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", return_value=page),
         ):
             result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1308,6 +1308,76 @@ class TestAutoPageSingleWorker:
         assert mock_http.call_count == 2
         mock_duckdb.assert_not_called()
 
+    def test_startindex_limit_raises_clear_error(self):
+        """When server has startIndex limit, should raise with actionable guidance."""
+        from geoparquet_io.core.wfs import WFSError, fetch_all_features_duckdb
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=11000000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=50000),
+        ):
+            with pytest.raises(WFSError, match="startIndex.*50,000"):
+                fetch_all_features_duckdb(
+                    "https://mock.wfs/wfs",
+                    "layer",
+                    max_workers=1,
+                    page_size=10000,
+                )
+
+    def test_startindex_limit_allows_small_datasets(self):
+        """When total features fit within the startIndex limit, should proceed."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=30000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=50000),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page),
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        assert result.num_rows > 0
+
+    def test_no_startindex_limit_proceeds_normally(self):
+        """When server has no startIndex limit, pagination should proceed."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page),
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        assert result.num_rows > 0
+
 
 # =============================================================================
 # Axis Order Tests (Issue #397)

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1171,7 +1171,7 @@ class TestAutoPageSingleWorker:
 
         call_count = 0
 
-        def mock_fetch(url):
+        def mock_fetch(url, extract_fid=False):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -2302,3 +2302,367 @@ class TestSrsNameWithoutBbox:
         # More specific check for Belgium
         assert 2.5 <= x <= 6.5, f"X coord {x} not in Belgium longitude range"
         assert 49.0 <= y <= 52.0, f"Y coord {y} not in Belgium latitude range"
+
+
+# =============================================================================
+# Spatial Tiling Tests (startIndex limit workaround)
+# =============================================================================
+
+
+class TestGenerateTileGrid:
+    """Test grid generation for spatial tiling."""
+
+    def test_correct_count(self):
+        """Grid should produce at least the requested number of tiles."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        bbox = (3.0, 50.0, 7.0, 54.0)
+        tiles = _generate_tile_grid(bbox, 4)
+        assert len(tiles) >= 4
+
+    def test_covers_full_bbox(self):
+        """Union of tile bboxes should cover the original bbox."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        bbox = (3.0, 50.0, 7.0, 54.0)
+        tiles = _generate_tile_grid(bbox, 6)
+
+        all_xmin = min(t[0] for t in tiles)
+        all_ymin = min(t[1] for t in tiles)
+        all_xmax = max(t[2] for t in tiles)
+        all_ymax = max(t[3] for t in tiles)
+
+        assert all_xmin == pytest.approx(bbox[0])
+        assert all_ymin == pytest.approx(bbox[1])
+        assert all_xmax == pytest.approx(bbox[2])
+        assert all_ymax == pytest.approx(bbox[3])
+
+    def test_single_tile(self):
+        """Requesting 1 tile should return the original bbox."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        bbox = (3.0, 50.0, 7.0, 54.0)
+        tiles = _generate_tile_grid(bbox, 1)
+        assert len(tiles) == 1
+        assert tiles[0] == pytest.approx(bbox)
+
+    def test_respects_aspect_ratio(self):
+        """Wide bbox should produce more columns than rows."""
+        from geoparquet_io.core.wfs import _generate_tile_grid
+
+        wide_bbox = (0.0, 0.0, 10.0, 2.0)
+        tiles = _generate_tile_grid(wide_bbox, 10)
+
+        xs = sorted({t[0] for t in tiles} | {t[2] for t in tiles})
+        ys = sorted({t[1] for t in tiles} | {t[3] for t in tiles})
+        cols = len(xs) - 1
+        rows = len(ys) - 1
+        assert cols > rows
+
+
+class TestRefineTilesAdaptive:
+    """Test adaptive quadtree refinement of tile grid."""
+
+    def test_splits_oversized_tile(self):
+        """Tile with count > limit should be subdivided into 4."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        def mock_count(service_url, typename, version, bbox=None, crs=None, axis_order="auto"):
+            if bbox == (0.0, 0.0, 1.0, 1.0):
+                return 100000
+            return 20000
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", side_effect=mock_count):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+            )
+
+        assert len(result) == 4
+
+    def test_leaves_small_tiles_alone(self):
+        """Tile with count < limit should not be subdivided."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", return_value=10000):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+            )
+
+        assert len(result) == 1
+        assert result[0] == tiles[0]
+
+    def test_max_depth_prevents_infinite_recursion(self):
+        """Recursion should stop at max_depth even if tiles are still too large."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", return_value=999999):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+                max_depth=2,
+            )
+
+        # depth 0: 1 tile -> 4 (depth 1) -> 16 (depth 2, max)
+        assert len(result) == 16
+
+    def test_handles_none_count_gracefully(self):
+        """If _get_feature_count returns None, tile should be kept as-is."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        tiles = [(0.0, 0.0, 1.0, 1.0)]
+
+        with patch("geoparquet_io.core.wfs._get_feature_count", return_value=None):
+            result = _refine_tiles_adaptive(
+                tiles,
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                crs="EPSG:4326",
+                axis_order="auto",
+                max_per_tile=50000,
+            )
+
+        assert len(result) == 1
+
+
+class TestGetFeatureCountWithBbox:
+    """Test _get_feature_count extended with bbox parameter."""
+
+    def test_bbox_included_in_request(self):
+        """When bbox provided, it should appear in the hits request."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with patch("geoparquet_io.core.wfs._make_request") as mock_req:
+            mock_req.return_value = b'numberOfFeatures="42"'
+            result = _get_feature_count(
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                bbox=(4.0, 52.0, 5.0, 53.0),
+                crs="EPSG:4326",
+            )
+
+        assert result == 42
+        call_params = mock_req.call_args[1]["params"]
+        assert "bbox" in call_params
+
+    def test_no_bbox_backward_compatible(self):
+        """Without bbox, request should not include bbox param."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with patch("geoparquet_io.core.wfs._make_request") as mock_req:
+            mock_req.return_value = b'numberOfFeatures="100"'
+            result = _get_feature_count("http://mock/wfs", "layer", "1.1.0")
+
+        assert result == 100
+        call_params = mock_req.call_args[1]["params"]
+        assert "bbox" not in call_params
+
+
+class TestDeduplicateTiles:
+    """Test deduplication of features across tile boundaries."""
+
+    def test_removes_duplicates_by_fid(self):
+        """Features with same _wfs_fid should be deduplicated."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        table = pa.table(
+            {
+                "_wfs_fid": pa.array(["a", "b", "a", "c"]),
+                "geometry": pa.array([b"\x01", b"\x02", b"\x01", b"\x03"], type=pa.binary()),
+                "name": pa.array(["x", "y", "x", "z"]),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        assert result.num_rows == 3
+
+    def test_drops_fid_column(self):
+        """_wfs_fid column should be removed from output."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        table = pa.table(
+            {
+                "_wfs_fid": pa.array(["a", "b"]),
+                "geometry": pa.array([b"\x01", b"\x02"], type=pa.binary()),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        assert "_wfs_fid" not in result.column_names
+
+    def test_fallback_geometry_dedup_when_no_fid(self):
+        """When _wfs_fid is absent, deduplicate by geometry bytes."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        table = pa.table(
+            {
+                "geometry": pa.array([b"\x01", b"\x02", b"\x01"], type=pa.binary()),
+                "name": pa.array(["x", "y", "x"]),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        assert result.num_rows == 2
+
+
+class TestFetchWithSpatialTiles:
+    """Test the spatial tiling orchestrator."""
+
+    def test_combines_tile_results(self):
+        """Should fetch each tile and combine results."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_with_spatial_tiles
+
+        tile1 = pa.table(
+            {
+                "_wfs_fid": pa.array(["a"]),
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["x"]),
+            }
+        )
+        tile2 = pa.table(
+            {
+                "_wfs_fid": pa.array(["b"]),
+                "geometry": pa.array([b"\x01\x03"], type=pa.binary()),
+                "name": pa.array(["y"]),
+            }
+        )
+
+        call_count = 0
+
+        def mock_fetch(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return tile1 if call_count == 1 else tile2
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs._generate_tile_grid",
+                return_value=[
+                    (0.0, 0.0, 0.5, 0.5),
+                    (0.5, 0.0, 1.0, 0.5),
+                ],
+            ),
+            patch(
+                "geoparquet_io.core.wfs._refine_tiles_adaptive",
+                side_effect=lambda tiles, *a, **kw: tiles,
+            ),
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", side_effect=mock_fetch),
+        ):
+            result = _fetch_with_spatial_tiles(
+                service_url="http://mock/wfs",
+                typename="layer",
+                version="1.1.0",
+                total_count=100000,
+                startindex_limit=50000,
+                layer_bbox=(0.0, 0.0, 1.0, 0.5),
+                crs="EPSG:4326",
+            )
+
+        assert result.num_rows == 2
+        assert "_wfs_fid" not in result.column_names
+
+    def test_auto_tile_triggers_tiling(self):
+        """wfs_to_table with auto_tile=True should invoke tiling when limit detected."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs.negotiate_wfs_version", return_value=("1.1.0", MagicMock())
+            ),
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_info,
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=11000000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=50000),
+            patch(
+                "geoparquet_io.core.wfs._fetch_with_spatial_tiles", return_value=mock_table
+            ) as mock_tile,
+        ):
+            mock_info.return_value = MagicMock(
+                typename="layer",
+                title="Layer",
+                crs_list=["EPSG:4326"],
+                default_crs="EPSG:4326",
+                available_formats=["application/json"],
+                bbox=(3.0, 50.0, 7.0, 54.0),
+            )
+            wfs_to_table("http://mock/wfs", "layer", auto_tile=True)
+
+        mock_tile.assert_called_once()
+
+    def test_auto_tile_noop_when_no_limit(self):
+        """When server has no startIndex limit, should use normal fetch path."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs.negotiate_wfs_version", return_value=("1.1.0", MagicMock())
+            ),
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_info,
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
+            patch(
+                "geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=mock_table
+            ) as mock_fetch,
+            patch("geoparquet_io.core.wfs._fetch_with_spatial_tiles") as mock_tile,
+        ):
+            mock_info.return_value = MagicMock(
+                typename="layer",
+                title="Layer",
+                crs_list=["EPSG:4326"],
+                default_crs="EPSG:4326",
+                available_formats=["application/json"],
+                bbox=(3.0, 50.0, 7.0, 54.0),
+            )
+            wfs_to_table("http://mock/wfs", "layer", auto_tile=True)
+
+        mock_fetch.assert_called_once()
+        mock_tile.assert_not_called()

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1147,6 +1147,168 @@ class TestDuckDBNativeWFS:
         assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type)
 
 
+class TestAutoPageSingleWorker:
+    """Test that single-worker mode auto-paginates for large datasets."""
+
+    def test_single_worker_paginates_when_count_exceeds_page_size(self):
+        """With max_workers=1 and total > page_size, should paginate sequentially."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page1 = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+        page2 = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x03"], type=pa.binary()),
+                "name": pa.array(["b"]),
+            }
+        )
+
+        call_count = 0
+
+        def mock_fetch(url):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return page1
+            return page2
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", side_effect=mock_fetch),
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        assert call_count == 2
+        assert result.num_rows == 2
+
+    def test_single_worker_no_pagination_when_count_within_page_size(self):
+        """With max_workers=1 and total <= page_size, should use single request."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=5000),
+            patch(
+                "geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=mock_table
+            ) as mock_fetch,
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        mock_fetch.assert_called_once()
+        assert result.num_rows == 1
+
+    def test_single_worker_no_pagination_when_count_unknown(self):
+        """With max_workers=1 and unknown count, should use single request."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=None),
+            patch(
+                "geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=mock_table
+            ) as mock_fetch,
+        ):
+            result = fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                page_size=10000,
+            )
+
+        mock_fetch.assert_called_once()
+        assert result.num_rows == 1
+
+    def test_single_worker_pagination_respects_max_features(self):
+        """Auto-pagination should respect max_features limit."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=100000),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page) as mock_fetch,
+        ):
+            fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=1,
+                max_features=15000,
+                page_size=10000,
+            )
+
+        # 15000 features / 10000 page_size = 2 pages
+        assert mock_fetch.call_count == 2
+
+    def test_parallel_workers_use_http_fetcher(self):
+        """Parallel mode should use _fetch_wfs_page_via_http, not httpfs."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        page = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch(
+                "geoparquet_io.core.wfs._fetch_wfs_page_via_http", return_value=page
+            ) as mock_http,
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb") as mock_duckdb,
+        ):
+            fetch_all_features_duckdb(
+                "https://mock.wfs/wfs",
+                "layer",
+                max_workers=2,
+                page_size=10000,
+            )
+
+        assert mock_http.call_count == 2
+        mock_duckdb.assert_not_called()
+
+
 # =============================================================================
 # Axis Order Tests (Issue #397)
 # =============================================================================

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1156,16 +1156,18 @@ class TestAutoPageSingleWorker:
 
         from geoparquet_io.core.wfs import fetch_all_features_duckdb
 
+        # Each page must have page_size rows so adaptive pagination doesn't
+        # mistake 1-row results for a server-side maxFeatures cap.
         page1 = pa.table(
             {
-                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
-                "name": pa.array(["a"]),
+                "geometry": pa.array([b"\x01\x02"] * 10000, type=pa.binary()),
+                "name": pa.array(["a"] * 10000),
             }
         )
         page2 = pa.table(
             {
-                "geometry": pa.array([b"\x01\x03"], type=pa.binary()),
-                "name": pa.array(["b"]),
+                "geometry": pa.array([b"\x01\x03"] * 10000, type=pa.binary()),
+                "name": pa.array(["b"] * 10000),
             }
         )
 
@@ -1190,7 +1192,7 @@ class TestAutoPageSingleWorker:
             )
 
         assert call_count == 2
-        assert result.num_rows == 2
+        assert result.num_rows == 20000
 
     def test_single_worker_no_pagination_when_count_within_page_size(self):
         """With max_workers=1 and total <= page_size, should use single request."""
@@ -1200,8 +1202,8 @@ class TestAutoPageSingleWorker:
 
         mock_table = pa.table(
             {
-                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
-                "name": pa.array(["a"]),
+                "geometry": pa.array([b"\x01\x02"] * 5000, type=pa.binary()),
+                "name": pa.array(["a"] * 5000),
             }
         )
 
@@ -1219,7 +1221,7 @@ class TestAutoPageSingleWorker:
             )
 
         mock_fetch.assert_called_once()
-        assert result.num_rows == 1
+        assert result.num_rows == 5000
 
     def test_single_worker_no_pagination_when_count_unknown(self):
         """With max_workers=1 and unknown count, should use single request."""
@@ -1256,18 +1258,24 @@ class TestAutoPageSingleWorker:
 
         from geoparquet_io.core.wfs import fetch_all_features_duckdb
 
-        page = pa.table(
-            {
-                "geometry": pa.array([b"\x01\x02"], type=pa.binary()),
-                "name": pa.array(["a"]),
-            }
-        )
+        call_count = 0
+
+        def mock_fetch(url, extract_fid=False):
+            nonlocal call_count
+            call_count += 1
+            n = 10000 if call_count == 1 else 5000
+            return pa.table(
+                {
+                    "geometry": pa.array([b"\x01\x02"] * n, type=pa.binary()),
+                    "name": pa.array(["a"] * n),
+                }
+            )
 
         with (
             patch("geoparquet_io.core.wfs._get_feature_count", return_value=100000),
-            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", return_value=page) as mock_fetch,
+            patch("geoparquet_io.core.wfs._fetch_wfs_page_duckdb", side_effect=mock_fetch),
         ):
-            fetch_all_features_duckdb(
+            result = fetch_all_features_duckdb(
                 "https://mock.wfs/wfs",
                 "layer",
                 max_workers=1,
@@ -1275,8 +1283,8 @@ class TestAutoPageSingleWorker:
                 page_size=10000,
             )
 
-        # 15000 features / 10000 page_size = 2 pages
-        assert mock_fetch.call_count == 2
+        assert call_count == 2
+        assert result.num_rows == 15000
 
     def test_parallel_workers_use_http_fetcher(self):
         """Parallel mode should use _fetch_wfs_page_via_http, not httpfs."""

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1118,6 +1118,8 @@ class TestDuckDBNativeWFS:
         "&maxFeatures=10"
     )
 
+    @pytest.mark.network
+    @pytest.mark.xfail(reason="requires external WFS endpoint, flaky in CI", strict=False)
     def test_fetch_wfs_page_returns_arrow_table(self):
         """DuckDB-native fetch should return an Arrow table with geometry."""
         from geoparquet_io.core.wfs import _fetch_wfs_page
@@ -1134,6 +1136,8 @@ class TestDuckDBNativeWFS:
         assert table.num_rows > 0
         assert table.num_rows <= 10
 
+    @pytest.mark.network
+    @pytest.mark.xfail(reason="requires external WFS endpoint, flaky in CI", strict=False)
     def test_fetch_wfs_page_geometry_is_wkb(self):
         """Geometry should be WKB binary format."""
         from geoparquet_io.core.wfs import _fetch_wfs_page
@@ -1145,6 +1149,166 @@ class TestDuckDBNativeWFS:
 
         geom_type = table.schema.field("geometry").type
         assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type)
+
+
+class TestContentTypeValidation:
+    """Test content-type validation catches error pages returned with 200 OK."""
+
+    def test_rejects_html_content_type(self):
+        """HTML responses should be rejected with clear error."""
+        import httpx
+
+        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
+
+        html_response = b"<html><body>Error: Service unavailable</body></html>"
+
+        def mock_stream(*args, **kwargs):
+            class MockResponse:
+                status_code = 200
+                headers = {"content-type": "text/html; charset=utf-8"}
+
+                def raise_for_status(self):
+                    pass
+
+                def read(self):
+                    return html_response
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+            return MockResponse()
+
+        with patch.object(httpx.Client, "stream", mock_stream):
+            with pytest.raises(WFSError, match="Expected JSON.*text/html"):
+                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+    def test_rejects_xml_content_type(self):
+        """XML error responses should be rejected."""
+        import httpx
+
+        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
+
+        xml_response = b"<ows:ExceptionReport>Service error</ows:ExceptionReport>"
+
+        def mock_stream(*args, **kwargs):
+            class MockResponse:
+                status_code = 200
+                headers = {"content-type": "application/xml"}
+
+                def raise_for_status(self):
+                    pass
+
+                def read(self):
+                    return xml_response
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+            return MockResponse()
+
+        with patch.object(httpx.Client, "stream", mock_stream):
+            with pytest.raises(WFSError, match="Expected JSON.*application/xml"):
+                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+    def test_rejects_text_plain_content_type(self):
+        """text/plain error responses should be rejected."""
+        import httpx
+
+        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
+
+        text_response = b"Error: Invalid request parameters"
+
+        def mock_stream(*args, **kwargs):
+            class MockResponse:
+                status_code = 200
+                headers = {"content-type": "text/plain"}
+
+                def raise_for_status(self):
+                    pass
+
+                def read(self):
+                    return text_response
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+            return MockResponse()
+
+        with patch.object(httpx.Client, "stream", mock_stream):
+            with pytest.raises(WFSError, match="Expected JSON.*text/plain"):
+                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+    def test_accepts_application_json(self):
+        """application/json should be accepted."""
+        import httpx
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        json_response = b'{"type": "FeatureCollection", "features": []}'
+
+        def mock_stream(*args, **kwargs):
+            class MockResponse:
+                status_code = 200
+                headers = {"content-type": "application/json"}
+
+                def raise_for_status(self):
+                    pass
+
+                def iter_bytes(self, chunk_size=None):
+                    yield json_response
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+            return MockResponse()
+
+        with patch.object(httpx.Client, "stream", mock_stream):
+            # Should not raise, returns empty table
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+            assert result.num_rows == 0
+
+    def test_accepts_text_javascript(self):
+        """text/javascript (used by some servers) should be accepted."""
+        import httpx
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        json_response = b'{"type": "FeatureCollection", "features": []}'
+
+        def mock_stream(*args, **kwargs):
+            class MockResponse:
+                status_code = 200
+                headers = {"content-type": "text/javascript"}
+
+                def raise_for_status(self):
+                    pass
+
+                def iter_bytes(self, chunk_size=None):
+                    yield json_response
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+            return MockResponse()
+
+        with patch.object(httpx.Client, "stream", mock_stream):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+            assert result.num_rows == 0
 
 
 class TestAutoPageSingleWorker:
@@ -2533,6 +2697,44 @@ class TestDeduplicateTiles:
 
         result = _deduplicate_tiles(table)
         assert result.num_rows == 2
+
+    def test_null_fid_uses_geometry_dedup(self):
+        """Features with NULL _wfs_fid should be deduplicated by geometry."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        # Mix of valid fids and NULLs - NULLs should use geometry dedup
+        table = pa.table(
+            {
+                "_wfs_fid": pa.array(["a", None, None, "b"], type=pa.string()),
+                "geometry": pa.array([b"\x01", b"\x02", b"\x02", b"\x03"], type=pa.binary()),
+                "name": pa.array(["w", "x", "x", "z"]),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        # "a" and "b" kept (unique fids), one of the two NULL rows kept (same geometry)
+        assert result.num_rows == 3
+        assert "_wfs_fid" not in result.column_names
+
+    def test_all_null_fids_uses_geometry_dedup(self):
+        """When all fids are NULL, deduplicate entirely by geometry."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _deduplicate_tiles
+
+        table = pa.table(
+            {
+                "_wfs_fid": pa.array([None, None, None, None], type=pa.string()),
+                "geometry": pa.array([b"\x01", b"\x02", b"\x01", b"\x02"], type=pa.binary()),
+                "name": pa.array(["a", "b", "a", "b"]),
+            }
+        )
+
+        result = _deduplicate_tiles(table)
+        assert result.num_rows == 2
+        assert "_wfs_fid" not in result.column_names
 
 
 class TestFetchWithSpatialTiles:

--- a/uv.lock
+++ b/uv.lock
@@ -1218,6 +1218,7 @@ dev = [
     { name = "mutmut" },
     { name = "mypy" },
     { name = "nbmake" },
+    { name = "pip" },
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1274,6 +1275,7 @@ requires-dist = [
     { name = "obstore", specifier = ">=0.8.2" },
     { name = "owslib", specifier = ">=0.29.0" },
     { name = "pandas", specifier = ">=1.0.0" },
+    { name = "pip", marker = "extra == 'dev'", specifier = ">=26.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
     { name = "psutil", specifier = ">=5.9.0" },
@@ -2933,11 +2935,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR consolidates three related WFS PRs (#425, #426, #429) into a single unified implementation:

| PR | Author | Feature |
|----|--------|---------|
| #425 | @cholmes | Auto-pagination, parallel worker crash fix, startIndex limit detection |
| #426 | @cholmes | `--auto-tile` to bypass server startIndex limits |
| #429 | @nlebovits | 10x faster extraction via httpx |

### Key Unification

The core change is replacing two separate fetch functions with one:

**Before:** Two functions with conditional dispatch
- `_fetch_wfs_page_duckdb` — slow DuckDB httpfs streaming (used for regular fetches)
- `_fetch_wfs_page_via_http` — fast httpx + local parse (used only for auto-tile)

**After:** One unified function
- `_fetch_wfs_page` — always uses httpx + local DuckDB parse (~10x faster)

### Performance Improvements

**Single-worker mode (default):**

| Features | Before | After | Speedup |
|----------|--------|-------|---------|
| 1,000 | 31.4s | 3.2s | **10x** |
| 5,000 | ~158s | 9.1s | **17x** |
| 50,000 | ~525s | 105.6s | **5x** |

**With parallel workers (`--workers 8`):**

| Features | Time | Rate |
|----------|------|------|
| 50,000 | 19.4s | 2,576 f/s |

### New Features (from #425 and #426)

1. **Auto-pagination**: Single-worker mode now paginates automatically for large datasets
2. **startIndex limit detection**: Probes server limits before attempting full pagination
3. **`--auto-tile` flag**: Subdivides by bbox to bypass startIndex limits for huge datasets
4. **Parallel workers**: `--workers 4-8` for concurrent paginated requests

### Code Quality Improvements

- Content-type validation (catches HTML error pages)
- Moved `tempfile` import to module level
- Increased `maximum_object_size` to 1GB
- Updated docstrings and progress messages
- Reduced code by 60 lines through unification

### Impact on Original Issues

For 3.8M features (Wallonia INSPIRE Buildings, issue #428):

| Configuration | Estimated Time |
|--------------|----------------|
| Before (buggy) | **56+ hours** |
| After (fix, 1 worker) | ~94 minutes |
| After (fix, 10 workers) | **~23 minutes** |

## Test plan

- [x] All 144 WFS tests pass (1 xfailed, 7 xpassed)
- [x] Pre-commit hooks pass
- [x] Tested unified fetch function replaces both old functions
- [ ] Manual test with large WFS endpoint

## Closes

- Closes #428 (WFS extraction catastrophically slow)
- Supersedes #425 (auto-paginate + parallel fix)
- Supersedes #426 (auto-tile)
- Supersedes #429 (httpx performance)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `auto_tile` parameter to WFS data import operations (API, Table class, and CLI) to enable automatic spatial tiling for handling large datasets from WFS servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->