### PR TITLE
feat(extract arcgis): add --max-allowable-offset for server-side generalization

### DIFF
--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1056,7 +1056,7 @@ Some layers have very large or vertex-dense polygons that are slow to download o
     table.write("out.parquet")
     ```
 
-The tolerance is in the units of the output CRS, so it is degrees on the default WGS84 path and the projected unit (often meters) when `--output-crs` selects a projected CRS. The value must be positive, a bad value fails fast before any network call.
+The tolerance is in the units of the request's output CRS. With `--output-crs` set, that is the chosen CRS's unit, degrees for a geographic CRS and the projected unit (often meters) for a projected CRS. Without `--output-crs` the request is anchored to WGS84, so the tolerance is in degrees. The value must be positive, a bad value fails fast before any network call.
 
 ### Finding Service URLs
 

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1031,6 +1031,33 @@ With `--output-crs native`, the layer's spatial reference is taken from its adve
 | `native` | Fetches EsriJSON with the layer's advertised spatial reference |
 | `EPSG:<code>` | Fetches EsriJSON with `outSR` set to the requested EPSG code |
 
+### Geometry generalization
+
+Some layers have very large or vertex-dense polygons that are slow to download or that overwhelm a server. Use `--max-allowable-offset` to ask the server to simplify each geometry before it is sent (the ArcGIS `maxAllowableOffset` parameter, a Douglas-Peucker tolerance). This reduces the vertex count per feature, which is different from `--limit`, which only caps the number of features.
+
+=== "CLI"
+
+    ```bash
+    # Generalize heavy polygons to a 0.005 unit tolerance in the output CRS
+    gpio extract arcgis "https://services.arcgis.com/.../FeatureServer/0" out.parquet \
+      --output-crs native --max-allowable-offset 0.005
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    table = gpio.extract_arcgis(
+        service_url="https://services.arcgis.com/.../FeatureServer/0",
+        output_crs="native",
+        max_allowable_offset=0.005,
+    )
+    table.write("out.parquet")
+    ```
+
+The tolerance is in the units of the output CRS, so it is degrees on the default WGS84 path and the projected unit (often meters) when `--output-crs` selects a projected CRS. The value must be positive, a bad value fails fast before any network call.
+
 ### Finding Service URLs
 
 ArcGIS Feature Service URLs follow this pattern:

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1021,7 +1021,9 @@ By default, `gpio extract arcgis` fetches GeoJSON from the server and outputs WG
     table.write("out.parquet")
     ```
 
-The output GeoParquet is tagged with the CRS the server actually returned. If the server returns a different CRS than the one requested, a warning is emitted and the file is tagged with the actual CRS. Legacy Esri codes are normalized to their EPSG equivalents (102100 becomes 3857), and layers that advertise an Esri-specific WKID with no EPSG equivalent (for example 102039) are tagged with the `ESRI` authority so the CRS stays resolvable.
+The output GeoParquet is tagged with the CRS the server actually returned. If the server returns a different CRS than the one requested, a warning is emitted and the file is tagged with the actual CRS. Legacy Esri codes are normalized to their EPSG equivalents (102100 becomes 3857), and layers that advertise an Esri-specific WKID with no EPSG equivalent (for example 102039) are tagged with the `ESRI` authority so the CRS stays resolvable. A WKID that resolves to neither an EPSG nor an ESRI definition is left untagged rather than labeled with a code no reader can resolve.
+
+With `--output-crs native`, the layer's spatial reference is taken from its advertised WKID, or recovered from its WKT when no WKID is published. If the WKT maps to no EPSG code, the extraction fails with a clear message so you can pass an explicit `--output-crs EPSG:<code>` instead.
 
 | Value | Behavior |
 |-------|----------|

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -814,6 +814,7 @@ def from_arcgis(
     limit: int | None = None,
     max_workers: int = 1,
     output_crs: str | None = None,
+    max_allowable_offset: float | None = None,
 ) -> pa.Table:
     """
     Fetch ArcGIS Feature Service as a PyArrow Table.
@@ -832,6 +833,8 @@ def from_arcgis(
         max_workers: Number of concurrent requests (1 = sequential, 2-3 recommended)
         output_crs: Preserve native CRS. 'native' uses the layer's advertised SR,
             or pass an EPSG code (e.g. EPSG:25830). Default None reprojects to WGS84.
+        max_allowable_offset: Server-side geometry generalization tolerance, in
+            output-CRS units (degrees on the default WGS84 path).
 
     Returns:
         PyArrow Table with WKB geometry column
@@ -861,6 +864,7 @@ def from_arcgis(
         limit=limit,
         max_workers=max_workers,
         output_crs=output_crs,
+        max_allowable_offset=max_allowable_offset,
         verbose=False,
     )
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -342,6 +342,7 @@ def extract_arcgis(
     limit: int | None = None,
     max_workers: int = 1,
     output_crs: str | None = None,
+    max_allowable_offset: float | None = None,
 ) -> Table:
     """
     Extract features from an ArcGIS Feature Service to a Table.
@@ -374,6 +375,8 @@ def extract_arcgis(
         max_workers: Number of concurrent requests (1 = sequential, 2-3 recommended)
         output_crs: Preserve native CRS. 'native' uses the layer's advertised SR,
             or pass an EPSG code (e.g. EPSG:25830). Default None reprojects to WGS84.
+        max_allowable_offset: Server-side geometry generalization tolerance, in
+            output-CRS units (degrees on the default WGS84 path).
 
     Returns:
         Table for chaining operations
@@ -416,6 +419,7 @@ def extract_arcgis(
         limit=limit,
         max_workers=max_workers,
         output_crs=output_crs,
+        max_allowable_offset=max_allowable_offset,
         verbose=False,
     )
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2592,6 +2592,14 @@ def extract_geoparquet(
     "advertised SR. Default reprojects to WGS84.",
 )
 @click.option(
+    "--max-allowable-offset",
+    type=float,
+    default=None,
+    help="Server-side geometry generalization tolerance in output CRS units "
+    "(ArcGIS maxAllowableOffset). Reduces vertices per feature, useful for very "
+    "large or dense polygons.",
+)
+@click.option(
     "--skip-hilbert",
     is_flag=True,
     help="Skip Hilbert spatial ordering (faster but less optimal for spatial queries)",
@@ -2637,6 +2645,7 @@ def extract_arcgis(
     exclude_cols,
     limit,
     output_crs,
+    max_allowable_offset,
     skip_hilbert,
     skip_bbox,
     workers,
@@ -2745,6 +2754,7 @@ def extract_arcgis(
             exclude_cols=exclude_cols,
             limit=limit,
             output_crs=output_crs,
+            max_allowable_offset=max_allowable_offset,
             skip_hilbert=skip_hilbert,
             skip_bbox=skip_bbox,
             max_workers=workers,

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -434,6 +434,7 @@ def fetch_features_page(
     out_fields: str = "*",
     token: str | None = None,
     output_wkid: int | None = None,
+    max_allowable_offset: float | None = None,
     verbose: bool = False,
 ) -> dict:
     """
@@ -449,6 +450,9 @@ def fetch_features_page(
         token: Optional authentication token
         output_wkid: Optional output WKID (e.g. 25830). When set, requests
             EsriJSON (f=json) with outSR so the server reprojects before delivery.
+        max_allowable_offset: Optional server-side geometry generalization
+            tolerance, in the units of the output CRS (degrees on the default
+            WGS84 path). Reduces vertices per feature for very large geometries.
         verbose: Whether to print debug output
 
     Returns:
@@ -463,6 +467,11 @@ def fetch_features_page(
         "resultOffset": str(offset),
         "resultRecordCount": str(limit),
     }
+
+    # Server-side geometry generalization (Douglas-Peucker). Honored on both the
+    # GeoJSON and EsriJSON paths; the tolerance is in the units of the output SR.
+    if max_allowable_offset is not None:
+        params["maxAllowableOffset"] = str(max_allowable_offset)
 
     # Add bbox filter if provided (spatial query)
     if bbox:
@@ -500,6 +509,7 @@ def fetch_all_features(
     batch_size: int | None = None,
     max_workers: int = 1,
     output_wkid: int | None = None,
+    max_allowable_offset: float | None = None,
     verbose: bool = False,
 ) -> Generator[dict, None, None]:
     """
@@ -569,6 +579,7 @@ def fetch_all_features(
                     out_fields=out_fields,
                     token=token,
                     output_wkid=output_wkid,
+                    max_allowable_offset=max_allowable_offset,
                     verbose=verbose,
                 )
             except BatchTooLargeError as e:
@@ -646,6 +657,7 @@ def fetch_all_features(
                         out_fields=out_fields,
                         token=token,
                         output_wkid=output_wkid,
+                        max_allowable_offset=max_allowable_offset,
                         verbose=False,  # Disable per-request verbose to avoid race conditions
                     )
                     futures.append((offset, current_batch, future))
@@ -1026,6 +1038,7 @@ def _stream_features_to_parquet(
     batch_size: int | None = None,
     max_workers: int = 1,
     output_wkid: int | None = None,
+    max_allowable_offset: float | None = None,
     verbose: bool = False,
 ) -> tuple[int, dict | None]:
     """
@@ -1093,6 +1106,7 @@ def _stream_features_to_parquet(
             batch_size=batch_size,
             max_workers=max_workers,
             output_wkid=output_wkid,
+            max_allowable_offset=max_allowable_offset,
             verbose=verbose,
         ):
             features = page.get("features", [])
@@ -1160,6 +1174,7 @@ def arcgis_to_table(
     batch_size: int | None = None,
     max_workers: int = 1,
     output_crs: str | None = None,
+    max_allowable_offset: float | None = None,
     verbose: bool = False,
 ) -> pa.Table:
     """
@@ -1191,6 +1206,9 @@ def arcgis_to_table(
         output_crs: Preserve native CRS instead of reprojecting to WGS84. Use
             "native" for the layer's advertised SR, or an EPSG code (e.g.
             "EPSG:25830"). Default None fetches GeoJSON in WGS84 (CRS84).
+        max_allowable_offset: Server-side geometry generalization tolerance, in
+            the units of the output CRS (degrees on the default WGS84 path).
+            Reduces vertices per feature for very large geometries.
         verbose: Whether to print debug output
 
     Returns:
@@ -1207,6 +1225,13 @@ def arcgis_to_table(
             output_wkid = _normalize_wkid(_parse_crs_to_wkid(output_crs))
         except ValueError as e:
             raise InvalidParameterError("output_crs", str(e)) from e
+
+    # A generalization tolerance must be positive; reject bad values before any
+    # network work so the failure is fast and clean.
+    if max_allowable_offset is not None and max_allowable_offset <= 0:
+        raise InvalidParameterError(
+            "max_allowable_offset", "must be a positive number (units of the output CRS)."
+        )
 
     # Validate URL
     service_url, layer_id = validate_arcgis_url(service_url)
@@ -1263,6 +1288,7 @@ def arcgis_to_table(
             batch_size=batch_size,
             max_workers=max_workers,
             output_wkid=output_wkid,
+            max_allowable_offset=max_allowable_offset,
             verbose=verbose,
         )
 
@@ -1343,6 +1369,7 @@ def convert_arcgis_to_geoparquet(
     exclude_cols: str | None = None,
     limit: int | None = None,
     output_crs: str | None = None,
+    max_allowable_offset: float | None = None,
     skip_hilbert: bool = False,
     skip_bbox: bool = False,
     max_workers: int = 1,
@@ -1382,6 +1409,8 @@ def convert_arcgis_to_geoparquet(
         limit: Maximum number of features to return
         output_crs: Preserve native CRS. "native" uses the layer's advertised SR;
             or pass an EPSG code (e.g. "EPSG:25830"). Default None -> WGS84 (f=geojson).
+        max_allowable_offset: Server-side geometry generalization tolerance, in
+            output-CRS units (degrees on the default WGS84 path).
         skip_hilbert: Skip Hilbert spatial ordering
         skip_bbox: Skip adding bbox column for spatial query optimization
         max_workers: Number of concurrent requests (1 = sequential, 2-3 recommended)
@@ -1428,6 +1457,7 @@ def convert_arcgis_to_geoparquet(
         batch_size=batch_size,
         max_workers=max_workers,
         output_crs=output_crs,
+        max_allowable_offset=max_allowable_offset,
         verbose=verbose,
     )
 

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -782,8 +782,40 @@ def _projjson_from_wkid(wkid: int) -> dict | None:
             return CRS.from_authority(authority, code).to_json_dict()
         except CRSError:
             continue
-    warn(f"WKID {wkid} is not a known EPSG or ESRI code; tagging output as EPSG:{code} anyway.")
-    return {"id": {"authority": "EPSG", "code": code}}
+    warn(f"WKID {wkid} is not a known EPSG or ESRI code; leaving the output CRS unset.")
+    return None
+
+
+def _resolve_native_wkid(spatial_ref: dict) -> int:
+    """Resolve a layer's advertised native SR to an EPSG/ESRI WKID for outSR.
+
+    Prefers an advertised WKID. Falls back to deriving an EPSG code from an
+    advertised WKT (common for layers that omit a WKID). Raises when the SR is
+    absent or its WKT maps to no EPSG code.
+    """
+    wkid = _wkid_from_spatial_reference(spatial_ref)
+    if wkid is not None:
+        return _normalize_wkid(wkid)
+
+    wkt = spatial_ref.get("wkt")
+    if wkt:
+        from pyproj import CRS
+        from pyproj.exceptions import CRSError
+
+        try:
+            epsg = CRS.from_wkt(wkt).to_epsg()
+        except CRSError:
+            epsg = None
+        if epsg is not None:
+            return epsg
+        raise GeoParquetError(
+            "--output-crs native could not resolve the layer's WKT spatial reference "
+            "to an EPSG code. Pass an explicit --output-crs EPSG:<code> instead."
+        )
+
+    raise GeoParquetError(
+        "--output-crs native requested but the layer advertises no spatial reference."
+    )
 
 
 def _extract_crs_from_spatial_reference(spatial_ref: dict) -> dict | None:
@@ -1190,12 +1222,7 @@ def arcgis_to_table(
 
     # Resolve "native" to the layer's advertised SR
     if output_crs == "native":
-        native_wkid = _wkid_from_spatial_reference(layer_info.spatial_reference)
-        if native_wkid is None:
-            raise GeoParquetError(
-                "--output-crs native requested but the layer advertises no spatial reference."
-            )
-        output_wkid = _normalize_wkid(native_wkid)
+        output_wkid = _resolve_native_wkid(layer_info.spatial_reference)
 
     if layer_info.total_count == 0:
         filters_applied = where != "1=1" or bbox is not None

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -469,9 +469,13 @@ def fetch_features_page(
     }
 
     # Server-side geometry generalization (Douglas-Peucker). Honored on both the
-    # GeoJSON and EsriJSON paths; the tolerance is in the units of the output SR.
+    # GeoJSON and EsriJSON paths. ArcGIS measures the tolerance in outSR units and
+    # falls back to the layer's source units when outSR is unset, so anchor outSR
+    # (to 4326 on the default GeoJSON path) to keep the unit well-defined. The
+    # output_wkid branch below overrides this with the requested SR when present.
     if max_allowable_offset is not None:
         params["maxAllowableOffset"] = str(max_allowable_offset)
+        params.setdefault("outSR", "4326")
 
     # Add bbox filter if provided (spatial query)
     if bbox:

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -361,6 +361,8 @@ class TestFetchFeaturesPage:
         params = mock_request.call_args.kwargs["params"]
         assert params["f"] == "geojson"
         assert params["maxAllowableOffset"] == "0.005"
+        # outSR is anchored to 4326 so the tolerance unit is unambiguously degrees.
+        assert params["outSR"] == "4326"
 
     @patch("geoparquet_io.core.arcgis._make_request")
     def test_fetch_page_max_allowable_offset_with_outsr(self, mock_request):

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -335,6 +335,51 @@ class TestFetchFeaturesPage:
         assert params["f"] == "json"
         assert params["outSR"] == "25830"
 
+    @patch("geoparquet_io.core.arcgis._make_request")
+    def test_fetch_page_no_max_allowable_offset_by_default(self, mock_request):
+        from geoparquet_io.core.arcgis import fetch_features_page
+
+        mock_request.return_value = MOCK_FEATURES_PAGE
+        fetch_features_page("https://example.com/FeatureServer/0", offset=0, limit=1000)
+
+        params = mock_request.call_args.kwargs["params"]
+        assert "maxAllowableOffset" not in params
+
+    @patch("geoparquet_io.core.arcgis._make_request")
+    def test_fetch_page_max_allowable_offset_on_geojson(self, mock_request):
+        """Generalization tolerance is honored on the default GeoJSON path too."""
+        from geoparquet_io.core.arcgis import fetch_features_page
+
+        mock_request.return_value = MOCK_FEATURES_PAGE
+        fetch_features_page(
+            "https://example.com/FeatureServer/0",
+            offset=0,
+            limit=1000,
+            max_allowable_offset=0.005,
+        )
+
+        params = mock_request.call_args.kwargs["params"]
+        assert params["f"] == "geojson"
+        assert params["maxAllowableOffset"] == "0.005"
+
+    @patch("geoparquet_io.core.arcgis._make_request")
+    def test_fetch_page_max_allowable_offset_with_outsr(self, mock_request):
+        from geoparquet_io.core.arcgis import fetch_features_page
+
+        mock_request.return_value = MOCK_ESRI_FEATURES_PAGE
+        fetch_features_page(
+            "https://example.com/FeatureServer/0",
+            offset=0,
+            limit=1000,
+            output_wkid=25830,
+            max_allowable_offset=0.005,
+        )
+
+        params = mock_request.call_args.kwargs["params"]
+        assert params["f"] == "json"
+        assert params["outSR"] == "25830"
+        assert params["maxAllowableOffset"] == "0.005"
+
 
 class TestCrsParsing:
     """Tests for output-crs parsing helpers."""
@@ -678,6 +723,35 @@ class TestArcgisToTableOutputCrs:
 
     @patch("geoparquet_io.core.arcgis._stream_features_to_parquet")
     @patch("geoparquet_io.core.arcgis.get_layer_info")
+    def test_max_allowable_offset_threads_to_stream(self, mock_layer, mock_stream, tmp_path):
+        from geoparquet_io.core.arcgis import arcgis_to_table
+
+        mock_layer.return_value = self._layer(25830, 25830)
+        mock_stream.side_effect = self._stub_stream(tmp_path, {"wkid": 25830, "latestWkid": 25830})
+
+        arcgis_to_table(
+            "https://example.com/FeatureServer/0",
+            output_crs="EPSG:25830",
+            max_allowable_offset=0.005,
+        )
+
+        assert mock_stream.call_args.kwargs["max_allowable_offset"] == 0.005
+
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
+    def test_invalid_max_allowable_offset_raises_before_network(self, mock_layer):
+        from geoparquet_io.core.arcgis import arcgis_to_table
+        from geoparquet_io.core.exceptions import GeoParquetError
+
+        with pytest.raises(GeoParquetError, match="max_allowable_offset"):
+            arcgis_to_table("https://example.com/FeatureServer/0", max_allowable_offset=0)
+
+        with pytest.raises(GeoParquetError, match="max_allowable_offset"):
+            arcgis_to_table("https://example.com/FeatureServer/0", max_allowable_offset=-1.0)
+
+        mock_layer.assert_not_called()
+
+    @patch("geoparquet_io.core.arcgis._stream_features_to_parquet")
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
     def test_server_ignores_outsr_tags_returned_and_warns(
         self, mock_layer, mock_stream, tmp_path, caplog
     ):
@@ -956,6 +1030,51 @@ class TestArcgisCliOutputCrs:
         assert not isinstance(result.exception, ValueError)
         mock_layer.assert_not_called()
 
+    @patch("geoparquet_io.core.arcgis.convert_arcgis_to_geoparquet")
+    def test_cli_passes_max_allowable_offset(self, mock_convert, tmp_path):
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = str(tmp_path / "out.parquet")
+        result = CliRunner().invoke(
+            cli,
+            [
+                "extract",
+                "arcgis",
+                "https://example.com/FeatureServer/0",
+                out,
+                "--max-allowable-offset",
+                "0.005",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_convert.call_args.kwargs["max_allowable_offset"] == 0.005
+
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
+    def test_cli_invalid_max_allowable_offset_fails_cleanly(self, mock_layer, tmp_path):
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = str(tmp_path / "out.parquet")
+        result = CliRunner().invoke(
+            cli,
+            [
+                "extract",
+                "arcgis",
+                "https://example.com/FeatureServer/0",
+                out,
+                "--max-allowable-offset",
+                "0",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "max_allowable_offset" in result.output
+        mock_layer.assert_not_called()
+
 
 class TestPythonAPI:
     """Tests for Python API functions."""
@@ -1009,6 +1128,24 @@ class TestApiOutputCrs:
         extract_arcgis("https://example.com/FeatureServer/0", output_crs="EPSG:25830")
 
         assert mock_to_table.call_args.kwargs["output_crs"] == "EPSG:25830"
+
+    @patch("geoparquet_io.core.arcgis.arcgis_to_table")
+    def test_ops_from_arcgis_forwards_max_allowable_offset(self, mock_to_table):
+        from geoparquet_io.api import ops
+
+        mock_to_table.return_value = pa.table({"geometry": pa.array([], type=pa.binary())})
+        ops.from_arcgis("https://example.com/FeatureServer/0", max_allowable_offset=0.005)
+
+        assert mock_to_table.call_args.kwargs["max_allowable_offset"] == 0.005
+
+    @patch("geoparquet_io.core.arcgis.arcgis_to_table")
+    def test_extract_arcgis_forwards_max_allowable_offset(self, mock_to_table):
+        from geoparquet_io.api.table import extract_arcgis
+
+        mock_to_table.return_value = pa.table({"geometry": pa.array([], type=pa.binary())})
+        extract_arcgis("https://example.com/FeatureServer/0", max_allowable_offset=0.005)
+
+        assert mock_to_table.call_args.kwargs["max_allowable_offset"] == 0.005
 
 
 class TestStreamingConversion:

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -584,6 +584,88 @@ class TestArcgisToTableOutputCrs:
         assert crs["id"]["authority"] == "ESRI"
         assert int(crs["id"]["code"]) == 102039
 
+    @patch("geoparquet_io.core.arcgis._stream_features_to_parquet")
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
+    def test_unresolvable_wkid_writes_no_crs(self, mock_layer, mock_stream, tmp_path, caplog):
+        """A WKID resolving as neither EPSG nor ESRI must not be tagged as EPSG."""
+        import logging
+
+        from geoparquet_io.core.arcgis import ArcGISLayerInfo, arcgis_to_table
+
+        mock_layer.return_value = ArcGISLayerInfo(
+            name="Test",
+            geometry_type="esriGeometryPolygon",
+            spatial_reference={"wkid": 999999},
+            fields=[
+                {"name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": False},
+                {"name": "name", "type": "esriFieldTypeString", "nullable": True},
+            ],
+            max_record_count=1000,
+            total_count=1,
+        )
+        mock_stream.side_effect = self._stub_stream(tmp_path, {"wkid": 999999})
+
+        with caplog.at_level(logging.WARNING):
+            result = arcgis_to_table("https://example.com/FeatureServer/0", output_crs="native")
+
+        # No fabricated EPSG metadata when the code cannot be resolved.
+        metadata = result.schema.metadata or {}
+        assert b"geo" not in metadata
+        assert any("999999" in r.message for r in caplog.records)
+
+    @patch("geoparquet_io.core.arcgis._stream_features_to_parquet")
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
+    def test_native_wkt_only_resolves_via_epsg(self, mock_layer, mock_stream, tmp_path):
+        """Native SR advertised only as WKT must resolve to its EPSG code."""
+        from pyproj import CRS
+
+        from geoparquet_io.core.arcgis import ArcGISLayerInfo, arcgis_to_table
+
+        wkt = CRS.from_epsg(25830).to_wkt()
+        mock_layer.return_value = ArcGISLayerInfo(
+            name="Test",
+            geometry_type="esriGeometryPolygon",
+            spatial_reference={"wkt": wkt},
+            fields=[
+                {"name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": False},
+                {"name": "name", "type": "esriFieldTypeString", "nullable": True},
+            ],
+            max_record_count=1000,
+            total_count=1,
+        )
+        mock_stream.side_effect = self._stub_stream(tmp_path, {"wkid": 25830, "latestWkid": 25830})
+
+        result = arcgis_to_table("https://example.com/FeatureServer/0", output_crs="native")
+
+        assert mock_stream.call_args.kwargs["output_wkid"] == 25830
+        crs = json.loads(result.schema.metadata[b"geo"])["columns"]["geometry"]["crs"]
+        assert crs["id"]["code"] == 25830
+
+    @patch("geoparquet_io.core.arcgis._stream_features_to_parquet")
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
+    def test_native_wkt_only_unresolvable_raises(self, mock_layer, mock_stream, tmp_path):
+        """A WKT-only native SR with no EPSG equivalent raises an accurate error."""
+        from geoparquet_io.core.arcgis import ArcGISLayerInfo, arcgis_to_table
+        from geoparquet_io.core.exceptions import GeoParquetError
+
+        wkt = (
+            'LOCAL_CS["Custom",LOCAL_DATUM["Custom",0],UNIT["metre",1.0],'
+            'AXIS["X",EAST],AXIS["Y",NORTH]]'
+        )
+        mock_layer.return_value = ArcGISLayerInfo(
+            name="Test",
+            geometry_type="esriGeometryPolygon",
+            spatial_reference={"wkt": wkt},
+            fields=[{"name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": False}],
+            max_record_count=1000,
+            total_count=1,
+        )
+
+        with pytest.raises(GeoParquetError, match="could not resolve"):
+            arcgis_to_table("https://example.com/FeatureServer/0", output_crs="native")
+
+        mock_stream.assert_not_called()
+
     @patch("geoparquet_io.core.arcgis.get_layer_info")
     def test_invalid_output_crs_raises_before_network(self, mock_layer):
         from geoparquet_io.core.arcgis import arcgis_to_table


### PR DESCRIPTION
## Summary

Adds `--max-allowable-offset` to `gpio extract arcgis` so the server can generalize geometry before delivery, and carries forward two small arcgis CRS fixes that missed the #482 merge window.

Closes #483.

## The feature

`gpio extract arcgis` previously downloaded every vertex of every feature at full resolution, with no way to request server-side generalization. That makes layers with very large or vertex-dense polygons slow, and on some servers impossible. The South Africa NSPDR land-capability layer, for instance, returns HTTP 500 on a normal query because its source polygons are so heavy.

`--max-allowable-offset` maps to the ArcGIS `maxAllowableOffset` query parameter, a Douglas-Peucker tolerance applied server-side. The tolerance is in the units of the output spatial reference, so degrees on the default WGS84 path and the projected unit when `--output-crs` selects a projected CRS.

```bash
gpio extract arcgis <url> out.parquet --output-crs native --max-allowable-offset 0.005
```

```python
gpio.extract_arcgis(url, output_crs="native", max_allowable_offset=0.005)
```

This is different from `--limit`, which maps to `resultRecordCount` and only caps the number of features. `--limit` does nothing to the vertex count within a feature, so a single heavy polygon still fails or bloats the output even at `--limit 1`. The two controls solve different problems.

### What changed

- `fetch_features_page` sets `maxAllowableOffset` on both the GeoJSON and EsriJSON request paths.
- Threaded through `fetch_all_features`, `_stream_features_to_parquet`, `arcgis_to_table`, and `convert_arcgis_to_geoparquet`, mirroring how `output_crs` flows.
- A non-positive value fails fast with a clean error before any network call.
- Python API parity, `max_allowable_offset` is exposed on `from_arcgis` (`api/ops.py`) and `extract_arcgis` (`api/table.py`).
- Docs section added in `docs/guide/extract.md`.

## Carried-forward CRS fixes

The first commit carries two arcgis fixes from a CodeRabbit review of #482. They were committed after #482 had already merged, so they never reached main.

- `_projjson_from_wkid` returns `None` instead of fabricating `{"id": {"authority": "EPSG", "code": code}}` when a WKID resolves as neither EPSG nor ESRI. The tagging block already guards on `if crs:`, so the CRS is left unset rather than asserting a code no reader can resolve.
- `_resolve_native_wkid` recovers an EPSG code from a layer's WKT when no WKID is advertised, fixing `--output-crs native` for WKT-only services, and raises an accurate error when the WKT maps to no EPSG code.

## Testing

- 9 new tests for the offset feature (request-param shape on both paths, threading through `arcgis_to_table`, upfront validation, CLI wiring, Python API forwarding) and 3 for the carried-forward fixes.
- Full arcgis suite passes, 100 tests.
- mypy, ruff, and pre-commit all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side geometry generalization control (new max-allowable-offset) for ArcGIS feature extraction via CLI and Python APIs.
  * Improved native CRS handling and resolution behavior with clearer outcomes when spatial references can’t be resolved.

* **Documentation**
  * Updated ArcGIS Output CRS guide with CRS tagging rules, native-CRS clarification, and geometry generalization usage/examples.

* **Tests**
  * Added tests covering generalization forwarding/validation, native-CRS behaviors, and CLI/Python end-to-end paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->