### PR TITLE
fix(partition): single-pass COPY PARTITION_BY instead of per-value re-scan (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,17 +80,28 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
-- Partition commands now read the input **once** instead of re-scanning it per
-  partition value (#478). `gpio partition string`, `gpio partition admin`, and
-  the cell-id partitioners (`a5`/`h3`/`s2`/`quadkey`/`kdtree`) all shared an
+- Partition commands now route all rows in a **single** `COPY … PARTITION_BY`
+  scan instead of re-scanning the input per partition value (#478).
+  `gpio partition string`, `gpio partition admin`, and the cell-id partitioners
+  (`a5`/`h3`/`s2`/`quadkey`/`kdtree`) all shared an
   `O(num_partitions × input_size)` per-value loop that made partitioning large
   datasets into many partitions infeasible (e.g. ~195 country partitions of a
-  220 GB input meant ~43 TB of reads). They now use a single streaming DuckDB
-  `COPY … PARTITION_BY` pass into a staging dir, then rewrite each (small)
-  partition into its final file with correct per-partition metadata. Output
-  layout, naming, flags, and per-partition `geo`/`bbox`/`covering` metadata
-  (plus passthrough KV like vecorel `collection` and non-nullable vecorel
-  columns) are unchanged.
+  220 GB input meant ~43 TB of reads). They now stream into a staging dir, then
+  rewrite each (small) partition into its final file with correct per-partition
+  metadata. Output layout, naming, flags, and per-partition
+  `geo`/`bbox`/`covering` metadata (plus passthrough KV like vecorel
+  `collection` and non-nullable vecorel columns) are unchanged.
+  - Distinct partition values that sanitize to the **same** filename (e.g.
+    `"São Paulo"` / `"São-Paulo"`) now raise a clear error instead of silently
+    dropping or overwriting rows; values that sanitize to empty fall back to
+    `_empty` rather than `.parquet`.
+  - `gpio partition admin` warns when features match a coarser admin level but
+    are missing a finer one (they cannot be placed in any partition).
+  - Note: row order *within* a partition is no longer guaranteed (sort each
+    output afterward if needed); with `--no-overwrite` the returned/printed
+    partition count reflects only files actually written this run; and when
+    partition analysis runs (the default) the input is read once more for that
+    cheap aggregate before the COPY.
 - Distinguish an explicit `crs: null` (CRS *unknown*) from an omitted `crs` key
   (defaults to OGC:CRS84), per the GeoParquet spec:
   - Reading a file with `crs: null` now logs a warning (once per input) from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- Partition commands now read the input **once** instead of re-scanning it per
+  partition value (#478). `gpio partition string`, `gpio partition admin`, and
+  the cell-id partitioners (`a5`/`h3`/`s2`/`quadkey`/`kdtree`) all shared an
+  `O(num_partitions × input_size)` per-value loop that made partitioning large
+  datasets into many partitions infeasible (e.g. ~195 country partitions of a
+  220 GB input meant ~43 TB of reads). They now use a single streaming DuckDB
+  `COPY … PARTITION_BY` pass into a staging dir, then rewrite each (small)
+  partition into its final file with correct per-partition metadata. Output
+  layout, naming, flags, and per-partition `geo`/`bbox`/`covering` metadata
+  (plus passthrough KV like vecorel `collection` and non-nullable vecorel
+  columns) are unchanged.
 - Distinguish an explicit `crs: null` (CRS *unknown*) from an omitted `crs` key
   (defaults to OGC:CRS84), per the GeoParquet spec:
   - Reading a file with `crs: null` now logs a warning (once per input) from the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,17 +80,28 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
-- Partition commands now read the input **once** instead of re-scanning it per
-  partition value (#478). `gpio partition string`, `gpio partition admin`, and
-  the cell-id partitioners (`a5`/`h3`/`s2`/`quadkey`/`kdtree`) all shared an
+- Partition commands now route all rows in a **single** `COPY … PARTITION_BY`
+  scan instead of re-scanning the input per partition value (#478).
+  `gpio partition string`, `gpio partition admin`, and the cell-id partitioners
+  (`a5`/`h3`/`s2`/`quadkey`/`kdtree`) all shared an
   `O(num_partitions × input_size)` per-value loop that made partitioning large
   datasets into many partitions infeasible (e.g. ~195 country partitions of a
-  220 GB input meant ~43 TB of reads). They now use a single streaming DuckDB
-  `COPY … PARTITION_BY` pass into a staging dir, then rewrite each (small)
-  partition into its final file with correct per-partition metadata. Output
-  layout, naming, flags, and per-partition `geo`/`bbox`/`covering` metadata
-  (plus passthrough KV like vecorel `collection` and non-nullable vecorel
-  columns) are unchanged.
+  220 GB input meant ~43 TB of reads). They now stream into a staging dir, then
+  rewrite each (small) partition into its final file with correct per-partition
+  metadata. Output layout, naming, flags, and per-partition
+  `geo`/`bbox`/`covering` metadata (plus passthrough KV like vecorel
+  `collection` and non-nullable vecorel columns) are unchanged.
+  - Distinct partition values that sanitize to the **same** filename (e.g.
+    `"São Paulo"` / `"São-Paulo"`) now raise a clear error instead of silently
+    dropping or overwriting rows; values that sanitize to empty fall back to
+    `_empty` rather than `.parquet`.
+  - `gpio partition admin` warns when features match a coarser admin level but
+    are missing a finer one (they cannot be placed in any partition).
+  - Note: row order *within* a partition is no longer guaranteed (sort each
+    output afterward if needed); with `--no-overwrite` the returned/printed
+    partition count reflects only files actually written this run; and when
+    partition analysis runs (the default) the input is read once more for that
+    cheap aggregate before the COPY.
 - Distinguish an explicit `crs: null` (CRS *unknown*) from an omitted `crs` key
   (defaults to OGC:CRS84), per the GeoParquet spec:
   - Reading a file with `crs: null` now logs a warning (once per input) from the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,6 +80,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- Partition commands now read the input **once** instead of re-scanning it per
+  partition value (#478). `gpio partition string`, `gpio partition admin`, and
+  the cell-id partitioners (`a5`/`h3`/`s2`/`quadkey`/`kdtree`) all shared an
+  `O(num_partitions × input_size)` per-value loop that made partitioning large
+  datasets into many partitions infeasible (e.g. ~195 country partitions of a
+  220 GB input meant ~43 TB of reads). They now use a single streaming DuckDB
+  `COPY … PARTITION_BY` pass into a staging dir, then rewrite each (small)
+  partition into its final file with correct per-partition metadata. Output
+  layout, naming, flags, and per-partition `geo`/`bbox`/`covering` metadata
+  (plus passthrough KV like vecorel `collection` and non-nullable vecorel
+  columns) are unchanged.
 - Distinguish an explicit `crs: null` (CRS *unknown*) from an omitted `crs` key
   (defaults to OGC:CRS84), per the GeoParquet spec:
   - Reading a file with `crs: null` now logs a warning (once per input) from the

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -11,6 +11,7 @@ This module provides partitioning by administrative boundaries through a two-ste
 from __future__ import annotations
 
 import os
+import shutil
 
 import duckdb
 
@@ -18,13 +19,16 @@ from geoparquet_io.core.admin_datasets import AdminDatasetFactory
 from geoparquet_io.core.common import (
     check_bbox_structure,
     get_parquet_metadata,
-    write_parquet_with_metadata,
 )
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, progress, success, warn
 from geoparquet_io.core.partition.common import (
+    _PARTITION_ALIAS,
+    _finalize_partition_file,
+    _iter_staging_partitions,
+    _run_partitioned_copy,
     sanitize_filename,
 )
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
@@ -148,16 +152,6 @@ def _build_admin_where_clause(
                 )
 
     return "WHERE " + " AND ".join(admin_where_clauses) if admin_where_clauses else ""
-
-
-def _build_partition_query(enriched_table, output_column_names, original_cols):
-    """Build partition query for specific combination."""
-    select_cols = ", ".join([f'"{col}"' for col in original_cols])
-    return f"""
-        SELECT {select_cols}
-        FROM {enriched_table}
-        WHERE {" AND ".join([f'"{col}" = ?' for col in output_column_names])}
-    """
 
 
 def _setup_admin_dataset(dataset_name, verbose, levels):
@@ -419,11 +413,30 @@ def _get_original_columns(con, input_url):
     return [desc[0] for desc in original_schema.description]
 
 
-def _create_all_partitions(
+def _build_admin_staging_select(enriched_table, output_column_names, original_cols, vecorel):
+    """Build the SELECT for the single admin partitioned COPY.
+
+    Keeps the original columns (plus the admin columns in Vecorel mode, so each
+    partition is Vecorel-compliant) and adds one aliased partition key per level.
+    PARTITION_BY drops those aliases from the written files, so the admin columns
+    are dropped from non-Vecorel output exactly as before.
+    """
+    keep_cols = list(original_cols)
+    if vecorel:
+        keep_cols += list(output_column_names)
+    keep_sql = ", ".join(f'"{col}"' for col in keep_cols)
+
+    alias_sql = ", ".join(
+        f'"{col}" AS {_PARTITION_ALIAS}{i}' for i, col in enumerate(output_column_names)
+    )
+    where_sql = " AND ".join(f'"{col}" IS NOT NULL' for col in output_column_names)
+    return f"SELECT {keep_sql}, {alias_sql} FROM {enriched_table} WHERE {where_sql}"
+
+
+def _finalize_admin_partition(
     con,
-    enriched_table,
-    output_column_names,
-    combinations,
+    values,
+    partition_dir,
     levels,
     output_folder,
     hive,
@@ -431,144 +444,118 @@ def _create_all_partitions(
     overwrite,
     metadata,
     verbose,
-    profile,
-    original_cols,
-    geoparquet_version=None,
-    compression="ZSTD",
-    compression_level=15,
-    row_group_size_mb=None,
-    row_group_rows=None,
-    memory_limit=None,
-    vecorel=False,
-    extra_kv=None,
+    vecorel,
+    extra_kv,
+    write_kwargs,
 ):
-    """Create all partition files."""
-    partition_count = 0
-    for combination in combinations:
-        if _create_partition_file(
-            con,
-            enriched_table,
-            output_column_names,
-            combination,
-            levels,
-            output_folder,
-            hive,
-            filename_prefix,
-            overwrite,
-            metadata,
-            verbose,
-            profile,
-            original_cols,
-            geoparquet_version,
-            compression,
-            compression_level,
-            row_group_size_mb,
-            row_group_rows,
-            memory_limit,
-            vecorel,
-            extra_kv,
-        ):
-            partition_count += 1
-    return partition_count
-
-
-def _create_partition_file(
-    con,
-    enriched_table,
-    output_column_names,
-    combination,
-    levels,
-    output_folder,
-    hive,
-    filename_prefix,
-    overwrite,
-    metadata,
-    verbose,
-    profile,
-    original_cols,
-    geoparquet_version=None,
-    compression="ZSTD",
-    compression_level=15,
-    row_group_size_mb=None,
-    row_group_rows=None,
-    memory_limit=None,
-    vecorel=False,
-    extra_kv=None,
-):
-    """Create a single partition file."""
-    # Build nested folder path
-    folder_parts = []
-    for level, value in zip(levels, combination, strict=True):
-        safe_value = sanitize_filename(str(value))
-        if hive:
-            folder_parts.append(f"{level}={safe_value}")
-        else:
-            folder_parts.append(safe_value)
-
-    # Create partition folder
+    """Rewrite one staging partition into its final nested location."""
+    folder_parts = [
+        f"{level}={sanitize_filename(str(value))}" if hive else sanitize_filename(str(value))
+        for level, value in zip(levels, values, strict=True)
+    ]
     partition_folder = os.path.join(output_folder, *folder_parts)
     os.makedirs(partition_folder, exist_ok=True)
 
-    # Generate output filename
-    safe_last_value = sanitize_filename(str(combination[-1]))
+    safe_last = sanitize_filename(str(values[-1]))
     filename = (
-        f"{filename_prefix}_{safe_last_value}.parquet"
-        if filename_prefix
-        else f"{safe_last_value}.parquet"
+        f"{filename_prefix}_{safe_last}.parquet" if filename_prefix else f"{safe_last}.parquet"
     )
     output_file = os.path.join(partition_folder, filename)
 
-    # Skip if exists and not overwriting
-    if os.path.exists(output_file) and not overwrite:
-        if verbose:
-            debug(f"  ⊘ Skipping existing: {'/'.join(folder_parts)}")
-        return False
-
-    if verbose:
+    if verbose and not (os.path.exists(output_file) and not overwrite):
         debug(f"  → Creating: {'/'.join(folder_parts)}")
 
-    # Build WHERE clause
-    where_conditions = [
-        f"\"{col}\" = '{value}'"
-        for col, value in zip(output_column_names, combination, strict=True)
-    ]
-    where_clause = " AND ".join(where_conditions)
-
-    # In Vecorel mode, keep the admin columns (e.g. admin:country_code) in the
-    # output so each partition is Vecorel-compliant. Otherwise they are only
-    # used to drive the split and are dropped from the output.
-    select_col_list = original_cols + output_column_names if vecorel else original_cols
-    select_cols = ", ".join([f'"{col}"' for col in select_col_list])
-    partition_query = f"""
-        SELECT {select_cols}
-        FROM {enriched_table}
-        WHERE {where_clause}
-    """
-
-    # Write partition
-    write_parquet_with_metadata(
+    created = _finalize_partition_file(
         con,
-        partition_query,
+        partition_dir,
         output_file,
-        original_metadata=metadata,
-        compression=compression,
-        compression_level=compression_level,
-        row_group_size_mb=row_group_size_mb,
-        row_group_rows=row_group_rows,
-        verbose=False,
-        profile=profile,
-        geoparquet_version=geoparquet_version,
-        memory_limit=memory_limit,
+        metadata,
+        overwrite,
+        verbose,
         extra_kv_metadata=extra_kv,
+        **write_kwargs,
     )
 
-    # Ensure Vecorel schema compliance (id column + non-nullable columns)
-    if vecorel:
+    # Ensure Vecorel schema compliance (id column + non-nullable columns) — DuckDB
+    # cannot write non-nullable Parquet columns, so this rewrites in place.
+    if created and vecorel:
         from geoparquet_io.core.constants import ensure_vecorel_columns
 
         ensure_vecorel_columns(output_file, verbose)
 
-    return True
+    return created
+
+
+def _create_all_partitions(
+    con,
+    enriched_table,
+    output_column_names,
+    levels,
+    output_folder,
+    hive,
+    filename_prefix,
+    overwrite,
+    metadata,
+    verbose,
+    profile,
+    original_cols,
+    geoparquet_version=None,
+    compression="ZSTD",
+    compression_level=15,
+    row_group_size_mb=None,
+    row_group_rows=None,
+    memory_limit=None,
+    vecorel=False,
+    extra_kv=None,
+):
+    """Create all partition files in a single pass.
+
+    Routes the enriched rows into a staging dir with one DuckDB
+    ``COPY ... PARTITION_BY`` (no per-combination re-scan, issue #478), then
+    rewrites each (small) staging partition into its final nested file with the
+    correct per-partition metadata.
+    """
+    staging_dir = os.path.join(output_folder, ".gpio_partition_staging")
+    shutil.rmtree(staging_dir, ignore_errors=True)
+    partition_cols = [f"{_PARTITION_ALIAS}{i}" for i in range(len(output_column_names))]
+    write_kwargs = {
+        "profile": profile,
+        "geoparquet_version": geoparquet_version,
+        "compression": compression,
+        "compression_level": compression_level,
+        "row_group_size_mb": row_group_size_mb,
+        "row_group_rows": row_group_rows,
+        "memory_limit": memory_limit,
+    }
+
+    partition_count = 0
+    try:
+        select_sql = _build_admin_staging_select(
+            enriched_table, output_column_names, original_cols, vecorel
+        )
+        _run_partitioned_copy(con, select_sql, partition_cols, staging_dir, verbose, memory_limit)
+
+        for values, partition_dir in _iter_staging_partitions(staging_dir):
+            if _finalize_admin_partition(
+                con,
+                values,
+                partition_dir,
+                levels,
+                output_folder,
+                hive,
+                filename_prefix,
+                overwrite,
+                metadata,
+                verbose,
+                vecorel,
+                extra_kv,
+                write_kwargs,
+            ):
+                partition_count += 1
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+    return partition_count
 
 
 def partition_by_admin_hierarchical(
@@ -759,7 +746,6 @@ def partition_by_admin_hierarchical(
                 con,
                 enriched_table,
                 output_column_names,
-                combinations,
                 levels,
                 output_folder,
                 hive,

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -20,16 +20,20 @@ from geoparquet_io.core.common import (
     check_bbox_structure,
     get_parquet_metadata,
 )
+from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, progress, success, warn
-from geoparquet_io.core.partition.common import (
-    _PARTITION_ALIAS,
-    _finalize_partition_file,
-    _iter_staging_partitions,
-    _run_partitioned_copy,
-    sanitize_filename,
+from geoparquet_io.core.partition.common import sanitize_filename
+from geoparquet_io.core.partition.staging import (
+    PartitionWriteOptions,
+    check_output_collision,
+    create_staging_dir,
+    finalize_partition_file,
+    iter_staging_partitions,
+    make_partition_aliases,
+    run_partitioned_copy,
 )
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
@@ -102,10 +106,45 @@ def _build_enrichment_query(
         """
 
 
-def _build_admin_where_clause(
-    dataset, levels, con, input_url, input_bbox_col, input_geom_col, admin_bbox_col, verbose
-):
-    """Build WHERE clause for admin boundaries with filters."""
+def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col):
+    """Compute the input's (xmin, xmax, ymin, ymax) extent in one scan.
+
+    The extent does not change across admin levels, so callers compute it once
+    and reuse it for every level's WHERE clause (issue #480) rather than
+    re-scanning the input per level — important when there is no bbox column and
+    the fallback decodes every geometry.
+    """
+    if input_bbox_col:
+        extent_query = f"""
+            SELECT
+                MIN({input_bbox_col}.xmin) as xmin,
+                MAX({input_bbox_col}.xmax) as xmax,
+                MIN({input_bbox_col}.ymin) as ymin,
+                MAX({input_bbox_col}.ymax) as ymax
+            FROM '{input_url}'
+        """
+    else:
+        qgeom = quote_identifier(input_geom_col)
+        extent_query = f"""
+            SELECT
+                MIN(ST_XMin({qgeom})) as xmin,
+                MAX(ST_XMax({qgeom})) as xmax,
+                MIN(ST_YMin({qgeom})) as ymin,
+                MAX(ST_YMax({qgeom})) as ymax
+            FROM '{input_url}'
+        """
+    extent = con.execute(extent_query).fetchone()
+    if extent and all(v is not None for v in extent):
+        return extent
+    return None
+
+
+def _build_admin_where_clause(dataset, levels, admin_bbox_col, extent, verbose):
+    """Build WHERE clause for admin boundaries with filters.
+
+    ``extent`` is the precomputed input extent (from ``_compute_input_extent``)
+    or None; it is reused across levels instead of being recomputed each call.
+    """
     admin_where_clauses = []
 
     # Add subtype filter if applicable
@@ -116,40 +155,19 @@ def _build_admin_where_clause(
             debug(f"  → Filtering admin boundaries: {subtype_filter}")
 
     # Add bbox extent filter
-    if admin_bbox_col:
-        if input_bbox_col:
-            extent_query = f"""
-                SELECT
-                    MIN({input_bbox_col}.xmin) as xmin,
-                    MAX({input_bbox_col}.xmax) as xmax,
-                    MIN({input_bbox_col}.ymin) as ymin,
-                    MAX({input_bbox_col}.ymax) as ymax
-                FROM '{input_url}'
-            """
-        else:
-            extent_query = f"""
-                SELECT
-                    MIN(ST_XMin("{input_geom_col}")) as xmin,
-                    MAX(ST_XMax("{input_geom_col}")) as xmax,
-                    MIN(ST_YMin("{input_geom_col}")) as ymin,
-                    MAX(ST_YMax("{input_geom_col}")) as ymax
-                FROM '{input_url}'
-            """
-
-        extent = con.execute(extent_query).fetchone()
-        if extent and all(v is not None for v in extent):
-            xmin, xmax, ymin, ymax = extent
-            extent_filter = f"""
-                ({admin_bbox_col}.xmin <= {xmax} AND
-                 {admin_bbox_col}.xmax >= {xmin} AND
-                 {admin_bbox_col}.ymin <= {ymax} AND
-                 {admin_bbox_col}.ymax >= {ymin})
-            """
-            admin_where_clauses.append(extent_filter)
-            if verbose:
-                debug(
-                    f"  → Filtering admin boundaries to input extent: ({xmin:.2f}, {ymin:.2f}, {xmax:.2f}, {ymax:.2f})"
-                )
+    if admin_bbox_col and extent:
+        xmin, xmax, ymin, ymax = extent
+        extent_filter = f"""
+            ({admin_bbox_col}.xmin <= {xmax} AND
+             {admin_bbox_col}.xmax >= {xmin} AND
+             {admin_bbox_col}.ymin <= {ymax} AND
+             {admin_bbox_col}.ymax >= {ymin})
+        """
+        admin_where_clauses.append(extent_filter)
+        if verbose:
+            debug(
+                f"  → Filtering admin boundaries to input extent: ({xmin:.2f}, {ymin:.2f}, {xmax:.2f}, {ymax:.2f})"
+            )
 
     return "WHERE " + " AND ".join(admin_where_clauses) if admin_where_clauses else ""
 
@@ -319,6 +337,10 @@ def _perform_per_level_enrichment_join(
     output_column_names = []
     intermediate_tables = []
 
+    # The data extent does not change across levels, so compute it once and reuse
+    # it for every level's WHERE clause rather than re-scanning per level (#480).
+    extent = _compute_input_extent(con, input_url, input_bbox_col, input_geom_col)
+
     for i, (level, col) in enumerate(zip(levels, boundary_columns, strict=True)):
         level_source = dataset.get_source_for_level(level)
         admin_table_ref = _build_admin_table_reference(dataset, f"'{level_source}'")
@@ -327,17 +349,8 @@ def _perform_per_level_enrichment_join(
         )
         output_column_names.extend(level_outputs)
 
-        # The data extent does not change across levels, so the extent filter is
-        # always computed from the original input file.
         admin_where_clause = _build_admin_where_clause(
-            dataset,
-            [level],
-            con,
-            input_url,
-            input_bbox_col,
-            input_geom_col,
-            admin_bbox_col,
-            verbose,
+            dataset, [level], admin_bbox_col, extent, verbose
         )
 
         is_last = i == len(levels) - 1
@@ -372,15 +385,23 @@ def _perform_per_level_enrichment_join(
 
 
 def _verify_enrichment_results(con, enriched_table, output_column_names):
-    """Verify enrichment results and return stats."""
+    """Verify enrichment results and return stats.
+
+    Also warns when features match a coarser level but are NULL at a finer level:
+    they pass the "matched" (any-level) check but are excluded from every
+    partition by the all-levels-NOT-NULL filter, so they would otherwise vanish
+    silently (#480).
+    """
+    any_clause = " OR ".join([f'"{col}" IS NOT NULL' for col in output_column_names])
+    all_clause = " AND ".join([f'"{col}" IS NOT NULL' for col in output_column_names])
     stats_query = f"""
         SELECT
             COUNT(*) as total,
-            COUNT(CASE WHEN {" OR ".join([f'"{col}" IS NOT NULL' for col in output_column_names])} THEN 1 END) as with_admin
+            COUNT(CASE WHEN {any_clause} THEN 1 END) as with_admin,
+            COUNT(CASE WHEN {all_clause} THEN 1 END) as with_all_admin
         FROM {enriched_table}
     """
-    stats = con.execute(stats_query).fetchone()
-    total_count, with_admin_count = stats
+    total_count, with_admin_count, with_all_count = con.execute(stats_query).fetchone()
 
     success(f"  ✓ Matched {with_admin_count:,} of {total_count:,} features to admin boundaries")
 
@@ -390,20 +411,14 @@ def _verify_enrichment_results(con, enriched_table, output_column_names):
             "are in compatible CRS and overlap geographically."
         )
 
+    dropped = with_admin_count - with_all_count
+    if dropped > 0:
+        warn(
+            f"  ⚠️  {dropped:,} feature(s) matched a coarser admin level but are missing a finer "
+            "level; they will not appear in any partition (incomplete admin hierarchy)."
+        )
+
     return total_count, with_admin_count
-
-
-def _get_partition_combinations(con, enriched_table, output_column_names):
-    """Get unique partition combinations."""
-    group_by_cols = ", ".join([f'"{col}"' for col in output_column_names])
-    combinations_query = f"""
-        SELECT DISTINCT {group_by_cols}
-        FROM {enriched_table}
-        WHERE {" AND ".join([f'"{col}" IS NOT NULL' for col in output_column_names])}
-        ORDER BY {group_by_cols}
-    """
-    result = con.execute(combinations_query)
-    return result.fetchall()
 
 
 def _get_original_columns(con, input_url):
@@ -413,23 +428,27 @@ def _get_original_columns(con, input_url):
     return [desc[0] for desc in original_schema.description]
 
 
-def _build_admin_staging_select(enriched_table, output_column_names, original_cols, vecorel):
+def _build_admin_staging_select(
+    enriched_table, output_column_names, original_cols, vecorel, aliases
+):
     """Build the SELECT for the single admin partitioned COPY.
 
     Keeps the original columns (plus the admin columns in Vecorel mode, so each
-    partition is Vecorel-compliant) and adds one aliased partition key per level.
-    PARTITION_BY drops those aliases from the written files, so the admin columns
-    are dropped from non-Vecorel output exactly as before.
+    partition is Vecorel-compliant) and adds one aliased partition key per level
+    (``aliases``, guaranteed not to collide with a real column). PARTITION_BY
+    drops those aliases from the written files, so the admin columns are dropped
+    from non-Vecorel output exactly as before.
     """
     keep_cols = list(original_cols)
     if vecorel:
         keep_cols += list(output_column_names)
-    keep_sql = ", ".join(f'"{col}"' for col in keep_cols)
+    keep_sql = ", ".join(quote_identifier(col) for col in keep_cols)
 
     alias_sql = ", ".join(
-        f'"{col}" AS {_PARTITION_ALIAS}{i}' for i, col in enumerate(output_column_names)
+        f"{quote_identifier(col)} AS {alias}"
+        for col, alias in zip(output_column_names, aliases, strict=True)
     )
-    where_sql = " AND ".join(f'"{col}" IS NOT NULL' for col in output_column_names)
+    where_sql = " AND ".join(f"{quote_identifier(col)} IS NOT NULL" for col in output_column_names)
     return f"SELECT {keep_sql}, {alias_sql} FROM {enriched_table} WHERE {where_sql}"
 
 
@@ -445,8 +464,8 @@ def _finalize_admin_partition(
     metadata,
     verbose,
     vecorel,
-    extra_kv,
-    write_kwargs,
+    write_options,
+    seen_outputs,
 ):
     """Rewrite one staging partition into its final nested location."""
     folder_parts = [
@@ -454,26 +473,20 @@ def _finalize_admin_partition(
         for level, value in zip(levels, values, strict=True)
     ]
     partition_folder = os.path.join(output_folder, *folder_parts)
-    os.makedirs(partition_folder, exist_ok=True)
 
     safe_last = sanitize_filename(str(values[-1]))
     filename = (
         f"{filename_prefix}_{safe_last}.parquet" if filename_prefix else f"{safe_last}.parquet"
     )
     output_file = os.path.join(partition_folder, filename)
+    check_output_collision(seen_outputs, output_file, tuple(values))
 
+    os.makedirs(partition_folder, exist_ok=True)
     if verbose and not (os.path.exists(output_file) and not overwrite):
         debug(f"  → Creating: {'/'.join(folder_parts)}")
 
-    created = _finalize_partition_file(
-        con,
-        partition_dir,
-        output_file,
-        metadata,
-        overwrite,
-        verbose,
-        extra_kv_metadata=extra_kv,
-        **write_kwargs,
+    created = finalize_partition_file(
+        con, partition_dir, output_file, metadata, overwrite, verbose, write_options
     )
 
     # Ensure Vecorel schema compliance (id column + non-nullable columns) — DuckDB
@@ -515,27 +528,31 @@ def _create_all_partitions(
     rewrites each (small) staging partition into its final nested file with the
     correct per-partition metadata.
     """
-    staging_dir = os.path.join(output_folder, ".gpio_partition_staging")
-    shutil.rmtree(staging_dir, ignore_errors=True)
-    partition_cols = [f"{_PARTITION_ALIAS}{i}" for i in range(len(output_column_names))]
-    write_kwargs = {
-        "profile": profile,
-        "geoparquet_version": geoparquet_version,
-        "compression": compression,
-        "compression_level": compression_level,
-        "row_group_size_mb": row_group_size_mb,
-        "row_group_rows": row_group_rows,
-        "memory_limit": memory_limit,
-    }
+    # Aliases must not collide with kept columns (originals + admin columns).
+    aliases = make_partition_aliases(
+        len(output_column_names), list(original_cols) + list(output_column_names)
+    )
+    write_options = PartitionWriteOptions(
+        geoparquet_version=geoparquet_version,
+        compression=compression,
+        compression_level=compression_level,
+        row_group_size_mb=row_group_size_mb,
+        row_group_rows=row_group_rows,
+        memory_limit=memory_limit,
+        profile=profile,
+        extra_kv_metadata=extra_kv,
+    )
 
+    staging_dir = create_staging_dir(output_folder)
     partition_count = 0
+    seen_outputs: dict[str, tuple] = {}
     try:
         select_sql = _build_admin_staging_select(
-            enriched_table, output_column_names, original_cols, vecorel
+            enriched_table, output_column_names, original_cols, vecorel, aliases
         )
-        _run_partitioned_copy(con, select_sql, partition_cols, staging_dir, verbose, memory_limit)
+        run_partitioned_copy(con, select_sql, aliases, staging_dir, verbose, memory_limit)
 
-        for values, partition_dir in _iter_staging_partitions(staging_dir):
+        for values, partition_dir in iter_staging_partitions(staging_dir):
             if _finalize_admin_partition(
                 con,
                 values,
@@ -548,10 +565,12 @@ def _create_all_partitions(
                 metadata,
                 verbose,
                 vecorel,
-                extra_kv,
-                write_kwargs,
+                write_options,
+                seen_outputs,
             ):
                 partition_count += 1
+            # Incremental cleanup caps peak staging disk at ~one partition.
+            shutil.rmtree(partition_dir, ignore_errors=True)
     finally:
         shutil.rmtree(staging_dir, ignore_errors=True)
 
@@ -674,15 +693,9 @@ def partition_by_admin_hierarchical(
                     levels, boundary_columns, dataset=dataset, vecorel=vecorel
                 )
                 admin_table_ref = _build_admin_table_reference(dataset, admin_source)
+                extent = _compute_input_extent(con, input_url, input_bbox_col, input_geom_col)
                 admin_where_clause = _build_admin_where_clause(
-                    dataset,
-                    levels,
-                    con,
-                    input_url,
-                    input_bbox_col,
-                    input_geom_col,
-                    admin_bbox_col,
-                    verbose,
+                    dataset, levels, admin_bbox_col, extent, verbose
                 )
                 _perform_enrichment_join(
                     con,
@@ -731,12 +744,6 @@ def partition_by_admin_hierarchical(
 
             # Create output directory
             os.makedirs(output_folder, exist_ok=True)
-
-            # Get unique partition combinations
-            combinations = _get_partition_combinations(con, enriched_table, output_column_names)
-
-            if verbose:
-                debug(f"  → Creating {len(combinations)} partition(s)...")
 
             # Get original columns (exclude temporary admin columns)
             original_cols = _get_original_columns(con, input_url)

--- a/geoparquet_io/core/partition/common.py
+++ b/geoparquet_io/core/partition/common.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+import shutil
+from urllib.parse import unquote
 
 from geoparquet_io.core.common import (
     get_parquet_metadata,
@@ -603,24 +605,118 @@ def _build_column_expression(column_name, column_prefix_length):
     return column_expr, partition_description
 
 
-def _get_unique_partition_values(con, input_url, column_expr, column_name, verbose):
-    """Get unique partition values from input."""
-    query = f"""
-        SELECT DISTINCT {column_expr} as partition_value
-        FROM '{input_url}'
-        WHERE "{column_name}" IS NOT NULL
-        ORDER BY partition_value
+# Internal alias used to drive the single-pass PARTITION_BY split. DuckDB drops
+# the PARTITION_BY column from the written files, so using a dedicated alias lets
+# us keep or drop the *original* column independently (see _build_staging_select).
+_PARTITION_ALIAS = "__gpio_part"
+
+
+def _build_staging_select(input_url, column_name, column_prefix_length, keep_partition_column):
+    """Build the SELECT for the single partitioned COPY.
+
+    Adds an aliased partition key (``__gpio_part``) that PARTITION_BY drops from
+    the output files, so the original column is kept or excluded independently
+    via ``keep_partition_column``. Only non-NULL partition values are written,
+    matching the previous per-value behaviour.
     """
-    result = con.execute(query)
-    partition_values = result.fetchall()
+    if column_prefix_length is not None:
+        pexpr = f'LEFT("{column_name}", {column_prefix_length})'
+    else:
+        pexpr = f'"{column_name}"'
 
-    if len(partition_values) == 0:
-        raise PartitionError(f"No non-NULL values found in column '{column_name}'")
+    projection = "*" if keep_partition_column else f'* EXCLUDE ("{column_name}")'
 
+    return (
+        f"SELECT {projection}, {pexpr} AS {_PARTITION_ALIAS} "
+        f"FROM '{input_url}' "
+        f'WHERE "{column_name}" IS NOT NULL'
+    )
+
+
+def _run_partitioned_copy(con, select_sql, partition_cols, staging_dir, verbose, memory_limit=None):
+    """Run a single DuckDB ``COPY ... PARTITION_BY`` into ``staging_dir``.
+
+    This reads the input exactly once and routes every row to its partition
+    writer (issue #478). Staging files use native geometry + SNAPPY (fast,
+    transient); the final files are rewritten with the requested settings and
+    correct per-partition metadata by the caller.
+    """
+    from geoparquet_io.core.write_strategies.duckdb_kv import get_default_memory_limit
+
+    con.execute("SET threads = 1")  # one file per partition + bounded memory
+    con.execute("SET preserve_insertion_order = false")
+    effective_limit = memory_limit or get_default_memory_limit()
+    con.execute(f"SET memory_limit = '{effective_limit}'")
+
+    part_cols = ", ".join(partition_cols)
+    escaped_dir = staging_dir.replace("'", "''")
+    copy_sql = (
+        f"COPY ({select_sql}) TO '{escaped_dir}' "
+        f"(FORMAT PARQUET, PARTITION_BY ({part_cols}), "
+        f"COMPRESSION SNAPPY, GEOPARQUET_VERSION 'NONE', OVERWRITE_OR_IGNORE)"
+    )
     if verbose:
-        debug(f"Found {len(partition_values)} unique partition values")
+        debug("Single-pass partition COPY (one scan of input):")
+        debug(copy_sql)
+    con.execute(copy_sql)
 
-    return partition_values
+
+def _iter_staging_partitions(staging_dir):
+    """Yield ``(values, partition_dir)`` for each leaf partition in staging.
+
+    ``values`` is the list of decoded partition values (one per PARTITION_BY
+    level), recovered from DuckDB's Hive-encoded ``alias=value`` directory
+    names. Supports nested (multi-level) partitioning.
+    """
+
+    def _walk(current_dir, prefix):
+        entries = sorted(
+            d
+            for d in os.listdir(current_dir)
+            if "=" in d and os.path.isdir(os.path.join(current_dir, d))
+        )
+        for entry in entries:
+            _, _, enc_value = entry.partition("=")
+            value = unquote(enc_value)
+            child = os.path.join(current_dir, entry)
+            sub = [
+                d for d in os.listdir(child) if "=" in d and os.path.isdir(os.path.join(child, d))
+            ]
+            if sub:
+                yield from _walk(child, [*prefix, value])
+            else:
+                yield [*prefix, value], child
+
+    yield from _walk(staging_dir, [])
+
+
+def _finalize_partition_file(
+    con, partition_dir, output_filename, metadata, overwrite, verbose, **write_kwargs
+):
+    """Rewrite one staging partition into its final file with correct metadata.
+
+    Reads the (small) staging partition via a glob so a partition that DuckDB
+    split across files still collapses into one output file. Recomputes the
+    tight per-partition bbox by stripping the inherited bbox.
+    """
+    if os.path.exists(output_filename) and not overwrite:
+        if verbose:
+            debug(f"Output file {output_filename} already exists, skipping...")
+        return False
+
+    staging_glob = os.path.join(partition_dir, "*.parquet").replace("'", "''")
+    query = f"SELECT * FROM read_parquet('{staging_glob}')"
+    write_parquet_with_metadata(
+        con,
+        query,
+        output_filename,
+        original_metadata=_strip_bbox_from_metadata(metadata),
+        verbose=False,
+        **write_kwargs,
+    )
+    if verbose:
+        debug(f"Wrote {output_filename}")
+    return True
 
 
 def _determine_output_path(
@@ -645,18 +741,6 @@ def _determine_output_path(
         output_filename = os.path.join(write_folder, filename)
 
     return output_filename
-
-
-def _build_select_clause(con, input_url, column_name, keep_partition_column):
-    """Build SELECT clause, optionally excluding partition column."""
-    if keep_partition_column:
-        return "*"
-
-    schema_query = f"SELECT * FROM '{input_url}' LIMIT 0"
-    schema_result = con.execute(schema_query)
-    all_columns = [desc[0] for desc in schema_result.description]
-    columns_to_select = [f'"{col}"' for col in all_columns if col != column_name]
-    return ", ".join(columns_to_select)
 
 
 def _strip_bbox_from_metadata(metadata: dict | None) -> dict | None:
@@ -708,79 +792,6 @@ def _strip_bbox_from_metadata(metadata: dict | None) -> dict | None:
                 metadata_copy[geo_key] = geo_dict
 
     return metadata_copy
-
-
-def _process_partition_value(
-    con,
-    input_url,
-    partition_value,
-    column_name,
-    column_prefix_length,
-    actual_output,
-    hive,
-    filename_prefix,
-    overwrite,
-    metadata,
-    keep_partition_column,
-    verbose,
-    geoparquet_version=None,
-    compression: str = "ZSTD",
-    compression_level: int = 15,
-    row_group_size_mb: int | None = None,
-    row_group_rows: int | None = None,
-    memory_limit: str | None = None,
-):
-    """Process a single partition value."""
-    output_filename = _determine_output_path(
-        actual_output, partition_value, column_name, column_prefix_length, hive, filename_prefix
-    )
-
-    if os.path.exists(output_filename) and not overwrite:
-        if verbose:
-            debug(f"Output file for {partition_value} already exists, skipping...")
-        return False
-
-    if verbose:
-        debug(f"Processing partition: {partition_value}...")
-
-    # Build WHERE clause
-    if column_prefix_length is not None:
-        where_clause = f"LEFT(\"{column_name}\", {column_prefix_length}) = '{partition_value}'"
-    else:
-        where_clause = f"\"{column_name}\" = '{partition_value}'"
-
-    # Build SELECT clause
-    select_clause = _build_select_clause(con, input_url, column_name, keep_partition_column)
-
-    # Build SELECT query for partition
-    partition_query = f"""
-        SELECT {select_clause}
-        FROM '{input_url}'
-        WHERE {where_clause}
-    """
-
-    # Strip bbox from metadata so it gets recomputed for this partition's data
-    partition_metadata = _strip_bbox_from_metadata(metadata)
-
-    # Write partition
-    write_parquet_with_metadata(
-        con,
-        partition_query,
-        output_filename,
-        original_metadata=partition_metadata,
-        compression=compression,
-        compression_level=compression_level,
-        row_group_size_mb=row_group_size_mb,
-        row_group_rows=row_group_rows,
-        verbose=False,
-        geoparquet_version=geoparquet_version,
-        memory_limit=memory_limit,
-    )
-
-    if verbose:
-        debug(f"Wrote {output_filename}")
-
-    return True
 
 
 def partition_by_column(
@@ -860,46 +871,55 @@ def partition_by_column(
         # Create DuckDB connection with httpfs if needed
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
 
-        # Build the column expression for partitioning
-        column_expr, partition_description = _build_column_expression(
-            column_name, column_prefix_length
-        )
-
-        # Get unique partition values
+        _, partition_description = _build_column_expression(column_name, column_prefix_length)
         if verbose:
-            debug(f"Finding unique values for {partition_description}...")
+            debug(f"Partitioning by {partition_description} in a single pass...")
 
-        partition_values = _get_unique_partition_values(
-            con, input_url, column_expr, column_name, verbose
-        )
-
-        # Process each partition value
-        for row in partition_values:
-            partition_value = row[0]
-            _process_partition_value(
-                con,
-                input_url,
-                partition_value,
-                column_name,
-                column_prefix_length,
-                actual_output,
-                hive,
-                filename_prefix,
-                overwrite,
-                metadata,
-                keep_partition_column,
-                verbose,
-                geoparquet_version,
-                compression,
-                compression_level,
-                row_group_size_mb,
-                row_group_rows,
-                memory_limit,
+        # Single pass: COPY ... PARTITION_BY routes every row in one input scan
+        # into a staging dir, then each (small) staging partition is rewritten
+        # into its final file with correct per-partition metadata (issue #478).
+        staging_dir = os.path.join(actual_output, ".gpio_partition_staging")
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        partition_count = 0
+        try:
+            select_sql = _build_staging_select(
+                input_url, column_name, column_prefix_length, keep_partition_column
+            )
+            _run_partitioned_copy(
+                con, select_sql, [_PARTITION_ALIAS], staging_dir, verbose, memory_limit
             )
 
-        con.close()
+            if not os.path.isdir(staging_dir) or not any("=" in d for d in os.listdir(staging_dir)):
+                raise PartitionError(f"No non-NULL values found in column '{column_name}'")
 
-        partition_count = len(partition_values)
+            for values, partition_dir in _iter_staging_partitions(staging_dir):
+                output_filename = _determine_output_path(
+                    actual_output,
+                    values[0],
+                    column_name,
+                    column_prefix_length,
+                    hive,
+                    filename_prefix,
+                )
+                if _finalize_partition_file(
+                    con,
+                    partition_dir,
+                    output_filename,
+                    metadata,
+                    overwrite,
+                    verbose,
+                    geoparquet_version=geoparquet_version,
+                    compression=compression,
+                    compression_level=compression_level,
+                    row_group_size_mb=row_group_size_mb,
+                    row_group_rows=row_group_rows,
+                    memory_limit=memory_limit,
+                ):
+                    partition_count += 1
+        finally:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+
+        con.close()
 
         # Upload to remote if needed
         if is_remote:

--- a/geoparquet_io/core/partition/common.py
+++ b/geoparquet_io/core/partition/common.py
@@ -3,16 +3,21 @@
 import os
 import re
 import shutil
-from urllib.parse import unquote
 
-from geoparquet_io.core.common import (
-    get_parquet_metadata,
-    write_parquet_with_metadata,
-)
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.common import get_parquet_metadata
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import debug, error, info, progress, warn
+from geoparquet_io.core.partition.staging import (
+    PartitionWriteOptions,
+    check_output_collision,
+    create_staging_dir,
+    finalize_partition_file,
+    iter_staging_partitions,
+    make_partition_aliases,
+    run_partitioned_copy,
+)
 from geoparquet_io.core.remote import (
     needs_httpfs,
     remote_write_context,
@@ -51,7 +56,9 @@ def sanitize_filename(value: str) -> str:
     sanitized = sanitized.strip("_.")
     # Collapse multiple underscores
     sanitized = re.sub(r"_+", "_", sanitized)
-    return sanitized
+    # Never return an empty name (e.g. value was "." / ".." / all-special): an
+    # empty filename would become ".parquet" and silently collide with others.
+    return sanitized or "_empty"
 
 
 def calculate_partition_stats(output_folder: str, num_partitions: int) -> tuple[float, float]:
@@ -605,118 +612,26 @@ def _build_column_expression(column_name, column_prefix_length):
     return column_expr, partition_description
 
 
-# Internal alias used to drive the single-pass PARTITION_BY split. DuckDB drops
-# the PARTITION_BY column from the written files, so using a dedicated alias lets
-# us keep or drop the *original* column independently (see _build_staging_select).
-_PARTITION_ALIAS = "__gpio_part"
-
-
-def _build_staging_select(input_url, column_name, column_prefix_length, keep_partition_column):
+def _build_staging_select(
+    input_url, column_name, column_prefix_length, keep_partition_column, alias
+):
     """Build the SELECT for the single partitioned COPY.
 
-    Adds an aliased partition key (``__gpio_part``) that PARTITION_BY drops from
-    the output files, so the original column is kept or excluded independently
-    via ``keep_partition_column``. Only non-NULL partition values are written,
-    matching the previous per-value behaviour.
+    Adds an aliased partition key (``alias``) that PARTITION_BY drops from the
+    output files, so the original column is kept or excluded independently via
+    ``keep_partition_column``. Only non-NULL partition values are written,
+    matching the previous per-value behaviour. The column name is quoted via
+    ``quote_identifier`` so names with quotes/spaces cannot break the SQL.
     """
+    qcol = quote_identifier(column_name)
     if column_prefix_length is not None:
-        pexpr = f'LEFT("{column_name}", {column_prefix_length})'
+        pexpr = f"LEFT({qcol}, {column_prefix_length})"
     else:
-        pexpr = f'"{column_name}"'
+        pexpr = qcol
 
-    projection = "*" if keep_partition_column else f'* EXCLUDE ("{column_name}")'
+    projection = "*" if keep_partition_column else f"* EXCLUDE ({qcol})"
 
-    return (
-        f"SELECT {projection}, {pexpr} AS {_PARTITION_ALIAS} "
-        f"FROM '{input_url}' "
-        f'WHERE "{column_name}" IS NOT NULL'
-    )
-
-
-def _run_partitioned_copy(con, select_sql, partition_cols, staging_dir, verbose, memory_limit=None):
-    """Run a single DuckDB ``COPY ... PARTITION_BY`` into ``staging_dir``.
-
-    This reads the input exactly once and routes every row to its partition
-    writer (issue #478). Staging files use native geometry + SNAPPY (fast,
-    transient); the final files are rewritten with the requested settings and
-    correct per-partition metadata by the caller.
-    """
-    from geoparquet_io.core.write_strategies.duckdb_kv import get_default_memory_limit
-
-    con.execute("SET threads = 1")  # one file per partition + bounded memory
-    con.execute("SET preserve_insertion_order = false")
-    effective_limit = memory_limit or get_default_memory_limit()
-    con.execute(f"SET memory_limit = '{effective_limit}'")
-
-    part_cols = ", ".join(partition_cols)
-    escaped_dir = staging_dir.replace("'", "''")
-    copy_sql = (
-        f"COPY ({select_sql}) TO '{escaped_dir}' "
-        f"(FORMAT PARQUET, PARTITION_BY ({part_cols}), "
-        f"COMPRESSION SNAPPY, GEOPARQUET_VERSION 'NONE', OVERWRITE_OR_IGNORE)"
-    )
-    if verbose:
-        debug("Single-pass partition COPY (one scan of input):")
-        debug(copy_sql)
-    con.execute(copy_sql)
-
-
-def _iter_staging_partitions(staging_dir):
-    """Yield ``(values, partition_dir)`` for each leaf partition in staging.
-
-    ``values`` is the list of decoded partition values (one per PARTITION_BY
-    level), recovered from DuckDB's Hive-encoded ``alias=value`` directory
-    names. Supports nested (multi-level) partitioning.
-    """
-
-    def _walk(current_dir, prefix):
-        entries = sorted(
-            d
-            for d in os.listdir(current_dir)
-            if "=" in d and os.path.isdir(os.path.join(current_dir, d))
-        )
-        for entry in entries:
-            _, _, enc_value = entry.partition("=")
-            value = unquote(enc_value)
-            child = os.path.join(current_dir, entry)
-            sub = [
-                d for d in os.listdir(child) if "=" in d and os.path.isdir(os.path.join(child, d))
-            ]
-            if sub:
-                yield from _walk(child, [*prefix, value])
-            else:
-                yield [*prefix, value], child
-
-    yield from _walk(staging_dir, [])
-
-
-def _finalize_partition_file(
-    con, partition_dir, output_filename, metadata, overwrite, verbose, **write_kwargs
-):
-    """Rewrite one staging partition into its final file with correct metadata.
-
-    Reads the (small) staging partition via a glob so a partition that DuckDB
-    split across files still collapses into one output file. Recomputes the
-    tight per-partition bbox by stripping the inherited bbox.
-    """
-    if os.path.exists(output_filename) and not overwrite:
-        if verbose:
-            debug(f"Output file {output_filename} already exists, skipping...")
-        return False
-
-    staging_glob = os.path.join(partition_dir, "*.parquet").replace("'", "''")
-    query = f"SELECT * FROM read_parquet('{staging_glob}')"
-    write_parquet_with_metadata(
-        con,
-        query,
-        output_filename,
-        original_metadata=_strip_bbox_from_metadata(metadata),
-        verbose=False,
-        **write_kwargs,
-    )
-    if verbose:
-        debug(f"Wrote {output_filename}")
-    return True
+    return f"SELECT {projection}, {pexpr} AS {alias} FROM '{input_url}' WHERE {qcol} IS NOT NULL"
 
 
 def _determine_output_path(
@@ -741,57 +656,6 @@ def _determine_output_path(
         output_filename = os.path.join(write_folder, filename)
 
     return output_filename
-
-
-def _strip_bbox_from_metadata(metadata: dict | None) -> dict | None:
-    """
-    Strip bbox from metadata so it will be recomputed for each partition.
-
-    When writing partitions, we must NOT use the original file's bbox since each
-    partition contains only a subset of the data with different bounds.
-
-    Args:
-        metadata: Original metadata dict (may contain 'geo' or b'geo' key)
-
-    Returns:
-        Copy of metadata with bbox stripped from geo columns, or None
-    """
-    if not metadata:
-        return None
-
-    import copy
-    import json
-
-    metadata_copy = copy.deepcopy(metadata)
-
-    # Handle both string and bytes keys
-    for geo_key in ("geo", b"geo"):
-        if geo_key in metadata_copy:
-            geo_data = metadata_copy[geo_key]
-
-            # Parse if needed
-            if isinstance(geo_data, bytes):
-                geo_dict = json.loads(geo_data.decode("utf-8"))
-            elif isinstance(geo_data, str):
-                geo_dict = json.loads(geo_data)
-            else:
-                geo_dict = copy.deepcopy(geo_data)
-
-            # Strip bbox from each geometry column
-            if "columns" in geo_dict:
-                for _col_name, col_meta in geo_dict["columns"].items():
-                    if "bbox" in col_meta:
-                        del col_meta["bbox"]
-
-            # Re-encode back to original format
-            if isinstance(geo_data, bytes):
-                metadata_copy[geo_key] = json.dumps(geo_dict).encode("utf-8")
-            elif isinstance(geo_data, str):
-                metadata_copy[geo_key] = json.dumps(geo_dict)
-            else:
-                metadata_copy[geo_key] = geo_dict
-
-    return metadata_copy
 
 
 def partition_by_column(
@@ -841,7 +705,18 @@ def partition_by_column(
         memory_limit: DuckDB memory limit for write operations (e.g., "2GB")
 
     Returns:
-        Number of partitions created
+        Number of partitions actually written this run. With overwrite=False,
+        partitions whose output file already exists are skipped and not counted.
+
+    Notes:
+        Rows are routed to partitions in a single ``COPY ... PARTITION_BY`` scan
+        of the input (issue #478); each staging partition is then re-encoded into
+        its final file (a second write of the data, for tight per-partition bbox
+        and the requested compression). When ``skip_analysis`` is False an extra
+        cheap aggregate pre-scan validates the strategy. Row order *within* a
+        partition is not preserved (sort each output file afterward if needed).
+        Distinct partition values that sanitize to the same filename raise a
+        ``PartitionError`` rather than silently dropping rows.
     """
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, input_parquet, output_folder)
@@ -875,24 +750,36 @@ def partition_by_column(
         if verbose:
             debug(f"Partitioning by {partition_description} in a single pass...")
 
+        # A partition alias that cannot collide with a real input column.
+        input_cols = [d[0] for d in con.execute(f"SELECT * FROM '{input_url}' LIMIT 0").description]
+        alias = make_partition_aliases(1, input_cols)[0]
+
+        write_options = PartitionWriteOptions(
+            geoparquet_version=geoparquet_version,
+            compression=compression,
+            compression_level=compression_level,
+            row_group_size_mb=row_group_size_mb,
+            row_group_rows=row_group_rows,
+            memory_limit=memory_limit,
+            profile=profile,
+        )
+
         # Single pass: COPY ... PARTITION_BY routes every row in one input scan
         # into a staging dir, then each (small) staging partition is rewritten
         # into its final file with correct per-partition metadata (issue #478).
-        staging_dir = os.path.join(actual_output, ".gpio_partition_staging")
-        shutil.rmtree(staging_dir, ignore_errors=True)
+        staging_dir = create_staging_dir(actual_output)
         partition_count = 0
+        seen_outputs: dict[str, str] = {}
         try:
             select_sql = _build_staging_select(
-                input_url, column_name, column_prefix_length, keep_partition_column
+                input_url, column_name, column_prefix_length, keep_partition_column, alias
             )
-            _run_partitioned_copy(
-                con, select_sql, [_PARTITION_ALIAS], staging_dir, verbose, memory_limit
-            )
+            run_partitioned_copy(con, select_sql, [alias], staging_dir, verbose, memory_limit)
 
             if not os.path.isdir(staging_dir) or not any("=" in d for d in os.listdir(staging_dir)):
                 raise PartitionError(f"No non-NULL values found in column '{column_name}'")
 
-            for values, partition_dir in _iter_staging_partitions(staging_dir):
+            for values, partition_dir in iter_staging_partitions(staging_dir):
                 output_filename = _determine_output_path(
                     actual_output,
                     values[0],
@@ -901,21 +788,13 @@ def partition_by_column(
                     hive,
                     filename_prefix,
                 )
-                if _finalize_partition_file(
-                    con,
-                    partition_dir,
-                    output_filename,
-                    metadata,
-                    overwrite,
-                    verbose,
-                    geoparquet_version=geoparquet_version,
-                    compression=compression,
-                    compression_level=compression_level,
-                    row_group_size_mb=row_group_size_mb,
-                    row_group_rows=row_group_rows,
-                    memory_limit=memory_limit,
+                check_output_collision(seen_outputs, output_filename, values[0])
+                if finalize_partition_file(
+                    con, partition_dir, output_filename, metadata, overwrite, verbose, write_options
                 ):
                     partition_count += 1
+                # Incremental cleanup caps peak staging disk at ~one partition.
+                shutil.rmtree(partition_dir, ignore_errors=True)
         finally:
             shutil.rmtree(staging_dir, ignore_errors=True)
 

--- a/geoparquet_io/core/partition/staging.py
+++ b/geoparquet_io/core/partition/staging.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 import tempfile
 from dataclasses import dataclass
 from urllib.parse import unquote
@@ -34,6 +35,27 @@ from geoparquet_io.core.write_strategies.duckdb_kv import get_default_memory_lim
 # the PARTITION_BY column from the written files, so using a dedicated alias lets
 # callers keep or drop the *original* column independently.
 PARTITION_ALIAS = "__gpio_part"
+
+# A DuckDB memory-limit size: digits, optional decimal, optional unit (defaults
+# to bytes). Used to validate the user-supplied value before it is interpolated
+# into a SET statement.
+_MEMORY_LIMIT_RE = re.compile(r"^\d+(\.\d+)?\s*(B|KB|MB|GB|TB)?$", re.IGNORECASE)
+
+
+def _validate_memory_limit(value: str) -> str:
+    """Validate/normalize a DuckDB memory-limit before interpolating into SQL.
+
+    ``memory_limit`` is user-supplied (``--write-memory``) and is interpolated
+    into ``SET memory_limit = '…'``; reject anything that isn't a plain size so a
+    crafted value cannot break out of the string literal. Returns the normalized
+    value (whitespace removed, unit upper-cased).
+    """
+    text = str(value).strip()
+    if not _MEMORY_LIMIT_RE.match(text):
+        raise ValueError(
+            f"Invalid memory_limit {value!r}; expected a size like '512MB', '2GB', or '4.5GB'."
+        )
+    return text.upper().replace(" ", "")
 
 
 @dataclass(frozen=True)
@@ -128,7 +150,7 @@ def run_partitioned_copy(con, select_sql, partition_cols, staging_dir, verbose, 
     """
     con.execute("SET threads = 1")  # one file per partition + bounded memory
     con.execute("SET preserve_insertion_order = false")
-    effective_limit = memory_limit or get_default_memory_limit()
+    effective_limit = _validate_memory_limit(memory_limit or get_default_memory_limit())
     con.execute(f"SET memory_limit = '{effective_limit}'")
 
     part_cols = ", ".join(partition_cols)

--- a/geoparquet_io/core/partition/staging.py
+++ b/geoparquet_io/core/partition/staging.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+
+"""Shared single-pass partitioning primitives (issue #478).
+
+Both ``partition_by_column`` (``common.py``) and
+``partition_by_admin_hierarchical`` (``admin_hierarchical.py``) drive the same
+two-phase write:
+
+1. One streaming DuckDB ``COPY ... PARTITION_BY`` routes every input row into a
+   staging directory (``run_partitioned_copy``) — the input is read exactly once.
+2. Each (small) staging partition is rewritten into its final file with correct
+   per-partition metadata (``finalize_partition_file``).
+
+These helpers are the public seam between the two partition drivers; keeping them
+here (rather than reaching into another module's underscore-private names) makes
+the shared contract explicit and lets ``import-linter`` reason about it.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from urllib.parse import unquote
+
+from geoparquet_io.core.common import write_parquet_with_metadata
+from geoparquet_io.core.exceptions import PartitionError
+from geoparquet_io.core.logging_config import debug
+from geoparquet_io.core.write_strategies.duckdb_kv import get_default_memory_limit
+
+# Internal alias used to drive the single-pass PARTITION_BY split. DuckDB drops
+# the PARTITION_BY column from the written files, so using a dedicated alias lets
+# callers keep or drop the *original* column independently.
+PARTITION_ALIAS = "__gpio_part"
+
+
+@dataclass(frozen=True)
+class PartitionWriteOptions:
+    """Per-partition write settings forwarded to ``write_parquet_with_metadata``.
+
+    Replaces an opaque ``**write_kwargs`` passthrough so both partition drivers
+    forward exactly the same, type-checked set of options to every partition.
+    """
+
+    geoparquet_version: str | None = None
+    compression: str = "ZSTD"
+    compression_level: int = 15
+    row_group_size_mb: int | None = None
+    row_group_rows: int | None = None
+    memory_limit: str | None = None
+    profile: str | None = None
+    extra_kv_metadata: dict[str, str] | None = None
+
+    def as_write_kwargs(self) -> dict:
+        """Return the kwargs accepted by ``write_parquet_with_metadata``."""
+        return {
+            "geoparquet_version": self.geoparquet_version,
+            "compression": self.compression,
+            "compression_level": self.compression_level,
+            "row_group_size_mb": self.row_group_size_mb,
+            "row_group_rows": self.row_group_rows,
+            "memory_limit": self.memory_limit,
+            "profile": self.profile,
+            "extra_kv_metadata": self.extra_kv_metadata,
+        }
+
+
+def make_partition_aliases(count: int, existing_columns) -> list[str]:
+    """Return ``count`` PARTITION_BY alias names guaranteed not to collide.
+
+    The aliases must not clash with any real input column (a column literally
+    named ``__gpio_part`` would otherwise produce an ambiguous ``SELECT *, ...``)
+    nor with each other. For a single level the base name is used when free.
+    """
+    existing = set(existing_columns)
+    aliases: list[str] = []
+    for i in range(count):
+        candidate = PARTITION_ALIAS if count == 1 else f"{PARTITION_ALIAS}{i}"
+        suffix = 0
+        while candidate in existing or candidate in aliases:
+            suffix += 1
+            candidate = f"{PARTITION_ALIAS}_{suffix}_{i}"
+        aliases.append(candidate)
+    return aliases
+
+
+def check_output_collision(seen_outputs: dict, output_filename: str, partition_value) -> None:
+    """Guard against two distinct partition values mapping to one output file.
+
+    Filename sanitization is lossy (e.g. ``"a b"`` and ``"a_b"`` both →
+    ``a_b.parquet``), so distinct staging partitions can resolve to the same
+    final path. Writing both would silently drop or overwrite rows, so raise
+    instead and tell the user which values clashed (issue #480). Records the
+    mapping so the next collision is detected.
+    """
+    prior = seen_outputs.get(output_filename)
+    if prior is not None and str(prior) != str(partition_value):
+        raise PartitionError(
+            f"Partition values {prior!r} and {partition_value!r} both map to the same "
+            f"output file {os.path.basename(output_filename)!r} after filename "
+            f"sanitization. Rename or pre-process these values to avoid silent data loss."
+        )
+    seen_outputs[output_filename] = partition_value
+
+
+def create_staging_dir(output_dir: str) -> str:
+    """Create a unique staging directory as a *sibling* of ``output_dir``.
+
+    Sibling (not child) so the staging tree can never be swept into a recursive
+    upload of ``output_dir`` even if cleanup fails; unique name so two partition
+    jobs targeting the same output folder don't clobber each other's staging.
+    Same parent volume as the output keeps the finalize rewrite on one device.
+    """
+    parent = os.path.dirname(os.path.abspath(output_dir))
+    os.makedirs(parent, exist_ok=True)
+    return tempfile.mkdtemp(prefix=".gpio_partition_staging_", dir=parent)
+
+
+def run_partitioned_copy(con, select_sql, partition_cols, staging_dir, verbose, memory_limit=None):
+    """Run a single DuckDB ``COPY ... PARTITION_BY`` into ``staging_dir``.
+
+    This reads the input exactly once and routes every row to its partition
+    writer (issue #478). Staging files use native geometry + SNAPPY (fast,
+    transient); the final files are rewritten with the requested settings and
+    correct per-partition metadata by the caller.
+    """
+    con.execute("SET threads = 1")  # one file per partition + bounded memory
+    con.execute("SET preserve_insertion_order = false")
+    effective_limit = memory_limit or get_default_memory_limit()
+    con.execute(f"SET memory_limit = '{effective_limit}'")
+
+    part_cols = ", ".join(partition_cols)
+    escaped_dir = staging_dir.replace("'", "''")
+    copy_sql = (
+        f"COPY ({select_sql}) TO '{escaped_dir}' "
+        f"(FORMAT PARQUET, PARTITION_BY ({part_cols}), "
+        f"COMPRESSION SNAPPY, GEOPARQUET_VERSION 'NONE', OVERWRITE_OR_IGNORE)"
+    )
+    if verbose:
+        debug("Single-pass partition COPY (one scan of input):")
+        debug(copy_sql)
+    con.execute(copy_sql)
+
+
+def iter_staging_partitions(staging_dir):
+    """Yield ``(values, partition_dir)`` for each leaf partition in staging.
+
+    ``values`` is the list of decoded partition values (one per PARTITION_BY
+    level), recovered from DuckDB's Hive-encoded ``alias=value`` directory
+    names. Supports nested (multi-level) partitioning.
+    """
+
+    def _walk(current_dir, prefix):
+        entries = sorted(
+            d
+            for d in os.listdir(current_dir)
+            if "=" in d and os.path.isdir(os.path.join(current_dir, d))
+        )
+        for entry in entries:
+            _, _, enc_value = entry.partition("=")
+            value = unquote(enc_value)
+            child = os.path.join(current_dir, entry)
+            sub = [
+                d for d in os.listdir(child) if "=" in d and os.path.isdir(os.path.join(child, d))
+            ]
+            if sub:
+                yield from _walk(child, [*prefix, value])
+            else:
+                yield [*prefix, value], child
+
+    yield from _walk(staging_dir, [])
+
+
+def finalize_partition_file(
+    con,
+    partition_dir,
+    output_filename,
+    metadata,
+    overwrite,
+    verbose,
+    options: PartitionWriteOptions,
+):
+    """Rewrite one staging partition into its final file with correct metadata.
+
+    Reads the (small) staging partition via a glob so a partition that DuckDB
+    split across files still collapses into one output file. Recomputes the
+    tight per-partition bbox by stripping the inherited bbox. Returns ``True``
+    when a file was written, ``False`` when skipped (exists and not overwrite).
+    """
+    if os.path.exists(output_filename) and not overwrite:
+        if verbose:
+            debug(f"Output file {output_filename} already exists, skipping...")
+        return False
+
+    # hive_partitioning=false: the staging path is ``__gpio_part=value/`` (the
+    # PARTITION_BY alias), and DuckDB would otherwise auto-detect that and re-add
+    # the dropped alias as a data column, leaking ``__gpio_part`` into every
+    # output file.
+    staging_glob = os.path.join(partition_dir, "*.parquet").replace("'", "''")
+    query = f"SELECT * FROM read_parquet('{staging_glob}', hive_partitioning=false)"
+    write_parquet_with_metadata(
+        con,
+        query,
+        output_filename,
+        original_metadata=_strip_bbox_from_metadata(metadata),
+        verbose=False,
+        **options.as_write_kwargs(),
+    )
+    if verbose:
+        debug(f"Wrote {output_filename}")
+    return True
+
+
+def _strip_bbox_from_metadata(metadata: dict | None) -> dict | None:
+    """Strip bbox from metadata so it is recomputed per partition.
+
+    Each partition holds only a subset of the data, so the original file's bbox
+    must not be reused. ``get_parquet_metadata`` returns bytes-keyed KV in this
+    codepath; the str/dict branches are defensive for other callers.
+    """
+    if not metadata:
+        return None
+
+    metadata_copy = copy.deepcopy(metadata)
+
+    for geo_key in ("geo", b"geo"):
+        if geo_key in metadata_copy:
+            geo_data = metadata_copy[geo_key]
+
+            if isinstance(geo_data, bytes):
+                geo_dict = json.loads(geo_data.decode("utf-8"))
+            elif isinstance(geo_data, str):
+                geo_dict = json.loads(geo_data)
+            else:
+                geo_dict = copy.deepcopy(geo_data)
+
+            if "columns" in geo_dict:
+                for _col_name, col_meta in geo_dict["columns"].items():
+                    if "bbox" in col_meta:
+                        del col_meta["bbox"]
+
+            if isinstance(geo_data, bytes):
+                metadata_copy[geo_key] = json.dumps(geo_dict).encode("utf-8")
+            elif isinstance(geo_data, str):
+                metadata_copy[geo_key] = json.dumps(geo_dict)
+            else:
+                metadata_copy[geo_key] = geo_dict
+
+    return metadata_copy

--- a/tests/test_partition_admin_vecorel.py
+++ b/tests/test_partition_admin_vecorel.py
@@ -12,6 +12,7 @@ import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.cli.main import partition
+from geoparquet_io.core import duckdb_utils
 
 
 class TestVecorelPartitionSelectClause:
@@ -192,6 +193,118 @@ class TestVecorelPartitionLocalIntegration:
             collection = json.loads(meta[b"collection"])
             assert VECOREL_ADMIN_SCHEMA in collection["schemas"]["default"]
             assert pf.schema_arrow.field("admin:country_code").nullable is False
+
+
+@pytest.mark.integration
+class TestNonVecorelPartitionLocalIntegration:
+    """End-to-end NON-vecorel admin partitioning against a local admin file.
+
+    Pins the single-pass invariants for the admin path (the new file only covered
+    partition_by_column): exactly one PARTITION_BY scan, row reconciliation with
+    no multiplication, admin columns dropped from output, nested layout.
+    """
+
+    def test_single_scan_reconciliation_and_dropped_admin_columns(
+        self, monkeypatch, temp_output_dir
+    ):
+        import os
+        from pathlib import Path
+
+        import duckdb
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.admin_datasets import OvertureAdminDataset
+        from geoparquet_io.core.partition.admin_hierarchical import (
+            partition_by_admin_hierarchical,
+        )
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+
+        admin_file = os.path.join(temp_output_dir, "admin.parquet")
+        input_file = os.path.join(temp_output_dir, "input.parquet")
+        out_dir = os.path.join(temp_output_dir, "out")
+
+        _write_geoparquet(
+            con,
+            """
+            SELECT subtype, country, region, geometry,
+                {'xmin': ST_XMin(geometry), 'xmax': ST_XMax(geometry),
+                 'ymin': ST_YMin(geometry), 'ymax': ST_YMax(geometry)} AS bbox
+            FROM (VALUES
+                ('country', 'US', NULL,
+                 ST_GeomFromText('POLYGON((0 0, 0 10, 20 10, 20 0, 0 0))')),
+                ('region', 'US', 'US-CA',
+                 ST_GeomFromText('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))')),
+                ('region', 'US', 'US-NV',
+                 ST_GeomFromText('POLYGON((10 0, 10 10, 20 10, 20 0, 10 0))'))
+            ) AS t(subtype, country, region, geometry)
+            """,
+            admin_file,
+        )
+        _write_geoparquet(
+            con,
+            """
+            SELECT id, geometry FROM (VALUES
+                (1, ST_GeomFromText('POINT(5 5)')),
+                (2, ST_GeomFromText('POINT(15 5)'))
+            ) AS t(id, geometry)
+            """,
+            input_file,
+        )
+        con.close()
+
+        def fake_create(dataset_name, source_path=None, verbose=False):
+            return OvertureAdminDataset(source_path=admin_file, verbose=verbose)
+
+        monkeypatch.setattr(
+            "geoparquet_io.core.partition.admin_hierarchical.AdminDatasetFactory.create",
+            staticmethod(fake_create),
+        )
+
+        # Spy the DuckDB connection factory to count partitioned scans.
+        executed: list[str] = []
+        real_get_conn = duckdb_utils.get_duckdb_connection
+
+        class SpyCon:
+            def __init__(self, con):
+                self._con = con
+
+            def execute(self, sql, *args, **kwargs):
+                executed.append(sql)
+                return self._con.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self._con, name)
+
+        def spy_get_conn(*args, **kwargs):
+            return SpyCon(real_get_conn(*args, **kwargs))
+
+        monkeypatch.setattr(duckdb_utils, "get_duckdb_connection", spy_get_conn)
+
+        count = partition_by_admin_hierarchical(
+            input_file,
+            out_dir,
+            dataset_name="overture",
+            levels=["country", "region"],
+            hive=True,
+        )
+
+        assert count == 2
+        files = list(Path(out_dir).rglob("*.parquet"))
+        assert len(files) == 2
+        # No row multiplication from the country×region polygon matches.
+        assert sum(pq.ParquetFile(str(f)).metadata.num_rows for f in files) == 2
+
+        # Exactly one partitioned scan of the enriched data; no per-combination writes.
+        partition_by_stmts = [s for s in executed if "PARTITION_BY" in s.upper()]
+        assert len(partition_by_stmts) == 1, executed
+
+        # Admin columns are dropped from non-vecorel output (via the alias trick).
+        for f in files:
+            names = pq.ParquetFile(str(f)).schema_arrow.names
+            assert not any(n.startswith("_admin_") or n.startswith("__gpio_part") for n in names)
+            assert "admin:country_code" not in names
 
 
 @pytest.mark.network

--- a/tests/test_partition_single_pass.py
+++ b/tests/test_partition_single_pass.py
@@ -1,0 +1,231 @@
+"""Tests for single-pass partitioning (issue #478).
+
+Partitioning must read the input ONCE via DuckDB ``COPY ... PARTITION_BY``
+instead of re-scanning the whole input per partition value. These tests pin the
+behaviour that matters: row totals reconcile, only one partitioned scan is
+issued, naming is unchanged, and per-partition geo metadata stays correct.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.partition.common import partition_by_column
+
+
+@pytest.fixture
+def multi_value_file(temp_output_dir):
+    """A small GeoParquet with a low-cardinality ``cat`` column, geometry, and a
+    passthrough KV key (``collection``) to verify metadata preservation.
+
+    Three categories with differing geographic extents so per-partition bbox
+    must differ from the global bbox.
+    """
+    from geoparquet_io.core.common import write_parquet_with_metadata
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    path = os.path.join(temp_output_dir, "multi.parquet")
+    # cat A in the lower-left, B in the middle, C in the upper-right.
+    con.execute(
+        """
+        CREATE TABLE t AS
+        SELECT cat, ST_Point(x, y) AS geometry FROM (
+            SELECT 'AAA' AS cat, i AS x, i AS y FROM range(10) tbl(i)
+            UNION ALL
+            SELECT 'BBB', 100 + i, 100 + i FROM range(20) tbl(i)
+            UNION ALL
+            SELECT 'CCC', 200 + i, 200 + i FROM range(5) tbl(i)
+        )
+        """
+    )
+    write_parquet_with_metadata(
+        con,
+        "SELECT * FROM t",
+        path,
+        extra_kv_metadata={"collection": json.dumps({"id": "test-collection"})},
+    )
+    con.close()
+    return path
+
+
+def _rglob_parquet(folder):
+    out = []
+    for root, _dirs, files in os.walk(folder):
+        out.extend(os.path.join(root, f) for f in files if f.endswith(".parquet"))
+    return out
+
+
+def _row_count(path):
+    return pq.ParquetFile(path).metadata.num_rows
+
+
+class TestReconciliation:
+    """sum(partition rows) == input rows; no duplication or loss."""
+
+    def test_flat_keep_column(self, multi_value_file, temp_output_dir):
+        out = os.path.join(temp_output_dir, "flat")
+        n = partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            keep_partition_column=True,
+            skip_analysis=True,
+        )
+        files = _rglob_parquet(out)
+        assert len(files) == 3
+        assert n == 3
+        assert sum(_row_count(f) for f in files) == 35
+        # Files named by value, flat layout
+        assert sorted(os.path.basename(f) for f in files) == [
+            "AAA.parquet",
+            "BBB.parquet",
+            "CCC.parquet",
+        ]
+        # Partition column kept
+        assert "cat" in pq.ParquetFile(files[0]).schema_arrow.names
+
+    def test_flat_drop_column(self, multi_value_file, temp_output_dir):
+        out = os.path.join(temp_output_dir, "drop")
+        partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            keep_partition_column=False,
+            skip_analysis=True,
+        )
+        files = _rglob_parquet(out)
+        assert sum(_row_count(f) for f in files) == 35
+        assert "cat" not in pq.ParquetFile(files[0]).schema_arrow.names
+
+    def test_hive_layout(self, multi_value_file, temp_output_dir):
+        out = os.path.join(temp_output_dir, "hive")
+        partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            hive=True,
+            skip_analysis=True,
+        )
+        # Hive dirs cat=AAA/AAA.parquet
+        assert os.path.isdir(os.path.join(out, "cat=AAA"))
+        assert os.path.isfile(os.path.join(out, "cat=AAA", "AAA.parquet"))
+        files = _rglob_parquet(out)
+        assert sum(_row_count(f) for f in files) == 35
+
+    def test_chars_prefix(self, multi_value_file, temp_output_dir):
+        # First char only -> A, B, C
+        out = os.path.join(temp_output_dir, "chars")
+        partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            column_prefix_length=1,
+            skip_analysis=True,
+        )
+        files = _rglob_parquet(out)
+        assert sorted(os.path.basename(f) for f in files) == [
+            "A.parquet",
+            "B.parquet",
+            "C.parquet",
+        ]
+        assert sum(_row_count(f) for f in files) == 35
+
+    def test_filename_prefix(self, multi_value_file, temp_output_dir):
+        out = os.path.join(temp_output_dir, "pfx")
+        partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            filename_prefix="places",
+            skip_analysis=True,
+        )
+        files = _rglob_parquet(out)
+        assert all(os.path.basename(f).startswith("places_") for f in files)
+        assert sum(_row_count(f) for f in files) == 35
+
+
+class TestSingleScan:
+    """Exactly one partitioned scan of the input; no per-value WHERE writes."""
+
+    def test_one_partition_by_no_per_value_loop(
+        self, multi_value_file, temp_output_dir, monkeypatch
+    ):
+        executed: list[str] = []
+
+        real_connect = duckdb.connect
+
+        class SpyCon:
+            def __init__(self, con):
+                self._con = con
+
+            def execute(self, sql, *args, **kwargs):
+                executed.append(sql)
+                return self._con.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self._con, name)
+
+        def fake_get_conn(*_args, **_kwargs):
+            con = real_connect()
+            con.execute("INSTALL spatial; LOAD spatial;")
+            con.execute("INSTALL httpfs; LOAD httpfs;")
+            return SpyCon(con)
+
+        # Patch the connection factory used inside partition_by_column.
+        monkeypatch.setattr(
+            "geoparquet_io.core.partition.common.get_duckdb_connection", fake_get_conn
+        )
+
+        out = os.path.join(temp_output_dir, "scan")
+        partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            skip_analysis=True,
+        )
+
+        partition_by_stmts = [s for s in executed if "PARTITION_BY" in s.upper()]
+        assert len(partition_by_stmts) == 1, executed
+
+        # No statement should filter the input by a single partition value
+        # (the old O(N) per-value pattern).
+        per_value = [s for s in executed if '"cat" =' in s or '"cat"=\'' in s]
+        assert per_value == [], per_value
+
+
+class TestMetadata:
+    """Each partition keeps valid geo metadata, tight bbox, and passthrough KV."""
+
+    def test_geo_and_passthrough_and_tight_bbox(self, multi_value_file, temp_output_dir):
+        out = os.path.join(temp_output_dir, "meta")
+        partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            skip_analysis=True,
+        )
+        files = {os.path.basename(f): f for f in _rglob_parquet(out)}
+
+        bboxes = {}
+        for name, path in files.items():
+            md = pq.ParquetFile(path).schema_arrow.metadata or {}
+            assert b"geo" in md, f"{name} missing geo metadata"
+            geo = json.loads(md[b"geo"])
+            col = geo["columns"][geo["primary_column"]]
+            assert "geometry_types" in col
+            assert "bbox" in col
+            bboxes[name] = col["bbox"]
+            # passthrough KV preserved
+            assert b"collection" in md, f"{name} missing collection KV"
+
+        # Per-partition bbox must be tight, not the global bbox.
+        # AAA is in lower-left (~0..9), CCC upper-right (~200..204).
+        assert bboxes["AAA.parquet"][0] < 50
+        assert bboxes["CCC.parquet"][0] > 150
+        assert bboxes["AAA.parquet"] != bboxes["CCC.parquet"]

--- a/tests/test_partition_single_pass.py
+++ b/tests/test_partition_single_pass.py
@@ -251,6 +251,28 @@ class TestMetadata:
         assert bboxes["AAA.parquet"] != bboxes["CCC.parquet"]
 
 
+class TestMemoryLimitValidation:
+    """memory_limit is interpolated into SET, so it must be validated."""
+
+    def test_rejects_injection(self, multi_value_file, temp_output_dir):
+        out = os.path.join(temp_output_dir, "mem")
+        with pytest.raises(ValueError, match="Invalid memory_limit"):
+            partition_by_column(
+                input_parquet=multi_value_file,
+                output_folder=out,
+                column_name="cat",
+                skip_analysis=True,
+                memory_limit="1GB'; ATTACH 'evil.db' AS evil; --",
+            )
+
+    def test_accepts_valid_sizes(self):
+        from geoparquet_io.core.partition.staging import _validate_memory_limit
+
+        assert _validate_memory_limit("512MB") == "512MB"
+        assert _validate_memory_limit("2gb") == "2GB"
+        assert _validate_memory_limit("4.5 GB") == "4.5GB"
+
+
 class TestCollision:
     """Distinct values that sanitize to the same filename must NOT lose rows."""
 

--- a/tests/test_partition_single_pass.py
+++ b/tests/test_partition_single_pass.py
@@ -15,7 +15,25 @@ import duckdb
 import pyarrow.parquet as pq
 import pytest
 
+from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.partition.common import partition_by_column
+
+
+def _write_points(path, rows):
+    """Write a tiny GeoParquet from ``rows`` of (cat, x, y); cat may be None."""
+    from geoparquet_io.core.common import write_parquet_with_metadata
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    con.execute("CREATE TABLE t (cat VARCHAR, geometry GEOMETRY)")
+    for cat, x, y in rows:
+        if cat is None:
+            con.execute("INSERT INTO t VALUES (NULL, ST_Point(?, ?))", [x, y])
+        else:
+            con.execute("INSERT INTO t VALUES (?, ST_Point(?, ?))", [cat, x, y])
+    write_parquet_with_metadata(con, "SELECT * FROM t", path)
+    con.close()
+    return path
 
 
 @pytest.fixture
@@ -87,8 +105,10 @@ class TestReconciliation:
             "BBB.parquet",
             "CCC.parquet",
         ]
-        # Partition column kept
-        assert "cat" in pq.ParquetFile(files[0]).schema_arrow.names
+        # Partition column kept; internal alias never leaks into output.
+        names = pq.ParquetFile(files[0]).schema_arrow.names
+        assert "cat" in names
+        assert not any(n.startswith("__gpio_part") for n in names)
 
     def test_flat_drop_column(self, multi_value_file, temp_output_dir):
         out = os.path.join(temp_output_dir, "drop")
@@ -229,3 +249,91 @@ class TestMetadata:
         assert bboxes["AAA.parquet"][0] < 50
         assert bboxes["CCC.parquet"][0] > 150
         assert bboxes["AAA.parquet"] != bboxes["CCC.parquet"]
+
+
+class TestCollision:
+    """Distinct values that sanitize to the same filename must NOT lose rows."""
+
+    def test_colliding_values_raise(self, temp_output_dir):
+        # "a b" and "a_b" both sanitize to "a_b.parquet" -> would collide.
+        path = _write_points(
+            os.path.join(temp_output_dir, "collide.parquet"),
+            [("a b", 1, 1), ("a b", 2, 2), ("a_b", 3, 3)],
+        )
+        out = os.path.join(temp_output_dir, "out")
+        with pytest.raises(PartitionError, match="map to the same output file"):
+            partition_by_column(
+                input_parquet=path,
+                output_folder=out,
+                column_name="cat",
+                skip_analysis=True,
+            )
+
+    def test_empty_sanitized_value_does_not_become_dotfile(self, temp_output_dir):
+        # A value of "." sanitizes to "" -> must fall back, not write ".parquet".
+        path = _write_points(
+            os.path.join(temp_output_dir, "dot.parquet"), [(".", 1, 1), ("ok", 2, 2)]
+        )
+        out = os.path.join(temp_output_dir, "out")
+        partition_by_column(
+            input_parquet=path, output_folder=out, column_name="cat", skip_analysis=True
+        )
+        names = sorted(os.path.basename(f) for f in _rglob_parquet(out))
+        assert ".parquet" not in names
+        assert "_empty.parquet" in names
+        assert sum(_row_count(f) for f in _rglob_parquet(out)) == 2
+
+
+class TestNullHandling:
+    """NULL partition values are dropped; non-NULL rows still reconcile."""
+
+    def test_null_values_dropped_rest_reconcile(self, temp_output_dir):
+        path = _write_points(
+            os.path.join(temp_output_dir, "nulls.parquet"),
+            [("AAA", 1, 1), ("AAA", 2, 2), (None, 3, 3), (None, 4, 4), ("BBB", 5, 5)],
+        )
+        out = os.path.join(temp_output_dir, "out")
+        n = partition_by_column(
+            input_parquet=path, output_folder=out, column_name="cat", skip_analysis=True
+        )
+        assert n == 2  # AAA, BBB — the two NULL rows excluded
+        files = _rglob_parquet(out)
+        assert sum(_row_count(f) for f in files) == 3  # 2 + 1, NULLs gone
+
+    def test_all_null_raises(self, temp_output_dir):
+        path = _write_points(
+            os.path.join(temp_output_dir, "allnull.parquet"), [(None, 1, 1), (None, 2, 2)]
+        )
+        out = os.path.join(temp_output_dir, "out")
+        with pytest.raises(PartitionError, match="No non-NULL values"):
+            partition_by_column(
+                input_parquet=path, output_folder=out, column_name="cat", skip_analysis=True
+            )
+
+
+class TestOverwrite:
+    """overwrite=False preserves existing files and counts only new writes."""
+
+    def test_existing_partitions_skipped(self, multi_value_file, temp_output_dir):
+        out = os.path.join(temp_output_dir, "ow")
+        first = partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            skip_analysis=True,
+        )
+        assert first == 3
+        mtimes = {f: os.path.getmtime(f) for f in _rglob_parquet(out)}
+
+        # Re-run with overwrite=False: everything exists -> nothing rewritten.
+        second = partition_by_column(
+            input_parquet=multi_value_file,
+            output_folder=out,
+            column_name="cat",
+            overwrite=False,
+            skip_analysis=True,
+        )
+        assert second == 0
+        for f, mtime in mtimes.items():
+            assert os.path.exists(f)
+            assert os.path.getmtime(f) == mtime  # untouched


### PR DESCRIPTION
## Summary

Fixes #478. Partition commands re-scanned the **entire input once per partition value** — an `O(num_partitions × input_size)` anti-pattern that made partitioning large datasets into many partitions infeasible (the FTW case: ~195 country partitions of a 220 GB input ≈ **43 TB** of reads, never completed).

Both affected code paths now read the input **exactly once** via a single streaming DuckDB `COPY … PARTITION_BY` into a staging dir, then rewrite each (small) staging partition into its final file with correct per-partition metadata.

## Changes

- **`partition_by_column`** (`core/partition/common.py`) — used by `partition string` **and** the cell-id partitioners (`a5`/`h3`/`s2`/`quadkey`/`kdtree`): replaced the `_get_unique_partition_values` + `_process_partition_value` per-value loop with one COPY + per-file finalize. New shared helpers: `_build_staging_select`, `_run_partitioned_copy`, `_iter_staging_partitions`, `_finalize_partition_file`.
- **`partition_by_admin_hierarchical`** (`core/partition/admin_hierarchical.py`): replaced the per-combination loop over the enriched temp table with one `COPY … PARTITION_BY` (multi-level → nested dirs), reusing the shared helpers. Keeps vecorel column-retention and the `ensure_vecorel_columns` nullability rewrite (DuckDB can't write non-nullable Parquet columns).

## Behavior preserved

Output layout, naming, and all flags (`--hive`, `--prefix`, `--chars`, `--compression(-level)`, `--row-group-size(-mb)`, `--geoparquet-version`, `--overwrite`, `keep_partition_column`) are unchanged. Tight per-partition `bbox`/`geometry_types`/`covering` and passthrough KV (vecorel `collection`) are preserved because each partition is rewritten through the existing `write_parquet_with_metadata` path. The aliased partition key (`__gpio_part`) lets DuckDB drop the split column while keeping/dropping the original independently.

## Single-scan, verified

`-v` shows exactly one `COPY … PARTITION_BY`:

```
Single-pass partition COPY (one scan of input):
COPY (SELECT *, LEFT("fsq_place_id", 1) AS __gpio_part FROM '…' WHERE "fsq_place_id" IS NOT NULL)
  TO '…/.gpio_partition_staging' (FORMAT PARQUET, PARTITION_BY (__gpio_part),
  COMPRESSION SNAPPY, GEOPARQUET_VERSION 'NONE', OVERWRITE_OR_IGNORE)
```

## Tests

New `tests/test_partition_single_pass.py`:
- **Reconciliation**: `sum(partition rows) == input rows` for flat / `--hive` / `--chars` / keep+drop column.
- **Single scan**: spies the DuckDB connection — asserts exactly **one** `PARTITION_BY` statement and **zero** per-value `WHERE "col" =` writes.
- **Metadata**: each partition has valid `geo`, **tight** (per-partition) bbox, and passthrough `collection` KV.

All existing partition tests pass (`test_partition`, `test_partition_by_string`, `test_hive_partition`, `test_partition_admin_vecorel` incl. the local nullability integration test, cell-id suites). Full fast suite: 2795 passed. ruff / xenon / vulture / import-linter clean.

## Acceptance criteria (#478)

- [x] Single pass over input regardless of partition count
- [x] Row totals reconcile exactly (no dup/loss)
- [x] Per-partition `geo` valid; passthrough KV (`collection`) retained; vecorel non-nullable columns preserved
- [x] Output naming identical for flat and `--hive` (incl. `--prefix`, `--chars`)
- [x] Existing partition tests pass; added single-scan + reconciliation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partitioning uses a single-pass staging + finalize flow for faster, streaming partition writes

* **Bug Fixes**
  * Errors on filename collisions from sanitized partition values
  * Values that sanitize to empty now use `_empty`
  * Warn when admin hierarchy is incomplete
  * Row order within partitions is no longer guaranteed
  * `--no-overwrite` reports only partitions written in the current run

* **Documentation**
  * Changelog updated with execution model and behavioral guarantees

* **Tests**
  * Added comprehensive tests covering single-pass partitioning, metadata, collisions, nulls, and overwrite behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->