### PR TITLE
fix(wfs): handle empty/null properties in GeoJSON features

### DIFF
--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+import duckdb
 import pyarrow as pa
 
 # Public API
@@ -1066,6 +1067,97 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
         con.close()
 
 
+def _probe_properties_type(
+    con: duckdb.DuckDBPyConnection, safe_path: str, max_object_size: int
+) -> tuple[str, bool]:
+    """
+    Probe the type of feature.properties to determine if unnest() will work.
+
+    Empty properties ({}) become MAP(VARCHAR, JSON), null properties become JSON,
+    missing properties key raises an error - none can be unnested.
+    Only STRUCT types support unnest().
+
+    Args:
+        con: DuckDB connection with spatial extension loaded
+        safe_path: Path to the GeoJSON file (already escaped for SQL)
+        max_object_size: Maximum JSON object size for read_json_auto
+
+    Returns:
+        Tuple of (props_type string, can_unnest_props bool)
+
+    See: https://github.com/geoparquet/geoparquet-io/issues/441
+    """
+    try:
+        props_type_result = con.execute(f"""
+            WITH features AS (
+                SELECT unnest(features) AS feature
+                FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
+            )
+            SELECT typeof(feature.properties) AS props_type
+            FROM features
+            LIMIT 1
+        """).fetchone()
+        props_type = props_type_result[0] if props_type_result else "NULL"
+    except duckdb.BinderException as e:
+        # Missing 'properties' key in feature struct (malformed GeoJSON per RFC 7946)
+        if "properties" in str(e):
+            props_type = "MISSING"
+        else:
+            raise
+
+    can_unnest_props = props_type.startswith("STRUCT")
+    return props_type, can_unnest_props
+
+
+def _build_wfs_feature_query(
+    safe_path: str, extract_fid: bool, can_unnest_props: bool, max_object_size: int
+) -> str:
+    """
+    Build SQL query to extract WFS features from GeoJSON.
+
+    Args:
+        safe_path: Path to the GeoJSON file (already escaped for SQL)
+        extract_fid: If True, include feature.id as _wfs_fid column
+        can_unnest_props: If True, unnest properties into columns; otherwise geometry-only
+        max_object_size: Maximum JSON object size for read_json_auto
+
+    Returns:
+        SQL query string
+    """
+    fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
+    fid_select = "_wfs_fid," if extract_fid else ""
+
+    if can_unnest_props:
+        # Normal path: unnest properties into separate columns
+        return f"""
+            WITH features AS (
+                SELECT unnest(features) AS feature
+                FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
+            ),
+            extracted AS (
+                SELECT
+                    {fid_col}
+                    ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
+                    feature.properties AS props
+                FROM features
+            )
+            SELECT {fid_select} geometry, unnest(props) FROM extracted
+        """
+    else:
+        # Fallback: properties are empty/null/missing (MAP, JSON, or MISSING type),
+        # return geometry-only table
+        return f"""
+            WITH features AS (
+                SELECT unnest(features) AS feature
+                FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
+            )
+            SELECT
+                {fid_col}
+                ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry
+            FROM features
+        """
+
+
 def _fetch_wfs_page(
     url: str, extract_fid: bool = False, max_retries: int = 3, retry_delay: float = 2.0
 ) -> pa.Table:
@@ -1186,57 +1278,15 @@ def _fetch_wfs_page(
             debug("Empty response, returning empty table")
             return pa.table({"geometry": pa.array([], type=pa.binary())})
 
-        # Detect property type to determine if unnest() will work.
-        # Empty properties ({}) become MAP(VARCHAR, JSON), null properties
-        # become JSON - neither can be unnested. Only STRUCT types work.
-        # See: https://github.com/geoparquet/geoparquet-io/issues/441
-        props_type_result = con.execute(f"""
-            WITH features AS (
-                SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
-            )
-            SELECT typeof(feature.properties) AS props_type
-            FROM features
-            LIMIT 1
-        """).fetchone()
-        props_type = props_type_result[0] if props_type_result else "NULL"
-        can_unnest_props = props_type.startswith("STRUCT")
-
-        # Extract features with geometry conversion
-        fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
-        fid_select = "_wfs_fid," if extract_fid else ""
-        parse_start = time.time()
-
-        if can_unnest_props:
-            # Normal path: unnest properties into separate columns
-            query = f"""
-                WITH features AS (
-                    SELECT unnest(features) AS feature
-                    FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
-                ),
-                extracted AS (
-                    SELECT
-                        {fid_col}
-                        ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
-                        feature.properties AS props
-                    FROM features
-                )
-                SELECT {fid_select} geometry, unnest(props) FROM extracted
-            """
-        else:
-            # Fallback: properties are empty/null (MAP or JSON type),
-            # return geometry-only table
+        # Detect property type and build extraction query
+        props_type, can_unnest_props = _probe_properties_type(con, safe_path, _MAX_JSON_OBJECT_SIZE)
+        if not can_unnest_props:
             debug(f"Properties type is {props_type}, cannot unnest - returning geometry-only table")
-            query = f"""
-                WITH features AS (
-                    SELECT unnest(features) AS feature
-                    FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
-                )
-                SELECT
-                    {fid_col}
-                    ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry
-                FROM features
-            """
+
+        parse_start = time.time()
+        query = _build_wfs_feature_query(
+            safe_path, extract_fid, can_unnest_props, _MAX_JSON_OBJECT_SIZE
+        )
 
         result = con.execute(query)
         table = result.arrow().read_all()

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1186,24 +1186,58 @@ def _fetch_wfs_page(
             debug("Empty response, returning empty table")
             return pa.table({"geometry": pa.array([], type=pa.binary())})
 
+        # Detect property type to determine if unnest() will work.
+        # Empty properties ({}) become MAP(VARCHAR, JSON), null properties
+        # become JSON - neither can be unnested. Only STRUCT types work.
+        # See: https://github.com/geoparquet/geoparquet-io/issues/441
+        props_type_result = con.execute(f"""
+            WITH features AS (
+                SELECT unnest(features) AS feature
+                FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
+            )
+            SELECT typeof(feature.properties) AS props_type
+            FROM features
+            LIMIT 1
+        """).fetchone()
+        props_type = props_type_result[0] if props_type_result else "NULL"
+        can_unnest_props = props_type.startswith("STRUCT")
+
         # Extract features with geometry conversion
         fid_col = "feature.id AS _wfs_fid," if extract_fid else ""
         fid_select = "_wfs_fid," if extract_fid else ""
         parse_start = time.time()
-        query = f"""
-            WITH features AS (
-                SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
-            ),
-            extracted AS (
+
+        if can_unnest_props:
+            # Normal path: unnest properties into separate columns
+            query = f"""
+                WITH features AS (
+                    SELECT unnest(features) AS feature
+                    FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
+                ),
+                extracted AS (
+                    SELECT
+                        {fid_col}
+                        ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
+                        feature.properties AS props
+                    FROM features
+                )
+                SELECT {fid_select} geometry, unnest(props) FROM extracted
+            """
+        else:
+            # Fallback: properties are empty/null (MAP or JSON type),
+            # return geometry-only table
+            debug(f"Properties type is {props_type}, cannot unnest - returning geometry-only table")
+            query = f"""
+                WITH features AS (
+                    SELECT unnest(features) AS feature
+                    FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
+                )
                 SELECT
                     {fid_col}
-                    ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry,
-                    feature.properties AS props
+                    ST_AsWKB(ST_GeomFromGeoJSON(feature.geometry)) AS geometry
                 FROM features
-            )
-            SELECT {fid_select} geometry, unnest(props) FROM extracted
-        """
+            """
+
         result = con.execute(query)
         table = result.arrow().read_all()
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1511,6 +1511,40 @@ class TestEmptyProperties:
         assert "geometry" in result.column_names
         assert "value" in result.column_names
 
+    def test_missing_properties_key_returns_geometry_only(self):
+        """Missing properties key (malformed GeoJSON) should return geometry-only table.
+
+        Per RFC 7946, the 'properties' member is required, but we handle
+        malformed GeoJSON gracefully by returning geometry-only results.
+        """
+        import json
+
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    # No 'properties' key - malformed per RFC 7946
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                },
+            ],
+        }
+
+        with self._make_mock_stream(json.dumps(geojson).encode()):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 2
+        assert result.column_names == ["geometry"]
+
 
 class TestAutoPageSingleWorker:
     """Test that single-worker mode auto-paginates for large datasets."""

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1311,6 +1311,207 @@ class TestContentTypeValidation:
             assert result.num_rows == 0
 
 
+class TestEmptyProperties:
+    """Test handling of empty/null properties in GeoJSON features.
+
+    When WFS features have empty properties ({}) or null properties,
+    DuckDB infers MAP(VARCHAR, JSON) or JSON types instead of STRUCT.
+    The unnest() function doesn't support these types, so we fall back
+    to returning geometry-only tables.
+
+    See: https://github.com/geoparquet/geoparquet-io/issues/441
+    """
+
+    def _make_mock_stream(self, geojson_bytes: bytes):
+        """Create a mock httpx stream response."""
+        import httpx
+
+        def mock_stream(*args, **kwargs):
+            class MockResponse:
+                status_code = 200
+                headers = {"content-type": "application/json"}
+
+                def raise_for_status(self):
+                    pass
+
+                def iter_bytes(self, chunk_size=None):
+                    yield geojson_bytes
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+            return MockResponse()
+
+        return patch.object(httpx.Client, "stream", mock_stream)
+
+    def test_empty_properties_returns_geometry_only(self):
+        """Empty properties ({}) should return geometry-only table."""
+        import json
+
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {},
+                },
+            ],
+        }
+
+        with self._make_mock_stream(json.dumps(geojson).encode()):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 2
+        assert "geometry" in result.column_names
+        # No property columns - only geometry
+        assert result.column_names == ["geometry"]
+
+    def test_null_properties_returns_geometry_only(self):
+        """Null properties should return geometry-only table."""
+        import json
+
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": None,
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": None,
+                },
+            ],
+        }
+
+        with self._make_mock_stream(json.dumps(geojson).encode()):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 2
+        assert result.column_names == ["geometry"]
+
+    def test_empty_properties_with_extract_fid(self):
+        """Empty properties with extract_fid=True should include _wfs_fid."""
+        import json
+
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "line.1",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {},
+                },
+                {
+                    "type": "Feature",
+                    "id": "line.2",
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {},
+                },
+            ],
+        }
+
+        with self._make_mock_stream(json.dumps(geojson).encode()):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS", extract_fid=True)
+
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 2
+        assert "_wfs_fid" in result.column_names
+        assert "geometry" in result.column_names
+        assert result.column_names == ["_wfs_fid", "geometry"]
+
+    def test_normal_properties_still_works(self):
+        """Normal properties should still be unnested into columns."""
+        import json
+
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {"name": "A", "population": 100},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {"name": "B", "population": 200},
+                },
+            ],
+        }
+
+        with self._make_mock_stream(json.dumps(geojson).encode()):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 2
+        assert "geometry" in result.column_names
+        assert "name" in result.column_names
+        assert "population" in result.column_names
+
+    def test_heterogeneous_value_types_still_works(self):
+        """Heterogeneous value types (promoted to JSON) should still work."""
+        import json
+
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "properties": {"value": 123},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [1, 1]},
+                    "properties": {"value": "text"},
+                },
+            ],
+        }
+
+        with self._make_mock_stream(json.dumps(geojson).encode()):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 2
+        assert "geometry" in result.column_names
+        assert "value" in result.column_names
+
+
 class TestAutoPageSingleWorker:
     """Test that single-worker mode auto-paginates for large datasets."""
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -5,6 +5,7 @@ Tests use mocked HTTP responses to avoid network dependencies.
 Network tests are marked separately for optional integration testing.
 """
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1723,7 +1724,10 @@ class TestAutoPageSingleWorker:
                     page_size=10000,
                 )
 
-    @pytest.mark.xfail(reason="DuckDB resource contention in pytest-xdist workers", strict=False)
+    @pytest.mark.skipif(
+        os.environ.get("PYTEST_XDIST_WORKER") is not None,
+        reason="DuckDB resource contention crashes pytest-xdist workers",
+    )
     def test_startindex_limit_allows_small_datasets(self):
         """When total features fit within the startIndex limit, should proceed."""
         import pyarrow as pa
@@ -1751,7 +1755,10 @@ class TestAutoPageSingleWorker:
 
         assert result.num_rows > 0
 
-    @pytest.mark.xfail(reason="DuckDB resource contention in pytest-xdist workers", strict=False)
+    @pytest.mark.skipif(
+        os.environ.get("PYTEST_XDIST_WORKER") is not None,
+        reason="DuckDB resource contention crashes pytest-xdist workers",
+    )
     def test_no_startindex_limit_proceeds_normally(self):
         """When server has no startIndex limit, pagination should proceed."""
         import pyarrow as pa


### PR DESCRIPTION
## Summary

Fixes WFS extraction crashing when features have empty (`{}`) or null properties.

- **Root cause**: DuckDB infers `MAP(VARCHAR, JSON)` or `JSON` for empty/null properties instead of `STRUCT`. The `unnest()` function doesn't support these types, causing a Binder Error.
- **Fix**: Detect the inferred type before unnesting; fall back to geometry-only extraction when properties can't be unnested.

## Changes

- Add type detection query in `_fetch_wfs_page()` to check if `feature.properties` is a `STRUCT`
- Add fallback geometry-only query path for `MAP`/`JSON` property types
- Add 6 regression tests covering empty, null, and heterogeneous property scenarios

## Test plan

- [x] All 152 existing WFS tests pass
- [x] 6 new tests for empty/null property handling
- [x] Pre-commit hooks pass

## Reproduction

```bash
# This previously crashed with "UNNEST() can only be applied to lists, structs and NULL, not MAP(VARCHAR, JSON)"
gpio extract wfs \
  'https://gislocal.md/geoserver/apl/wfs' \
  --layer apl:s0100_red_lines \
  --output /tmp/red_lines.parquet
```

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient handling of WFS GeoJSON features with empty, null, or missing properties — avoids extraction failures, returns geometry-only results when properties cannot be processed, and preserves feature IDs when requested.

* **Tests**
  * Added tests covering empty/null/missing properties, heterogeneous value types, and geometry-only behavior; updated pagination tests to avoid crashes in parallel test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geoparquet/geoparquet-io/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->