### PR TITLE
feat(convert): add --geoparquet-version 1.1-geoarrow output format

### DIFF
--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -832,7 +832,7 @@ class Table:
             compression_level: Compression level for GeoParquet
             row_group_size_mb: Target row group size in MB for GeoParquet
             row_group_rows: Exact rows per row group for GeoParquet
-            geoparquet_version: GeoParquet version (1.0, 1.1, 2.0, or None to preserve)
+            geoparquet_version: GeoParquet version (1.0, 1.1, 1.1-geoarrow, 2.0, or None to preserve)
             write_strategy: Write strategy for GeoParquet ('in-memory', 'streaming',
                            'duckdb-kv', 'disk-rewrite'). Default: 'duckdb-kv'
             profile: AWS profile for S3 operations
@@ -1641,7 +1641,7 @@ class Table:
             compression_level: Compression level
             row_group_size_mb: Target row group size in MB
             row_group_rows: Exact rows per row group
-            geoparquet_version: GeoParquet version (1.0, 1.1, 2.0, or None to preserve)
+            geoparquet_version: GeoParquet version (1.0, 1.1, 1.1-geoarrow, 2.0, or None to preserve)
             profile: AWS profile name for S3
             s3_endpoint: Custom S3-compatible endpoint (e.g., "minio.example.com:9000")
             s3_region: S3 region (default: us-east-1 when using custom endpoint)

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -247,6 +247,7 @@ def geoparquet_version_option(func):
     Allows specifying the GeoParquet version for output files:
     - 1.0: GeoParquet 1.0 with WKB encoding
     - 1.1: GeoParquet 1.1 with WKB encoding
+    - 1.1-geoarrow: GeoParquet 1.1 with native GeoArrow encoding (no bbox column)
     - 2.0: GeoParquet 2.0 with native Parquet geo types
     - parquet-geo-only: Native Parquet geo types without GeoParquet metadata
 
@@ -255,9 +256,9 @@ def geoparquet_version_option(func):
     """
     return click.option(
         "--geoparquet-version",
-        type=click.Choice(["1.0", "1.1", "2.0", "parquet-geo-only"]),
+        type=click.Choice(["1.0", "1.1", "1.1-geoarrow", "2.0", "parquet-geo-only"]),
         default=None,
-        help="GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only). "
+        help="GeoParquet version to write (1.0, 1.1, 1.1-geoarrow, 2.0, parquet-geo-only). "
         "Auto-detects from input if not specified: preserves input version, "
         "upgrades native geo types to 2.0, defaults to 1.1.",
     )(func)

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -74,7 +74,7 @@ def should_skip_bbox(geoparquet_version):
     Returns:
         bool: True if bbox should be skipped, False if bbox should be added
     """
-    return geoparquet_version in ("2.0", "parquet-geo-only")
+    return geoparquet_version in ("2.0", "parquet-geo-only", "1.1-geoarrow")
 
 
 # LRU cache for detect_geoparquet_file_type results

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -214,18 +214,20 @@ def _calculate_bounds(con, input_file, geom_column, verbose, is_parquet=False, e
     quoted_geom = quote_identifier(geom_column)
 
     # GeoArrow native encodings store geometry as nested structs/arrays that
-    # DuckDB cannot pass to ST_XMin directly. Use UNNEST to extract x/y coords;
-    # the WHERE filter excludes NaN coordinates (e.g. empty-geometry sentinels).
+    # DuckDB cannot pass to ST_XMin directly. Use list_min/list_max via
+    # _geoarrow_coord_exprs — consistent with _build_conversion_query and
+    # avoids UNNEST row explosion for large multipolygon datasets.
     geoarrow_native = encoding.lower() not in {"wkb", "wkt"}
     if geoarrow_native:
+        xmin_e, ymin_e, xmax_e, ymax_e, _, _ = _geoarrow_coord_exprs(quoted_geom, encoding)
         bounds_query = f"""
             SELECT
-                MIN(x) as xmin,
-                MIN(y) as ymin,
-                MAX(x) as xmax,
-                MAX(y) as ymax
-            FROM (SELECT UNNEST({quoted_geom}, recursive := true) FROM {table_expr})
-            WHERE NOT isnan(x) AND NOT isnan(y)
+                MIN({xmin_e}) as xmin,
+                MIN({ymin_e}) as ymin,
+                MAX({xmax_e}) as xmax,
+                MAX({ymax_e}) as ymax
+            FROM {table_expr}
+            WHERE NOT isnan({xmax_e}) AND NOT isnan({ymax_e})
         """
     else:
         bounds_query = f"""
@@ -1436,7 +1438,7 @@ def convert_to_geoparquet(
         skip_invalid: Skip rows with invalid geometries instead of failing
         allow_no_geometry: Allow conversion to plain Parquet if no geometry detected
         profile: AWS profile name for S3 operations
-        geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        geoparquet_version: GeoParquet version to write (1.0, 1.1, 1.1-geoarrow, 2.0, parquet-geo-only)
 
     Raises:
         GeoParquetError: If input file not found or conversion fails

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -349,13 +349,17 @@ def _geoarrow_coord_exprs(quoted_geom: str, encoding: str) -> tuple:
 
     x_arr = f"list_transform({flat}, p -> p.x)"
     y_arr = f"list_transform({flat}, p -> p.y)"
+    x_min = f"list_min({x_arr})"
+    x_max = f"list_max({x_arr})"
+    y_min = f"list_min({y_arr})"
+    y_max = f"list_max({y_arr})"
     return (
-        f"list_min({x_arr})",
-        f"list_min({y_arr})",
-        f"list_max({x_arr})",
-        f"list_max({y_arr})",
-        f"list_avg({x_arr})",
-        f"list_avg({y_arr})",
+        x_min,
+        y_min,
+        x_max,
+        y_max,
+        f"({x_min} + {x_max}) / 2.0",
+        f"({y_min} + {y_max}) / 2.0",
     )
 
 

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -345,6 +345,7 @@ def compute_bbox_via_sql(
                 MAX({xmax_e}) as xmax,
                 MAX({ymax_e}) as ymax
             FROM ({query})
+            WHERE NOT isnan({xmax_e}) AND NOT isnan({ymax_e})
         """
     else:
         bbox_query = f"""

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 GEOPARQUET_VERSIONS = {
     "1.0": {"duckdb_param": "V1", "metadata_version": "1.0.0", "rewrite_metadata": True},
     "1.1": {"duckdb_param": "V1", "metadata_version": "1.1.0", "rewrite_metadata": True},
+    "1.1-geoarrow": {"duckdb_param": "V1", "metadata_version": "1.1.0", "rewrite_metadata": True},
     "2.0": {"duckdb_param": "V2", "metadata_version": "2.0.0", "rewrite_metadata": False},
     "parquet-geo-only": {
         "duckdb_param": "NONE",

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -71,7 +71,14 @@ def build_geo_metadata(
 
     # Encoding (required by GeoParquet spec)
     if "encoding" not in col_meta:
-        col_meta["encoding"] = "WKB"
+        # For 1.1-geoarrow, preserve the input encoding (native type) from geometry_info.
+        # For all other v1.x versions, geometry is converted to WKB blob before writing.
+        input_encoding = (
+            geometry_info.get("metadata", {}).get(geometry_column, {}).get("encoding")
+            if geometry_info and geoparquet_version == "1.1-geoarrow"
+            else None
+        )
+        col_meta["encoding"] = input_encoding or "WKB"
 
     # Geometry types
     if geometry_types is not None:

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1263,3 +1263,96 @@ class TestPartitionGeoParquetVersion:
         partition_file = os.path.join(temp_output_dir, parquet_files[0])
         assert get_geoparquet_version(partition_file) == "2.0.0"
         assert has_native_geo_types(partition_file)
+
+
+class TestGeoParquet11GeoArrow:
+    """Tests for --geoparquet-version 1.1-geoarrow output.
+
+    This version writes GeoParquet 1.1 metadata but skips the bbox column,
+    keeping the geometry in its native Arrow encoding (no WKB blob conversion).
+    Useful for GeoArrow-native parquet files that don't benefit from bbox columns.
+    """
+
+    def test_version_constant_exists(self):
+        """1.1-geoarrow must be a registered version."""
+        assert "1.1-geoarrow" in GEOPARQUET_VERSIONS
+
+    def test_version_constant_structure(self):
+        """1.1-geoarrow config must have the required keys."""
+        config = GEOPARQUET_VERSIONS["1.1-geoarrow"]
+        assert config["metadata_version"] == "1.1.0"
+        assert "duckdb_param" in config
+        assert "rewrite_metadata" in config
+
+    def test_should_skip_bbox(self):
+        """should_skip_bbox must return True for 1.1-geoarrow."""
+        from geoparquet_io.core.common import should_skip_bbox
+
+        assert should_skip_bbox("1.1-geoarrow") is True
+
+    def test_cli_accepts_version(self, geojson_input, temp_output_file):
+        """CLI must accept --geoparquet-version 1.1-geoarrow without error."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["convert", geojson_input, temp_output_file, "--geoparquet-version", "1.1-geoarrow"],
+        )
+        assert result.exit_code == 0, f"CLI rejected 1.1-geoarrow: {result.output}"
+
+    def test_output_has_1_1_metadata(self, geojson_input, temp_output_file):
+        """Output must carry GeoParquet 1.1.0 version in the geo metadata."""
+        convert_to_geoparquet(
+            geojson_input, temp_output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+        assert get_geoparquet_version(temp_output_file) == "1.1.0"
+
+    def test_output_has_no_bbox_column(self, geojson_input, temp_output_file):
+        """Output must not have a bbox column (the key benefit over plain 1.1)."""
+        from geoparquet_io.core.common import check_bbox_structure
+
+        convert_to_geoparquet(
+            geojson_input, temp_output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+        bbox_info = check_bbox_structure(temp_output_file)
+        assert not bbox_info["has_bbox_column"]
+
+    def test_plain_1_1_has_bbox_column(self, geojson_input, temp_output_file):
+        """Sanity check: plain 1.1 DOES add a bbox column."""
+        from geoparquet_io.core.common import check_bbox_structure
+
+        convert_to_geoparquet(
+            geojson_input, temp_output_file, geoparquet_version="1.1", verbose=False
+        )
+        bbox_info = check_bbox_structure(temp_output_file)
+        assert bbox_info["has_bbox_column"]
+
+    def test_native_input_preserves_encoding(self, test_data_dir, tmp_path):
+        """Converting a native-encoded file with 1.1-geoarrow keeps native geometry."""
+        import pyarrow.parquet as pq
+
+        input_file = str(test_data_dir / "data-multipolygon-encoding_native.parquet")
+        output_file = str(tmp_path / "output.parquet")
+
+        convert_to_geoparquet(
+            input_file, output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        schema = pq.read_schema(output_file)
+        geom_field = schema.field("geometry")
+        # Native geometry should NOT be a plain binary blob
+        assert str(geom_field.type) != "binary", "geometry should remain native, not WKB blob"
+
+    def test_native_input_metadata_encoding_preserved(self, test_data_dir, tmp_path):
+        """GeoParquet metadata must record the actual native encoding, not WKB."""
+        input_file = str(test_data_dir / "data-multipolygon-encoding_native.parquet")
+        output_file = str(tmp_path / "output.parquet")
+
+        convert_to_geoparquet(
+            input_file, output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        geo_meta = get_geo_metadata(output_file)
+        encoding = geo_meta["columns"]["geometry"]["encoding"]
+        assert encoding == "multipolygon", (
+            f"Expected 'multipolygon' encoding in metadata, got '{encoding}'"
+        )

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1356,3 +1356,59 @@ class TestGeoParquet11GeoArrow:
         assert encoding == "multipolygon", (
             f"Expected 'multipolygon' encoding in metadata, got '{encoding}'"
         )
+
+    def test_wkb_input_writes_binary_geometry(self, geojson_input, temp_output_file):
+        """WKB-encoded input (GeoJSON) with 1.1-geoarrow must write binary WKB, not native type."""
+        import pyarrow.parquet as pq
+
+        convert_to_geoparquet(
+            geojson_input, temp_output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        geo_meta = get_geo_metadata(temp_output_file)
+        geom_col = geo_meta["primary_column"]
+        schema = pq.read_schema(temp_output_file)
+        geom_field = schema.field(geom_col)
+        assert str(geom_field.type) == "binary", (
+            f"WKB input should remain binary blob, got {geom_field.type}"
+        )
+
+    def test_wkb_input_metadata_encoding_is_wkb(self, geojson_input, temp_output_file):
+        """WKB-encoded input with 1.1-geoarrow must record 'WKB' in geo metadata."""
+        convert_to_geoparquet(
+            geojson_input, temp_output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        geo_meta = get_geo_metadata(temp_output_file)
+        geom_col = geo_meta["primary_column"]
+        encoding = geo_meta["columns"][geom_col]["encoding"]
+        assert encoding == "WKB", (
+            f"Expected 'WKB' encoding in metadata for WKB input, got '{encoding}'"
+        )
+
+    @pytest.mark.parametrize(
+        "geom_type",
+        ["point", "linestring", "polygon", "multipoint", "multilinestring", "multipolygon"],
+    )
+    def test_all_native_types_preserve_encoding(self, geom_type, test_data_dir, tmp_path):
+        """All 6 native geometry types must preserve their encoding through 1.1-geoarrow."""
+        import pyarrow.parquet as pq
+
+        input_file = str(test_data_dir / f"data-{geom_type}-encoding_native.parquet")
+        output_file = str(tmp_path / f"output_{geom_type}.parquet")
+
+        convert_to_geoparquet(
+            input_file, output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        schema = pq.read_schema(output_file)
+        geom_field = schema.field("geometry")
+        assert str(geom_field.type) != "binary", (
+            f"{geom_type}: geometry should remain native, not WKB blob"
+        )
+
+        geo_meta = get_geo_metadata(output_file)
+        encoding = geo_meta["columns"]["geometry"]["encoding"]
+        assert encoding == geom_type, (
+            f"Expected '{geom_type}' encoding in metadata, got '{encoding}'"
+        )


### PR DESCRIPTION
## Summary

Adds \`--geoparquet-version 1.1-geoarrow\` as a new output format option. It writes GeoParquet 1.1 metadata but skips the bbox column and preserves native GeoArrow geometry encoding — the same lightweight geometry handling as \`2.0\` but with \`1.1.0\` metadata for broader client compatibility.

**Depends on:** #435 (fix for reading GeoArrow native input)

## Behavior

| | \`1.1\` | \`1.1-geoarrow\` | \`2.0\` |
|--|--|--|--|
| GeoParquet version | 1.1.0 | **1.1.0** | 2.0.0 |
| Geometry encoding | WKB blob | **native GeoArrow** | native Parquet geo |
| bbox column | ✅ added | ❌ skipped | ❌ skipped |

WKB-encoded input (GeoJSON, Shapefile, etc.) written with \`1.1-geoarrow\` stays as WKB binary — the version only preserves native Arrow encoding when the input already uses it.

## Changes

**Core feature:**
- **\`geo_metadata.py\`**: register \`"1.1-geoarrow"\` in \`GEOPARQUET_VERSIONS\` (V1 DuckDB param, \`metadata_version: "1.1.0"\`)
- **\`common.py\`**: \`should_skip_bbox\` returns \`True\` for \`"1.1-geoarrow"\`
- **\`decorators.py\`**: add \`"1.1-geoarrow"\` to CLI \`click.Choice\`
- **\`write_strategies/base.py\`**: \`build_geo_metadata\` preserves input encoding from \`geometry_info\` for \`"1.1-geoarrow"\` (e.g. \`"multipolygon"\` instead of defaulting to \`"WKB"\`)

**GeoArrow coordinate handling** (also fixes input conversion for all versions):
- **\`duckdb_utils.py\`**: \`_geoarrow_coord_exprs\` uses \`(list_min + list_max) / 2\` for Hilbert centroid instead of \`list_avg\` — bounding-box midpoint gives better spatial clustering than vertex-density-biased average
- **\`convert.py\`**: \`_calculate_bounds\` now uses \`_geoarrow_coord_exprs\` list_min/list_max instead of \`UNNEST(recursive := true)\` — consistent with \`_build_conversion_query\`, O(N) memory instead of O(N×V) row explosion for large multipolygon datasets
- **\`geo_metadata.py\`**: \`compute_bbox_via_sql\` GeoArrow path adds \`WHERE NOT isnan(xmax) AND NOT isnan(ymax)\` — \`MAX\` propagates NaN but \`MIN\` does not, so without the filter a single geometry with a NaN coordinate would silently write NaN into the global bbox metadata

**API / docs:**
- **\`api/table.py\`**: \`Table.write()\` and \`Table.upload()\` docstrings now list \`"1.1-geoarrow"\` as a valid \`geoparquet_version\` value
- **\`core/convert.py\`**: \`convert_to_geoparquet\` docstring updated to match

## Test plan

- [x] \`test_version_constant_exists\` — \`"1.1-geoarrow"\` registered
- [x] \`test_should_skip_bbox\` — returns True
- [x] \`test_cli_accepts_version\` — CLI accepts the option without error
- [x] \`test_output_has_1_1_metadata\` — output carries \`"version": "1.1.0"\`
- [x] \`test_output_has_no_bbox_column\` — no bbox struct column written
- [x] \`test_plain_1_1_has_bbox_column\` — sanity check: plain 1.1 still adds bbox
- [x] \`test_native_input_preserves_encoding\` — geometry is native Arrow type, not binary
- [x] \`test_native_input_metadata_encoding_preserved\` — metadata says \`"multipolygon"\`, not \`"WKB"\`
- [x] \`test_wkb_input_writes_binary_geometry\` — WKB input stays binary blob through 1.1-geoarrow
- [x] \`test_wkb_input_metadata_encoding_is_wkb\` — metadata correctly says \`"WKB"\` for WKB input
- [x] \`test_all_native_types_preserve_encoding[point|linestring|polygon|multipoint|multilinestring|multipolygon]\` — all 6 GeoArrow native types preserve encoding
- [x] Full suite: \`uv run pytest -n auto -m "not slow and not network"\` — 2641 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `1.1-geoarrow` as a supported GeoParquet output version, accessible via `--geoparquet-version 1.1-geoarrow` CLI option.
  * Geometry encoding is now preserved from input data when using `1.1-geoarrow` format.

* **Tests**
  * Comprehensive test coverage added for the `1.1-geoarrow` output mode, including geometry encoding preservation and output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->