### PR TITLE
chore: deterministic guardrails for recurring fix/review cycles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,18 @@ repos:
               echo "ERROR: Use TRY(ST_GeomFromText(x)) instead of TRY_CAST(x AS GEOMETRY)"
               errors=1
             fi
+            # Per-call always_xy in ST_Transform is an antipattern - set it once at the
+            # session level instead. Scoped to ST_Transform so pyproj Transformer(always_xy=True),
+            # which is correct, is not flagged. (Recurring CRS fix; see CLAUDE.md.)
+            if grep -rnE 'ST_Transform[^;]*always_xy' geoparquet_io/ --include="*.py" | grep -v "^\s*#" | grep -v "instead"; then
+              echo "ERROR: Use session-level 'SET geometry_always_xy = true' instead of ST_Transform(..., always_xy := true)"
+              errors=1
+            fi
+            # apply_crs_to_parquet() was removed - use _wrap_query_with_crs() instead
+            if grep -rn 'apply_crs_to_parquet' geoparquet_io/ --include="*.py" | grep -v "^\s*#" | grep -v "instead"; then
+              echo "ERROR: apply_crs_to_parquet() was removed. Use _wrap_query_with_crs() instead."
+              errors=1
+            fi
             exit $errors
         language: system
         pass_filenames: false
@@ -78,6 +90,27 @@ repos:
           - |
             if grep -rn "click\.echo" geoparquet_io/core/ --include="*.py" | grep -v "logging_config.py"; then
               echo "ERROR: Use logger instead of click.echo in core/. See CLAUDE.md Logging section."
+              exit 1
+            fi
+        language: system
+        pass_filenames: false
+        types: [python]
+
+      # Forbid hand-rolling paginated-schema reconciliation in extractors.
+      # WFS and ArcGIS each grew separate, separately-buggy schema-alignment code
+      # (18 + 8 fix commits). The canonical helpers live in core/common.py:
+      # _compute_unified_schema and _cast_table_to_schema. New extractors must reuse them.
+      - id: forbid-bespoke-schema-reconciliation
+        name: forbid-bespoke-schema-reconciliation
+        description: Use shared schema helpers from core/common.py, not hand-rolled ones
+        entry: bash
+        args:
+          - -c
+          - |
+            if grep -rnE 'def _(align|unify|reconcile)[a-zA-Z_]*schema' geoparquet_io/core/ --include="*.py" | grep -v "common.py"; then
+              echo "ERROR: Reuse _compute_unified_schema / _cast_table_to_schema from core/common.py"
+              echo "       instead of hand-rolling schema reconciliation. See the WFS/ArcGIS history"
+              echo "       and docs/contributing.md (External extractors)."
               exit 1
             fi
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,12 +66,15 @@ repos:
             # Per-call always_xy in ST_Transform is an antipattern - set it once at the
             # session level instead. Scoped to ST_Transform so pyproj Transformer(always_xy=True),
             # which is correct, is not flagged. (Recurring CRS fix; see CLAUDE.md.)
-            if grep -rnE 'ST_Transform[^;]*always_xy' geoparquet_io/ --include="*.py" | grep -v "^\s*#" | grep -v "instead"; then
+            # awk filters comment lines by testing the code text (field 3+), since
+            # grep -rn prefixes each line with "path:line:" so "^\s*#" never matches.
+            # grep . restores exit-status gating (awk always exits 0).
+            if grep -rnE 'ST_Transform[^;]*always_xy' geoparquet_io/ --include="*.py" | awk -F: '$3 !~ /^[[:space:]]*#/' | grep .; then
               echo "ERROR: Use session-level 'SET geometry_always_xy = true' instead of ST_Transform(..., always_xy := true)"
               errors=1
             fi
             # apply_crs_to_parquet() was removed - use _wrap_query_with_crs() instead
-            if grep -rn 'apply_crs_to_parquet' geoparquet_io/ --include="*.py" | grep -v "^\s*#" | grep -v "instead"; then
+            if grep -rn 'apply_crs_to_parquet' geoparquet_io/ --include="*.py" | awk -F: '$3 !~ /^[[:space:]]*#/' | grep .; then
               echo "ERROR: apply_crs_to_parquet() was removed. Use _wrap_query_with_crs() instead."
               errors=1
             fi

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,6 +64,25 @@ New CLI commands need corresponding Python API:
 
 See `CLAUDE.md` for full architecture details.
 
+### External extractors
+
+Extractors that page through a remote service (`wfs`, `arcgis`, `carto`, `bigquery`) keep
+re-discovering the same edge cases. Reuse the shared schema helpers in `core/common.py`
+(`_compute_unified_schema`, `_cast_table_to_schema`, `_promote_numeric_type`) rather than
+hand-rolling schema reconciliation — the `forbid-bespoke-schema-reconciliation` pre-commit hook
+enforces this. Known edge cases to handle:
+
+- **Pagination**: detect server `startIndex`/page-size limits; supply a stable sort
+  (`sortBy`/`orderByFields`) for layers without a primary key.
+- **Schema across pages**: never trust the first page's inferred schema. Where a source has an
+  authoritative schema (ArcGIS layer metadata), cast each page to it via `_cast_table_to_schema`.
+  Where it does not (WFS), unify with `_compute_unified_schema` (handles int/float/decimal mixes,
+  uint64 overflow).
+- **Empty/null responses**: handle empty result sets and null properties without crashing.
+- **CRS/SR**: normalize WKID/SR; resolve native WKT → EPSG; unset CRS for unresolvable codes; honor
+  `--output-crs` by reprojecting when the server returns a different CRS.
+- **Network**: retry transient errors; surface upstream stderr.
+
 ## Releasing
 
 (Maintainers only)

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from geoparquet_io.core.common import write_geoparquet_table
+from geoparquet_io.core.common import _cast_table_to_schema, write_geoparquet_table
 from geoparquet_io.core.crs_utils import _extract_crs_identifier, parse_crs_string_to_projjson
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 from geoparquet_io.core.exceptions import (
@@ -849,44 +849,6 @@ def _extract_crs_from_spatial_reference(spatial_ref: dict) -> dict | None:
     return parse_crs_string_to_projjson("EPSG:4326")
 
 
-def _align_table_to_schema(table: pa.Table, target_schema: pa.Schema) -> pa.Table:
-    """
-    Align a table's columns to match a target schema.
-
-    This handles three types of mismatches between DuckDB output and ArcGIS metadata:
-    1. Column order differences - reorders columns to match target schema
-    2. Extra columns - drops columns not in target schema
-    3. Missing columns - adds null columns of the correct type
-
-    This is critical for handling schema variance in paginated ArcGIS responses
-    (issue #334), where different batches may have different column ordering or
-    missing/extra fields.
-
-    Args:
-        table: Source table from DuckDB with potentially different column order
-        target_schema: Target schema from ArcGIS layer metadata
-
-    Returns:
-        Table with columns aligned to target schema
-    """
-    source_columns = set(table.column_names)
-    target_columns = [field.name for field in target_schema]
-
-    aligned_arrays = []
-    for field in target_schema:
-        if field.name in source_columns:
-            # Column exists - select it (handles reordering)
-            col = table.column(field.name)
-            aligned_arrays.append(col)
-        else:
-            # Column missing - create null array of correct type
-            null_array = pa.nulls(table.num_rows, type=field.type)
-            aligned_arrays.append(null_array)
-
-    # Create new table with aligned columns (automatically drops extra columns)
-    return pa.table(dict(zip(target_columns, aligned_arrays, strict=True)))
-
-
 def _build_schema_from_layer_info(layer_info: ArcGISLayerInfo) -> pa.Schema:
     """
     Build a fixed PyArrow schema from ArcGIS layer metadata.
@@ -1020,7 +982,7 @@ def _esrijson_page_to_table(page: dict, con=None) -> pa.Table | None:
     (geometryType / spatialReference / fields / features), so the raw page is
     written verbatim. `attributes` are flattened to columns by the driver.
     GDAL may or may not add OGC_FID for EsriJSON; extra columns are kept here
-    and dropped later by _align_table_to_schema.
+    and dropped later by _cast_table_to_schema.
 
     Returns a PyArrow Table with WKB geometry column, or None if no features.
     """
@@ -1131,25 +1093,31 @@ def _stream_features_to_parquet(
 
             page_count += 1
 
-            # Align columns to target schema (handles order/missing/extra columns)
-            # This is required because DuckDB may return columns in different order
-            # than ArcGIS metadata, or some batches may have different fields
-            page_table = _align_table_to_schema(page_table, target_schema)
-
-            # Cast to fixed schema (handles type mismatches between batches)
+            # Reconcile this page to the authoritative metadata schema using the
+            # shared helper from core/common.py (same code path as the WFS extractor):
+            # it reorders columns, fills missing fields with typed nulls, drops extras,
+            # and casts each column to the metadata type with page context in errors.
+            # The metadata schema stays authoritative (e.g. int32 declared fields are
+            # narrowed back from DuckDB's int64 inference); promotion is intentionally
+            # NOT used here because, unlike WFS, ArcGIS has an authoritative schema.
             try:
-                page_table = page_table.cast(target_schema, safe=True)
-            except pa.ArrowInvalid as e:
-                # If safe casting fails, try to provide helpful error message
+                page_table = _cast_table_to_schema(
+                    page_table, target_schema, page_info=f"batch {page_count}"
+                )
+            except ValueError as e:
+                # Cast failure (e.g. a value that overflows a declared narrower type)
                 raise GeoParquetError(
                     f"Failed to cast batch {page_count} to target schema. "
-                    f"This may indicate data corruption or unexpected types from the service. "
-                    f"Error: {e}"
+                    f"This may indicate unexpected types from the service. {e}"
                 ) from e
 
-            # Initialize writer with fixed schema on first page
+            # Initialize writer on first page using the reconciled page's schema.
+            # _cast_table_to_schema produces nullable columns (it rebuilds the table),
+            # so we seed the writer from the reconciled table rather than the metadata
+            # schema to avoid a nullability mismatch. Column types still match metadata;
+            # geo metadata is (re)derived in the second pass, not from this writer.
             if writer is None:
-                writer = pq.ParquetWriter(output_path, target_schema)
+                writer = pq.ParquetWriter(output_path, page_table.schema)
 
             # Write this page
             writer.write_table(page_table)

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1476,12 +1476,18 @@ class TestNetworkIntegration:
         assert "geometry" in table.column_names
 
 
-class TestAlignTableToSchema:
-    """Unit tests for the _align_table_to_schema helper function."""
+class TestCastTableToSchema:
+    """Schema-reconciliation tests for the shared _cast_table_to_schema helper.
+
+    ArcGIS converged onto core/common._cast_table_to_schema (the same helper WFS
+    uses) instead of a bespoke _align_table_to_schema + raw cast. These tests
+    preserve the reorder/drop/add coverage of the deleted helper and add the new
+    page-context-error and geometry-binary guarantees the convergence provides.
+    """
 
     def test_reorders_columns_to_match_schema(self):
-        """Test that columns are reordered to match target schema."""
-        from geoparquet_io.core.arcgis import _align_table_to_schema
+        """Columns are reordered to match the target schema."""
+        from geoparquet_io.core.common import _cast_table_to_schema
 
         # Source table with different column order
         source = pa.table(
@@ -1500,7 +1506,7 @@ class TestAlignTableToSchema:
             ]
         )
 
-        result = _align_table_to_schema(source, target_schema)
+        result = _cast_table_to_schema(source, target_schema)
 
         assert result.column_names == ["a", "b", "c"]
         assert result.column("a").to_pylist() == [1, 4]
@@ -1508,8 +1514,8 @@ class TestAlignTableToSchema:
         assert result.column("c").to_pylist() == [3, 6]
 
     def test_drops_extra_columns(self):
-        """Test that extra columns not in target schema are dropped."""
-        from geoparquet_io.core.arcgis import _align_table_to_schema
+        """Extra columns not in the target schema are dropped."""
+        from geoparquet_io.core.common import _cast_table_to_schema
 
         source = pa.table(
             {
@@ -1526,14 +1532,14 @@ class TestAlignTableToSchema:
             ]
         )
 
-        result = _align_table_to_schema(source, target_schema)
+        result = _cast_table_to_schema(source, target_schema)
 
         assert result.column_names == ["a", "b"]
         assert "extra" not in result.column_names
 
     def test_adds_missing_columns_with_nulls(self):
-        """Test that missing columns are filled with nulls."""
-        from geoparquet_io.core.arcgis import _align_table_to_schema
+        """Missing columns are filled with typed nulls."""
+        from geoparquet_io.core.common import _cast_table_to_schema
 
         source = pa.table(
             {
@@ -1548,14 +1554,14 @@ class TestAlignTableToSchema:
             ]
         )
 
-        result = _align_table_to_schema(source, target_schema)
+        result = _cast_table_to_schema(source, target_schema)
 
         assert result.column_names == ["a", "missing"]
         assert result.column("missing").to_pylist() == [None, None]
 
     def test_handles_all_mismatches_together(self):
-        """Test reorder + drop + add in combination."""
-        from geoparquet_io.core.arcgis import _align_table_to_schema
+        """Reorder + drop + add + cast in combination."""
+        from geoparquet_io.core.common import _cast_table_to_schema
 
         source = pa.table(
             {
@@ -1573,13 +1579,58 @@ class TestAlignTableToSchema:
             ]
         )
 
-        result = _align_table_to_schema(source, target_schema)
+        result = _cast_table_to_schema(source, target_schema)
 
         assert result.column_names == ["a", "missing", "z"]
         assert result.column("a").to_pylist() == [1, 2]
         assert result.column("missing").to_pylist() == [None, None]
         assert result.column("z").to_pylist() == [9, 10]
         assert "extra" not in result.column_names
+
+    def test_geometry_binary_is_preserved(self):
+        """A WKB geometry column stays binary even when attributes are strings.
+
+        Guards against any regression that coerces the geometry column toward
+        string when reconciling an ArcGIS page table to the metadata schema.
+        """
+        from geoparquet_io.core.common import _cast_table_to_schema
+
+        source = pa.table(
+            {
+                "geometry": pa.array([b"\x01\x02", b"\x03\x04"], type=pa.binary()),
+                "name": ["a", "b"],
+            }
+        )
+
+        target_schema = pa.schema(
+            [
+                pa.field("geometry", pa.binary()),
+                pa.field("name", pa.string()),
+            ]
+        )
+
+        result = _cast_table_to_schema(source, target_schema)
+
+        assert result.schema.field("geometry").type == pa.binary()
+        assert result.column("geometry").to_pylist() == [b"\x01\x02", b"\x03\x04"]
+
+    def test_cast_failure_reports_page_context(self):
+        """An impossible cast raises ValueError carrying the page/column context.
+
+        This is the new diagnostic the convergence buys: ArcGIS wraps this
+        ValueError into a GeoParquetError that names the batch and column,
+        replacing the previous generic message.
+        """
+        from geoparquet_io.core.common import _cast_table_to_schema
+
+        # A non-numeric string cannot be safely cast to int64
+        source = pa.table({"amount": ["not_a_number", "also_bad"]})
+        target_schema = pa.schema([pa.field("amount", pa.int64())])
+
+        with pytest.raises(ValueError, match="amount") as exc_info:
+            _cast_table_to_schema(source, target_schema, page_info="batch 7")
+
+        assert "batch 7" in str(exc_info.value)
 
 
 class TestSchemaMismatchBetweenBatches:


### PR DESCRIPTION
## Context

A review of the last 3 months of history (432 commits) showed a large, recurring maintenance tax paid one commit at a time:

- **113 explicit `fix` commits (26%)**; 215 (50%) match the broad fix/revert/ci/flaky pattern.
- **WFS is the #1 fix scope (18 commits)**, ArcGIS #3 (8) — the external-service extractors dominate the leak surface, repeatedly re-discovering the same paginated-schema edge cases.
- **~18% of merged PRs needed a second "address review findings" cycle** (24 such commits).
- Helpers to prevent the recurring bug classes already existed (`_cast_table_to_schema`, `quote_identifier`, etc.), but nothing enforced their use.

This PR adds **deterministic guardrails only** — no agent/LLM steps, which spend tokens rather than removing them.

## Changes

### ArcGIS → shared schema helper (the structural win)
- Deleted the bespoke `_align_table_to_schema` + raw `.cast()`; reuse the shared `_cast_table_to_schema` that WFS already uses (reorder / fill-missing / drop-extras / cast-with-context in one place).
- **Metadata schema stays authoritative**: ArcGIS intentionally narrows DuckDB's `int64` back to a declared `int32`. WFS-style *type promotion* would widen it and break `test_handles_multiple_type_variance_columns`, so promotion is deliberately **not** used here — this is a pure DRY win plus per-batch/column error context.
- `ParquetWriter` is seeded from the reconciled page schema to avoid a nullability mismatch (the helper rebuilds tables as nullable).

### Pre-commit hooks (both proven to fire on injected violations)
- `forbid-bespoke-schema-reconciliation` — blocks new hand-rolled schema-alignment defs so future extractors (carto, bigquery) reuse the shared helpers. Zero defs after the ArcGIS change, so it ships **blocking**.
- Folded two documented CRS antipatterns into `duckdb-antipatterns`: per-call `ST_Transform(..., always_xy)` and the removed `apply_crs_to_parquet()`. Scoped to `ST_Transform` so pyproj's correct `always_xy=True` is **not** flagged.

### Docs
- "External extractors" checklist in `docs/contributing.md` — the rationale consulted when the schema-reconciliation hook fires.

## What was intentionally dropped
Three originally-planned hooks (hardcoded-`"geometry"`, SQL identifier-quoting, URLs-in-logs) were dropped after calibrating against the codebase: each fires on a pervasive *intentional idiom* (fallback-after-detection geometry default; safe manual identifier double-quoting). A noisy hook creates the very churn it's meant to kill. Logic errors, platform crashes, and flaky tests are not mechanically catchable and are addressed structurally (the shared code path) where possible, not faked with a checklist.

## Testing
- **102/102** ArcGIS tests pass; integration tests unchanged (the acceptance criterion).
- Ported the 4 `_align_table_to_schema` unit tests onto `_cast_table_to_schema`; added `test_geometry_binary_is_preserved` and `test_cast_failure_reports_page_context`.
- Full fast suite: 2906 passed, coverage 72% (gate 67%). `lint-imports` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “External extractors” guidance covering pagination, schema reconciliation, empty/null handling, CRS normalization, output-CRS behavior, and retry/error surfacing.

* **Bug Fixes**
  * ArcGIS extraction now reconciles page tables via casting, seeds writers from reconciled schemas, and surfaces cast/type failures with page/batch context.

* **Tests**
  * Expanded schema-reconciliation tests, including geometry preservation and cast-failure context reporting.

* **Chores**
  * New pre-commit checks to forbid certain antipatterns and bespoke schema-reconciliation code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->