### PR TITLE
fix(arcgis): use CRS84 for metadata when extracting via f=geojson

### DIFF
--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -1107,7 +1107,9 @@ def arcgis_to_table(
                 debug(f"Excluded columns: {cols_to_exclude}")
 
         # Add CRS to metadata
-        crs = _extract_crs_from_spatial_reference(layer_info.spatial_reference)
+        # Always use CRS84 (WGS84 lon/lat) because we request f=geojson,
+        # which per RFC 7946 is always WGS84 regardless of the layer's native SR
+        crs = parse_crs_string_to_projjson("OGC:CRS84")
         if crs:
             geo_metadata = {
                 "version": "1.1.0",

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -5,6 +5,7 @@ Tests use mocked HTTP responses to avoid network dependencies.
 Network tests are marked separately for optional integration testing.
 """
 
+import json
 import tempfile
 import uuid
 from pathlib import Path
@@ -249,6 +250,66 @@ class TestCrsExtraction:
 
         result = _extract_crs_from_spatial_reference({})
         assert result is not None  # Should default to WGS84
+
+    @patch("geoparquet_io.core.arcgis._stream_features_to_parquet")
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
+    def test_output_crs_is_wgs84_regardless_of_native_sr(
+        self, mock_get_layer, mock_stream, tmp_path
+    ):
+        """Test that output CRS is always WGS84 even when layer's native SR is 3857 (issue #427).
+
+        ArcGIS f=geojson always returns WGS84 per RFC 7946, so the output metadata
+        must reflect that, not the layer's native spatial reference.
+        """
+        from geoparquet_io.core.arcgis import ArcGISLayerInfo, arcgis_to_table
+
+        # Layer advertises Web Mercator (EPSG:3857), but f=geojson returns WGS84
+        layer_info = ArcGISLayerInfo(
+            name="Test",
+            geometry_type="esriGeometryPoint",
+            spatial_reference={"wkid": 102100, "latestWkid": 3857},
+            fields=[
+                {"name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": False},
+                {"name": "name", "type": "esriFieldTypeString", "nullable": True},
+            ],
+            max_record_count=1000,
+            total_count=3,
+        )
+        mock_get_layer.return_value = layer_info
+
+        # Create a temp parquet with test data that _stream_features_to_parquet would produce
+        temp_parquet = str(tmp_path / "temp.parquet")
+        test_table = pa.table(
+            {
+                "geometry": [
+                    b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                ],
+                "OBJECTID": [1],
+                "name": ["Test Point"],
+            }
+        )
+        pq.write_table(test_table, temp_parquet)
+
+        def mock_stream_side_effect(*args, **kwargs):
+            # Copy our test parquet to where arcgis_to_table expects it
+            import shutil
+
+            output_path = kwargs.get("output_path") or args[2]
+            shutil.copy(temp_parquet, output_path)
+            return 1
+
+        mock_stream.side_effect = mock_stream_side_effect
+
+        # Call arcgis_to_table which sets CRS metadata
+        result = arcgis_to_table("https://example.com/FeatureServer/0")
+
+        # Verify output CRS is WGS84, not 3857
+        geo_meta = json.loads(result.schema.metadata[b"geo"])
+        crs = geo_meta["columns"]["geometry"]["crs"]
+
+        # CRS84 is WGS84 with lon/lat axis order (matches GeoJSON)
+        assert crs["id"]["authority"] == "OGC"
+        assert crs["id"]["code"] == "CRS84"
 
 
 class TestSchemaBuilding:


### PR DESCRIPTION
## Summary

Fixes #427 — ArcGIS extract writes wrong CRS metadata when layer's native SR is not EPSG:4326.

- When extracting via `f=geojson`, ArcGIS always returns WGS84 coordinates per RFC 7946
- Previously we tagged output with the layer's native SR (often EPSG:3857), causing a mismatch
- This caused silent garbage on downstream reprojections (coordinates are degrees but metadata claims meters)

**Fix:** Always use `OGC:CRS84` for metadata since `f=geojson` guarantees WGS84 output.

## Test plan

- [x] New test `test_output_crs_is_wgs84_regardless_of_native_sr` verifies CRS is WGS84 even when layer advertises 3857
- [x] All 59 arcgis tests pass
- [ ] Manually verify with reproducer from issue:
  ```sh
  gpio extract arcgis \
    https://gis.unhcr.org/arcgis/rest/services/core_v2/wrl_polbnd_int_1m_a_unhcr/MapServer/0 \
    out.parquet
  gpio inspect meta out.parquet  # Should show CRS: OGC:CRS84, not EPSG:3857
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GeoParquet coordinate system metadata in ArcGIS-to-table conversions to consistently use WGS84 (OGC:CRS84) for the geometry column, preventing misalignment when source layers use different spatial references.

* **Tests**
  * Added validation tests for GeoParquet geometry CRS metadata in ArcGIS conversions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geoparquet/geoparquet-io/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->