### PR TITLE
fix(wfs): auto-tiling fails with --workers > 1

### DIFF
--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -2104,6 +2104,7 @@ def fetch_all_features_duckdb(
     axis_order: str = "auto",
     extract_fid: bool = False,
     sort_by: str | None = None,
+    total_count: int | None = None,
 ) -> pa.Table:
     """
     Fetch WFS features via Python httpx download and DuckDB local parsing.
@@ -2129,14 +2130,17 @@ def fetch_all_features_duckdb(
         axis_order: Bbox axis order ("auto", "xy", "latlon")
         extract_fid: If True, extract WFS feature IDs for deduplication
         sort_by: Attribute to sort by for stable pagination (auto-detected if None)
+        total_count: Pre-fetched feature count (avoids re-querying at this version).
+            Pass this when the caller already has a trusted count from WFS 2.0.0.
 
     Returns:
         PyArrow Table with geometry (WKB) and all properties
     """
-    # Get expected count for progress and pagination
-    total_count = _get_feature_count(
-        service_url, typename, version, bbox=bbox, crs=crs, axis_order=axis_order
-    )
+    # Use provided count or query at this version
+    if total_count is None:
+        total_count = _get_feature_count(
+            service_url, typename, version, bbox=bbox, crs=crs, axis_order=axis_order
+        )
     if max_features and total_count:
         total_count = min(total_count, max_features)
 
@@ -2261,13 +2265,17 @@ def _looks_like_server_cap(count: int) -> bool:
     """Check if a feature count looks like a server-imposed cap.
 
     Server caps are typically round numbers like 1000000, 500000, 100000, etc.
+    Parallel workers may drift slightly past exact caps due to network retries
+    (e.g., 1,000,002 instead of 1,000,000), so we allow ±0.1% tolerance around
+    common cap values (issue #503).
     """
     if count <= 0:
         return False
-    # Check for common cap values
+    # Check for common cap values with ±0.1% tolerance for parallel-worker drift
     common_caps = {1000000, 500000, 100000, 50000, 10000}
-    if count in common_caps:
-        return True
+    for cap in common_caps:
+        if abs(count - cap) <= cap * 0.001:
+            return True
     # Check if it's a round number (divisible by 10000 with at least 5 digits)
     if count >= 10000 and count % 10000 == 0:
         return True
@@ -2429,7 +2437,8 @@ def wfs_to_table(
             sort_by=effective_sort_by,
         )
     else:
-        # Normal fetch
+        # Normal fetch — pass expected_count so we don't re-query at this version
+        # (some servers return different counts by WFS version; issue #503)
         table = fetch_all_features_duckdb(
             service_url=service_url,
             typename=layer_info.typename,
@@ -2441,6 +2450,7 @@ def wfs_to_table(
             page_size=page_size,
             axis_order=axis_order,
             sort_by=effective_sort_by,
+            total_count=expected_count,
         )
 
         # Check for maxFeatures cap (reactive tiling)

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -3820,6 +3820,169 @@ class TestFetchWithSpatialTiles:
         mock_tile.assert_not_called()
 
 
+class TestServerCapDetection:
+    """Cap detection must tolerate slight count drift (issue #503).
+
+    Parallel workers retry pages on transient errors, which can nudge the total
+    a few features past an exact server cap (e.g. 1,000,002 instead of
+    1,000,000). The detector must still recognise these as caps so reactive
+    auto-tiling fires.
+    """
+
+    def test_exact_common_caps_detected(self):
+        from geoparquet_io.core.wfs import _looks_like_server_cap
+
+        for cap in (1000000, 500000, 100000, 50000, 10000):
+            assert _looks_like_server_cap(cap) is True
+
+    def test_slight_drift_above_cap_detected(self):
+        """The core #503 bug: parallel-worker drift past a round cap."""
+        from geoparquet_io.core.wfs import _looks_like_server_cap
+
+        assert _looks_like_server_cap(1000002) is True
+        assert _looks_like_server_cap(1000500) is True  # +0.05%
+
+    def test_slight_drift_below_cap_detected(self):
+        from geoparquet_io.core.wfs import _looks_like_server_cap
+
+        assert _looks_like_server_cap(999998) is True
+        assert _looks_like_server_cap(49997) is True
+
+    def test_outside_tolerance_not_detected(self):
+        """Counts beyond ±0.1% of a cap (and not round) are real totals."""
+        from geoparquet_io.core.wfs import _looks_like_server_cap
+
+        assert _looks_like_server_cap(1002000) is False  # +0.2%, not round
+        assert _looks_like_server_cap(1234567) is False
+
+    def test_round_numbers_still_detected(self):
+        """Existing divisible-by-10000 heuristic is preserved."""
+        from geoparquet_io.core.wfs import _looks_like_server_cap
+
+        assert _looks_like_server_cap(1230000) is True
+        assert _looks_like_server_cap(40000) is True
+
+    def test_zero_and_negative_not_detected(self):
+        from geoparquet_io.core.wfs import _looks_like_server_cap
+
+        assert _looks_like_server_cap(0) is False
+        assert _looks_like_server_cap(-5) is False
+
+    def test_reactive_tiling_triggers_on_drifted_cap(self):
+        """End-to-end: a capped response of 10,005 (drifted from 10,000) with a
+        higher 2.0.0 count must trigger reactive spatial tiling (issue #503)."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        # Build a real table whose row count looks like a drifted server cap.
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            capped_table = (
+                con.execute("SELECT ST_AsWKB(ST_Point(0, 0)) AS geometry FROM range(10005)")
+                .arrow()
+                .read_all()
+            )
+        finally:
+            con.close()
+
+        tiled_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01"], type=pa.binary()),
+                "name": pa.array(["full"]),
+            }
+        )
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs.negotiate_wfs_version", return_value=("1.1.0", MagicMock())
+            ),
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_info,
+            # 2.0.0 reports the true count; the capped fetch returns fewer.
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=11000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=capped_table),
+            patch(
+                "geoparquet_io.core.wfs._fetch_with_spatial_tiles", return_value=tiled_table
+            ) as mock_tile,
+        ):
+            mock_info.return_value = MagicMock(
+                typename="layer",
+                title="Layer",
+                crs_list=["EPSG:4326"],
+                default_crs="EPSG:4326",
+                available_formats=["application/json"],
+                bbox=(3.0, 50.0, 7.0, 54.0),
+            )
+            wfs_to_table("http://mock/wfs", "layer", auto_tile=True)
+
+        mock_tile.assert_called_once()
+
+
+class TestCountThreadedToFetch:
+    """The trusted 2.0.0 count must be threaded into the fetch (issue #503).
+
+    Previously ``fetch_all_features_duckdb`` re-queried the count at the
+    requested version (e.g. 1.1.0), which on some GeoServer instances returns a
+    DIFFERENT (capped) number than 2.0.0 — so pagination stopped early.
+    """
+
+    def test_fetch_uses_provided_total_count(self):
+        """When total_count is passed, fetch must not re-query the count."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import fetch_all_features_duckdb
+
+        # Table size must match total_count to avoid fallback to pagination
+        small_table = pa.table({"geometry": pa.array([b"\x01"], type=pa.binary())})
+
+        with (
+            patch("geoparquet_io.core.wfs._get_feature_count") as mock_count,
+            patch("geoparquet_io.core.wfs._single_fetch_mode", return_value=small_table),
+        ):
+            fetch_all_features_duckdb("http://mock/wfs", "layer", version="1.1.0", total_count=1)
+
+        mock_count.assert_not_called()
+
+    def test_wfs_to_table_threads_count_into_fetch(self):
+        """wfs_to_table must pass the 2.0.0 expected_count as total_count."""
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs.negotiate_wfs_version", return_value=("1.1.0", MagicMock())
+            ),
+            patch("geoparquet_io.core.wfs.get_layer_info") as mock_info,
+            patch("geoparquet_io.core.wfs._get_feature_count", return_value=20000),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
+            patch(
+                "geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=mock_table
+            ) as mock_fetch,
+        ):
+            mock_info.return_value = MagicMock(
+                typename="layer",
+                title="Layer",
+                crs_list=["EPSG:4326"],
+                default_crs="EPSG:4326",
+                available_formats=["application/json"],
+                bbox=(3.0, 50.0, 7.0, 54.0),
+            )
+            wfs_to_table("http://mock/wfs", "layer", auto_tile=True)
+
+        mock_fetch.assert_called_once()
+        assert mock_fetch.call_args.kwargs.get("total_count") == 20000
+
+
 class TestMultiLayerExtraction:
     """Tests for multi-layer parallel extraction."""
 


### PR DESCRIPTION
## Summary

Fixes #503. Two bugs caused auto-tiling to fail when using parallel workers:

- **Version mismatch:** `wfs_to_table` queried WFS 2.0.0 for feature count (returns true count), but `fetch_all_features_duckdb` re-queried at 1.1.0 (returns capped count on some servers). Pagination stopped early, silently truncating data.
- **Strict cap detection:** `_looks_like_server_cap()` only matched exact round numbers. Parallel retries can drift past exact caps (e.g., 1,000,002 instead of 1,000,000), bypassing reactive tiling.

## Changes

- Add `total_count` param to `fetch_all_features_duckdb` and thread the trusted 2.0.0 count through
- Allow ±0.1% tolerance around common cap values while preserving the divisible-by-10000 heuristic

## Test plan

- [x] Unit tests for cap detection tolerance (exact caps, drift above/below, outside tolerance)
- [x] Integration test for reactive tiling with drifted cap
- [x] Integration test confirming count is threaded without re-query
- [x] All 204 WFS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized WFS feature fetching to avoid redundant count queries and improve pagination efficiency.

* **Bug Fixes**
  * Enhanced server capability detection to better tolerate minor count variations under concurrent operations, improving reliability when auto-tiling is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->