### PR TITLE
fix(wfs): handle type mismatches across paginated pages

### DIFF
--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -540,13 +540,16 @@ def _promote_numeric_type(type_a, type_b):
 
     Type promotion rules (ordered by preference):
     - Same types → return as-is
+    - null + any → any
+    - bool + int* → int64
     - int8/16/32 + int64 → int64
     - float32 + float64 → float64
     - int* + float* → float64
     - int* + decimal128 → float64
-    - decimal128 + float64 → float64
-    - any numeric + string → string
-    - null + any → any
+    - decimal128 + float* → float64
+    - timestamp[*] + timestamp[*] → timestamp with finest unit
+    - any numeric + string → string (but not binary + string)
+    - incompatible types → first type (caller handles cast errors)
 
     Args:
         type_a: First PyArrow type
@@ -573,10 +576,30 @@ def _promote_numeric_type(type_a, type_b):
     b_is_decimal = pa.types.is_decimal(type_b)
     a_is_string = pa.types.is_string(type_a) or pa.types.is_large_string(type_a)
     b_is_string = pa.types.is_string(type_b) or pa.types.is_large_string(type_b)
+    a_is_bool = pa.types.is_boolean(type_a)
+    b_is_bool = pa.types.is_boolean(type_b)
+    a_is_timestamp = pa.types.is_timestamp(type_a)
+    b_is_timestamp = pa.types.is_timestamp(type_b)
+    a_is_binary = pa.types.is_binary(type_a) or pa.types.is_large_binary(type_a)
+    b_is_binary = pa.types.is_binary(type_b) or pa.types.is_large_binary(type_b)
 
-    # String wins over numeric (safest fallback)
+    # Binary types: don't promote to string (would corrupt geometry data)
+    if a_is_binary or b_is_binary:
+        if a_is_binary and b_is_binary:
+            return pa.large_binary()  # Safest binary type
+        return type_a  # Can't promote binary + non-binary safely
+
+    # String wins over numeric (safest fallback for text data)
     if a_is_string or b_is_string:
         return pa.string()
+
+    # bool + int → int64 (bool can safely cast to int)
+    if (a_is_bool and b_is_int) or (a_is_int and b_is_bool):
+        return pa.int64()
+
+    # bool + float → float64
+    if (a_is_bool and b_is_float) or (a_is_float and b_is_bool):
+        return pa.float64()
 
     # int + int → largest int
     if a_is_int and b_is_int:
@@ -602,7 +625,17 @@ def _promote_numeric_type(type_a, type_b):
     if a_is_decimal and b_is_decimal:
         return pa.float64()
 
-    # Fallback: return first type (caller should handle incompatible types)
+    # timestamp + timestamp → finest unit (ns > us > ms > s)
+    if a_is_timestamp and b_is_timestamp:
+        unit_order = {"ns": 0, "us": 1, "ms": 2, "s": 3}
+        a_unit = type_a.unit
+        b_unit = type_b.unit
+        # Return the finer-grained unit (lower number = finer)
+        if unit_order.get(a_unit, 99) <= unit_order.get(b_unit, 99):
+            return type_a
+        return type_b
+
+    # Fallback: return first type (caller handles cast errors with context)
     return type_a
 
 
@@ -650,7 +683,7 @@ def _compute_unified_schema(schemas: list):
     return pa.schema(unified_fields)
 
 
-def _cast_table_to_schema(table, target_schema):
+def _cast_table_to_schema(table, target_schema, *, page_info: str | None = None):
     """
     Cast a table's columns to match target schema types.
 
@@ -660,11 +693,17 @@ def _cast_table_to_schema(table, target_schema):
     Args:
         table: PyArrow table to cast
         target_schema: Target schema with desired types
+        page_info: Optional context string for error messages (e.g., "page 3")
 
     Returns:
         Table with columns cast to target schema types
+
+    Raises:
+        ValueError: If a column cannot be cast to the target type
     """
     import pyarrow as pa
+
+    from geoparquet_io.core.logging_config import warn
 
     if table.schema.equals(target_schema):
         return table
@@ -674,8 +713,21 @@ def _cast_table_to_schema(table, target_schema):
         if field.name in table.column_names:
             col = table.column(field.name)
             if col.type != field.type:
-                # Cast to target type
-                col = col.cast(field.type, safe=True)
+                # Warn about precision loss for decimal → float64
+                if pa.types.is_decimal(col.type) and pa.types.is_floating(field.type):
+                    warn(
+                        f"Column '{field.name}' cast from {col.type} to {field.type} "
+                        f"may lose precision for large values"
+                    )
+                # Cast to target type with error context
+                try:
+                    col = col.cast(field.type, safe=True)
+                except pa.ArrowInvalid as e:
+                    context = f" ({page_info})" if page_info else ""
+                    raise ValueError(
+                        f"Failed to cast column '{field.name}' from {col.type} to "
+                        f"{field.type}{context}: {e}"
+                    ) from e
             new_columns.append(col)
         else:
             # Missing column - create null array

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -601,8 +601,15 @@ def _promote_numeric_type(type_a, type_b):
     if (a_is_bool and b_is_float) or (a_is_float and b_is_bool):
         return pa.float64()
 
-    # int + int → largest int
+    # int + int → check for unsigned overflow risk
     if a_is_int and b_is_int:
+        a_unsigned = pa.types.is_unsigned_integer(type_a)
+        b_unsigned = pa.types.is_unsigned_integer(type_b)
+        # uint64 mixed with signed int → float64 (avoids overflow for large uint64)
+        if (a_unsigned and type_a == pa.uint64() and not b_unsigned) or (
+            b_unsigned and type_b == pa.uint64() and not a_unsigned
+        ):
+            return pa.float64()
         return pa.int64()
 
     # float + float → float64

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -534,6 +534,157 @@ def _rebuild_array_with_type(
     return pa.chunked_array(new_chunks, type=new_type)
 
 
+def _promote_numeric_type(type_a, type_b):
+    """
+    Compute a common type that both input types can safely cast to.
+
+    Type promotion rules (ordered by preference):
+    - Same types → return as-is
+    - int8/16/32 + int64 → int64
+    - float32 + float64 → float64
+    - int* + float* → float64
+    - int* + decimal128 → float64
+    - decimal128 + float64 → float64
+    - any numeric + string → string
+    - null + any → any
+
+    Args:
+        type_a: First PyArrow type
+        type_b: Second PyArrow type
+
+    Returns:
+        PyArrow type that both can safely cast to
+    """
+    import pyarrow as pa
+
+    if type_a == type_b:
+        return type_a
+
+    if pa.types.is_null(type_a):
+        return type_b
+    if pa.types.is_null(type_b):
+        return type_a
+
+    a_is_int = pa.types.is_integer(type_a)
+    b_is_int = pa.types.is_integer(type_b)
+    a_is_float = pa.types.is_floating(type_a)
+    b_is_float = pa.types.is_floating(type_b)
+    a_is_decimal = pa.types.is_decimal(type_a)
+    b_is_decimal = pa.types.is_decimal(type_b)
+    a_is_string = pa.types.is_string(type_a) or pa.types.is_large_string(type_a)
+    b_is_string = pa.types.is_string(type_b) or pa.types.is_large_string(type_b)
+
+    # String wins over numeric (safest fallback)
+    if a_is_string or b_is_string:
+        return pa.string()
+
+    # int + int → largest int
+    if a_is_int and b_is_int:
+        return pa.int64()
+
+    # float + float → float64
+    if a_is_float and b_is_float:
+        return pa.float64()
+
+    # int + float → float64
+    if (a_is_int and b_is_float) or (a_is_float and b_is_int):
+        return pa.float64()
+
+    # int + decimal → float64 (safest common type)
+    if (a_is_int and b_is_decimal) or (a_is_decimal and b_is_int):
+        return pa.float64()
+
+    # decimal + float → float64
+    if (a_is_decimal and b_is_float) or (a_is_float and b_is_decimal):
+        return pa.float64()
+
+    # decimal + decimal with different precision → float64
+    if a_is_decimal and b_is_decimal:
+        return pa.float64()
+
+    # Fallback: return first type (caller should handle incompatible types)
+    return type_a
+
+
+def _compute_unified_schema(schemas: list):
+    """
+    Compute unified schema from multiple schemas with safe type promotion.
+
+    Used when merging paginated results where different pages may have
+    different inferred types for the same field (e.g., int64 vs decimal128).
+
+    Args:
+        schemas: List of PyArrow schemas to unify
+
+    Returns:
+        Unified PyArrow schema that all input schemas can safely cast to
+    """
+    import pyarrow as pa
+
+    if not schemas:
+        return pa.schema([])
+
+    if len(schemas) == 1:
+        return schemas[0]
+
+    # Build field name → list of types mapping
+    field_types: dict[str, list] = {}
+    field_order: list[str] = []
+
+    for schema in schemas:
+        for field in schema:
+            if field.name not in field_types:
+                field_types[field.name] = []
+                field_order.append(field.name)
+            field_types[field.name].append(field.type)
+
+    # Compute unified type for each field
+    unified_fields = []
+    for name in field_order:
+        types = field_types[name]
+        unified_type = types[0]
+        for t in types[1:]:
+            unified_type = _promote_numeric_type(unified_type, t)
+        unified_fields.append(pa.field(name, unified_type))
+
+    return pa.schema(unified_fields)
+
+
+def _cast_table_to_schema(table, target_schema):
+    """
+    Cast a table's columns to match target schema types.
+
+    Handles type conversions that PyArrow's concat_tables(promote=True) cannot,
+    such as int64 → float64 when another table has decimal128.
+
+    Args:
+        table: PyArrow table to cast
+        target_schema: Target schema with desired types
+
+    Returns:
+        Table with columns cast to target schema types
+    """
+    import pyarrow as pa
+
+    if table.schema.equals(target_schema):
+        return table
+
+    new_columns = []
+    for field in target_schema:
+        if field.name in table.column_names:
+            col = table.column(field.name)
+            if col.type != field.type:
+                # Cast to target type
+                col = col.cast(field.type, safe=True)
+            new_columns.append(col)
+        else:
+            # Missing column - create null array
+            null_array = pa.nulls(table.num_rows, type=field.type)
+            new_columns.append(null_array)
+
+    return pa.table(dict(zip([f.name for f in target_schema], new_columns, strict=True)))
+
+
 def _detect_version_from_table(table, verbose: bool = False) -> str | None:
     """
     Detect GeoParquet version from table's schema metadata.

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -39,7 +39,11 @@ __all__ = [
     "wfs_to_table",
 ]
 
-from geoparquet_io.core.common import write_geoparquet_table
+from geoparquet_io.core.common import (
+    _cast_table_to_schema,
+    _compute_unified_schema,
+    write_geoparquet_table,
+)
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
 from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection
 from geoparquet_io.core.http_retry import (
@@ -1527,7 +1531,13 @@ def _fetch_with_spatial_tiles(
     if not all_tables:
         raise WFSError("No features returned from any spatial tile.")
 
-    combined = pa.concat_tables(all_tables, promote=True)
+    # Unify schemas to handle type mismatches across tiles (e.g., int64 vs decimal128)
+    if len(all_tables) > 1:
+        schemas = [t.schema for t in all_tables]
+        unified_schema = _compute_unified_schema(schemas)
+        all_tables = [_cast_table_to_schema(t, unified_schema) for t in all_tables]
+
+    combined = pa.concat_tables(all_tables)
     before_dedup = combined.num_rows
 
     combined = _deduplicate_tiles(combined)
@@ -1920,7 +1930,14 @@ def fetch_all_features_duckdb(
         raise WFSError("No features returned from WFS service.")
 
     tables = [results[i] for i in sorted(results.keys())]
-    combined = pa.concat_tables(tables, promote=True)
+
+    # Unify schemas to handle type mismatches across pages (e.g., int64 vs decimal128)
+    if len(tables) > 1:
+        schemas = [t.schema for t in tables]
+        unified_schema = _compute_unified_schema(schemas)
+        tables = [_cast_table_to_schema(t, unified_schema) for t in tables]
+
+    combined = pa.concat_tables(tables)
     debug(f"Combined {len(tables)} pages: {combined.num_rows:,} total features")
 
     # Skip type inference for tile fetches — the tiling orchestrator handles it

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1535,7 +1535,10 @@ def _fetch_with_spatial_tiles(
     if len(all_tables) > 1:
         schemas = [t.schema for t in all_tables]
         unified_schema = _compute_unified_schema(schemas)
-        all_tables = [_cast_table_to_schema(t, unified_schema) for t in all_tables]
+        all_tables = [
+            _cast_table_to_schema(t, unified_schema, page_info=f"tile {i + 1}")
+            for i, t in enumerate(all_tables)
+        ]
 
     combined = pa.concat_tables(all_tables)
     before_dedup = combined.num_rows
@@ -1935,7 +1938,10 @@ def fetch_all_features_duckdb(
     if len(tables) > 1:
         schemas = [t.schema for t in tables]
         unified_schema = _compute_unified_schema(schemas)
-        tables = [_cast_table_to_schema(t, unified_schema) for t in tables]
+        tables = [
+            _cast_table_to_schema(t, unified_schema, page_info=f"page {i + 1}")
+            for i, t in enumerate(tables)
+        ]
 
     combined = pa.concat_tables(tables)
     debug(f"Combined {len(tables)} pages: {combined.num_rows:,} total features")

--- a/tests/test_schema_unification.py
+++ b/tests/test_schema_unification.py
@@ -217,3 +217,124 @@ class TestSchemaUnificationIntegration:
 
         assert combined.num_rows == 4
         assert combined.schema.field("x").type == pa.float64()
+
+    def test_pages_with_different_field_orders(self):
+        """Tests that field order is unified correctly across pages."""
+        table1 = pa.table({"a": [1], "b": [2], "c": [3]})
+        table2 = pa.table({"c": [6], "a": [4], "b": [5]})  # Different order
+
+        schemas = [table1.schema, table2.schema]
+        unified = _compute_unified_schema(schemas)
+        cast_tables = [_cast_table_to_schema(t, unified) for t in [table1, table2]]
+
+        combined = pa.concat_tables(cast_tables)
+
+        assert combined.num_rows == 2
+        assert combined.column_names == ["a", "b", "c"]
+
+    def test_pages_with_different_columns(self):
+        """Tests that missing columns are filled with nulls."""
+        table1 = pa.table({"a": [1, 2], "b": ["x", "y"]})
+        table2 = pa.table({"a": [3, 4], "c": [5.0, 6.0]})
+
+        schemas = [table1.schema, table2.schema]
+        unified = _compute_unified_schema(schemas)
+        cast_tables = [_cast_table_to_schema(t, unified) for t in [table1, table2]]
+
+        combined = pa.concat_tables(cast_tables)
+
+        assert combined.num_rows == 4
+        assert combined.column("b").to_pylist() == ["x", "y", None, None]
+        assert combined.column("c").to_pylist() == [None, None, 5.0, 6.0]
+
+
+class TestPromoteNumericTypeEdgeCases:
+    """Tests for edge cases in type promotion."""
+
+    def test_bool_int_promotes_to_int64(self):
+        """Boolean + integer should promote to int64."""
+        assert _promote_numeric_type(pa.bool_(), pa.int64()) == pa.int64()
+        assert _promote_numeric_type(pa.int32(), pa.bool_()) == pa.int64()
+
+    def test_bool_float_promotes_to_float64(self):
+        """Boolean + float should promote to float64."""
+        assert _promote_numeric_type(pa.bool_(), pa.float64()) == pa.float64()
+        assert _promote_numeric_type(pa.float32(), pa.bool_()) == pa.float64()
+
+    def test_timestamp_promotes_to_finest_unit(self):
+        """Timestamps with different units should promote to finest."""
+        assert _promote_numeric_type(pa.timestamp("ns"), pa.timestamp("us")) == pa.timestamp("ns")
+        assert _promote_numeric_type(pa.timestamp("us"), pa.timestamp("ns")) == pa.timestamp("ns")
+        assert _promote_numeric_type(pa.timestamp("ms"), pa.timestamp("s")) == pa.timestamp("ms")
+        assert _promote_numeric_type(pa.timestamp("s"), pa.timestamp("us")) == pa.timestamp("us")
+
+    def test_binary_types_promote_to_large_binary(self):
+        """Binary + binary should promote to large_binary for safety."""
+        assert _promote_numeric_type(pa.binary(), pa.binary()) == pa.binary()
+        assert _promote_numeric_type(pa.large_binary(), pa.binary()) == pa.large_binary()
+        assert _promote_numeric_type(pa.binary(), pa.large_binary()) == pa.large_binary()
+
+    def test_binary_string_does_not_promote(self):
+        """Binary + string should not promote to string (would corrupt geometry)."""
+        result = _promote_numeric_type(pa.binary(), pa.string())
+        assert result == pa.binary()
+
+    def test_unsigned_int_promotes_to_int64(self):
+        """Unsigned integers should promote to int64."""
+        assert _promote_numeric_type(pa.uint8(), pa.int64()) == pa.int64()
+        assert _promote_numeric_type(pa.uint64(), pa.int32()) == pa.int64()
+        assert _promote_numeric_type(pa.uint16(), pa.uint32()) == pa.int64()
+
+
+class TestCastTableEdgeCases:
+    """Tests for edge cases in table casting."""
+
+    def test_cast_error_includes_page_info(self):
+        """Cast errors should include page context for debugging."""
+        table = pa.table({"x": ["not_a_number", "also_not"]})
+        target = pa.schema([("x", pa.float64())])
+
+        import pytest
+
+        with pytest.raises(ValueError) as exc_info:
+            _cast_table_to_schema(table, target, page_info="page 3")
+
+        error_msg = str(exc_info.value)
+        assert "x" in error_msg
+        assert "page 3" in error_msg
+        assert "float64" in error_msg or "double" in error_msg
+
+    def test_cast_error_without_page_info(self):
+        """Cast errors should work without page_info too."""
+        table = pa.table({"x": ["not_a_number"]})
+        target = pa.schema([("x", pa.float64())])
+
+        import pytest
+
+        with pytest.raises(ValueError) as exc_info:
+            _cast_table_to_schema(table, target)
+
+        error_msg = str(exc_info.value)
+        assert "x" in error_msg
+        assert "page" not in error_msg
+
+    def test_bool_to_int64_cast_succeeds(self):
+        """Boolean values should cast to int64 successfully."""
+        table = pa.table({"flag": pa.array([True, False, True], type=pa.bool_())})
+        target = pa.schema([("flag", pa.int64())])
+
+        result = _cast_table_to_schema(table, target)
+
+        assert result.column("flag").to_pylist() == [1, 0, 1]
+
+    def test_timestamp_unit_conversion(self):
+        """Timestamps should convert between units correctly."""
+        import datetime
+
+        ts = datetime.datetime(2026, 6, 10, 12, 0, 0)
+        table = pa.table({"ts": pa.array([ts], type=pa.timestamp("us"))})
+        target = pa.schema([("ts", pa.timestamp("ns"))])
+
+        result = _cast_table_to_schema(table, target)
+
+        assert result.schema.field("ts").type == pa.timestamp("ns")

--- a/tests/test_schema_unification.py
+++ b/tests/test_schema_unification.py
@@ -268,8 +268,8 @@ class TestPromoteNumericTypeEdgeCases:
         assert _promote_numeric_type(pa.timestamp("ms"), pa.timestamp("s")) == pa.timestamp("ms")
         assert _promote_numeric_type(pa.timestamp("s"), pa.timestamp("us")) == pa.timestamp("us")
 
-    def test_binary_types_promote_to_large_binary(self):
-        """Binary + binary should promote to large_binary for safety."""
+    def test_binary_types_handling(self):
+        """Binary types: same returns same, mixed returns large_binary."""
         assert _promote_numeric_type(pa.binary(), pa.binary()) == pa.binary()
         assert _promote_numeric_type(pa.large_binary(), pa.binary()) == pa.large_binary()
         assert _promote_numeric_type(pa.binary(), pa.large_binary()) == pa.large_binary()
@@ -279,10 +279,15 @@ class TestPromoteNumericTypeEdgeCases:
         result = _promote_numeric_type(pa.binary(), pa.string())
         assert result == pa.binary()
 
-    def test_unsigned_int_promotes_to_int64(self):
-        """Unsigned integers should promote to int64."""
+    def test_unsigned_int_promotion(self):
+        """Unsigned integers: small ones to int64, uint64+signed to float64."""
+        # Small unsigned + signed → int64 (no overflow risk)
         assert _promote_numeric_type(pa.uint8(), pa.int64()) == pa.int64()
-        assert _promote_numeric_type(pa.uint64(), pa.int32()) == pa.int64()
+        assert _promote_numeric_type(pa.uint16(), pa.int32()) == pa.int64()
+        # uint64 + signed → float64 (avoids overflow for values > 2^63)
+        assert _promote_numeric_type(pa.uint64(), pa.int32()) == pa.float64()
+        assert _promote_numeric_type(pa.int64(), pa.uint64()) == pa.float64()
+        # All unsigned → int64
         assert _promote_numeric_type(pa.uint16(), pa.uint32()) == pa.int64()
 
 

--- a/tests/test_schema_unification.py
+++ b/tests/test_schema_unification.py
@@ -1,0 +1,219 @@
+"""
+Tests for schema unification utilities in core/common.py.
+
+These utilities handle type mismatches when merging paginated results,
+specifically the int64 vs decimal128 issue (GitHub #475).
+"""
+
+import pyarrow as pa
+
+from geoparquet_io.core.common import (
+    _cast_table_to_schema,
+    _compute_unified_schema,
+    _promote_numeric_type,
+)
+
+
+class TestPromoteNumericType:
+    """Tests for _promote_numeric_type()."""
+
+    def test_same_types_unchanged(self):
+        assert _promote_numeric_type(pa.int64(), pa.int64()) == pa.int64()
+        assert _promote_numeric_type(pa.float64(), pa.float64()) == pa.float64()
+        assert _promote_numeric_type(pa.string(), pa.string()) == pa.string()
+
+    def test_null_yields_other_type(self):
+        assert _promote_numeric_type(pa.null(), pa.int64()) == pa.int64()
+        assert _promote_numeric_type(pa.float64(), pa.null()) == pa.float64()
+        assert _promote_numeric_type(pa.null(), pa.null()) == pa.null()
+
+    def test_int_int_promotes_to_int64(self):
+        assert _promote_numeric_type(pa.int16(), pa.int32()) == pa.int64()
+        assert _promote_numeric_type(pa.int32(), pa.int64()) == pa.int64()
+        assert _promote_numeric_type(pa.int8(), pa.int64()) == pa.int64()
+
+    def test_float_float_promotes_to_float64(self):
+        assert _promote_numeric_type(pa.float32(), pa.float64()) == pa.float64()
+        assert _promote_numeric_type(pa.float64(), pa.float32()) == pa.float64()
+
+    def test_int_float_promotes_to_float64(self):
+        assert _promote_numeric_type(pa.int64(), pa.float64()) == pa.float64()
+        assert _promote_numeric_type(pa.float32(), pa.int32()) == pa.float64()
+
+    def test_int_decimal_promotes_to_float64(self):
+        """This is the key case from issue #475."""
+        assert _promote_numeric_type(pa.int64(), pa.decimal128(38, 0)) == pa.float64()
+        assert _promote_numeric_type(pa.decimal128(38, 0), pa.int64()) == pa.float64()
+
+    def test_decimal_float_promotes_to_float64(self):
+        assert _promote_numeric_type(pa.decimal128(38, 0), pa.float64()) == pa.float64()
+        assert _promote_numeric_type(pa.float32(), pa.decimal128(18, 2)) == pa.float64()
+
+    def test_decimal_decimal_different_precision_promotes_to_float64(self):
+        assert _promote_numeric_type(pa.decimal128(38, 0), pa.decimal128(18, 2)) == pa.float64()
+
+    def test_string_wins_over_numeric(self):
+        assert _promote_numeric_type(pa.string(), pa.int64()) == pa.string()
+        assert _promote_numeric_type(pa.float64(), pa.string()) == pa.string()
+        assert _promote_numeric_type(pa.decimal128(38, 0), pa.string()) == pa.string()
+
+    def test_large_string_treated_as_string(self):
+        assert _promote_numeric_type(pa.large_string(), pa.int64()) == pa.string()
+
+
+class TestComputeUnifiedSchema:
+    """Tests for _compute_unified_schema()."""
+
+    def test_empty_list_returns_empty_schema(self):
+        result = _compute_unified_schema([])
+        assert result == pa.schema([])
+
+    def test_single_schema_unchanged(self):
+        schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
+        result = _compute_unified_schema([schema])
+        assert result == schema
+
+    def test_identical_schemas_unchanged(self):
+        schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
+        result = _compute_unified_schema([schema, schema, schema])
+        assert result == schema
+
+    def test_int_decimal_unified_to_float64(self):
+        """Core test case for issue #475."""
+        schema1 = pa.schema([("fun", pa.int64()), ("name", pa.string())])
+        schema2 = pa.schema([("fun", pa.decimal128(38, 0)), ("name", pa.string())])
+
+        result = _compute_unified_schema([schema1, schema2])
+
+        assert result.field("fun").type == pa.float64()
+        assert result.field("name").type == pa.string()
+
+    def test_preserves_field_order_from_first_schema(self):
+        schema1 = pa.schema([("a", pa.int64()), ("b", pa.string()), ("c", pa.float32())])
+        schema2 = pa.schema([("a", pa.int32()), ("b", pa.string()), ("c", pa.float64())])
+
+        result = _compute_unified_schema([schema1, schema2])
+
+        assert [f.name for f in result] == ["a", "b", "c"]
+        assert result.field("a").type == pa.int64()
+        assert result.field("c").type == pa.float64()
+
+    def test_handles_null_type_in_some_schemas(self):
+        schema1 = pa.schema([("x", pa.null())])
+        schema2 = pa.schema([("x", pa.int64())])
+
+        result = _compute_unified_schema([schema1, schema2])
+
+        assert result.field("x").type == pa.int64()
+
+    def test_multiple_schemas_progressive_promotion(self):
+        schema1 = pa.schema([("val", pa.int32())])
+        schema2 = pa.schema([("val", pa.int64())])
+        schema3 = pa.schema([("val", pa.float64())])
+
+        result = _compute_unified_schema([schema1, schema2, schema3])
+
+        assert result.field("val").type == pa.float64()
+
+
+class TestCastTableToSchema:
+    """Tests for _cast_table_to_schema()."""
+
+    def test_identical_schema_returns_same_table(self):
+        table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        result = _cast_table_to_schema(table, table.schema)
+        assert result.equals(table)
+
+    def test_casts_int64_to_float64(self):
+        table = pa.table({"x": pa.array([1, 2, 3], type=pa.int64())})
+        target = pa.schema([("x", pa.float64())])
+
+        result = _cast_table_to_schema(table, target)
+
+        assert result.schema.field("x").type == pa.float64()
+        assert result.column("x").to_pylist() == [1.0, 2.0, 3.0]
+
+    def test_casts_decimal_to_float64(self):
+        table = pa.table({"x": pa.array([1, 2, 3], type=pa.decimal128(38, 0))})
+        target = pa.schema([("x", pa.float64())])
+
+        result = _cast_table_to_schema(table, target)
+
+        assert result.schema.field("x").type == pa.float64()
+        assert result.column("x").to_pylist() == [1.0, 2.0, 3.0]
+
+    def test_adds_missing_columns_as_nulls(self):
+        table = pa.table({"a": [1, 2, 3]})
+        target = pa.schema([("a", pa.int64()), ("b", pa.string())])
+
+        result = _cast_table_to_schema(table, target)
+
+        assert result.num_columns == 2
+        assert result.column("b").to_pylist() == [None, None, None]
+
+    def test_preserves_column_order_from_target(self):
+        table = pa.table({"b": ["x", "y"], "a": [1, 2]})
+        target = pa.schema([("a", pa.int64()), ("b", pa.string())])
+
+        result = _cast_table_to_schema(table, target)
+
+        assert result.column_names == ["a", "b"]
+
+
+class TestSchemaUnificationIntegration:
+    """Integration tests for the full unification workflow."""
+
+    def test_concat_after_unification_succeeds(self):
+        """Simulates the WFS pagination scenario from issue #475."""
+        # Page 1: column 'fun' inferred as int64
+        table1 = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02", b"\x03\x04"], type=pa.binary()),
+                "fun": pa.array([100, 200], type=pa.int64()),
+                "name": pa.array(["a", "b"], type=pa.string()),
+            }
+        )
+
+        # Page 2: column 'fun' inferred as decimal128 (large integers)
+        table2 = pa.table(
+            {
+                "geometry": pa.array([b"\x05\x06", b"\x07\x08"], type=pa.binary()),
+                "fun": pa.array([300, 400], type=pa.decimal128(38, 0)),
+                "name": pa.array(["c", "d"], type=pa.string()),
+            }
+        )
+
+        # Without unification, this would fail:
+        # pa.concat_tables([table1, table2], promote=True)
+        # -> "Unable to merge: Field fun has incompatible types"
+
+        # With unification:
+        schemas = [table1.schema, table2.schema]
+        unified = _compute_unified_schema(schemas)
+
+        cast1 = _cast_table_to_schema(table1, unified)
+        cast2 = _cast_table_to_schema(table2, unified)
+
+        combined = pa.concat_tables([cast1, cast2])
+
+        assert combined.num_rows == 4
+        assert combined.schema.field("fun").type == pa.float64()
+        assert combined.column("fun").to_pylist() == [100.0, 200.0, 300.0, 400.0]
+
+    def test_multiple_pages_with_varying_types(self):
+        """Tests unification across many pages with different type patterns."""
+        tables = [
+            pa.table({"x": pa.array([1], type=pa.int32())}),
+            pa.table({"x": pa.array([2], type=pa.int64())}),
+            pa.table({"x": pa.array([3], type=pa.decimal128(38, 0))}),
+            pa.table({"x": pa.array([4], type=pa.float32())}),
+        ]
+
+        schemas = [t.schema for t in tables]
+        unified = _compute_unified_schema(schemas)
+        cast_tables = [_cast_table_to_schema(t, unified) for t in tables]
+
+        combined = pa.concat_tables(cast_tables)
+
+        assert combined.num_rows == 4
+        assert combined.schema.field("x").type == pa.float64()


### PR DESCRIPTION
## Summary
- Fixes #475 - WFS pagination fails when field types differ across pages (e.g., `decimal128(38, 0)` vs `int64`)
- Added schema unification utilities to `core/common.py` that compute a unified schema and cast pages before concatenation
- Applied fix to both `fetch_all_features_duckdb()` and `_fetch_with_spatial_tiles()`

## Root Cause
Different pages can have different inferred types for the same field. DuckDB's `read_json_auto()` infers types per-page based on that page's values. PyArrow's `concat_tables(promote=True)` cannot reconcile incompatible numeric types like `decimal128(38, 0)` vs `int64`.

## Solution
Before concatenating paginated tables:
1. Collect schemas from all pages
2. Compute a unified schema that safely accommodates all types
3. Cast each page to the unified schema
4. Then concatenate (no longer needs `promote=True`)

Type promotion rules:
| Type A | Type B | Result |
|--------|--------|--------|
| int* | int* | int64 |
| float* | float* | float64 |
| int* | float* | float64 |
| int* | decimal128 | float64 |
| decimal128 | float* | float64 |
| any numeric | string | string |

## Test plan
- [x] 24 new unit tests for schema unification utilities
- [x] All 155 existing WFS tests pass
- [ ] Manual test with IGN Argentina endpoint (`gpio extract wfs "https://wms.ign.gob.ar/geoserver/ows" --layer "ign:vial_terciaria" --output test.parquet --limit 20000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WFS fetching now deterministically unifies differing column types across pages/tiles and safely casts each result before concatenation, avoiding type-mismatch failures and ensuring consistent column ordering and null-filling for missing fields.
* **Tests**
  * Expanded tests cover numeric promotion rules, timestamp/unit and binary/string edge cases, casting behavior (including error messaging with page context), and multi-page/tile integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->