### PR TITLE
fix(add): restore bbox pre-filter in spatial join ON clause

### DIFF
--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -325,13 +325,27 @@ def _build_query_components(
         admin_where_clauses,
     )
 
+    q_input_geom = quote_identifier(input_geom_col)
+    q_admin_geom = quote_identifier(admin_geom_col)
+
+    if input_bbox_col and admin_bbox_col:
+        q_input_bbox = quote_identifier(input_bbox_col)
+        q_admin_bbox = quote_identifier(admin_bbox_col)
+        join_condition = f"""(a.{q_input_bbox}.xmin <= b.{q_admin_bbox}.xmax AND
+        a.{q_input_bbox}.xmax >= b.{q_admin_bbox}.xmin AND
+        a.{q_input_bbox}.ymin <= b.{q_admin_bbox}.ymax AND
+        a.{q_input_bbox}.ymax >= b.{q_admin_bbox}.ymin)
+        AND ST_Intersects(b.{q_admin_geom}, a.{q_input_geom})"""
+    else:
+        join_condition = f"ST_Intersects(b.{q_admin_geom}, a.{q_input_geom})"
+
     query = f"""
     SELECT
         a.*,
         {admin_select_clause}
     FROM '{input_url}' a
     LEFT JOIN {admin_subquery} b
-    ON ST_Intersects(b.{quote_identifier(admin_geom_col)}, a.{quote_identifier(input_geom_col)})
+    ON {join_condition}
 """
 
     return query, admin_source

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -14,7 +14,7 @@ from geoparquet_io.core.common import (
     resolve_input_bbox_info,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import build_spatial_join_condition, quote_identifier
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
@@ -116,10 +116,11 @@ def _add_extent_filter(con, input_url, input_bbox_col, input_geom_col, admin_bbo
 
 
 def _handle_bbox_optimization(input_parquet, input_bbox_info, add_bbox_flag, verbose):
-    """Handle bbox column setup for extent pre-filtering of admin boundaries.
+    """Handle bbox column setup for spatial pre-filtering of admin boundaries.
 
-    Bbox columns help pre-filter admin boundaries by spatial extent (WHERE clause).
-    DuckDB's SPATIAL_JOIN operator handles join optimization automatically.
+    Bbox columns serve two pre-filters: narrowing admin boundaries to the input
+    extent (WHERE clause) and the cheap per-row bbox-overlap test ANDed before
+    ST_Intersects in the join ON clause (see build_spatial_join_condition).
     """
     if input_bbox_info.get("status") == "native":
         return input_bbox_info
@@ -325,19 +326,12 @@ def _build_query_components(
         admin_where_clauses,
     )
 
-    q_input_geom = quote_identifier(input_geom_col)
-    q_admin_geom = quote_identifier(admin_geom_col)
-
-    if input_bbox_col and admin_bbox_col:
-        q_input_bbox = quote_identifier(input_bbox_col)
-        q_admin_bbox = quote_identifier(admin_bbox_col)
-        join_condition = f"""(a.{q_input_bbox}.xmin <= b.{q_admin_bbox}.xmax AND
-        a.{q_input_bbox}.xmax >= b.{q_admin_bbox}.xmin AND
-        a.{q_input_bbox}.ymin <= b.{q_admin_bbox}.ymax AND
-        a.{q_input_bbox}.ymax >= b.{q_admin_bbox}.ymin)
-        AND ST_Intersects(b.{q_admin_geom}, a.{q_input_geom})"""
-    else:
-        join_condition = f"ST_Intersects(b.{q_admin_geom}, a.{q_input_geom})"
+    join_condition = build_spatial_join_condition(
+        input_geom_col,
+        admin_geom_col,
+        input_bbox_col=input_bbox_col,
+        target_bbox_col=admin_bbox_col,
+    )
 
     query = f"""
     SELECT
@@ -378,7 +372,10 @@ def _handle_dry_run_mode(
         admin_bbox_col,
     )
 
-    info("-- Main spatial join query (using DuckDB SPATIAL_JOIN operator)")
+    if input_bbox_col and admin_bbox_col:
+        info("-- Main spatial join query (bbox-overlap pre-filter before ST_Intersects)")
+    else:
+        info("-- Main spatial join query (ST_Intersects via DuckDB SPATIAL_JOIN operator)")
 
     if compression in ["GZIP", "ZSTD", "BROTLI"]:
         compression_str = f"{compression}:{compression_level}"

--- a/geoparquet_io/core/add/country_codes.py
+++ b/geoparquet_io/core/add/country_codes.py
@@ -549,13 +549,27 @@ def add_country_codes(
         if countries_bbox_col:
             debug(f"Countries bbox column: {countries_bbox_col} (used for extent filtering)")
 
+    q_input_geom = quote_identifier(input_geom_col)
+    q_countries_geom = quote_identifier(countries_geom_col)
+
+    if input_bbox_col and countries_bbox_col:
+        q_input_bbox = quote_identifier(input_bbox_col)
+        q_countries_bbox = quote_identifier(countries_bbox_col)
+        join_condition = f"""(a.{q_input_bbox}.xmin <= b.{q_countries_bbox}.xmax AND
+        a.{q_input_bbox}.xmax >= b.{q_countries_bbox}.xmin AND
+        a.{q_input_bbox}.ymin <= b.{q_countries_bbox}.ymax AND
+        a.{q_input_bbox}.ymax >= b.{q_countries_bbox}.ymin)
+        AND ST_Intersects(b.{q_countries_geom}, a.{q_input_geom})"""
+    else:
+        join_condition = f"ST_Intersects(b.{q_countries_geom}, a.{q_input_geom})"
+
     query = f"""
     SELECT
         a.*,
         {select_clause}
     FROM '{input_url}' a
     LEFT JOIN {countries_source} b
-    ON ST_Intersects(b.{quote_identifier(countries_geom_col)}, a.{quote_identifier(input_geom_col)})
+    ON {join_condition}
 """
 
     if dry_run:

--- a/geoparquet_io/core/add/country_codes.py
+++ b/geoparquet_io/core/add/country_codes.py
@@ -9,7 +9,7 @@ from geoparquet_io.core.common import (
     resolve_input_bbox_info,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import build_spatial_join_condition, quote_identifier
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -103,10 +103,11 @@ def find_subdivision_code_column(con, countries_source, is_subquery=False):
 
 
 def _handle_bbox_optimization(file_path, bbox_info, add_bbox_flag, file_label, verbose):
-    """Handle bbox column setup for extent pre-filtering.
+    """Handle bbox column setup for spatial pre-filtering.
 
-    Bbox columns help pre-filter data by spatial extent (WHERE clause).
-    DuckDB's SPATIAL_JOIN operator handles join optimization automatically.
+    Bbox columns serve two pre-filters: narrowing countries to the input extent
+    (WHERE clause) and the cheap per-row bbox-overlap test ANDed before
+    ST_Intersects in the join ON clause (see build_spatial_join_condition).
     """
     if bbox_info["status"] == "optimal":
         return bbox_info
@@ -315,7 +316,11 @@ def _print_dry_run_query(
 ):
     """Print the dry-run query output."""
     final_step = "3" if using_default else "1"
-    info(f"-- Step {final_step}: Main spatial join query (using DuckDB SPATIAL_JOIN operator)")
+    if "bbox-overlap pre-filter" in query:
+        detail = "bbox-overlap pre-filter before ST_Intersects"
+    else:
+        detail = "ST_Intersects via DuckDB SPATIAL_JOIN operator"
+    info(f"-- Step {final_step}: Main spatial join query ({detail})")
 
     compression_str = (
         f"{compression}:{compression_level}"
@@ -385,11 +390,11 @@ def _setup_default_countries(
 def _prepare_bbox_columns(
     input_parquet, countries_parquet, using_default, add_bbox_flag, dry_run, verbose
 ):
-    """Prepare bbox columns for extent filtering of countries data.
+    """Prepare bbox columns for spatial pre-filtering of countries data.
 
-    Bbox columns are used to pre-filter countries by spatial extent (WHERE clause),
-    not for join optimization — DuckDB's SPATIAL_JOIN operator handles that
-    automatically via its R-tree.
+    Bbox columns drive two pre-filters: narrowing countries to the input extent
+    (WHERE clause) and the cheap per-row bbox-overlap test ANDed before
+    ST_Intersects in the join ON clause (see build_spatial_join_condition).
     """
     input_bbox_info, input_bbox_col = resolve_input_bbox_info(input_parquet, verbose)
 
@@ -549,19 +554,12 @@ def add_country_codes(
         if countries_bbox_col:
             debug(f"Countries bbox column: {countries_bbox_col} (used for extent filtering)")
 
-    q_input_geom = quote_identifier(input_geom_col)
-    q_countries_geom = quote_identifier(countries_geom_col)
-
-    if input_bbox_col and countries_bbox_col:
-        q_input_bbox = quote_identifier(input_bbox_col)
-        q_countries_bbox = quote_identifier(countries_bbox_col)
-        join_condition = f"""(a.{q_input_bbox}.xmin <= b.{q_countries_bbox}.xmax AND
-        a.{q_input_bbox}.xmax >= b.{q_countries_bbox}.xmin AND
-        a.{q_input_bbox}.ymin <= b.{q_countries_bbox}.ymax AND
-        a.{q_input_bbox}.ymax >= b.{q_countries_bbox}.ymin)
-        AND ST_Intersects(b.{q_countries_geom}, a.{q_input_geom})"""
-    else:
-        join_condition = f"ST_Intersects(b.{q_countries_geom}, a.{q_input_geom})"
+    join_condition = build_spatial_join_condition(
+        input_geom_col,
+        countries_geom_col,
+        input_bbox_col=input_bbox_col,
+        target_bbox_col=countries_bbox_col,
+    )
 
     query = f"""
     SELECT

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -106,6 +106,63 @@ def quote_identifier(name: str) -> str:
     return f'"{escaped}"'
 
 
+def build_spatial_join_condition(
+    input_geom_col: str,
+    target_geom_col: str,
+    input_bbox_col: str | None = None,
+    target_bbox_col: str | None = None,
+    input_alias: str = "a",
+    target_alias: str = "b",
+) -> str:
+    """Build the ON-clause condition for a spatial join between two tables.
+
+    The precise predicate is always ``ST_Intersects(target_geom, input_geom)``.
+    When *both* sides expose a bbox covering column, a cheap bounding-box
+    overlap test is ANDed in front of it: DuckDB evaluates the four numeric
+    comparisons first and only runs the expensive geometry intersection on the
+    surviving candidate pairs. Because bbox overlap is a necessary condition for
+    geometry intersection, the result is identical to ST_Intersects alone -- it
+    is purely a performance pre-filter.
+
+    Dropping this pre-filter (as #457 did) makes the Overture remote datasets
+    run a full ST_Intersects against every admin geometry, which effectively
+    hangs. See PR #460.
+
+    Args:
+        input_geom_col: Geometry column on the input (left) table.
+        target_geom_col: Geometry column on the target (right) table.
+        input_bbox_col: Optional bbox covering column on the input table.
+        target_bbox_col: Optional bbox covering column on the target table.
+        input_alias: SQL alias for the input table (default "a").
+        target_alias: SQL alias for the target table (default "b").
+
+    Returns:
+        A SQL boolean expression for use directly after ``ON``.
+    """
+    qi_geom = quote_identifier(input_geom_col)
+    qt_geom = quote_identifier(target_geom_col)
+    intersects = f"ST_Intersects({target_alias}.{qt_geom}, {input_alias}.{qi_geom})"
+
+    # A one-sided bbox cannot form an overlap test, so fall back to the
+    # precise predicate alone.
+    if not (input_bbox_col and target_bbox_col):
+        return intersects
+
+    qi_bbox = quote_identifier(input_bbox_col)
+    qt_bbox = quote_identifier(target_bbox_col)
+    return (
+        "(\n"
+        "        -- Fast bbox-overlap pre-filter (cheap; eliminates most candidate pairs)\n"
+        f"        {input_alias}.{qi_bbox}.xmin <= {target_alias}.{qt_bbox}.xmax AND\n"
+        f"        {input_alias}.{qi_bbox}.xmax >= {target_alias}.{qt_bbox}.xmin AND\n"
+        f"        {input_alias}.{qi_bbox}.ymin <= {target_alias}.{qt_bbox}.ymax AND\n"
+        f"        {input_alias}.{qi_bbox}.ymax >= {target_alias}.{qt_bbox}.ymin\n"
+        "    )\n"
+        "    -- Precise check only runs on the bbox matches\n"
+        f"    AND {intersects}"
+    )
+
+
 def get_duckdb_connection(
     load_spatial=True,
     load_httpfs=None,

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -125,7 +125,12 @@ class TestDryRunCommands:
         assert not os.path.exists(temp_output_file)
 
     def test_dry_run_with_bbox_column_present(self, places_test_file):
-        """Test dry-run when input has bbox column (for admin-divisions)."""
+        """When input has a bbox column, the ON clause must include the bbox pre-filter.
+
+        Regression guard for PR #460: #457 removed this cheap bbox-overlap test,
+        which made `add admin-divisions --dataset overture` hang. The pre-filter
+        is ANDed before the expensive ST_Intersects.
+        """
         runner = CliRunner()
         result = runner.invoke(
             add, ["admin-divisions", places_test_file, "output.parquet", "--dry-run", "--no-cache"]
@@ -133,9 +138,14 @@ class TestDryRunCommands:
 
         assert result.exit_code == 0
         assert "DRY RUN MODE" in result.output
-        # Should use DuckDB's SPATIAL_JOIN operator (pure ST_Intersects, no bbox in ON clause)
-        assert "SPATIAL_JOIN operator" in result.output
         assert "ST_Intersects" in result.output
+        # Both sides expose a bbox column -> the four-sided overlap pre-filter must
+        # appear in the ON clause. These struct comparisons can only come from the
+        # pre-filter, so their presence is unambiguous proof it was emitted.
+        assert 'a."bbox".xmin <= b."geometry_bbox".xmax' in result.output
+        assert 'a."bbox".ymax >= b."geometry_bbox".ymin' in result.output
+        # The header must advertise the pre-filter, not claim a bare SPATIAL_JOIN.
+        assert "bbox-overlap pre-filter" in result.output
 
     def test_dry_run_with_native_geometry_input(self, fields_v2_file):
         """Test dry-run with GeoParquet 2.0 native geometry input."""

--- a/tests/test_duckdb_utils.py
+++ b/tests/test_duckdb_utils.py
@@ -5,6 +5,7 @@ from geoparquet_io.core.duckdb_utils import (
     _bucket_needs_auth,
     _clear_s3_cache,
     _escape_sql_string,
+    build_spatial_join_condition,
     get_duckdb_connection,
     get_duckdb_connection_for_s3,
     quote_identifier,
@@ -70,6 +71,57 @@ class TestQuoteIdentifier:
         """SQL reserved words are safely quoted."""
         assert quote_identifier("select") == '"select"'
         assert quote_identifier("from") == '"from"'
+
+
+class TestBuildSpatialJoinCondition:
+    """Tests for the spatial-join ON-clause builder.
+
+    Regression guard for PR #460: the cheap bbox-overlap pre-filter must be
+    emitted whenever both sides have a bbox column. It was silently removed in
+    #457, which made `add admin-divisions --dataset overture` hang.
+    """
+
+    def test_without_bbox_columns_is_plain_intersects(self):
+        """No bbox columns -> bare ST_Intersects, no pre-filter."""
+        cond = build_spatial_join_condition("geometry", "geom")
+        assert cond == 'ST_Intersects(b."geom", a."geometry")'
+
+    def test_with_bbox_columns_adds_prefilter(self):
+        """Both sides have bbox -> four-sided overlap test ANDed before ST_Intersects."""
+        cond = build_spatial_join_condition("geometry", "geom", "bbox", "geom_bbox")
+        assert 'a."bbox".xmin <= b."geom_bbox".xmax' in cond
+        assert 'a."bbox".xmax >= b."geom_bbox".xmin' in cond
+        assert 'a."bbox".ymin <= b."geom_bbox".ymax' in cond
+        assert 'a."bbox".ymax >= b."geom_bbox".ymin' in cond
+        assert 'ST_Intersects(b."geom", a."geometry")' in cond
+        # The cheap bbox test must precede the expensive geometry intersection.
+        assert cond.index("xmin") < cond.index("ST_Intersects")
+        assert " AND " in cond
+
+    def test_one_sided_bbox_falls_back_to_intersects(self):
+        """A bbox on only one side cannot form a safe overlap test -> fall back."""
+        plain = 'ST_Intersects(b."g", a."g")'
+        assert build_spatial_join_condition("g", "g", input_bbox_col="bbox") == plain
+        assert build_spatial_join_condition("g", "g", target_bbox_col="bbox") == plain
+
+    def test_custom_aliases(self):
+        """Table aliases are configurable for both sides."""
+        cond = build_spatial_join_condition(
+            "geometry",
+            "geom",
+            "bbox",
+            "geom_bbox",
+            input_alias="lhs",
+            target_alias="rhs",
+        )
+        assert 'lhs."bbox".xmin <= rhs."geom_bbox".xmax' in cond
+        assert 'ST_Intersects(rhs."geom", lhs."geometry")' in cond
+
+    def test_identifiers_are_quoted(self):
+        """Column names with special characters are safely quoted."""
+        cond = build_spatial_join_condition("geo m", 'g"x', "b b", "q")
+        assert '"geo m"' in cond
+        assert '"g""x"' in cond  # embedded double-quote doubled
 
 
 class TestGetDuckdbConnection:


### PR DESCRIPTION
## Summary

PR #457 removed the cheap bbox-overlap pre-filter from the spatial join `ON` clause in `add admin-divisions` and `add country-codes`, relying on DuckDB's `SPATIAL_JOIN` operator to optimize the join automatically. For the **Overture remote datasets** this optimization does not kick in, so every input row runs a full `ST_Intersects` against all admin geometries.

### Regression observed

`gpio add admin-divisions <in> <out> --dataset overture --overwrite`:
- **Before #457** (`44af1b8`): completes in under a minute
- **After #457** (`0af6122`, current main): hangs / never finishes

## Fix

Restore the bbox-overlap pre-filter (only when both sides have bbox columns) before the expensive `ST_Intersects` check, in both `admin_divisions.py` and `country_codes.py`. The fast bbox test eliminates the vast majority of candidate pairs before the precise geometry intersection runs.

Identifiers remain quoted via `quote_identifier` (the SQL-safety improvement from #457 is preserved).

## Test plan

- [ ] `gpio add admin-divisions ... --dataset overture --overwrite` completes in under a minute again
- [ ] Existing dry-run / common-utils tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Spatial joins now use an optional bbox-overlap pre-filter when bounding boxes are present, improving query speed and avoiding full geometry-only checks.
* **Bug Fixes**
  * Prevents hangs/regressions by applying bbox pre-filtering before precise geometry intersection checks when possible.
* **New Features**
  * Dry-run output now reports whether a bbox-overlap pre-filter is used or a geometry-only spatial join is performed.
* **Tests**
  * Added/updated tests to validate bbox pre-filter behavior, aliasing, and identifier quoting.
* **Documentation**
  * Clarified bbox optimization and pre-filter behavior in docstrings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->