### PR TITLE
fix(crs): distinguish null CRS (unknown) from omitted CRS (default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`gpio convert reproject --assume-crs84`**: treat a file's unknown (explicit
+  `crs: null`) CRS as OGC:CRS84 and rewrite it so the `crs` key is omitted (the
+  spec default). No coordinates are changed. Also available as the
+  `assume_crs84=` argument on the `reproject` Python API.
+
 #### New Spatial Indexing Systems
 - **S2 support**: Add S2 cell indexing with `gpio add s2` and `gpio partition s2`
   - Full S2 geometry library integration for spherical indexing
@@ -75,6 +80,14 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- Distinguish an explicit `crs: null` (CRS *unknown*) from an omitted `crs` key
+  (defaults to OGC:CRS84), per the GeoParquet spec:
+  - Reading a file with `crs: null` now logs a warning (once per input) from the
+    shared CRS read path, and `gpio check spec` reports it as a WARNING instead
+    of incorrectly passing it as "defaults to OGC:CRS84".
+  - Reprojecting to a default CRS now omits the `crs` key instead of writing an
+    explicit CRS84 object (or, if CRS parsing failed, a stray `null`) into the
+    output geo metadata. Affected the Arrow/Python-API and streaming paths.
 - Fix out-of-memory crash in `gpio add admin-divisions --dataset overture` on
   large inputs (#461)
   - Overture now uses a **per-level cache** (separate country and region cache

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`gpio convert reproject --assume-crs84`**: treat a file's unknown (explicit
+  `crs: null`) CRS as OGC:CRS84 and rewrite it so the `crs` key is omitted (the
+  spec default). No coordinates are changed. Also available as the
+  `assume_crs84=` argument on the `reproject` Python API.
+
 #### New Spatial Indexing Systems
 - **S2 support**: Add S2 cell indexing with `gpio add s2` and `gpio partition s2`
   - Full S2 geometry library integration for spherical indexing
@@ -75,6 +80,14 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- Distinguish an explicit `crs: null` (CRS *unknown*) from an omitted `crs` key
+  (defaults to OGC:CRS84), per the GeoParquet spec:
+  - Reading a file with `crs: null` now logs a warning (once per input) from the
+    shared CRS read path, and `gpio check spec` reports it as a WARNING instead
+    of incorrectly passing it as "defaults to OGC:CRS84".
+  - Reprojecting to a default CRS now omits the `crs` key instead of writing an
+    explicit CRS84 object (or, if CRS parsing failed, a stray `null`) into the
+    output geo metadata. Affected the Arrow/Python-API and streaming paths.
 - Fix out-of-memory crash in `gpio add admin-divisions --dataset overture` on
   large inputs (#461)
   - Overture now uses a **per-level cache** (separate country and region cache

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -536,7 +536,7 @@ table = gpio.read('input.parquet').sort_quadkey(remove_column=True)
 table = gpio.read('input.parquet').sort_quadkey(column_name='my_quadkey')
 ```
 
-#### `reproject(target_crs='EPSG:4326', source_crs=None)`
+#### `reproject(target_crs='EPSG:4326', source_crs=None, assume_crs84=False)`
 
 Reproject geometry to a different coordinate reference system.
 
@@ -549,6 +549,16 @@ table = gpio.read('input.parquet').reproject(
     target_crs='EPSG:3857',
     source_crs='EPSG:4326'
 )
+```
+
+A geometry column's `crs` may be **omitted** (defaults to OGC:CRS84) or set to
+**`null`** (CRS is *unknown*) — these mean different things in the GeoParquet
+spec. If a file declares `crs: null` but the coordinates are really lon/lat
+WGS84, use `assume_crs84=True` to treat them as OGC:CRS84 and write the default
+(the `crs` key is omitted on output, no coordinates are changed):
+
+```python
+table = gpio.read('unknown_crs.parquet').reproject(assume_crs84=True)
 ```
 
 #### `extract(columns=None, exclude_columns=None, bbox=None, where=None, limit=None)`
@@ -1129,7 +1139,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.sort_hilbert(table, geometry_column=None)` | Reorder by Hilbert curve |
 | `ops.sort_column(table, column, descending=False)` | Sort by column(s) |
 | `ops.sort_quadkey(table, column_name='quadkey', resolution=13, use_centroid=False, remove_column=False)` | Sort by quadkey |
-| `ops.reproject(table, target_crs='EPSG:4326', source_crs=None, geometry_column=None)` | Reproject geometry |
+| `ops.reproject(table, target_crs='EPSG:4326', source_crs=None, geometry_column=None, assume_crs84=False)` | Reproject geometry (`assume_crs84` treats an unknown/null CRS as OGC:CRS84) |
 | `ops.extract(table, columns=None, exclude_columns=None, bbox=None, where=None, limit=None, geometry_column=None)` | Filter columns/rows |
 | `ops.read_bigquery(table_id, project=None, credentials_file=None, where=None, bbox=None, bbox_mode='auto', bbox_threshold=500000, limit=None, columns=None, exclude_columns=None)` | Read BigQuery table |
 | `ops.from_arcgis(service_url, token=None, where='1=1', bbox=None, include_cols=None, exclude_cols=None, limit=None)` | Fetch ArcGIS Feature Service |

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -192,6 +192,12 @@ changed):
 gpio convert reproject unknown_crs.parquet fixed.parquet --assume-crs84
 ```
 
+!!! note "Reprojecting to the default CRS omits the `crs` key"
+    Because EPSG:4326 and OGC:CRS84 are equivalent in GeoParquet (the spec fixes
+    lon/lat axis order), reprojecting to the default — `--dst-crs EPSG:4326`, the
+    default — writes the output with the `crs` key **omitted** rather than an
+    explicit CRS object. This is the spec-correct way to signal the default.
+
 See `gpio convert reproject --help` for all options.
 
 ## S3-Compatible Storage

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -176,6 +176,22 @@ Reproject a GeoParquet file to a different CRS.
 gpio convert reproject input.parquet output.parquet --dst-crs EPSG:32610
 ```
 
+### Unknown vs default CRS
+
+The GeoParquet spec distinguishes two states for a geometry column's `crs`:
+
+- **omitted** → defaults to OGC:CRS84 (lon/lat WGS84)
+- **`null`** → CRS is *unknown*
+
+A file declaring `crs: null` cannot be read by DuckDB and won't reproject. If the
+coordinates are really lon/lat WGS84, use `--assume-crs84` to treat them as
+OGC:CRS84 and rewrite the file so the `crs` key is omitted (no coordinates are
+changed):
+
+```bash
+gpio convert reproject unknown_crs.parquet fixed.parquet --assume-crs84
+```
+
 See `gpio convert reproject --help` for all options.
 
 ## S3-Compatible Storage

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -314,6 +314,7 @@ def reproject(
     target_crs: str = "EPSG:4326",
     source_crs: str | None = None,
     geometry_column: str | None = None,
+    assume_crs84: bool = False,
 ) -> pa.Table:
     """
     Reproject geometry to a different coordinate reference system.
@@ -323,6 +324,8 @@ def reproject(
         target_crs: Target CRS (default: EPSG:4326)
         source_crs: Source CRS. If None, detected from metadata.
         geometry_column: Geometry column name (auto-detected if None)
+        assume_crs84: Treat an unknown/null input CRS as OGC:CRS84 instead of
+            whatever detection finds (no coordinate change).
 
     Returns:
         New table with reprojected geometry
@@ -332,6 +335,7 @@ def reproject(
         target_crs=target_crs,
         source_crs=source_crs,
         geometry_column=geometry_column,
+        assume_crs84=assume_crs84,
     )
 
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1408,6 +1408,7 @@ class Table:
         self,
         target_crs: str = "EPSG:4326",
         source_crs: str | None = None,
+        assume_crs84: bool = False,
     ) -> Table:
         """
         Reproject geometry to a different coordinate reference system.
@@ -1415,6 +1416,8 @@ class Table:
         Args:
             target_crs: Target CRS (default: EPSG:4326)
             source_crs: Source CRS. If None, detected from metadata.
+            assume_crs84: Treat an unknown/null input CRS as OGC:CRS84 instead of
+                whatever detection finds (no coordinate change).
 
         Returns:
             New Table with reprojected geometry
@@ -1426,6 +1429,7 @@ class Table:
             target_crs=target_crs,
             source_crs=source_crs,
             geometry_column=self._geometry_column,
+            assume_crs84=assume_crs84,
         )
         return Table(result, self._geometry_column)
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1440,6 +1440,7 @@ def _reproject_impl_cli(
     row_group_size_mb=None,
     row_group_rows=None,
     memory_limit=None,
+    assume_crs84=False,
 ):
     """Shared reproject CLI implementation."""
     from geoparquet_io.core.remote import validate_profile_for_urls
@@ -1450,20 +1451,24 @@ def _reproject_impl_cli(
     # Validate profile is only used with S3
     validate_profile_for_urls(None, input_file, output_file)
 
-    result = reproject_core(
-        input_parquet=input_file,
-        output_parquet=output_file,
-        target_crs=dst_crs,
-        source_crs=src_crs,
-        overwrite=overwrite,
-        compression=compression,
-        compression_level=compression_level,
-        verbose=verbose,
-        geoparquet_version=geoparquet_version,
-        row_group_size_mb=row_group_size_mb,
-        row_group_rows=row_group_rows,
-        memory_limit=memory_limit,
-    )
+    try:
+        result = reproject_core(
+            input_parquet=input_file,
+            output_parquet=output_file,
+            target_crs=dst_crs,
+            source_crs=src_crs,
+            overwrite=overwrite,
+            compression=compression,
+            compression_level=compression_level,
+            verbose=verbose,
+            geoparquet_version=geoparquet_version,
+            row_group_size_mb=row_group_size_mb,
+            row_group_rows=row_group_rows,
+            memory_limit=memory_limit,
+            assume_crs84=assume_crs84,
+        )
+    except ValueError as e:
+        raise click.ClickException(str(e)) from None
 
     # result is None for streaming mode (stdout)
     if result:
@@ -1489,6 +1494,15 @@ def _reproject_impl_cli(
     default=None,
     help="Override source CRS (e.g., 'EPSG:4326'). If not provided, detected from file metadata.",
 )
+@click.option(
+    "--assume-crs84",
+    is_flag=True,
+    help=(
+        "Treat an unknown (explicit null) input CRS as OGC:CRS84 and rewrite the "
+        "file so the crs key is omitted (the default). Use when data is really "
+        "lon/lat WGS84 but the file declares crs:null."
+    ),
+)
 @overwrite_option
 @verbose_option
 @aws_profile_option
@@ -1503,6 +1517,7 @@ def convert_reproject(
     output_file,
     dst_crs,
     src_crs,
+    assume_crs84,
     overwrite,
     verbose,
     aws_profile,
@@ -1552,6 +1567,7 @@ def convert_reproject(
             row_group_size_mb=row_group_mb,
             row_group_rows=row_group_size,
             memory_limit=write_memory,
+            assume_crs84=assume_crs84,
         )
 
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1486,7 +1486,11 @@ def _reproject_impl_cli(
     "-d",
     default="EPSG:4326",
     show_default=True,
-    help="Destination CRS (e.g., 'EPSG:4326', 'EPSG:32610')",
+    help=(
+        "Destination CRS (e.g., 'EPSG:4326', 'EPSG:32610'). The default "
+        "(EPSG:4326 / OGC:CRS84) is written by omitting the crs key per the "
+        "GeoParquet spec, so the output has no explicit crs."
+    ),
 )
 @click.option(
     "--src-crs",

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -11,6 +11,7 @@ import pyarrow.parquet as pq
 from geoparquet_io.core.crs_utils import (
     _format_crs_display,
     _wrap_query_with_crs,
+    apply_output_crs,
     is_default_crs,
 )
 from geoparquet_io.core.duckdb_utils import (
@@ -943,20 +944,12 @@ def _assemble_and_apply_geo_metadata(
     Returns:
         pa.Table: Table with geo metadata applied
     """
-    # Add CRS to geo metadata if provided (for v1.x and v2.0)
+    # Set/clear the geometry column's crs per the GeoParquet null-vs-default rule
+    # (shared helper is the single source of truth across all write paths).
     columns = geo_meta.setdefault("columns", {})
-    if input_crs and not is_default_crs(input_crs):
-        columns.setdefault(geometry_column, {})["crs"] = input_crs
-        if verbose:
-            debug(f"Added CRS to geo metadata: {_format_crs_display(input_crs)}")
-    elif geometry_column in columns and "crs" in columns[geometry_column]:
-        # The GeoParquet default CRS (OGC:CRS84 / EPSG:4326) is signalled by
-        # *omitting* the key — never an explicit crs:null. Strip any null/default
-        # crs the source or DuckDB may have attached so it isn't written through.
-        if is_default_crs(columns[geometry_column]["crs"]):
-            columns[geometry_column].pop("crs", None)
-            if verbose:
-                debug("Omitting default/null crs from geo metadata (spec default)")
+    apply_output_crs(columns.setdefault(geometry_column, {}), input_crs)
+    if verbose and input_crs and not is_default_crs(input_crs):
+        debug(f"Added CRS to geo metadata: {_format_crs_display(input_crs)}")
 
     # Apply metadata to table
     existing_metadata = dict(table.schema.metadata) if table.schema.metadata else {}

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -944,12 +944,19 @@ def _assemble_and_apply_geo_metadata(
         pa.Table: Table with geo metadata applied
     """
     # Add CRS to geo metadata if provided (for v1.x and v2.0)
+    columns = geo_meta.setdefault("columns", {})
     if input_crs and not is_default_crs(input_crs):
-        if geometry_column not in geo_meta.get("columns", {}):
-            geo_meta["columns"][geometry_column] = {}
-        geo_meta["columns"][geometry_column]["crs"] = input_crs
+        columns.setdefault(geometry_column, {})["crs"] = input_crs
         if verbose:
             debug(f"Added CRS to geo metadata: {_format_crs_display(input_crs)}")
+    elif geometry_column in columns and "crs" in columns[geometry_column]:
+        # The GeoParquet default CRS (OGC:CRS84 / EPSG:4326) is signalled by
+        # *omitting* the key — never an explicit crs:null. Strip any null/default
+        # crs the source or DuckDB may have attached so it isn't written through.
+        if is_default_crs(columns[geometry_column]["crs"]):
+            columns[geometry_column].pop("crs", None)
+            if verbose:
+                debug("Omitting default/null crs from geo metadata (spec default)")
 
     # Apply metadata to table
     existing_metadata = dict(table.schema.metadata) if table.schema.metadata else {}

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -7,6 +7,7 @@ CRS information from GeoParquet files and other spatial formats.
 
 import json
 import os
+from functools import lru_cache
 
 from geoparquet_io.core.duckdb_utils import _escape_sql_string
 from geoparquet_io.core.logging_config import debug, warn
@@ -74,15 +75,19 @@ def is_default_crs(crs):
     return False
 
 
-# Per-process set of inputs we've already warned about, to keep the broad
-# null-CRS warning from firing repeatedly within a single CLI invocation.
-_warned_null_crs_paths: set[str] = set()
-
-#: Shared guidance appended to null-CRS warnings/validation messages.
+#: Shared guidance appended to null-CRS warnings and the validate message.
 NULL_CRS_HINT = (
     "An explicit null CRS means the CRS is *unknown* (not the OGC:CRS84 default). "
     "If the coordinates are really lon/lat WGS84, run "
     "`gpio convert reproject <input> <output> --assume-crs84` to set the default."
+)
+
+#: Raised by the file/streaming reproject paths when DuckDB hits a ``crs: null``
+#: input without ``--assume-crs84`` (DuckDB's GeoParquet reader rejects it).
+NULL_CRS_NO_FLAG_ERROR = (
+    "Input has an explicit null CRS (unknown). DuckDB cannot read it. "
+    "If the coordinates are lon/lat WGS84, re-run with --assume-crs84 to "
+    "treat them as OGC:CRS84 and write the default."
 )
 
 
@@ -96,7 +101,11 @@ def crs_is_explicitly_null(col_meta: dict) -> bool:
 
 
 def geoparquet_crs_is_null(parquet_file) -> bool:
-    """Return True if the primary geometry column has an explicit ``crs: null``."""
+    """Return True if the primary geometry column has an explicit ``crs: null``.
+
+    ``parquet_file`` must be a *raw* path/URL — this helper SQL-escapes it
+    internally, so passing an already-escaped URL double-escapes it.
+    """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
     from geoparquet_io.core.file_utils import safe_file_url
 
@@ -109,12 +118,40 @@ def geoparquet_crs_is_null(parquet_file) -> bool:
     return crs_is_explicitly_null(col_meta)
 
 
-def warn_null_crs_once(key: str) -> None:
-    """Emit the null-CRS warning at most once per ``key`` for this process."""
-    if not key or key in _warned_null_crs_paths:
-        return
-    _warned_null_crs_paths.add(key)
+@lru_cache(maxsize=256)
+def _emit_null_crs_warning(key: str) -> None:
+    """Emit the null-CRS warning exactly once per ``key`` (LRU-bounded)."""
     warn(f"Input has an explicit null CRS (unknown). {NULL_CRS_HINT}")
+
+
+def warn_null_crs_once(key: str) -> None:
+    """Emit the null-CRS warning at most once per ``key`` for this process.
+
+    Dedup is bounded by an LRU cache so long-running processes (the Python API)
+    don't accumulate keys without limit.
+    """
+    if key:
+        _emit_null_crs_warning(key)
+
+
+def reset_null_crs_warnings() -> None:
+    """Clear the warn-once dedup cache. Intended for tests."""
+    _emit_null_crs_warning.cache_clear()
+
+
+def apply_target_crs_to_geo_meta(geo_meta: dict, geom_col: str, target_crs: str, con) -> None:
+    """Set or clear a geometry column's CRS in ``geo_meta`` in place.
+
+    The GeoParquet default CRS (EPSG:4326 / OGC:CRS84) is signalled by *omitting*
+    the ``crs`` key entirely — never by writing an explicit CRS84 object or null.
+    """
+    columns = geo_meta.get("columns", {})
+    if geom_col not in columns:
+        return
+    if is_default_crs(target_crs):
+        columns[geom_col].pop("crs", None)
+    else:
+        columns[geom_col]["crs"] = parse_crs_string_to_projjson(target_crs, con)
 
 
 def _validate_projjson(crs: dict) -> bool:

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -74,6 +74,49 @@ def is_default_crs(crs):
     return False
 
 
+# Per-process set of inputs we've already warned about, to keep the broad
+# null-CRS warning from firing repeatedly within a single CLI invocation.
+_warned_null_crs_paths: set[str] = set()
+
+#: Shared guidance appended to null-CRS warnings/validation messages.
+NULL_CRS_HINT = (
+    "An explicit null CRS means the CRS is *unknown* (not the OGC:CRS84 default). "
+    "If the coordinates are really lon/lat WGS84, run "
+    "`gpio convert reproject <input> <output> --assume-crs84` to set the default."
+)
+
+
+def crs_is_explicitly_null(col_meta: dict) -> bool:
+    """Return True only when a geometry column's metadata sets ``crs`` to null.
+
+    An explicit ``"crs": null`` means the CRS is unknown, which is different
+    from omitting the key entirely (the omitted case defaults to OGC:CRS84).
+    """
+    return isinstance(col_meta, dict) and "crs" in col_meta and col_meta["crs"] is None
+
+
+def geoparquet_crs_is_null(parquet_file) -> bool:
+    """Return True if the primary geometry column has an explicit ``crs: null``."""
+    from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.file_utils import safe_file_url
+
+    safe_url = safe_file_url(str(parquet_file), verbose=False)
+    geo_meta = get_geo_metadata(safe_url)
+    if not geo_meta:
+        return False
+    primary_col = geo_meta.get("primary_column", "geometry")
+    col_meta = geo_meta.get("columns", {}).get(primary_col, {})
+    return crs_is_explicitly_null(col_meta)
+
+
+def warn_null_crs_once(key: str) -> None:
+    """Emit the null-CRS warning at most once per ``key`` for this process."""
+    if not key or key in _warned_null_crs_paths:
+        return
+    _warned_null_crs_paths.add(key)
+    warn(f"Input has an explicit null CRS (unknown). {NULL_CRS_HINT}")
+
+
 def _validate_projjson(crs: dict) -> bool:
     """Validate that a CRS dict has the expected PROJJSON structure."""
     if not isinstance(crs, dict):
@@ -133,6 +176,8 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
         primary_col = geo_meta.get("primary_column", "geometry")
         columns = geo_meta.get("columns", {})
         if primary_col in columns:
+            if crs_is_explicitly_null(columns[primary_col]):
+                warn_null_crs_once(safe_url)
             crs = columns[primary_col].get("crs")
             if crs and not is_default_crs(crs):
                 if verbose:

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -75,6 +75,30 @@ def is_default_crs(crs):
     return False
 
 
+def apply_output_crs(col_meta: dict, input_crs) -> None:
+    """Set or clear a geometry column's ``crs`` for the requested output CRS.
+
+    Single source of truth for the GeoParquet null-vs-default CRS rule across all
+    write paths. The default CRS (OGC:CRS84 / EPSG:4326) is signalled by
+    *omitting* the ``crs`` key — never an explicit ``crs: null`` or ``crs: 4326``.
+
+    - ``input_crs`` non-default -> write it explicitly.
+    - ``input_crs`` default -> drop ``crs`` (output is the spec default), so a
+      stale value carried from the source (e.g. EPSG:3857 after reprojecting to
+      4326, or an explicit ``crs: null``) is not written through.
+    - ``input_crs`` is ``None`` (CRS unchanged) -> preserve a real ``crs`` but
+      still strip a stray default/null one the source or DuckDB may have attached.
+
+    Mutates ``col_meta`` in place.
+    """
+    if input_crs and not is_default_crs(input_crs):
+        col_meta["crs"] = input_crs
+    elif input_crs:
+        col_meta.pop("crs", None)
+    elif is_default_crs(col_meta.get("crs")):
+        col_meta.pop("crs", None)
+
+
 #: Shared guidance appended to null-CRS warnings and the validate message.
 NULL_CRS_HINT = (
     "An explicit null CRS means the CRS is *unknown* (not the OGC:CRS84 default). "

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import tempfile
-import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 
 from geoparquet_io.core.common import (
     check_bbox_structure,
@@ -18,11 +19,12 @@ from geoparquet_io.core.common import (
     write_parquet_with_metadata,
 )
 from geoparquet_io.core.crs_utils import (
+    NULL_CRS_NO_FLAG_ERROR,
     _extract_crs_identifier,
+    apply_target_crs_to_geo_meta,
     crs_is_explicitly_null,
     extract_crs_from_parquet,
     geoparquet_crs_is_null,
-    is_default_crs,
     parse_crs_string_to_projjson,
 )
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
@@ -127,6 +129,24 @@ def _detect_crs_from_table(table: pa.Table, geom_col: str) -> str:
     return "EPSG:4326"
 
 
+def _table_geo_column_meta(table: pa.Table, geom_col: str) -> dict:
+    """Return the geo-metadata dict for ``geom_col``, or ``{}`` if unavailable."""
+    if table.schema.metadata and b"geo" in table.schema.metadata:
+        try:
+            geo_meta = json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
+            return geo_meta.get("columns", {}).get(geom_col, {})
+        except (json.JSONDecodeError, KeyError):
+            return {}
+    return {}
+
+
+#: Raised by the Arrow/Python-API path on an explicit ``crs: null`` input.
+NULL_CRS_TABLE_ERROR = (
+    "Input table has an explicit null CRS (unknown). Pass assume_crs84=True to "
+    "treat the coordinates as OGC:CRS84 (lon/lat WGS84), or set source_crs."
+)
+
+
 def reproject_table(
     table: pa.Table,
     target_crs: str = "EPSG:4326",
@@ -149,15 +169,27 @@ def reproject_table(
 
     Returns:
         New table with reprojected geometry
+
+    Raises:
+        ValueError: If the input has an explicit ``crs: null`` (unknown CRS) and
+            neither ``source_crs`` nor ``assume_crs84`` is set. This mirrors the
+            CLI contract so the Python API never silently treats unknown data as
+            the default.
     """
     # Detect geometry column
     geom_col = geometry_column or _detect_geometry_column_from_table(table)
 
-    # Detect or use source CRS. When the input CRS is explicitly null/unknown and
-    # assume_crs84 is set, fall back to CRS84 rather than whatever detection finds.
-    effective_source_crs = source_crs or _detect_crs_from_table(table, geom_col)
-    if assume_crs84 and not source_crs:
+    # Resolve source CRS. An explicit crs:null is *unknown*, not the default — so
+    # mirror the CLI contract: require source_crs or assume_crs84, else raise,
+    # rather than silently transforming unknown coordinates as if lon/lat WGS84.
+    if source_crs:
+        effective_source_crs = source_crs
+    elif crs_is_explicitly_null(_table_geo_column_meta(table, geom_col)):
+        if not assume_crs84:
+            raise ValueError(NULL_CRS_TABLE_ERROR)
         effective_source_crs = "OGC:CRS84"
+    else:
+        effective_source_crs = _detect_crs_from_table(table, geom_col)
 
     # Create connection and register table
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
@@ -206,18 +238,11 @@ def reproject_table(
             if b"geo" in new_metadata:
                 try:
                     geo_meta = json.loads(new_metadata[b"geo"].decode("utf-8"))
-                    columns = geo_meta.get("columns", {})
-                    if geom_col in columns:
-                        if is_default_crs(target_crs):
-                            # Default CRS is signalled by omitting the key, never
-                            # by writing an explicit CRS84 object or null.
-                            columns[geom_col].pop("crs", None)
-                        else:
-                            columns[geom_col]["crs"] = parse_crs_string_to_projjson(target_crs, con)
+                    apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
                     new_metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
                     result = result.replace_schema_metadata(new_metadata)
-                except (json.JSONDecodeError, KeyError):
-                    pass
+                except (json.JSONDecodeError, KeyError) as e:
+                    debug(f"Could not update CRS in geo metadata, leaving as-is: {e}")
             else:
                 result = result.replace_schema_metadata(table.schema.metadata)
 
@@ -264,36 +289,89 @@ def _get_bbox_column_name(input_url: str, verbose: bool) -> str | None:
     return None
 
 
-def _sanitize_null_crs_file(input_url: str, verbose: bool = False) -> tuple[str, str | None]:
+def _row_group_compression(parquet_file: pq.ParquetFile) -> str:
+    """Return the file's first-column compression codec for ParquetWriter.
+
+    Preserves the input codec so the sanitized copy isn't silently re-encoded to
+    a different (e.g. larger) compression. Falls back to ZSTD for empty files.
+    """
+    md = parquet_file.metadata
+    if md.num_row_groups > 0 and md.row_group(0).num_columns > 0:
+        codec = md.row_group(0).column(0).compression
+        if codec:
+            codec = codec.lower()
+            return "none" if codec == "uncompressed" else codec
+    return "zstd"
+
+
+def _sanitize_null_crs_file(raw_path: str, verbose: bool = False) -> tuple[str, str | None]:
     """Strip an explicit ``crs: null`` so the file presents as default OGC:CRS84.
 
     DuckDB's GeoParquet reader rejects ``crs: null`` outright, so for the
-    ``assume_crs84`` path we rewrite the geo metadata (no coordinate change) to
-    a temp file and read from that instead.
+    ``assume_crs84`` path we rewrite the geo metadata (no coordinate change) to a
+    temp file and read from that instead. The rewrite streams row group by row
+    group so memory stays bounded — the rest of reproject is built to handle
+    larger-than-RAM files and a whole-file load would defeat that.
+
+    ``raw_path`` must be the *unescaped* path/URL (it is handed to PyArrow, not
+    SQL).
 
     Returns:
-        ``(url_to_read, temp_path_or_None)`` — the second element, when set, is a
+        ``(path_to_read, temp_path_or_None)`` — the second element, when set, is a
         temp file the caller must delete.
     """
-    import pyarrow.parquet as pq
+    if not geoparquet_crs_is_null(raw_path):
+        return raw_path, None
 
-    if not geoparquet_crs_is_null(input_url):
-        return input_url, None
-
-    table = pq.read_table(input_url)
-    metadata = dict(table.schema.metadata or {})
+    parquet_file = pq.ParquetFile(raw_path)
+    metadata = dict(parquet_file.schema_arrow.metadata or {})
     geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
     for col in geo_meta.get("columns", {}).values():
         if crs_is_explicitly_null(col):
             col.pop("crs", None)
     metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
-    table = table.replace_schema_metadata(metadata)
+    new_schema = parquet_file.schema_arrow.with_metadata(metadata)
 
-    temp_path = str(Path(tempfile.gettempdir()) / f"gpio_assume_crs84_{uuid.uuid4()}.parquet")
-    pq.write_table(table, temp_path)
+    # mkstemp creates the file atomically with 0600 perms (it holds a full copy
+    # of the user's data) and a collision-free name.
+    fd, temp_path = tempfile.mkstemp(suffix=".parquet", prefix="gpio_assume_crs84_")
+    os.close(fd)
+    try:
+        writer = pq.ParquetWriter(
+            temp_path, new_schema, compression=_row_group_compression(parquet_file)
+        )
+        try:
+            for i in range(parquet_file.num_row_groups):
+                writer.write_table(parquet_file.read_row_group(i))
+        finally:
+            writer.close()
+    except BaseException:
+        # Self-clean on any failure after creation so we never orphan the copy.
+        Path(temp_path).unlink(missing_ok=True)
+        raise
     if verbose:
-        debug(f"Treating unknown (null) CRS as OGC:CRS84 for {input_url}")
+        debug(f"Treating unknown (null) CRS as OGC:CRS84 for {raw_path}")
     return temp_path, temp_path
+
+
+def _resolve_null_crs_input(
+    raw_path: str, assume_crs84: bool, verbose: bool
+) -> tuple[str, str | None]:
+    """Resolve an explicit null CRS before DuckDB reads the file.
+
+    Without ``assume_crs84`` an explicit ``crs: null`` raises a friendly error
+    (DuckDB can't read it); with it, the file is sanitized to a temp copy.
+
+    ``raw_path`` must be the *unescaped* path/URL.
+
+    Returns:
+        ``(path_to_read, temp_path_or_None)`` — both are raw (unescaped) paths.
+    """
+    if assume_crs84:
+        return _sanitize_null_crs_file(raw_path, verbose=verbose)
+    if geoparquet_crs_is_null(raw_path):
+        raise ValueError(NULL_CRS_NO_FLAG_ERROR)
+    return raw_path, None
 
 
 def reproject_impl(
@@ -355,24 +433,15 @@ def reproject_impl(
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, input_parquet, output_parquet)
 
-    # Get safe URL for input
-    input_url = safe_file_url(input_parquet, verbose=verbose)
+    # Resolve an explicit null CRS before DuckDB reads the file: raise a friendly
+    # error without --assume-crs84, or sanitize to a temp copy with it. Pass the
+    # raw path (not the SQL-escaped URL) to the PyArrow/metadata helpers.
+    read_source, temp_sanitized = _resolve_null_crs_input(
+        input_parquet, assume_crs84, verbose=verbose
+    )
 
-    # When asked, rewrite an explicit null CRS to the default so DuckDB (which
-    # rejects crs:null) can read the file. The temp copy is read in place of the
-    # original; the geometry column source for detection follows it too.
-    temp_sanitized = None
-    geom_detect_source = input_parquet
-    if assume_crs84:
-        input_url, temp_sanitized = _sanitize_null_crs_file(input_url, verbose=verbose)
-        if temp_sanitized:
-            geom_detect_source = temp_sanitized
-    elif geoparquet_crs_is_null(input_url):
-        raise ValueError(
-            "Input has an explicit null CRS (unknown). DuckDB cannot read it. "
-            "If the coordinates are lon/lat WGS84, re-run with --assume-crs84 to "
-            "treat them as OGC:CRS84 and write the default."
-        )
+    # Safe URL for SQL interpolation, computed from the (possibly sanitized) path.
+    input_url = safe_file_url(read_source, verbose=verbose)
 
     # Create DuckDB connection with spatial extension
     con = get_duckdb_connection(
@@ -382,7 +451,7 @@ def reproject_impl(
 
     try:
         # Detect geometry column
-        geom_col = find_primary_geometry_column(geom_detect_source, verbose=verbose)
+        geom_col = find_primary_geometry_column(read_source, verbose=verbose)
         log(f"Geometry column: {geom_col}")
 
         # Detect source CRS from metadata
@@ -549,8 +618,9 @@ def reproject_impl(
 
     finally:
         con.close()
-        if temp_sanitized and Path(temp_sanitized).exists():
-            Path(temp_sanitized).unlink()
+        # unlink(missing_ok) avoids a TOCTOU and can't mask the real exception.
+        if temp_sanitized:
+            Path(temp_sanitized).unlink(missing_ok=True)
 
 
 def _reproject_streaming(
@@ -566,10 +636,6 @@ def _reproject_streaming(
     assume_crs84: bool = False,
 ) -> None:
     """Handle streaming input/output for reproject."""
-    import os
-
-    import pyarrow.parquet as pq
-
     # Suppress verbose when streaming to stdout
     if should_stream_output(output_path):
         verbose = False
@@ -590,21 +656,14 @@ def _reproject_streaming(
         else:
             working_file = input_path
 
-        # Get safe URL
-        working_url = safe_file_url(working_file, verbose=False)
+        # Resolve an explicit null CRS (raise without the flag, sanitize with it),
+        # passing the raw path — not the SQL-escaped URL — to PyArrow helpers.
+        working_file, temp_sanitized = _resolve_null_crs_input(
+            working_file, assume_crs84, verbose=verbose
+        )
 
-        # Rewrite an explicit null CRS to the default so DuckDB can read it.
-        if assume_crs84:
-            sanitized_url, temp_sanitized = _sanitize_null_crs_file(working_url, verbose=verbose)
-            if temp_sanitized:
-                working_file = temp_sanitized
-                working_url = sanitized_url
-        elif geoparquet_crs_is_null(working_url):
-            raise ValueError(
-                "Input has an explicit null CRS (unknown). DuckDB cannot read it. "
-                "If the coordinates are lon/lat WGS84, re-run with --assume-crs84 to "
-                "treat them as OGC:CRS84 and write the default."
-            )
+        # Get safe URL for SQL interpolation
+        working_url = safe_file_url(working_file, verbose=False)
 
         # Create connection
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(working_file))
@@ -670,16 +729,10 @@ def _reproject_streaming(
             if metadata and b"geo" in metadata:
                 try:
                     geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-                    columns = geo_meta.get("columns", {})
-                    if geom_col in columns:
-                        if is_default_crs(target_crs):
-                            # Default CRS is signalled by omitting the key.
-                            columns[geom_col].pop("crs", None)
-                        else:
-                            columns[geom_col]["crs"] = parse_crs_string_to_projjson(target_crs, con)
+                    apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
                     metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
-                except (json.JSONDecodeError, KeyError):
-                    pass
+                except (json.JSONDecodeError, KeyError) as e:
+                    debug(f"Could not update CRS in geo metadata, leaving as-is: {e}")
 
             # Write output using stream_io
             write_output(
@@ -701,11 +754,11 @@ def _reproject_streaming(
             con.close()
 
     finally:
-        # Clean up temp input file(s)
-        if temp_input_file and os.path.exists(temp_input_file):
-            os.remove(temp_input_file)
-        if temp_sanitized and os.path.exists(temp_sanitized):
-            os.remove(temp_sanitized)
+        # Clean up temp input file(s). unlink(missing_ok) avoids masking errors.
+        if temp_input_file:
+            Path(temp_input_file).unlink(missing_ok=True)
+        if temp_sanitized:
+            Path(temp_sanitized).unlink(missing_ok=True)
 
 
 def reproject(

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import tempfile
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,7 +19,10 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.crs_utils import (
     _extract_crs_identifier,
+    crs_is_explicitly_null,
     extract_crs_from_parquet,
+    geoparquet_crs_is_null,
+    is_default_crs,
     parse_crs_string_to_projjson,
 )
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
@@ -128,6 +132,7 @@ def reproject_table(
     target_crs: str = "EPSG:4326",
     source_crs: str | None = None,
     geometry_column: str | None = None,
+    assume_crs84: bool = False,
 ) -> pa.Table:
     """
     Reproject an Arrow Table to a different CRS.
@@ -139,6 +144,8 @@ def reproject_table(
         target_crs: Target CRS (default: EPSG:4326)
         source_crs: Source CRS. If None, detected from table metadata.
         geometry_column: Geometry column name. If None, detected from metadata.
+        assume_crs84: If True, treat an unknown/null input CRS as OGC:CRS84
+            instead of raising. Useful for fixing files that carry ``crs: null``.
 
     Returns:
         New table with reprojected geometry
@@ -146,8 +153,11 @@ def reproject_table(
     # Detect geometry column
     geom_col = geometry_column or _detect_geometry_column_from_table(table)
 
-    # Detect or use source CRS
+    # Detect or use source CRS. When the input CRS is explicitly null/unknown and
+    # assume_crs84 is set, fall back to CRS84 rather than whatever detection finds.
     effective_source_crs = source_crs or _detect_crs_from_table(table, geom_col)
+    if assume_crs84 and not source_crs:
+        effective_source_crs = "OGC:CRS84"
 
     # Create connection and register table
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
@@ -196,9 +206,14 @@ def reproject_table(
             if b"geo" in new_metadata:
                 try:
                     geo_meta = json.loads(new_metadata[b"geo"].decode("utf-8"))
-                    target_crs_projjson = parse_crs_string_to_projjson(target_crs, con)
-                    if geom_col in geo_meta.get("columns", {}):
-                        geo_meta["columns"][geom_col]["crs"] = target_crs_projjson
+                    columns = geo_meta.get("columns", {})
+                    if geom_col in columns:
+                        if is_default_crs(target_crs):
+                            # Default CRS is signalled by omitting the key, never
+                            # by writing an explicit CRS84 object or null.
+                            columns[geom_col].pop("crs", None)
+                        else:
+                            columns[geom_col]["crs"] = parse_crs_string_to_projjson(target_crs, con)
                     new_metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
                     result = result.replace_schema_metadata(new_metadata)
                 except (json.JSONDecodeError, KeyError):
@@ -249,6 +264,38 @@ def _get_bbox_column_name(input_url: str, verbose: bool) -> str | None:
     return None
 
 
+def _sanitize_null_crs_file(input_url: str, verbose: bool = False) -> tuple[str, str | None]:
+    """Strip an explicit ``crs: null`` so the file presents as default OGC:CRS84.
+
+    DuckDB's GeoParquet reader rejects ``crs: null`` outright, so for the
+    ``assume_crs84`` path we rewrite the geo metadata (no coordinate change) to
+    a temp file and read from that instead.
+
+    Returns:
+        ``(url_to_read, temp_path_or_None)`` — the second element, when set, is a
+        temp file the caller must delete.
+    """
+    import pyarrow.parquet as pq
+
+    if not geoparquet_crs_is_null(input_url):
+        return input_url, None
+
+    table = pq.read_table(input_url)
+    metadata = dict(table.schema.metadata or {})
+    geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
+    for col in geo_meta.get("columns", {}).values():
+        if crs_is_explicitly_null(col):
+            col.pop("crs", None)
+    metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
+    table = table.replace_schema_metadata(metadata)
+
+    temp_path = str(Path(tempfile.gettempdir()) / f"gpio_assume_crs84_{uuid.uuid4()}.parquet")
+    pq.write_table(table, temp_path)
+    if verbose:
+        debug(f"Treating unknown (null) CRS as OGC:CRS84 for {input_url}")
+    return temp_path, temp_path
+
+
 def reproject_impl(
     input_parquet: str,
     output_parquet: str | None = None,
@@ -264,6 +311,7 @@ def reproject_impl(
     row_group_size_mb: int | None = None,
     row_group_rows: int | None = None,
     memory_limit: str | None = None,
+    assume_crs84: bool = False,
 ) -> ReprojectResult:
     """
     Reproject a GeoParquet file to a different CRS using DuckDB.
@@ -273,6 +321,8 @@ def reproject_impl(
         output_parquet: Path to output file. If None, generates name from input.
         target_crs: Target CRS (default: EPSG:4326)
         source_crs: Override source CRS. If None, detected from metadata.
+        assume_crs84: Treat an unknown/null input CRS as OGC:CRS84 (rewrites the
+            metadata so DuckDB can read the file; no coordinate change).
         overwrite: If True and output_parquet is None, overwrite input file
         compression: Compression type (ZSTD, GZIP, BROTLI, LZ4, SNAPPY, UNCOMPRESSED)
         compression_level: Compression level (varies by format)
@@ -308,6 +358,22 @@ def reproject_impl(
     # Get safe URL for input
     input_url = safe_file_url(input_parquet, verbose=verbose)
 
+    # When asked, rewrite an explicit null CRS to the default so DuckDB (which
+    # rejects crs:null) can read the file. The temp copy is read in place of the
+    # original; the geometry column source for detection follows it too.
+    temp_sanitized = None
+    geom_detect_source = input_parquet
+    if assume_crs84:
+        input_url, temp_sanitized = _sanitize_null_crs_file(input_url, verbose=verbose)
+        if temp_sanitized:
+            geom_detect_source = temp_sanitized
+    elif geoparquet_crs_is_null(input_url):
+        raise ValueError(
+            "Input has an explicit null CRS (unknown). DuckDB cannot read it. "
+            "If the coordinates are lon/lat WGS84, re-run with --assume-crs84 to "
+            "treat them as OGC:CRS84 and write the default."
+        )
+
     # Create DuckDB connection with spatial extension
     con = get_duckdb_connection(
         load_spatial=True,
@@ -316,7 +382,7 @@ def reproject_impl(
 
     try:
         # Detect geometry column
-        geom_col = find_primary_geometry_column(input_parquet, verbose=verbose)
+        geom_col = find_primary_geometry_column(geom_detect_source, verbose=verbose)
         log(f"Geometry column: {geom_col}")
 
         # Detect source CRS from metadata
@@ -483,6 +549,8 @@ def reproject_impl(
 
     finally:
         con.close()
+        if temp_sanitized and Path(temp_sanitized).exists():
+            Path(temp_sanitized).unlink()
 
 
 def _reproject_streaming(
@@ -495,6 +563,7 @@ def _reproject_streaming(
     verbose: bool,
     profile: str | None,
     geoparquet_version: str | None,
+    assume_crs84: bool = False,
 ) -> None:
     """Handle streaming input/output for reproject."""
     import os
@@ -506,6 +575,7 @@ def _reproject_streaming(
         verbose = False
 
     temp_input_file = None
+    temp_sanitized = None
 
     try:
         # If reading from stdin, write to temp file first
@@ -522,6 +592,19 @@ def _reproject_streaming(
 
         # Get safe URL
         working_url = safe_file_url(working_file, verbose=False)
+
+        # Rewrite an explicit null CRS to the default so DuckDB can read it.
+        if assume_crs84:
+            sanitized_url, temp_sanitized = _sanitize_null_crs_file(working_url, verbose=verbose)
+            if temp_sanitized:
+                working_file = temp_sanitized
+                working_url = sanitized_url
+        elif geoparquet_crs_is_null(working_url):
+            raise ValueError(
+                "Input has an explicit null CRS (unknown). DuckDB cannot read it. "
+                "If the coordinates are lon/lat WGS84, re-run with --assume-crs84 to "
+                "treat them as OGC:CRS84 and write the default."
+            )
 
         # Create connection
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(working_file))
@@ -584,12 +667,16 @@ def _reproject_streaming(
             metadata, _ = get_parquet_metadata(working_file, verbose=False)
 
             # Update metadata with target CRS
-            target_crs_projjson = parse_crs_string_to_projjson(target_crs, con)
             if metadata and b"geo" in metadata:
                 try:
                     geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-                    if geom_col in geo_meta.get("columns", {}):
-                        geo_meta["columns"][geom_col]["crs"] = target_crs_projjson
+                    columns = geo_meta.get("columns", {})
+                    if geom_col in columns:
+                        if is_default_crs(target_crs):
+                            # Default CRS is signalled by omitting the key.
+                            columns[geom_col].pop("crs", None)
+                        else:
+                            columns[geom_col]["crs"] = parse_crs_string_to_projjson(target_crs, con)
                     metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
                 except (json.JSONDecodeError, KeyError):
                     pass
@@ -614,9 +701,11 @@ def _reproject_streaming(
             con.close()
 
     finally:
-        # Clean up temp input file
+        # Clean up temp input file(s)
         if temp_input_file and os.path.exists(temp_input_file):
             os.remove(temp_input_file)
+        if temp_sanitized and os.path.exists(temp_sanitized):
+            os.remove(temp_sanitized)
 
 
 def reproject(
@@ -634,6 +723,7 @@ def reproject(
     row_group_size_mb: int | None = None,
     row_group_rows: int | None = None,
     memory_limit: str | None = None,
+    assume_crs84: bool = False,
 ) -> ReprojectResult | None:
     """
     Reproject a GeoParquet file to a different CRS.
@@ -675,6 +765,7 @@ def reproject(
             verbose,
             profile,
             geoparquet_version,
+            assume_crs84=assume_crs84,
         )
         return None
 
@@ -694,4 +785,5 @@ def reproject(
         row_group_size_mb,
         row_group_rows,
         memory_limit,
+        assume_crs84=assume_crs84,
     )

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -258,9 +258,14 @@ def get_crs_from_arrow_table(table: pa.Table, geometry_column: str) -> str | Non
         return None
 
     try:
+        from geoparquet_io.core.crs_utils import crs_is_explicitly_null, warn_null_crs_once
+
         geo_meta = json.loads(geo_bytes.decode("utf-8"))
         columns = geo_meta.get("columns", {})
         col_meta = columns.get(geometry_column, {})
+
+        if crs_is_explicitly_null(col_meta):
+            warn_null_crs_once(f"table:{hash(geo_bytes)}")
 
         crs = col_meta.get("crs")
         if crs:
@@ -399,11 +404,16 @@ def extract_crs_from_table(
     # Fall back to geo metadata
     if table.schema.metadata and b"geo" in table.schema.metadata:
         try:
-            geo_meta = json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
+            from geoparquet_io.core.crs_utils import crs_is_explicitly_null, warn_null_crs_once
+
+            geo_bytes = table.schema.metadata[b"geo"]
+            geo_meta = json.loads(geo_bytes.decode("utf-8"))
             if isinstance(geo_meta, dict):
                 columns = geo_meta.get("columns", {})
                 geom_col_name = geometry_column or geo_meta.get("primary_column", "geometry")
                 if geom_col_name in columns:
+                    if crs_is_explicitly_null(columns[geom_col_name]):
+                        warn_null_crs_once(f"table:{hash(geo_bytes)}")
                     return columns[geom_col_name].get("crs")
         except (json.JSONDecodeError, UnicodeDecodeError):
             pass

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -16,6 +16,7 @@ Arrow IPC is used because:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 
@@ -265,7 +266,7 @@ def get_crs_from_arrow_table(table: pa.Table, geometry_column: str) -> str | Non
         col_meta = columns.get(geometry_column, {})
 
         if crs_is_explicitly_null(col_meta):
-            warn_null_crs_once(f"table:{hash(geo_bytes)}")
+            warn_null_crs_once(f"table:{hashlib.sha1(geo_bytes).hexdigest()}")
 
         crs = col_meta.get("crs")
         if crs:
@@ -413,7 +414,7 @@ def extract_crs_from_table(
                 geom_col_name = geometry_column or geo_meta.get("primary_column", "geometry")
                 if geom_col_name in columns:
                     if crs_is_explicitly_null(columns[geom_col_name]):
-                        warn_null_crs_once(f"table:{hash(geo_bytes)}")
+                        warn_null_crs_once(f"table:{hashlib.sha1(geo_bytes).hexdigest()}")
                     return columns[geom_col_name].get("crs")
         except (json.JSONDecodeError, UnicodeDecodeError):
             pass

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -266,7 +266,9 @@ def get_crs_from_arrow_table(table: pa.Table, geometry_column: str) -> str | Non
         col_meta = columns.get(geometry_column, {})
 
         if crs_is_explicitly_null(col_meta):
-            warn_null_crs_once(f"table:{hashlib.sha1(geo_bytes).hexdigest()}")
+            warn_null_crs_once(
+                f"table:{hashlib.sha1(geo_bytes, usedforsecurity=False).hexdigest()}"
+            )
 
         crs = col_meta.get("crs")
         if crs:
@@ -414,7 +416,9 @@ def extract_crs_from_table(
                 geom_col_name = geometry_column or geo_meta.get("primary_column", "geometry")
                 if geom_col_name in columns:
                     if crs_is_explicitly_null(columns[geom_col_name]):
-                        warn_null_crs_once(f"table:{hashlib.sha1(geo_bytes).hexdigest()}")
+                        warn_null_crs_once(
+                            f"table:{hashlib.sha1(geo_bytes, usedforsecurity=False).hexdigest()}"
+                        )
                     return columns[geom_col_name].get("crs")
         except (json.JSONDecodeError, UnicodeDecodeError):
             pass

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -266,14 +266,33 @@ def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck
 
 
 def _check_crs_valid(col_meta: dict, col_name: str) -> ValidationCheck:
-    """Check 9: optional 'crs' must be null or a PROJJSON object."""
-    crs = col_meta.get("crs")
+    """Check 9: optional 'crs' must be null or a PROJJSON object.
 
-    if crs is None:
+    Note the spec distinction: an omitted ``crs`` key defaults to OGC:CRS84,
+    while an explicit ``"crs": null`` means the CRS is *unknown*.
+    """
+    # Key omitted entirely -> defaults to OGC:CRS84 (the common, correct case).
+    if "crs" not in col_meta:
         return ValidationCheck(
             name=f"crs_valid_{col_name}",
             status=CheckStatus.PASSED,
             message=f'column "{col_name}" has no CRS (defaults to OGC:CRS84)',
+            category="column_metadata",
+        )
+
+    crs = col_meta.get("crs")
+
+    # Key present but null -> unknown CRS. Valid per spec, but usually a mistake
+    # when the data is really default lon/lat, so surface it as a warning.
+    if crs is None:
+        return ValidationCheck(
+            name=f"crs_valid_{col_name}",
+            status=CheckStatus.WARNING,
+            message=(
+                f'column "{col_name}" has an explicit null CRS (unknown CRS, not the '
+                "OGC:CRS84 default). If the data is lon/lat WGS84, use "
+                "`gpio convert reproject --assume-crs84` to set the default."
+            ),
             category="column_metadata",
         )
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from rich.console import Console
 
-from geoparquet_io.core.crs_utils import get_crs_display_name, is_geographic_crs
+from geoparquet_io.core.crs_utils import NULL_CRS_HINT, get_crs_display_name, is_geographic_crs
 
 
 class CheckStatus(Enum):
@@ -288,11 +288,7 @@ def _check_crs_valid(col_meta: dict, col_name: str) -> ValidationCheck:
         return ValidationCheck(
             name=f"crs_valid_{col_name}",
             status=CheckStatus.WARNING,
-            message=(
-                f'column "{col_name}" has an explicit null CRS (unknown CRS, not the '
-                "OGC:CRS84 default). If the data is lon/lat WGS84, use "
-                "`gpio convert reproject --assume-crs84` to set the default."
-            ),
+            message=f'column "{col_name}" has an explicit null CRS. {NULL_CRS_HINT}',
             category="column_metadata",
         )
 

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -222,7 +222,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geometry_info: dict | None = None,
     ) -> dict | None:
         """Build geo metadata for query results."""
-        from geoparquet_io.core.crs_utils import is_default_crs
+        from geoparquet_io.core.crs_utils import apply_output_crs
         from geoparquet_io.core.geo_metadata import create_geo_metadata
 
         if not should_add_geo_metadata:
@@ -239,8 +239,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         )
 
         col_meta = geo_meta["columns"][geometry_column]
-        if input_crs and not is_default_crs(input_crs):
-            col_meta["crs"] = input_crs
+        apply_output_crs(col_meta, input_crs)
         col_meta["encoding"] = "WKB"
         col_meta["geometry_types"] = precomputed_geom_types
         if precomputed_bbox is not None:
@@ -425,7 +424,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             _detect_version_from_table,
             validate_compression_settings,
         )
-        from geoparquet_io.core.crs_utils import is_default_crs
+        from geoparquet_io.core.crs_utils import apply_output_crs
         from geoparquet_io.core.geo_metadata import GEOPARQUET_VERSIONS, create_geo_metadata
 
         configure_verbose(verbose)
@@ -473,8 +472,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             geo_meta["columns"][geometry_column]["encoding"] = "WKB"
             geo_meta["columns"][geometry_column]["geometry_types"] = geom_types
 
-            if input_crs and not is_default_crs(input_crs):
-                geo_meta["columns"][geometry_column]["crs"] = input_crs
+            apply_output_crs(geo_meta["columns"][geometry_column], input_crs)
 
         schema_with_meta = self._build_streaming_schema(
             schema=table.schema,

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -55,7 +55,7 @@ def build_geo_metadata(
     Returns:
         dict: Complete geo metadata structure ready for embedding in Parquet
     """
-    from geoparquet_io.core.crs_utils import is_default_crs
+    from geoparquet_io.core.crs_utils import apply_output_crs
     from geoparquet_io.core.geo_metadata import GEOPARQUET_VERSIONS
 
     version_config = GEOPARQUET_VERSIONS.get(geoparquet_version, GEOPARQUET_VERSIONS["1.1"])
@@ -88,9 +88,9 @@ def build_geo_metadata(
     if bbox is not None:
         col_meta["bbox"] = bbox
 
-    # CRS (only if non-default)
-    if input_crs and not is_default_crs(input_crs):
-        col_meta["crs"] = input_crs
+    # CRS: write non-default explicitly; omit (and strip any stale/default/null
+    # value carried from the source) when the output is the spec default.
+    apply_output_crs(col_meta, input_crs)
 
     # Merge custom metadata into geometry column
     if custom_metadata:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,43 @@ def temp_output_file(temp_output_dir):
     return os.path.join(temp_output_dir, "output.parquet")
 
 
+def _write_with_crs_state(source_file, dest_file, crs_state):
+    """Write a copy of source_file with the geometry column's crs key adjusted.
+
+    crs_state: "null" sets crs to None (explicit unknown CRS); "absent" removes
+    the crs key entirely (defaults to OGC:CRS84 per the GeoParquet spec).
+    """
+    table = pq.read_table(source_file)
+    metadata = dict(table.schema.metadata or {})
+    geo = json.loads(metadata[b"geo"].decode("utf-8"))
+    primary = geo.get("primary_column", "geometry")
+    col_meta = geo["columns"][primary]
+    if crs_state == "null":
+        col_meta["crs"] = None
+    elif crs_state == "absent":
+        col_meta.pop("crs", None)
+    metadata[b"geo"] = json.dumps(geo).encode("utf-8")
+    table = table.replace_schema_metadata(metadata)
+    pq.write_table(table, dest_file)
+    return dest_file
+
+
+@pytest.fixture
+def null_crs_parquet(tmp_path):
+    """A GeoParquet file with an explicit ``"crs": null`` (unknown CRS)."""
+    return _write_with_crs_state(
+        str(BUILDINGS_TEST_FILE), str(tmp_path / "null_crs.parquet"), "null"
+    )
+
+
+@pytest.fixture
+def absent_crs_parquet(tmp_path):
+    """A GeoParquet file with the crs key omitted (defaults to OGC:CRS84)."""
+    return _write_with_crs_state(
+        str(BUILDINGS_TEST_FILE), str(tmp_path / "absent_crs.parquet"), "absent"
+    )
+
+
 @contextmanager
 def duckdb_connection():
     """

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -387,13 +387,6 @@ class TestChainOperationExecution:
             assert "final_rows" in result
             assert "final_size_mb" in result
 
-    @pytest.mark.skip(
-        reason="Known CRS bug on main: reprojecting EPSG:3857 -> EPSG:4326 leaves the "
-        "stale 3857 in geo metadata (_assemble_and_apply_geo_metadata only overwrites "
-        "crs when non-default), so the quadkey step rejects the file. The real fix lives "
-        "on the fix/crs-null-vs-default branch (PR #471) - remove this skip there, do NOT "
-        "carry it into that PR."
-    )
     def test_chain_filter_reproject_partition_runs(self, places_test_file):
         """Test chain-filter-reproject-partition operation runs."""
         from geoparquet_io.benchmarks.operations import get_operation

--- a/tests/test_crs_null_vs_default.py
+++ b/tests/test_crs_null_vs_default.py
@@ -10,13 +10,15 @@ Covers:
 """
 
 import pyarrow.parquet as pq
+import pytest
 
 from geoparquet_io.core.crs_utils import (
     crs_is_explicitly_null,
     extract_crs_from_parquet,
     geoparquet_crs_is_null,
+    reset_null_crs_warnings,
 )
-from geoparquet_io.core.reproject import reproject, reproject_table
+from geoparquet_io.core.reproject import _reproject_streaming, reproject, reproject_table
 from geoparquet_io.core.validate import CheckStatus, _check_crs_valid
 from tests.conftest import get_geo_metadata
 
@@ -108,13 +110,108 @@ def test_reproject_to_real_crs_still_writes_crs(buildings_test_file, temp_output
     assert present and value is not None
 
 
-def test_reproject_streaming_default_target_omits_crs(buildings_test_file, temp_output_file):
+def test_reproject_default_target_omits_crs(buildings_test_file, temp_output_file):
     # buildings_test is default CRS; reproject to default should keep crs omitted, not null.
     reproject(buildings_test_file, temp_output_file, target_crs="EPSG:4326")
     present, value = _col_crs(temp_output_file)
     assert value is not None or present is False
     # The key must never be present-and-null.
     assert not (present and value is None)
+
+
+# --------------------------------------------------------------------------- #
+# streaming path: _reproject_streaming is exercised directly (file->file routes
+# through reproject_impl, so these call the streaming function explicitly).
+# --------------------------------------------------------------------------- #
+
+
+def _stream(input_file, output_file, target_crs, assume_crs84=False):
+    """Drive _reproject_streaming directly with file paths."""
+    _reproject_streaming(
+        input_file,
+        output_file,
+        target_crs,
+        None,  # source_crs
+        "ZSTD",  # compression
+        None,  # compression_level
+        False,  # verbose
+        None,  # profile
+        None,  # geoparquet_version
+        assume_crs84=assume_crs84,
+    )
+
+
+def test_streaming_default_target_omits_crs(buildings_test_file, temp_output_file):
+    _stream(buildings_test_file, temp_output_file, "EPSG:4326")
+    present, value = _col_crs(temp_output_file)
+    assert not (present and value is None), "streaming default must not write crs:null"
+
+
+def test_streaming_real_target_writes_crs(buildings_test_file, temp_output_file):
+    _stream(buildings_test_file, temp_output_file, "EPSG:3857")
+    present, value = _col_crs(temp_output_file)
+    assert present and value is not None
+
+
+def test_streaming_null_input_without_flag_raises(null_crs_parquet, temp_output_file):
+    with pytest.raises(ValueError, match="assume-crs84"):
+        _stream(null_crs_parquet, temp_output_file, "EPSG:4326")
+
+
+def test_streaming_assume_crs84_null_input_succeeds(null_crs_parquet, temp_output_file):
+    _stream(null_crs_parquet, temp_output_file, "EPSG:4326", assume_crs84=True)
+    assert "crs" not in get_geo_metadata(temp_output_file)["columns"]["geometry"]
+
+
+# --------------------------------------------------------------------------- #
+# Arrow/Python-API path (reproject_table) must not silently coerce crs:null
+# --------------------------------------------------------------------------- #
+
+
+def _table_with_crs_state(buildings_test_file, crs_state):
+    """Return an in-memory table whose geometry crs is null/absent/present."""
+    import json
+
+    table = pq.read_table(buildings_test_file)
+    metadata = dict(table.schema.metadata)
+    geo = json.loads(metadata[b"geo"].decode("utf-8"))
+    col = geo["columns"][geo.get("primary_column", "geometry")]
+    if crs_state == "null":
+        col["crs"] = None
+    elif crs_state == "absent":
+        col.pop("crs", None)
+    metadata[b"geo"] = json.dumps(geo).encode("utf-8")
+    return table.replace_schema_metadata(metadata)
+
+
+def test_reproject_table_null_crs_without_flag_raises(buildings_test_file):
+    table = _table_with_crs_state(buildings_test_file, "null")
+    with pytest.raises(ValueError, match="null CRS"):
+        reproject_table(table, target_crs="EPSG:3857")
+
+
+def test_reproject_table_null_crs_assume_crs84_succeeds(buildings_test_file):
+    import json
+
+    table = _table_with_crs_state(buildings_test_file, "null")
+    result = reproject_table(table, target_crs="EPSG:3857", assume_crs84=True)
+    out_geo = json.loads(result.schema.metadata[b"geo"].decode("utf-8"))
+    assert out_geo["columns"]["geometry"]["crs"] is not None
+
+
+def test_reproject_table_null_crs_explicit_source_crs_succeeds(buildings_test_file):
+    # An explicit source_crs satisfies the contract even with crs:null input.
+    table = _table_with_crs_state(buildings_test_file, "null")
+    result = reproject_table(table, target_crs="EPSG:4326", source_crs="EPSG:4326")
+    out_geo = result.schema.metadata[b"geo"].decode("utf-8")
+    assert '"crs"' not in out_geo or "null" not in out_geo
+
+
+def test_reproject_table_absent_crs_still_reprojects(buildings_test_file):
+    # Omitted crs (true default) must NOT raise — it is the common case.
+    table = _table_with_crs_state(buildings_test_file, "absent")
+    result = reproject_table(table, target_crs="EPSG:3857")
+    assert result.num_rows == table.num_rows
 
 
 # --------------------------------------------------------------------------- #
@@ -160,30 +257,47 @@ def test_assume_crs84_coords_unchanged_for_default(null_crs_parquet, temp_output
 # --------------------------------------------------------------------------- #
 
 
+def _null_crs_warnings(records):
+    return [r for r in records if "null" in r.message.lower() and "crs" in r.message.lower()]
+
+
 def test_warn_on_null_crs_emitted_once(null_crs_parquet, caplog):
     import logging
 
-    from geoparquet_io.core import crs_utils
-
-    crs_utils._warned_null_crs_paths.clear()
+    reset_null_crs_warnings()
     with caplog.at_level(logging.WARNING):
         extract_crs_from_parquet(null_crs_parquet)
         extract_crs_from_parquet(null_crs_parquet)
-    null_warnings = [
-        r for r in caplog.records if "null" in r.message.lower() and "crs" in r.message.lower()
-    ]
-    assert len(null_warnings) == 1
+    assert len(_null_crs_warnings(caplog.records)) == 1
 
 
 def test_no_warn_on_absent_crs(absent_crs_parquet, caplog):
     import logging
 
-    from geoparquet_io.core import crs_utils
-
-    crs_utils._warned_null_crs_paths.clear()
+    reset_null_crs_warnings()
     with caplog.at_level(logging.WARNING):
         extract_crs_from_parquet(absent_crs_parquet)
-    null_warnings = [
-        r for r in caplog.records if "null" in r.message.lower() and "crs" in r.message.lower()
-    ]
-    assert null_warnings == []
+    assert _null_crs_warnings(caplog.records) == []
+
+
+def test_warn_on_two_distinct_null_files(null_crs_parquet, buildings_test_file, tmp_path, caplog):
+    """Two different null-CRS inputs must each warn (dedup key not over-broad)."""
+    import json
+    import logging
+
+    # Build a second, distinct null-CRS file (different path + a tweaked metadata
+    # field so its geo bytes differ from the first).
+    second = pq.read_table(buildings_test_file)
+    meta = dict(second.schema.metadata)
+    geo = json.loads(meta[b"geo"].decode("utf-8"))
+    geo["columns"]["geometry"]["crs"] = None
+    geo["columns"]["geometry"]["geometry_types"] = []  # make bytes distinct
+    meta[b"geo"] = json.dumps(geo).encode("utf-8")
+    second_path = str(tmp_path / "second_null.parquet")
+    pq.write_table(second.replace_schema_metadata(meta), second_path)
+
+    reset_null_crs_warnings()
+    with caplog.at_level(logging.WARNING):
+        extract_crs_from_parquet(null_crs_parquet)
+        extract_crs_from_parquet(second_path)
+    assert len(_null_crs_warnings(caplog.records)) == 2

--- a/tests/test_crs_null_vs_default.py
+++ b/tests/test_crs_null_vs_default.py
@@ -1,0 +1,189 @@
+"""Tests distinguishing an explicit ``"crs": null`` (unknown CRS) from an
+omitted crs key (defaults to OGC:CRS84) per the GeoParquet spec.
+
+Covers:
+- the new ``crs_is_explicitly_null`` / ``geoparquet_crs_is_null`` helpers
+- the ``_check_crs_valid`` validate behavior (null -> WARNING, absent -> PASSED)
+- the latent reproject bug (default target must omit crs, never write null)
+- the ``--assume-crs84`` / ``assume_crs84`` fix path
+- the broad "encountered null CRS" warning fired from the shared read path
+"""
+
+import pyarrow.parquet as pq
+
+from geoparquet_io.core.crs_utils import (
+    crs_is_explicitly_null,
+    extract_crs_from_parquet,
+    geoparquet_crs_is_null,
+)
+from geoparquet_io.core.reproject import reproject, reproject_table
+from geoparquet_io.core.validate import CheckStatus, _check_crs_valid
+from tests.conftest import get_geo_metadata
+
+
+def _col_crs(parquet_file, geometry_column="geometry"):
+    """Return (key_present, value) for the geometry column's crs."""
+    geo = get_geo_metadata(parquet_file)
+    col = geo["columns"][geo.get("primary_column", geometry_column)]
+    return ("crs" in col, col.get("crs"))
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_crs_is_explicitly_null_true_for_null():
+    assert crs_is_explicitly_null({"crs": None}) is True
+
+
+def test_crs_is_explicitly_null_false_for_absent():
+    assert crs_is_explicitly_null({}) is False
+
+
+def test_crs_is_explicitly_null_false_for_present():
+    assert crs_is_explicitly_null({"crs": {"id": {"authority": "EPSG", "code": 4326}}}) is False
+
+
+def test_geoparquet_crs_is_null_detects_null(null_crs_parquet):
+    assert geoparquet_crs_is_null(null_crs_parquet) is True
+
+
+def test_geoparquet_crs_is_null_false_for_absent(absent_crs_parquet):
+    assert geoparquet_crs_is_null(absent_crs_parquet) is False
+
+
+def test_geoparquet_crs_is_null_false_for_normal(buildings_test_file):
+    assert geoparquet_crs_is_null(buildings_test_file) is False
+
+
+# --------------------------------------------------------------------------- #
+# validate
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_crs_null_is_warning():
+    check = _check_crs_valid({"crs": None}, "geometry")
+    assert check.status == CheckStatus.WARNING
+    assert "unknown" in check.message.lower()
+    assert "assume-crs84" in check.message
+
+
+def test_validate_crs_absent_is_passed():
+    check = _check_crs_valid({}, "geometry")
+    assert check.status == CheckStatus.PASSED
+    assert "CRS84" in check.message
+
+
+def test_validate_crs_projjson_still_passes():
+    check = _check_crs_valid({"crs": {"type": "GeographicCRS", "name": "WGS 84"}}, "geometry")
+    assert check.status == CheckStatus.PASSED
+
+
+# --------------------------------------------------------------------------- #
+# latent reproject bug: default target must omit crs (never null)
+# --------------------------------------------------------------------------- #
+
+
+def test_reproject_table_default_target_omits_crs_key(buildings_test_file):
+    import json
+
+    # Build a WKB table that claims a non-default CRS, then reproject to default.
+    table = pq.read_table(buildings_test_file)
+    metadata = dict(table.schema.metadata)
+    geo = json.loads(metadata[b"geo"].decode("utf-8"))
+    geo["columns"]["geometry"]["crs"] = {"id": {"authority": "EPSG", "code": 3857}}
+    metadata[b"geo"] = json.dumps(geo).encode("utf-8")
+    table = table.replace_schema_metadata(metadata)
+
+    result = reproject_table(table, target_crs="EPSG:4326")
+    out_geo = json.loads(result.schema.metadata[b"geo"].decode("utf-8"))
+    col = out_geo["columns"]["geometry"]
+    assert "crs" not in col, f"default target should omit crs, got {col.get('crs')!r}"
+
+
+def test_reproject_to_real_crs_still_writes_crs(buildings_test_file, temp_output_file):
+    reproject(buildings_test_file, temp_output_file, target_crs="EPSG:3857")
+    present, value = _col_crs(temp_output_file)
+    assert present and value is not None
+
+
+def test_reproject_streaming_default_target_omits_crs(buildings_test_file, temp_output_file):
+    # buildings_test is default CRS; reproject to default should keep crs omitted, not null.
+    reproject(buildings_test_file, temp_output_file, target_crs="EPSG:4326")
+    present, value = _col_crs(temp_output_file)
+    assert value is not None or present is False
+    # The key must never be present-and-null.
+    assert not (present and value is None)
+
+
+# --------------------------------------------------------------------------- #
+# assume_crs84 fix path
+# --------------------------------------------------------------------------- #
+
+
+def test_assume_crs84_null_input_default_dst(null_crs_parquet, temp_output_file):
+    reproject(null_crs_parquet, temp_output_file, target_crs="EPSG:4326", assume_crs84=True)
+    present, value = _col_crs(temp_output_file)
+    assert not (present and value is None), "output should not carry crs:null"
+    # default target -> crs key omitted
+    assert "crs" not in get_geo_metadata(temp_output_file)["columns"]["geometry"]
+
+
+def test_assume_crs84_null_input_real_dst(null_crs_parquet, temp_output_file):
+    reproject(null_crs_parquet, temp_output_file, target_crs="EPSG:3857", assume_crs84=True)
+    present, value = _col_crs(temp_output_file)
+    assert present and value is not None
+
+
+def test_reproject_null_input_without_flag_raises(null_crs_parquet, temp_output_file):
+    import pytest
+
+    with pytest.raises(ValueError, match="assume-crs84"):
+        reproject(null_crs_parquet, temp_output_file, target_crs="EPSG:4326")
+
+
+def test_assume_crs84_coords_unchanged_for_default(null_crs_parquet, temp_output_file):
+    import json
+
+    before = pq.read_table(null_crs_parquet)
+    reproject(null_crs_parquet, temp_output_file, target_crs="EPSG:4326", assume_crs84=True)
+    after = pq.read_table(temp_output_file)
+    assert before.num_rows == after.num_rows
+    # geo metadata crs must be gone
+    geo = json.loads(after.schema.metadata[b"geo"].decode("utf-8"))
+    assert "crs" not in geo["columns"]["geometry"]
+
+
+# --------------------------------------------------------------------------- #
+# warning fired from the shared read path (deduped)
+# --------------------------------------------------------------------------- #
+
+
+def test_warn_on_null_crs_emitted_once(null_crs_parquet, caplog):
+    import logging
+
+    from geoparquet_io.core import crs_utils
+
+    crs_utils._warned_null_crs_paths.clear()
+    with caplog.at_level(logging.WARNING):
+        extract_crs_from_parquet(null_crs_parquet)
+        extract_crs_from_parquet(null_crs_parquet)
+    null_warnings = [
+        r for r in caplog.records if "null" in r.message.lower() and "crs" in r.message.lower()
+    ]
+    assert len(null_warnings) == 1
+
+
+def test_no_warn_on_absent_crs(absent_crs_parquet, caplog):
+    import logging
+
+    from geoparquet_io.core import crs_utils
+
+    crs_utils._warned_null_crs_paths.clear()
+    with caplog.at_level(logging.WARNING):
+        extract_crs_from_parquet(absent_crs_parquet)
+    null_warnings = [
+        r for r in caplog.records if "null" in r.message.lower() and "crs" in r.message.lower()
+    ]
+    assert null_warnings == []


### PR DESCRIPTION
## Problem

The GeoParquet spec treats two states on a geometry column's `crs` differently:

- **`crs` key omitted** → defaults to **OGC:CRS84** (lon/lat WGS84)
- **`"crs": null`** → CRS is **unknown**

gpio conflated these (`is_default_crs()` / `extract_crs_from_parquet()` collapse `null` → `None` → "default", and geo metadata is serialized with `json.dumps()` without filtering `None`). As a result, an input file carrying `"crs": null` had that null **passed straight through to output**. Users reported getting `"crs": null` in output when their data was really default lon/lat.

## Changes

1. **Warn on null CRS (broad).** New `crs_is_explicitly_null` / `geoparquet_crs_is_null` helpers; the shared CRS read path (`extract_crs_from_parquet`, the streaming read helpers) now logs a warning once per input when it encounters an explicit `crs: null`.
2. **`gpio check spec`** now reports `crs: null` as a **WARNING** ("unknown CRS, not the OGC:CRS84 default") instead of incorrectly passing it as "defaults to OGC:CRS84".
3. **Latent reproject bug fixed.** Reprojecting to a *default* CRS previously wrote an explicit CRS84 object (or a stray `null` if CRS parsing failed) into the output geo metadata. It now **omits** the key. Affected the Arrow/Python-API (`reproject_table`) and streaming (`_reproject_streaming`) paths; the file path was already guarded via `write_parquet_with_metadata`.
4. **New `gpio convert reproject --assume-crs84` flag** (and `assume_crs84=` on `ops.reproject` / `Table.reproject`). Treats an unknown/null-CRS input as OGC:CRS84 and rewrites so the `crs` key is omitted — no coordinates change. DuckDB rejects `crs: null` at read, so the flag sanitizes the geo metadata to a temp file first. Without the flag, reproject now raises a **clear error** pointing at it instead of a raw DuckDB traceback.

## Out of scope

`carto.py`, `arcgis.py`, `wfs.py`, `write_strategies/`, `geo_metadata.py` mint fresh CRS from a known source and don't pass an input `crs:null` through — left unchanged.

## Tests

New `tests/test_crs_null_vs_default.py` (18 tests) covering the helpers, the validate WARNING vs PASSED distinction, the reproject omit-key regression, the `--assume-crs84` fix path (default + real destination), the friendly error, and warn-once behavior. Fixtures added to `conftest.py`. Full fast suite green (2732 passed).

## Verification

```bash
# file with crs:null
gpio check spec null.parquet          # -> WARNING: unknown CRS
gpio convert reproject null.parquet out.parquet            # -> clear error, suggests --assume-crs84
gpio convert reproject null.parquet out.parquet --assume-crs84   # -> succeeds, crs key omitted, coords unchanged
gpio convert reproject buildings.parquet out2.parquet -d EPSG:4326   # -> crs omitted, never null
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI flag and Python API option to treat an explicit null CRS as OGC:CRS84, rewriting output metadata to omit the CRS without changing coordinates.

* **Bug Fixes**
  * Distinguish explicit `crs: null` from omitted CRS: now emits a WARNING (and shows WARNING in checks). Reproject-to-default omits the CRS key. Reprojection without the flag errors for null CRS; with the flag it succeeds.

* **Documentation**
  * Docs updated to explain behaviors, flag/parameter usage, and validation messaging.

* **Tests**
  * Added tests for null-vs-absent CRS handling, warning deduplication, and reprojection outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->