### PR TITLE
fix(add): preserve bloom filters and GEOMETRY type in bbox-metadata

### DIFF
--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -5,7 +5,11 @@ This module adds bbox covering metadata to existing GeoParquet files,
 enabling spatial filtering optimizations in readers that support it.
 
 Uses DuckDB COPY TO with KV_METADATA to preserve file properties including
-bloom filters and native GEOMETRY logical type (fixes #433).
+bloom filters, native GEOMETRY logical type, and existing key-value metadata
+(fixes #433).
+
+Note: This operation only supports local files. Remote URLs (S3, GCS, Azure)
+are not supported for in-place metadata modification.
 """
 
 import json
@@ -22,71 +26,134 @@ from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, error, success
 
 
-def _detect_native_geometry(parquet_file: str) -> bool:
+def _is_remote_url(path: str) -> bool:
+    """Check if the path is a remote URL (S3, GCS, Azure, HTTP)."""
+    remote_prefixes = ("s3://", "gs://", "az://", "azure://", "http://", "https://")
+    return path.lower().startswith(remote_prefixes)
+
+
+def _detect_native_geometry(conn: duckdb.DuckDBPyConnection, parquet_file: str) -> bool:
     """Detect if the file uses native GEOMETRY logical type (GeoParquet 2.0).
 
     Args:
+        conn: DuckDB connection (reused to avoid repeated INSTALL/LOAD)
         parquet_file: Path to the parquet file
 
     Returns:
         True if the file has native GEOMETRY type, False otherwise
     """
-    conn = duckdb.connect()
-    try:
-        result = conn.execute(f"""
-            SELECT logical_type
-            FROM parquet_schema('{parquet_file}')
-            WHERE name = 'geometry'
-        """).fetchone()
+    result = conn.execute(f"""
+        SELECT logical_type
+        FROM parquet_schema('{parquet_file}')
+        WHERE name = 'geometry'
+    """).fetchone()
 
-        if result and result[0]:
-            logical_type = str(result[0])
-            return "Geometry" in logical_type or "Geography" in logical_type
-        return False
-    finally:
-        conn.close()
+    if result and result[0]:
+        logical_type = str(result[0])
+        return "Geometry" in logical_type or "Geography" in logical_type
+    return False
 
 
-def _escape_json_for_duckdb(json_str: str) -> str:
-    """Escape JSON string for use in DuckDB KV_METADATA option.
+def _get_existing_kv_metadata(conn: duckdb.DuckDBPyConnection, parquet_file: str) -> dict:
+    """Read existing key-value metadata from a parquet file.
 
-    Single quotes must be doubled for DuckDB string literals.
+    Args:
+        conn: DuckDB connection
+        parquet_file: Path to the parquet file
+
+    Returns:
+        Dict mapping metadata keys to values (both as strings)
     """
-    return json_str.replace("'", "''")
+    result = conn.execute(
+        f"SELECT key, value FROM parquet_kv_metadata('{parquet_file}')"
+    ).fetchall()
+
+    metadata = {}
+    for key, value in result:
+        # Keys and values come as bytes, decode them
+        key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
+        value_str = value.decode("utf-8") if isinstance(value, bytes) else str(value)
+        metadata[key_str] = value_str
+
+    return metadata
+
+
+def _build_kv_metadata_clause(existing_metadata: dict, new_geo_meta: dict) -> str:
+    """Build the KV_METADATA clause preserving existing metadata.
+
+    DuckDB's KV_METADATA replaces all metadata, so we must include all existing
+    keys we want to preserve, plus the updated geo key.
+
+    Args:
+        existing_metadata: Dict of existing key-value pairs
+        new_geo_meta: The new geo metadata dict to set
+
+    Returns:
+        KV_METADATA clause string for DuckDB COPY
+    """
+    kv_parts = []
+
+    # Preserve all existing metadata except 'geo' (which we're updating)
+    for key, value in existing_metadata.items():
+        if key == "geo":
+            continue  # Skip - we'll add the updated geo below
+        # Escape single quotes for DuckDB string literals
+        escaped_value = value.replace("'", "''")
+        kv_parts.append(f"{key}: '{escaped_value}'")
+
+    # Add the new geo metadata
+    geo_json = json.dumps(new_geo_meta)
+    escaped_geo = geo_json.replace("'", "''")
+    kv_parts.append(f"geo: '{escaped_geo}'")
+
+    return f"KV_METADATA {{{', '.join(kv_parts)}}}"
 
 
 def add_bbox_metadata(
     parquet_file: str,
     verbose: bool = False,
-    write_strategy: str = "duckdb-kv",
 ) -> None:
     """Add bbox covering metadata to a GeoParquet file.
 
     Updates the GeoParquet metadata to include bbox covering information,
     which enables spatial filtering optimizations in readers that support it.
 
-    This operation preserves all file properties including bloom filters,
-    native GEOMETRY logical type, compression, and row group structure.
+    This operation preserves all file properties including:
+    - Bloom filters on all columns
+    - Native GEOMETRY logical type (GeoParquet 2.0)
+    - Compression settings
+    - Row group structure
+    - All existing key-value metadata (pandas, ARROW:schema, custom, etc.)
+
+    Note: Only local files are supported. Remote URLs will raise an error.
 
     Args:
         parquet_file: Path to the parquet file (will be modified in place)
         verbose: Print verbose output
-        write_strategy: Write strategy (currently only 'duckdb-kv' supported for
-            this operation to preserve file properties)
+
+    Raises:
+        GeoParquetError: If the file is remote or the operation fails
     """
+    # Reject remote URLs - in-place modification requires local filesystem
+    if _is_remote_url(parquet_file):
+        raise GeoParquetError(
+            f"Remote URLs are not supported for in-place metadata modification: {parquet_file}\n"
+            "Download the file locally, modify it, then upload."
+        )
+
     safe_url = safe_file_url(parquet_file, verbose)
 
     # Check current bbox structure
-    bbox_info = check_bbox_structure(parquet_file, verbose)
+    bbox_info = check_bbox_structure(safe_url, verbose)
 
     if bbox_info["has_bbox_metadata"]:
         success(
-            f"✓ Bbox covering metadata already exists for column '{bbox_info['bbox_column_name']}'"
+            f"Bbox covering metadata already exists for column '{bbox_info['bbox_column_name']}'"
         )
         return
 
     if not bbox_info["has_bbox_column"]:
-        error("❌ No valid bbox column found in the file. Please add a bbox column first.")
+        error("No valid bbox column found in the file. Please add a bbox column first.")
         return
 
     # Get existing metadata
@@ -121,19 +188,10 @@ def add_bbox_metadata(
         debug(json.dumps(geo_meta, indent=2))
 
     # Get original file properties
-    row_group_stats = get_row_group_stats(parquet_file)
-    compression_info = get_compression_info(parquet_file, primary_col)
+    row_group_stats = get_row_group_stats(safe_url)
+    compression_info = get_compression_info(safe_url, primary_col)
     row_group_size = int(row_group_stats["avg_rows_per_group"])
     compression = compression_info[primary_col]
-
-    # Detect if file uses native GEOMETRY type (GeoParquet 2.0)
-    has_native_geometry = _detect_native_geometry(parquet_file)
-
-    if verbose:
-        debug("\nPreserving file properties:")
-        debug(f"Row group size: {row_group_size:,} rows")
-        debug(f"Compression: {compression}")
-        debug(f"Native GEOMETRY type: {has_native_geometry}")
 
     # Create a temporary file for the rewrite
     temp_file = parquet_file + ".tmp"
@@ -143,8 +201,21 @@ def add_bbox_metadata(
         conn = duckdb.connect()
         conn.execute("INSTALL spatial; LOAD spatial;")
 
-        # Escape the geo metadata JSON for DuckDB
-        geo_meta_escaped = _escape_json_for_duckdb(json.dumps(geo_meta))
+        # Detect if file uses native GEOMETRY type (GeoParquet 2.0)
+        has_native_geometry = _detect_native_geometry(conn, safe_url)
+
+        # Read existing KV metadata to preserve non-geo keys
+        existing_kv = _get_existing_kv_metadata(conn, safe_url)
+
+        if verbose:
+            debug("\nPreserving file properties:")
+            debug(f"Row group size: {row_group_size:,} rows")
+            debug(f"Compression: {compression}")
+            debug(f"Native GEOMETRY type: {has_native_geometry}")
+            debug(f"Existing metadata keys: {list(existing_kv.keys())}")
+
+        # Build KV_METADATA clause preserving all existing metadata
+        kv_metadata_clause = _build_kv_metadata_clause(existing_kv, geo_meta)
 
         # Build COPY options
         # Use GEOPARQUET_VERSION 'V2' if native geometry, 'NONE' otherwise
@@ -155,12 +226,12 @@ def add_bbox_metadata(
             "FORMAT PARQUET",
             f"COMPRESSION {compression}",
             f"GEOPARQUET_VERSION '{geoparquet_version}'",
-            f"KV_METADATA {{geo: '{geo_meta_escaped}'}}",
+            kv_metadata_clause,
             f"ROW_GROUP_SIZE {row_group_size}",
         ]
 
         copy_sql = f"""
-            COPY (SELECT * FROM '{parquet_file}')
+            COPY (SELECT * FROM '{safe_url}')
             TO '{temp_file}'
             ({", ".join(copy_options)})
         """
@@ -174,7 +245,7 @@ def add_bbox_metadata(
         # Replace original file atomically
         os.replace(temp_file, parquet_file)
 
-        success(f"✓ Added bbox covering metadata for column '{bbox_info['bbox_column_name']}'")
+        success(f"Added bbox covering metadata for column '{bbox_info['bbox_column_name']}'")
 
     except Exception as e:
         # Clean up temporary file if something goes wrong

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
+"""Add bbox covering metadata to GeoParquet files.
 
-import gc
+This module adds bbox covering metadata to existing GeoParquet files,
+enabling spatial filtering optimizations in readers that support it.
+
+Uses DuckDB COPY TO with KV_METADATA to preserve file properties including
+bloom filters and native GEOMETRY logical type (fixes #433).
+"""
+
 import json
 import os
 
-import pyarrow.parquet as pq
+import duckdb
 
 from geoparquet_io.core.check_parquet_structure import get_compression_info, get_row_group_stats
 from geoparquet_io.core.common import check_bbox_structure, get_parquet_metadata
@@ -15,16 +22,57 @@ from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, error, success
 
 
-def add_bbox_metadata(parquet_file, verbose=False):
+def _detect_native_geometry(parquet_file: str) -> bool:
+    """Detect if the file uses native GEOMETRY logical type (GeoParquet 2.0).
+
+    Args:
+        parquet_file: Path to the parquet file
+
+    Returns:
+        True if the file has native GEOMETRY type, False otherwise
     """
-    Add bbox covering metadata to a GeoParquet file.
+    conn = duckdb.connect()
+    try:
+        result = conn.execute(f"""
+            SELECT logical_type
+            FROM parquet_schema('{parquet_file}')
+            WHERE name = 'geometry'
+        """).fetchone()
+
+        if result and result[0]:
+            logical_type = str(result[0])
+            return "Geometry" in logical_type or "Geography" in logical_type
+        return False
+    finally:
+        conn.close()
+
+
+def _escape_json_for_duckdb(json_str: str) -> str:
+    """Escape JSON string for use in DuckDB KV_METADATA option.
+
+    Single quotes must be doubled for DuckDB string literals.
+    """
+    return json_str.replace("'", "''")
+
+
+def add_bbox_metadata(
+    parquet_file: str,
+    verbose: bool = False,
+    write_strategy: str = "duckdb-kv",
+) -> None:
+    """Add bbox covering metadata to a GeoParquet file.
 
     Updates the GeoParquet metadata to include bbox covering information,
     which enables spatial filtering optimizations in readers that support it.
 
+    This operation preserves all file properties including bloom filters,
+    native GEOMETRY logical type, compression, and row group structure.
+
     Args:
         parquet_file: Path to the parquet file (will be modified in place)
         verbose: Print verbose output
+        write_strategy: Write strategy (currently only 'duckdb-kv' supported for
+            this operation to preserve file properties)
     """
     safe_url = safe_file_url(parquet_file, verbose)
 
@@ -75,47 +123,55 @@ def add_bbox_metadata(parquet_file, verbose=False):
     # Get original file properties
     row_group_stats = get_row_group_stats(parquet_file)
     compression_info = get_compression_info(parquet_file, primary_col)
-    row_group_size = row_group_stats["avg_rows_per_group"]
+    row_group_size = int(row_group_stats["avg_rows_per_group"])
     compression = compression_info[primary_col]
+
+    # Detect if file uses native GEOMETRY type (GeoParquet 2.0)
+    has_native_geometry = _detect_native_geometry(parquet_file)
 
     if verbose:
         debug("\nPreserving file properties:")
-        debug(f"Row group size: {row_group_size:,.0f} rows")
+        debug(f"Row group size: {row_group_size:,} rows")
         debug(f"Compression: {compression}")
+        debug(f"Native GEOMETRY type: {has_native_geometry}")
 
-    # Create a temporary file for the new metadata
+    # Create a temporary file for the rewrite
     temp_file = parquet_file + ".tmp"
     try:
-        # Read the original file
-        table = pq.read_table(parquet_file)
+        # Use DuckDB COPY TO with KV_METADATA to preserve file properties
+        # This preserves bloom filters and native GEOMETRY logical type (fixes #433)
+        conn = duckdb.connect()
+        conn.execute("INSTALL spatial; LOAD spatial;")
 
-        # Update metadata
-        existing_metadata = table.schema.metadata or {}
-        new_metadata = {
-            k: v for k, v in existing_metadata.items() if not k.decode("utf-8").startswith("geo")
-        }
-        new_metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
+        # Escape the geo metadata JSON for DuckDB
+        geo_meta_escaped = _escape_json_for_duckdb(json.dumps(geo_meta))
 
-        # Create new table with updated metadata
-        new_table = table.replace_schema_metadata(new_metadata)
+        # Build COPY options
+        # Use GEOPARQUET_VERSION 'V2' if native geometry, 'NONE' otherwise
+        # (NONE means "don't touch the geometry column, just copy as-is with custom metadata")
+        geoparquet_version = "V2" if has_native_geometry else "NONE"
 
-        # Write to temporary file with same properties as original
-        pq.write_table(
-            new_table,
-            temp_file,
-            row_group_size=int(row_group_size),
-            compression=compression,
-            write_statistics=True,
-            use_dictionary=True,
-            version="2.6",
-            write_page_index=False,
-        )
+        copy_options = [
+            "FORMAT PARQUET",
+            f"COMPRESSION {compression}",
+            f"GEOPARQUET_VERSION '{geoparquet_version}'",
+            f"KV_METADATA {{geo: '{geo_meta_escaped}'}}",
+            f"ROW_GROUP_SIZE {row_group_size}",
+        ]
 
-        # Release references before file replace (Windows file locking)
-        del table, new_table
-        gc.collect()
+        copy_sql = f"""
+            COPY (SELECT * FROM '{parquet_file}')
+            TO '{temp_file}'
+            ({", ".join(copy_options)})
+        """
 
-        # Replace original file
+        if verbose:
+            debug(f"\nDuckDB COPY SQL:\n{copy_sql}")
+
+        conn.execute(copy_sql)
+        conn.close()
+
+        # Replace original file atomically
         os.replace(temp_file, parquet_file)
 
         success(f"✓ Added bbox covering metadata for column '{bbox_info['bbox_column_name']}'")

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -18,7 +18,11 @@ import os
 import duckdb
 
 from geoparquet_io.core.check_parquet_structure import get_compression_info, get_row_group_stats
-from geoparquet_io.core.common import check_bbox_structure, get_parquet_metadata
+from geoparquet_io.core.common import (
+    check_bbox_structure,
+    get_duckdb_connection,
+    get_parquet_metadata,
+)
 from geoparquet_io.core.exceptions import GeoParquetError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geo_metadata import parse_geo_metadata
@@ -32,12 +36,15 @@ def _is_remote_url(path: str) -> bool:
     return path.lower().startswith(remote_prefixes)
 
 
-def _detect_native_geometry(conn: duckdb.DuckDBPyConnection, parquet_file: str) -> bool:
+def _detect_native_geometry(
+    conn: duckdb.DuckDBPyConnection, parquet_file: str, geometry_column: str
+) -> bool:
     """Detect if the file uses native GEOMETRY logical type (GeoParquet 2.0).
 
     Args:
         conn: DuckDB connection (reused to avoid repeated INSTALL/LOAD)
         parquet_file: Path to the parquet file
+        geometry_column: Name of the geometry column to check
 
     Returns:
         True if the file has native GEOMETRY type, False otherwise
@@ -45,7 +52,7 @@ def _detect_native_geometry(conn: duckdb.DuckDBPyConnection, parquet_file: str) 
     result = conn.execute(f"""
         SELECT logical_type
         FROM parquet_schema('{parquet_file}')
-        WHERE name = 'geometry'
+        WHERE name = '{geometry_column}'
     """).fetchone()
 
     if result and result[0]:
@@ -198,11 +205,11 @@ def add_bbox_metadata(
     try:
         # Use DuckDB COPY TO with KV_METADATA to preserve file properties
         # This preserves bloom filters and native GEOMETRY logical type (fixes #433)
-        conn = duckdb.connect()
-        conn.execute("INSTALL spatial; LOAD spatial;")
+        conn = get_duckdb_connection()
 
         # Detect if file uses native GEOMETRY type (GeoParquet 2.0)
-        has_native_geometry = _detect_native_geometry(conn, safe_url)
+        # Pass the actual geometry column name - it might not be 'geometry'
+        has_native_geometry = _detect_native_geometry(conn, safe_url, primary_col)
 
         # Read existing KV metadata to preserve non-geo keys
         existing_kv = _get_existing_kv_metadata(conn, safe_url)

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -683,3 +683,133 @@ class TestAddBboxMetadataPreservesFileProperties:
         col_meta = geo_meta.get("columns", {}).get(primary_col, {})
         covering = col_meta.get("covering", {})
         assert "bbox" in covering, "covering.bbox should exist in geo metadata"
+
+    def test_preserves_existing_kv_metadata(self, tmp_path):
+        """Test that add bbox-metadata preserves non-geo KV metadata.
+
+        Regression test: DuckDB KV_METADATA replaces all metadata, so we must
+        explicitly preserve existing keys like 'pandas', 'ARROW:schema', and
+        custom application metadata.
+        """
+        import json
+
+        test_file = str(tmp_path / "test_with_custom_metadata.parquet")
+
+        # Create a GeoParquet file with custom metadata using DuckDB
+        # Use GEOPARQUET_VERSION to handle geometry encoding properly
+        conn = duckdb.connect()
+        conn.execute("INSTALL spatial; LOAD spatial;")
+
+        # First create with GEOPARQUET_VERSION to get proper geo metadata
+        conn.execute(f"""
+            COPY (
+                SELECT
+                    'test' AS name,
+                    STRUCT_PACK(
+                        xmin := -1.0::FLOAT,
+                        ymin := -1.0::FLOAT,
+                        xmax := 1.0::FLOAT,
+                        ymax := 1.0::FLOAT
+                    ) AS bbox,
+                    ST_Point(0, 0) AS geometry
+            ) TO '{test_file}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V1')
+        """)
+
+        # Read the geo metadata that DuckDB created
+        geo_meta_row = conn.execute(
+            f"SELECT value FROM parquet_kv_metadata('{test_file}') WHERE key = 'geo'"
+        ).fetchone()
+        geo_meta_value = geo_meta_row[0].decode("utf-8") if geo_meta_row else "{}"
+
+        # Now rewrite with additional custom metadata
+        temp_file = str(tmp_path / "temp_with_meta.parquet")
+        escaped_geo = geo_meta_value.replace("'", "''")
+        conn.execute(f"""
+            COPY (SELECT * FROM '{test_file}')
+            TO '{temp_file}' (
+                FORMAT PARQUET,
+                KV_METADATA {{
+                    geo: '{escaped_geo}',
+                    pandas: '{{"index_columns": [], "columns": []}}',
+                    custom_app: 'important_value_123',
+                    another_key: 'should_be_preserved'
+                }}
+            )
+        """)
+        conn.close()
+
+        # Use the file with custom metadata
+        import shutil
+
+        shutil.move(temp_file, test_file)
+
+        # BEFORE: Verify custom metadata exists
+        conn = duckdb.connect()
+        before_kv = conn.execute(
+            f"SELECT key, value FROM parquet_kv_metadata('{test_file}')"
+        ).fetchall()
+        conn.close()
+
+        before_keys = {k.decode("utf-8") if isinstance(k, bytes) else k for k, _ in before_kv}
+        assert "pandas" in before_keys, "BEFORE: Expected 'pandas' metadata"
+        assert "custom_app" in before_keys, "BEFORE: Expected 'custom_app' metadata"
+        assert "another_key" in before_keys, "BEFORE: Expected 'another_key' metadata"
+
+        # Run add bbox-metadata
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox-metadata", test_file, "--verbose"])
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Added bbox covering metadata" in result.output
+
+        # AFTER: Verify all metadata keys are preserved
+        conn = duckdb.connect()
+        after_kv = conn.execute(
+            f"SELECT key, value FROM parquet_kv_metadata('{test_file}')"
+        ).fetchall()
+        conn.close()
+
+        after_dict = {
+            (k.decode("utf-8") if isinstance(k, bytes) else k): (
+                v.decode("utf-8") if isinstance(v, bytes) else v
+            )
+            for k, v in after_kv
+        }
+
+        # Verify all original keys are preserved
+        assert "pandas" in after_dict, "AFTER: 'pandas' metadata was destroyed!"
+        assert "custom_app" in after_dict, "AFTER: 'custom_app' metadata was destroyed!"
+        assert "another_key" in after_dict, "AFTER: 'another_key' metadata was destroyed!"
+
+        # Verify values are preserved correctly
+        assert after_dict["custom_app"] == "important_value_123", (
+            f"AFTER: 'custom_app' value changed: {after_dict['custom_app']}"
+        )
+        assert after_dict["another_key"] == "should_be_preserved", (
+            f"AFTER: 'another_key' value changed: {after_dict['another_key']}"
+        )
+
+        # Verify geo metadata was updated with covering
+        geo_meta = json.loads(after_dict["geo"])
+        primary_col = geo_meta.get("primary_column", "geometry")
+        covering = geo_meta.get("columns", {}).get(primary_col, {}).get("covering", {})
+        assert "bbox" in covering, "covering.bbox should exist in updated geo metadata"
+
+    def test_rejects_remote_urls(self, tmp_path):
+        """Test that add bbox-metadata rejects remote URLs with clear error."""
+        from geoparquet_io.core.add.bbox_metadata import add_bbox_metadata
+        from geoparquet_io.core.exceptions import GeoParquetError
+
+        # Test various remote URL formats
+        remote_urls = [
+            "s3://bucket/file.parquet",
+            "gs://bucket/file.parquet",
+            "az://container/file.parquet",
+            "https://example.com/file.parquet",
+        ]
+
+        for url in remote_urls:
+            with pytest.raises(GeoParquetError) as exc_info:
+                add_bbox_metadata(url)
+            assert "Remote URLs are not supported" in str(exc_info.value), (
+                f"Expected clear error for {url}, got: {exc_info.value}"
+            )

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -583,3 +583,103 @@ class TestAddBboxCoveringMetadata:
         bbox_covering = covering["bbox"]
         assert bbox_covering.get("xmin") == ["bbox", "xmin"]
         assert bbox_covering.get("ymax") == ["bbox", "ymax"]
+
+
+class TestAddBboxMetadataPreservesFileProperties:
+    """Tests for issue #433: bbox-metadata must preserve bloom filters and GEOMETRY type."""
+
+    def test_preserves_bloom_filters_and_geometry_type(self, tmp_path):
+        """Test that add bbox-metadata preserves bloom filters and native GEOMETRY logical type.
+
+        Regression test for issue #433: gpio add bbox-metadata was using PyArrow
+        read_table/write_table which destroys bloom filters and drops the native
+        GEOMETRY logical type from GeoParquet 2.0 files.
+        """
+        import json
+
+        import pyarrow.parquet as pq
+
+        # Create a GeoParquet 2.0 file with DuckDB
+        # - 5000+ rows triggers bloom filter creation on VARCHAR columns
+        # - GEOPARQUET_VERSION 'V2' writes native GEOMETRY logical type
+        test_file = str(tmp_path / "test_v2_with_bloom.parquet")
+
+        conn = duckdb.connect()
+        conn.execute("INSTALL spatial; LOAD spatial;")
+        conn.execute(f"""
+            COPY (
+                SELECT
+                    'name_' || (i % 50) AS name,
+                    STRUCT_PACK(
+                        xmin := ST_XMin(geometry)::FLOAT,
+                        ymin := ST_YMin(geometry)::FLOAT,
+                        xmax := ST_XMax(geometry)::FLOAT,
+                        ymax := ST_YMax(geometry)::FLOAT
+                    ) AS bbox,
+                    geometry
+                FROM (
+                    SELECT i, ST_Point(i * 0.001, i * 0.001) AS geometry
+                    FROM range(5000) t(i)
+                )
+            ) TO '{test_file}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+        """)
+        conn.close()
+
+        # BEFORE: Verify bloom filter and GEOMETRY type exist
+        # Check bloom filter on 'name' column
+        conn = duckdb.connect()
+        bloom_before = conn.execute(f"""
+            SELECT bloom_filter_offset IS NOT NULL AS has_bloom
+            FROM parquet_metadata('{test_file}')
+            WHERE path_in_schema = 'name'
+            LIMIT 1
+        """).fetchone()[0]
+
+        # Check GEOMETRY logical type
+        schema_before = conn.execute(f"""
+            SELECT logical_type
+            FROM parquet_schema('{test_file}')
+            WHERE name = 'geometry'
+        """).fetchone()[0]
+        conn.close()
+
+        assert bloom_before, "BEFORE: Expected bloom filter on 'name' column"
+        assert schema_before is not None, "BEFORE: Expected GEOMETRY logical type"
+        assert "Geometry" in str(schema_before), (
+            f"BEFORE: Expected GeometryType, got {schema_before}"
+        )
+
+        # Run add bbox-metadata
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox-metadata", test_file, "--verbose"])
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Added bbox covering metadata" in result.output
+
+        # AFTER: Verify bloom filter and GEOMETRY type are preserved
+        conn = duckdb.connect()
+        bloom_after = conn.execute(f"""
+            SELECT bloom_filter_offset IS NOT NULL AS has_bloom
+            FROM parquet_metadata('{test_file}')
+            WHERE path_in_schema = 'name'
+            LIMIT 1
+        """).fetchone()[0]
+
+        schema_after = conn.execute(f"""
+            SELECT logical_type
+            FROM parquet_schema('{test_file}')
+            WHERE name = 'geometry'
+        """).fetchone()[0]
+        conn.close()
+
+        # These assertions will FAIL on current code (issue #433)
+        assert bloom_after, "AFTER: Bloom filter on 'name' column was destroyed!"
+        assert schema_after is not None, "AFTER: GEOMETRY logical type was dropped!"
+        assert "Geometry" in str(schema_after), f"AFTER: Expected GeometryType, got {schema_after}"
+
+        # Also verify the covering metadata was actually added
+        pf = pq.ParquetFile(test_file)
+        geo_meta = json.loads(pf.schema_arrow.metadata.get(b"geo", b"{}"))
+        primary_col = geo_meta.get("primary_column", "geometry")
+        col_meta = geo_meta.get("columns", {}).get(primary_col, {})
+        covering = col_meta.get("covering", {})
+        assert "bbox" in covering, "covering.bbox should exist in geo metadata"


### PR DESCRIPTION
## Summary

Fixes #433: `gpio add bbox-metadata` was silently destroying bloom filters and the native GEOMETRY logical type when updating GeoParquet files.

**Root cause:** The previous implementation used PyArrow's `read_table()` → `write_table()` cycle, which:
1. Doesn't preserve bloom filters (PyArrow only writes them with explicit options)
2. Doesn't preserve Parquet extension types like `GeometryType`

**Fix:** Replace PyArrow with DuckDB `COPY TO` using `KV_METADATA` option, which preserves all file properties while allowing metadata injection.

## Changes

- **`bbox_metadata.py`**: Complete rewrite to use DuckDB COPY instead of PyArrow
  - Detects native GEOMETRY type and uses `GEOPARQUET_VERSION 'V2'` when present
  - Preserves compression, row group size, bloom filters
  - Added `write_strategy` parameter for API consistency

- **`test_add.py`**: New regression test class `TestAddBboxMetadataPreservesFileProperties`
  - Creates GeoParquet 2.0 file with 5000+ rows (triggers bloom filter creation)
  - Verifies bloom filters and GEOMETRY type survive the operation

## Test plan

- [x] New regression test passes: `test_preserves_bloom_filters_and_geometry_type`
- [x] All existing bbox-metadata tests pass (3 tests)
- [x] All add command tests pass (30 tests)
- [x] Pre-commit hooks pass (ruff, duckdb-antipatterns, no-click-echo, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bbox metadata addition now preserves file-level properties (bloom filters, native geometry types) and existing non-geo metadata; updates geo covering info without losing other KV entries.
  * Writes updates via an atomic rewrite to avoid partial corruption.
  * CLI now rejects remote URLs with a clear error.

* **Tests**
  * Added regression tests verifying preservation of file properties, KV metadata, and remote-URL rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geoparquet/geoparquet-io/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->