### PR TITLE
feat(extract): add Carto SQL API extractor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ geoparquet_io/
 | `gpio benchmark` | compare, explain, report, suite | Benchmark GeoParquet performance |
 | `gpio check` | all, bbox, compression, optimization, row-group, spatial, spec, stac | Check GeoParquet files for best practices |
 | `gpio convert` | csv, flatgeobuf, geojson, geopackage, geoparquet, reproject, shapefile | Convert between formats and coordinate systems |
-| `gpio extract` | arcgis, bigquery, geoparquet, wfs | Extract data from files and services to GeoParquet |
+| `gpio extract` | arcgis, bigquery, carto, geoparquet, wfs | Extract data from files and services to GeoParquet |
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or statistics |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files |
 | `gpio pmtiles` | create | PMTiles generation commands |

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1169,6 +1169,130 @@ gpio extract wfs https://geo.example.com/wfs cities output.parquet \
 - State GIS portals (varies by state)
 - Municipal open data portals
 
+## Extracting from Carto SQL API
+
+Extract data from Carto SQL API endpoints directly to GeoParquet. Carto's SQL API provides access to PostgreSQL/PostGIS tables via HTTP, commonly used by municipal open data portals.
+
+### Basic Usage
+
+=== "CLI"
+
+    ```bash
+    # Extract entire table
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        opa_properties_public output.parquet
+
+    # Extract with row limit
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        opa_properties_public output.parquet --limit 10000
+    ```
+
+=== "Python"
+
+    ```python
+    from geoparquet_io.api import ops
+
+    # Extract from Carto
+    table = ops.from_carto(
+        'https://phl.carto.com/api/v2/sql',
+        'opa_properties_public',
+        limit=10000
+    )
+    ```
+
+### Server-Side Filtering
+
+Filters are pushed to the Carto server for efficient querying:
+
+=== "CLI"
+
+    ```bash
+    # WHERE filter (PostgreSQL syntax)
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        opa_properties_public output.parquet \
+        --where "category_code_description = 'SINGLE FAMILY'"
+
+    # Bounding box filter (uses ST_Intersects on server)
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        opa_properties_public output.parquet \
+        --bbox "-75.2,39.9,-75.1,40.0"
+
+    # Select specific columns
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        opa_properties_public output.parquet \
+        --include-cols "parcel_number,market_value,the_geom"
+
+    # Combined filters
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        opa_properties_public output.parquet \
+        --bbox "-75.2,39.9,-75.1,40.0" \
+        --where "market_value > 100000" \
+        --limit 5000
+    ```
+
+=== "Python"
+
+    ```python
+    from geoparquet_io.api import ops
+
+    # With filters
+    table = ops.from_carto(
+        'https://phl.carto.com/api/v2/sql',
+        'opa_properties_public',
+        where="category_code_description = 'SINGLE FAMILY'",
+        bbox=(-75.2, 39.9, -75.1, 40.0),
+        limit=5000
+    )
+    ```
+
+### URL Format
+
+The Carto SQL API URL follows this pattern:
+
+    https://<account>.carto.com/api/v2/sql
+
+You can provide either the full API URL or just the base domain:
+
+```bash
+# Full URL (explicit)
+gpio extract carto https://phl.carto.com/api/v2/sql opa_properties_public output.parquet
+
+# Base domain (api/v2/sql is appended automatically)
+gpio extract carto https://phl.carto.com opa_properties_public output.parquet
+```
+
+### Geometry Column
+
+Carto tables typically have geometry in a column named `the_geom` (WGS84). This is automatically renamed to `geometry` in the output for consistency with other geoparquet-io extractors.
+
+### Output Optimization
+
+By default, Carto extracts include Hilbert spatial ordering and bbox columns:
+
+```bash
+# Skip optimizations for faster extraction
+gpio extract carto https://phl.carto.com/api/v2/sql \
+    opa_properties_public output.parquet \
+    --skip-hilbert \
+    --skip-bbox
+
+# Custom compression
+gpio extract carto https://phl.carto.com/api/v2/sql \
+    opa_properties_public output.parquet \
+    --compression GZIP
+```
+
+### Common Public Carto Endpoints
+
+- **Philadelphia**: `https://phl.carto.com/api/v2/sql`
+  - Tables: `opa_properties_public`, `public_cases_fc`, many more
+- **Chicago**: `https://data.cityofchicago.org` (via Socrata, different API)
+- Other municipal open data portals using Carto
+
+!!! tip "Finding Available Tables"
+    Check the city's open data portal documentation for available table names.
+    For Philadelphia, see [cityofphiladelphia.github.io/carto-api-explorer](https://cityofphiladelphia.github.io/carto-api-explorer/).
+
 ## Working with Partitioned Input Data
 
 The `extract` command can read from partitioned GeoParquet datasets, including directories containing multiple parquet files and hive-style partitions.

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1282,11 +1282,67 @@ gpio extract carto https://phl.carto.com/api/v2/sql \
     --compression GZIP
 ```
 
+### Large Tables and Timeouts
+
+For large tables, Carto's SQL API may time out or return errors. Use filters to reduce the result set:
+
+```bash
+# Use --limit for sampling or testing
+gpio extract carto https://phl.carto.com/api/v2/sql \
+    opa_properties_public output.parquet \
+    --limit 50000
+
+# Use --bbox to extract a geographic subset
+gpio extract carto https://phl.carto.com/api/v2/sql \
+    opa_properties_public output.parquet \
+    --bbox "-75.2,39.9,-75.1,40.0"
+
+# Increase timeout for slower connections (default: 120s)
+gpio extract carto https://phl.carto.com/api/v2/sql \
+    opa_properties_public output.parquet \
+    --timeout 300
+```
+
+!!! warning "Large Table Limitations"
+    Carto's SQL API has response size limits (~4MB by default). For tables with
+    hundreds of thousands of rows, always use `--limit`, `--where`, or `--bbox`
+    to reduce the result set. The extractor includes retry logic for transient
+    failures, but very large unbounded queries will likely fail.
+
+### Authentication
+
+For private Carto tables or enterprise endpoints, set the `CARTO_API_KEY` environment variable:
+
+```bash
+export CARTO_API_KEY="your_api_key_here"
+gpio extract carto https://your-org.carto.com/api/v2/sql \
+    private_table output.parquet
+```
+
+Or in Python:
+
+```python
+import os
+os.environ["CARTO_API_KEY"] = "your_api_key_here"
+
+table = ops.from_carto(
+    'https://your-org.carto.com/api/v2/sql',
+    'private_table'
+)
+
+# Or pass directly:
+table = ops.from_carto(
+    'https://your-org.carto.com/api/v2/sql',
+    'private_table',
+    api_key='your_api_key_here'
+)
+```
+
 ### Common Public Carto Endpoints
 
 - **Philadelphia**: `https://phl.carto.com/api/v2/sql`
   - Tables: `opa_properties_public`, `public_cases_fc`, many more
-- **Chicago**: `https://data.cityofchicago.org` (via Socrata, different API)
+- **Los Angeles**: `https://lahub.maps.arcgis.com` (ArcGIS - use `gpio extract arcgis`)
 - Other municipal open data portals using Carto
 
 !!! tip "Finding Available Tables"

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -812,6 +812,66 @@ def from_wfs(
     )
 
 
+def from_carto(
+    url: str,
+    table_name: str,
+    where: str | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    limit: int | None = None,
+    include_cols: str | None = None,
+    exclude_cols: str | None = None,
+) -> pa.Table:
+    """
+    Fetch Carto SQL API table as PyArrow Table.
+
+    Uses DuckDB's ST_Read for efficient GeoJSON parsing from Carto's SQL API.
+    Filters are pushed to the server for optimal performance.
+
+    Args:
+        url: Carto SQL API URL (e.g., 'https://phl.carto.com/api/v2/sql')
+            or base domain (e.g., 'https://phl.carto.com')
+        table_name: Name of the table to query
+        where: SQL WHERE clause for filtering
+        bbox: Optional bounding box filter (xmin, ymin, xmax, ymax) in WGS84
+        limit: Maximum rows to fetch
+        include_cols: Comma-separated columns to include
+        exclude_cols: Comma-separated columns to exclude
+
+    Returns:
+        PyArrow Table with geometry column named 'geometry'
+
+    Note:
+        The Carto geometry column 'the_geom' is renamed to 'geometry'
+        for consistency with other geoparquet-io extractors.
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> table = ops.from_carto(
+        ...     'https://phl.carto.com/api/v2/sql',
+        ...     'opa_properties_public',
+        ...     limit=100
+        ... )
+        >>> # With filters:
+        >>> table = ops.from_carto(
+        ...     'https://phl.carto.com/api/v2/sql',
+        ...     'opa_properties_public',
+        ...     where="category_code_description = 'SINGLE FAMILY'",
+        ...     bbox=(-75.2, 39.9, -75.1, 40.0)
+        ... )
+    """
+    from geoparquet_io.core.carto import carto_to_table
+
+    return carto_to_table(
+        url=url,
+        table_name=table_name,
+        where=where,
+        bbox=bbox,
+        limit=limit,
+        include_cols=include_cols,
+        exclude_cols=exclude_cols,
+    )
+
+
 def get_row_group_geo_stats(parquet_file: str) -> list[dict]:
     """
     Get per-row-group geo_bbox statistics from a GeoParquet file.

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -820,6 +820,8 @@ def from_carto(
     limit: int | None = None,
     include_cols: str | None = None,
     exclude_cols: str | None = None,
+    api_key: str | None = None,
+    timeout: float = 120.0,
 ) -> pa.Table:
     """
     Fetch Carto SQL API table as PyArrow Table.
@@ -836,6 +838,8 @@ def from_carto(
         limit: Maximum rows to fetch
         include_cols: Comma-separated columns to include
         exclude_cols: Comma-separated columns to exclude
+        api_key: API key for authenticated requests (or set CARTO_API_KEY env var)
+        timeout: Request timeout in seconds (default: 120)
 
     Returns:
         PyArrow Table with geometry column named 'geometry'
@@ -843,6 +847,9 @@ def from_carto(
     Note:
         The Carto geometry column 'the_geom' is renamed to 'geometry'
         for consistency with other geoparquet-io extractors.
+
+        For authenticated endpoints, either pass api_key or set the
+        CARTO_API_KEY environment variable.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -869,6 +876,8 @@ def from_carto(
         limit=limit,
         include_cols=include_cols,
         exclude_cols=exclude_cols,
+        api_key=api_key,
+        timeout=timeout,
     )
 
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3250,7 +3250,10 @@ def extract_wfs_cmd(
 @overwrite_option
 @verbose_option
 @any_extension_option
+@aws_profile_option
+@click.pass_context
 def extract_carto_cmd(
+    ctx,
     url,
     table_name,
     output_file,
@@ -3270,6 +3273,7 @@ def extract_carto_cmd(
     overwrite,
     verbose,
     any_extension,
+    aws_profile,
 ):
     """
     Extract Carto SQL API table to GeoParquet.
@@ -3337,29 +3341,30 @@ def extract_carto_cmd(
                 "Expected: xmin,ymin,xmax,ymax (e.g., -75.2,39.9,-75.1,40.0)"
             ) from e
 
-    try:
-        convert_carto_to_geoparquet(
-            url=url,
-            table_name=table_name,
-            output_file=output_file,
-            where=where,
-            bbox=bbox_tuple,
-            limit=limit,
-            include_cols=include_cols,
-            exclude_cols=exclude_cols,
-            timeout=float(timeout),
-            skip_hilbert=skip_hilbert,
-            skip_bbox=skip_bbox,
-            compression=compression.upper(),
-            compression_level=compression_level,
-            row_group_size_mb=row_group_mb,
-            row_group_rows=row_group_size,
-            geoparquet_version=geoparquet_version,
-            overwrite=overwrite,
-            verbose=verbose,
-        )
-    except CartoError as e:
-        raise click.ClickException(str(e)) from None
+    with _activate_s3(ctx, aws_profile=aws_profile):
+        try:
+            convert_carto_to_geoparquet(
+                url=url,
+                table_name=table_name,
+                output_file=output_file,
+                where=where,
+                bbox=bbox_tuple,
+                limit=limit,
+                include_cols=include_cols,
+                exclude_cols=exclude_cols,
+                timeout=float(timeout),
+                skip_hilbert=skip_hilbert,
+                skip_bbox=skip_bbox,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                row_group_size_mb=row_group_mb,
+                row_group_rows=row_group_size,
+                geoparquet_version=geoparquet_version,
+                overwrite=overwrite,
+                verbose=verbose,
+            )
+        except CartoError as e:
+            raise click.ClickException(str(e)) from None
 
 
 # Meta command - delegates to core.inspect.display_metadata

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3202,6 +3202,157 @@ def extract_wfs_cmd(
         raise click.ClickException(str(e)) from None
 
 
+@extract.command(name="carto")
+@handle_geoparquet_errors
+@click.argument("url")
+@click.argument("table_name")
+@click.argument("output_file", type=click.Path())
+@click.option(
+    "--where",
+    help="SQL WHERE clause for filtering (e.g., \"status = 'active'\")",
+)
+@click.option(
+    "--bbox",
+    help="Bounding box filter: xmin,ymin,xmax,ymax in WGS84",
+)
+@click.option(
+    "--limit",
+    type=click.IntRange(0, None),
+    help="Maximum number of rows to extract",
+)
+@click.option(
+    "--include-cols",
+    help="Comma-separated columns to include (default: all)",
+)
+@click.option(
+    "--exclude-cols",
+    help="Comma-separated columns to exclude",
+)
+@click.option(
+    "--skip-hilbert",
+    is_flag=True,
+    help="Skip Hilbert curve sorting (faster, but no spatial clustering)",
+)
+@click.option(
+    "--skip-bbox",
+    is_flag=True,
+    help="Skip adding bbox column (faster, but no per-geometry bbox)",
+)
+@compression_options
+@row_group_options
+@geoparquet_version_option
+@overwrite_option
+@verbose_option
+@any_extension_option
+def extract_carto_cmd(
+    url,
+    table_name,
+    output_file,
+    where,
+    bbox,
+    limit,
+    include_cols,
+    exclude_cols,
+    skip_hilbert,
+    skip_bbox,
+    compression,
+    compression_level,
+    row_group_size,
+    row_group_size_mb,
+    geoparquet_version,
+    overwrite,
+    verbose,
+    any_extension,
+):
+    """
+    Extract Carto SQL API table to GeoParquet.
+
+    URL is the Carto SQL API endpoint (e.g., https://phl.carto.com/api/v2/sql).
+    You can also provide just the base domain (e.g., https://phl.carto.com).
+
+    TABLE_NAME is the table to extract (e.g., 'opa_properties_public').
+
+    OUTPUT_FILE is the output GeoParquet file path.
+
+    \b
+    Notes:
+        - Geometry column 'the_geom' is renamed to 'geometry' for consistency
+        - Filters (--where, --bbox) are pushed to the server for efficiency
+        - Large tables work without pagination (Carto handles it)
+
+    \b
+    Examples:
+
+        \b
+        # Extract entire table
+        gpio extract carto https://phl.carto.com/api/v2/sql \\
+            opa_properties_public output.parquet
+
+        \b
+        # With WHERE filter
+        gpio extract carto https://phl.carto.com/api/v2/sql \\
+            opa_properties_public output.parquet \\
+            --where "category_code_description LIKE 'LAND%'"
+
+        \b
+        # With bbox filter
+        gpio extract carto https://phl.carto.com/api/v2/sql \\
+            opa_properties_public output.parquet \\
+            --bbox "-75.2,39.9,-75.1,40.0"
+
+        \b
+        # Select specific columns and limit rows
+        gpio extract carto https://phl.carto.com/api/v2/sql \\
+            opa_properties_public output.parquet \\
+            --include-cols "parcel_number,market_value,the_geom" \\
+            --limit 10000
+    """
+    from geoparquet_io.core.carto import CartoError, convert_carto_to_geoparquet
+
+    # Validate .parquet extension
+    validate_parquet_extension(output_file, any_extension)
+
+    # Parse row group options
+    row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+
+    # Parse bbox if provided
+    bbox_tuple = None
+    if bbox:
+        try:
+            parts = [float(x.strip()) for x in bbox.split(",")]
+            if len(parts) != 4:
+                raise ValueError("Expected 4 values")
+            bbox_tuple = tuple(parts)
+        except ValueError as e:
+            raise click.ClickException(
+                f"Invalid bbox format: {bbox}\n"
+                "Expected: xmin,ymin,xmax,ymax (e.g., -75.2,39.9,-75.1,40.0)"
+            ) from e
+
+    try:
+        convert_carto_to_geoparquet(
+            url=url,
+            table_name=table_name,
+            output_file=output_file,
+            where=where,
+            bbox=bbox_tuple,
+            limit=limit,
+            include_cols=include_cols,
+            exclude_cols=exclude_cols,
+            skip_hilbert=skip_hilbert,
+            skip_bbox=skip_bbox,
+            compression=compression.upper(),
+            compression_level=compression_level,
+            row_group_size_mb=row_group_mb,
+            row_group_rows=row_group_size,
+            geoparquet_version=geoparquet_version,
+            overwrite=overwrite,
+            verbose=verbose,
+        )
+    except CartoError as e:
+        raise click.ClickException(str(e)) from None
+
+
 # Meta command - delegates to core.inspect.display_metadata
 def _handle_meta_display(
     parquet_file: str,

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3229,6 +3229,12 @@ def extract_wfs_cmd(
     help="Comma-separated columns to exclude",
 )
 @click.option(
+    "--timeout",
+    type=click.IntRange(1, 3600),
+    default=120,
+    help="Request timeout in seconds (default: 120)",
+)
+@click.option(
     "--skip-hilbert",
     is_flag=True,
     help="Skip Hilbert curve sorting (faster, but no spatial clustering)",
@@ -3253,6 +3259,7 @@ def extract_carto_cmd(
     limit,
     include_cols,
     exclude_cols,
+    timeout,
     skip_hilbert,
     skip_bbox,
     compression,
@@ -3278,7 +3285,8 @@ def extract_carto_cmd(
     Notes:
         - Geometry column 'the_geom' is renamed to 'geometry' for consistency
         - Filters (--where, --bbox) are pushed to the server for efficiency
-        - Large tables work without pagination (Carto handles it)
+        - For large tables, use --limit or --where to avoid timeouts
+        - Set CARTO_API_KEY env var for authenticated endpoints
 
     \b
     Examples:
@@ -3339,6 +3347,7 @@ def extract_carto_cmd(
             limit=limit,
             include_cols=include_cols,
             exclude_cols=exclude_cols,
+            timeout=float(timeout),
             skip_hilbert=skip_hilbert,
             skip_bbox=skip_bbox,
             compression=compression.upper(),

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -7,18 +7,20 @@ for efficient GeoJSON parsing.
 from __future__ import annotations
 
 import json
+import os
+import time
 from pathlib import Path
 from urllib.parse import quote, urlparse
 
 import pyarrow as pa
 
 from geoparquet_io.core.common import (
-    GeoParquetError,
     InvalidParameterError,
     get_duckdb_connection,
     write_geoparquet_table,
 )
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
+from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,
@@ -28,8 +30,16 @@ from geoparquet_io.core.logging_config import (
     warn,
 )
 
+# Default timeout and retry settings
+DEFAULT_TIMEOUT = 120  # seconds
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RETRY_DELAY = 2.0  # seconds
 
-class CartoError(GeoParquetError):
+# Environment variable for API key
+CARTO_API_KEY_ENV = "CARTO_API_KEY"
+
+
+class CartoError(Exception):
     """Carto-specific error."""
 
     pass
@@ -72,6 +82,31 @@ def _validate_carto_url(url: str) -> str:
     )
 
 
+def _validate_table_name(table_name: str) -> str:
+    """Validate table name to prevent SQL injection.
+
+    Args:
+        table_name: Table name to validate
+
+    Returns:
+        Validated table name
+
+    Raises:
+        InvalidParameterError: If table name contains dangerous characters
+    """
+    # Basic validation - table names should be alphanumeric with underscores
+    # Allow schema-qualified names (schema.table)
+    import re
+
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$", table_name):
+        raise InvalidParameterError(
+            "table_name",
+            f"Invalid table name: {table_name}. "
+            "Table names must be alphanumeric with underscores, optionally schema-qualified.",
+        )
+    return table_name
+
+
 def _build_carto_query(
     table_name: str,
     columns: list[str] | None = None,
@@ -82,35 +117,47 @@ def _build_carto_query(
     """Build SQL query for Carto API.
 
     Args:
-        table_name: Name of the table to query
+        table_name: Name of the table to query (will be quoted for safety)
         columns: Columns to select (None = all)
-        where: SQL WHERE clause
+        where: SQL WHERE clause (user-provided, passed through)
         bbox: Bounding box filter (minx, miny, maxx, maxy)
         limit: Maximum rows to return
 
     Returns:
         SQL query string
+
+    Note:
+        The table_name is quoted using PostgreSQL identifier quoting.
+        The where clause is user-provided and passed through - Carto's
+        server-side validation handles SQL injection for WHERE clauses.
     """
-    # Column selection
+    # Validate and quote table name to prevent SQL injection
+    _validate_table_name(table_name)
+    quoted_table = quote_identifier(table_name)
+
+    # Column selection - quote each column name
     if columns:
         # Always include the_geom for geometry
         if "the_geom" not in columns:
             columns = [*columns, "the_geom"]
-        col_str = ", ".join(columns)
+        col_str = ", ".join(quote_identifier(c) for c in columns)
     else:
         col_str = "*"
 
-    sql = f"SELECT {col_str} FROM {table_name}"
+    sql = f"SELECT {col_str} FROM {quoted_table}"
 
     # Build WHERE clause
     conditions = []
     if where:
+        # WHERE clause is user-provided - Carto validates on server side
         conditions.append(f"({where})")
     if bbox:
         minx, miny, maxx, maxy = bbox
         # Use ST_Intersects with ST_MakeEnvelope for spatial filter
+        # the_geom is quoted for safety
         conditions.append(
-            f"ST_Intersects(the_geom, ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
+            f"ST_Intersects({quote_identifier('the_geom')}, "
+            f"ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
         )
 
     if conditions:
@@ -127,6 +174,8 @@ def _get_row_count(
     table_name: str,
     where: str | None = None,
     bbox: tuple[float, float, float, float] | None = None,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> int:
     """Get row count from Carto table with optional filters.
 
@@ -135,12 +184,18 @@ def _get_row_count(
         table_name: Table name
         where: Optional WHERE clause
         bbox: Optional bounding box filter
+        api_key: Optional API key for authenticated requests
+        timeout: Request timeout in seconds
 
     Returns:
         Number of rows matching the filter
     """
+    # Validate and quote table name
+    _validate_table_name(table_name)
+    quoted_table = quote_identifier(table_name)
+
     # Build count query with same filters
-    sql = f"SELECT COUNT(*) as count FROM {table_name}"
+    sql = f"SELECT COUNT(*) as count FROM {quoted_table}"
 
     conditions = []
     if where:
@@ -148,18 +203,148 @@ def _get_row_count(
     if bbox:
         minx, miny, maxx, maxy = bbox
         conditions.append(
-            f"ST_Intersects(the_geom, ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
+            f"ST_Intersects({quote_identifier('the_geom')}, "
+            f"ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
         )
 
     if conditions:
         sql += " WHERE " + " AND ".join(conditions)
 
     full_url = f"{url}?q={quote(sql)}"
+    if api_key:
+        full_url += f"&api_key={quote(api_key)}"
 
     conn = get_duckdb_connection()
+    conn.execute(f"SET http_timeout = {int(timeout * 1000)}")  # DuckDB uses milliseconds
     result = conn.execute(f"SELECT rows[1].count FROM read_json_auto('{full_url}')").fetchone()
 
     return int(result[0]) if result else 0
+
+
+def _create_empty_geoparquet_table(geoparquet_version: str | None = None) -> pa.Table:
+    """Create an empty table with proper GeoParquet metadata.
+
+    Args:
+        geoparquet_version: GeoParquet version string (default: "1.1.0")
+
+    Returns:
+        Empty PyArrow table with valid GeoParquet metadata
+    """
+    version = geoparquet_version or "1.1.0"
+    crs = parse_crs_string_to_projjson("OGC:CRS84")
+
+    geo_metadata = {
+        "version": version,
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "crs": crs,
+                "geometry_types": [],
+            }
+        },
+    }
+
+    table = pa.table({"geometry": pa.array([], type=pa.binary())})
+    new_metadata = {b"geo": json.dumps(geo_metadata).encode("utf-8")}
+    return table.replace_schema_metadata(new_metadata)
+
+
+def _fetch_with_retry(
+    url: str,
+    table_name: str,
+    sql: str,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_delay: float = DEFAULT_RETRY_DELAY,
+) -> pa.Table:
+    """Fetch data from Carto with retry logic for transient failures.
+
+    Args:
+        url: Carto SQL API URL
+        table_name: Table name (for error messages)
+        sql: SQL query to execute
+        api_key: Optional API key
+        timeout: Request timeout in seconds
+        max_retries: Number of retry attempts
+        retry_delay: Base delay between retries (exponential backoff)
+
+    Returns:
+        PyArrow Table from DuckDB ST_Read
+
+    Raises:
+        CartoError: On fatal errors or exhausted retries
+    """
+    # Construct full URL with GeoJSON format
+    full_url = f"{url}?q={quote(sql)}&format=GeoJSON"
+    if api_key:
+        full_url += f"&api_key={quote(api_key)}"
+
+    debug(f"Request URL: {full_url[:100]}...")
+
+    last_exception: Exception | None = None
+
+    for attempt in range(max_retries):
+        try:
+            conn = get_duckdb_connection()
+            conn.execute("SET allow_asterisks_in_http_paths = true")
+            conn.execute(f"SET http_timeout = {int(timeout * 1000)}")  # milliseconds
+
+            table = conn.execute(f'SELECT * FROM ST_Read("{full_url}")').arrow().read_all()
+            return table
+
+        except Exception as e:
+            last_exception = e
+            error_msg = str(e).lower()
+
+            # Non-retryable errors - fail immediately
+            if "404" in error_msg or "not found" in error_msg:
+                raise CartoError(
+                    f"Table '{table_name}' not found. Check the table name and ensure "
+                    f"it is publicly accessible."
+                ) from e
+
+            if "401" in error_msg or "unauthorized" in error_msg:
+                raise CartoError(
+                    f"Unauthorized access to table '{table_name}'. "
+                    "Set CARTO_API_KEY environment variable or check permissions."
+                ) from e
+
+            if "403" in error_msg or "forbidden" in error_msg:
+                raise CartoError(
+                    f"Access forbidden to table '{table_name}'. Check permissions."
+                ) from e
+
+            # Retryable errors
+            if attempt < max_retries - 1:
+                delay = retry_delay * (2**attempt)  # Exponential backoff
+                if "timeout" in error_msg:
+                    warn(
+                        f"Request timed out (attempt {attempt + 1}/{max_retries}), retrying in {delay:.1f}s..."
+                    )
+                elif "connection" in error_msg or "network" in error_msg:
+                    warn(
+                        f"Connection error (attempt {attempt + 1}/{max_retries}), retrying in {delay:.1f}s..."
+                    )
+                else:
+                    warn(
+                        f"Request failed (attempt {attempt + 1}/{max_retries}): {e}, retrying in {delay:.1f}s..."
+                    )
+                time.sleep(delay)
+            else:
+                # Final attempt failed
+                if "timeout" in error_msg:
+                    raise CartoError(
+                        f"Request timed out after {max_retries} attempts. "
+                        "The table may be too large. Try using --limit or --where to reduce the result set, "
+                        "or increase --timeout."
+                    ) from e
+
+    # All retries exhausted
+    raise CartoError(
+        f"Failed to fetch data from Carto after {max_retries} attempts: {last_exception}"
+    ) from last_exception
 
 
 def carto_to_table(
@@ -171,6 +356,10 @@ def carto_to_table(
     limit: int | None = None,
     include_cols: str | None = None,
     exclude_cols: str | None = None,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    geoparquet_version: str | None = None,
     verbose: bool = False,
 ) -> pa.Table:
     """Extract data from Carto SQL API to PyArrow Table.
@@ -186,6 +375,10 @@ def carto_to_table(
         limit: Maximum number of rows to return
         include_cols: Comma-separated column names to include
         exclude_cols: Comma-separated column names to exclude (applied after fetch)
+        api_key: API key for authenticated requests (or set CARTO_API_KEY env var)
+        timeout: Request timeout in seconds (default: 120)
+        max_retries: Number of retry attempts for transient failures (default: 3)
+        geoparquet_version: GeoParquet version for metadata (default: "1.1.0")
         verbose: Enable verbose output
 
     Returns:
@@ -193,7 +386,7 @@ def carto_to_table(
 
     Raises:
         CartoError: If the Carto API request fails
-        InvalidParameterError: If URL is invalid
+        InvalidParameterError: If URL or table name is invalid
     """
     configure_verbose(verbose)
 
@@ -201,13 +394,18 @@ def carto_to_table(
     url = _validate_carto_url(url)
     debug(f"Carto URL: {url}")
 
+    # Get API key from parameter or environment
+    effective_api_key = api_key or os.environ.get(CARTO_API_KEY_ENV)
+    if effective_api_key:
+        debug("Using API key for authentication")
+
     # Parse column lists
     include_list = [c.strip() for c in include_cols.split(",")] if include_cols else None
     exclude_set = {c.strip() for c in exclude_cols.split(",")} if exclude_cols else set()
 
     # Get row count for progress
     try:
-        total_count = _get_row_count(url, table_name, where, bbox)
+        total_count = _get_row_count(url, table_name, where, bbox, effective_api_key, timeout)
         info(f"Table: {table_name}")
         info(f"Total rows matching filter: {total_count:,}")
     except Exception as e:
@@ -216,8 +414,7 @@ def carto_to_table(
 
     if total_count == 0:
         warn("No rows match the specified filters")
-        # Return empty table with geometry column
-        return pa.table({"geometry": pa.array([], type=pa.binary())})
+        return _create_empty_geoparquet_table(geoparquet_version)
 
     # Build query
     sql = _build_carto_query(
@@ -229,34 +426,20 @@ def carto_to_table(
     )
     debug(f"SQL: {sql}")
 
-    # Construct full URL with GeoJSON format
-    full_url = f"{url}?q={quote(sql)}&format=GeoJSON"
-    debug(f"Request URL: {full_url[:100]}...")
-
-    # Use DuckDB ST_Read to fetch and parse GeoJSON
+    # Fetch data with retry logic
     progress("Fetching data from Carto...")
-    conn = get_duckdb_connection()
-    conn.execute("SET allow_asterisks_in_http_paths = true")
-
-    try:
-        table = conn.execute(f'SELECT * FROM ST_Read("{full_url}")').arrow().read_all()
-    except Exception as e:
-        error_msg = str(e)
-        if "404" in error_msg or "Not Found" in error_msg:
-            raise CartoError(
-                f"Table '{table_name}' not found. Check the table name and ensure "
-                f"it is publicly accessible."
-            ) from e
-        if "timeout" in error_msg.lower():
-            raise CartoError(
-                "Request timed out. The table may be too large. "
-                "Try using --limit or --where to reduce the result set."
-            ) from e
-        raise CartoError(f"Failed to fetch data from Carto: {e}") from e
+    table = _fetch_with_retry(
+        url=url,
+        table_name=table_name,
+        sql=sql,
+        api_key=effective_api_key,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
 
     if table.num_rows == 0:
         warn("Query returned no rows")
-        return pa.table({"geometry": pa.array([], type=pa.binary())})
+        return _create_empty_geoparquet_table(geoparquet_version)
 
     debug(f"Received {table.num_rows:,} rows")
 
@@ -281,10 +464,11 @@ def carto_to_table(
             debug(f"Excluded columns: {exclude_set}")
 
     # Add CRS metadata (Carto uses WGS84)
+    version = geoparquet_version or "1.1.0"
     crs = parse_crs_string_to_projjson("OGC:CRS84")
     if crs:
         geo_metadata = {
-            "version": "1.1.0",
+            "version": version,
             "primary_column": "geometry",
             "columns": {
                 "geometry": {
@@ -313,6 +497,9 @@ def convert_carto_to_geoparquet(
     limit: int | None = None,
     include_cols: str | None = None,
     exclude_cols: str | None = None,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
     skip_hilbert: bool = False,
     skip_bbox: bool = False,
     compression: str = "ZSTD",
@@ -334,6 +521,9 @@ def convert_carto_to_geoparquet(
         limit: Maximum rows to extract
         include_cols: Comma-separated columns to include
         exclude_cols: Comma-separated columns to exclude
+        api_key: API key for authenticated requests (or set CARTO_API_KEY env var)
+        timeout: Request timeout in seconds (default: 120)
+        max_retries: Number of retry attempts (default: 3)
         skip_hilbert: Skip Hilbert curve sorting
         skip_bbox: Skip adding bbox column
         compression: Compression algorithm
@@ -360,6 +550,10 @@ def convert_carto_to_geoparquet(
         limit=limit,
         include_cols=include_cols,
         exclude_cols=exclude_cols,
+        api_key=api_key,
+        timeout=timeout,
+        max_retries=max_retries,
+        geoparquet_version=geoparquet_version,
         verbose=verbose,
     )
 

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -163,7 +163,7 @@ def _build_carto_query(
     if conditions:
         sql += " WHERE " + " AND ".join(conditions)
 
-    if limit:
+    if limit is not None:
         sql += f" LIMIT {limit}"
 
     return sql
@@ -456,10 +456,14 @@ def carto_to_table(
         cols_to_keep = [c for c in table.column_names if c != "OGC_FID"]
         table = table.select(cols_to_keep)
 
-    # Apply column exclusions
+    # Apply column exclusions (but never exclude geometry)
     if exclude_set:
-        cols_to_keep = [c for c in table.column_names if c not in exclude_set]
-        if cols_to_keep:
+        # Prevent excluding the geometry column - it's required for GeoParquet
+        if "geometry" in exclude_set:
+            exclude_set = exclude_set - {"geometry"}
+            warn("Cannot exclude 'geometry' column - it is required for GeoParquet output")
+        if exclude_set:
+            cols_to_keep = [c for c in table.column_names if c not in exclude_set]
             table = table.select(cols_to_keep)
             debug(f"Excluded columns: {exclude_set}")
 

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -1,0 +1,394 @@
+"""Carto SQL API to GeoParquet conversion.
+
+Extracts data from Carto SQL API endpoints using DuckDB's ST_Read
+for efficient GeoJSON parsing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import quote, urlparse
+
+import pyarrow as pa
+
+from geoparquet_io.core.common import (
+    GeoParquetError,
+    InvalidParameterError,
+    get_duckdb_connection,
+    write_geoparquet_table,
+)
+from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
+from geoparquet_io.core.logging_config import (
+    configure_verbose,
+    debug,
+    info,
+    progress,
+    success,
+    warn,
+)
+
+
+class CartoError(GeoParquetError):
+    """Carto-specific error."""
+
+    pass
+
+
+def _validate_carto_url(url: str) -> str:
+    """Validate and normalize Carto SQL API URL.
+
+    Args:
+        url: Carto SQL API URL
+
+    Returns:
+        Normalized URL ending with /api/v2/sql
+
+    Raises:
+        InvalidParameterError: If URL is not a valid Carto SQL API endpoint
+    """
+    url = url.rstrip("/")
+    parsed = urlparse(url)
+
+    if not parsed.scheme:
+        raise InvalidParameterError(
+            "url",
+            f"Invalid URL: {url}. Must include scheme (https://)",
+        )
+
+    # Accept URLs ending with /api/v2/sql or /api/v1/sql
+    if url.endswith("/api/v2/sql") or url.endswith("/api/v1/sql"):
+        return url
+
+    # Try to construct the URL if user gave base domain
+    if not parsed.path or parsed.path == "/":
+        # User gave just the domain, append standard path
+        return f"{url}/api/v2/sql"
+
+    raise InvalidParameterError(
+        "url",
+        f"Invalid Carto SQL API URL: {url}. "
+        "Expected format: https://account.carto.com/api/v2/sql or https://account.carto.com",
+    )
+
+
+def _build_carto_query(
+    table_name: str,
+    columns: list[str] | None = None,
+    where: str | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    limit: int | None = None,
+) -> str:
+    """Build SQL query for Carto API.
+
+    Args:
+        table_name: Name of the table to query
+        columns: Columns to select (None = all)
+        where: SQL WHERE clause
+        bbox: Bounding box filter (minx, miny, maxx, maxy)
+        limit: Maximum rows to return
+
+    Returns:
+        SQL query string
+    """
+    # Column selection
+    if columns:
+        # Always include the_geom for geometry
+        if "the_geom" not in columns:
+            columns = [*columns, "the_geom"]
+        col_str = ", ".join(columns)
+    else:
+        col_str = "*"
+
+    sql = f"SELECT {col_str} FROM {table_name}"
+
+    # Build WHERE clause
+    conditions = []
+    if where:
+        conditions.append(f"({where})")
+    if bbox:
+        minx, miny, maxx, maxy = bbox
+        # Use ST_Intersects with ST_MakeEnvelope for spatial filter
+        conditions.append(
+            f"ST_Intersects(the_geom, ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
+        )
+
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+
+    if limit:
+        sql += f" LIMIT {limit}"
+
+    return sql
+
+
+def _get_row_count(
+    url: str,
+    table_name: str,
+    where: str | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+) -> int:
+    """Get row count from Carto table with optional filters.
+
+    Args:
+        url: Carto SQL API URL
+        table_name: Table name
+        where: Optional WHERE clause
+        bbox: Optional bounding box filter
+
+    Returns:
+        Number of rows matching the filter
+    """
+    # Build count query with same filters
+    sql = f"SELECT COUNT(*) as count FROM {table_name}"
+
+    conditions = []
+    if where:
+        conditions.append(f"({where})")
+    if bbox:
+        minx, miny, maxx, maxy = bbox
+        conditions.append(
+            f"ST_Intersects(the_geom, ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
+        )
+
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+
+    full_url = f"{url}?q={quote(sql)}"
+
+    conn = get_duckdb_connection()
+    result = conn.execute(f"SELECT rows[1].count FROM read_json_auto('{full_url}')").fetchone()
+
+    return int(result[0]) if result else 0
+
+
+def carto_to_table(
+    url: str,
+    table_name: str,
+    *,
+    where: str | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    limit: int | None = None,
+    include_cols: str | None = None,
+    exclude_cols: str | None = None,
+    verbose: bool = False,
+) -> pa.Table:
+    """Extract data from Carto SQL API to PyArrow Table.
+
+    Uses DuckDB's ST_Read to efficiently parse GeoJSON from Carto's
+    SQL API endpoint.
+
+    Args:
+        url: Carto SQL API URL (e.g., https://phl.carto.com/api/v2/sql)
+        table_name: Name of the table to query
+        where: SQL WHERE clause for filtering
+        bbox: Bounding box filter as (minx, miny, maxx, maxy) in WGS84
+        limit: Maximum number of rows to return
+        include_cols: Comma-separated column names to include
+        exclude_cols: Comma-separated column names to exclude (applied after fetch)
+        verbose: Enable verbose output
+
+    Returns:
+        PyArrow Table with WKB geometry column named 'geometry'
+
+    Raises:
+        CartoError: If the Carto API request fails
+        InvalidParameterError: If URL is invalid
+    """
+    configure_verbose(verbose)
+
+    # Validate URL
+    url = _validate_carto_url(url)
+    debug(f"Carto URL: {url}")
+
+    # Parse column lists
+    include_list = [c.strip() for c in include_cols.split(",")] if include_cols else None
+    exclude_set = {c.strip() for c in exclude_cols.split(",")} if exclude_cols else set()
+
+    # Get row count for progress
+    try:
+        total_count = _get_row_count(url, table_name, where, bbox)
+        info(f"Table: {table_name}")
+        info(f"Total rows matching filter: {total_count:,}")
+    except Exception as e:
+        debug(f"Could not get row count: {e}")
+        total_count = None
+
+    if total_count == 0:
+        warn("No rows match the specified filters")
+        # Return empty table with geometry column
+        return pa.table({"geometry": pa.array([], type=pa.binary())})
+
+    # Build query
+    sql = _build_carto_query(
+        table_name=table_name,
+        columns=include_list,
+        where=where,
+        bbox=bbox,
+        limit=limit,
+    )
+    debug(f"SQL: {sql}")
+
+    # Construct full URL with GeoJSON format
+    full_url = f"{url}?q={quote(sql)}&format=GeoJSON"
+    debug(f"Request URL: {full_url[:100]}...")
+
+    # Use DuckDB ST_Read to fetch and parse GeoJSON
+    progress("Fetching data from Carto...")
+    conn = get_duckdb_connection()
+    conn.execute("SET allow_asterisks_in_http_paths = true")
+
+    try:
+        table = conn.execute(f'SELECT * FROM ST_Read("{full_url}")').arrow().read_all()
+    except Exception as e:
+        error_msg = str(e)
+        if "404" in error_msg or "Not Found" in error_msg:
+            raise CartoError(
+                f"Table '{table_name}' not found. Check the table name and ensure "
+                f"it is publicly accessible."
+            ) from e
+        if "timeout" in error_msg.lower():
+            raise CartoError(
+                "Request timed out. The table may be too large. "
+                "Try using --limit or --where to reduce the result set."
+            ) from e
+        raise CartoError(f"Failed to fetch data from Carto: {e}") from e
+
+    if table.num_rows == 0:
+        warn("Query returned no rows")
+        return pa.table({"geometry": pa.array([], type=pa.binary())})
+
+    debug(f"Received {table.num_rows:,} rows")
+
+    # Rename 'geom' to 'geometry' for consistency
+    # DuckDB ST_Read uses 'geom' by default
+    col_names = table.column_names
+    if "geom" in col_names:
+        idx = col_names.index("geom")
+        col_names[idx] = "geometry"
+        table = table.rename_columns(col_names)
+
+    # Remove OGC_FID if present (added by ST_Read)
+    if "OGC_FID" in table.column_names:
+        cols_to_keep = [c for c in table.column_names if c != "OGC_FID"]
+        table = table.select(cols_to_keep)
+
+    # Apply column exclusions
+    if exclude_set:
+        cols_to_keep = [c for c in table.column_names if c not in exclude_set]
+        if cols_to_keep:
+            table = table.select(cols_to_keep)
+            debug(f"Excluded columns: {exclude_set}")
+
+    # Add CRS metadata (Carto uses WGS84)
+    crs = parse_crs_string_to_projjson("OGC:CRS84")
+    if crs:
+        geo_metadata = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "crs": crs,
+                    "geometry_types": [],  # Mixed types possible
+                }
+            },
+        }
+
+        existing_metadata = table.schema.metadata or {}
+        new_metadata = {**existing_metadata, b"geo": json.dumps(geo_metadata).encode("utf-8")}
+        table = table.replace_schema_metadata(new_metadata)
+
+    success(f"Extracted {table.num_rows:,} features")
+    return table
+
+
+def convert_carto_to_geoparquet(
+    url: str,
+    table_name: str,
+    output_file: str,
+    *,
+    where: str | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    limit: int | None = None,
+    include_cols: str | None = None,
+    exclude_cols: str | None = None,
+    skip_hilbert: bool = False,
+    skip_bbox: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    row_group_size_mb: float | None = None,
+    row_group_rows: int | None = None,
+    geoparquet_version: str | None = None,
+    overwrite: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Extract Carto table and save as optimized GeoParquet.
+
+    Args:
+        url: Carto SQL API URL
+        table_name: Name of the table to query
+        output_file: Output GeoParquet file path
+        where: SQL WHERE clause for filtering
+        bbox: Bounding box filter as (minx, miny, maxx, maxy)
+        limit: Maximum rows to extract
+        include_cols: Comma-separated columns to include
+        exclude_cols: Comma-separated columns to exclude
+        skip_hilbert: Skip Hilbert curve sorting
+        skip_bbox: Skip adding bbox column
+        compression: Compression algorithm
+        compression_level: Compression level
+        row_group_size_mb: Row group size in MB
+        row_group_rows: Row group size in rows
+        geoparquet_version: GeoParquet version
+        overwrite: Overwrite existing file
+        verbose: Enable verbose output
+    """
+    configure_verbose(verbose)
+
+    # Check output file
+    output_path = Path(output_file)
+    if output_path.exists() and not overwrite:
+        raise CartoError(f"Output file exists: {output_file}\nUse --overwrite to replace it.")
+
+    # Fetch data
+    table = carto_to_table(
+        url=url,
+        table_name=table_name,
+        where=where,
+        bbox=bbox,
+        limit=limit,
+        include_cols=include_cols,
+        exclude_cols=exclude_cols,
+        verbose=verbose,
+    )
+
+    # Apply Hilbert ordering (unless skipped)
+    if not skip_hilbert and table.num_rows > 0:
+        progress("Applying Hilbert curve ordering...")
+        from geoparquet_io.core.hilbert_order import hilbert_order_table
+
+        table = hilbert_order_table(table, geometry_column="geometry")
+        debug("Hilbert sort complete")
+
+    # Add bbox column (unless skipped)
+    if not skip_bbox and table.num_rows > 0:
+        progress("Adding bbox column...")
+        from geoparquet_io.core.add.bbox import add_bbox_table
+
+        table = add_bbox_table(table, geometry_column="geometry")
+        debug("Bbox column added")
+
+    # Write output
+    progress(f"Writing to {output_file}...")
+    write_geoparquet_table(
+        table,
+        output_file,
+        compression=compression,
+        compression_level=compression_level,
+        row_group_size_mb=row_group_size_mb,
+        row_group_rows=row_group_rows,
+        geoparquet_version=geoparquet_version,
+    )
+
+    success(f"Wrote {table.num_rows:,} features to {output_file}")

--- a/geoparquet_io/skills/geoparquet.md
+++ b/geoparquet_io/skills/geoparquet.md
@@ -33,7 +33,7 @@ Be proactive - analyze the data and make recommendations rather than waiting to 
 | `gpio benchmark` | compare, explain, report, suite | Benchmark GeoParquet performance. Commands for measuring... |
 | `gpio check` | all, bbox, compression, optimization, row-group, spatial, spec, stac | Check GeoParquet files for best practices. By default, runs... |
 | `gpio convert` | csv, flatgeobuf, geojson, geopackage, geoparquet, reproject, shapefile | Convert between formats and coordinate systems.... |
-| `gpio extract` | arcgis, bigquery, geoparquet, wfs | Extract data from files and services to GeoParquet. By... |
+| `gpio extract` | arcgis, bigquery, carto, geoparquet, wfs | Extract data from files and services to GeoParquet. By... |
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or... |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files. |
 | `gpio pmtiles` | create | PMTiles generation commands. Generate PMTiles from... |

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -1,11 +1,19 @@
 """Tests for Carto SQL API extractor."""
 
-import pytest
+import json
+import tempfile
+from pathlib import Path
 
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
 from geoparquet_io.core.carto import (
     CartoError,
     _build_carto_query,
+    _create_empty_geoparquet_table,
     _validate_carto_url,
+    _validate_table_name,
     carto_to_table,
 )
 from geoparquet_io.core.common import InvalidParameterError
@@ -45,39 +53,88 @@ class TestValidateCartoUrl:
             _validate_carto_url("https://phl.carto.com/some/other/path")
 
 
+class TestValidateTableName:
+    """Tests for table name validation (SQL injection protection)."""
+
+    def test_valid_simple_name(self):
+        """Simple table name passes validation."""
+        assert _validate_table_name("my_table") == "my_table"
+
+    def test_valid_schema_qualified(self):
+        """Schema-qualified name passes validation."""
+        assert _validate_table_name("public.my_table") == "public.my_table"
+
+    def test_valid_with_numbers(self):
+        """Table name with numbers passes."""
+        assert _validate_table_name("table_123") == "table_123"
+
+    def test_invalid_sql_injection_semicolon(self):
+        """Table name with semicolon is rejected."""
+        with pytest.raises(InvalidParameterError, match="Invalid table name"):
+            _validate_table_name("users; DROP TABLE users--")
+
+    def test_invalid_sql_injection_quotes(self):
+        """Table name with quotes is rejected."""
+        with pytest.raises(InvalidParameterError, match="Invalid table name"):
+            _validate_table_name("users' OR '1'='1")
+
+    def test_invalid_spaces(self):
+        """Table name with spaces is rejected."""
+        with pytest.raises(InvalidParameterError, match="Invalid table name"):
+            _validate_table_name("my table")
+
+    def test_invalid_special_chars(self):
+        """Table name with special characters is rejected."""
+        with pytest.raises(InvalidParameterError, match="Invalid table name"):
+            _validate_table_name("my-table")
+
+    def test_invalid_starts_with_number(self):
+        """Table name starting with number is rejected."""
+        with pytest.raises(InvalidParameterError, match="Invalid table name"):
+            _validate_table_name("123_table")
+
+
 class TestBuildCartoQuery:
     """Tests for SQL query building."""
 
     def test_simple_query(self):
         """Basic query with just table name."""
         sql = _build_carto_query("my_table")
-        assert sql == "SELECT * FROM my_table"
+        # Table name should be quoted
+        assert 'FROM "my_table"' in sql
+        assert "SELECT *" in sql
 
     def test_with_columns(self):
         """Query with column selection."""
         sql = _build_carto_query("my_table", columns=["id", "name"])
-        assert sql == "SELECT id, name, the_geom FROM my_table"
+        # Column names should be quoted
+        assert '"id"' in sql
+        assert '"name"' in sql
+        assert '"the_geom"' in sql
+        assert 'FROM "my_table"' in sql
 
     def test_columns_include_geom(self):
         """the_geom is not duplicated if already in columns."""
         sql = _build_carto_query("my_table", columns=["id", "the_geom"])
-        assert sql == "SELECT id, the_geom FROM my_table"
+        # Should only have one the_geom
+        assert sql.count('"the_geom"') == 1
 
     def test_with_where(self):
         """Query with WHERE clause."""
         sql = _build_carto_query("my_table", where="status = 'active'")
-        assert sql == "SELECT * FROM my_table WHERE (status = 'active')"
+        assert "WHERE (status = 'active')" in sql
 
     def test_with_bbox(self):
         """Query with bounding box filter."""
         sql = _build_carto_query("my_table", bbox=(-75.2, 39.9, -75.1, 40.0))
         assert "ST_Intersects" in sql
+        assert '"the_geom"' in sql
         assert "ST_MakeEnvelope(-75.2, 39.9, -75.1, 40.0, 4326)" in sql
 
     def test_with_limit(self):
         """Query with LIMIT clause."""
         sql = _build_carto_query("my_table", limit=100)
-        assert sql == "SELECT * FROM my_table LIMIT 100"
+        assert "LIMIT 100" in sql
 
     def test_combined_filters(self):
         """Query with WHERE, bbox, and limit."""
@@ -89,6 +146,43 @@ class TestBuildCartoQuery:
         )
         assert "WHERE (status = 'active') AND ST_Intersects" in sql
         assert "LIMIT 100" in sql
+
+
+class TestEmptyGeoparquetTable:
+    """Tests for empty table creation with proper metadata."""
+
+    def test_empty_table_has_geometry_column(self):
+        """Empty table has geometry column."""
+        table = _create_empty_geoparquet_table()
+        assert "geometry" in table.column_names
+        assert table.num_rows == 0
+
+    def test_empty_table_has_geo_metadata(self):
+        """Empty table has valid GeoParquet metadata."""
+        table = _create_empty_geoparquet_table()
+        assert b"geo" in table.schema.metadata
+
+        geo_meta = json.loads(table.schema.metadata[b"geo"])
+        assert geo_meta["version"] == "1.1.0"
+        assert geo_meta["primary_column"] == "geometry"
+        assert "geometry" in geo_meta["columns"]
+
+    def test_empty_table_has_crs(self):
+        """Empty table has CRS metadata."""
+        table = _create_empty_geoparquet_table()
+        geo_meta = json.loads(table.schema.metadata[b"geo"])
+
+        crs = geo_meta["columns"]["geometry"]["crs"]
+        assert crs is not None
+        # Should be OGC:CRS84
+        assert crs["id"]["authority"] == "OGC"
+        assert crs["id"]["code"] == "CRS84"
+
+    def test_empty_table_respects_version(self):
+        """Empty table uses specified GeoParquet version."""
+        table = _create_empty_geoparquet_table(geoparquet_version="1.0.0")
+        geo_meta = json.loads(table.schema.metadata[b"geo"])
+        assert geo_meta["version"] == "1.0.0"
 
 
 @pytest.mark.network
@@ -106,6 +200,42 @@ class TestCartoToTable:
         assert "geometry" in table.column_names
         # Verify the_geom was renamed to geometry
         assert "the_geom" not in table.column_names
+
+    def test_output_has_geoparquet_metadata(self):
+        """Extracted table has valid GeoParquet metadata."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            limit=5,
+        )
+        assert b"geo" in table.schema.metadata
+
+        geo_meta = json.loads(table.schema.metadata[b"geo"])
+        assert geo_meta["version"] == "1.1.0"
+        assert geo_meta["primary_column"] == "geometry"
+
+    def test_output_has_correct_crs(self):
+        """Extracted table has OGC:CRS84 CRS."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            limit=5,
+        )
+        geo_meta = json.loads(table.schema.metadata[b"geo"])
+        crs = geo_meta["columns"]["geometry"]["crs"]
+
+        assert crs["id"]["authority"] == "OGC"
+        assert crs["id"]["code"] == "CRS84"
+
+    def test_output_has_wkb_encoding(self):
+        """Extracted table uses WKB encoding."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            limit=5,
+        )
+        geo_meta = json.loads(table.schema.metadata[b"geo"])
+        assert geo_meta["columns"]["geometry"]["encoding"] == "WKB"
 
     def test_with_where_filter(self):
         """Extract with WHERE filter."""
@@ -164,9 +294,144 @@ class TestCartoToTable:
 
     def test_invalid_table_raises(self):
         """Non-existent table raises CartoError."""
-        with pytest.raises(CartoError, match="Failed to fetch data from Carto"):
+        with pytest.raises(CartoError):
             carto_to_table(
                 url="https://phl.carto.com/api/v2/sql",
                 table_name="nonexistent_table_12345",
                 limit=1,
             )
+
+    def test_sql_injection_table_name_rejected(self):
+        """SQL injection in table name is rejected before request."""
+        with pytest.raises(InvalidParameterError, match="Invalid table name"):
+            carto_to_table(
+                url="https://phl.carto.com/api/v2/sql",
+                table_name="users; DROP TABLE opa_properties_public--",
+                limit=1,
+            )
+
+
+@pytest.mark.network
+class TestCartoCli:
+    """CLI integration tests for Carto extraction."""
+
+    def test_cli_basic_extraction(self):
+        """Basic CLI extraction works."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.parquet"
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "carto",
+                    "https://phl.carto.com/api/v2/sql",
+                    "opa_properties_public",
+                    str(output_file),
+                    "--limit",
+                    "5",
+                    "--skip-hilbert",
+                    "--skip-bbox",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert output_file.exists()
+
+    def test_cli_with_filters(self):
+        """CLI with --where and --bbox filters."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.parquet"
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "carto",
+                    "https://phl.carto.com/api/v2/sql",
+                    "opa_properties_public",
+                    str(output_file),
+                    "--where",
+                    "category_code_description = 'SINGLE FAMILY'",
+                    "--bbox",
+                    "-75.2,39.9,-75.1,40.0",
+                    "--limit",
+                    "5",
+                    "--skip-hilbert",
+                    "--skip-bbox",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+
+    def test_cli_invalid_bbox_format(self):
+        """CLI rejects invalid bbox format."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.parquet"
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "carto",
+                    "https://phl.carto.com/api/v2/sql",
+                    "opa_properties_public",
+                    str(output_file),
+                    "--bbox",
+                    "invalid,bbox",
+                ],
+            )
+            assert result.exit_code != 0
+            assert "Invalid bbox format" in result.output
+
+    def test_cli_timeout_option(self):
+        """CLI accepts --timeout option."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.parquet"
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "carto",
+                    "https://phl.carto.com/api/v2/sql",
+                    "opa_properties_public",
+                    str(output_file),
+                    "--limit",
+                    "5",
+                    "--timeout",
+                    "60",
+                    "--skip-hilbert",
+                    "--skip-bbox",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+
+    def test_cli_help(self):
+        """CLI help shows all options."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["extract", "carto", "--help"])
+        assert result.exit_code == 0
+        assert "--where" in result.output
+        assert "--bbox" in result.output
+        assert "--limit" in result.output
+        assert "--timeout" in result.output
+        assert "--include-cols" in result.output
+        assert "--exclude-cols" in result.output
+        assert "CARTO_API_KEY" in result.output
+
+    def test_cli_invalid_table_name(self):
+        """CLI rejects invalid table names."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.parquet"
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "carto",
+                    "https://phl.carto.com/api/v2/sql",
+                    "users; DROP TABLE x--",
+                    str(output_file),
+                ],
+            )
+            assert result.exit_code != 0
+            assert "Invalid table name" in result.output

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -1,0 +1,172 @@
+"""Tests for Carto SQL API extractor."""
+
+import pytest
+
+from geoparquet_io.core.carto import (
+    CartoError,
+    _build_carto_query,
+    _validate_carto_url,
+    carto_to_table,
+)
+from geoparquet_io.core.common import InvalidParameterError
+
+
+class TestValidateCartoUrl:
+    """Tests for URL validation."""
+
+    def test_valid_full_url(self):
+        """Full SQL API URL passes validation."""
+        url = _validate_carto_url("https://phl.carto.com/api/v2/sql")
+        assert url == "https://phl.carto.com/api/v2/sql"
+
+    def test_valid_v1_url(self):
+        """V1 API URL is also valid."""
+        url = _validate_carto_url("https://example.carto.com/api/v1/sql")
+        assert url == "https://example.carto.com/api/v1/sql"
+
+    def test_base_domain_gets_api_path(self):
+        """Base domain gets /api/v2/sql appended."""
+        url = _validate_carto_url("https://phl.carto.com")
+        assert url == "https://phl.carto.com/api/v2/sql"
+
+    def test_trailing_slash_removed(self):
+        """Trailing slashes are stripped."""
+        url = _validate_carto_url("https://phl.carto.com/api/v2/sql/")
+        assert url == "https://phl.carto.com/api/v2/sql"
+
+    def test_missing_scheme_raises(self):
+        """URL without scheme raises error."""
+        with pytest.raises(InvalidParameterError, match="Must include scheme"):
+            _validate_carto_url("phl.carto.com/api/v2/sql")
+
+    def test_invalid_path_raises(self):
+        """Invalid path raises error."""
+        with pytest.raises(InvalidParameterError, match="Invalid Carto SQL API URL"):
+            _validate_carto_url("https://phl.carto.com/some/other/path")
+
+
+class TestBuildCartoQuery:
+    """Tests for SQL query building."""
+
+    def test_simple_query(self):
+        """Basic query with just table name."""
+        sql = _build_carto_query("my_table")
+        assert sql == "SELECT * FROM my_table"
+
+    def test_with_columns(self):
+        """Query with column selection."""
+        sql = _build_carto_query("my_table", columns=["id", "name"])
+        assert sql == "SELECT id, name, the_geom FROM my_table"
+
+    def test_columns_include_geom(self):
+        """the_geom is not duplicated if already in columns."""
+        sql = _build_carto_query("my_table", columns=["id", "the_geom"])
+        assert sql == "SELECT id, the_geom FROM my_table"
+
+    def test_with_where(self):
+        """Query with WHERE clause."""
+        sql = _build_carto_query("my_table", where="status = 'active'")
+        assert sql == "SELECT * FROM my_table WHERE (status = 'active')"
+
+    def test_with_bbox(self):
+        """Query with bounding box filter."""
+        sql = _build_carto_query("my_table", bbox=(-75.2, 39.9, -75.1, 40.0))
+        assert "ST_Intersects" in sql
+        assert "ST_MakeEnvelope(-75.2, 39.9, -75.1, 40.0, 4326)" in sql
+
+    def test_with_limit(self):
+        """Query with LIMIT clause."""
+        sql = _build_carto_query("my_table", limit=100)
+        assert sql == "SELECT * FROM my_table LIMIT 100"
+
+    def test_combined_filters(self):
+        """Query with WHERE, bbox, and limit."""
+        sql = _build_carto_query(
+            "my_table",
+            where="status = 'active'",
+            bbox=(-75.2, 39.9, -75.1, 40.0),
+            limit=100,
+        )
+        assert "WHERE (status = 'active') AND ST_Intersects" in sql
+        assert "LIMIT 100" in sql
+
+
+@pytest.mark.network
+class TestCartoToTable:
+    """Integration tests for Carto extraction (requires network)."""
+
+    def test_basic_extraction(self):
+        """Extract a small sample from Philadelphia Carto."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            limit=10,
+        )
+        assert table.num_rows == 10
+        assert "geometry" in table.column_names
+        # Verify the_geom was renamed to geometry
+        assert "the_geom" not in table.column_names
+
+    def test_with_where_filter(self):
+        """Extract with WHERE filter."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            where="category_code_description = 'SINGLE FAMILY'",
+            limit=5,
+        )
+        assert table.num_rows == 5
+
+    def test_with_bbox_filter(self):
+        """Extract with bounding box filter."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            bbox=(-75.18, 39.95, -75.15, 39.97),
+            limit=10,
+        )
+        assert table.num_rows <= 10
+        assert "geometry" in table.column_names
+
+    def test_include_cols(self):
+        """Extract with column selection."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            include_cols="cartodb_id,parcel_number,market_value",
+            limit=5,
+        )
+        # Should have requested columns plus geometry
+        assert "cartodb_id" in table.column_names
+        assert "parcel_number" in table.column_names
+        assert "market_value" in table.column_names
+        assert "geometry" in table.column_names
+
+    def test_exclude_cols(self):
+        """Extract with column exclusion."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            exclude_cols="cartodb_id",
+            limit=5,
+        )
+        assert "cartodb_id" not in table.column_names
+        assert "geometry" in table.column_names
+
+    def test_base_domain_url(self):
+        """URL without /api/v2/sql works."""
+        table = carto_to_table(
+            url="https://phl.carto.com",
+            table_name="opa_properties_public",
+            limit=5,
+        )
+        assert table.num_rows == 5
+
+    def test_invalid_table_raises(self):
+        """Non-existent table raises CartoError."""
+        with pytest.raises(CartoError, match="Failed to fetch data from Carto"):
+            carto_to_table(
+                url="https://phl.carto.com/api/v2/sql",
+                table_name="nonexistent_table_12345",
+                limit=1,
+            )

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -136,6 +136,11 @@ class TestBuildCartoQuery:
         sql = _build_carto_query("my_table", limit=100)
         assert "LIMIT 100" in sql
 
+    def test_with_limit_zero(self):
+        """Query with LIMIT 0 (edge case - should not be falsy)."""
+        sql = _build_carto_query("my_table", limit=0)
+        assert "LIMIT 0" in sql
+
     def test_combined_filters(self):
         """Query with WHERE, bbox, and limit."""
         sql = _build_carto_query(
@@ -310,6 +315,19 @@ class TestCartoToTable:
                 limit=1,
             )
 
+    def test_exclude_cols_cannot_drop_geometry(self):
+        """Excluding geometry column is prevented."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            exclude_cols="geometry,cartodb_id",
+            limit=5,
+        )
+        # Geometry should still be present (cannot be excluded)
+        assert "geometry" in table.column_names
+        # Other columns should be excluded
+        assert "cartodb_id" not in table.column_names
+
 
 @pytest.mark.network
 class TestCartoCli:
@@ -416,6 +434,7 @@ class TestCartoCli:
         assert "--timeout" in result.output
         assert "--include-cols" in result.output
         assert "--exclude-cols" in result.output
+        # Note: --aws-profile is hidden (global option) so not in help
         assert "CARTO_API_KEY" in result.output
 
     def test_cli_invalid_table_name(self):


### PR DESCRIPTION
## Summary

- Add new `gpio extract carto` command for extracting data from Carto SQL API endpoints
- Uses DuckDB's `ST_Read` for efficient GeoJSON parsing directly from HTTP (no pagination needed)
- Server-side filtering via `--where` (PostgreSQL syntax) and `--bbox` (uses `ST_Intersects`)
- Consistent with existing extractors (ArcGIS, WFS, BigQuery)

## Implementation Details

- **Core module**: `geoparquet_io/core/carto.py` (~350 lines)
- **CLI command**: `gpio extract carto URL TABLE_NAME OUTPUT_FILE`
- **Python API**: `ops.from_carto(url, table_name, ...)`

### Design Decisions

1. **No pagination**: Carto handles large queries server-side; DuckDB streams the GeoJSON response
2. **Geometry rename**: `the_geom` → `geometry` for consistency with other extractors (documented)
3. **URL flexibility**: Accepts full API URL or base domain (auto-appends `/api/v2/sql`)
4. **No API key option**: YAGNI - public tables work without auth, private tables can be added later

## Test Plan

- [x] Unit tests for URL validation and query building
- [x] Integration tests against Philadelphia's Carto API (`phl.carto.com`)
- [x] Manual testing with filters, bbox, column selection
- [ ] CI passes

## Examples

```bash
# Basic extraction
gpio extract carto https://phl.carto.com/api/v2/sql \
    opa_properties_public output.parquet --limit 1000

# With filters
gpio extract carto https://phl.carto.com/api/v2/sql \
    opa_properties_public output.parquet \
    --where "category_code_description = 'SINGLE FAMILY'" \
    --bbox "-75.2,39.9,-75.1,40.0"
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export Carto SQL API tables to GeoParquet via CLI and API, with server-side filtering, column selection, bbox support, timeouts, and optional optimizations (Hilbert ordering, bbox column, compression).

* **Documentation**
  * Comprehensive guide with CLI and Python examples, authentication notes, output behavior, and large-table guidance.

* **Tests**
  * Expanded unit and integration test suite covering URL/table validation, query building, extraction behavior, CLI flows, and GeoParquet metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->