### PR TITLE
feat(carto): extract non-geo (tabular) tables to plain Parquet (issue #508)

### DIFF
--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1369,6 +1369,49 @@ gpio extract carto https://phl.carto.com opa_properties_public output.parquet
 
 Carto tables typically have geometry in a column named `the_geom` (WGS84). This is automatically renamed to `geometry` in the output for consistency with other geoparquet-io extractors.
 
+### Non-Geometry (Tabular) Tables
+
+Carto accounts often include geometry-less lookup or demographics tables. `gpio` auto-detects these from the table schema and extracts them as **plain Parquet** (no GeoParquet `geo` metadata key) — the same behavior as converting a non-spatial file. Hilbert ordering, the bbox column, and `--bbox` filtering are skipped (they require geometry); `--where`, `--limit`, `--include-cols`, and `--exclude-cols` are still honored.
+
+Use `--geometry` / `--no-geometry` to override auto-detection:
+
+=== "CLI"
+
+    ```bash
+    # Auto-detect (default): plain Parquet if the table has no geometry
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        my_lookup_table output.parquet
+
+    # Force tabular extraction (plain Parquet, no geo metadata)
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        my_lookup_table output.parquet \
+        --no-geometry
+
+    # Force geometry extraction (GeoParquet)
+    gpio extract carto https://phl.carto.com/api/v2/sql \
+        opa_properties_public output.parquet \
+        --geometry
+    ```
+
+=== "Python"
+
+    ```python
+    from geoparquet_io.api import ops
+
+    # Auto-detect (default): returns a plain table for geometry-less sources
+    table = ops.from_carto(
+        'https://phl.carto.com/api/v2/sql',
+        'my_lookup_table',
+    )
+
+    # Force tabular extraction
+    table = ops.from_carto(
+        'https://phl.carto.com/api/v2/sql',
+        'my_lookup_table',
+        geometry=False,
+    )
+    ```
+
 ### Output Optimization
 
 By default, Carto extracts include Hilbert spatial ordering and bbox columns:

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1371,7 +1371,10 @@ Carto tables typically have geometry in a column named `the_geom` (WGS84). This 
 
 ### Non-Geometry (Tabular) Tables
 
-Carto accounts often include geometry-less lookup or demographics tables. `gpio` auto-detects these from the table schema and extracts them as **plain Parquet** (no GeoParquet `geo` metadata key) — the same behavior as converting a non-spatial file. Hilbert ordering, the bbox column, and `--bbox` filtering are skipped (they require geometry); `--where`, `--limit`, `--include-cols`, and `--exclude-cols` are still honored.
+Carto accounts often include geometry-less lookup or demographics tables. `gpio` auto-detects these and extracts them as **plain Parquet** (no GeoParquet `geo` metadata key) — the same behavior as converting a non-spatial file. Hilbert ordering, the bbox column, and `--bbox` filtering are skipped (they require geometry); `--where`, `--limit`, `--include-cols`, and `--exclude-cols` are still honored.
+
+!!! note "How detection works"
+    Carto attaches a `the_geom` column (type `geometry`) to nearly every managed table — even purely tabular ones, where it is entirely `NULL`. So inspecting the schema alone isn't enough. `gpio` first checks the schema for a geometry-typed column, then runs a fast `WHERE the_geom IS NOT NULL LIMIT 1` probe to confirm the column actually holds geometry before choosing the GeoParquet path.
 
 Use `--geometry` / `--no-geometry` to override auto-detection:
 

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1034,27 +1034,37 @@ def from_carto(
     api_key: str | None = None,
     timeout: float = 120.0,
     repair_geometry: bool = True,
+    geometry: bool | None = None,
 ) -> pa.Table:
     """
     Fetch Carto SQL API table as PyArrow Table.
 
-    Uses DuckDB's ST_Read for efficient GeoJSON parsing from Carto's SQL API.
-    Filters are pushed to the server for optimal performance.
+    Geometry tables are parsed via DuckDB's ST_Read (GeoJSON) and carry
+    GeoParquet metadata. Geometry-less (tabular) tables are fetched as CSV and
+    returned as a plain table with no ``geo`` metadata. Filters are pushed to
+    the server for optimal performance.
 
     Args:
         url: Carto SQL API URL (e.g., 'https://phl.carto.com/api/v2/sql')
             or base domain (e.g., 'https://phl.carto.com')
         table_name: Name of the table to query
         where: SQL WHERE clause for filtering
-        bbox: Optional bounding box filter (xmin, ymin, xmax, ymax) in WGS84
+        bbox: Optional bounding box filter (xmin, ymin, xmax, ymax) in WGS84.
+            Ignored for geometry-less tables.
         limit: Maximum rows to fetch
         include_cols: Comma-separated columns to include
         exclude_cols: Comma-separated columns to exclude
         api_key: API key for authenticated requests (or set CARTO_API_KEY env var)
         timeout: Request timeout in seconds (default: 120)
+        repair_geometry: Repair invalid geometry with ST_MakeValid (geometry
+            tables only; default: True)
+        geometry: Extraction mode. ``None`` (default) auto-detects from the
+            table schema; ``True`` forces geometry extraction; ``False`` forces
+            plain/tabular extraction (no ``geo`` metadata).
 
     Returns:
-        PyArrow Table with geometry column named 'geometry'
+        PyArrow Table. For geometry tables, a 'geometry' column with GeoParquet
+        metadata; for tabular tables, a plain table with no ``geo`` metadata.
 
     Note:
         The Carto geometry column 'the_geom' is renamed to 'geometry'
@@ -1091,6 +1101,7 @@ def from_carto(
         api_key=api_key,
         timeout=timeout,
         repair_geometry=repair_geometry,
+        geometry=geometry,
     )
 
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3376,6 +3376,13 @@ def extract_wfs_cmd(
     is_flag=True,
     help="Skip adding bbox column (faster, but no per-geometry bbox)",
 )
+@click.option(
+    "--geometry/--no-geometry",
+    "geometry",
+    default=None,
+    help="Force geometry (GeoParquet) or plain tabular (plain Parquet) "
+    "extraction. Default: auto-detect from the table schema.",
+)
 @compression_options
 @row_group_options
 @geoparquet_version_option
@@ -3398,6 +3405,7 @@ def extract_carto_cmd(
     timeout,
     skip_hilbert,
     skip_bbox,
+    geometry,
     compression,
     compression_level,
     row_group_size,
@@ -3422,7 +3430,11 @@ def extract_carto_cmd(
     \b
     Notes:
         - Geometry column 'the_geom' is renamed to 'geometry' for consistency
+        - Tables with no geometry are written as plain Parquet (no geo metadata);
+          use --no-geometry to force tabular extraction or --geometry to force
+          GeoParquet (default: auto-detect)
         - Filters (--where, --bbox) are pushed to the server for efficiency
+          (--bbox applies only to geometry tables)
         - For large tables, use --limit or --where to avoid timeouts
         - Set CARTO_API_KEY env var for authenticated endpoints
 
@@ -3497,6 +3509,7 @@ def extract_carto_cmd(
                 overwrite=overwrite,
                 verbose=verbose,
                 repair_geometry=repair_geometry,
+                geometry=geometry,
             )
         except CartoError as e:
             raise click.ClickException(str(e)) from None

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -63,10 +63,12 @@ def _validate_carto_url(url: str) -> str:
     url = url.rstrip("/")
     parsed = urlparse(url)
 
-    if not parsed.scheme:
+    # Restrict to http(s) — rejects empty, file://, and other schemes so the
+    # URL can be safely handed to urllib.request.urlopen (see _carto_sql_json).
+    if parsed.scheme not in ("http", "https"):
         raise InvalidParameterError(
             "url",
-            f"Invalid URL: {url}. Must include scheme (https://)",
+            f"Invalid URL: {url}. Must include an http:// or https:// scheme",
         )
 
     # Accept URLs ending with /api/v2/sql or /api/v1/sql
@@ -248,7 +250,7 @@ def _geometry_column_from_fields(fields: object) -> str | None:
         return None
     for col_name, descriptor in fields.items():
         if isinstance(descriptor, dict) and descriptor.get("type") == "geometry":
-            return col_name
+            return str(col_name)
     return None
 
 
@@ -271,8 +273,9 @@ def _carto_sql_json(
         full_url += f"&api_key={quote(api_key)}"
 
     try:
+        # url scheme is constrained to http(s) by _validate_carto_url upstream.
         request = urllib.request.Request(full_url, headers={"User-Agent": "geoparquet-io"})
-        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310  # nosec B310
             payload = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, OSError, ValueError) as e:
         raise CartoError(f"Carto SQL request failed: {e}") from e

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 import os
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 from urllib.parse import quote, urlparse
 
@@ -114,6 +116,7 @@ def _build_carto_query(
     where: str | None = None,
     bbox: tuple[float, float, float, float] | None = None,
     limit: int | None = None,
+    include_geom: bool = True,
 ) -> str:
     """Build SQL query for Carto API.
 
@@ -123,6 +126,10 @@ def _build_carto_query(
         where: SQL WHERE clause (user-provided, passed through)
         bbox: Bounding box filter (minx, miny, maxx, maxy)
         limit: Maximum rows to return
+        include_geom: When True (geometry extraction), force-include ``the_geom``
+            in an explicit column list and honor the ``bbox`` spatial filter.
+            When False (plain/tabular extraction), neither applies since the
+            table has no geometry column.
 
     Returns:
         SQL query string
@@ -138,8 +145,8 @@ def _build_carto_query(
 
     # Column selection - quote each column name
     if columns:
-        # Always include the_geom for geometry
-        if "the_geom" not in columns:
+        # Always include the_geom for geometry extraction
+        if include_geom and "the_geom" not in columns:
             columns = [*columns, "the_geom"]
         col_str = ", ".join(quote_identifier(c) for c in columns)
     else:
@@ -152,7 +159,7 @@ def _build_carto_query(
     if where:
         # WHERE clause is user-provided - Carto validates on server side
         conditions.append(f"({where})")
-    if bbox:
+    if bbox and include_geom:
         minx, miny, maxx, maxy = bbox
         # Use ST_Intersects with ST_MakeEnvelope for spatial filter
         # the_geom is quoted for safety
@@ -222,6 +229,101 @@ def _get_row_count(
     return int(result[0]) if result else 0
 
 
+def _geometry_column_from_fields(fields: object) -> str | None:
+    """Return the first geometry column from a Carto ``fields`` schema block.
+
+    Carto's SQL API returns a ``fields`` object mapping each column name to a
+    descriptor whose ``type`` is ``"geometry"`` for spatial columns. This pure
+    helper inspects that mapping so callers can decide between geometry and
+    plain/tabular extraction without a second request.
+
+    Args:
+        fields: The ``fields`` value from a Carto SQL API JSON response.
+
+    Returns:
+        Name of the first column whose type is ``"geometry"``, or None if the
+        schema has no geometry column (or is malformed).
+    """
+    if not isinstance(fields, dict):
+        return None
+    for col_name, descriptor in fields.items():
+        if isinstance(descriptor, dict) and descriptor.get("type") == "geometry":
+            return col_name
+    return None
+
+
+def _detect_geometry_column(
+    url: str,
+    table_name: str,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> str | None:
+    """Probe the Carto SQL API for a geometry column.
+
+    Issues ``SELECT * FROM <table> LIMIT 0`` (returns only the schema, no rows)
+    and inspects the ``fields`` block. This is cheap and lets the extractor
+    route geometry-less tables to a plain-Parquet path.
+
+    Args:
+        url: Carto SQL API URL (already normalized)
+        table_name: Table to inspect
+        api_key: Optional API key for authenticated requests
+        timeout: Request timeout in seconds
+
+    Returns:
+        Name of the first geometry column, or None if the table has none.
+
+    Raises:
+        CartoError: If the probe request fails (network/HTTP/parse error) or
+            the API returns an error payload.
+    """
+    _validate_table_name(table_name)
+    quoted_table = quote_identifier(table_name)
+    sql = f"SELECT * FROM {quoted_table} LIMIT 0"
+    full_url = f"{url}?q={quote(sql)}"
+    if api_key:
+        full_url += f"&api_key={quote(api_key)}"
+
+    try:
+        request = urllib.request.Request(full_url, headers={"User-Agent": "geoparquet-io"})
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        raise CartoError(f"Failed to probe schema for table '{table_name}': {e}") from e
+
+    if isinstance(payload, dict) and payload.get("error"):
+        raise CartoError(f"Carto API error probing table '{table_name}': {payload['error']}")
+
+    fields = payload.get("fields") if isinstance(payload, dict) else None
+    return _geometry_column_from_fields(fields)
+
+
+def _table_has_geometry(
+    url: str,
+    table_name: str,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> bool:
+    """Decide whether a Carto table should be extracted as geometry.
+
+    Wraps :func:`_detect_geometry_column`. If the probe is inconclusive (network
+    error, etc.) we fall back to the geometry path so the normal extraction and
+    error handling apply — preserving prior behavior for transient failures.
+    """
+    try:
+        geom_col = _detect_geometry_column(url, table_name, api_key, timeout)
+    except CartoError as e:
+        debug(f"Geometry detection inconclusive ({e}); assuming geometry present")
+        return True
+
+    if geom_col:
+        debug(f"Detected geometry column: {geom_col}")
+        return True
+
+    debug("No geometry column detected; extracting as plain table")
+    return False
+
+
 def _create_empty_geoparquet_table(geoparquet_version: str | None = None) -> pa.Table:
     """Create an empty table with proper GeoParquet metadata.
 
@@ -255,6 +357,7 @@ def _fetch_with_retry(
     url: str,
     table_name: str,
     sql: str,
+    fmt: str = "GeoJSON",
     api_key: str | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     max_retries: int = DEFAULT_MAX_RETRIES,
@@ -266,21 +369,31 @@ def _fetch_with_retry(
         url: Carto SQL API URL
         table_name: Table name (for error messages)
         sql: SQL query to execute
+        fmt: Carto response format. ``"GeoJSON"`` (default) parses geometry via
+            DuckDB ``ST_Read``; ``"csv"`` reads geometry-less tables via
+            ``read_csv_auto`` for plain/tabular extraction.
         api_key: Optional API key
         timeout: Request timeout in seconds
         max_retries: Number of retry attempts
         retry_delay: Base delay between retries (exponential backoff)
 
     Returns:
-        PyArrow Table from DuckDB ST_Read
+        PyArrow Table from DuckDB
 
     Raises:
         CartoError: On fatal errors or exhausted retries
     """
-    # Construct full URL with GeoJSON format
-    full_url = f"{url}?q={quote(sql)}&format=GeoJSON"
+    # Construct full URL with the requested response format
+    fmt_param = "GeoJSON" if fmt == "GeoJSON" else "csv"
+    full_url = f"{url}?q={quote(sql)}&format={fmt_param}"
     if api_key:
         full_url += f"&api_key={quote(api_key)}"
+
+    # GeoJSON is parsed with ST_Read; CSV (geometry-less) with read_csv_auto.
+    if fmt == "GeoJSON":
+        read_expr = f'ST_Read("{full_url}")'
+    else:
+        read_expr = f"read_csv_auto('{full_url}')"
 
     debug(f"Request URL: {full_url[:100]}...")
 
@@ -292,7 +405,7 @@ def _fetch_with_retry(
             conn.execute("SET allow_asterisks_in_http_paths = true")
             conn.execute(f"SET http_timeout = {int(timeout * 1000)}")  # milliseconds
 
-            table = conn.execute(f'SELECT * FROM ST_Read("{full_url}")').arrow().read_all()
+            table = conn.execute(f"SELECT * FROM {read_expr}").arrow().read_all()
             return table
 
         except Exception as e:
@@ -363,17 +476,22 @@ def carto_to_table(
     geoparquet_version: str | None = None,
     verbose: bool = False,
     repair_geometry: bool = True,
+    geometry: bool | None = None,
 ) -> pa.Table:
     """Extract data from Carto SQL API to PyArrow Table.
 
-    Uses DuckDB's ST_Read to efficiently parse GeoJSON from Carto's
-    SQL API endpoint.
+    For tables with a geometry column, DuckDB's ``ST_Read`` parses Carto's
+    GeoJSON output and the result carries GeoParquet ``geo`` metadata. For
+    geometry-less (tabular) tables, the data is fetched as CSV and returned as a
+    plain table with **no** ``geo`` metadata, mirroring gpio's file-conversion
+    behavior for non-spatial inputs.
 
     Args:
         url: Carto SQL API URL (e.g., https://phl.carto.com/api/v2/sql)
         table_name: Name of the table to query
         where: SQL WHERE clause for filtering
-        bbox: Bounding box filter as (minx, miny, maxx, maxy) in WGS84
+        bbox: Bounding box filter as (minx, miny, maxx, maxy) in WGS84.
+            Ignored for geometry-less tables.
         limit: Maximum number of rows to return
         include_cols: Comma-separated column names to include
         exclude_cols: Comma-separated column names to exclude (applied after fetch)
@@ -382,9 +500,15 @@ def carto_to_table(
         max_retries: Number of retry attempts for transient failures (default: 3)
         geoparquet_version: GeoParquet version for metadata (default: "1.1.0")
         verbose: Enable verbose output
+        repair_geometry: Repair invalid geometry with ST_MakeValid (geometry
+            tables only; default: True).
+        geometry: Extraction mode. ``None`` (default) auto-detects from the
+            table schema; ``True`` forces geometry extraction (GeoParquet);
+            ``False`` forces plain/tabular extraction (no ``geo`` metadata).
 
     Returns:
-        PyArrow Table with WKB geometry column named 'geometry'
+        PyArrow Table. For geometry tables, a WKB geometry column named
+        'geometry' with GeoParquet metadata; for tabular tables, a plain table.
 
     Raises:
         CartoError: If the Carto API request fails
@@ -405,9 +529,62 @@ def carto_to_table(
     include_list = [c.strip() for c in include_cols.split(",")] if include_cols else None
     exclude_set = {c.strip() for c in exclude_cols.split(",")} if exclude_cols else set()
 
+    # Decide between geometry and plain/tabular extraction.
+    if geometry is None:
+        has_geometry = _table_has_geometry(url, table_name, effective_api_key, timeout)
+    else:
+        has_geometry = geometry
+
+    if not has_geometry:
+        if bbox:
+            warn("Ignoring --bbox: table has no geometry column (tabular extraction)")
+        return _carto_plain_table(
+            url,
+            table_name,
+            where=where,
+            limit=limit,
+            include_list=include_list,
+            exclude_set=exclude_set,
+            api_key=effective_api_key,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
+    return _carto_geo_table(
+        url,
+        table_name,
+        where=where,
+        bbox=bbox,
+        limit=limit,
+        include_list=include_list,
+        exclude_set=exclude_set,
+        api_key=effective_api_key,
+        timeout=timeout,
+        max_retries=max_retries,
+        geoparquet_version=geoparquet_version,
+        repair_geometry=repair_geometry,
+    )
+
+
+def _carto_geo_table(
+    url: str,
+    table_name: str,
+    *,
+    where: str | None,
+    bbox: tuple[float, float, float, float] | None,
+    limit: int | None,
+    include_list: list[str] | None,
+    exclude_set: set[str],
+    api_key: str | None,
+    timeout: float,
+    max_retries: int,
+    geoparquet_version: str | None,
+    repair_geometry: bool,
+) -> pa.Table:
+    """Extract a Carto table with geometry to a GeoParquet-ready PyArrow Table."""
     # Get row count for progress
     try:
-        total_count = _get_row_count(url, table_name, where, bbox, effective_api_key, timeout)
+        total_count = _get_row_count(url, table_name, where, bbox, api_key, timeout)
         info(f"Table: {table_name}")
         info(f"Total rows matching filter: {total_count:,}")
     except Exception as e:
@@ -434,7 +611,8 @@ def carto_to_table(
         url=url,
         table_name=table_name,
         sql=sql,
-        api_key=effective_api_key,
+        fmt="GeoJSON",
+        api_key=api_key,
         timeout=timeout,
         max_retries=max_retries,
     )
@@ -497,6 +675,68 @@ def carto_to_table(
     return table
 
 
+def _carto_plain_table(
+    url: str,
+    table_name: str,
+    *,
+    where: str | None,
+    limit: int | None,
+    include_list: list[str] | None,
+    exclude_set: set[str],
+    api_key: str | None,
+    timeout: float,
+    max_retries: int,
+) -> pa.Table:
+    """Extract a geometry-less Carto table to a plain PyArrow Table.
+
+    Fetches via the SQL API's CSV format (no geometry required) and returns a
+    table with no GeoParquet ``geo`` metadata. ``bbox`` does not apply here.
+    """
+    # Get row count for progress (no spatial filter for tabular tables)
+    try:
+        total_count = _get_row_count(url, table_name, where, None, api_key, timeout)
+        info(f"Table: {table_name} (no geometry — extracting as plain table)")
+        info(f"Total rows matching filter: {total_count:,}")
+    except Exception as e:
+        debug(f"Could not get row count: {e}")
+
+    # Build query without geometry/bbox
+    sql = _build_carto_query(
+        table_name=table_name,
+        columns=include_list,
+        where=where,
+        limit=limit,
+        include_geom=False,
+    )
+    debug(f"SQL: {sql}")
+
+    # Fetch data with retry logic (CSV format)
+    progress("Fetching data from Carto...")
+    table = _fetch_with_retry(
+        url=url,
+        table_name=table_name,
+        sql=sql,
+        fmt="csv",
+        api_key=api_key,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+
+    if table.num_rows == 0:
+        warn("Query returned no rows")
+
+    debug(f"Received {table.num_rows:,} rows")
+
+    # Apply column exclusions (no geometry to protect here)
+    if exclude_set:
+        cols_to_keep = [c for c in table.column_names if c not in exclude_set]
+        table = table.select(cols_to_keep)
+        debug(f"Excluded columns: {exclude_set}")
+
+    success(f"Extracted {table.num_rows:,} rows (plain table, no geometry)")
+    return table
+
+
 def convert_carto_to_geoparquet(
     url: str,
     table_name: str,
@@ -520,23 +760,30 @@ def convert_carto_to_geoparquet(
     overwrite: bool = False,
     verbose: bool = False,
     repair_geometry: bool = True,
+    geometry: bool | None = None,
 ) -> None:
-    """Extract Carto table and save as optimized GeoParquet.
+    """Extract Carto table and save as optimized GeoParquet or plain Parquet.
+
+    Geometry tables are written as optimized GeoParquet (Hilbert-sorted, bbox
+    column). Geometry-less (tabular) tables are written as plain Parquet with no
+    ``geo`` metadata, and Hilbert/bbox steps are skipped since they require
+    geometry.
 
     Args:
         url: Carto SQL API URL
         table_name: Name of the table to query
-        output_file: Output GeoParquet file path
+        output_file: Output Parquet file path
         where: SQL WHERE clause for filtering
-        bbox: Bounding box filter as (minx, miny, maxx, maxy)
+        bbox: Bounding box filter as (minx, miny, maxx, maxy). Ignored for
+            geometry-less tables.
         limit: Maximum rows to extract
         include_cols: Comma-separated columns to include
         exclude_cols: Comma-separated columns to exclude
         api_key: API key for authenticated requests (or set CARTO_API_KEY env var)
         timeout: Request timeout in seconds (default: 120)
         max_retries: Number of retry attempts (default: 3)
-        skip_hilbert: Skip Hilbert curve sorting
-        skip_bbox: Skip adding bbox column
+        skip_hilbert: Skip Hilbert curve sorting (geometry tables only)
+        skip_bbox: Skip adding bbox column (geometry tables only)
         compression: Compression algorithm
         compression_level: Compression level
         row_group_size_mb: Row group size in MB
@@ -546,6 +793,9 @@ def convert_carto_to_geoparquet(
         verbose: Enable verbose output
         repair_geometry: Repair invalid geometry with ST_MakeValid (default: True).
             When False, invalid geometry is preserved and a warning reports the count.
+        geometry: Extraction mode. ``None`` (default) auto-detects from the
+            table schema; ``True`` forces GeoParquet output; ``False`` forces
+            plain/tabular Parquet output.
     """
     configure_verbose(verbose)
 
@@ -569,34 +819,43 @@ def convert_carto_to_geoparquet(
         geoparquet_version=geoparquet_version,
         verbose=verbose,
         repair_geometry=repair_geometry,
+        geometry=geometry,
     )
 
-    # Apply Hilbert ordering (unless skipped)
-    if not skip_hilbert and table.num_rows > 0:
+    # Plain/tabular tables carry no 'geo' metadata; Hilbert/bbox don't apply.
+    is_geo = bool(table.schema.metadata and b"geo" in table.schema.metadata)
+
+    # Apply Hilbert ordering (unless skipped, geometry only)
+    if is_geo and not skip_hilbert and table.num_rows > 0:
         progress("Applying Hilbert curve ordering...")
         from geoparquet_io.core.hilbert_order import hilbert_order_table
 
         table = hilbert_order_table(table, geometry_column="geometry")
         debug("Hilbert sort complete")
 
-    # Add bbox column (unless skipped)
-    if not skip_bbox and table.num_rows > 0:
+    # Add bbox column (unless skipped, geometry only)
+    if is_geo and not skip_bbox and table.num_rows > 0:
         progress("Adding bbox column...")
         from geoparquet_io.core.add.bbox import add_bbox_table
 
         table = add_bbox_table(table, geometry_column="geometry")
         debug("Bbox column added")
 
-    # Write output
+    # Write output. For plain/tabular tables pass an empty geometry_column so
+    # write_geoparquet_table skips its name-based auto-detection (which would
+    # otherwise mistake a Carto 'the_geom' string column for geometry) and emits
+    # plain Parquet with no 'geo' metadata key.
     progress(f"Writing to {output_file}...")
     write_geoparquet_table(
         table,
         output_file,
+        geometry_column=None if is_geo else "",
         compression=compression,
         compression_level=compression_level,
         row_group_size_mb=row_group_size_mb,
         row_group_rows=row_group_rows,
-        geoparquet_version=geoparquet_version,
+        geoparquet_version=geoparquet_version if is_geo else None,
     )
 
-    success(f"Wrote {table.num_rows:,} features to {output_file}")
+    noun = "features" if is_geo else "rows"
+    success(f"Wrote {table.num_rows:,} {noun} to {output_file}")

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -252,34 +252,20 @@ def _geometry_column_from_fields(fields: object) -> str | None:
     return None
 
 
-def _detect_geometry_column(
+def _carto_sql_json(
     url: str,
-    table_name: str,
+    sql: str,
     api_key: str | None = None,
     timeout: float = DEFAULT_TIMEOUT,
-) -> str | None:
-    """Probe the Carto SQL API for a geometry column.
+) -> dict:
+    """Run a SQL query against the Carto API and return the parsed JSON response.
 
-    Issues ``SELECT * FROM <table> LIMIT 0`` (returns only the schema, no rows)
-    and inspects the ``fields`` block. This is cheap and lets the extractor
-    route geometry-less tables to a plain-Parquet path.
-
-    Args:
-        url: Carto SQL API URL (already normalized)
-        table_name: Table to inspect
-        api_key: Optional API key for authenticated requests
-        timeout: Request timeout in seconds
-
-    Returns:
-        Name of the first geometry column, or None if the table has none.
+    Used for lightweight metadata/detection probes (schema, existence checks).
+    Bulk data is fetched via DuckDB in :func:`_fetch_with_retry` instead.
 
     Raises:
-        CartoError: If the probe request fails (network/HTTP/parse error) or
-            the API returns an error payload.
+        CartoError: On request/parse failure or an API error payload.
     """
-    _validate_table_name(table_name)
-    quoted_table = quote_identifier(table_name)
-    sql = f"SELECT * FROM {quoted_table} LIMIT 0"
     full_url = f"{url}?q={quote(sql)}"
     if api_key:
         full_url += f"&api_key={quote(api_key)}"
@@ -289,13 +275,69 @@ def _detect_geometry_column(
         with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
             payload = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, OSError, ValueError) as e:
-        raise CartoError(f"Failed to probe schema for table '{table_name}': {e}") from e
+        raise CartoError(f"Carto SQL request failed: {e}") from e
 
-    if isinstance(payload, dict) and payload.get("error"):
-        raise CartoError(f"Carto API error probing table '{table_name}': {payload['error']}")
+    if not isinstance(payload, dict):
+        raise CartoError("Unexpected Carto SQL API response (not a JSON object)")
+    if payload.get("error"):
+        raise CartoError(f"Carto API error: {payload['error']}")
+    return payload
 
-    fields = payload.get("fields") if isinstance(payload, dict) else None
-    return _geometry_column_from_fields(fields)
+
+def _detect_geometry_column(
+    url: str,
+    table_name: str,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> str | None:
+    """Probe the Carto SQL API for a geometry-typed column.
+
+    Issues ``SELECT * FROM <table> LIMIT 0`` (schema only, no rows) and inspects
+    the ``fields`` block for a column whose ``type`` is ``"geometry"``.
+
+    Note:
+        Carto attaches ``the_geom``/``the_geom_webmercator`` (type ``geometry``)
+        to nearly every managed table, even purely tabular ones where those
+        columns are entirely NULL. A column reported here therefore does *not*
+        guarantee the table actually holds geometry — confirm with
+        :func:`_geometry_column_has_values`.
+
+    Returns:
+        Name of the first geometry-typed column, or None if the schema has none.
+
+    Raises:
+        CartoError: If the probe request fails.
+    """
+    _validate_table_name(table_name)
+    quoted_table = quote_identifier(table_name)
+    payload = _carto_sql_json(url, f"SELECT * FROM {quoted_table} LIMIT 0", api_key, timeout)
+    return _geometry_column_from_fields(payload.get("fields"))
+
+
+def _geometry_column_has_values(
+    url: str,
+    table_name: str,
+    geom_col: str,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> bool:
+    """Probe whether a geometry column holds any non-NULL value.
+
+    Carto attaches an often entirely-NULL ``the_geom`` to managed tabular
+    tables, so the schema alone misclassifies them as spatial. A bounded
+    ``... WHERE <geom> IS NOT NULL LIMIT 1`` probe confirms real geometry
+    (returns instantly for spatial tables; ~sub-second even for large all-NULL
+    tables since Postgres stops at the first match / table statistics).
+
+    Raises:
+        CartoError: If the probe request fails.
+    """
+    _validate_table_name(table_name)
+    quoted_table = quote_identifier(table_name)
+    quoted_geom = quote_identifier(geom_col)
+    sql = f"SELECT 1 AS has_geom FROM {quoted_table} WHERE {quoted_geom} IS NOT NULL LIMIT 1"
+    payload = _carto_sql_json(url, sql, api_key, timeout)
+    return bool(payload.get("rows"))
 
 
 def _table_has_geometry(
@@ -306,22 +348,25 @@ def _table_has_geometry(
 ) -> bool:
     """Decide whether a Carto table should be extracted as geometry.
 
-    Wraps :func:`_detect_geometry_column`. If the probe is inconclusive (network
-    error, etc.) we fall back to the geometry path so the normal extraction and
-    error handling apply — preserving prior behavior for transient failures.
+    Two-step: (1) find a geometry-typed column in the schema; (2) confirm it
+    actually holds non-NULL geometry. Both are needed because Carto adds an
+    often-empty ``the_geom`` to managed tabular tables. If detection is
+    inconclusive (network error, etc.) we fall back to the geometry path so the
+    normal extraction and error handling apply.
     """
     try:
         geom_col = _detect_geometry_column(url, table_name, api_key, timeout)
+        if not geom_col:
+            debug("No geometry-typed column in schema; extracting as plain table")
+            return False
+        if _geometry_column_has_values(url, table_name, geom_col, api_key, timeout):
+            debug(f"Detected populated geometry column: {geom_col}")
+            return True
+        debug(f"Geometry column {geom_col!r} is entirely NULL; extracting as plain table")
+        return False
     except CartoError as e:
         debug(f"Geometry detection inconclusive ({e}); assuming geometry present")
         return True
-
-    if geom_col:
-        debug(f"Detected geometry column: {geom_col}")
-        return True
-
-    debug("No geometry column detected; extracting as plain table")
-    return False
 
 
 def _create_empty_geoparquet_table(geoparquet_version: str | None = None) -> pa.Table:

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -12,6 +12,8 @@ from geoparquet_io.core.carto import (
     CartoError,
     _build_carto_query,
     _create_empty_geoparquet_table,
+    _detect_geometry_column,
+    _geometry_column_from_fields,
     _validate_carto_url,
     _validate_table_name,
     carto_to_table,
@@ -151,6 +153,71 @@ class TestBuildCartoQuery:
         )
         assert "WHERE (status = 'active') AND ST_Intersects" in sql
         assert "LIMIT 100" in sql
+
+    def test_no_geom_does_not_force_the_geom(self):
+        """Tabular query (include_geom=False) does not append the_geom."""
+        sql = _build_carto_query("my_table", columns=["id", "name"], include_geom=False)
+        assert '"id"' in sql
+        assert '"name"' in sql
+        assert '"the_geom"' not in sql
+
+    def test_no_geom_ignores_bbox(self):
+        """Tabular query (include_geom=False) ignores the bbox spatial filter."""
+        sql = _build_carto_query(
+            "my_table",
+            bbox=(-75.2, 39.9, -75.1, 40.0),
+            include_geom=False,
+        )
+        assert "ST_Intersects" not in sql
+        assert "ST_MakeEnvelope" not in sql
+
+    def test_no_geom_honors_where_and_limit(self):
+        """Tabular query still applies where/limit filters."""
+        sql = _build_carto_query(
+            "my_table",
+            where="pop > 1000",
+            limit=50,
+            include_geom=False,
+        )
+        assert "WHERE (pop > 1000)" in sql
+        assert "LIMIT 50" in sql
+
+
+class TestGeometryColumnFromFields:
+    """Tests for the pure Carto fields-schema geometry parser."""
+
+    def test_detects_the_geom(self):
+        """A field with type 'geometry' is detected."""
+        fields = {
+            "cartodb_id": {"type": "number"},
+            "the_geom": {"type": "geometry"},
+            "name": {"type": "string"},
+        }
+        assert _geometry_column_from_fields(fields) == "the_geom"
+
+    def test_no_geometry_returns_none(self):
+        """Schema with only scalar columns returns None."""
+        fields = {
+            "id": {"type": "number"},
+            "name": {"type": "string"},
+            "value": {"type": "number"},
+        }
+        assert _geometry_column_from_fields(fields) is None
+
+    def test_webmercator_geometry_detected(self):
+        """A webmercator geometry column still counts as geometry."""
+        fields = {"the_geom_webmercator": {"type": "geometry"}}
+        assert _geometry_column_from_fields(fields) == "the_geom_webmercator"
+
+    def test_empty_returns_none(self):
+        """Empty fields dict returns None."""
+        assert _geometry_column_from_fields({}) is None
+
+    def test_malformed_returns_none(self):
+        """Non-dict input returns None instead of raising."""
+        assert _geometry_column_from_fields(None) is None
+        assert _geometry_column_from_fields("not a dict") is None
+        assert _geometry_column_from_fields({"x": "not a dict"}) is None
 
 
 class TestEmptyGeoparquetTable:
@@ -328,6 +395,40 @@ class TestCartoToTable:
         # Other columns should be excluded
         assert "cartodb_id" not in table.column_names
 
+    def test_detect_geometry_column_on_geo_table(self):
+        """Detection probe finds the geometry column on a spatial table."""
+        geom_col = _detect_geometry_column(
+            "https://phl.carto.com/api/v2/sql",
+            "opa_properties_public",
+        )
+        assert geom_col is not None
+
+    def test_forced_no_geometry_returns_plain_table(self):
+        """geometry=False extracts as a plain table with no geo metadata."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            geometry=False,
+            limit=5,
+        )
+        # Plain/tabular output carries no GeoParquet metadata.
+        assert not (table.schema.metadata and b"geo" in table.schema.metadata)
+        # No geom→geometry rename happens on the plain path.
+        assert "geometry" not in table.column_names
+
+    def test_forced_no_geometry_honors_include_cols(self):
+        """Plain extraction respects include_cols without forcing the_geom."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            geometry=False,
+            include_cols="cartodb_id,parcel_number",
+            limit=5,
+        )
+        assert "cartodb_id" in table.column_names
+        assert "parcel_number" in table.column_names
+        assert "the_geom" not in table.column_names
+
 
 @pytest.mark.network
 class TestCartoCli:
@@ -379,6 +480,31 @@ class TestCartoCli:
                 ],
             )
             assert result.exit_code == 0, result.output
+
+    def test_cli_no_geometry_writes_plain_parquet(self):
+        """--no-geometry writes plain Parquet with no 'geo' metadata key."""
+        import pyarrow.parquet as pq
+
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "plain.parquet"
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "carto",
+                    "https://phl.carto.com/api/v2/sql",
+                    "opa_properties_public",
+                    str(output_file),
+                    "--no-geometry",
+                    "--limit",
+                    "5",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert output_file.exists()
+            metadata = pq.read_table(str(output_file)).schema.metadata or {}
+            assert b"geo" not in metadata
 
     def test_cli_invalid_bbox_format(self):
         """CLI rejects invalid bbox format."""
@@ -434,6 +560,8 @@ class TestCartoCli:
         assert "--timeout" in result.output
         assert "--include-cols" in result.output
         assert "--exclude-cols" in result.output
+        assert "--geometry" in result.output
+        assert "--no-geometry" in result.output
         # Note: --aws-profile is hidden (global option) so not in help
         assert "CARTO_API_KEY" in result.output
 

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -47,8 +47,13 @@ class TestValidateCartoUrl:
 
     def test_missing_scheme_raises(self):
         """URL without scheme raises error."""
-        with pytest.raises(InvalidParameterError, match="Must include scheme"):
+        with pytest.raises(InvalidParameterError, match="http://"):
             _validate_carto_url("phl.carto.com/api/v2/sql")
+
+    def test_non_http_scheme_raises(self):
+        """Non-http(s) schemes (e.g. file://) are rejected."""
+        with pytest.raises(InvalidParameterError, match="http://"):
+            _validate_carto_url("file:///etc/passwd/api/v2/sql")
 
     def test_invalid_path_raises(self):
         """Invalid path raises error."""

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -14,6 +14,7 @@ from geoparquet_io.core.carto import (
     _create_empty_geoparquet_table,
     _detect_geometry_column,
     _geometry_column_from_fields,
+    _table_has_geometry,
     _validate_carto_url,
     _validate_table_name,
     carto_to_table,
@@ -403,6 +404,30 @@ class TestCartoToTable:
         )
         assert geom_col is not None
 
+    def test_table_has_geometry_true_for_spatial(self):
+        """A populated spatial table is detected as geometry."""
+        assert (
+            _table_has_geometry("https://phl.carto.com/api/v2/sql", "opa_properties_public") is True
+        )
+
+    def test_table_has_geometry_false_for_tabular(self):
+        """A tabular table whose Carto the_geom is all-NULL is detected as plain.
+
+        Carto attaches an empty the_geom (type=geometry) to managed tabular
+        tables, so schema inspection alone is insufficient; the non-NULL probe
+        must classify hr_pay_range (0 non-null geometries) as plain.
+        """
+        assert _table_has_geometry("https://phl.carto.com/api/v2/sql", "hr_pay_range") is False
+
+    def test_autodetect_tabular_returns_plain_table(self):
+        """Auto-detect (geometry=None) on a tabular table yields no geo metadata."""
+        table = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="hr_pay_range",
+        )
+        assert not (table.schema.metadata and b"geo" in table.schema.metadata)
+        assert "geometry" not in table.column_names
+
     def test_forced_no_geometry_returns_plain_table(self):
         """geometry=False extracts as a plain table with no geo metadata."""
         table = carto_to_table(
@@ -499,6 +524,32 @@ class TestCartoCli:
                     "--no-geometry",
                     "--limit",
                     "5",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert output_file.exists()
+            metadata = pq.read_table(str(output_file)).schema.metadata or {}
+            assert b"geo" not in metadata
+
+    def test_cli_autodetect_tabular_writes_plain_parquet(self):
+        """Auto-detect (no flags) on a real tabular table writes plain Parquet.
+
+        This is the issue #508 reprex: a geometry-less Carto table is extracted
+        to plain Parquet with no 'geo' metadata key.
+        """
+        import pyarrow.parquet as pq
+
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "tabular.parquet"
+            result = runner.invoke(
+                cli,
+                [
+                    "extract",
+                    "carto",
+                    "https://phl.carto.com/api/v2/sql",
+                    "hr_pay_range",
+                    str(output_file),
                 ],
             )
             assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

Closes #508. The Carto extraction path (`core/carto.py`) was geometry-only — it read via DuckDB `ST_Read` over the SQL API's **GeoJSON** output (which requires geometry) and unconditionally attached GeoParquet `geo` metadata. Geometry-less (tabular) Carto tables (lookup/demographics tables with only scalar columns) could not be extracted.

This adds a non-geo extraction path that produces **plain Parquet** (no `geo` metadata key), mirroring gpio's existing file-conversion behavior for non-spatial inputs.

## What changed

- **Auto-detect (preferred, option 1):** probe the SQL API with `SELECT * FROM <table> LIMIT 0` and inspect the `fields` schema — a column with `type == "geometry"` means geometry. Cheap, no row fetch.
- **Plain path:** geometry-less tables are fetched via `format=csv`, skip `ST_Read`/Hilbert/bbox, and are written as plain Parquet with **no** `b"geo"` key.
- **Override (option 3):** `geometry: bool | None = None` parameter (`None` = auto) on `carto_to_table`, `convert_carto_to_geoparquet`, and `ops.from_carto`; CLI `--geometry/--no-geometry` flag.
- Honors existing `where` / `limit` / `include-cols` / `exclude-cols` / `api_key` / `timeout`. `--bbox` is ignored for tabular tables (warns) since it requires geometry.
- The write call passes an explicit empty `geometry_column` for plain output so `write_geoparquet_table`'s name-based auto-detection can't mistake a Carto `the_geom` string column for geometry — guaranteeing no `geo` key.

## Downstream

Unblocks portolan-cli's `portolan extract carto`: non-geo Carto tables can now be emitted as plain Parquet and routed into portolan's existing tabular pipeline (classified by absence of the `geo` key) instead of being skipped.

## Testing

- Unit tests: no-geom query building (no forced `the_geom`, bbox ignored), `fields`-schema geometry parser (incl. webmercator/malformed cases), CLI help.
- Network tests (against `https://phl.carto.com/api/v2/sql`): geometry detection on a spatial table, forced `--no-geometry`/`geometry=False` returns a plain table, `include_cols` honored on the plain path, and an end-to-end CLI test asserting the output Parquet has **no** `geo` key. Existing geometry-path tests still pass.

All pre-commit + pre-push hooks pass (ruff, codespell, duckdb-antipatterns, no-click-echo, import-linter, xenon, doc-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detect geometry-less Carto tables and extract them as plain Parquet (no GeoParquet `geo` metadata).
  * Added `--geometry` / `--no-geometry` flags to the `extract carto` command to force tabular vs. geometry extraction.
  * Added a `geometry` parameter to the Python API to control extraction mode explicitly.

* **Documentation**
  * Documented “Non-Geometry (Tabular) Tables” behavior, including CLI/Python examples and override semantics.

* **Tests**
  * Expanded coverage for geometry detection, tabular extraction, and CLI metadata assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->