### PR TITLE
fix(check): use spatial locality metrics instead of row-count heuristic

### DIFF
--- a/geoparquet_io/core/check_optimization.py
+++ b/geoparquet_io/core/check_optimization.py
@@ -87,11 +87,11 @@ def _check_spatial_sorting(parquet_file, verbose=False):
             return_results=True,
             quiet=True,
         )
-        if result and result.get("passed"):
+        if isinstance(result, dict) and result.get("passed"):
             ratio = result.get("ratio")
             ratio_str = f" (ratio: {ratio:.2f})" if ratio is not None else ""
             return {"passed": True, "detail": f"Data appears spatially sorted{ratio_str}"}
-        ratio = result.get("ratio") if result else None
+        ratio = result.get("ratio") if isinstance(result, dict) else None
         ratio_str = f" (ratio: {ratio:.2f})" if ratio is not None else ""
         return {"passed": False, "detail": f"Data is not spatially sorted{ratio_str}"}
     except Exception:

--- a/geoparquet_io/core/check_spatial_order.py
+++ b/geoparquet_io/core/check_spatial_order.py
@@ -2,12 +2,20 @@
 
 
 import random as _random
+from statistics import mean
 
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, progress
 from geoparquet_io.core.remote import needs_httpfs
+
+_OVERLAP_RATIO_THRESHOLD = 0.3
+_AREA_RATIO_THRESHOLD = 0.25
+_SKIP_RATE_THRESHOLD = 0.5
+_DEFAULT_NUM_SAMPLES = 20
+_DEFAULT_QUERY_FRACTION = 0.1
+_DEFAULT_SEED = 42
 
 
 def _bboxes_overlap(bbox1: dict, bbox2: dict) -> bool:
@@ -124,13 +132,18 @@ def _print_bbox_stats_results(ratio, overlap_count, total_pairs):
     debug(f"Overlapping pairs: {overlap_count}")
     progress(f"Overlap ratio: {ratio:.2f}")
 
-    if ratio < 0.3:
+    if ratio < _OVERLAP_RATIO_THRESHOLD:
         progress("=> Data appears well spatially ordered (low row group overlap).")
     else:
         progress("=> Data may benefit from spatial ordering (high row group overlap).")
 
 
-def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=False, quiet=False):
+def check_spatial_order_bbox_stats(
+    parquet_file: str,
+    verbose: bool = False,
+    return_results: bool = False,
+    quiet: bool = False,
+) -> float | dict:
     """Check spatial ordering using row group bbox statistics.
 
     This method is faster than sampling because it only reads row group metadata
@@ -153,7 +166,6 @@ def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=F
 
     safe_url = safe_file_url(parquet_file, verbose)
 
-    # Check for bbox column
     has_bbox, bbox_col_name = has_bbox_column(safe_url)
     if not has_bbox or not bbox_col_name:
         raise ValueError(
@@ -164,93 +176,25 @@ def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=F
     if verbose:
         debug(f"Using bbox column: {bbox_col_name}")
 
-    # Get bbox stats per row group
     row_group_bboxes = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
 
     if verbose:
         debug(f"Analyzing {len(row_group_bboxes)} row groups")
 
-    # Handle edge cases
-    if len(row_group_bboxes) <= 1:
-        # Can't meaningfully check ordering with 0 or 1 row groups
-        # (need at least 2 groups to compare consecutive pairs).
-        # Return ratio=0.0 (perfect ordering) since there's no evidence of poor ordering.
-        if verbose:
-            debug("Only one or zero row groups - assuming well ordered")
-        ratio = 0.0
-        overlap_count = 0
-        total_pairs = 0
-    else:
-        # Count overlaps in consecutive row group pairs
-        overlap_count = 0
-        for i in range(len(row_group_bboxes) - 1):
-            bbox1 = row_group_bboxes[i]
-            bbox2 = row_group_bboxes[i + 1]
-            if _bboxes_overlap(bbox1, bbox2):
-                overlap_count += 1
-                if verbose:
-                    debug(f"Row groups {bbox1['row_group_id']} and {bbox2['row_group_id']} overlap")
-
-        total_pairs = len(row_group_bboxes) - 1
-        ratio = overlap_count / total_pairs if total_pairs > 0 else 0.0
-
-        if verbose:
-            debug(f"Overlapping pairs: {overlap_count}/{total_pairs}")
-
-    # Primary check: pass if < 30% consecutive overlap
-    passed = ratio < 0.3
-    avg_area_ratio = 0.0
-    avg_skip_rate = 0.0
-
-    # Secondary check: when overlap is high, measure actual spatial locality.
-    # Hilbert-sorted data often has overlapping consecutive row group bboxes
-    # but each bbox covers only a small fraction of the total extent.
-    if not passed and len(row_group_bboxes) >= 3:
-        extent = _compute_data_extent(row_group_bboxes)
-        avg_area_ratio = _compute_avg_bbox_area_ratio(row_group_bboxes, extent)
-        samples = _generate_sample_query_bboxes(extent, num_samples=20, query_fraction=0.1, seed=42)
-        skip_rates = [_compute_skip_rate_for_query(s, row_group_bboxes) for s in samples]
-        avg_skip_rate = sum(skip_rates) / len(skip_rates)
-
-        if verbose:
-            debug(
-                f"Secondary locality check: area_ratio={avg_area_ratio:.4f}, skip_rate={avg_skip_rate:.2%}"
-            )
-
-        if avg_area_ratio < 0.25 and avg_skip_rate >= 0.5:
-            passed = True
-
-    # Build results dict
-    issues = []
-    recommendations = []
-    if not passed:
-        issues.append(f"Poor spatial ordering (overlap ratio: {ratio:.2f})")
-        recommendations.append("Apply Hilbert spatial ordering for better query performance")
-
-    if not quiet and not return_results and not verbose:
-        _print_bbox_stats_results(ratio, overlap_count, total_pairs)
-
-    if return_results:
-        return {
-            "passed": passed,
-            "ratio": ratio,
-            "overlap_count": overlap_count,
-            "total_pairs": total_pairs,
-            "method": "bbox_stats",
-            "issues": issues,
-            "recommendations": recommendations,
-            "fix_available": not passed,
-            "estimated_skip_rate": avg_skip_rate,
-            "avg_bbox_area_ratio": avg_area_ratio,
-        }
-
-    return ratio
+    return _check_spatial_order_from_row_group_bboxes(
+        row_group_bboxes, parquet_file, verbose, return_results, quiet, method="bbox_stats"
+    )
 
 
 def _check_spatial_order_from_row_group_bboxes(
-    row_group_bboxes, parquet_file, verbose=False, return_results=False, quiet=False
-):
-    """Check spatial ordering from row group bboxes (native geo_bbox stats).
+    row_group_bboxes: list[dict],
+    parquet_file: str,
+    verbose: bool = False,
+    return_results: bool = False,
+    quiet: bool = False,
+    method: str = "native_geo_bbox",
+) -> float | dict:
+    """Check spatial ordering from row group bboxes.
 
     Shared logic for checking spatial order from pre-fetched row group bboxes.
     Used by both bbox column method and native geo_bbox stats method.
@@ -261,6 +205,7 @@ def _check_spatial_order_from_row_group_bboxes(
         verbose: Print additional information
         return_results: If True, return structured results dict
         quiet: If True, suppress all output
+        method: Method label for results dict ("bbox_stats" or "native_geo_bbox")
 
     Returns:
         ratio (float) if return_results=False, or dict if return_results=True
@@ -287,23 +232,31 @@ def _check_spatial_order_from_row_group_bboxes(
         if verbose:
             debug(f"Overlapping pairs: {overlap_count}/{total_pairs}")
 
-    passed = ratio < 0.3
+    passed = ratio < _OVERLAP_RATIO_THRESHOLD
     avg_area_ratio = 0.0
     avg_skip_rate = 0.0
 
+    # Secondary check: when overlap is high, measure actual spatial locality.
+    # Hilbert-sorted data often has overlapping consecutive row group bboxes
+    # but each bbox covers only a small fraction of the total extent.
     if not passed and len(row_group_bboxes) >= 3:
         extent = _compute_data_extent(row_group_bboxes)
         avg_area_ratio = _compute_avg_bbox_area_ratio(row_group_bboxes, extent)
-        samples = _generate_sample_query_bboxes(extent, num_samples=20, query_fraction=0.1, seed=42)
+        samples = _generate_sample_query_bboxes(
+            extent,
+            num_samples=_DEFAULT_NUM_SAMPLES,
+            query_fraction=_DEFAULT_QUERY_FRACTION,
+            seed=_DEFAULT_SEED,
+        )
         skip_rates = [_compute_skip_rate_for_query(s, row_group_bboxes) for s in samples]
-        avg_skip_rate = sum(skip_rates) / len(skip_rates)
+        avg_skip_rate = mean(skip_rates)
 
         if verbose:
             debug(
                 f"Secondary locality check: area_ratio={avg_area_ratio:.4f}, skip_rate={avg_skip_rate:.2%}"
             )
 
-        if avg_area_ratio < 0.25 and avg_skip_rate >= 0.5:
+        if avg_area_ratio < _AREA_RATIO_THRESHOLD and avg_skip_rate >= _SKIP_RATE_THRESHOLD:
             passed = True
 
     issues = []
@@ -321,7 +274,7 @@ def _check_spatial_order_from_row_group_bboxes(
             "ratio": ratio,
             "overlap_count": overlap_count,
             "total_pairs": total_pairs,
-            "method": "native_geo_bbox",
+            "method": method,
             "issues": issues,
             "recommendations": recommendations,
             "fix_available": not passed,
@@ -333,8 +286,13 @@ def _check_spatial_order_from_row_group_bboxes(
 
 
 def check_spatial_order(
-    parquet_file, random_sample_size, limit_rows, verbose, return_results=False, quiet=False
-):
+    parquet_file: str,
+    random_sample_size: int,
+    limit_rows: int,
+    verbose: bool,
+    return_results: bool = False,
+    quiet: bool = False,
+) -> float | dict | None:
     """Check if a GeoParquet file is spatially ordered.
 
     Automatically detects if the file has a bbox column (GeoParquet 2.0+) and uses
@@ -521,21 +479,21 @@ def _compute_avg_bbox_area_ratio(row_group_bboxes: list[dict], extent: dict) -> 
         Average area ratio (0.0 to 1.0). Returns 0.0 if extent area is zero.
     """
     extent_area = (extent["xmax"] - extent["xmin"]) * (extent["ymax"] - extent["ymin"])
-    if extent_area <= 0:
+    if extent_area <= 0 or not row_group_bboxes:
         return 0.0
-    ratios = []
-    for rg in row_group_bboxes:
-        rg_area = (rg["xmax"] - rg["xmin"]) * (rg["ymax"] - rg["ymin"])
-        ratios.append(rg_area / extent_area)
-    return sum(ratios) / len(ratios) if ratios else 0.0
+    ratios = [
+        (rg["xmax"] - rg["xmin"]) * (rg["ymax"] - rg["ymin"]) / extent_area
+        for rg in row_group_bboxes
+    ]
+    return mean(ratios)
 
 
 def check_spatial_pushdown_readiness(
     parquet_file: str,
     verbose: bool = False,
-    num_samples: int = 20,
-    query_fraction: float = 0.1,
-    seed: int = 42,
+    num_samples: int = _DEFAULT_NUM_SAMPLES,
+    query_fraction: float = _DEFAULT_QUERY_FRACTION,
+    seed: int = _DEFAULT_SEED,
 ) -> dict:
     """Check how well a file supports spatial filter pushdown.
 
@@ -623,12 +581,12 @@ def check_spatial_pushdown_readiness(
         extent, num_samples=num_samples, query_fraction=query_fraction, seed=seed
     )
     skip_rates = [_compute_skip_rate_for_query(s, row_group_bboxes) for s in sample_bboxes]
-    avg_skip_rate = sum(skip_rates) / len(skip_rates)
+    avg_skip_rate = mean(skip_rates)
 
     if verbose:
         debug(f"Estimated average skip rate: {avg_skip_rate:.2%}")
 
-    passed = avg_skip_rate >= 0.5
+    passed = avg_skip_rate >= _SKIP_RATE_THRESHOLD
 
     if not passed:
         issues.append(

--- a/geoparquet_io/core/check_spatial_order.py
+++ b/geoparquet_io/core/check_spatial_order.py
@@ -170,41 +170,6 @@ def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=F
     if verbose:
         debug(f"Analyzing {len(row_group_bboxes)} row groups")
 
-    # Detect if this looks like Hilbert ordering with large row groups
-    # (row groups with ~100k rows each AND high spatial overlap is expected)
-    likely_hilbert_with_large_groups = False
-    if len(row_group_bboxes) >= 5:  # Needs multiple row groups to be meaningful
-        # Check average rows per group from parquet metadata
-        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-        from geoparquet_io.core.remote import needs_httpfs
-
-        con = get_duckdb_connection(load_spatial=False, load_httpfs=needs_httpfs(parquet_file))
-        try:
-            result = con.execute(f"""
-                SELECT num_rows::DOUBLE / num_row_groups as avg_rows
-                FROM parquet_file_metadata('{safe_url}')
-            """).fetchone()
-            avg_rows = result[0] if result else 0
-            # Require BOTH correct row count AND high spatial overlap
-            # (Hilbert curves with large row groups inherently have high bbox overlap)
-            if 80000 <= avg_rows <= 120000:
-                # Calculate overlap ratio to confirm spatial characteristic
-                prelim_overlap_count = 0
-                for i in range(len(row_group_bboxes) - 1):
-                    if _bboxes_overlap(row_group_bboxes[i], row_group_bboxes[i + 1]):
-                        prelim_overlap_count += 1
-                prelim_ratio = prelim_overlap_count / (len(row_group_bboxes) - 1)
-
-                # High overlap (>70%) + correct row count = likely Hilbert
-                if prelim_ratio > 0.7:
-                    likely_hilbert_with_large_groups = True
-                    if verbose:
-                        debug(
-                            f"Detected likely Hilbert ordering (avg {avg_rows:.0f} rows/group, {prelim_ratio:.0%} overlap)"
-                        )
-        finally:
-            con.close()
-
     # Handle edge cases
     if len(row_group_bboxes) <= 1:
         # Can't meaningfully check ordering with 0 or 1 row groups
@@ -232,8 +197,28 @@ def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=F
         if verbose:
             debug(f"Overlapping pairs: {overlap_count}/{total_pairs}")
 
-    # Pass if < 30% overlap, OR if Hilbert-ordered with large groups (expected behavior)
-    passed = ratio < 0.3 or likely_hilbert_with_large_groups
+    # Primary check: pass if < 30% consecutive overlap
+    passed = ratio < 0.3
+    avg_area_ratio = 0.0
+    avg_skip_rate = 0.0
+
+    # Secondary check: when overlap is high, measure actual spatial locality.
+    # Hilbert-sorted data often has overlapping consecutive row group bboxes
+    # but each bbox covers only a small fraction of the total extent.
+    if not passed and len(row_group_bboxes) >= 3:
+        extent = _compute_data_extent(row_group_bboxes)
+        avg_area_ratio = _compute_avg_bbox_area_ratio(row_group_bboxes, extent)
+        samples = _generate_sample_query_bboxes(extent, num_samples=20, query_fraction=0.1, seed=42)
+        skip_rates = [_compute_skip_rate_for_query(s, row_group_bboxes) for s in samples]
+        avg_skip_rate = sum(skip_rates) / len(skip_rates)
+
+        if verbose:
+            debug(
+                f"Secondary locality check: area_ratio={avg_area_ratio:.4f}, skip_rate={avg_skip_rate:.2%}"
+            )
+
+        if avg_area_ratio < 0.25 and avg_skip_rate >= 0.5:
+            passed = True
 
     # Build results dict
     issues = []
@@ -242,7 +227,6 @@ def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=F
         issues.append(f"Poor spatial ordering (overlap ratio: {ratio:.2f})")
         recommendations.append("Apply Hilbert spatial ordering for better query performance")
 
-    # Print standalone results if not quiet and not return_results
     if not quiet and not return_results and not verbose:
         _print_bbox_stats_results(ratio, overlap_count, total_pairs)
 
@@ -255,8 +239,9 @@ def check_spatial_order_bbox_stats(parquet_file, verbose=False, return_results=F
             "method": "bbox_stats",
             "issues": issues,
             "recommendations": recommendations,
-            # Don't offer fix if already Hilbert-ordered with large groups
-            "fix_available": not passed and not likely_hilbert_with_large_groups,
+            "fix_available": not passed,
+            "estimated_skip_rate": avg_skip_rate,
+            "avg_bbox_area_ratio": avg_area_ratio,
         }
 
     return ratio
@@ -303,6 +288,23 @@ def _check_spatial_order_from_row_group_bboxes(
             debug(f"Overlapping pairs: {overlap_count}/{total_pairs}")
 
     passed = ratio < 0.3
+    avg_area_ratio = 0.0
+    avg_skip_rate = 0.0
+
+    if not passed and len(row_group_bboxes) >= 3:
+        extent = _compute_data_extent(row_group_bboxes)
+        avg_area_ratio = _compute_avg_bbox_area_ratio(row_group_bboxes, extent)
+        samples = _generate_sample_query_bboxes(extent, num_samples=20, query_fraction=0.1, seed=42)
+        skip_rates = [_compute_skip_rate_for_query(s, row_group_bboxes) for s in samples]
+        avg_skip_rate = sum(skip_rates) / len(skip_rates)
+
+        if verbose:
+            debug(
+                f"Secondary locality check: area_ratio={avg_area_ratio:.4f}, skip_rate={avg_skip_rate:.2%}"
+            )
+
+        if avg_area_ratio < 0.25 and avg_skip_rate >= 0.5:
+            passed = True
 
     issues = []
     recommendations = []
@@ -323,6 +325,8 @@ def _check_spatial_order_from_row_group_bboxes(
             "issues": issues,
             "recommendations": recommendations,
             "fix_available": not passed,
+            "estimated_skip_rate": avg_skip_rate,
+            "avg_bbox_area_ratio": avg_area_ratio,
         }
 
     return ratio

--- a/tests/test_check_fixes_core.py
+++ b/tests/test_check_fixes_core.py
@@ -371,24 +371,27 @@ class TestHilbertDetectionAndWarnings:
         assert result["fix_available"] is False
 
     def test_spatial_check_fails_for_non_hilbert_files(self, places_test_file, temp_output_dir):
-        """Test that files without proper row grouping get spatial warnings."""
+        """Test that randomly shuffled data gets spatial warnings."""
+        import random
+
         import pyarrow.parquet as pq
 
         from geoparquet_io.core.check_spatial_order import check_spatial_order_bbox_stats
 
-        # Use places_test_file which has ~1000 rows (enough for multiple row groups)
         output_file = os.path.join(temp_output_dir, "non_hilbert.parquet")
 
-        # Write with very small row groups (not Hilbert pattern, and will cause high overlap)
+        # Shuffle rows to destroy spatial order before writing with small row groups
         table = pq.read_table(places_test_file)
+        indices = list(range(table.num_rows))
+        random.seed(42)
+        random.shuffle(indices)
+        table = table.take(indices)
         pq.write_table(table, output_file, compression="ZSTD", row_group_size=50)
 
         result = check_spatial_order_bbox_stats(
             output_file, verbose=False, return_results=True, quiet=True
         )
 
-        # Should fail (small row groups with high overlap, not Hilbert pattern)
-        # (places data has high spatial mixing so small row groups will have high overlap)
         assert result["passed"] is False
         assert result["fix_available"] is True
 

--- a/tests/test_check_spatial_order.py
+++ b/tests/test_check_spatial_order.py
@@ -490,6 +490,53 @@ class TestSpatialLocalitySecondaryCheck:
             "Should fail because bboxes cover nearly the entire extent"
         )
 
+    def test_two_row_groups_skips_secondary_check(self):
+        """With only 2 row groups, secondary locality check is skipped."""
+        from geoparquet_io.core.check_spatial_order import (
+            _check_spatial_order_from_row_group_bboxes,
+        )
+
+        row_group_bboxes = [
+            {"row_group_id": 0, "xmin": 0.0, "ymin": 0.0, "xmax": 10.0, "ymax": 10.0},
+            {"row_group_id": 1, "xmin": 5.0, "ymin": 5.0, "xmax": 15.0, "ymax": 15.0},
+        ]
+
+        result = _check_spatial_order_from_row_group_bboxes(
+            row_group_bboxes,
+            parquet_file="test_two_rg.parquet",
+            verbose=False,
+            return_results=True,
+            quiet=True,
+        )
+
+        assert result["ratio"] == 1.0, "Both groups overlap"
+        assert result["passed"] is False, "Secondary check not applied with < 3 row groups"
+        assert result["estimated_skip_rate"] == 0.0
+        assert result["avg_bbox_area_ratio"] == 0.0
+
+    def test_return_ratio_when_return_results_false(self):
+        """_check_spatial_order_from_row_group_bboxes returns float when return_results=False."""
+        from geoparquet_io.core.check_spatial_order import (
+            _check_spatial_order_from_row_group_bboxes,
+        )
+
+        row_group_bboxes = [
+            {"row_group_id": 0, "xmin": 0.0, "ymin": 0.0, "xmax": 10.0, "ymax": 10.0},
+            {"row_group_id": 1, "xmin": 20.0, "ymin": 20.0, "xmax": 30.0, "ymax": 30.0},
+            {"row_group_id": 2, "xmin": 40.0, "ymin": 40.0, "xmax": 50.0, "ymax": 50.0},
+        ]
+
+        result = _check_spatial_order_from_row_group_bboxes(
+            row_group_bboxes,
+            parquet_file="test_ratio.parquet",
+            verbose=False,
+            return_results=False,
+            quiet=True,
+        )
+
+        assert isinstance(result, float)
+        assert result == 0.0
+
     def test_secondary_metrics_included_in_bbox_stats_result(self, places_test_file):
         """check_spatial_order_bbox_stats should include locality metrics."""
         result = check_spatial_order_bbox_stats(

--- a/tests/test_check_spatial_order.py
+++ b/tests/test_check_spatial_order.py
@@ -414,3 +414,86 @@ class TestNativeGeoBboxDetection:
         assert result["method"] == "native_geo_bbox"
         assert "overlap_count" in result
         assert "total_pairs" in result
+
+
+class TestSpatialLocalitySecondaryCheck:
+    """Tests for secondary locality metrics (area ratio + skip rate).
+
+    When consecutive overlap ratio is high but data has good spatial locality
+    (tight row group bboxes, high skip rate), the check should still pass.
+    This is the common pattern with Hilbert-sorted global data.
+    """
+
+    def test_hilbert_like_overlapping_but_tight_bboxes_pass(self):
+        """Hilbert-sorted data: consecutive RGs overlap but bboxes are tight."""
+        from geoparquet_io.core.check_spatial_order import (
+            _check_spatial_order_from_row_group_bboxes,
+        )
+
+        # Simulate Hilbert-sorted global data: consecutive RGs overlap
+        # but each covers only a small fraction of the total extent.
+        # Modeled after real Hilbert-sorted data with 9 row groups.
+        row_group_bboxes = [
+            {"row_group_id": 0, "xmin": 0.0, "ymin": 0.0, "xmax": 20.0, "ymax": 15.0},
+            {"row_group_id": 1, "xmin": 5.0, "ymin": 10.0, "xmax": 20.0, "ymax": 15.0},
+            {"row_group_id": 2, "xmin": 15.0, "ymin": 5.0, "xmax": 35.0, "ymax": 12.0},
+            {"row_group_id": 3, "xmin": 25.0, "ymin": 7.0, "xmax": 35.0, "ymax": 12.0},
+            {"row_group_id": 4, "xmin": 30.0, "ymin": 10.0, "xmax": 45.0, "ymax": 13.0},
+            {"row_group_id": 5, "xmin": 40.0, "ymin": 9.0, "xmax": 45.0, "ymax": 13.0},
+            {"row_group_id": 6, "xmin": 38.0, "ymin": 7.0, "xmax": 45.0, "ymax": 10.0},
+            {"row_group_id": 7, "xmin": 25.0, "ymin": 0.0, "xmax": 45.0, "ymax": 10.0},
+            {"row_group_id": 8, "xmin": 25.0, "ymin": -5.0, "xmax": 44.0, "ymax": 1.0},
+        ]
+        # All consecutive pairs overlap → overlap ratio = 1.0
+        # But each RG covers a small fraction of total extent (45x20=900)
+
+        result = _check_spatial_order_from_row_group_bboxes(
+            row_group_bboxes,
+            parquet_file="test_hilbert.parquet",
+            verbose=False,
+            return_results=True,
+            quiet=True,
+        )
+
+        assert result["ratio"] >= 0.3, "Overlap ratio should be high"
+        assert result["passed"] is True, (
+            "Should pass because bbox area ratio is low and skip rate is high"
+        )
+        assert "estimated_skip_rate" in result
+        assert "avg_bbox_area_ratio" in result
+
+    def test_genuinely_poor_spatial_order_still_fails(self):
+        """Truly unordered data: large overlapping bboxes covering most of extent."""
+        from geoparquet_io.core.check_spatial_order import (
+            _check_spatial_order_from_row_group_bboxes,
+        )
+
+        # Each RG bbox covers nearly the entire extent → poor locality
+        row_group_bboxes = [
+            {"row_group_id": 0, "xmin": 0.0, "ymin": 0.0, "xmax": 95.0, "ymax": 95.0},
+            {"row_group_id": 1, "xmin": 5.0, "ymin": 5.0, "xmax": 100.0, "ymax": 100.0},
+            {"row_group_id": 2, "xmin": 2.0, "ymin": 2.0, "xmax": 98.0, "ymax": 98.0},
+            {"row_group_id": 3, "xmin": 1.0, "ymin": 1.0, "xmax": 99.0, "ymax": 99.0},
+            {"row_group_id": 4, "xmin": 3.0, "ymin": 3.0, "xmax": 97.0, "ymax": 97.0},
+        ]
+
+        result = _check_spatial_order_from_row_group_bboxes(
+            row_group_bboxes,
+            parquet_file="test_unsorted.parquet",
+            verbose=False,
+            return_results=True,
+            quiet=True,
+        )
+
+        assert result["ratio"] >= 0.3, "Overlap ratio should be high"
+        assert result["passed"] is False, (
+            "Should fail because bboxes cover nearly the entire extent"
+        )
+
+    def test_secondary_metrics_included_in_bbox_stats_result(self, places_test_file):
+        """check_spatial_order_bbox_stats should include locality metrics."""
+        result = check_spatial_order_bbox_stats(
+            places_test_file, verbose=False, return_results=True, quiet=True
+        )
+        assert "estimated_skip_rate" in result
+        assert "avg_bbox_area_ratio" in result


### PR DESCRIPTION
## Summary

- Replaced the brittle `likely_hilbert_with_large_groups` heuristic (which only fired for 80K-120K rows/group) with a secondary locality check using bbox area ratio and simulated query skip rate
- When consecutive overlap ratio >= 0.3, computes avg bbox area ratio and query skip rate. Passes if area ratio < 0.25 AND skip rate >= 0.5 (good spatial locality despite overlapping consecutive row groups)
- Applied the same secondary check to both `check_spatial_order_bbox_stats` and `_check_spatial_order_from_row_group_bboxes` (native geo_bbox path)

## Context

Hilbert-sorted data (especially global datasets) produces consecutive row group bbox overlap ratio of 1.00 because adjacent groups on the Hilbert curve can overlap spatially. The existing check flagged this as "poor spatial ordering" even though the data had excellent spatial locality (88% query skip rate, 12% avg area ratio).

## Test plan

- [x] Added `TestSpatialLocalitySecondaryCheck` with synthetic Hilbert-like bboxes (overlapping but tight) → passes
- [x] Added test with genuinely poor spatial order (large overlapping bboxes) → still fails
- [x] Fixed `test_spatial_check_fails_for_non_hilbert_files` to shuffle rows (places data was already spatially ordered)
- [x] All 57 spatial order tests pass
- [x] Verified against real Hilbert-sorted file: `gpio check spatial` now correctly reports "spatially ordered"
- [x] Full test suite: 2687 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced spatial order validation with improved two-stage decision logic for more accurate assessment of data organization
  * Returns additional spatial locality metrics including estimated skip rate and bbox area statistics
  * Added type annotations to function signatures for better code clarity and IDE support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->