### PR TITLE
fix(sort): handle empty/null geometries in Hilbert ordering

### DIFF
--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -49,6 +49,9 @@ def hilbert_order_table(
 
     This is the table-centric version for the Python API.
 
+    Empty or NULL geometries are placed at the end of the result since they
+    have no spatial extent and cannot be assigned a Hilbert curve index.
+
     Args:
         table: Input PyArrow Table
         geometry_column: Geometry column name (auto-detected if None)
@@ -82,7 +85,21 @@ def hilbert_order_table(
         else:
             source_ref = "__input_table"
 
-        # Calculate dataset bounds
+        # Count empty/null geometries to handle them separately
+        # ST_IsEmpty returns TRUE for empty geometries, NULL for NULL geometries
+        empty_count_result = con.execute(f"""
+            SELECT COUNT(*) FROM {source_ref}
+            WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+        """).fetchone()
+        empty_count = empty_count_result[0] if empty_count_result else 0
+
+        if empty_count > 0:
+            warn(
+                f"Found {empty_count} empty/null geometries. "
+                "These will be placed at the end of the sorted output."
+            )
+
+        # Calculate dataset bounds from non-empty geometries only
         bounds_result = con.execute(f"""
             SELECT
                 MIN(ST_XMin("{geom_col}")) as xmin,
@@ -90,10 +107,13 @@ def hilbert_order_table(
                 MAX(ST_XMax("{geom_col}")) as xmax,
                 MAX(ST_YMax("{geom_col}")) as ymax
             FROM {source_ref}
+            WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
         """).fetchone()
 
+        # If all geometries are empty/null, return table unchanged
         if not bounds_result or any(v is None for v in bounds_result):
-            raise ValueError("Could not calculate dataset bounds from table")
+            warn("All geometries are empty or null. Returning table without Hilbert ordering.")
+            return table
 
         xmin, ymin, xmax, ymax = bounds_result
 
@@ -101,22 +121,32 @@ def hilbert_order_table(
         other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
         select_cols = ", ".join(other_cols) if other_cols else ""
 
-        # Build Hilbert ordering query with geometry converted back to WKB
+        # Build column selection with WKB conversion
         if select_cols:
-            query = f"""
-                SELECT {select_cols},
-                       ST_AsWKB("{geom_col}") AS "{geom_col}"
-                FROM {source_ref}
-                ORDER BY ST_Hilbert("{geom_col}",
-                    ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
-            """
+            wkb_select = f'{select_cols}, ST_AsWKB("{geom_col}") AS "{geom_col}"'
         else:
-            query = f"""
-                SELECT ST_AsWKB("{geom_col}") AS "{geom_col}"
+            wkb_select = f'ST_AsWKB("{geom_col}") AS "{geom_col}"'
+
+        # Build Hilbert ordering query that handles empty geometries:
+        # 1. Non-empty geometries are ordered by Hilbert curve
+        # 2. Empty/null geometries are appended at the end
+        query = f"""
+            WITH non_empty AS (
+                SELECT {wkb_select}
                 FROM {source_ref}
+                WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
                 ORDER BY ST_Hilbert("{geom_col}",
                     ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
-            """
+            ),
+            empty_or_null AS (
+                SELECT {wkb_select}
+                FROM {source_ref}
+                WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+            )
+            SELECT * FROM non_empty
+            UNION ALL
+            SELECT * FROM empty_or_null
+        """
         result = con.execute(query).arrow().read_all()
 
         # Preserve metadata
@@ -290,7 +320,20 @@ def _hilbert_order_streaming(
             debug(f"Using geometry column: {geom_col}")
             debug("Calculating dataset bounds for Hilbert ordering...")
 
-        # Calculate dataset bounds
+        # Count empty/null geometries
+        empty_count_result = con.execute(f"""
+            SELECT COUNT(*) FROM {source}
+            WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+        """).fetchone()
+        empty_count = empty_count_result[0] if empty_count_result else 0
+
+        if empty_count > 0:
+            warn(
+                f"Found {empty_count} empty/null geometries. "
+                "These will be placed at the end of the sorted output."
+            )
+
+        # Calculate dataset bounds from non-empty geometries only
         bounds_result = con.execute(f"""
             SELECT
                 MIN(ST_XMin("{geom_col}")) as xmin,
@@ -298,6 +341,7 @@ def _hilbert_order_streaming(
                 MAX(ST_XMax("{geom_col}")) as xmax,
                 MAX(ST_YMax("{geom_col}")) as ymax
             FROM {source}
+            WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
         """).fetchone()
 
         if not bounds_result or any(v is None for v in bounds_result):
@@ -308,11 +352,22 @@ def _hilbert_order_streaming(
             debug(f"Dataset bounds: ({xmin:.6f}, {ymin:.6f}, {xmax:.6f}, {ymax:.6f})")
             debug("Reordering data using Hilbert curve...")
 
-        # Build Hilbert ordering query
+        # Build Hilbert ordering query with empty geometry handling
+        # Non-empty geometries are ordered by Hilbert curve, empty/null appended at end
         query = f"""
-            SELECT * FROM {source}
-            ORDER BY ST_Hilbert("{geom_col}",
-                ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
+            WITH non_empty AS (
+                SELECT * FROM {source}
+                WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
+                ORDER BY ST_Hilbert("{geom_col}",
+                    ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
+            ),
+            empty_or_null AS (
+                SELECT * FROM {source}
+                WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+            )
+            SELECT * FROM non_empty
+            UNION ALL
+            SELECT * FROM empty_or_null
         """
 
         if verbose:
@@ -380,6 +435,20 @@ def _hilbert_order_file_based(
     if verbose:
         debug("Calculating dataset bounds for Hilbert ordering...")
 
+    # Count empty/null geometries
+    empty_count_result = con.execute(f"""
+        SELECT COUNT(*) FROM '{safe_url}'
+        WHERE {geometry_column} IS NULL OR ST_IsEmpty({geometry_column})
+    """).fetchone()
+    empty_count = empty_count_result[0] if empty_count_result else 0
+
+    if empty_count > 0:
+        warn(
+            f"Found {empty_count} empty/null geometries. "
+            "These will be placed at the end of the sorted output."
+        )
+
+    # Get bounds from non-empty geometries only
     bounds = get_dataset_bounds(working_parquet, geometry_column, verbose=verbose)
     if not bounds:
         raise GeoParquetError("Could not calculate dataset bounds")
@@ -389,10 +458,22 @@ def _hilbert_order_file_based(
         debug(f"Dataset bounds: ({xmin:.6f}, {ymin:.6f}, {xmax:.6f}, {ymax:.6f})")
         debug("Reordering data using Hilbert curve...")
 
+    # Build Hilbert ordering query with empty geometry handling
+    # Non-empty geometries are ordered by Hilbert curve, empty/null appended at end
     order_query = f"""
-        SELECT * FROM '{safe_url}'
-        ORDER BY ST_Hilbert({geometry_column},
-            ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
+        WITH non_empty AS (
+            SELECT * FROM '{safe_url}'
+            WHERE {geometry_column} IS NOT NULL AND NOT ST_IsEmpty({geometry_column})
+            ORDER BY ST_Hilbert({geometry_column},
+                ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
+        ),
+        empty_or_null AS (
+            SELECT * FROM '{safe_url}'
+            WHERE {geometry_column} IS NULL OR ST_IsEmpty({geometry_column})
+        )
+        SELECT * FROM non_empty
+        UNION ALL
+        SELECT * FROM empty_or_null
     """
 
     try:

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -14,7 +14,7 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import RemoteAccessError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geo_metadata import DEFAULT_GEOPARQUET_VERSION
@@ -63,6 +63,7 @@ def hilbert_order_table(
     geom_col = geometry_column or find_geometry_column_from_table(table)
     if not geom_col:
         geom_col = "geometry"
+    quoted_geom = quote_identifier(geom_col)
 
     # Register table and execute query
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
@@ -75,8 +76,8 @@ def hilbert_order_table(
 
         if geom_is_blob and geom_col in table.column_names:
             # Quote column names to handle special characters (colons, spaces, etc.)
-            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-            col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+            other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+            col_defs = other_cols + [f"ST_GeomFromWKB({quoted_geom}) AS {quoted_geom}"]
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
             )
@@ -89,7 +90,7 @@ def hilbert_order_table(
         # ST_IsEmpty returns TRUE for empty geometries, NULL for NULL geometries
         empty_count_result = con.execute(f"""
             SELECT COUNT(*) FROM {source_ref}
-            WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+            WHERE {quoted_geom} IS NULL OR ST_IsEmpty({quoted_geom})
         """).fetchone()
         empty_count = empty_count_result[0] if empty_count_result else 0
 
@@ -102,12 +103,12 @@ def hilbert_order_table(
         # Calculate dataset bounds from non-empty geometries only
         bounds_result = con.execute(f"""
             SELECT
-                MIN(ST_XMin("{geom_col}")) as xmin,
-                MIN(ST_YMin("{geom_col}")) as ymin,
-                MAX(ST_XMax("{geom_col}")) as xmax,
-                MAX(ST_YMax("{geom_col}")) as ymax
+                MIN(ST_XMin({quoted_geom})) as xmin,
+                MIN(ST_YMin({quoted_geom})) as ymin,
+                MAX(ST_XMax({quoted_geom})) as xmax,
+                MAX(ST_YMax({quoted_geom})) as ymax
             FROM {source_ref}
-            WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
+            WHERE {quoted_geom} IS NOT NULL AND NOT ST_IsEmpty({quoted_geom})
         """).fetchone()
 
         # If all geometries are empty/null, return table unchanged
@@ -118,14 +119,14 @@ def hilbert_order_table(
         xmin, ymin, xmax, ymax = bounds_result
 
         # Get non-geometry columns
-        other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
+        other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
         select_cols = ", ".join(other_cols) if other_cols else ""
 
         # Build column selection with WKB conversion
         if select_cols:
-            wkb_select = f'{select_cols}, ST_AsWKB("{geom_col}") AS "{geom_col}"'
+            wkb_select = f"{select_cols}, ST_AsWKB({quoted_geom}) AS {quoted_geom}"
         else:
-            wkb_select = f'ST_AsWKB("{geom_col}") AS "{geom_col}"'
+            wkb_select = f"ST_AsWKB({quoted_geom}) AS {quoted_geom}"
 
         # Build Hilbert ordering query that handles empty geometries:
         # 1. Non-empty geometries are ordered by Hilbert curve
@@ -134,14 +135,14 @@ def hilbert_order_table(
             WITH non_empty AS (
                 SELECT {wkb_select}
                 FROM {source_ref}
-                WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
-                ORDER BY ST_Hilbert("{geom_col}",
+                WHERE {quoted_geom} IS NOT NULL AND NOT ST_IsEmpty({quoted_geom})
+                ORDER BY ST_Hilbert({quoted_geom},
                     ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
             ),
             empty_or_null AS (
                 SELECT {wkb_select}
                 FROM {source_ref}
-                WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+                WHERE {quoted_geom} IS NULL OR ST_IsEmpty({quoted_geom})
             )
             SELECT * FROM non_empty
             UNION ALL
@@ -315,6 +316,7 @@ def _hilbert_order_streaming(
                 if name in col_names:
                     geom_col = name
                     break
+        quoted_geom = quote_identifier(geom_col)
 
         if verbose:
             debug(f"Using geometry column: {geom_col}")
@@ -323,7 +325,7 @@ def _hilbert_order_streaming(
         # Count empty/null geometries
         empty_count_result = con.execute(f"""
             SELECT COUNT(*) FROM {source}
-            WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+            WHERE {quoted_geom} IS NULL OR ST_IsEmpty({quoted_geom})
         """).fetchone()
         empty_count = empty_count_result[0] if empty_count_result else 0
 
@@ -336,12 +338,12 @@ def _hilbert_order_streaming(
         # Calculate dataset bounds from non-empty geometries only
         bounds_result = con.execute(f"""
             SELECT
-                MIN(ST_XMin("{geom_col}")) as xmin,
-                MIN(ST_YMin("{geom_col}")) as ymin,
-                MAX(ST_XMax("{geom_col}")) as xmax,
-                MAX(ST_YMax("{geom_col}")) as ymax
+                MIN(ST_XMin({quoted_geom})) as xmin,
+                MIN(ST_YMin({quoted_geom})) as ymin,
+                MAX(ST_XMax({quoted_geom})) as xmax,
+                MAX(ST_YMax({quoted_geom})) as ymax
             FROM {source}
-            WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
+            WHERE {quoted_geom} IS NOT NULL AND NOT ST_IsEmpty({quoted_geom})
         """).fetchone()
 
         # If all geometries are empty/null, pass through unchanged
@@ -377,13 +379,13 @@ def _hilbert_order_streaming(
         query = f"""
             WITH non_empty AS (
                 SELECT * FROM {source}
-                WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
-                ORDER BY ST_Hilbert("{geom_col}",
+                WHERE {quoted_geom} IS NOT NULL AND NOT ST_IsEmpty({quoted_geom})
+                ORDER BY ST_Hilbert({quoted_geom},
                     ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
             ),
             empty_or_null AS (
                 SELECT * FROM {source}
-                WHERE "{geom_col}" IS NULL OR ST_IsEmpty("{geom_col}")
+                WHERE {quoted_geom} IS NULL OR ST_IsEmpty({quoted_geom})
             )
             SELECT * FROM non_empty
             UNION ALL
@@ -490,7 +492,7 @@ def _hilbert_order_file_based(
         )
         con.close()
         if temp_file_created and temp_file:
-            temp_file.cleanup()
+            _cleanup_temp_file(temp_file, verbose)
         success(f"Wrote data without Hilbert ordering to: {output_parquet}")
         return
 

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -15,7 +15,7 @@ from geoparquet_io.core.common import (
     write_parquet_with_metadata,
 )
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-from geoparquet_io.core.exceptions import GeoParquetError, RemoteAccessError
+from geoparquet_io.core.exceptions import RemoteAccessError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geo_metadata import DEFAULT_GEOPARQUET_VERSION
 from geoparquet_io.core.geometry_detection import (
@@ -344,8 +344,28 @@ def _hilbert_order_streaming(
             WHERE "{geom_col}" IS NOT NULL AND NOT ST_IsEmpty("{geom_col}")
         """).fetchone()
 
+        # If all geometries are empty/null, pass through unchanged
         if not bounds_result or any(v is None for v in bounds_result):
-            raise GeoParquetError("Could not calculate dataset bounds")
+            warn("All geometries are empty or null. Writing file without Hilbert ordering.")
+            # Pass through data unchanged
+            passthrough_query = f"SELECT * FROM {source}"
+            write_output(
+                con,
+                passthrough_query,
+                output_path,
+                original_metadata=metadata,
+                geometry_column=geom_col,
+                compression=compression,
+                compression_level=compression_level,
+                row_group_size_mb=row_group_size_mb,
+                row_group_rows=row_group_rows,
+                verbose=verbose,
+                profile=profile,
+                geoparquet_version=geoparquet_version,
+            )
+            if not should_stream_output(output_path):
+                success(f"Wrote data without Hilbert ordering to: {output_path}")
+            return
 
         xmin, ymin, xmax, ymax = bounds_result
         if verbose:
@@ -438,7 +458,7 @@ def _hilbert_order_file_based(
     # Count empty/null geometries
     empty_count_result = con.execute(f"""
         SELECT COUNT(*) FROM '{safe_url}'
-        WHERE {geometry_column} IS NULL OR ST_IsEmpty({geometry_column})
+        WHERE "{geometry_column}" IS NULL OR ST_IsEmpty("{geometry_column}")
     """).fetchone()
     empty_count = empty_count_result[0] if empty_count_result else 0
 
@@ -448,10 +468,31 @@ def _hilbert_order_file_based(
             "These will be placed at the end of the sorted output."
         )
 
-    # Get bounds from non-empty geometries only
+    # Get bounds (empty geometries naturally excluded since ST_XMin returns NULL for them)
     bounds = get_dataset_bounds(working_parquet, geometry_column, verbose=verbose)
+
+    # If all geometries are empty/null, copy file unchanged
     if not bounds:
-        raise GeoParquetError("Could not calculate dataset bounds")
+        warn("All geometries are empty or null. Writing file without Hilbert ordering.")
+        passthrough_query = f"SELECT * FROM '{safe_url}'"
+        write_parquet_with_metadata(
+            con,
+            passthrough_query,
+            output_parquet,
+            original_metadata=metadata,
+            compression=compression,
+            compression_level=compression_level,
+            row_group_size_mb=row_group_size_mb,
+            row_group_rows=row_group_rows,
+            verbose=verbose,
+            profile=profile,
+            geoparquet_version=geoparquet_version,
+        )
+        con.close()
+        if temp_file_created and temp_file:
+            temp_file.cleanup()
+        success(f"Wrote data without Hilbert ordering to: {output_parquet}")
+        return
 
     xmin, ymin, xmax, ymax = bounds
     if verbose:
@@ -463,13 +504,13 @@ def _hilbert_order_file_based(
     order_query = f"""
         WITH non_empty AS (
             SELECT * FROM '{safe_url}'
-            WHERE {geometry_column} IS NOT NULL AND NOT ST_IsEmpty({geometry_column})
-            ORDER BY ST_Hilbert({geometry_column},
+            WHERE "{geometry_column}" IS NOT NULL AND NOT ST_IsEmpty("{geometry_column}")
+            ORDER BY ST_Hilbert("{geometry_column}",
                 ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
         ),
         empty_or_null AS (
             SELECT * FROM '{safe_url}'
-            WHERE {geometry_column} IS NULL OR ST_IsEmpty({geometry_column})
+            WHERE "{geometry_column}" IS NULL OR ST_IsEmpty("{geometry_column}")
         )
         SELECT * FROM non_empty
         UNION ALL

--- a/tests/test_hilbert_order_helpers.py
+++ b/tests/test_hilbert_order_helpers.py
@@ -167,6 +167,156 @@ class TestHilbertRgSizeGuidance:
         assert "spatial filter pushdown" not in caplog.text
 
 
+class TestHilbertOrderTableEmptyGeometries:
+    """Tests for hilbert_order_table handling of empty/null geometries.
+
+    Issue #442: ST_Hilbert does not support empty geometries.
+    Fix: Empty/null geometries are placed at the end of the sorted output.
+    """
+
+    def test_mixed_empty_and_valid_geometries(self):
+        """Table with mix of valid and empty geometries should sort correctly."""
+        import duckdb
+
+        from geoparquet_io.core.hilbert_order import hilbert_order_table
+
+        # Create table with valid and empty geometries
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+
+        arrow_table = (
+            con.execute("""
+            SELECT * FROM (VALUES
+                (1, ST_AsWKB(ST_GeomFromText('POINT(10 20)'))),
+                (2, ST_AsWKB(ST_GeomFromText('POINT EMPTY'))),
+                (3, ST_AsWKB(ST_GeomFromText('POINT(30 40)'))),
+                (4, ST_AsWKB(ST_GeomFromText('POLYGON EMPTY'))),
+                (5, ST_AsWKB(ST_GeomFromText('POINT(5 5)')))
+            ) t(id, geometry)
+        """)
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        # Should not raise - empty geometries handled gracefully
+        with patch("geoparquet_io.core.hilbert_order.warn") as mock_warn:
+            result = hilbert_order_table(arrow_table, geometry_column="geometry")
+
+        # Verify warning was issued about empty geometries
+        mock_warn.assert_any_call(
+            "Found 2 empty/null geometries. These will be placed at the end of the sorted output."
+        )
+
+        # Verify row count preserved
+        assert result.num_rows == 5
+
+        # Verify empty geometries are at the end (IDs 2 and 4)
+        result_ids = result.column("id").to_pylist()
+        # Last two should be the empty geometry rows
+        assert set(result_ids[-2:]) == {2, 4}
+
+    def test_all_empty_geometries_returns_unchanged(self):
+        """Table with only empty/null geometries should return unchanged."""
+        import duckdb
+
+        from geoparquet_io.core.hilbert_order import hilbert_order_table
+
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+
+        arrow_table = (
+            con.execute("""
+            SELECT * FROM (VALUES
+                (1, ST_AsWKB(ST_GeomFromText('POINT EMPTY'))),
+                (2, ST_AsWKB(ST_GeomFromText('LINESTRING EMPTY'))),
+                (3, NULL)
+            ) t(id, geometry)
+        """)
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        with patch("geoparquet_io.core.hilbert_order.warn") as mock_warn:
+            result = hilbert_order_table(arrow_table, geometry_column="geometry")
+
+        # Should warn about all geometries being empty
+        mock_warn.assert_any_call(
+            "All geometries are empty or null. Returning table without Hilbert ordering."
+        )
+
+        # Row count preserved
+        assert result.num_rows == 3
+
+    def test_null_geometries_placed_at_end(self):
+        """NULL geometries should be placed at the end."""
+        import duckdb
+
+        from geoparquet_io.core.hilbert_order import hilbert_order_table
+
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+
+        arrow_table = (
+            con.execute("""
+            SELECT * FROM (VALUES
+                (1, ST_AsWKB(ST_GeomFromText('POINT(10 20)'))),
+                (2, NULL),
+                (3, ST_AsWKB(ST_GeomFromText('POINT(30 40)')))
+            ) t(id, geometry)
+        """)
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        with patch("geoparquet_io.core.hilbert_order.warn"):
+            result = hilbert_order_table(arrow_table, geometry_column="geometry")
+
+        # Verify row count preserved
+        assert result.num_rows == 3
+
+        # NULL geometry (id=2) should be last
+        result_ids = result.column("id").to_pylist()
+        assert result_ids[-1] == 2
+
+    def test_preserves_metadata(self):
+        """Schema metadata should be preserved when handling empty geometries."""
+        import duckdb
+
+        from geoparquet_io.core.hilbert_order import hilbert_order_table
+
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+
+        arrow_table = (
+            con.execute("""
+            SELECT * FROM (VALUES
+                (1, ST_AsWKB(ST_GeomFromText('POINT(10 20)'))),
+                (2, ST_AsWKB(ST_GeomFromText('POINT EMPTY')))
+            ) t(id, geometry)
+        """)
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        # Add metadata
+        metadata = {b"geo": b'{"primary_column": "geometry"}'}
+        table_with_meta = arrow_table.replace_schema_metadata(metadata)
+
+        with patch("geoparquet_io.core.hilbert_order.warn"):
+            result = hilbert_order_table(table_with_meta, geometry_column="geometry")
+
+        # Metadata should be preserved
+        assert result.schema.metadata == metadata
+
+
 class TestHilbertOrderIntegration:
     """Integration tests for hilbert_order."""
 

--- a/tests/test_hilbert_order_helpers.py
+++ b/tests/test_hilbert_order_helpers.py
@@ -317,6 +317,117 @@ class TestHilbertOrderTableEmptyGeometries:
         assert result.schema.metadata == metadata
 
 
+class TestHilbertOrderCLIEmptyGeometries:
+    """CLI integration tests for empty/null geometry handling.
+
+    Tests that the CLI paths (_hilbert_order_streaming, _hilbert_order_file_based)
+    handle empty geometries gracefully, matching the Python API behavior.
+    """
+
+    @pytest.fixture
+    def mixed_empty_parquet(self, tmp_path):
+        """Create a GeoParquet file with mixed valid and empty geometries."""
+        import duckdb
+        import pyarrow.parquet as pq
+
+        output_path = tmp_path / "mixed_empty.parquet"
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+
+        # Create table with WKB geometries
+        arrow_table = (
+            con.execute("""
+                SELECT * FROM (VALUES
+                    (1, ST_AsWKB(ST_GeomFromText('POINT(10 20)'))),
+                    (2, ST_AsWKB(ST_GeomFromText('POINT EMPTY'))),
+                    (3, ST_AsWKB(ST_GeomFromText('POINT(30 40)')))
+                ) t(id, geometry)
+            """)
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        # Add GeoParquet metadata so DuckDB recognizes geometry column
+        geo_metadata = b'{"version": "1.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}}}'
+        table_with_meta = arrow_table.replace_schema_metadata({b"geo": geo_metadata})
+        pq.write_table(table_with_meta, output_path)
+        return str(output_path)
+
+    @pytest.fixture
+    def all_empty_parquet(self, tmp_path):
+        """Create a GeoParquet file with only empty/null geometries."""
+        import duckdb
+        import pyarrow.parquet as pq
+
+        output_path = tmp_path / "all_empty.parquet"
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+
+        # Create table with empty/null WKB geometries
+        arrow_table = (
+            con.execute("""
+                SELECT * FROM (VALUES
+                    (1, ST_AsWKB(ST_GeomFromText('POINT EMPTY'))),
+                    (2, ST_AsWKB(ST_GeomFromText('LINESTRING EMPTY'))),
+                    (3, NULL)
+                ) t(id, geometry)
+            """)
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        # Add GeoParquet metadata so DuckDB recognizes geometry column
+        geo_metadata = b'{"version": "1.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point", "LineString"]}}}'
+        table_with_meta = arrow_table.replace_schema_metadata({b"geo": geo_metadata})
+        pq.write_table(table_with_meta, output_path)
+        return str(output_path)
+
+    def test_cli_mixed_empty_geometries(self, mixed_empty_parquet, tmp_path):
+        """CLI should handle mixed valid/empty geometries without crashing."""
+        import pyarrow.parquet as pq
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        output_path = str(tmp_path / "output.parquet")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sort", "hilbert", mixed_empty_parquet, output_path])
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert "empty/null geometries" in result.output
+
+        # Verify output exists and has correct row count
+        output_table = pq.read_table(output_path)
+        assert output_table.num_rows == 3
+
+        # Empty geometry (id=2) should be at the end
+        ids = output_table.column("id").to_pylist()
+        assert ids[-1] == 2
+
+    def test_cli_all_empty_geometries_graceful(self, all_empty_parquet, tmp_path):
+        """CLI should handle all-empty geometries gracefully (not crash)."""
+        import pyarrow.parquet as pq
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        output_path = str(tmp_path / "output.parquet")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sort", "hilbert", all_empty_parquet, output_path])
+
+        # Should succeed, not crash
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert "empty or null" in result.output.lower()
+
+        # Output should exist and preserve all rows
+        output_table = pq.read_table(output_path)
+        assert output_table.num_rows == 3
+
+
 class TestHilbertOrderIntegration:
     """Integration tests for hilbert_order."""
 


### PR DESCRIPTION
## Summary

Fixes #442 - WFS→GeoParquet conversion no longer aborts when features have empty geometries.

**Problem:**
`ST_Hilbert` does not support empty geometries and throws:
```
Invalid Input Error: ST_Hilbert(geom, bounds) does not support empty geometries
```

**Solution:**
- Calculate bounds only from non-empty geometries
- Order non-empty geometries by Hilbert curve
- Append empty/null geometries at the end of the result
- Warn users about the empty geometries found

This fix applies to all three Hilbert ordering paths:
- `hilbert_order_table` (Python API, used by WFS extraction)
- `_hilbert_order_streaming` (CLI streaming mode)
- `_hilbert_order_file_based` (CLI file mode)

## Test plan

- [x] Added unit tests for `hilbert_order_table` covering:
  - Mixed empty and valid geometries
  - All empty geometries (returns unchanged with warning)
  - NULL geometries placed at end
  - Metadata preservation
- [x] Tested against the real Moldova GIS endpoint from issue #442:
  ```
  gpio extract wfs 'https://gislocal.md/geoserver/apl/wfs' 'apl:s0100_passage' /tmp/test.parquet
  ```
  Output: `Found 1 empty/null geometries. These will be placed at the end of the sorted output.`
- [x] All 17 hilbert_order tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hilbert ordering now treats empty/NULL geometries as non-indexable: they are counted (with a warning), placed last, and sorting is computed only from non-empty geometries; when all geometries are empty/NULL the input is returned unchanged. Documentation updated to reflect this behavior.

* **Tests**
  * Added unit and CLI tests covering mixed, all-empty, and null geometry cases and metadata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->