### PR TITLE
fix(cli): reconfigure stdout/stderr to UTF-8 at CLI entry

### DIFF
--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from contextlib import contextmanager
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -169,6 +170,14 @@ def _activate_s3(ctx, aws_profile=None, s3_endpoint=None, s3_region=None, s3_no_
 @click.pass_context
 def cli(ctx, timestamps, s3_endpoint, s3_region, s3_no_ssl, aws_profile):
     """Fast I/O and transformation tools for GeoParquet files."""
+    # Ensure stdout/stderr can emit UTF-8 even on Windows, where the default
+    # codec (cp1252) raises UnicodeEncodeError on non-ASCII GeoJSON content.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")
+            except Exception:
+                pass
     ctx.ensure_object(dict)
     ctx.obj["timestamps"] = timestamps
     ctx.obj["s3_endpoint"] = s3_endpoint


### PR DESCRIPTION
Fixes #423.

Reconfigures stdout and stderr to UTF-8 at the top-level Click group so non-ASCII output (e.g. \`gpio convert geojson\` writing place names with characters outside Latin-1) no longer crashes on Windows where the default codec is cp1252. The change is guarded by \`hasattr(stream, "reconfigure")\` and a try/except so it is a no-op on streams that don't support reconfiguration.

Verified locally that the equivalent reconfigure pattern allows writing characters like \`U+016B\` to a stream that initially rejects them under cp1252. Ruff passes. The \`test_streaming_handles_broken_pipe\` test currently skipped on Windows for cp1252 reasons can be re-enabled in a follow-up once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Unicode encoding problems when emitting GeoJSON on Windows by ensuring the CLI uses UTF-8 output streams where supported, while safely ignoring any stream reconfiguration errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geoparquet/geoparquet-io/pull/432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->