### PR TITLE
fix(wfs): trust server-declared CRS from GeoJSON response (#499)

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -286,7 +286,7 @@ table = ops.from_wfs('https://geo.example.com/wfs', 'cities', limit=100)
 | `max_workers` | int | Number of parallel fetch workers (default: 1) |
 | `page_size` | int | Features per WFS request page (default: 10000) |
 | `axis_order` | str | Bbox axis order: `auto` (default), `xy`, `latlon`. Auto detects from CRS format. |
-| `strict_crs` | bool | Fail on CRS mismatch (default: False, warns instead) |
+| `strict_crs` | bool | Fail when the server returns a different CRS than requested (default: False, warns and uses the server's actual CRS instead). gpio trusts the CRS the server declares in its GeoJSON response and never guesses from coordinates. |
 
 !!! note "No automatic Hilbert sorting"
     Like other Python API extraction methods, `from_wfs()` does NOT apply Hilbert sorting by default. Chain `.sort_hilbert()` explicitly if needed.

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1227,10 +1227,22 @@ gpio extract wfs https://geo.example.com/wfs cities output.parquet \
     --output-crs EPSG:3857
 ```
 
-Some servers ignore `srsName` and return data in their native CRS. gpio detects this and warns:
+When a server reports the CRS it actually used (GeoServer and most WFS servers
+echo it in the GeoJSON `crs` member), gpio trusts that declaration verbatim —
+it never second-guesses a server-honored CRS by inspecting coordinates. This
+matters for projected systems: a bounding box alone cannot distinguish, say,
+EPSG:22174 (Argentine Gauss-Krüger) from EPSG:3857 (Web Mercator), so guessing
+would silently mislabel the output and corrupt any later reprojection (#499).
+
+If a server ignores `srsName` and returns a *different* CRS than requested,
+gpio honors the real CRS rather than the one you asked for:
+
+- with `--output-crs`, it reprojects from the server's actual CRS to your target;
+- without `--output-crs`, it labels the output with the server's actual CRS and warns;
+- with `--strict-crs`, it fails instead of proceeding.
 
 ```bash
-# Fail instead of warn on CRS mismatch
+# Fail instead of warn when the server returns a different CRS than requested
 gpio extract wfs https://geo.example.com/wfs cities output.parquet \
     --strict-crs
 ```

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -898,8 +898,10 @@ def from_wfs(
         page_size: Features per page when using parallel mode (default: 10000)
         axis_order: Bbox axis order ('auto', 'xy', 'latlon'). 'auto' detects from
             CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
-        strict_crs: If True, fail when server returns coordinates that don't match
-            requested CRS. If False (default), warn and use detected CRS.
+        strict_crs: If True, fail when the server returns a different CRS than
+            requested. If False (default), warn and use the server's actual CRS.
+            The CRS the server declares in its GeoJSON response is authoritative;
+            gpio never guesses from coordinates when the server states it (#499).
         auto_tile: Automatically subdivide into spatial tiles for servers with
             startIndex limits (default: False)
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -604,8 +604,11 @@ class Table:
             page_size: Features per page when using parallel mode (default: 10000)
             axis_order: Bbox axis order ('auto', 'xy', 'latlon'). 'auto' detects from
                 CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
-            strict_crs: If True, fail when server returns coordinates that don't match
-                requested CRS. If False (default), warn and use detected CRS.
+            strict_crs: If True, fail when the server returns a different CRS than
+                requested. If False (default), warn and use the server's actual
+                CRS. The CRS the server declares in its GeoJSON response is
+                authoritative; gpio never guesses from coordinates when the
+                server states it (#499).
             auto_tile: Automatically subdivide into spatial tiles for servers with
                 startIndex limits (default: False)
 

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -129,6 +129,13 @@ GML_FORMATS = [
     "text/xml; subtype=gml/2.1.2",
 ]
 
+# Schema-metadata key under which the CRS declared by the server in its GeoJSON
+# response (the FeatureCollection ``crs`` member) is carried up from the fetch
+# layer to wfs_to_table. This is the authoritative statement of which CRS the
+# server actually honored — far more reliable than guessing from a bbox. See
+# https://github.com/geoparquet/geoparquet-io/issues/499
+_SERVER_CRS_METADATA_KEY = b"_wfs_server_crs"
+
 
 @dataclass
 class WFSLayerInfo:
@@ -412,6 +419,27 @@ def _crs_matches(crs1: str, crs2: str) -> bool:
     return _normalize_crs(crs1) == _normalize_crs(crs2)
 
 
+def _with_server_crs(table: pa.Table, server_crs: str | None) -> pa.Table:
+    """Attach the server-declared CRS to a table's schema metadata.
+
+    Carries the CRS the server reported in its GeoJSON response up through the
+    fetch/concat/type-inference pipeline so wfs_to_table can trust it instead of
+    guessing from coordinates. No-op when ``server_crs`` is None.
+    """
+    if not server_crs:
+        return table
+    metadata = dict(table.schema.metadata or {})
+    metadata[_SERVER_CRS_METADATA_KEY] = server_crs.encode()
+    return table.replace_schema_metadata(metadata)
+
+
+def _read_server_crs(table: pa.Table) -> str | None:
+    """Read the server-declared CRS previously attached via _with_server_crs."""
+    metadata = table.schema.metadata or {}
+    value = metadata.get(_SERVER_CRS_METADATA_KEY)
+    return value.decode() if value else None
+
+
 def _estimate_crs_from_bbox(
     bbox: tuple[float, float, float, float],
 ) -> str | None:
@@ -548,6 +576,89 @@ def _validate_crs_coordinates(
     except Exception as e:
         debug(f"CRS validation skipped due to error: {e}")
         return True, None
+
+
+def _reconcile_source_crs(
+    table: pa.Table,
+    *,
+    source_crs: str,
+    requested_crs: str,
+    output_crs: str | None,
+    strict_crs: bool,
+    origin: str,
+) -> tuple[pa.Table, str]:
+    """Reconcile a known source CRS against the requested CRS.
+
+    ``source_crs`` is the CRS the data is actually in (from the server's GeoJSON
+    ``crs`` member, or — as a last resort — guessed from coordinates). When it
+    matches what we requested, the data is trusted as-is. When it genuinely
+    differs, the server ignored ``srsName``; we reproject to ``output_crs`` if
+    one was given, raise under ``strict_crs``, else label the output with the
+    real ``source_crs`` rather than silently mislabeling it (issue #499).
+    """
+    if _crs_matches(source_crs, requested_crs):
+        return table, requested_crs
+
+    lead = "Server declared" if origin == "server" else "Coordinates look like"
+    base_msg = (
+        f"{lead} {source_crs} but {requested_crs} was requested; server may have ignored srsName."
+    )
+
+    if strict_crs:
+        raise WFSError(base_msg)
+
+    if output_crs:
+        info(f"{base_msg} Reprojecting from {source_crs} to {output_crs}.")
+        try:
+            table = reproject_table(table, target_crs=output_crs, source_crs=source_crs)
+        except Exception as e:
+            raise WFSError(f"Failed to reproject from {source_crs} to {output_crs}: {e}") from e
+        return table, output_crs
+
+    warn(f"{base_msg} Labeling output with {source_crs}.")
+    return table, source_crs
+
+
+def _resolve_crs_for_output(
+    table: pa.Table,
+    requested_crs: str,
+    output_crs: str | None,
+    strict_crs: bool,
+) -> tuple[pa.Table, str]:
+    """Decide the CRS to label (and optionally reproject) the fetched data to.
+
+    Trust order:
+      1. The CRS the server declared in its GeoJSON response — authoritative.
+         When present we never second-guess it with coordinate heuristics.
+      2. A bbox-coordinate guess — last resort, only when the server declared
+         nothing. The guess cannot tell two projected CRSs apart, so it is used
+         conservatively (see _validate_crs_coordinates).
+
+    Returns ``(table, crs)`` where ``table`` may have been reprojected.
+    """
+    server_crs = _read_server_crs(table)
+    if server_crs:
+        debug(f"Server declared CRS {server_crs} in GeoJSON response")
+        return _reconcile_source_crs(
+            table,
+            source_crs=server_crs,
+            requested_crs=requested_crs,
+            output_crs=output_crs,
+            strict_crs=strict_crs,
+            origin="server",
+        )
+
+    crs_valid, detected_crs = _validate_crs_coordinates(table, requested_crs, strict=strict_crs)
+    if crs_valid or not detected_crs:
+        return table, requested_crs
+    return _reconcile_source_crs(
+        table,
+        source_crs=detected_crs,
+        requested_crs=requested_crs,
+        output_crs=output_crs,
+        strict_crs=strict_crs,
+        origin="detected",
+    )
 
 
 def _detect_geometry_column(wfs, typename: str) -> str:
@@ -1252,6 +1363,35 @@ def _build_wfs_feature_query(
         """
 
 
+def _extract_server_crs_from_geojson(
+    con: duckdb.DuckDBPyConnection, safe_path: str, max_object_size: int
+) -> str | None:
+    """Read the CRS the server declared in a GeoJSON FeatureCollection.
+
+    WFS servers (e.g. GeoServer) echo the CRS actually used in a top-level
+    ``crs`` member, e.g. ``{"crs": {"properties": {"name":
+    "urn:ogc:def:crs:EPSG::22174"}}}``. This is authoritative — when present it
+    tells us exactly what the server honored, so we never have to guess from
+    coordinate ranges. Returns a normalized ``EPSG:<code>`` string, or None when
+    the response omits the member (RFC 7946 GeoJSON has no ``crs``).
+
+    See https://github.com/geoparquet/geoparquet-io/issues/499
+    """
+    try:
+        row = con.execute(f"""
+            SELECT crs.properties.name AS crs_name
+            FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
+            LIMIT 1
+        """).fetchone()
+    except (duckdb.BinderException, duckdb.Error):
+        # No 'crs' member, or a shape we don't recognize — fall back to guessing.
+        return None
+
+    if not row or not row[0]:
+        return None
+    return _normalize_crs(str(row[0]))
+
+
 def _fetch_wfs_page(
     url: str, extract_fid: bool = False, max_retries: int = 3, retry_delay: float = 2.0
 ) -> pa.Table:
@@ -1368,9 +1508,13 @@ def _fetch_wfs_page(
         """).fetchone()
         feature_count = count_result[0] if count_result else 0
 
+        # Authoritative CRS the server reported in its GeoJSON response, if any.
+        server_crs = _extract_server_crs_from_geojson(con, safe_path, _MAX_JSON_OBJECT_SIZE)
+
         if feature_count == 0:
             debug("Empty response, returning empty table")
-            return pa.table({"geometry": pa.array([], type=pa.binary())})
+            empty = pa.table({"geometry": pa.array([], type=pa.binary())})
+            return _with_server_crs(empty, server_crs)
 
         # Detect property type and build extraction query
         props_type, can_unnest_props = _probe_properties_type(con, safe_path, _MAX_JSON_OBJECT_SIZE)
@@ -1388,7 +1532,7 @@ def _fetch_wfs_page(
         parse_time = time.time() - parse_start
         total_time = time.time() - start_time
         debug(f"Parsed {table.num_rows:,} rows in {parse_time:.1f}s (total: {total_time:.1f}s)")
-        return table
+        return _with_server_crs(table, server_crs)
     except WFSError:
         raise
     except Exception as e:
@@ -1623,6 +1767,9 @@ def _fetch_with_spatial_tiles(
     if not all_tables:
         raise EmptyLayerError(typename)
 
+    # All tiles share one server CRS; capture before schema unification drops it.
+    server_crs = _read_server_crs(all_tables[0])
+
     # Unify schemas to handle type mismatches across tiles (e.g., int64 vs decimal128)
     if len(all_tables) > 1:
         schemas = [t.schema for t in all_tables]
@@ -1643,7 +1790,7 @@ def _fetch_with_spatial_tiles(
             f"Deduplicated: {before_dedup:,} → {after_dedup:,} ({before_dedup - after_dedup:,} duplicates)"
         )
 
-    return _infer_column_types(combined)
+    return _with_server_crs(_infer_column_types(combined), server_crs)
 
 
 def _probe_startindex_limit(
@@ -1771,7 +1918,11 @@ def _single_fetch_mode(
         axis_order=axis_order,
     )
     table = _fetch_wfs_page(url, extract_fid=extract_fid)
-    return table if extract_fid else _infer_column_types(table)
+    if extract_fid:
+        return table
+    # _infer_column_types rebuilds the schema and drops metadata; re-attach the
+    # server-declared CRS captured by _fetch_wfs_page.
+    return _with_server_crs(_infer_column_types(table), _read_server_crs(table))
 
 
 def _sequential_pagination_mode(
@@ -2039,6 +2190,10 @@ def fetch_all_features_duckdb(
 
     tables = [results[i] for i in sorted(results.keys())]
 
+    # All pages come from the same layer/request, so they share one server CRS.
+    # Capture it before schema unification, which drops metadata.
+    server_crs = _read_server_crs(tables[0])
+
     # Unify schemas to handle type mismatches across pages (e.g., int64 vs decimal128)
     if len(tables) > 1:
         schemas = [t.schema for t in tables]
@@ -2053,8 +2208,8 @@ def fetch_all_features_duckdb(
 
     # Skip type inference for tile fetches — the tiling orchestrator handles it
     if extract_fid:
-        return combined
-    return _infer_column_types(combined)
+        return _with_server_crs(combined, server_crs)
+    return _with_server_crs(_infer_column_types(combined), server_crs)
 
 
 def wfs_to_table(
@@ -2090,14 +2245,19 @@ def wfs_to_table(
         version: WFS version (1.0.0, 1.1.0, or 2.0.0)
         bbox: Bounding box filter (xmin, ymin, xmax, ymax)
         bbox_mode: Bbox strategy ("auto", "server", "local")
-        output_crs: Guarantee output in this CRS. If server returns different CRS, data is
-            reprojected automatically. (e.g., "EPSG:4326")
+        output_crs: Guarantee output in this CRS. If the server returns a
+            different CRS than requested, data is reprojected automatically from
+            the server's actual CRS. (e.g., "EPSG:4326")
         limit: Maximum features to fetch
         max_workers: Parallel requests for large datasets (default: 1 = single request)
         page_size: Features per page when using parallel mode (default: 10000)
         axis_order: Bbox axis order ("auto", "xy", "latlon")
-        strict_crs: If True, fail on CRS mismatch (before reprojection). If False and
-            output_crs is set, reproject automatically; otherwise warn and use detected CRS
+        strict_crs: If True, fail when the server returns a different CRS than
+            requested. If False and output_crs is set, reproject from the
+            server's actual CRS; otherwise warn and label the output with the
+            server's actual CRS. The CRS the server declares in its GeoJSON
+            response is authoritative — gpio never guesses from coordinates when
+            the server states which CRS it used (issue #499).
         verbose: Enable debug output
         sort_by: Attribute to sort by for stable pagination. If None, auto-detected from
             DescribeFeatureType. Required for layers without a primary key.
@@ -2218,23 +2378,9 @@ def wfs_to_table(
         finally:
             con.close()
 
-    # Validate CRS - check if coordinates match requested CRS
-    crs_valid, detected_crs = _validate_crs_coordinates(table, crs, strict=strict_crs)
-    if not crs_valid and detected_crs:
-        if output_crs:
-            # User explicitly requested CRS but server returned different — reproject
-            info(f"Server returned {detected_crs}, reprojecting to requested {output_crs}")
-            try:
-                table = reproject_table(table, target_crs=output_crs, source_crs=detected_crs)
-            except Exception as e:
-                raise WFSError(
-                    f"Failed to reproject from {detected_crs} to {output_crs}: {e}"
-                ) from e
-            crs = output_crs
-        else:
-            # No explicit request — use detected CRS for metadata
-            info(f"Using detected CRS {detected_crs} for output metadata")
-            crs = detected_crs
+    # Resolve the CRS to label/reproject to. Trust the server's declared CRS
+    # when it gave one; otherwise fall back to a coordinate-range guess.
+    table, crs = _resolve_crs_for_output(table, crs, output_crs, strict_crs)
 
     # Add CRS metadata to schema
     projjson = parse_crs_string_to_projjson(_normalize_crs(crs))
@@ -2249,7 +2395,9 @@ def wfs_to_table(
                 }
             },
         }
-        existing_meta = table.schema.metadata or {}
+        existing_meta = dict(table.schema.metadata or {})
+        # Drop the internal server-CRS marker so it doesn't leak into the file.
+        existing_meta.pop(_SERVER_CRS_METADATA_KEY, None)
         existing_meta[b"geo"] = json.dumps(geo_meta).encode("utf-8")
         table = table.replace_schema_metadata(existing_meta)
 
@@ -2297,8 +2445,11 @@ def convert_wfs_to_geoparquet(
         max_workers: Parallel requests for large datasets (default: 1)
         page_size: Features per page when using parallel mode (default: 10000)
         axis_order: Bbox axis order ("auto", "xy", "latlon")
-        strict_crs: If True, fail on CRS mismatch (before reprojection). If False and
-            output_crs is set, reproject automatically; otherwise warn and use detected CRS
+        strict_crs: If True, fail when the server returns a different CRS than
+            requested. If False and output_crs is set, reproject from the
+            server's actual CRS; otherwise warn and label with the server's
+            actual CRS. The server's declared CRS is trusted over any coordinate
+            guess (issue #499).
         skip_hilbert: Skip Hilbert curve sorting
         skip_bbox: Skip adding bbox column
         compression: Compression algorithm

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -648,6 +648,10 @@ def _resolve_crs_for_output(
             origin="server",
         )
 
+    debug(
+        f"Server declared no CRS in its GeoJSON response; inferring from "
+        f"coordinates and trusting the requested {requested_crs} unless they clearly disagree."
+    )
     crs_valid, detected_crs = _validate_crs_coordinates(table, requested_crs, strict=strict_crs)
     if crs_valid or not detected_crs:
         return table, requested_crs

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -651,12 +651,16 @@ def _resolve_crs_for_output(
     crs_valid, detected_crs = _validate_crs_coordinates(table, requested_crs, strict=strict_crs)
     if crs_valid or not detected_crs:
         return table, requested_crs
+    # A real mismatch under strict_crs already raised inside
+    # _validate_crs_coordinates, so reconciliation here is only ever reached in
+    # non-strict mode — pass strict_crs=False to keep that the single source of
+    # truth and avoid a redundant raise.
     return _reconcile_source_crs(
         table,
         source_crs=detected_crs,
         requested_crs=requested_crs,
         output_crs=output_crs,
-        strict_crs=strict_crs,
+        strict_crs=False,
         origin="detected",
     )
 
@@ -1112,7 +1116,9 @@ def _build_local_bbox_filter(
 
     xmin, ymin, xmax, ymax = bbox
     wkt = f"POLYGON(({xmin} {ymin}, {xmax} {ymin}, {xmax} {ymax}, {xmin} {ymax}, {xmin} {ymin}))"
-    return f"ST_Intersects(\"{safe_column}\", ST_GeomFromText('{wkt}'))"
+    # Fetched features carry geometry as WKB (BLOB), so decode it before the
+    # spatial predicate — ST_Intersects has no BLOB overload.
+    return f"ST_Intersects(ST_GeomFromWKB(\"{safe_column}\"), ST_GeomFromText('{wkt}'))"
 
 
 def _get_feature_count(
@@ -1375,33 +1381,39 @@ def _build_wfs_feature_query(
         """
 
 
-def _extract_server_crs_from_geojson(
-    con: duckdb.DuckDBPyConnection, safe_path: str, max_object_size: int
-) -> str | None:
-    """Read the CRS the server declared in a GeoJSON FeatureCollection.
+def _read_count_and_server_crs(
+    con: duckdb.DuckDBPyConnection, safe_path: str
+) -> tuple[int, str | None]:
+    """Read the feature count and the server-declared CRS in a single pass.
 
-    WFS servers (e.g. GeoServer) echo the CRS actually used in a top-level
-    ``crs`` member, e.g. ``{"crs": {"properties": {"name":
-    "urn:ogc:def:crs:EPSG::22174"}}}``. This is authoritative — when present it
-    tells us exactly what the server honored, so we never have to guess from
-    coordinate ranges. Returns a normalized ``EPSG:<code>`` string, or None when
-    the response omits the member (RFC 7946 GeoJSON has no ``crs``).
+    A WFS GeoJSON response is one FeatureCollection object, so we read it once
+    as raw text and pull out both things we need before parsing features:
+
+    * the ``features`` array length — DuckDB can't UNNEST an empty array, so we
+      must branch on the count;
+    * the optional top-level ``crs`` member. WFS servers (e.g. GeoServer) echo
+      the CRS they actually honored there, e.g. ``{"crs": {"properties":
+      {"name": "urn:ogc:def:crs:EPSG::22174"}}}``. This is authoritative — when
+      present we never have to guess the CRS from coordinate ranges.
+
+    ``json_extract_string`` returns NULL (rather than raising) when the ``crs``
+    member is absent (RFC 7946 GeoJSON has none) or has an unexpected shape, so
+    we transparently fall back to the coordinate heuristic. Reading once here
+    replaces a separate count query and a separate CRS query with one scan.
 
     See https://github.com/geoparquet/geoparquet-io/issues/499
     """
-    try:
-        row = con.execute(f"""
-            SELECT crs.properties.name AS crs_name
-            FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
-            LIMIT 1
-        """).fetchone()
-    except (duckdb.BinderException, duckdb.Error):
-        # No 'crs' member, or a shape we don't recognize — fall back to guessing.
-        return None
-
-    if not row or not row[0]:
-        return None
-    return _normalize_crs(str(row[0]))
+    row = con.execute(f"""
+        SELECT
+            json_array_length(content, '$.features') AS cnt,
+            json_extract_string(content, '$.crs.properties.name') AS crs_name
+        FROM read_text('{safe_path}')
+    """).fetchone()
+    if not row:
+        return 0, None
+    feature_count = row[0] or 0
+    server_crs = _normalize_crs(str(row[1])) if row[1] else None
+    return feature_count, server_crs
 
 
 def _fetch_wfs_page(
@@ -1513,15 +1525,10 @@ def _fetch_wfs_page(
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         safe_path = _escape_sql_string(tmp_path)
 
-        # Check feature count first (DuckDB can't UNNEST empty JSON arrays)
-        count_result = con.execute(f"""
-            SELECT len(features) AS cnt
-            FROM read_json_auto('{safe_path}', maximum_object_size={_MAX_JSON_OBJECT_SIZE})
-        """).fetchone()
-        feature_count = count_result[0] if count_result else 0
-
-        # Authoritative CRS the server reported in its GeoJSON response, if any.
-        server_crs = _extract_server_crs_from_geojson(con, safe_path, _MAX_JSON_OBJECT_SIZE)
+        # Read the feature count (DuckDB can't UNNEST empty JSON arrays) and the
+        # authoritative CRS the server reported in its GeoJSON response, if any,
+        # in a single scan over the response.
+        feature_count, server_crs = _read_count_and_server_crs(con, safe_path)
 
         if feature_count == 0:
             debug("Empty response, returning empty table")
@@ -2381,11 +2388,15 @@ def wfs_to_table(
     if bbox and not use_server_bbox:
         debug("Applying local bbox filter...")
         filter_sql = _build_local_bbox_filter(bbox, "geometry")
+        # The DuckDB roundtrip below drops Arrow schema metadata, which would
+        # discard the server-declared CRS and silently fall back to the bbox
+        # heuristic (issue #499). Capture it first and re-attach afterwards.
+        server_crs = _read_server_crs(table)
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         try:
             con.register("features", table)
             filtered = con.execute(f"SELECT * FROM features WHERE {filter_sql}").arrow()
-            table = filtered.read_all()
+            table = _with_server_crs(filtered.read_all(), server_crs)
             debug(f"After local filter: {table.num_rows:,} features")
         finally:
             con.close()
@@ -2393,6 +2404,11 @@ def wfs_to_table(
     # Resolve the CRS to label/reproject to. Trust the server's declared CRS
     # when it gave one; otherwise fall back to a coordinate-range guess.
     table, crs = _resolve_crs_for_output(table, crs, output_crs, strict_crs)
+
+    # Drop the internal server-CRS marker unconditionally so it never leaks into
+    # the output file, regardless of whether geo metadata is written below.
+    existing_meta = dict(table.schema.metadata or {})
+    existing_meta.pop(_SERVER_CRS_METADATA_KEY, None)
 
     # Add CRS metadata to schema
     projjson = parse_crs_string_to_projjson(_normalize_crs(crs))
@@ -2407,11 +2423,9 @@ def wfs_to_table(
                 }
             },
         }
-        existing_meta = dict(table.schema.metadata or {})
-        # Drop the internal server-CRS marker so it doesn't leak into the file.
-        existing_meta.pop(_SERVER_CRS_METADATA_KEY, None)
         existing_meta[b"geo"] = json.dumps(geo_meta).encode("utf-8")
-        table = table.replace_schema_metadata(existing_meta)
+
+    table = table.replace_schema_metadata(existing_meta)
 
     success(f"Fetched {table.num_rows:,} features from WFS")
     return table

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1125,6 +1125,31 @@ def _build_local_bbox_filter(
     return f"ST_Intersects(ST_GeomFromWKB(\"{safe_column}\"), ST_GeomFromText('{wkt}'))"
 
 
+def _reproject_bbox_for_local_filter(
+    bbox: tuple[float, float, float, float], source_crs: str, target_crs: str
+) -> tuple[float, float, float, float]:
+    """Reproject a filter bbox from ``source_crs`` into ``target_crs``.
+
+    The local bbox filter compares fetched geometries against this bbox. The
+    bbox is expressed in the requested CRS, but when the server honors a
+    different CRS the geometries are in *that* CRS — comparing the two as-is
+    drops valid rows (issue #499). Aligning the bbox to the geometries' CRS
+    avoids reprojecting the whole geometry column just to filter. On failure we
+    fall back to the original bbox rather than crash the extraction.
+    """
+    try:
+        from pyproj import Transformer
+
+        transformer = Transformer.from_crs(
+            _normalize_crs(source_crs), _normalize_crs(target_crs), always_xy=True
+        )
+        xmin, ymin, xmax, ymax = transformer.transform_bounds(*bbox)
+        return (xmin, ymin, xmax, ymax)
+    except Exception as e:
+        warn(f"Could not reproject bbox from {source_crs} to {target_crs} for local filter: {e}")
+        return bbox
+
+
 def _get_feature_count(
     service_url: str,
     typename: str,
@@ -2391,11 +2416,17 @@ def wfs_to_table(
     # Apply local bbox filter if needed
     if bbox and not use_server_bbox:
         debug("Applying local bbox filter...")
-        filter_sql = _build_local_bbox_filter(bbox, "geometry")
         # The DuckDB roundtrip below drops Arrow schema metadata, which would
         # discard the server-declared CRS and silently fall back to the bbox
         # heuristic (issue #499). Capture it first and re-attach afterwards.
         server_crs = _read_server_crs(table)
+        # The bbox is in the requested CRS, but the geometries are in the CRS the
+        # server actually returned. When those differ, align the bbox to the
+        # geometries' CRS so the filter doesn't drop valid rows (issue #499).
+        filter_bbox = bbox
+        if server_crs and not _crs_matches(server_crs, crs):
+            filter_bbox = _reproject_bbox_for_local_filter(bbox, crs, server_crs)
+        filter_sql = _build_local_bbox_filter(filter_bbox, "geometry")
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         try:
             con.register("features", table)

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -513,8 +513,17 @@ def _validate_crs_coordinates(
             if not (2_000_000 < xmin < 7_500_000 and 1_000_000 < ymin < 5_500_000):
                 mismatch = True
         elif detected and detected != normalized_crs:
-            # Generic check: if we detected a CRS and it differs from requested
-            mismatch = True
+            # The bbox heuristic can reliably distinguish coordinate *categories*
+            # (geographic degrees vs. projected meters) but NOT one projected CRS
+            # from another — e.g. EPSG:22174 (POSGAR 98 / Argentina 4) and
+            # EPSG:3857 both use large metric coordinates. Only treat this as a
+            # mismatch when the categories disagree; otherwise trust the
+            # server-honored CRS rather than relabel it on a guess, which silently
+            # corrupts downstream reprojection (issue #499).
+            requested_geographic = _is_geographic_crs(normalized_crs)
+            detected_geographic = detected == "EPSG:4326"
+            if requested_geographic != detected_geographic:
+                mismatch = True
 
         if mismatch:
             msg = (

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -965,16 +965,28 @@ def _is_urn_crs(crs: str) -> bool:
 
 
 def _is_geographic_crs(crs: str) -> bool:
-    """Check if CRS is a geographic coordinate system (lat/lon, not projected)."""
+    """Check if CRS is a geographic coordinate system (lat/lon, not projected).
+
+    Uses pyproj for authoritative detection across all geographic CRSs rather
+    than a hardcoded list — an allowlist misclassifies valid geographic systems
+    outside it (e.g. EPSG:4171 RGF93) as projected, which would flag a false
+    coordinate mismatch and relabel correct data to EPSG:4326. Falls back to a
+    small known set only when pyproj cannot resolve the CRS.
+    """
     normalized = _normalize_crs(crs)
-    # Common geographic CRS codes
-    geographic_codes = {
-        "EPSG:4326",  # WGS84
-        "EPSG:4269",  # NAD83
-        "EPSG:4267",  # NAD27
-        "EPSG:4258",  # ETRS89
-    }
-    return normalized in geographic_codes or "CRS84" in crs.upper()
+    try:
+        from pyproj import CRS as _PyprojCRS
+
+        return bool(_PyprojCRS.from_user_input(normalized).is_geographic)
+    except Exception:
+        # pyproj unavailable or CRS unrecognized — fall back to a known set.
+        geographic_codes = {
+            "EPSG:4326",  # WGS84
+            "EPSG:4269",  # NAD83
+            "EPSG:4267",  # NAD27
+            "EPSG:4258",  # ETRS89
+        }
+        return normalized in geographic_codes or "CRS84" in crs.upper()
 
 
 def _needs_axis_swap(crs: str, version: str, axis_order: str = "auto") -> bool:

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -2513,6 +2513,257 @@ class TestCRSValidation:
             assert "EPSG:4326" in str(exc_info.value)
 
 
+class TestServerDeclaredCRS:
+    """The server's GeoJSON ``crs`` member is authoritative (issue #499).
+
+    When a WFS server echoes the CRS it actually used in the FeatureCollection
+    ``crs`` member, we must read and trust it rather than guessing from the
+    bounding box — the bbox heuristic cannot tell two projected CRSs apart.
+    """
+
+    def _make_mock_stream(self, geojson_bytes: bytes):
+        """Create a mock httpx stream response yielding the given bytes."""
+        import httpx
+
+        def mock_stream(*args, **kwargs):
+            class MockResponse:
+                status_code = 200
+                headers = {"content-type": "application/json"}
+
+                def raise_for_status(self):
+                    pass
+
+                def iter_bytes(self, chunk_size=None):
+                    yield geojson_bytes
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+            return MockResponse()
+
+        return patch.object(httpx.Client, "stream", mock_stream)
+
+    def _geojson_with_crs(self, crs_name: str | None) -> bytes:
+        import json
+
+        feature_collection: dict = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [4527586.01, 6386852.32]},
+                    "properties": {"name": "a"},
+                }
+            ],
+        }
+        if crs_name is not None:
+            feature_collection["crs"] = {"type": "name", "properties": {"name": crs_name}}
+        return json.dumps(feature_collection).encode()
+
+    def test_fetch_wfs_page_extracts_server_crs(self):
+        """_fetch_wfs_page records the server-declared CRS in schema metadata."""
+        from geoparquet_io.core.wfs import _SERVER_CRS_METADATA_KEY, _fetch_wfs_page
+
+        body = self._geojson_with_crs("urn:ogc:def:crs:EPSG::22174")
+        with self._make_mock_stream(body):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert table.schema.metadata is not None
+        assert table.schema.metadata[_SERVER_CRS_METADATA_KEY] == b"EPSG:22174"
+
+    def test_fetch_wfs_page_no_crs_member(self):
+        """No ``crs`` member (RFC 7946 GeoJSON) leaves no server-CRS metadata."""
+        from geoparquet_io.core.wfs import _SERVER_CRS_METADATA_KEY, _fetch_wfs_page
+
+        with self._make_mock_stream(self._geojson_with_crs(None)):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        metadata = table.schema.metadata or {}
+        assert _SERVER_CRS_METADATA_KEY not in metadata
+
+    def test_fetch_wfs_page_empty_response_carries_crs(self):
+        """An empty FeatureCollection still propagates its declared CRS."""
+        import json
+
+        from geoparquet_io.core.wfs import _SERVER_CRS_METADATA_KEY, _fetch_wfs_page
+
+        body = json.dumps(
+            {
+                "type": "FeatureCollection",
+                "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:EPSG::22174"}},
+                "features": [],
+            }
+        ).encode()
+        with self._make_mock_stream(body):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert table.num_rows == 0
+        assert (table.schema.metadata or {}).get(_SERVER_CRS_METADATA_KEY) == b"EPSG:22174"
+
+    def test_read_and_with_server_crs_roundtrip(self):
+        """_with_server_crs / _read_server_crs round-trip through metadata."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _read_server_crs, _with_server_crs
+
+        table = pa.table({"geometry": pa.array([], type=pa.binary())})
+        assert _read_server_crs(table) is None
+
+        tagged = _with_server_crs(table, "EPSG:22174")
+        assert _read_server_crs(tagged) == "EPSG:22174"
+
+        # No-op when CRS is None.
+        assert _read_server_crs(_with_server_crs(table, None)) is None
+
+    def test_fetch_all_features_propagates_server_crs(self):
+        """Server CRS survives the single-request fetch path."""
+        from unittest.mock import patch
+
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import (
+            _read_server_crs,
+            _with_server_crs,
+            fetch_all_features_duckdb,
+        )
+
+        page = _with_server_crs(
+            pa.table({"geometry": pa.array([b"\x00"], type=pa.binary())}),
+            "EPSG:22174",
+        )
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=1),
+            patch("geoparquet_io.core.wfs._fetch_wfs_page", return_value=page),
+            patch("geoparquet_io.core.wfs._infer_column_types", side_effect=lambda t: t),
+        ):
+            result = fetch_all_features_duckdb("http://mock.wfs/wfs", "layer", version="2.0.0")
+
+        assert _read_server_crs(result) == "EPSG:22174"
+
+
+class TestResolveCRSForOutput:
+    """wfs_to_table CRS resolution: trust the server, guess only as a fallback."""
+
+    def _point_table(self, x: float, y: float):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            result = con.execute(f"SELECT ST_AsWKB(ST_Point({x}, {y})) as geometry").arrow()
+            return result.read_all()
+        finally:
+            con.close()
+
+    def test_trusts_matching_server_crs_without_guessing(self):
+        """Issue #499: server honored EPSG:22174 → keep it, never guess EPSG:3857."""
+        from unittest.mock import patch
+
+        from geoparquet_io.core.wfs import _resolve_crs_for_output, _with_server_crs
+
+        # Argentine Gauss-Krüger coords the bbox heuristic would misread as 3857.
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:22174")
+
+        with patch("geoparquet_io.core.wfs._validate_crs_coordinates") as mock_validate:
+            out_table, crs = _resolve_crs_for_output(table, "EPSG:22174", None, False)
+
+        assert crs == "EPSG:22174"
+        # The heuristic validator must not even run when the server declared a CRS.
+        mock_validate.assert_not_called()
+
+    def test_server_crs_contradiction_labels_with_server_crs(self):
+        """Server ignored srsName (returned 3857 for 22174) and no output_crs → label 3857."""
+        from geoparquet_io.core.wfs import _resolve_crs_for_output, _with_server_crs
+
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:3857")
+
+        out_table, crs = _resolve_crs_for_output(table, "EPSG:22174", None, False)
+
+        # Authoritative server CRS wins over the requested label; no bbox guess.
+        assert crs == "EPSG:3857"
+        assert out_table is table
+
+    def test_server_crs_contradiction_reprojects_to_output_crs(self):
+        """Contradiction with output_crs set → reproject from the server CRS."""
+        from unittest.mock import patch
+
+        from geoparquet_io.core.wfs import _resolve_crs_for_output, _with_server_crs
+
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:3857")
+
+        with patch(
+            "geoparquet_io.core.wfs.reproject_table", return_value="REPROJECTED"
+        ) as mock_reproject:
+            out_table, crs = _resolve_crs_for_output(table, "EPSG:22174", "EPSG:4326", False)
+
+        assert crs == "EPSG:4326"
+        assert out_table == "REPROJECTED"
+        mock_reproject.assert_called_once()
+        assert mock_reproject.call_args.kwargs["source_crs"] == "EPSG:3857"
+        assert mock_reproject.call_args.kwargs["target_crs"] == "EPSG:4326"
+
+    def test_server_crs_contradiction_strict_raises(self):
+        """Contradiction under strict_crs → WFSError, even with no output_crs."""
+        from geoparquet_io.core.wfs import WFSError, _resolve_crs_for_output, _with_server_crs
+
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:3857")
+
+        with pytest.raises(WFSError, match="server may have ignored srsName"):
+            _resolve_crs_for_output(table, "EPSG:22174", None, True)
+
+    def test_falls_back_to_heuristic_without_server_crs(self):
+        """No server CRS → fall back to coordinate-range guessing (degrees for 4326)."""
+        from geoparquet_io.core.wfs import _resolve_crs_for_output
+
+        # Projected metric coords but WGS84 requested, no server CRS declared.
+        table = self._point_table(3900000, 3000000)
+
+        out_table, crs = _resolve_crs_for_output(table, "EPSG:4326", None, False)
+
+        # Heuristic detects projected data and relabels (fallback path preserved).
+        assert crs == "EPSG:3035"
+
+    def test_wfs_to_table_trusts_server_crs_end_to_end(self):
+        """End-to-end #499 regression: declared EPSG:22174 stays EPSG:22174."""
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
+        from geoparquet_io.core.wfs import _with_server_crs, wfs_to_table
+
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:22174")
+
+        with (
+            patch("geoparquet_io.core.wfs.negotiate_wfs_version") as mock_version,
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_layer_info,
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=table),
+            patch("geoparquet_io.core.wfs._validate_crs_coordinates") as mock_validate,
+        ):
+            mock_version.return_value = ("2.0.0", MagicMock())
+            mock_layer_info.return_value = MagicMock(
+                typename="mock:layer",
+                title="Mock Layer",
+                crs_list=["EPSG:22174"],
+                default_crs="EPSG:22174",
+                available_formats=["application/json"],
+                sortable_attribute=None,
+                bbox=None,
+            )
+            result = wfs_to_table(
+                service_url="https://mock.wfs.server/wfs",
+                typename="mock:layer",
+                output_crs="EPSG:22174",
+            )
+
+        mock_validate.assert_not_called()
+        # Output metadata must encode EPSG:22174, not a bbox guess.
+        geo = json.loads(result.schema.metadata[b"geo"])
+        expected = parse_crs_string_to_projjson("EPSG:22174")
+        assert geo["columns"]["geometry"]["crs"] == expected
+
+
 # =============================================================================
 # Integration Tests for WFS 2.0 (Issue #312)
 # =============================================================================

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -2271,6 +2271,73 @@ class TestCRSValidation:
         assert is_valid is False
         assert detected == "EPSG:3035"
 
+    def test_validate_crs_coordinates_does_not_override_projected_crs(self):
+        """Should NOT override a server-honored projected CRS on a bbox guess (issue #499).
+
+        EPSG:22174 (POSGAR 98 / Argentina 4) and EPSG:3857 both use large metric
+        coordinates that the bbox heuristic cannot distinguish. When the server
+        honored the requested projected CRS, we must trust it rather than relabel
+        it as the heuristic's guess, which silently corrupts downstream reprojection.
+        """
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.wfs import _validate_crs_coordinates
+
+        # Real EPSG:22174 coordinates from IDECOR (Córdoba, Argentina)
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            result = con.execute("""
+                SELECT ST_AsWKB(ST_Point(4527586.01, 6386852.32)) as geometry
+            """).arrow()
+            table = result.read_all()
+        finally:
+            con.close()
+
+        # Requested and server-returned 22174 — heuristic would guess 3857, but
+        # both are projected, so there is no real (category) mismatch.
+        is_valid, detected = _validate_crs_coordinates(table, "EPSG:22174", strict=False)
+        assert is_valid is True
+        assert detected is None
+
+    def test_validate_crs_coordinates_detects_projected_data_for_geographic_request(self):
+        """Should still flag a real category mismatch: geographic requested, metric data."""
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.wfs import _validate_crs_coordinates
+
+        # Projected (metric) coordinates returned for a non-4326 geographic request
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            result = con.execute("""
+                SELECT ST_AsWKB(ST_Point(4527586.01, 6386852.32)) as geometry
+            """).arrow()
+            table = result.read_all()
+        finally:
+            con.close()
+
+        # EPSG:4258 (ETRS89) is geographic — metric values are a real mismatch.
+        is_valid, detected = _validate_crs_coordinates(table, "EPSG:4258", strict=False)
+        assert is_valid is False
+        assert detected == "EPSG:3857"
+
+    def test_validate_crs_coordinates_detects_geographic_data_for_projected_request(self):
+        """Should flag a real category mismatch: projected requested, degree data."""
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.wfs import _validate_crs_coordinates
+
+        # Degree-range coordinates returned for a projected request
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            result = con.execute("""
+                SELECT ST_AsWKB(ST_Point(-62.7, -32.6)) as geometry
+            """).arrow()
+            table = result.read_all()
+        finally:
+            con.close()
+
+        # EPSG:22174 is projected — degree values are a real mismatch.
+        is_valid, detected = _validate_crs_coordinates(table, "EPSG:22174", strict=False)
+        assert is_valid is False
+        assert detected == "EPSG:4326"
+
     def test_validate_crs_coordinates_raises_on_strict_mismatch(self):
         """Should raise error in strict mode when CRS doesn't match."""
         from geoparquet_io.core.duckdb_utils import get_duckdb_connection

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -3204,6 +3204,51 @@ class TestSrsNameWithoutBbox:
         assert 49.0 <= y <= 52.0, f"Y coord {y} not in Belgium latitude range"
 
 
+@pytest.mark.integration
+@pytest.mark.network
+@pytest.mark.slow
+class TestProjectedCRSPreservedIntegration:
+    """Live regression for #499: a server-honored projected CRS must be kept.
+
+    IDECOR (Córdoba, Argentina) serves all layers in EPSG:22174 (an Argentine
+    Gauss-Krüger zone). The old bbox heuristic saw the large metric coordinates
+    (~4.5M, ~6.4M) and relabeled the output EPSG:3857, silently corrupting any
+    downstream reprojection. The geometry was correct, so this can only be
+    caught by asserting on the stored CRS metadata, not coordinate ranges.
+    """
+
+    IDECOR_WFS = "https://idecor-ws.mapascordoba.gob.ar/geoserver/idecor/wfs"
+    IDECOR_LAYER = "idecor:puntos_interes_bv"
+
+    @pytest.mark.xfail(
+        reason="External WFS service may be unavailable",
+        strict=False,
+        raises=(Exception,),  # Only xfail on connection/service errors
+    )
+    def test_projected_crs_not_relabeled(self):
+        """Output metadata must report EPSG:22174, never the bbox-guessed 3857."""
+        import json
+
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        table = wfs_to_table(
+            self.IDECOR_WFS,
+            self.IDECOR_LAYER,
+            output_crs="EPSG:22174",
+            limit=5,
+        )
+
+        assert table.num_rows > 0
+
+        geo = json.loads(table.schema.metadata[b"geo"])
+        crs = geo["columns"]["geometry"]["crs"]
+        # PROJJSON for EPSG:22174 — the authoritative code must be preserved.
+        assert crs["id"]["authority"] == "EPSG"
+        assert int(crs["id"]["code"]) == 22174, (
+            f"Output mislabeled as {crs['id']}; expected EPSG:22174 (issue #499)"
+        )
+
+
 # =============================================================================
 # Spatial Tiling Tests (startIndex limit workaround)
 # =============================================================================

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -2856,6 +2856,47 @@ class TestResolveCRSForOutput:
         geo = json.loads(result.schema.metadata[b"geo"])
         assert geo["columns"]["geometry"]["crs"] == parse_crs_string_to_projjson("EPSG:22174")
 
+    def test_local_bbox_filter_reprojects_bbox_to_server_crs(self):
+        """Issue #499: a bbox in the requested CRS must be aligned to the CRS the
+        server actually returned, or local filtering drops valid rows.
+
+        Requested EPSG:4326 (bbox in degrees), but the server returns EPSG:22174
+        geometry. The degree bbox would not intersect the metric point unless it
+        is reprojected into EPSG:22174 first.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from geoparquet_io.core.wfs import _with_server_crs, wfs_to_table
+
+        # EPSG:22174 point near Córdoba, AR (= -62.7059, -32.6603 in EPSG:4326).
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:22174")
+        deg_bbox = (-62.8059, -32.7603, -62.6059, -32.5603)
+
+        with (
+            patch("geoparquet_io.core.wfs.negotiate_wfs_version") as mock_version,
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_layer_info,
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=table),
+        ):
+            mock_version.return_value = ("2.0.0", MagicMock())
+            mock_layer_info.return_value = MagicMock(
+                typename="mock:layer",
+                title="Mock Layer",
+                crs_list=["EPSG:4326"],
+                default_crs="EPSG:4326",
+                available_formats=["application/json"],
+                sortable_attribute=None,
+                bbox=None,
+            )
+            result = wfs_to_table(
+                service_url="https://mock.wfs.server/wfs",
+                typename="mock:layer",
+                bbox=deg_bbox,
+                bbox_mode="local",
+            )
+
+        # The point is retained because the bbox was reprojected to EPSG:22174.
+        assert result.num_rows == 1
+
     def test_wfs_to_table_strips_server_crs_marker_when_no_projjson(self):
         """The internal server-CRS marker never leaks into the output schema.
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -2617,6 +2617,35 @@ class TestServerDeclaredCRS:
         assert table.num_rows == 0
         assert (table.schema.metadata or {}).get(_SERVER_CRS_METADATA_KEY) == b"EPSG:22174"
 
+    def test_fetch_wfs_page_unrecognized_crs_shape(self):
+        """A ``crs`` member without a name (e.g. a link CRS) yields no metadata.
+
+        ``json_extract_string`` returns NULL rather than raising on an
+        unexpected shape, so extraction falls back to the bbox heuristic.
+        """
+        import json
+
+        from geoparquet_io.core.wfs import _SERVER_CRS_METADATA_KEY, _fetch_wfs_page
+
+        body = json.dumps(
+            {
+                "type": "FeatureCollection",
+                "crs": {"type": "link", "properties": {"href": "http://example/crs"}},
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [4527586.01, 6386852.32]},
+                        "properties": {"name": "a"},
+                    }
+                ],
+            }
+        ).encode()
+        with self._make_mock_stream(body):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert table.num_rows == 1
+        assert _SERVER_CRS_METADATA_KEY not in (table.schema.metadata or {})
+
     def test_read_and_with_server_crs_roundtrip(self):
         """_with_server_crs / _read_server_crs round-trip through metadata."""
         import pyarrow as pa
@@ -2776,6 +2805,93 @@ class TestResolveCRSForOutput:
         geo = json.loads(result.schema.metadata[b"geo"])
         expected = parse_crs_string_to_projjson("EPSG:22174")
         assert geo["columns"]["geometry"]["crs"] == expected
+
+    def test_wfs_to_table_preserves_server_crs_through_local_bbox_filter(self):
+        """Issue #499: local bbox filtering must not drop the server CRS.
+
+        The local-filter path round-trips the table through DuckDB, which
+        strips Arrow schema metadata. If the server-declared CRS is lost there,
+        resolution silently falls back to the bbox heuristic — the exact bug
+        #499 fixes — so we assert the heuristic validator is never consulted.
+        """
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
+        from geoparquet_io.core.wfs import _with_server_crs, wfs_to_table
+
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:22174")
+
+        with (
+            patch("geoparquet_io.core.wfs.negotiate_wfs_version") as mock_version,
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_layer_info,
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=table),
+            patch("geoparquet_io.core.wfs._validate_crs_coordinates") as mock_validate,
+        ):
+            mock_version.return_value = ("2.0.0", MagicMock())
+            mock_layer_info.return_value = MagicMock(
+                typename="mock:layer",
+                title="Mock Layer",
+                crs_list=["EPSG:22174"],
+                default_crs="EPSG:22174",
+                available_formats=["application/json"],
+                sortable_attribute=None,
+                bbox=None,
+            )
+            result = wfs_to_table(
+                service_url="https://mock.wfs.server/wfs",
+                typename="mock:layer",
+                bbox=(4_000_000, 6_000_000, 5_000_000, 7_000_000),
+                bbox_mode="local",
+            )
+
+        # Server CRS survived the local-filter roundtrip → no heuristic guess.
+        mock_validate.assert_not_called()
+        assert result.num_rows == 1
+        geo = json.loads(result.schema.metadata[b"geo"])
+        assert geo["columns"]["geometry"]["crs"] == parse_crs_string_to_projjson("EPSG:22174")
+
+    def test_wfs_to_table_strips_server_crs_marker_when_no_projjson(self):
+        """The internal server-CRS marker never leaks into the output schema.
+
+        Even when no geo metadata is written (projjson unavailable for the
+        resolved CRS), the ``_wfs_server_crs`` marker must be removed.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from geoparquet_io.core.wfs import (
+            _SERVER_CRS_METADATA_KEY,
+            _with_server_crs,
+            wfs_to_table,
+        )
+
+        table = _with_server_crs(self._point_table(4527586.01, 6386852.32), "EPSG:22174")
+
+        with (
+            patch("geoparquet_io.core.wfs.negotiate_wfs_version") as mock_version,
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_layer_info,
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=table),
+            patch("geoparquet_io.core.wfs.parse_crs_string_to_projjson", return_value=None),
+        ):
+            mock_version.return_value = ("2.0.0", MagicMock())
+            mock_layer_info.return_value = MagicMock(
+                typename="mock:layer",
+                title="Mock Layer",
+                crs_list=["EPSG:22174"],
+                default_crs="EPSG:22174",
+                available_formats=["application/json"],
+                sortable_attribute=None,
+                bbox=None,
+            )
+            result = wfs_to_table(
+                service_url="https://mock.wfs.server/wfs",
+                typename="mock:layer",
+                output_crs="EPSG:22174",
+            )
+
+        metadata = result.schema.metadata or {}
+        assert _SERVER_CRS_METADATA_KEY not in metadata
+        assert b"geo" not in metadata
 
 
 # =============================================================================

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1980,6 +1980,20 @@ class TestAxisOrder:
         assert _is_geographic_crs("EPSG:3857") is False  # Web Mercator (projected)
         assert _is_geographic_crs("EPSG:3035") is False  # LAEA (projected)
 
+    def test_is_geographic_crs_handles_codes_outside_allowlist(self):
+        """Geographic CRSs beyond the small allowlist must not be called projected.
+
+        pyproj-backed detection identifies any geographic CRS; a hardcoded list
+        would misclassify these and trigger a false coordinate mismatch.
+        """
+        from geoparquet_io.core.wfs import _is_geographic_crs
+
+        assert _is_geographic_crs("EPSG:4171") is True  # RGF93 (geographic)
+        assert _is_geographic_crs("EPSG:4258") is True  # ETRS89 (geographic)
+        assert _is_geographic_crs("urn:ogc:def:crs:EPSG::4171") is True
+        assert _is_geographic_crs("EPSG:22174") is False  # POSGAR 98 (projected)
+        assert _is_geographic_crs("EPSG:25830") is False  # ETRS89 / UTM 30N (projected)
+
     @pytest.mark.parametrize(
         "crs,version,axis_order,expected_swap",
         [

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -2758,15 +2758,20 @@ class TestResolveCRSForOutput:
 
     def test_falls_back_to_heuristic_without_server_crs(self):
         """No server CRS → fall back to coordinate-range guessing (degrees for 4326)."""
+        from unittest.mock import patch
+
         from geoparquet_io.core.wfs import _resolve_crs_for_output
 
         # Projected metric coords but WGS84 requested, no server CRS declared.
         table = self._point_table(3900000, 3000000)
 
-        out_table, crs = _resolve_crs_for_output(table, "EPSG:4326", None, False)
+        with patch("geoparquet_io.core.wfs.debug") as mock_debug:
+            out_table, crs = _resolve_crs_for_output(table, "EPSG:4326", None, False)
 
         # Heuristic detects projected data and relabels (fallback path preserved).
         assert crs == "EPSG:3035"
+        # The fallback to coordinate inference is announced (visible under --verbose).
+        assert any("declared no CRS" in str(call.args[0]) for call in mock_debug.call_args_list)
 
     def test_wfs_to_table_trusts_server_crs_end_to_end(self):
         """End-to-end #499 regression: declared EPSG:22174 stays EPSG:22174."""


### PR DESCRIPTION
## Problem

`gpio extract wfs` could silently mislabel the output GeoParquet's CRS. When a WFS server honored a requested projected CRS (e.g. EPSG:22174, Argentine Gauss-Krüger), gpio relabeled the output as EPSG:3857. The geometry was correct but the stored CRS metadata was wrong, so any downstream reprojection produced nonsense coordinates.

Root cause: gpio second-guessed the server with a bounding-box heuristic (`_estimate_crs_from_bbox`). That heuristic classifies *any* projected bbox with magnitudes between 1M–21M meters as EPSG:3857 — a range that also covers Argentine POSGAR/Gauss-Krüger zones. It fundamentally cannot distinguish one projected CRS from another, yet its guess was used both for output metadata and for the `output_crs` reprojection source.

## Fix

Read the CRS the server actually reports in its GeoJSON FeatureCollection `crs` member and treat it as **authoritative**:

- **Server honored the request** → trust it verbatim; skip coordinate validation entirely. (Fixes the #499 regression at the root.)
- **Server declared a contradicting CRS** (ignored `srsName`):
  - with `output_crs` → reproject from the server's *actual* CRS to the target;
  - with `strict_crs` → raise;
  - otherwise → label the output with the server's *actual* CRS (never a guess) and warn.
- **Server declared nothing** → fall back to the bbox heuristic, now demoted to a last resort (the category-aware behavior from the first commit).

The server CRS is carried up through the fetch → concat → type-inference pipeline via schema metadata, then stripped before the file is written.

## Tests

- `TestServerDeclaredCRS` — `crs`-member extraction and propagation through the fetch path (with/without the member, empty collections, metadata round-trip).
- `TestResolveCRSForOutput` — trust-on-match (asserts the heuristic is *not* invoked), contradiction handling (label / reproject / strict), heuristic fallback, and an end-to-end `wfs_to_table` #499 regression test.
- The earlier category-aware validation tests are retained as fallback-path coverage.

All 185 fast WFS tests pass; pre-commit (ruff, duckdb-antipatterns, no-click-echo, import-linter) and xenon complexity pass for the changed modules.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trusts the WFS server’s declared CRS from the GeoJSON response, avoiding incorrect CRS inference from coordinates.
  * Refines CRS mismatch detection to reduce false positives between projected CRS variants, and improves CRS handling across pagination and local bbox filtering.
  * Prevents internal CRS metadata from leaking into persisted outputs.
* **Documentation**
  * Clarified `strict_crs` semantics: warn+use server CRS when compatible, and fail only on true contradictions.
* **Tests**
  * Added regression coverage for server-declared CRS propagation, CRS classification edge cases, and output CRS resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->