### PR TITLE
feat(wfs): add typed exception subclasses for downstream consumers

### DIFF
--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -28,6 +28,9 @@ import pyarrow as pa
 
 # Public API
 __all__ = [
+    "EmptyLayerError",
+    "LayerNotFoundError",
+    "WFSAuthenticationError",
     "WFSError",
     "WFSLayerInfo",
     "WFS_VERSIONS",
@@ -70,6 +73,40 @@ class WFSError(Exception):
     """Exception raised for WFS-related errors."""
 
     pass
+
+
+class EmptyLayerError(WFSError):
+    """Raised when a WFS layer has 0 features."""
+
+    def __init__(self, typename: str) -> None:
+        self.typename = typename
+        super().__init__(
+            f"No features returned from WFS service for layer '{typename}'.\n"
+            "Check that the layer exists and is not empty."
+        )
+
+
+class LayerNotFoundError(WFSError):
+    """Raised when a WFS layer does not exist in the service."""
+
+    def __init__(self, typename: str, available: list[str] | None = None) -> None:
+        self.typename = typename
+        self.available = available or []
+        hint = (
+            f"\nAvailable layers (first 10): {', '.join(self.available[:10])}"
+            if self.available
+            else ""
+        )
+        super().__init__(f"Layer '{typename}' not found in WFS service.{hint}")
+
+
+class WFSAuthenticationError(WFSError):
+    """Raised when WFS service requires authentication or access is denied."""
+
+    def __init__(self, url: str, status_code: int, message: str) -> None:
+        self.url = url
+        self.status_code = status_code
+        super().__init__(message)
 
 
 # GeoJSON output format identifiers (in preference order)
@@ -204,9 +241,13 @@ def _make_request(
                     time.sleep(delay)
                     continue
             elif status == 401:
-                raise WFSError("Authentication required. WFS server requires credentials.") from e
+                raise WFSAuthenticationError(
+                    url, 401, "Authentication required. WFS server requires credentials."
+                ) from e
             elif status == 403:
-                raise WFSError("Access denied. Check your permissions for this WFS service.") from e
+                raise WFSAuthenticationError(
+                    url, 403, "Access denied. Check your permissions for this WFS service."
+                ) from e
             elif status == 404:
                 raise WFSError(f"WFS service not found (404). Check the URL: {url}") from e
             raise WFSError(f"HTTP error {status}: {e}") from e
@@ -559,8 +600,7 @@ def get_layer_info(service_url: str, typename: str, version: str = "1.1.0") -> W
 
     if layer is None:
         available = list(wfs.contents.keys())[:10]
-        hint = f"\nAvailable layers (first 10): {', '.join(available)}" if available else ""
-        raise WFSError(f"Layer '{typename}' not found in WFS service.{hint}")
+        raise LayerNotFoundError(typename, available)
 
     # Extract CRS list
     crs_list = []
@@ -1529,7 +1569,7 @@ def _fetch_with_spatial_tiles(
         progress(f"Tile {i + 1}/{len(tiles)}: {tile_table.num_rows:,} features")
 
     if not all_tables:
-        raise WFSError("No features returned from any spatial tile.")
+        raise EmptyLayerError(typename)
 
     # Unify schemas to handle type mismatches across tiles (e.g., int64 vs decimal128)
     if len(all_tables) > 1:
@@ -1930,7 +1970,7 @@ def fetch_all_features_duckdb(
 
     # Combine tables in order
     if not results:
-        raise WFSError("No features returned from WFS service.")
+        raise EmptyLayerError(typename)
 
     tables = [results[i] for i in sorted(results.keys())]
 
@@ -2085,10 +2125,7 @@ def wfs_to_table(
             warn(f"No features found in bbox for layer '{typename}'. Writing empty file.")
         else:
             # Empty results without bbox likely indicates a problem
-            raise WFSError(
-                f"No features returned from WFS service for layer '{typename}'.\n"
-                "Check that the layer exists and is not empty."
-            )
+            raise EmptyLayerError(typename)
 
     # Apply local bbox filter if needed
     if bbox and not use_server_bbox:

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -12,6 +12,9 @@ import pytest
 
 # Module-level imports for WFS functions (avoids per-test imports)
 from geoparquet_io.core.wfs import (
+    EmptyLayerError,
+    LayerNotFoundError,
+    WFSAuthenticationError,
     WFSError,
     WFSLayerInfo,
     _build_bbox_param,
@@ -594,6 +597,73 @@ class TestErrorHandling:
 
         with pytest.raises(WFSError, match="not found"):
             get_layer_info("http://mock.wfs.server/wfs", "nonexistent:data")
+
+
+class TestWFSExceptionHierarchy:
+    """Test typed WFS exception subclasses for downstream consumers."""
+
+    def test_empty_layer_error_is_wfs_error(self):
+        """EmptyLayerError should be catchable as WFSError (backward compatible)."""
+        assert issubclass(EmptyLayerError, WFSError)
+
+    def test_layer_not_found_error_is_wfs_error(self):
+        """LayerNotFoundError should be catchable as WFSError (backward compatible)."""
+        assert issubclass(LayerNotFoundError, WFSError)
+
+    def test_auth_error_is_wfs_error(self):
+        """WFSAuthenticationError should be catchable as WFSError (backward compatible)."""
+        assert issubclass(WFSAuthenticationError, WFSError)
+
+    def test_empty_layer_error_has_typename(self):
+        """EmptyLayerError should expose typename attribute."""
+        err = EmptyLayerError("ns:layername")
+        assert err.typename == "ns:layername"
+        assert "ns:layername" in str(err)
+        assert "No features returned" in str(err)
+
+    def test_layer_not_found_error_has_typename_and_available(self):
+        """LayerNotFoundError should expose typename and available layers."""
+        err = LayerNotFoundError("ns:missing", ["ns:layer1", "ns:layer2"])
+        assert err.typename == "ns:missing"
+        assert err.available == ["ns:layer1", "ns:layer2"]
+        assert "ns:missing" in str(err)
+        assert "not found" in str(err)
+
+    def test_layer_not_found_error_with_no_available(self):
+        """LayerNotFoundError should work without available layers."""
+        err = LayerNotFoundError("ns:missing")
+        assert err.typename == "ns:missing"
+        assert err.available == []
+        assert "ns:missing" in str(err)
+
+    def test_auth_error_has_url_and_status_code(self):
+        """WFSAuthenticationError should expose url and status_code."""
+        err = WFSAuthenticationError("http://example.com/wfs", 401, "Auth required")
+        assert err.url == "http://example.com/wfs"
+        assert err.status_code == 401
+        assert "Auth required" in str(err)
+
+    def test_empty_layer_error_caught_as_wfs_error(self):
+        """Verify backward compatibility - catching as WFSError works."""
+        try:
+            raise EmptyLayerError("test:layer")
+        except WFSError as e:
+            assert isinstance(e, EmptyLayerError)
+            assert e.typename == "test:layer"
+
+    @patch("owslib.wfs.WebFeatureService")
+    def test_layer_not_found_raises_typed_error(self, mock_wfs_class):
+        """LayerNotFoundError is raised when layer doesn't exist."""
+        mock_wfs = MagicMock()
+        mock_wfs.contents = {"ns:cities": MagicMock(), "ns:roads": MagicMock()}
+        mock_wfs_class.return_value = mock_wfs
+
+        with pytest.raises(LayerNotFoundError) as exc_info:
+            get_layer_info("http://mock.wfs.server/wfs", "nonexistent:data")
+
+        assert exc_info.value.typename == "nonexistent:data"
+        assert "ns:cities" in exc_info.value.available
+        assert "ns:roads" in exc_info.value.available
 
 
 # Helper Data Structures for Tests


### PR DESCRIPTION
## Summary

- Add `EmptyLayerError`, `LayerNotFoundError`, and `WFSAuthenticationError` as subclasses of `WFSError`
- Enables downstream tools (like portolan-cli) to catch specific error types instead of fragile string matching
- All backward compatible — existing `except WFSError` catches all subclasses

## Motivation

Currently, portolan-cli must string-match error messages to distinguish error types:

```python
# Current fragile approach in portolan-cli
def _is_empty_layer_error(error_msg: str | None) -> bool:
    return "No features returned" in error_msg  # coupled to message text
```

After this change:

```python
# Clean typed approach
try:
    convert_wfs_to_geoparquet(...)
except EmptyLayerError as e:
    logger.warning("Layer %s is empty", e.typename)
except LayerNotFoundError as e:
    logger.warning("Layer %s not found", e.typename)
except WFSAuthenticationError as e:
    logger.error("Auth failed (%d): %s", e.status_code, e)
except WFSError as e:
    logger.error("Failed: %s", e)
```

## Exception Details

| Exception | Attributes | Use Case |
|-----------|------------|----------|
| `EmptyLayerError` | `typename` | Layer has 0 features |
| `LayerNotFoundError` | `typename`, `available` | Layer doesn't exist |
| `WFSAuthenticationError` | `url`, `status_code` | 401/403 HTTP errors |

## Test plan

- [x] 9 new tests in `TestWFSExceptionHierarchy`
- [x] All 164 existing WFS tests pass
- [x] Backward compatibility verified

## Related

- Closes #448
- Enables portolan-cli #504 (show error details inline)
- Supports portolan-cli #311 (auth module design)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling with more specific exception types for authentication failures, missing layers, and empty result sets, providing clearer error messages for debugging.

* **Tests**
  * Added comprehensive test coverage for the new exception hierarchy and their properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->