### PR TITLE
docs(convert): clarify geometry column is auto-detected

### DIFF
--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -272,9 +272,11 @@ GeoParquet files can have multiple geometry columns (e.g., `geometry` for point 
 !!! note "Bbox and Hilbert Ordering"
     Bbox computation and Hilbert spatial ordering use the **primary geometry column only**. Secondary geometry columns are preserved but do not influence spatial indexing.
 
-### Custom Geometry Column Names
+### Geometry Column Detection
 
-GeoParquet files can use non-standard geometry column names (e.g., `the_geom`, `my_geometry`). These names are preserved during conversion:
+The geometry column is auto-detected — you don't need to name it `geometry`. Detection is case-insensitive and recognizes the standard names `geometry`, `geom`, `wkb_geometry`, `shape`, and `the_geom`. For GeoParquet input, whatever name is recorded in the file's `primary_column` metadata is used (so any name works).
+
+For GeoParquet → GeoParquet conversion, the original geometry column name is preserved on output:
 
 === "CLI"
 
@@ -292,10 +294,6 @@ GeoParquet files can use non-standard geometry column names (e.g., `the_geom`, `
     # Input has primary_column: "the_geom"
     # Output preserves "the_geom" (not renamed to "geometry")
     gpio.convert('input.parquet').write('output.parquet')
-
-    # Custom geometry column names are automatically detected
-    # For files without GeoParquet metadata, specify the column:
-    gpio.convert('input.parquet', geometry_column='the_geom').write('output.parquet')
     ```
 
 ## Remote Files

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -228,11 +228,19 @@ See the [Write Strategies Guide](guide/write-strategies.md) for detailed informa
 
 **Symptom**: Error about missing geometry column.
 
+`gpio convert` auto-detects geometry columns named `geometry`, `geom`,
+`wkb_geometry`, `shape`, or `the_geom` (case-insensitive), and reads the
+`primary_column` from GeoParquet metadata when present. You should only see this
+error if the column has a truly non-standard name.
+
 **Solutions**:
 
-1. Verify file is actually GeoParquet: `gpio inspect file.parquet`
-2. Check if geometry column has a different name
-3. Specify geometry column explicitly if supported
+1. Verify the file is actually spatial: `gpio inspect file.parquet`
+2. Check the column name with `ogrinfo -so` (for OGR formats) or
+   `gpio inspect meta` (for Parquet) — if it matches a standard name, file an issue
+3. For CSV/TSV, pass `--wkt-column` or `--lat-column`/`--lon-column`
+4. For non-CSV inputs with a non-standard column name, rename the column upstream
+   (no `--geometry-column` flag exists for `gpio convert` today)
 
 ### CRS Warning: Coordinates Look Wrong
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -287,9 +287,18 @@ def convert(
     Unlike the CLI convert command, this does NOT apply Hilbert sorting by default.
     Chain .sort_hilbert() explicitly if you want spatial ordering.
 
+    The input geometry column is auto-detected — you do NOT need it to be named
+    `geometry`. Detection is case-insensitive and matches any of:
+    `geometry`, `geom`, `wkb_geometry`, `shape`, `the_geom`. For GeoParquet input,
+    the column recorded in `primary_column` metadata is used (any name works).
+    For CSV/TSV, use `wkt_column` or `lat_column`/`lon_column` instead.
+
     Args:
         path: Path to input file (local or S3 URL)
-        geometry_column: Name for geometry column in output (default: 'geometry')
+        geometry_column: Label used for the returned Table's geometry attribute.
+            Does NOT control input detection (input is auto-detected) and does NOT
+            rename the column in the underlying Arrow data. Most callers should
+            leave this at the default.
         wkt_column: For CSV: column containing WKT geometry
         lat_column: For CSV: latitude column
         lon_column: For CSV: longitude column

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1087,6 +1087,11 @@ def read_spatial_to_arrow(
     This is the core reading function used by both the Python API and CLI.
     Does NOT apply Hilbert sorting or bbox column - those are chainable operations.
 
+    The input geometry column is auto-detected from standard names
+    (`geometry`, `geom`, `wkb_geometry`, `shape`, `the_geom`, case-insensitive)
+    or, for GeoParquet input, from the `primary_column` metadata. For CSV/TSV,
+    pass `wkt_column` or `lat_column`/`lon_column` to identify the geometry source.
+
     Args:
         input_file: Path to input file (GeoPackage, GeoJSON, Shapefile, CSV/TSV, etc.)
         verbose: Print detailed progress
@@ -1097,7 +1102,9 @@ def read_spatial_to_arrow(
         crs: CRS for CSV geometry data (default: EPSG:4326/WGS84)
         skip_invalid: Skip rows with invalid geometries instead of failing
         profile: AWS profile name for S3 operations
-        geometry_column: Name for output geometry column (default: 'geometry')
+        geometry_column: Label returned as the third tuple element. Does NOT
+            influence input detection (input is always auto-detected) and does NOT
+            rename the underlying Arrow column.
         layer: Layer name for multi-layer formats (GeoPackage, FileGDB). If not specified,
                reads the first/default layer.
 


### PR DESCRIPTION
## Summary

A docs/docstring fix to correct a misconception that `gpio convert` requires the input geometry column to be named `geometry`. It doesn't — the column is auto-detected.

## Why

While converting a Dutch BRP FileGDB whose geometry column is `Shape`, a Claude Code session concluded "gpio's convert needs the geom column to be named `geometry`." The conversion in fact worked fine (case-insensitive match against `shape` in `STANDARD_GEOMETRY_NAMES`). Tracing where the agent got that idea surfaced three real sources of confusion in our own docs and code:

1. **`api/table.py:271`** — `def convert(..., geometry_column: str = "geometry", ...)`. The default value `"geometry"` reads like an input requirement. The docstring said "Name for geometry column in output (default: 'geometry')", but the parameter doesn't actually control input detection AND doesn't rename the underlying Arrow column (`_read_spatial_to_arrow` hardcodes `AS geometry` at convert.py:1308). It only sets the label returned as the third tuple element / stored on the `Table` object.

2. **`docs/guide/convert.md:296-298`** — under "Custom Geometry Column Names":
   ```python
   # Custom geometry column names are automatically detected
   # For files without GeoParquet metadata, specify the column:
   gpio.convert('input.parquet', geometry_column='the_geom').write('output.parquet')
   ```
   This contradicts itself (auto-detected vs specify it) and pointed at a parameter that doesn't do what the comment implies. The example also used `.parquet` after introducing "files without GeoParquet metadata".

3. **`docs/troubleshooting.md:227-235`** — "No geometry column found" suggested "Specify geometry column explicitly if supported" without saying when that's supported.

## What changed

- `geoparquet_io/api/table.py` — `convert()` docstring now states input is auto-detected, lists the recognized standard names, and is explicit that `geometry_column=` does NOT control detection or rename the column.
- `geoparquet_io/core/convert.py` — same treatment for `read_spatial_to_arrow()`.
- `docs/guide/convert.md` — renamed the section to "Geometry Column Detection", listed the standard names, removed the misleading Python example, kept the GeoParquet name-preservation example.
- `docs/troubleshooting.md` — "No geometry column found" now explains the auto-detection up front and gives actionable next steps (use `ogrinfo` / `gpio inspect meta`, use `--wkt-column` for CSV, rename upstream as a last resort).

## Follow-up (not in this PR)

The `geometry_column` parameter on `gpio.convert()` / `read_spatial_to_arrow()` appears to be a near-dead knob: the underlying Arrow column is always named `geometry` (hardcoded in `_read_spatial_to_arrow`), so passing `geometry_column='custom'` produces a `Table` whose `geometry_column` attribute points at a column that does not exist in the Arrow data. Worth either fixing it to actually rename the output column or removing the parameter, but that's a behavior change and out of scope for a docs PR.

## Test plan

- [x] `uv run ruff check` on touched files — passes
- [x] Pre-commit hooks (ruff, codespell, doc-sync, etc.) — all passed at commit time
- [x] Verified actual behavior: `gpio convert geoparquet BRP_Gewaspercelen_2009.gdb out.parquet` succeeds on a FileGDB whose geometry column is `Shape` (819K rows, valid GeoParquet output)
- [ ] Reviewer spot-check that the new convert.md section still renders correctly under the tabbed format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated guidance on geometry column auto-detection, now specifying recognized standard column names and GeoParquet metadata handling.
  * Enhanced troubleshooting documentation with step-by-step solutions for geometry column detection issues, including column inspection methods and alternative column specifications.
  * Clarified that the geometry column parameter only affects output labeling without renaming underlying data columns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geoparquet/geoparquet-io/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->