### PR TITLE
fix(add): filter Overture admin caches to land — stop ~2.6x row multiplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,10 +95,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   separate maritime (EEZ) polygon per division whose geometry spans the entire
   territory including the landmass, so every land feature matched both the land
   and maritime polygon at each level (~2x for country, ~1.3x for region). The
-  per-level caches are now filtered to land polygons (`is_land = true`), making
-  them genuinely non-overlapping so the memory-safe plain spatial join no longer
-  multiplies rows. Cache files gain a `-land` suffix, which invalidates stale
-  maritime-contaminated caches automatically.
+  per-level caches are now filtered to land polygons (`is_land IS NOT FALSE`),
+  making them genuinely non-overlapping so the memory-safe plain spatial join no
+  longer multiplies rows. Cache files gain a `-land` suffix, which invalidates
+  stale maritime-contaminated caches automatically (the old unsuffixed files are
+  also removed on the next download).
+  - `gpio partition admin` now joins each level against its own land-only cache
+    (chained per-level joins), the same memory-bounded approach as
+    `gpio add admin-divisions`; previously it joined the raw remote dataset and
+    still multiplied rows / risked OOM.
+  - Behavior change: genuinely offshore features (outside any land polygon, e.g.
+    buoys or platforms that previously matched the surrounding EEZ) now receive
+    no admin code — `ZZ` in `--vecorel` mode, `NULL` otherwise. This is correct
+    for land datasets; a maritime opt-in could be added later if needed.
   - Overture now uses a **per-level cache** (separate country and region cache
     files instead of one combined file), with simplified boundaries, to keep
     memory bounded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
     output geo metadata. Affected the Arrow/Python-API and streaming paths.
 - Fix out-of-memory crash in `gpio add admin-divisions --dataset overture` on
   large inputs (#461)
+- Fix `gpio add admin-divisions`/`gpio partition admin` with the Overture
+  dataset producing ~2.6x as many output rows as the input. Overture stores a
+  separate maritime (EEZ) polygon per division whose geometry spans the entire
+  territory including the landmass, so every land feature matched both the land
+  and maritime polygon at each level (~2x for country, ~1.3x for region). The
+  per-level caches are now filtered to land polygons (`is_land = true`), making
+  them genuinely non-overlapping so the memory-safe plain spatial join no longer
+  multiplies rows. Cache files gain a `-land` suffix, which invalidates stale
+  maritime-contaminated caches automatically.
   - Overture now uses a **per-level cache** (separate country and region cache
     files instead of one combined file), with simplified boundaries, to keep
     memory bounded.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -95,10 +95,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   separate maritime (EEZ) polygon per division whose geometry spans the entire
   territory including the landmass, so every land feature matched both the land
   and maritime polygon at each level (~2x for country, ~1.3x for region). The
-  per-level caches are now filtered to land polygons (`is_land = true`), making
-  them genuinely non-overlapping so the memory-safe plain spatial join no longer
-  multiplies rows. Cache files gain a `-land` suffix, which invalidates stale
-  maritime-contaminated caches automatically.
+  per-level caches are now filtered to land polygons (`is_land IS NOT FALSE`),
+  making them genuinely non-overlapping so the memory-safe plain spatial join no
+  longer multiplies rows. Cache files gain a `-land` suffix, which invalidates
+  stale maritime-contaminated caches automatically (the old unsuffixed files are
+  also removed on the next download).
+  - `gpio partition admin` now joins each level against its own land-only cache
+    (chained per-level joins), the same memory-bounded approach as
+    `gpio add admin-divisions`; previously it joined the raw remote dataset and
+    still multiplied rows / risked OOM.
+  - Behavior change: genuinely offshore features (outside any land polygon, e.g.
+    buoys or platforms that previously matched the surrounding EEZ) now receive
+    no admin code — `ZZ` in `--vecorel` mode, `NULL` otherwise. This is correct
+    for land datasets; a maritime opt-in could be added later if needed.
   - Overture now uses a **per-level cache** (separate country and region cache
     files instead of one combined file), with simplified boundaries, to keep
     memory bounded.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
     output geo metadata. Affected the Arrow/Python-API and streaming paths.
 - Fix out-of-memory crash in `gpio add admin-divisions --dataset overture` on
   large inputs (#461)
+- Fix `gpio add admin-divisions`/`gpio partition admin` with the Overture
+  dataset producing ~2.6x as many output rows as the input. Overture stores a
+  separate maritime (EEZ) polygon per division whose geometry spans the entire
+  territory including the landmass, so every land feature matched both the land
+  and maritime polygon at each level (~2x for country, ~1.3x for region). The
+  per-level caches are now filtered to land polygons (`is_land = true`), making
+  them genuinely non-overlapping so the memory-safe plain spatial join no longer
+  multiplies rows. Cache files gain a `-land` suffix, which invalidates stale
+  maritime-contaminated caches automatically.
   - Overture now uses a **per-level cache** (separate country and region cache
     files instead of one combined file), with simplified boundaries, to keep
     memory bounded.

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -37,6 +37,22 @@ CACHE_AGE_THRESHOLD_SECONDS = 6 * 30 * 24 * 60 * 60  # ~180 days
 # independently, so shared borders are not perfectly coincident (see todo 016).
 _OVERTURE_SIMPLIFY_TOLERANCE_DEG = 0.0001
 
+# Per-level cache schema for Overture. Declares, in one place, the columns each
+# level's cache projects and any level-specific row filters, so the cache
+# producer (_build_level_cache_query) has a single source of truth and an
+# unknown level fails loudly instead of being silently treated as a region.
+_OVERTURE_LEVEL_CACHE_CONFIG: dict[str, dict[str, list[str]]] = {
+    "country": {
+        "cols": ["bbox", "country", "subtype"],
+        # Exclude disputed (X*) territories and Antarctica.
+        "extra_filters": ["country NOT LIKE 'X%'", "country != 'AQ'"],
+    },
+    "region": {
+        "cols": ["bbox", "country", "region", "subtype"],
+        "extra_filters": [],
+    },
+}
+
 
 def get_cache_dir() -> Path:
     """
@@ -750,35 +766,42 @@ class OvertureAdminDataset(AdminDataset):
     def get_cached_path_for_level(self, level: str) -> Path:
         cache_dir = get_cache_dir()
         version = self.get_version()
-        # The "-land" suffix encodes the land-only filter applied at download
-        # time. It also invalidates older caches that mixed in maritime (EEZ)
-        # polygons, which caused ~2x row multiplication in spatial joins.
+        # "-land" suffix invalidates pre-fix caches that mixed in maritime (EEZ)
+        # polygons; see _build_level_cache_query for the rationale.
         return cache_dir / f"overture-{version}-{level}-land.parquet"
 
     def _build_level_cache_query(self, level: str, source: str) -> str:
         """Build the SELECT that produces a non-overlapping per-level cache.
 
-        Only land polygons are kept (``is_land = true``). Overture stores a
-        separate maritime (EEZ) polygon per division whose geometry spans the
-        whole territory — including the entire landmass — so keeping both
-        classes makes every land feature match two polygons per level,
-        inflating spatial-join output ~2x per level. Land-only keeps each
-        level's polygons non-overlapping, which is what the plain (memory-safe)
-        LEFT JOIN relies on instead of an OOM-prone dedup window.
+        Only land polygons are kept. Overture stores a separate maritime (EEZ)
+        polygon per division whose geometry spans the whole territory —
+        including the entire landmass — so keeping both classes makes every
+        land feature match two polygons per level, inflating spatial-join
+        output ~2x per level. Land-only keeps each level's polygons
+        non-overlapping, which is what the plain (memory-safe) LEFT JOIN relies
+        on instead of an OOM-prone dedup window.
+
+        The filter is ``is_land IS NOT FALSE`` (not ``= true``): it drops only
+        explicitly-maritime polygons and keeps land polygons whose flag is
+        NULL, so genuine territory with an unset flag is not silently lost to
+        SQL three-valued logic. Columns and level-specific filters come from
+        :data:`_OVERTURE_LEVEL_CACHE_CONFIG` so an unknown level raises rather
+        than being mis-projected.
         """
+        try:
+            config = _OVERTURE_LEVEL_CACHE_CONFIG[level]
+        except KeyError:
+            raise ValueError(f"No per-level cache config for admin level: {level!r}") from None
         tol = _OVERTURE_SIMPLIFY_TOLERANCE_DEG
-        if level == "country":
-            cols = "bbox, country, subtype"
-            # Exclude disputed (X*) territories and Antarctica.
-            extra = "AND country NOT LIKE 'X%' AND country != 'AQ' "
-        else:
-            cols = "bbox, country, region, subtype"
-            extra = ""
+        cols = ", ".join(config["cols"])
+        where = " AND ".join(
+            [f"subtype = '{level}'", "is_land IS NOT FALSE", *config["extra_filters"]]
+        )
         return (
             f"SELECT ST_SimplifyPreserveTopology(geometry, {tol}) as geometry, "
             f"{cols} "
             f"FROM read_parquet('{source}', hive_partitioning=1) "
-            f"WHERE subtype = '{level}' AND is_land = true {extra}"
+            f"WHERE {where}"
         )
 
     def get_source_for_level(self, level: str, no_cache: bool = False) -> str:
@@ -825,9 +848,17 @@ class OvertureAdminDataset(AdminDataset):
             con = get_duckdb_connection(
                 load_spatial=True, load_httpfs=True, temp_directory=str(cache_dir)
             )
+            version = self.get_version()
             try:
                 for level in self.get_available_levels():
                     cache_path = self.get_cached_path_for_level(level)
+                    # Remove the pre-fix (maritime-contaminated) unsuffixed cache
+                    # for this level/version so it doesn't linger after the
+                    # "-land" rename (todo 031).
+                    legacy_cache = cache_dir / f"overture-{version}-{level}.parquet"
+                    if legacy_cache.exists():
+                        legacy_cache.unlink()
+
                     if cache_path.exists() and cache_path.stat().st_size > 0:
                         continue
 

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -750,7 +750,36 @@ class OvertureAdminDataset(AdminDataset):
     def get_cached_path_for_level(self, level: str) -> Path:
         cache_dir = get_cache_dir()
         version = self.get_version()
-        return cache_dir / f"overture-{version}-{level}.parquet"
+        # The "-land" suffix encodes the land-only filter applied at download
+        # time. It also invalidates older caches that mixed in maritime (EEZ)
+        # polygons, which caused ~2x row multiplication in spatial joins.
+        return cache_dir / f"overture-{version}-{level}-land.parquet"
+
+    def _build_level_cache_query(self, level: str, source: str) -> str:
+        """Build the SELECT that produces a non-overlapping per-level cache.
+
+        Only land polygons are kept (``is_land = true``). Overture stores a
+        separate maritime (EEZ) polygon per division whose geometry spans the
+        whole territory — including the entire landmass — so keeping both
+        classes makes every land feature match two polygons per level,
+        inflating spatial-join output ~2x per level. Land-only keeps each
+        level's polygons non-overlapping, which is what the plain (memory-safe)
+        LEFT JOIN relies on instead of an OOM-prone dedup window.
+        """
+        tol = _OVERTURE_SIMPLIFY_TOLERANCE_DEG
+        if level == "country":
+            cols = "bbox, country, subtype"
+            # Exclude disputed (X*) territories and Antarctica.
+            extra = "AND country NOT LIKE 'X%' AND country != 'AQ' "
+        else:
+            cols = "bbox, country, region, subtype"
+            extra = ""
+        return (
+            f"SELECT ST_SimplifyPreserveTopology(geometry, {tol}) as geometry, "
+            f"{cols} "
+            f"FROM read_parquet('{source}', hive_partitioning=1) "
+            f"WHERE subtype = '{level}' AND is_land = true {extra}"
+        )
 
     def get_source_for_level(self, level: str, no_cache: bool = False) -> str:
         """Get the cached source path for a specific admin level."""
@@ -775,9 +804,10 @@ class OvertureAdminDataset(AdminDataset):
         """Download separate country and region cache files.
 
         The full Overture divisions dataset is ~4.5GB with 1M+ rows. We split
-        into per-level files so spatial joins run against non-overlapping
-        polygons, preventing row multiplication. Geometries are simplified to
-        ~11m tolerance to keep files small.
+        into per-level, land-only files (see :meth:`_build_level_cache_query`)
+        so spatial joins run against non-overlapping polygons, preventing row
+        multiplication. Geometries are simplified to ~11m tolerance to keep
+        files small.
         """
         from geoparquet_io.core.duckdb_utils import s3_config_scope
         from geoparquet_io.core.logging_config import info
@@ -801,24 +831,7 @@ class OvertureAdminDataset(AdminDataset):
                     if cache_path.exists() and cache_path.stat().st_size > 0:
                         continue
 
-                    tol = _OVERTURE_SIMPLIFY_TOLERANCE_DEG
-                    if level == "country":
-                        query = (
-                            f"SELECT ST_SimplifyPreserveTopology(geometry, {tol}) as geometry, "
-                            "bbox, country, subtype "
-                            f"FROM read_parquet('{source}', hive_partitioning=1) "
-                            "WHERE subtype = 'country' "
-                            "AND country NOT LIKE 'X%' "
-                            "AND country != 'AQ'"
-                        )
-                    else:
-                        query = (
-                            f"SELECT ST_SimplifyPreserveTopology(geometry, {tol}) as geometry, "
-                            "bbox, country, region, subtype "
-                            f"FROM read_parquet('{source}', hive_partitioning=1) "
-                            f"WHERE subtype = '{level}'"
-                        )
-
+                    query = self._build_level_cache_query(level, source)
                     con.execute(
                         f"COPY ({query}) TO '{cache_path}' (FORMAT PARQUET, COMPRESSION ZSTD)"
                     )

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -41,8 +41,14 @@ def _build_enrichment_query(
     input_geom_col,
     input_bbox_col,
     enriched_table,
+    input_is_table_ref=False,
 ):
-    """Build enrichment query for spatial join."""
+    """Build enrichment query for spatial join.
+
+    ``input_is_table_ref`` marks ``input_url`` as a DuckDB temp-table name
+    (per-level chaining) rather than a file path, so it is referenced without
+    surrounding quotes.
+    """
     # Build column list for subquery - handle struct access
     subquery_cols = []
     for i, col in enumerate(boundary_columns):
@@ -51,6 +57,8 @@ def _build_enrichment_query(
         else:
             subquery_cols.append(f'"{col}"')
     subquery_cols_str = ", ".join(subquery_cols)
+
+    input_ref = input_url if input_is_table_ref else f"'{input_url}'"
 
     if input_bbox_col and admin_bbox_col:
         bbox_filter = f"""
@@ -65,7 +73,7 @@ def _build_enrichment_query(
             SELECT
                 a.*,
                 {admin_select_clause}
-            FROM '{input_url}' a
+            FROM {input_ref} a
             LEFT JOIN (
                 SELECT {admin_geom_col}, {admin_bbox_col}, {subquery_cols_str}
                 FROM {admin_table_ref}
@@ -80,7 +88,7 @@ def _build_enrichment_query(
             SELECT
                 a.*,
                 {admin_select_clause}
-            FROM '{input_url}' a
+            FROM {input_ref} a
             LEFT JOIN (
                 SELECT {admin_geom_col}, {subquery_cols_str}
                 FROM {admin_table_ref}
@@ -180,6 +188,29 @@ def _get_input_file_info(input_parquet, verbose):
     return input_url, input_geom_col, input_bbox_col
 
 
+def _setup_admin_join_connection(dataset, get_duckdb_connection):
+    """Create the DuckDB connection for the enrichment join.
+
+    Per-level datasets (Overture) can join multi-million-feature inputs and need
+    the same memory discipline as ``gpio add admin-divisions`` to spill rather
+    than OOM (see add_divisions todo 013): a temp directory for spill,
+    single-threaded execution (parallel spatial-join operators each grab memory
+    and cannot coordinate spilling, so they OOM even with a temp dir), and no
+    insertion-order buffering. Other datasets keep the simple default connection.
+    """
+    if dataset.supports_per_level_sources():
+        from geoparquet_io.core.admin_datasets import get_cache_dir
+
+        temp_dir = get_cache_dir()
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        con = get_duckdb_connection(
+            load_spatial=True, load_httpfs=True, temp_directory=str(temp_dir), threads=1
+        )
+        con.execute("SET preserve_insertion_order = false")
+        return con
+    return get_duckdb_connection(load_spatial=True, load_httpfs=True)
+
+
 def _setup_duckdb_extensions(con):
     """Load required DuckDB extensions."""
     con.execute("INSTALL spatial;")
@@ -259,6 +290,91 @@ def _perform_enrichment_join(
         enriched_table,
     )
     con.execute(enrichment_query)
+
+
+def _perform_per_level_enrichment_join(
+    con,
+    dataset,
+    levels,
+    boundary_columns,
+    enriched_table,
+    input_url,
+    admin_geom_col,
+    admin_bbox_col,
+    input_geom_col,
+    input_bbox_col,
+    vecorel,
+    verbose,
+):
+    """Enrich by chaining one LEFT JOIN per level against its own land cache.
+
+    Datasets that ``supports_per_level_sources()`` (Overture) split each admin
+    level into a separate, land-only cache file (see
+    ``OvertureAdminDataset._build_level_cache_query``). Joining each level
+    against its own non-overlapping cache — rather than one combined join over
+    the raw remote dataset, which still contains the maritime (EEZ) polygons
+    that double-match every land feature — is what keeps the output row count
+    ≈ the input and bounds memory. Each level reads the previous level's temp
+    table so a feature carries all admin columns forward; the final join
+    produces ``enriched_table``.
+
+    Returns the list of output admin column names.
+    """
+    current_source = input_url
+    current_is_table_ref = False
+    output_column_names = []
+    intermediate_tables = []
+
+    for i, (level, col) in enumerate(zip(levels, boundary_columns, strict=True)):
+        level_source = dataset.get_source_for_level(level)
+        admin_table_ref = _build_admin_table_reference(dataset, f"'{level_source}'")
+        select_clause, level_outputs = _build_admin_select_for_partitioning(
+            [level], [col], dataset=dataset, vecorel=vecorel
+        )
+        output_column_names.extend(level_outputs)
+
+        # The data extent does not change across levels, so the extent filter is
+        # always computed from the original input file.
+        admin_where_clause = _build_admin_where_clause(
+            dataset,
+            [level],
+            con,
+            input_url,
+            input_bbox_col,
+            input_geom_col,
+            admin_bbox_col,
+            verbose,
+        )
+
+        is_last = i == len(levels) - 1
+        target = enriched_table if is_last else f"_admin_step_{i}"
+        if verbose:
+            debug(f"  → Level {i + 1}/{len(levels)}: joining {level} from {level_source}")
+
+        con.execute(
+            _build_enrichment_query(
+                current_source,
+                admin_table_ref,
+                admin_where_clause,
+                select_clause,
+                admin_geom_col,
+                admin_bbox_col,
+                [col],
+                input_geom_col,
+                input_bbox_col,
+                target,
+                input_is_table_ref=current_is_table_ref,
+            )
+        )
+        if not is_last:
+            intermediate_tables.append(target)
+        current_source = target
+        current_is_table_ref = True
+
+    for table in intermediate_tables:
+        con.execute(f"DROP TABLE IF EXISTS {table}")
+
+    return output_column_names
 
 
 def _verify_enrichment_results(con, enriched_table, output_column_names):
@@ -536,54 +652,64 @@ def partition_by_admin_hierarchical(
         from geoparquet_io.core.duckdb_utils import get_duckdb_connection, s3_config_scope
 
         with s3_config_scope(dataset.get_s3_config()):
-            con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
+            con = _setup_admin_join_connection(dataset, get_duckdb_connection)
 
             # STEP 1: Spatial join to create enriched data with admin columns
             progress("\n📍 Step 1/2: Performing spatial join with admin boundaries...")
 
             enriched_table = "_enriched_with_admin"
-            admin_source = dataset.prepare_data_source(con)
 
-            # Build SELECT clause for admin columns
-            admin_select_clause, output_column_names = _build_admin_select_for_partitioning(
-                levels, boundary_columns, dataset=dataset, vecorel=vecorel
-            )
-
-            # Build admin data source with read_parquet options if needed
-            admin_table_ref = _build_admin_table_reference(dataset, admin_source)
-
-            # Build WHERE clause for admin boundaries
-            admin_where_clause = _build_admin_where_clause(
-                dataset,
-                levels,
-                con,
-                input_url,
-                input_bbox_col,
-                input_geom_col,
-                admin_bbox_col,
-                verbose,
-            )
-
-            # Build efficient spatial join query
             if input_bbox_col and admin_bbox_col and verbose:
                 debug("  → Using bbox columns for optimized spatial join")
             elif not (input_bbox_col and admin_bbox_col) and verbose:
                 debug("  → Using full geometry intersection (no bbox optimization)")
 
-            # Perform enrichment join
-            _perform_enrichment_join(
-                con,
-                enriched_table,
-                input_url,
-                admin_table_ref,
-                admin_where_clause,
-                admin_select_clause,
-                admin_geom_col,
-                admin_bbox_col,
-                boundary_columns,
-                input_geom_col,
-                input_bbox_col,
-            )
+            if dataset.supports_per_level_sources():
+                # Per-level land caches: chain one join per level so maritime
+                # (EEZ) polygons don't double-match and memory stays bounded.
+                output_column_names = _perform_per_level_enrichment_join(
+                    con,
+                    dataset,
+                    levels,
+                    boundary_columns,
+                    enriched_table,
+                    input_url,
+                    admin_geom_col,
+                    admin_bbox_col,
+                    input_geom_col,
+                    input_bbox_col,
+                    vecorel,
+                    verbose,
+                )
+            else:
+                admin_source = dataset.prepare_data_source(con)
+                admin_select_clause, output_column_names = _build_admin_select_for_partitioning(
+                    levels, boundary_columns, dataset=dataset, vecorel=vecorel
+                )
+                admin_table_ref = _build_admin_table_reference(dataset, admin_source)
+                admin_where_clause = _build_admin_where_clause(
+                    dataset,
+                    levels,
+                    con,
+                    input_url,
+                    input_bbox_col,
+                    input_geom_col,
+                    admin_bbox_col,
+                    verbose,
+                )
+                _perform_enrichment_join(
+                    con,
+                    enriched_table,
+                    input_url,
+                    admin_table_ref,
+                    admin_where_clause,
+                    admin_select_clause,
+                    admin_geom_col,
+                    admin_bbox_col,
+                    boundary_columns,
+                    input_geom_col,
+                    input_bbox_col,
+                )
 
             # Verify enrichment results
             _verify_enrichment_results(con, enriched_table, output_column_names)

--- a/tests/test_admin_datasets.py
+++ b/tests/test_admin_datasets.py
@@ -243,6 +243,34 @@ class TestOvertureAdminDataset:
         # Should use dataset prefix
         assert col_name == "overture_unknown_level"
 
+    def test_per_level_cache_query_filters_to_land(self):
+        """Per-level cache must keep only land polygons.
+
+        Overture stores a separate maritime (EEZ) polygon per division whose
+        geometry spans the entire territory including the landmass. Keeping it
+        makes every land feature match two polygons per level, inflating
+        spatial-join output ~2x per level (issue: admin-divisions 2.6x rows).
+        """
+        dataset = OvertureAdminDataset()
+        for level in ("country", "region"):
+            query = dataset._build_level_cache_query(level, "s3://example/*")
+            assert "is_land = true" in query, f"{level} cache must filter to land"
+            assert f"subtype = '{level}'" in query
+
+    def test_per_level_cache_query_excludes_disputed_countries(self):
+        """Country cache still excludes disputed (X*) territories and Antarctica."""
+        dataset = OvertureAdminDataset()
+        query = dataset._build_level_cache_query("country", "s3://example/*")
+        assert "X%" in query
+        assert "AQ" in query
+
+    def test_cached_path_distinguishes_land_only_caches(self):
+        """Cache filename encodes the land-only filter so stale (maritime-
+        contaminated) caches are not silently reused after the fix."""
+        dataset = OvertureAdminDataset()
+        path = dataset.get_cached_path_for_level("country")
+        assert path.name.endswith("-country-land.parquet")
+
 
 class TestBaseAdminDatasetDefaults:
     """Test base AdminDataset default implementations for backwards compatibility."""

--- a/tests/test_admin_datasets.py
+++ b/tests/test_admin_datasets.py
@@ -244,17 +244,18 @@ class TestOvertureAdminDataset:
         assert col_name == "overture_unknown_level"
 
     def test_per_level_cache_query_filters_to_land(self):
-        """Per-level cache must keep only land polygons.
+        """Per-level cache keeps only land polygons (see _build_level_cache_query
+        for the maritime-EEZ-overlap rationale).
 
-        Overture stores a separate maritime (EEZ) polygon per division whose
-        geometry spans the entire territory including the landmass. Keeping it
-        makes every land feature match two polygons per level, inflating
-        spatial-join output ~2x per level (issue: admin-divisions 2.6x rows).
+        The predicate is ``IS NOT FALSE`` (not ``= true``) so land polygons with
+        a NULL flag are kept rather than silently dropped by SQL three-valued
+        logic.
         """
         dataset = OvertureAdminDataset()
         for level in ("country", "region"):
             query = dataset._build_level_cache_query(level, "s3://example/*")
-            assert "is_land = true" in query, f"{level} cache must filter to land"
+            assert "is_land IS NOT FALSE" in query, f"{level} cache must filter to land"
+            assert "is_land = true" not in query, f"{level} must not drop NULL is_land"
             assert f"subtype = '{level}'" in query
 
     def test_per_level_cache_query_excludes_disputed_countries(self):
@@ -264,12 +265,80 @@ class TestOvertureAdminDataset:
         assert "X%" in query
         assert "AQ" in query
 
+    def test_per_level_cache_query_rejects_unknown_level(self):
+        """An unconfigured level must raise rather than be silently mis-projected
+        as a region (which would produce a wrong-schema cache)."""
+        dataset = OvertureAdminDataset()
+        with pytest.raises(ValueError, match="cache config"):
+            dataset._build_level_cache_query("locality", "s3://example/*")
+
     def test_cached_path_distinguishes_land_only_caches(self):
         """Cache filename encodes the land-only filter so stale (maritime-
         contaminated) caches are not silently reused after the fix."""
         dataset = OvertureAdminDataset()
         path = dataset.get_cached_path_for_level("country")
         assert path.name.endswith("-country-land.parquet")
+
+    def test_land_filter_removes_maritime_double_match(self, tmp_path):
+        """Behavioral: the land-only filter makes a feature match exactly one
+        polygon per level instead of two (land + maritime EEZ) — the root cause
+        of the ~2.6x row multiplication (PR #474).
+
+        Runs the real ``_build_level_cache_query`` output, only substituting the
+        ``ST_SimplifyPreserveTopology`` wrapper (not implemented in the test
+        DuckDB build; the multiplication is in the join/filter, not the
+        simplification).
+        """
+        from geoparquet_io.core.admin_datasets import _OVERTURE_SIMPLIFY_TOLERANCE_DEG
+
+        duckdb = pytest.importorskip("duckdb")
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute("SET geometry_always_xy=true;")
+        src = tmp_path / "division_area.parquet"
+        # US: a land polygon AND a maritime (EEZ) polygon spanning the whole
+        # territory (incl. the landmass). CA: a land polygon with NULL is_land.
+        con.execute(
+            f"""
+            COPY (
+              SELECT ST_AsWKB(ST_GeomFromText('POLYGON((0 0,0 1,1 1,1 0,0 0))')) AS geometry,
+                     {{'xmin':0.0,'xmax':1.0,'ymin':0.0,'ymax':1.0}} AS bbox,
+                     'US' AS country, 'country' AS subtype, true AS is_land
+              UNION ALL SELECT ST_AsWKB(ST_GeomFromText('POLYGON((-5 -5,-5 5,5 5,5 -5,-5 -5))')),
+                     {{'xmin':-5.0,'xmax':5.0,'ymin':-5.0,'ymax':5.0}}, 'US', 'country', false
+              UNION ALL SELECT ST_AsWKB(ST_GeomFromText('POLYGON((10 10,10 11,11 11,11 10,10 10))')),
+                     {{'xmin':10.0,'xmax':11.0,'ymin':10.0,'ymax':11.0}}, 'CA', 'country', NULL
+            ) TO '{src}' (FORMAT PARQUET)
+            """
+        )
+
+        query = OvertureAdminDataset()._build_level_cache_query("country", str(src))
+        runnable = query.replace(
+            f"ST_SimplifyPreserveTopology(geometry, {_OVERTURE_SIMPLIFY_TOLERANCE_DEG})",
+            "geometry",
+        )
+        con.execute(f"CREATE TABLE land AS SELECT * FROM ({runnable})")
+
+        # Maritime US polygon dropped; NULL-is_land CA land polygon kept.
+        countries = [
+            r[0] for r in con.execute("SELECT country FROM land ORDER BY country").fetchall()
+        ]
+        assert countries == ["CA", "US"]
+
+        pt = "ST_GeomFromText('POINT(0.5 0.5)')"
+        n_land = con.execute(
+            f"SELECT count(*) FROM land WHERE ST_Intersects(ST_GeomFromWKB(geometry), {pt})"
+        ).fetchone()[0]
+        assert n_land == 1, "land-only cache must match each feature exactly once"
+
+        # Sanity: against the unfiltered source the point matches both polygons.
+        n_all = con.execute(
+            f"""
+            SELECT count(*) FROM read_parquet('{src}')
+            WHERE subtype='country' AND ST_Intersects(ST_GeomFromWKB(geometry), {pt})
+            """
+        ).fetchone()[0]
+        assert n_all == 2
 
 
 class TestBaseAdminDatasetDefaults:

--- a/tests/test_partition_admin_vecorel.py
+++ b/tests/test_partition_admin_vecorel.py
@@ -116,7 +116,10 @@ class TestVecorelPartitionLocalIntegration:
         input_file = os.path.join(temp_output_dir, "input.parquet")
         out_dir = os.path.join(temp_output_dir, "out")
 
-        # Overture-shaped admin file: two region polygons with country + region
+        # Overture-shaped admin file. Per-level joins read each level's own
+        # polygons, so the country level needs a country-subtype polygon (real
+        # Overture has these; region rows alone are not enough). One country
+        # polygon covering both regions, plus the two region polygons.
         _write_geoparquet(
             con,
             """
@@ -124,6 +127,8 @@ class TestVecorelPartitionLocalIntegration:
                 {'xmin': ST_XMin(geometry), 'xmax': ST_XMax(geometry),
                  'ymin': ST_YMin(geometry), 'ymax': ST_YMax(geometry)} AS bbox
             FROM (VALUES
+                ('country', 'US', NULL,
+                 ST_GeomFromText('POLYGON((0 0, 0 10, 20 10, 20 0, 0 0))')),
                 ('region', 'US', 'US-CA',
                  ST_GeomFromText('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')),
                 ('region', 'US', 'US-NV',
@@ -166,6 +171,11 @@ class TestVecorelPartitionLocalIntegration:
 
         files = list(Path(out_dir).rglob("*.parquet"))
         assert len(files) == 2
+
+        # No row multiplication: per-level chaining must emit one row per input
+        # feature, not one per (country × region) polygon match (PR #474).
+        total_rows = sum(pq.ParquetFile(str(f)).metadata.num_rows for f in files)
+        assert total_rows == 2
 
         for f in files:
             pf = pq.ParquetFile(str(f))


### PR DESCRIPTION
## Problem

`gpio add admin-divisions` / `gpio partition admin` with the Overture dataset produced **~2.6x as many output rows as the input**. Reported real case: a 2,014,667-feature FTW file → 5,296,931 output rows.

```
gpio add admin-divisions ftw_global_00000.parquet out.parquet --vecorel --overwrite
Processing 2,014,667 input features...
- Added admin division data to 5,296,931 of 5,296,931 features   # 2.63x
```

## Root cause

Overture `division_area` stores **two polygons per division** — `class='land'` and `class='maritime'`. The maritime (EEZ) polygon's geometry **spans the entire territory including the whole landmass** (verified: inland points like Kansas and central Brazil match *both* polygons).

The per-level admin caches (`OvertureAdminDataset._download_per_level_caches`) split country/region into separate files *assuming each level is non-overlapping*, but only filtered `subtype` — not `class`/`is_land`. So every land feature matched both the land and maritime polygon at each level:

- country join: **2.0x**
- region join: **1.3x**
- chained: **2.63x**

The OOM fix (#461) had removed the in-join dedup window (DuckDB window operators cannot spill and OOM'd ~14 GiB on large inputs) and relied on the caches being non-overlapping — but they never were, because maritime was retained. This was masking the bug, not fixing it. (A `QUALIFY ROW_NUMBER()` dedup approach was explored but is the OOM-prone path and would crash on large files.)

## Fix

Filter the per-level cache downloads to `is_land = true` so each level's polygons are genuinely non-overlapping. This keeps the **memory-safe plain `LEFT JOIN`** (no dedup window) while eliminating the multiplication.

- Extracted `_build_level_cache_query()` adding `AND is_land = true`.
- Cache filenames gain a `-land` suffix so stale maritime-contaminated caches are auto-invalidated (next run regenerates).

## Verification

On the real 2M-feature FTW file (50k sample shown; full file behaves identically):

| | before | after |
|---|---|---|
| country join | 2.000x | 1.0008x |
| region join | 1.315x | 1.0009x |
| combined output | 2.63x | **1.002x** |

The remaining ~0.2% extra rows are genuine border-straddling features (a feature physically crossing an admin boundary), as expected. Vecorel columns (`admin:country_code`, `admin:subdivision_code`) correct; unmatched features → `ZZ`.

## Tradeoff

Genuinely offshore features now get no admin assignment (correct for land datasets; a maritime opt-in could be added later if needed).

## Tests

- 3 new tests in `tests/test_admin_datasets.py` (land filter present, disputed-territory exclusion retained, cache-name invalidation).
- All 104 admin tests + 46 admin/vecorel/partition tests pass; ruff / duckdb-antipatterns / no-click-echo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed massive row multiplication and OOM risk when using the Overture admin dataset by filtering cached admin sources to land-only polygons.
  * Updated cache handling to invalidate previously maritime-contaminated caches so new downloads use land-only data.
  * Offshore features outside land polygons no longer receive admin codes (will be blank/null or `ZZ` in vecorel mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->