### PR TITLE
fix(validate): guard against None logical_type in schema lookups

### DIFF
--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -141,7 +141,7 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
 
     schema_info = get_schema_info(safe_url)
     for col in schema_info:
-        logical_type = col.get("logical_type", "")
+        logical_type = col.get("logical_type") or ""
         if logical_type and (
             logical_type.startswith("GeometryType(") or logical_type.startswith("GeographyType(")
         ):

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -194,7 +194,7 @@ def _get_crs_from_file(input_parquet: str, geometry_col: str) -> dict | str | No
             name = col.get("name", "")
             if name != geometry_col:
                 continue
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             # DuckDB returns GeometryType(...) and GeographyType(...) from parquet_schema()
             if logical_type and (
                 logical_type.startswith("GeometryType(")

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -273,7 +273,7 @@ def extract_geo_info(parquet_file: str, con=None) -> dict[str, Any]:
             geometry_column = col_name
 
             # Parse additional details from logical type
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             if logical_type:
                 geom_details = parse_geometry_logical_type(logical_type)
                 if geom_details:

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -889,7 +889,7 @@ def _build_geo_columns_info(schema_info: list, geo_columns: dict) -> dict:
     for col in schema_info:
         col_name = col.get("name", "")
         if col_name in geo_columns:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             parsed = parse_geometry_logical_type(logical_type) if logical_type else {}
             geo_columns_info[col_name] = {
                 "logical_type": geo_columns.get(col_name),

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -1095,7 +1095,7 @@ def _check_native_geo_type_present(schema_info: list, geom_col: str) -> Validati
 
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             if is_geometry_column(logical_type):
                 geo_type = "GEOMETRY" if "GeometryType" in logical_type else "GEOGRAPHY"
                 return ValidationCheck(
@@ -1125,7 +1125,7 @@ def _check_native_crs_format(schema_info: list, geom_col: str) -> ValidationChec
 
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             parsed = parse_geometry_logical_type(logical_type)
 
             if not parsed:
@@ -1186,7 +1186,7 @@ def _check_geography_edges_valid(schema_info: list, geom_col: str) -> Validation
 
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
 
             if "GeographyType" not in logical_type:
                 return ValidationCheck(
@@ -1234,7 +1234,7 @@ def _is_geography_column(schema_info: list, geom_col: str) -> bool:
     """Check if a geometry column is a GEOGRAPHY type."""
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             return "GeographyType" in logical_type
     return False
 
@@ -1712,7 +1712,7 @@ def _check_v2_uses_native_types(schema_info: list, geom_col: str) -> ValidationC
 
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             if is_geometry_column(logical_type):
                 return ValidationCheck(
                     name=f"v2_native_types_{geom_col}",
@@ -1757,7 +1757,7 @@ def _check_v2_crs_in_parquet_type(
     # Find the Parquet schema CRS
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             parsed = parse_geometry_logical_type(logical_type)
 
             if parsed and parsed.get("crs"):
@@ -1795,7 +1795,7 @@ def _check_v2_crs_consistency(geo_meta: dict, schema_info: list, geom_col: str) 
     schema_crs = None
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             parsed = parse_geometry_logical_type(logical_type)
             if parsed:
                 schema_crs = parsed.get("crs")
@@ -1842,7 +1842,7 @@ def _check_v2_edges_consistency(
     is_geography = False
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             if "GeographyType" in logical_type:
                 is_geography = True
                 parsed = parse_geometry_logical_type(logical_type)
@@ -1891,7 +1891,7 @@ def _check_parquet_geo_only_crs(
 
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             parsed = parse_geometry_logical_type(logical_type)
 
             if not parsed:
@@ -2294,7 +2294,7 @@ def _get_crs_from_schema(schema_info: list, geom_col: str) -> Any:
 
     for col in schema_info:
         if col.get("name") == geom_col:
-            logical_type = col.get("logical_type", "")
+            logical_type = col.get("logical_type") or ""
             parsed = parse_geometry_logical_type(logical_type)
             if parsed:
                 return parsed.get("crs")


### PR DESCRIPTION
## Summary

- Fixes `TypeError: argument of type 'NoneType' is not iterable` crash in `gpio check spec/all` when geometry column has no Parquet logical type
- Root cause: `dict.get(key, default)` returns `None` when key exists with `None` value — default only applies to missing keys
- Fix: use `.get("logical_type") or ""` pattern across all 14 occurrences in 5 files

## Files Changed

| File | Occurrences |
|------|-------------|
| `validate.py` | 10 |
| `crs_utils.py` | 1 |
| `metadata_utils.py` | 1 |
| `inspect_utils.py` | 1 |
| `extract.py` | 1 |

Note: `duckdb_metadata.py` already used the correct pattern.

## Test plan

- [x] 283 check-related tests pass
- [ ] CI passes

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of missing or undefined logical type values in GeoParquet metadata. This prevents errors when processing GeoParquet files where the logical type field may be absent or null, ensuring more robust metadata parsing across multiple validation and extraction operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geoparquet/geoparquet-io/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->