### PR TITLE
docs(api): document geoparquet_version on Table.write/upload; drop write_memory

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -644,7 +644,7 @@ table = gpio.read('input.parquet').extract(bbox=(-122.5, 37.5, -122.0, 38.0))
 table = gpio.read('input.parquet').extract(where="population > 10000")
 ```
 
-#### `write(path, compression='ZSTD', compression_level=None, row_group_size_mb=None, row_group_rows=None, geoparquet_version=None, write_strategy=None, write_memory=None)`
+#### `write(path, format=None, compression='ZSTD', compression_level=None, row_group_size_mb=None, row_group_rows=None, geoparquet_version=None, write_strategy='duckdb-kv', profile=None, verbose=False, ...)`
 
 Write the table to a GeoParquet file. Returns the output `Path` for chaining or confirmation.
 
@@ -675,23 +675,20 @@ table.write('output.parquet', geoparquet_version='2.0')
 
 **Write Strategy Options**
 
-For large files, you can control memory usage with write strategies:
+For large files, choose a write strategy to control memory behavior:
 
 ```python
 # Use streaming strategy (constant memory usage)
 table.write('output.parquet', write_strategy='streaming')
-
-# Limit DuckDB memory for containerized environments
-table.write('output.parquet', write_memory='512MB')
-
-# Combine both options
-table.write('output.parquet', write_strategy='streaming', write_memory='1GB')
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `write_strategy` | str | Write strategy: `duckdb-kv` (default), `streaming`, `disk-rewrite`, or `in-memory` |
-| `write_memory` | str | DuckDB memory limit (e.g., `'2GB'`, `'512MB'`). Auto-detected if not specified |
+
+DuckDB's memory limit is auto-detected and respects container cgroup limits. To
+set it explicitly, use the CLI `gpio extract --write-memory` flag; the Python
+API does not expose a memory-limit argument.
 
 See the [Write Strategies Guide](../guide/write-strategies.md) for detailed information on each strategy.
 

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -644,7 +644,7 @@ table = gpio.read('input.parquet').extract(bbox=(-122.5, 37.5, -122.0, 38.0))
 table = gpio.read('input.parquet').extract(where="population > 10000")
 ```
 
-#### `write(path, compression='ZSTD', compression_level=None, row_group_size_mb=None, row_group_rows=None, write_strategy=None, write_memory=None)`
+#### `write(path, compression='ZSTD', compression_level=None, row_group_size_mb=None, row_group_rows=None, geoparquet_version=None, write_strategy=None, write_memory=None)`
 
 Write the table to a GeoParquet file. Returns the output `Path` for chaining or confirmation.
 
@@ -659,6 +659,19 @@ table.write('output.parquet', compression='GZIP', compression_level=6)
 # With row group size
 table.write('output.parquet', row_group_size_mb=128)
 ```
+
+**GeoParquet Version**
+
+Control the GeoParquet spec version written into the file metadata:
+
+```python
+# Write GeoParquet 2.0
+table.write('output.parquet', geoparquet_version='2.0')
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `geoparquet_version` | str | Spec version to write: `1.0`, `1.1`, `1.1-geoarrow`, `2.0`, or `parquet-geo-only`. Defaults to `None`, which lets gpio select the version (normally `1.1`). |
 
 **Write Strategy Options**
 
@@ -992,7 +1005,7 @@ if result.passed():
 result = table.validate(version='1.1')
 ```
 
-#### `upload(destination, compression='ZSTD', profile=None, s3_endpoint=None, ...)`
+#### `upload(destination, compression='ZSTD', compression_level=None, row_group_size_mb=None, row_group_rows=None, geoparquet_version=None, profile=None, s3_endpoint=None, ...)`
 
 Write and upload the table to cloud object storage (S3, GCS, Azure).
 
@@ -1015,6 +1028,9 @@ table.upload(
 
 # Upload to GCS
 table.upload('gs://bucket/data.parquet')
+
+# Upload as GeoParquet 2.0
+table.upload('s3://bucket/data.parquet', geoparquet_version='2.0')
 ```
 
 ## Converting Other Formats

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1808,8 +1808,8 @@ For containerized environments or when you need explicit control:
     ```python
     import geoparquet_io as gpio
 
-    # Explicit memory limit
-    gpio.read('input.parquet').write('output.parquet', write_memory='512MB')
+    # Memory limit is auto-detected; select a write strategy if needed
+    gpio.read('input.parquet').write('output.parquet', write_strategy='streaming')
     ```
 
 For detailed information on write strategies, memory configuration, and container environments, see the [Write Strategies Guide](write-strategies.md).

--- a/docs/guide/write-strategies.md
+++ b/docs/guide/write-strategies.md
@@ -137,18 +137,15 @@ Override auto-detection when needed:
 
 === "Python"
 
+    The fluent API auto-detects DuckDB's memory limit (respecting container
+    cgroup limits). Explicit override is currently CLI-only via
+    `--write-memory`; from Python you select the write strategy:
+
     ```python
     import geoparquet_io as gpio
 
-    # Limit DuckDB memory
-    gpio.read('input.parquet').write('output.parquet', write_memory='2GB')
-
-    # Combine with strategy selection
-    gpio.read('input.parquet').write(
-        'output.parquet',
-        write_strategy='streaming',
-        write_memory='1GB'
-    )
+    # Streaming strategy for constant memory usage
+    gpio.read('input.parquet').write('output.parquet', write_strategy='streaming')
     ```
 
 ### Memory Sizing Guidelines
@@ -214,10 +211,10 @@ For serverless environments with tight memory constraints:
     import geoparquet_io as gpio
 
     def handler(event, context):
-        # Lambda with 1GB memory
+        # Memory limit is auto-detected from the Lambda environment
         gpio.read('s3://bucket/input.parquet') \
             .extract(bbox=event['bbox']) \
-            .write('/tmp/output.parquet', write_memory='384MB')
+            .write('/tmp/output.parquet')
     ```
 
 ## Examples
@@ -301,11 +298,11 @@ If you suspect the default strategy is producing incorrect output:
     import geoparquet_io as gpio
     from pathlib import Path
 
-    # Batch processing with explicit memory limit
+    # Batch processing (memory limit auto-detected per environment)
     for input_file in Path('data').glob('*.parquet'):
         gpio.read(input_file) \
             .extract(bbox=(-122.5, 37.5, -122.0, 38.0)) \
-            .write(f'output/{input_file.name}', write_memory='512MB')
+            .write(f'output/{input_file.name}', write_strategy='streaming')
     ```
 
 ## See Also


### PR DESCRIPTION
## Context

A user looking for GeoParquet 2.0 output via the Python API couldn't find any
way to select the spec version in the docs, and `geoparquet_version` did not
show up on the `Table` object in their editor. The parameter has in fact been
on `Table.write()` / `Table.upload()` since v0.8.0 — it was just undocumented.
While confirming this, the `write()` doc turned out to also document a
`write_memory` argument that the Python API never accepted (it's the CLI
`--write-memory` flag), so every documented Python `write_memory` snippet
raised `TypeError`.

This is a docs-only change. No public API behavior changes.

## Changes

**Document `geoparquet_version`** (`docs/api/python-api.md`)
- Add `geoparquet_version` to the `write()` and `upload()` signatures, with an
  example and a parameter table listing accepted values: `1.0`, `1.1`,
  `1.1-geoarrow`, `2.0`, `parquet-geo-only`.

**Remove the nonexistent `write_memory` Python argument**
- `Table.write()` never accepted `write_memory`; the examples raised
  `TypeError`. Removed from the API reference, `guide/write-strategies.md`, and
  `guide/extract.md`. Noted that the Python API auto-detects the DuckDB memory
  limit (respecting container cgroup limits) and that explicit override stays
  CLI-only via `gpio extract --write-memory`.

**Correct the `write()` signature in the API reference**
- Add `format`/`profile`/`verbose`, fix the `write_strategy` default to
  `'duckdb-kv'`, and drop `write_memory`. Documented args now match the real
  method signature (verified via `inspect.signature`).

## Verification

- `Table.write(path, geoparquet_version="2.0")` produces geo metadata
  `version: 2.0.0` (matches `gpio convert geoparquet --geoparquet-version 2.0`).
- Confirmed `table.write(..., write_memory=...)` raises
  `TypeError: unexpected keyword argument 'write_memory'`.
- Verified every documented `write()`/`upload()` argument is a real parameter
  via `inspect.signature`.
- No `write_memory` references remain in docs outside the CLI `--write-memory`
  flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `Table.write()` and `Table.upload()` method documentation with new parameters for GeoParquet version specification and write strategy selection.
  * Updated Python examples across guides to demonstrate using the `write_strategy` parameter for controlling memory usage and processing behavior.
  * Enhanced API reference documentation with detailed GeoParquet version options and available write strategy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->