### PR TITLE
feat(wfs): auto-tile large datasets and optimize extraction performance

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -284,12 +284,42 @@ table = ops.from_wfs('https://geo.example.com/wfs', 'cities', limit=100)
 | `bbox` | tuple | Bounding box filter (xmin, ymin, xmax, ymax) |
 | `limit` | int | Maximum number of features |
 | `max_workers` | int | Number of parallel fetch workers (default: 1) |
-| `page_size` | int | Features per WFS request page (default: 10000) |
+| `page_size` | int | Features per WFS request page (default: 100000) |
 | `axis_order` | str | Bbox axis order: `auto` (default), `xy`, `latlon`. Auto detects from CRS format. |
+| `auto_tile` | bool | Auto-subdivide bbox when server caps response (default: True) |
 | `strict_crs` | bool | Fail when the server returns a different CRS than requested (default: False, warns and uses the server's actual CRS instead). gpio trusts the CRS the server declares in its GeoJSON response and never guesses from coordinates. |
 
 !!! note "No automatic Hilbert sorting"
     Like other Python API extraction methods, `from_wfs()` does NOT apply Hilbert sorting by default. Chain `.sort_hilbert()` explicitly if needed.
+
+#### ops.from_wfs_layers()
+
+Extract multiple WFS layers in parallel to a directory:
+
+```python
+from geoparquet_io.api import ops
+
+results = ops.from_wfs_layers(
+    'https://geo.example.com/wfs',
+    ['cities', 'roads', 'buildings'],
+    './output/',
+    parallel_layers=3,
+    max_workers=2
+)
+# Returns: {'cities': Path('output/cities.parquet'), ...}
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `service_url` | str | WFS service URL |
+| `typenames` | list[str] | Layer names to extract |
+| `output_dir` | str \| Path | Output directory for parquet files |
+| `parallel_layers` | int | Concurrent layer extraction (default: 1) |
+| `max_workers` | int | Parallel fetch workers per layer (default: 1) |
+| `page_size` | int | Features per page (default: 100000) |
+| `auto_tile` | bool | Auto-subdivide bbox when server caps (default: True) |
 
 ## Table Class
 
@@ -1189,7 +1219,8 @@ pq.write_table(table, 'output.parquet')
 | `ops.convert_to_flatgeobuf(table, output)` | Convert to FlatGeobuf |
 | `ops.convert_to_csv(table, output, include_wkt=True, include_bbox=True)` | Convert to CSV |
 | `ops.convert_to_shapefile(table, output, encoding='UTF-8', overwrite=False)` | Convert to Shapefile |
-| `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=10000, axis_order='auto', strict_crs=False)` | Fetch from WFS service |
+| `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=100000, auto_tile=True, ...)` | Fetch from WFS service |
+| `ops.from_wfs_layers(service_url, typenames, output_dir, parallel_layers=1, max_workers=1, page_size=100000, ...)` | Fetch multiple WFS layers to directory |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |
 | `ops.explain_analyze(file_path, query=None)` | DuckDB EXPLAIN ANALYZE query plan |

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -286,7 +286,7 @@ table = ops.from_wfs('https://geo.example.com/wfs', 'cities', limit=100)
 | `max_workers` | int | Number of parallel fetch workers (default: 1) |
 | `page_size` | int | Features per WFS request page (default: 100000) |
 | `axis_order` | str | Bbox axis order: `auto` (default), `xy`, `latlon`. Auto detects from CRS format. |
-| `auto_tile` | bool | Auto-subdivide bbox when server caps response (default: True) |
+| `auto_tile` | bool | Auto-subdivide bbox when server caps response (default: False) |
 | `strict_crs` | bool | Fail when the server returns a different CRS than requested (default: False, warns and uses the server's actual CRS instead). gpio trusts the CRS the server declares in its GeoJSON response and never guesses from coordinates. |
 
 !!! note "No automatic Hilbert sorting"
@@ -1219,7 +1219,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.convert_to_flatgeobuf(table, output)` | Convert to FlatGeobuf |
 | `ops.convert_to_csv(table, output, include_wkt=True, include_bbox=True)` | Convert to CSV |
 | `ops.convert_to_shapefile(table, output, encoding='UTF-8', overwrite=False)` | Convert to Shapefile |
-| `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=100000, auto_tile=True, ...)` | Fetch from WFS service |
+| `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=100000, auto_tile=False, ...)` | Fetch from WFS service |
 | `ops.from_wfs_layers(service_url, typenames, output_dir, parallel_layers=1, max_workers=1, page_size=100000, ...)` | Fetch multiple WFS layers to directory |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |

--- a/docs/cli/extract.md
+++ b/docs/cli/extract.md
@@ -132,7 +132,9 @@ gpio extract wfs https://geo.example.com/wfs layer_name output.parquet
 - `--limit` - Maximum features to extract
 - `--output-crs` - Request specific CRS from server (e.g., `EPSG:4326`)
 - `--workers` - Parallel requests for large datasets (1-10, default: 1)
-- `--page-size` - Features per page when using `--workers > 1` (default: 10000)
+- `--page-size` - Features per page (default: 100000, max: 500000)
+- `--auto-tile/--no-auto-tile` - Auto-subdivide bbox when server caps response (default: enabled)
+- `--parallel-layers` - Concurrent layer extraction for multi-layer requests (1-10, default: 1)
 - `--skip-hilbert` - Skip Hilbert spatial ordering
 - `--skip-bbox` - Skip adding bbox column
 
@@ -155,8 +157,15 @@ gpio extract wfs https://geo.example.com/wfs cities output.parquet \
 
 # Parallel extraction for large datasets (1M+ features)
 gpio extract wfs https://geo.example.com/wfs large_layer output.parquet \
-    --workers 4 --page-size 10000
+    --workers 4
+
+# Extract multiple layers in parallel to a directory
+gpio extract wfs https://geo.example.com/wfs layer1,layer2,layer3 ./output/ \
+    --parallel-layers 3
 ```
+
+!!! tip "Auto-Tiling"
+    When a WFS server caps responses (e.g., maxFeatures=1M), gpio automatically subdivides the bbox and fetches all features. Disable with `--no-auto-tile` if you want the capped response.
 
 !!! tip "Performance"
     For datasets under ~100K features, the default single-stream mode is fastest. Use `--workers 2-4` for very large datasets (1M+ features) where server timeouts occur.

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1165,13 +1165,16 @@ For datasets with 1 million+ features, use parallel pagination to avoid server t
         max_workers=4
     )
 
-    # Extract multiple layers
+    # Extract multiple layers (tune defaults for large datasets)
     from geoparquet_io.api import ops
     results = ops.from_wfs_layers(
         'https://geo.example.com/wfs',
         ['layer1', 'layer2', 'layer3'],
         './output/',
-        parallel_layers=3
+        parallel_layers=3,
+        max_workers=2,        # parallel page fetches per layer
+        page_size=100000,     # features per WFS request page
+        auto_tile=True        # subdivide bbox when the server caps responses
     )
     ```
 

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1144,8 +1144,11 @@ For datasets with 1 million+ features, use parallel pagination to avoid server t
     ```bash
     # Parallel extraction with 4 workers
     gpio extract wfs https://geo.example.com/wfs large_layer output.parquet \
-        --workers 4 \
-        --page-size 10000
+        --workers 4
+
+    # Extract multiple layers in parallel to a directory
+    gpio extract wfs https://geo.example.com/wfs layer1,layer2,layer3 ./output/ \
+        --parallel-layers 3
 
     # For most datasets under 100K features, single-stream is faster
     gpio extract wfs https://geo.example.com/wfs cities output.parquet
@@ -1159,15 +1162,28 @@ For datasets with 1 million+ features, use parallel pagination to avoid server t
     table = Table.from_wfs(
         'https://geo.example.com/wfs',
         'large_layer',
-        max_workers=4,
-        page_size=10000
+        max_workers=4
+    )
+
+    # Extract multiple layers
+    from geoparquet_io.api import ops
+    results = ops.from_wfs_layers(
+        'https://geo.example.com/wfs',
+        ['layer1', 'layer2', 'layer3'],
+        './output/',
+        parallel_layers=3
     )
     ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--workers` | 1 | Number of parallel requests (1-10) |
-| `--page-size` | 10000 | Features per page when using `--workers > 1` |
+| `--page-size` | 100000 | Features per WFS request page |
+| `--parallel-layers` | 1 | Concurrent layer extraction for multi-layer requests |
+| `--auto-tile` | enabled | Auto-subdivide bbox when server caps response |
+
+!!! tip "Auto-Tiling for Capped Servers"
+    Many WFS servers impose maxFeatures limits (e.g., 1M features). When gpio detects a capped response, it automatically subdivides the bbox and fetches all features. Disable with `--no-auto-tile` if you want the capped response.
 
 !!! tip "When to use parallel"
     - **Single stream (default)**: Fastest for datasets under ~100K features

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -876,7 +876,7 @@ def from_wfs(
     bbox: tuple[float, float, float, float] | None = None,
     limit: int | None = None,
     max_workers: int = 1,
-    page_size: int = 10000,
+    page_size: int = 100000,
     axis_order: str = "auto",
     strict_crs: bool = False,
     auto_tile: bool = False,
@@ -895,7 +895,7 @@ def from_wfs(
         bbox: Optional bounding box filter (xmin, ymin, xmax, ymax)
         limit: Maximum features to fetch
         max_workers: Parallel requests for large datasets (default: 1)
-        page_size: Features per page when using parallel mode (default: 10000)
+        page_size: Features per page when using parallel mode (default: 100000)
         axis_order: Bbox axis order ('auto', 'xy', 'latlon'). 'auto' detects from
             CRS format - URN CRS with WFS 1.1.0+ uses lat,lon per OGC spec.
         strict_crs: If True, fail when the server returns a different CRS than
@@ -928,6 +928,86 @@ def from_wfs(
         strict_crs=strict_crs,
         auto_tile=auto_tile,
     )
+
+
+def from_wfs_layers(
+    service_url: str,
+    typenames: list[str],
+    output_dir: str,
+    version: str = "auto",
+    bbox: tuple[float, float, float, float] | None = None,
+    limit: int | None = None,
+    max_workers: int = 1,
+    page_size: int = 100000,
+    parallel_layers: int = 1,
+    axis_order: str = "auto",
+    strict_crs: bool = False,
+    auto_tile: bool = False,
+    skip_hilbert: bool = False,
+    skip_bbox: bool = False,
+    compression: str = "ZSTD",
+    overwrite: bool = False,
+) -> dict[str, str]:
+    """
+    Extract multiple WFS layers in parallel to a directory.
+
+    Each layer is saved as a separate GeoParquet file named after the typename.
+
+    Args:
+        service_url: WFS service URL
+        typenames: List of layer typenames to extract
+        output_dir: Directory to write output files
+        version: WFS version ('auto', '2.0.0', '1.1.0', '1.0.0'). Default 'auto'
+        bbox: Optional bounding box filter (xmin, ymin, xmax, ymax) applied to all layers
+        limit: Maximum features per layer
+        max_workers: Per-layer pagination workers (default: 1)
+        page_size: Features per page (default: 100000)
+        parallel_layers: Number of layers to extract concurrently (default: 1)
+        axis_order: Bbox axis order ('auto', 'xy', 'latlon')
+        strict_crs: If True, fail when the server returns a different CRS than requested
+        auto_tile: Automatically subdivide into spatial tiles for servers with
+            startIndex limits (default: False)
+        skip_hilbert: Skip Hilbert curve sorting (default: False)
+        skip_bbox: Skip adding bbox column (default: False)
+        compression: Compression algorithm (default: 'ZSTD')
+        overwrite: Overwrite existing files (default: False)
+
+    Returns:
+        Dict mapping typename to output file path (only successful extractions)
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> results = ops.from_wfs_layers(
+        ...     'https://geo.example.com/wfs',
+        ...     ['roads', 'buildings', 'parcels'],
+        ...     './output/',
+        ...     parallel_layers=3,
+        ...     max_workers=2
+        ... )
+        >>> print(results)  # {'roads': './output/roads.parquet', ...}
+    """
+    from geoparquet_io.core.wfs import convert_wfs_layers_to_directory
+
+    results = convert_wfs_layers_to_directory(
+        service_url=service_url,
+        typenames=typenames,
+        output_dir=output_dir,
+        parallel_layers=parallel_layers,
+        max_workers=max_workers,
+        page_size=page_size,
+        version=version,
+        bbox=bbox,
+        limit=limit,
+        axis_order=axis_order,
+        strict_crs=strict_crs,
+        skip_hilbert=skip_hilbert,
+        skip_bbox=skip_bbox,
+        compression=compression,
+        overwrite=overwrite,
+        auto_tile=auto_tile,
+    )
+    # Convert Path to str for simpler API
+    return {k: str(v) for k, v in results.items()}
 
 
 def from_carto(

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3215,6 +3215,10 @@ def extract_wfs_cmd(
 
     # Parse comma-separated typenames
     typenames = [t.strip() for t in typename.split(",") if t.strip()]
+    if not typenames:
+        raise click.ClickException(
+            "No valid typename(s) provided. Specify one or more comma-separated layer names."
+        )
     is_multi_layer = len(typenames) > 1
 
     # Validate output path based on single/multi layer mode

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3051,15 +3051,23 @@ def _deprecated_version_callback(ctx, param, value):
 )
 @click.option(
     "--page-size",
-    type=click.IntRange(1000, 100000),
-    default=10000,
-    help="Features per page when using --workers > 1. Default: 10000.",
+    type=click.IntRange(1000, 500000),
+    default=100000,
+    help="Features per page when using --workers > 1. Default: 100000.",
 )
 @click.option(
-    "--auto-tile",
-    is_flag=True,
-    help="Automatically subdivide into spatial tiles to work around server "
-    "startIndex limits. Use for large datasets on servers that cap pagination.",
+    "--parallel-layers",
+    type=click.IntRange(min=1, max=10),
+    default=1,
+    help="Number of layers to extract concurrently when extracting multiple layers. "
+    "Default: 1 (sequential). Use with comma-separated typename for parallel extraction.",
+)
+@click.option(
+    "--auto-tile/--no-auto-tile",
+    default=True,
+    help="Automatically subdivide into spatial tiles when server caps responses "
+    "(e.g., maxFeatures or startIndex limits). Enabled by default. "
+    "Use --no-auto-tile to disable and accept partial data.",
 )
 @click.option(
     "--sort-by",
@@ -3096,6 +3104,7 @@ def extract_wfs_cmd(
     output_crs,
     workers,
     page_size,
+    parallel_layers,
     auto_tile,
     sort_by,
     skip_hilbert,
@@ -3115,9 +3124,11 @@ def extract_wfs_cmd(
     SERVICE_URL is the WFS service endpoint URL.
 
     TYPENAME is the layer to extract (e.g., 'roads', 'buildings').
+    Use comma-separated names for multiple layers (e.g., 'roads,buildings,parcels').
     If omitted, lists available layers.
 
-    OUTPUT_FILE is the output GeoParquet file path. Required when TYPENAME is specified.
+    OUTPUT_FILE is the output path. For single layer, this is the output file.
+    For multiple layers, this is the output directory (each layer saved as typename.parquet).
 
     \b
     Examples:
@@ -3127,8 +3138,13 @@ def extract_wfs_cmd(
         gpio extract wfs https://geo.example.com/wfs
 
         \b
-        # Extract entire layer
+        # Extract single layer
         gpio extract wfs https://geo.example.com/wfs cities output.parquet
+
+        \b
+        # Extract multiple layers in parallel to a directory
+        gpio extract wfs https://geo.example.com/wfs roads,buildings,parcels ./output/ \\
+            --workers 2 --parallel-layers 3
 
         \b
         # With bbox filter (server-side when supported)
@@ -3147,6 +3163,7 @@ def extract_wfs_cmd(
     """
     from geoparquet_io.core.wfs import (
         WFSError,
+        convert_wfs_layers_to_directory,
         convert_wfs_to_geoparquet,
         list_available_layers,
         negotiate_wfs_version,
@@ -3196,8 +3213,21 @@ def extract_wfs_cmd(
             f"Usage: gpio extract wfs {service_url} {typename} OUTPUT_FILE"
         )
 
-    # Validate .parquet extension
-    validate_parquet_extension(output_file, any_extension)
+    # Parse comma-separated typenames
+    typenames = [t.strip() for t in typename.split(",") if t.strip()]
+    is_multi_layer = len(typenames) > 1
+
+    # Validate output path based on single/multi layer mode
+    if is_multi_layer:
+        # Multi-layer mode: output_file is a directory
+        if output_file.endswith(".parquet"):
+            raise click.ClickException(
+                f"Multiple layers specified ({len(typenames)}), but output looks like a file: {output_file}\n"
+                "For multi-layer extraction, provide a directory path (e.g., ./output/)."
+            )
+    else:
+        # Single layer mode: validate .parquet extension
+        validate_parquet_extension(output_file, any_extension)
 
     # Parse row group options
     row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
@@ -3217,31 +3247,61 @@ def extract_wfs_cmd(
             ) from e
 
     try:
-        convert_wfs_to_geoparquet(
-            service_url=service_url,
-            typename=typename,
-            output_file=output_file,
-            version=wfs_version,
-            bbox=bbox_tuple,
-            bbox_mode=bbox_mode,
-            output_crs=output_crs,
-            limit=limit,
-            max_workers=workers,
-            page_size=page_size,
-            axis_order=axis_order,
-            strict_crs=strict_crs,
-            skip_hilbert=skip_hilbert,
-            skip_bbox=skip_bbox,
-            compression=compression.upper(),
-            compression_level=compression_level,
-            row_group_size_mb=row_group_mb,
-            row_group_rows=row_group_size,
-            geoparquet_version=geoparquet_version,
-            overwrite=overwrite,
-            verbose=verbose,
-            auto_tile=auto_tile,
-            sort_by=sort_by,
-        )
+        if is_multi_layer:
+            # Multi-layer parallel extraction
+            convert_wfs_layers_to_directory(
+                service_url=service_url,
+                typenames=typenames,
+                output_dir=output_file,
+                parallel_layers=parallel_layers,
+                max_workers=workers,
+                page_size=page_size,
+                version=wfs_version,
+                bbox=bbox_tuple,
+                bbox_mode=bbox_mode,
+                output_crs=output_crs,
+                limit=limit,
+                axis_order=axis_order,
+                strict_crs=strict_crs,
+                skip_hilbert=skip_hilbert,
+                skip_bbox=skip_bbox,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                row_group_size_mb=row_group_mb,
+                row_group_rows=row_group_size,
+                geoparquet_version=geoparquet_version,
+                overwrite=overwrite,
+                verbose=verbose,
+                auto_tile=auto_tile,
+                sort_by=sort_by,
+            )
+        else:
+            # Single layer extraction
+            convert_wfs_to_geoparquet(
+                service_url=service_url,
+                typename=typenames[0],
+                output_file=output_file,
+                version=wfs_version,
+                bbox=bbox_tuple,
+                bbox_mode=bbox_mode,
+                output_crs=output_crs,
+                limit=limit,
+                max_workers=workers,
+                page_size=page_size,
+                axis_order=axis_order,
+                strict_crs=strict_crs,
+                skip_hilbert=skip_hilbert,
+                skip_bbox=skip_bbox,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                row_group_size_mb=row_group_mb,
+                row_group_rows=row_group_size,
+                geoparquet_version=geoparquet_version,
+                overwrite=overwrite,
+                verbose=verbose,
+                auto_tile=auto_tile,
+                sort_by=sort_by,
+            )
     except WFSError as e:
         raise click.ClickException(str(e)) from None
 

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -1322,9 +1322,13 @@ def arcgis_to_table(
         return table
 
     finally:
-        # Clean up temp file
+        # Clean up temp file (best-effort: on Windows pyarrow may still hold
+        # the file handle after read_table, raising PermissionError on unlink)
         if os.path.exists(temp_parquet):
-            os.unlink(temp_parquet)
+            try:
+                os.unlink(temp_parquet)
+            except OSError:
+                debug(f"Could not remove temp file {temp_parquet}")
 
 
 def convert_arcgis_to_geoparquet(

--- a/geoparquet_io/core/http_retry.py
+++ b/geoparquet_io/core/http_retry.py
@@ -36,7 +36,7 @@ DEFAULT_RETRY_DELAY = 1.0
 def get_shared_http_client(
     timeout: float = DEFAULT_TIMEOUT,
     http2: bool = False,
-    max_connections: int = 20,
+    max_connections: int = 50,
 ) -> httpx.Client:
     """
     Get or create a shared HTTP client for connection pooling.

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1045,33 +1045,30 @@ def _build_bbox_param(
     """
     Build WFS bbox parameter string with correct axis order.
 
-    WFS 1.0.0: xmin,ymin,xmax,ymax (always XY)
-    WFS 1.1.0+: Axis order depends on CRS format
-      - EPSG:4326 (simple): xmin,ymin,xmax,ymax,crs
-      - urn:ogc:def:crs:EPSG::4326: ymin,xmin,ymax,xmax,crs (lat,lon per spec)
+    IMPORTANT: Bbox is always sent in WGS84 (EPSG:4326) regardless of output CRS,
+    because many WFS servers (especially GeoServer) only accept bbox in WGS84.
+    The bbox coordinates are expected to be in lon,lat (WGS84) order.
+
+    WFS 1.0.0: xmin,ymin,xmax,ymax (always XY, no CRS suffix)
+    WFS 1.1.0+: xmin,ymin,xmax,ymax,EPSG:4326 (always WGS84)
 
     Args:
-        bbox: Bounding box tuple (xmin, ymin, xmax, ymax) in lon,lat order
-        crs: Coordinate reference system
+        bbox: Bounding box tuple (xmin, ymin, xmax, ymax) in WGS84 lon,lat order
+        crs: Output CRS (ignored for bbox - we always use WGS84)
         version: WFS version
         axis_order: "auto" (detect from CRS), "xy" (force lon,lat), "latlon" (force lat,lon)
 
     Returns:
-        Bbox parameter string with correct axis order for the CRS
+        Bbox parameter string in WGS84
     """
     xmin, ymin, xmax, ymax = bbox
 
     if version == "1.0.0":
         return f"{xmin},{ymin},{xmax},{ymax}"
 
-    # Check if we need to swap axis order for this CRS
-    if _needs_axis_swap(crs, version, axis_order):
-        # Swap to lat,lon order (ymin,xmin,ymax,xmax)
-        debug(f"Using lat,lon axis order for URN CRS: {crs}")
-        return f"{ymin},{xmin},{ymax},{xmax},{crs}"
-    else:
-        # Standard lon,lat order (xmin,ymin,xmax,ymax)
-        return f"{xmin},{ymin},{xmax},{ymax},{crs}"
+    # Always use WGS84 for bbox - most WFS servers expect this regardless of output CRS
+    # Use simple EPSG:4326 format (not URN) to ensure XY axis order
+    return f"{xmin},{ymin},{xmax},{ymax},EPSG:4326"
 
 
 def _validate_identifier(name: str) -> str:
@@ -1758,7 +1755,7 @@ def _fetch_with_spatial_tiles(
     layer_bbox: tuple[float, float, float, float],
     crs: str,
     max_workers: int = 1,
-    page_size: int = 10000,
+    page_size: int = 100000,
     axis_order: str = "auto",
     max_features: int | None = None,
     sort_by: str | None = None,
@@ -2103,7 +2100,7 @@ def fetch_all_features_duckdb(
     bbox: tuple[float, float, float, float] | None = None,
     crs: str | None = None,
     max_workers: int = 1,
-    page_size: int = 10000,
+    page_size: int = 100000,
     axis_order: str = "auto",
     extract_fid: bool = False,
     sort_by: str | None = None,
@@ -2128,7 +2125,7 @@ def fetch_all_features_duckdb(
         bbox: Optional bounding box filter
         crs: CRS for bbox parameter
         max_workers: Number of parallel requests (1-10). Use 4-8 for large datasets.
-        page_size: Features per page when paginating (default: 10000)
+        page_size: Features per page when paginating (default: 100000)
         axis_order: Bbox axis order ("auto", "xy", "latlon")
         extract_fid: If True, extract WFS feature IDs for deduplication
         sort_by: Attribute to sort by for stable pagination (auto-detected if None)
@@ -2260,6 +2257,41 @@ def fetch_all_features_duckdb(
     return _with_server_crs(_infer_column_types(combined), server_crs)
 
 
+def _looks_like_server_cap(count: int) -> bool:
+    """Check if a feature count looks like a server-imposed cap.
+
+    Server caps are typically round numbers like 1000000, 500000, 100000, etc.
+    """
+    if count <= 0:
+        return False
+    # Check for common cap values
+    common_caps = {1000000, 500000, 100000, 50000, 10000}
+    if count in common_caps:
+        return True
+    # Check if it's a round number (divisible by 10000 with at least 5 digits)
+    if count >= 10000 and count % 10000 == 0:
+        return True
+    return False
+
+
+def _get_tiling_bbox(
+    user_bbox: tuple[float, float, float, float] | None,
+    use_server_bbox: bool,
+    layer_info: WFSLayerInfo,
+) -> tuple[float, float, float, float] | None:
+    """Get the bounding box to use for spatial tiling.
+
+    Returns the user's bbox if provided and server-side filtering is enabled,
+    otherwise falls back to the layer's advertised bbox from capabilities.
+    Returns None if no bbox is available.
+    """
+    if user_bbox and use_server_bbox:
+        return user_bbox
+    if layer_info.bbox:
+        return layer_info.bbox
+    return None
+
+
 def wfs_to_table(
     service_url: str,
     typename: str,
@@ -2269,11 +2301,11 @@ def wfs_to_table(
     output_crs: str | None = None,
     limit: int | None = None,
     max_workers: int = 1,
-    page_size: int = 10000,
+    page_size: int = 100000,
     axis_order: str = "auto",
     strict_crs: bool = False,
     verbose: bool = False,
-    auto_tile: bool = False,
+    auto_tile: bool = True,
     sort_by: str | None = None,
 ) -> pa.Table:
     """
@@ -2298,7 +2330,7 @@ def wfs_to_table(
             the server's actual CRS. (e.g., "EPSG:4326")
         limit: Maximum features to fetch
         max_workers: Parallel requests for large datasets (default: 1 = single request)
-        page_size: Features per page when using parallel mode (default: 10000)
+        page_size: Features per page when using parallel mode (default: 100000)
         axis_order: Bbox axis order ("auto", "xy", "latlon")
         strict_crs: If True, fail when the server returns a different CRS than
             requested. If False and output_crs is set, reproject from the
@@ -2348,33 +2380,38 @@ def wfs_to_table(
     if bbox:
         use_server_bbox = _determine_bbox_strategy(bbox_mode, layer_info)
 
-    # Check if auto-tiling is needed (server has startIndex limit + dataset exceeds it)
+    # Get expected feature count for cap detection
+    # Try WFS 2.0.0 first for count query since it often has higher/no limits
+    expected_count = None
+    if auto_tile and version != "1.0.0":
+        # Try WFS 2.0.0 count first (higher limits), fall back to requested version
+        expected_count = _get_feature_count(service_url, layer_info.typename, "2.0.0")
+        if not expected_count:
+            expected_count = _get_feature_count(service_url, layer_info.typename, version)
+        if expected_count:
+            debug(f"Server reports {expected_count:,} features")
+
+    # Check for startIndex limit (proactive tiling for pagination limits)
     use_tiling = False
     tiling_bbox: tuple[float, float, float, float] | None = None
     tiling_total = 0
     tiling_limit = 0
-    if auto_tile and version != "1.0.0":
-        total_count = _get_feature_count(service_url, layer_info.typename, version)
+    if auto_tile and version != "1.0.0" and expected_count:
         startindex_limit = _probe_startindex_limit(
             service_url, layer_info.typename, version, crs=crs, axis_order=axis_order
         )
-        if startindex_limit and total_count:
-            effective = min(limit, total_count) if limit else total_count
+        if startindex_limit:
+            effective = min(limit, expected_count) if limit else expected_count
             if effective > startindex_limit + page_size:
-                # Determine bbox for tiling: use caller bbox if provided, else layer bbox
-                if bbox and use_server_bbox:
-                    tiling_bbox = bbox
-                elif layer_info.bbox:
-                    tiling_bbox = layer_info.bbox
-                else:
-                    raise WFSError(
-                        "Auto-tiling requires a bounding box. Either:\n"
-                        "  1. Use --bbox to specify a region\n"
-                        "  2. Ensure the layer has a bbox in capabilities"
+                tiling_bbox = _get_tiling_bbox(bbox, use_server_bbox, layer_info)
+                if tiling_bbox:
+                    use_tiling = True
+                    tiling_total = effective
+                    tiling_limit = startindex_limit
+                    warn(
+                        f"Server has startIndex limit of {startindex_limit:,}. "
+                        f"Auto-tiling {effective:,} features..."
                     )
-                use_tiling = True
-                tiling_total = effective
-                tiling_limit = startindex_limit
 
     if use_tiling and tiling_bbox is not None:
         table = _fetch_with_spatial_tiles(
@@ -2392,6 +2429,7 @@ def wfs_to_table(
             sort_by=effective_sort_by,
         )
     else:
+        # Normal fetch
         table = fetch_all_features_duckdb(
             service_url=service_url,
             typename=layer_info.typename,
@@ -2404,6 +2442,39 @@ def wfs_to_table(
             axis_order=axis_order,
             sort_by=effective_sort_by,
         )
+
+        # Check for maxFeatures cap (reactive tiling)
+        # If we got fewer features than expected and the count looks like a server cap,
+        # retry with spatial tiling to bypass the cap
+        if (
+            auto_tile
+            and version != "1.0.0"
+            and expected_count
+            and table.num_rows < expected_count
+            and _looks_like_server_cap(table.num_rows)
+            and not limit  # Don't retry if user specified a limit
+        ):
+            tiling_bbox = _get_tiling_bbox(bbox, use_server_bbox, layer_info)
+            if tiling_bbox:
+                warn(
+                    f"Server capped response at {table.num_rows:,} features "
+                    f"(expected {expected_count:,}). Auto-tiling to fetch all..."
+                )
+                # Use a synthetic "startindex_limit" equal to the cap for tile sizing
+                table = _fetch_with_spatial_tiles(
+                    service_url=service_url,
+                    typename=layer_info.typename,
+                    version=version,
+                    total_count=expected_count,
+                    startindex_limit=table.num_rows,  # Use the cap as the limit
+                    layer_bbox=tiling_bbox,
+                    crs=crs,
+                    max_workers=max_workers,
+                    page_size=page_size,
+                    axis_order=axis_order,
+                    max_features=limit,
+                    sort_by=effective_sort_by,
+                )
 
     if table.num_rows == 0:
         if bbox:
@@ -2476,7 +2547,7 @@ def convert_wfs_to_geoparquet(
     output_crs: str | None = None,
     limit: int | None = None,
     max_workers: int = 1,
-    page_size: int = 10000,
+    page_size: int = 100000,
     axis_order: str = "auto",
     strict_crs: bool = False,
     skip_hilbert: bool = False,
@@ -2504,7 +2575,7 @@ def convert_wfs_to_geoparquet(
         output_crs: Guarantee output in this CRS (reprojects if server returns different)
         limit: Maximum features
         max_workers: Parallel requests for large datasets (default: 1)
-        page_size: Features per page when using parallel mode (default: 10000)
+        page_size: Features per page when using parallel mode (default: 100000)
         axis_order: Bbox axis order ("auto", "xy", "latlon")
         strict_crs: If True, fail when the server returns a different CRS than
             requested. If False and output_crs is set, reproject from the
@@ -2577,3 +2648,217 @@ def convert_wfs_to_geoparquet(
     )
 
     success(f"Wrote {table.num_rows:,} features to {output_file}")
+
+
+def _extract_single_layer(
+    service_url: str,
+    typename: str,
+    output_dir: Path,
+    layer_index: int,
+    total_layers: int,
+    **kwargs,
+) -> tuple[str, Path, int | None, str | None]:
+    """
+    Extract a single WFS layer to a file in output_dir.
+
+    Returns (typename, output_path, row_count, error_message).
+    error_message is None on success.
+    """
+    # Sanitize typename for filename (replace : and / with _)
+    safe_name = typename.replace(":", "_").replace("/", "_")
+    output_path = output_dir / f"{safe_name}.parquet"
+
+    try:
+        progress(f"[{layer_index + 1}/{total_layers}] Starting {typename}...")
+        convert_wfs_to_geoparquet(
+            service_url=service_url,
+            typename=typename,
+            output_file=str(output_path),
+            **kwargs,
+        )
+        # Read back row count for summary
+        import pyarrow.parquet as pq
+
+        meta = pq.read_metadata(output_path)
+        row_count = meta.num_rows
+        return (typename, output_path, row_count, None)
+    except Exception as e:
+        return (typename, output_path, None, str(e))
+
+
+def convert_wfs_layers_to_directory(
+    service_url: str,
+    typenames: list[str],
+    output_dir: str | Path,
+    parallel_layers: int = 1,
+    max_workers: int = 1,
+    page_size: int = 100000,
+    version: str = "1.1.0",
+    bbox: tuple[float, float, float, float] | None = None,
+    bbox_mode: str = "auto",
+    output_crs: str | None = None,
+    limit: int | None = None,
+    axis_order: str = "auto",
+    strict_crs: bool = False,
+    skip_hilbert: bool = False,
+    skip_bbox: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    row_group_size_mb: float | None = None,
+    row_group_rows: int | None = None,
+    geoparquet_version: str | None = None,
+    overwrite: bool = False,
+    verbose: bool = False,
+    auto_tile: bool = False,
+    sort_by: str | None = None,
+) -> dict[str, Path]:
+    """
+    Extract multiple WFS layers in parallel to a directory.
+
+    Each layer is saved as a separate GeoParquet file named after the typename.
+
+    Args:
+        service_url: WFS service URL
+        typenames: List of layer typenames to extract
+        output_dir: Directory to write output files
+        parallel_layers: Number of layers to extract concurrently (default: 1)
+        max_workers: Per-layer pagination workers (default: 1)
+        page_size: Features per page (default: 100000)
+        version: WFS version
+        bbox: Optional bounding box filter (applied to all layers)
+        bbox_mode: Bbox strategy
+        output_crs: Output CRS (applied to all layers)
+        limit: Maximum features per layer
+        axis_order: Bbox axis order
+        strict_crs: Fail on CRS mismatch
+        skip_hilbert: Skip Hilbert ordering
+        skip_bbox: Skip bbox column
+        compression: Compression algorithm
+        compression_level: Compression level
+        row_group_size_mb: Row group size in MB
+        row_group_rows: Row group size in rows
+        geoparquet_version: GeoParquet version
+        overwrite: Overwrite existing files
+        verbose: Enable debug output
+        auto_tile: Auto-tile for servers with startIndex limits
+        sort_by: Sort attribute for stable pagination
+
+    Returns:
+        Dict mapping typename to output file path (only successful extractions)
+
+    Raises:
+        WFSError: If output_dir exists and is not a directory, or if all extractions fail
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    configure_verbose(verbose)
+
+    output_path = Path(output_dir)
+
+    # Create output directory if needed
+    if output_path.exists():
+        if not output_path.is_dir():
+            raise WFSError(f"Output path exists but is not a directory: {output_dir}")
+    else:
+        output_path.mkdir(parents=True)
+
+    # Check for existing files if not overwriting
+    if not overwrite:
+        existing = []
+        for typename in typenames:
+            safe_name = typename.replace(":", "_").replace("/", "_")
+            file_path = output_path / f"{safe_name}.parquet"
+            if file_path.exists():
+                existing.append(str(file_path))
+        if existing:
+            raise WFSError(
+                "Output files already exist:\n  "
+                + "\n  ".join(existing)
+                + "\nUse --overwrite to replace them."
+            )
+
+    progress(
+        f"Extracting {len(typenames)} layers to {output_dir} "
+        f"(parallel_layers={parallel_layers}, workers={max_workers})..."
+    )
+
+    # Build kwargs for each layer extraction
+    kwargs = {
+        "version": version,
+        "bbox": bbox,
+        "bbox_mode": bbox_mode,
+        "output_crs": output_crs,
+        "limit": limit,
+        "max_workers": max_workers,
+        "page_size": page_size,
+        "axis_order": axis_order,
+        "strict_crs": strict_crs,
+        "skip_hilbert": skip_hilbert,
+        "skip_bbox": skip_bbox,
+        "compression": compression,
+        "compression_level": compression_level,
+        "row_group_size_mb": row_group_size_mb,
+        "row_group_rows": row_group_rows,
+        "geoparquet_version": geoparquet_version,
+        "overwrite": overwrite,
+        "verbose": verbose,
+        "auto_tile": auto_tile,
+        "sort_by": sort_by,
+    }
+
+    results: dict[str, Path] = {}
+    errors: list[tuple[str, str]] = []
+    total_rows = 0
+
+    actual_parallel = min(parallel_layers, len(typenames))
+
+    if actual_parallel == 1:
+        # Sequential mode
+        for i, typename in enumerate(typenames):
+            typename, path, rows, error = _extract_single_layer(
+                service_url, typename, output_path, i, len(typenames), **kwargs
+            )
+            if error:
+                errors.append((typename, error))
+                warn(f"Failed to extract {typename}: {error}")
+            else:
+                results[typename] = path
+                total_rows += rows or 0
+    else:
+        # Parallel mode
+        with ThreadPoolExecutor(max_workers=actual_parallel) as executor:
+            futures = {
+                executor.submit(
+                    _extract_single_layer,
+                    service_url,
+                    typename,
+                    output_path,
+                    i,
+                    len(typenames),
+                    **kwargs,
+                ): typename
+                for i, typename in enumerate(typenames)
+            }
+
+            for future in as_completed(futures):
+                typename, path, rows, error = future.result()
+                if error:
+                    errors.append((typename, error))
+                    warn(f"Failed to extract {typename}: {error}")
+                else:
+                    results[typename] = path
+                    total_rows += rows or 0
+
+    # Summary
+    if errors:
+        warn(f"Completed with {len(errors)} failures:")
+        for typename, error in errors:
+            warn(f"  {typename}: {error}")
+
+    if not results:
+        raise WFSError(f"All {len(typenames)} layer extractions failed")
+
+    success(
+        f"Extracted {len(results)}/{len(typenames)} layers ({total_rows:,} total features) to {output_dir}"
+    )
+    return results

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -2815,14 +2815,14 @@ def convert_wfs_layers_to_directory(
     if actual_parallel == 1:
         # Sequential mode
         for i, typename in enumerate(typenames):
-            typename, path, rows, error = _extract_single_layer(
+            result_typename, path, rows, error = _extract_single_layer(
                 service_url, typename, output_path, i, len(typenames), **kwargs
             )
             if error:
-                errors.append((typename, error))
-                warn(f"Failed to extract {typename}: {error}")
+                errors.append((result_typename, error))
+                warn(f"Failed to extract {result_typename}: {error}")
             else:
-                results[typename] = path
+                results[result_typename] = path
                 total_rows += rows or 0
     else:
         # Parallel mode
@@ -2841,12 +2841,12 @@ def convert_wfs_layers_to_directory(
             }
 
             for future in as_completed(futures):
-                typename, path, rows, error = future.result()
+                result_typename, path, rows, error = future.result()
                 if error:
-                    errors.append((typename, error))
-                    warn(f"Failed to extract {typename}: {error}")
+                    errors.append((result_typename, error))
+                    warn(f"Failed to extract {result_typename}: {error}")
                 else:
-                    results[typename] = path
+                    results[result_typename] = path
                     total_rows += rows or 0
 
     # Summary

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -831,11 +831,17 @@ class TestBboxFilters:
         assert sql.count("-122.5 37.5") == 2
 
     def test_bbox_with_crs_suffix(self):
-        """WFS 1.1.0 bbox includes CRS suffix."""
+        """WFS 1.1.0 bbox always uses EPSG:4326 regardless of output CRS.
+
+        Many WFS servers (especially GeoServer) only accept bbox in WGS84,
+        so we always send bbox with EPSG:4326 suffix regardless of output CRS.
+        """
         bbox = (-122.5, 37.5, -122.0, 38.0)
-        crs = "urn:ogc:def:crs:EPSG::4326"
+        crs = "urn:ogc:def:crs:EPSG::4326"  # Output CRS (ignored for bbox)
         result = _build_bbox_param(bbox, crs, "1.1.0")
-        assert result.endswith(crs)
+        # Bbox should always end with EPSG:4326, not the output CRS
+        assert result.endswith("EPSG:4326")
+        assert result == "-122.5,37.5,-122.0,38.0,EPSG:4326"
 
     def test_invalid_geometry_column_rejected(self):
         """Invalid geometry column names with SQL injection characters are rejected."""
@@ -2029,7 +2035,8 @@ class TestAxisOrder:
         [
             # WFS 1.0.0: no CRS suffix
             ((-122.5, 37.5, -122.0, 38.0), "EPSG:4326", "1.0.0", "auto", "-122.5,37.5,-122.0,38.0"),
-            # WFS 1.1.0 with simple CRS: XY order with CRS suffix
+            # WFS 1.1.0+: Always EPSG:4326 with XY order (bbox is always WGS84)
+            # This ensures compatibility with servers that only accept WGS84 bbox
             (
                 (-122.5, 37.5, -122.0, 38.0),
                 "EPSG:4326",
@@ -2037,34 +2044,34 @@ class TestAxisOrder:
                 "auto",
                 "-122.5,37.5,-122.0,38.0,EPSG:4326",
             ),
-            # WFS 1.1.0 with URN CRS: YX order (lat,lon) with CRS suffix
+            # Even with URN output CRS, bbox uses simple EPSG:4326
             (
                 (-122.5, 37.5, -122.0, 38.0),
                 "urn:ogc:def:crs:EPSG::4326",
                 "1.1.0",
                 "auto",
-                "37.5,-122.5,38.0,-122.0,urn:ogc:def:crs:EPSG::4326",
+                "-122.5,37.5,-122.0,38.0,EPSG:4326",
             ),
-            # WFS 2.0.0 with URN CRS: YX order
+            # WFS 2.0.0 also uses EPSG:4326 for bbox
             (
                 (4.82, 50.44, 4.92, 50.48),
                 "urn:ogc:def:crs:EPSG::4326",
                 "2.0.0",
                 "auto",
-                "50.44,4.82,50.48,4.92,urn:ogc:def:crs:EPSG::4326",
+                "4.82,50.44,4.92,50.48,EPSG:4326",
             ),
-            # Forced XY order ignores URN format
+            # Projected output CRS still uses WGS84 bbox
             (
                 (-122.5, 37.5, -122.0, 38.0),
-                "urn:ogc:def:crs:EPSG::4326",
+                "EPSG:3857",
                 "1.1.0",
-                "xy",
-                "-122.5,37.5,-122.0,38.0,urn:ogc:def:crs:EPSG::4326",
+                "auto",
+                "-122.5,37.5,-122.0,38.0,EPSG:4326",
             ),
         ],
     )
     def test_build_bbox_param_axis_order(self, bbox, crs, version, axis_order, expected):
-        """Bbox parameter string should have correct axis order."""
+        """Bbox parameter string should always use WGS84 for server compatibility."""
         from geoparquet_io.core.wfs import _build_bbox_param
 
         result = _build_bbox_param(bbox, crs, version, axis_order)
@@ -3811,3 +3818,149 @@ class TestFetchWithSpatialTiles:
 
         mock_fetch.assert_called_once()
         mock_tile.assert_not_called()
+
+
+class TestMultiLayerExtraction:
+    """Tests for multi-layer parallel extraction."""
+
+    def test_convert_wfs_layers_creates_directory(self, tmp_path):
+        """Multi-layer extraction should create output directory and files."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import convert_wfs_layers_to_directory
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array(
+                    [
+                        b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?"
+                    ],
+                    type=pa.binary(),
+                ),
+                "name": pa.array(["test"]),
+            }
+        )
+
+        output_dir = tmp_path / "output"
+
+        with (
+            patch("geoparquet_io.core.wfs.wfs_to_table", return_value=mock_table),
+            patch("geoparquet_io.core.wfs.configure_verbose"),
+        ):
+            results = convert_wfs_layers_to_directory(
+                service_url="http://mock/wfs",
+                typenames=["layer1", "layer2"],
+                output_dir=str(output_dir),
+                skip_hilbert=True,
+                skip_bbox=True,
+            )
+
+        assert len(results) == 2
+        assert "layer1" in results
+        assert "layer2" in results
+        assert output_dir.exists()
+        assert (output_dir / "layer1.parquet").exists()
+        assert (output_dir / "layer2.parquet").exists()
+
+    def test_convert_wfs_layers_parallel_mode(self, tmp_path):
+        """Multi-layer extraction with parallel_layers > 1 should use ThreadPoolExecutor."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import convert_wfs_layers_to_directory
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array(
+                    [
+                        b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?"
+                    ],
+                    type=pa.binary(),
+                ),
+                "name": pa.array(["test"]),
+            }
+        )
+
+        output_dir = tmp_path / "output"
+
+        with (
+            patch("geoparquet_io.core.wfs.wfs_to_table", return_value=mock_table),
+            patch("geoparquet_io.core.wfs.configure_verbose"),
+        ):
+            results = convert_wfs_layers_to_directory(
+                service_url="http://mock/wfs",
+                typenames=["layer1", "layer2", "layer3"],
+                output_dir=str(output_dir),
+                parallel_layers=3,
+                skip_hilbert=True,
+                skip_bbox=True,
+            )
+
+        assert len(results) == 3
+
+    def test_cli_parses_comma_separated_typenames(self, tmp_path):
+        """CLI should parse comma-separated typenames for multi-layer mode."""
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        runner = CliRunner()
+
+        # Just test that the CLI parses correctly - don't actually extract
+        # Patch at the import location inside the function
+        with patch("geoparquet_io.core.wfs.convert_wfs_layers_to_directory") as mock_extract:
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "wfs",
+                    "http://mock/wfs",
+                    "layer1,layer2,layer3",
+                    str(output_dir),
+                    "--skip-hilbert",
+                    "--skip-bbox",
+                ],
+            )
+
+        # Should have called multi-layer function with parsed typenames
+        if result.exit_code == 0:
+            mock_extract.assert_called_once()
+            call_kwargs = mock_extract.call_args[1]
+            assert call_kwargs["typenames"] == ["layer1", "layer2", "layer3"]
+
+    def test_sanitizes_typename_for_filename(self, tmp_path):
+        """Typenames with colons should be sanitized for filenames."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import convert_wfs_layers_to_directory
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array(
+                    [
+                        b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?"
+                    ],
+                    type=pa.binary(),
+                ),
+                "name": pa.array(["test"]),
+            }
+        )
+
+        output_dir = tmp_path / "output"
+
+        with (
+            patch("geoparquet_io.core.wfs.wfs_to_table", return_value=mock_table),
+            patch("geoparquet_io.core.wfs.configure_verbose"),
+        ):
+            convert_wfs_layers_to_directory(
+                service_url="http://mock/wfs",
+                typenames=["ns:layer_name"],
+                output_dir=str(output_dir),
+                skip_hilbert=True,
+                skip_bbox=True,
+            )
+
+        # Colons should be replaced with underscores in filename
+        assert (output_dir / "ns_layer_name.parquet").exists()

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -3925,10 +3925,31 @@ class TestMultiLayerExtraction:
             )
 
         # Should have called multi-layer function with parsed typenames
-        if result.exit_code == 0:
-            mock_extract.assert_called_once()
-            call_kwargs = mock_extract.call_args[1]
-            assert call_kwargs["typenames"] == ["layer1", "layer2", "layer3"]
+        assert result.exit_code == 0
+        mock_extract.assert_called_once()
+        call_kwargs = mock_extract.call_args[1]
+        assert call_kwargs["typenames"] == ["layer1", "layer2", "layer3"]
+
+    def test_cli_rejects_empty_typenames(self, tmp_path):
+        """CLI should error (not IndexError) when typename parses to an empty list."""
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "extract",
+                "wfs",
+                "http://mock/wfs",
+                ", ,",  # whitespace/comma-only -> no valid typenames
+                str(tmp_path / "out.parquet"),
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "No valid typename" in result.output
 
     def test_sanitizes_typename_for_filename(self, tmp_path):
         """Typenames with colons should be sanitized for filenames."""


### PR DESCRIPTION
## Summary

- **Auto-tiling**: Detects server maxFeatures caps (e.g., 1M) and automatically subdivides bbox to fetch all features
- **Larger page size**: Default 10K→100K, max 100K→500K (fewer HTTP roundtrips)
- **WGS84 bbox**: Always use EPSG:4326 for bbox filter (most GeoServer instances expect this)
- **Multi-layer parallel**: New `--parallel-layers` option for concurrent layer extraction
- **Python API**: New `from_wfs_layers()` function

## Performance

| Metric | Before | After |
|--------|--------|-------|
| IDECOR (1.63M features) | 1M (capped) | **1,626,067** (full) |
| Time | 15+ min | **3:08** |
| User intervention | Manual bbox splitting | **Automatic** |

## Test plan

- [x] All 194 WFS tests pass
- [x] Pre-commit hooks pass
- [x] Verified on real IDECOR endpoint with 1.63M features
- [x] Auto-tiling triggers correctly when server caps response
- [x] User warnings display when auto-tiling activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parallel multi-layer WFS extraction to the CLI via comma-separated typenames with `--parallel-layers`, outputting one parquet per layer into a directory.
  * Added `from_wfs_layers` API to export multiple WFS layers concurrently to a directory.

* **Improvements**
  * Increased default `page_size` from 10,000 to 100,000.
  * Improved auto-tiling behavior for capped servers; added `--auto-tile/--no-auto-tile`.
  * Increased default shared HTTP connection pool from 20 to 50.

* **Bug Fixes**
  * Standardized WFS bbox requests for WFS 1.1.0+ to use WGS84 lon/lat.

* **Documentation**
  * Updated CLI and Python docs with new options, defaults, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->