### PR TITLE
feat(geoarrow): produce native GeoArrow encoding for 1.1-geoarrow from any input

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -696,6 +696,38 @@ API does not expose a memory-limit argument.
 
 See the [Write Strategies Guide](../guide/write-strategies.md) for detailed information on each strategy.
 
+**GeoParquet Version Options**
+
+Control the GeoParquet encoding version when writing:
+
+=== "Python"
+
+    ```python
+    # GeoParquet 1.1 with native GeoArrow nested-coordinate encoding
+    # (no bbox column; incompatible mixed-geometry columns fall back to WKB)
+    table.write('output.parquet', geoparquet_version='1.1-geoarrow')
+
+    # GeoParquet 1.0 with WKB encoding
+    table.write('output.parquet', geoparquet_version='1.0')
+
+    # GeoParquet 1.1 with WKB encoding (default)
+    table.write('output.parquet', geoparquet_version='1.1')
+    ```
+
+=== "CLI"
+
+    ```bash
+    # GeoParquet 1.1 with native GeoArrow nested-coordinate encoding
+    gpio convert input.geojson output.parquet --geoparquet-version 1.1-geoarrow
+
+    # GeoParquet 1.0 with WKB encoding
+    gpio convert input.shp output.parquet --geoparquet-version 1.0
+    ```
+
+`1.1-geoarrow` converts geometry from any input to native GeoArrow (nested-coordinate) types.
+Compatible geometry type mixes are promoted (e.g. Polygon + MultiPolygon → MultiPolygon).
+Incompatible mixes (e.g. Point + Polygon) fall back to WKB. No bbox column is added.
+
 #### `to_arrow()`
 
 Get the underlying PyArrow Table for interop with other Arrow-based tools.

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -388,6 +388,52 @@ Available compression types:
 - `SNAPPY` - Fast compression
 - `UNCOMPRESSED` - No compression
 
+### GeoParquet Version
+
+Control the GeoParquet encoding version written to output:
+
+=== "CLI"
+
+    ```bash
+    # GeoParquet 1.1 with native GeoArrow nested-coordinate encoding
+    # (no bbox column; incompatible mixed-geometry columns fall back to WKB)
+    gpio convert input.geojson output.parquet --geoparquet-version 1.1-geoarrow
+
+    # GeoParquet 1.0 with WKB encoding
+    gpio convert input.shp output.parquet --geoparquet-version 1.0
+
+    # GeoParquet 1.1 with WKB encoding (default)
+    gpio convert input.shp output.parquet --geoparquet-version 1.1
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    # GeoParquet 1.1 with native GeoArrow nested-coordinate encoding
+    # Converts geometry from any input (GeoJSON, Shapefile, GeoPackage, CSV, WKB GeoParquet)
+    # to native GeoArrow types. No bbox column is added.
+    # Columns mixing incompatible geometry types fall back to WKB.
+    gpio.convert('input.geojson').write(
+        'output.parquet', geoparquet_version='1.1-geoarrow'
+    )
+
+    # GeoParquet 1.0 with WKB encoding
+    gpio.convert('input.shp').write(
+        'output.parquet', geoparquet_version='1.0'
+    )
+    ```
+
+Available versions:
+- `1.0` — GeoParquet 1.0 with WKB encoding
+- `1.1` — GeoParquet 1.1 with WKB encoding (default)
+- `1.1-geoarrow` — GeoParquet 1.1 with native GeoArrow (nested-coordinate) encoding; no bbox
+  column; compatible geometry type mixes are promoted (e.g. Polygon + MultiPolygon →
+  MultiPolygon); incompatible mixes fall back to WKB
+- `2.0` — GeoParquet 2.0 with native Parquet geo types
+- `parquet-geo-only` — Native Parquet geo types without GeoParquet metadata
+
 ### Verbose Output
 
 Track progress and see detailed information:

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -968,6 +968,24 @@ class Table:
             local_path = PathLib(path)
 
         try:
+            # 1.1-geoarrow produces native GeoArrow encoding from WKB geometry, which
+            # requires the streaming strategy (duckdb-kv COPY TO can only emit WKB).
+            # Already-native nested geometry is left on the default strategy.
+            if geoparquet_version == "1.1-geoarrow" and self._geometry_column:
+                geom_field = self._table.schema.field(self._geometry_column)
+                geom_type = geom_field.type
+                is_wkb = (
+                    pa.types.is_binary(geom_type)
+                    or pa.types.is_large_binary(geom_type)
+                    or getattr(geom_type, "extension_name", "") == "geoarrow.wkb"
+                )
+                if is_wkb and write_strategy != "streaming":
+                    if verbose:
+                        from geoparquet_io.core.logging_config import debug
+
+                        debug("Routing 1.1-geoarrow WKB input through streaming strategy")
+                    write_strategy = "streaming"
+
             # Get the appropriate write strategy
             strategy_enum = WriteStrategy(write_strategy)
             strategy = WriteStrategyFactory.get_strategy(strategy_enum)

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -990,6 +990,15 @@ class Table:
             strategy_enum = WriteStrategy(write_strategy)
             strategy = WriteStrategyFactory.get_strategy(strategy_enum)
 
+            # Forward the input CRS so a non-default CRS survives the write (otherwise
+            # the geometry silently defaults to OGC:CRS84). write_from_table expects a
+            # PROJJSON dict, so normalise a string identifier (e.g. "EPSG:3857").
+            input_crs = self.crs
+            if isinstance(input_crs, str):
+                from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
+
+                input_crs = parse_crs_string_to_projjson(input_crs)
+
             strategy.write_from_table(
                 table=self._table,
                 output_path=str(local_path),
@@ -1000,6 +1009,7 @@ class Table:
                 row_group_size_mb=row_group_size_mb,
                 row_group_rows=row_group_rows,
                 verbose=verbose,
+                input_crs=input_crs,
             )
 
             # Upload to remote if needed

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -855,7 +855,9 @@ class Table:
             compression_level: Compression level for GeoParquet
             row_group_size_mb: Target row group size in MB for GeoParquet
             row_group_rows: Exact rows per row group for GeoParquet
-            geoparquet_version: GeoParquet version (1.0, 1.1, 1.1-geoarrow, 2.0, or None to preserve)
+            geoparquet_version: GeoParquet version (1.0, 1.1, 1.1-geoarrow, 2.0, or None to preserve).
+                1.1-geoarrow converts geometry from any input to native GeoArrow nested-coordinate
+                encoding and omits the bbox column; columns with incompatible mixed types fall back to WKB.
             write_strategy: Write strategy for GeoParquet ('in-memory', 'streaming',
                            'duckdb-kv', 'disk-rewrite'). Default: 'duckdb-kv'
             profile: AWS profile for S3 operations
@@ -1699,7 +1701,9 @@ class Table:
             compression_level: Compression level
             row_group_size_mb: Target row group size in MB
             row_group_rows: Exact rows per row group
-            geoparquet_version: GeoParquet version (1.0, 1.1, 1.1-geoarrow, 2.0, or None to preserve)
+            geoparquet_version: GeoParquet version (1.0, 1.1, 1.1-geoarrow, 2.0, or None to preserve).
+                1.1-geoarrow converts geometry from any input to native GeoArrow nested-coordinate
+                encoding and omits the bbox column; columns with incompatible mixed types fall back to WKB.
             profile: AWS profile name for S3
             s3_endpoint: Custom S3-compatible endpoint (e.g., "minio.example.com:9000")
             s3_region: S3 region (default: us-east-1 when using custom endpoint)

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -264,7 +264,9 @@ def geoparquet_version_option(func):
     Allows specifying the GeoParquet version for output files:
     - 1.0: GeoParquet 1.0 with WKB encoding
     - 1.1: GeoParquet 1.1 with WKB encoding
-    - 1.1-geoarrow: GeoParquet 1.1 with native GeoArrow encoding (no bbox column)
+    - 1.1-geoarrow: GeoParquet 1.1 with native GeoArrow (nested-coordinate) encoding
+      and no bbox column. Geometry is converted to native GeoArrow types from any
+      input; columns mixing incompatible geometry types fall back to WKB.
     - 2.0: GeoParquet 2.0 with native Parquet geo types
     - parquet-geo-only: Native Parquet geo types without GeoParquet metadata
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1865,6 +1865,24 @@ def write_parquet_with_metadata(
             )
         else:
             # Metadata rewrite needed - use strategy pattern
+
+            # 1.1-geoarrow produces native GeoArrow encoding from WKB/text inputs,
+            # which requires the arrow-streaming strategy (DuckDB COPY TO cannot emit
+            # nested GeoArrow types). Already-native inputs keep their preservation
+            # path (duckdb-kv passes the native column through unchanged).
+            if geoparquet_version == "1.1-geoarrow":
+                primary = (geometry_info or {}).get("primary")
+                input_encoding = (
+                    (geometry_info or {}).get("metadata", {}).get(primary, {}).get("encoding")
+                )
+                already_native = bool(
+                    input_encoding and input_encoding.lower() not in ("wkb", "wkt")
+                )
+                if not already_native and write_strategy != "streaming":
+                    if verbose:
+                        debug("Routing 1.1-geoarrow WKB input through arrow-streaming")
+                    write_strategy = "streaming"
+
             strategy_enum = WriteStrategy(write_strategy)
             strategy = WriteStrategyFactory.get_strategy(strategy_enum)
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -508,6 +508,59 @@ def compute_geometry_types_via_sql(
     return sorted(set(types))
 
 
+# DuckDB ST_ZMFlag codes -> geoarrow.types.Dimensions values.
+# DuckDB: 0=XY, 1=XYM, 2=XYZ, 3=XYZM. geoarrow: 1=XY, 2=XYZ, 3=XYM, 4=XYZM.
+_DUCKDB_ZMFLAG_TO_GEOARROW_DIM = {0: 1, 1: 3, 2: 2, 3: 4}
+
+
+def compute_geometry_dimensions_via_sql(
+    con,
+    query: str,
+    geometry_column: str,
+) -> set[int]:
+    """Compute the distinct coordinate dimensions of a geometry column via DuckDB.
+
+    Used by the 1.1-geoarrow native path to pick a Z/M-aware GeoArrow type rather
+    than silently coercing 3D/measured coordinates down to 2D.
+
+    Returns:
+        Set of geoarrow dimension codes (1=XY, 2=XYZ, 3=XYM, 4=XYZM). Empty set when
+        the column is absent, native nested (STRUCT), or the dimension is undetectable.
+    """
+    try:
+        columns = _get_query_columns(con, query)
+        if geometry_column not in columns:
+            return set()
+    except (duckdb.Error, RuntimeError, ValueError, AttributeError):
+        return set()
+
+    # Native nested GeoArrow (STRUCT) cannot use ST_ZMFlag; leave dimension unknown.
+    col_type = _get_query_column_type(con, query, geometry_column) or ""
+    if "STRUCT" in col_type:
+        return set()
+
+    escaped_col = geometry_column.replace('"', '""')
+    geom_expr = f'"{escaped_col}"'
+    if "BLOB" in col_type or "BINARY" in col_type:
+        geom_expr = f"ST_GeomFromWKB({geom_expr})"
+
+    dims_query = f"""
+        SELECT DISTINCT ST_ZMFlag({geom_expr}) AS zm
+        FROM ({query})
+        WHERE "{escaped_col}" IS NOT NULL
+    """
+    try:
+        results = con.execute(dims_query).fetchall()
+    except (duckdb.Error, RuntimeError, ValueError):
+        return set()
+
+    dims: set[int] = set()
+    for (zm,) in results:
+        if zm is not None and zm in _DUCKDB_ZMFLAG_TO_GEOARROW_DIM:
+            dims.add(_DUCKDB_ZMFLAG_TO_GEOARROW_DIM[zm])
+    return dims
+
+
 def _rebuild_array_with_type(
     chunked_array,
     new_type,

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1451,7 +1451,9 @@ def convert_to_geoparquet(
         skip_invalid: Skip rows with invalid geometries instead of failing
         allow_no_geometry: Allow conversion to plain Parquet if no geometry detected
         profile: AWS profile name for S3 operations
-        geoparquet_version: GeoParquet version to write (1.0, 1.1, 1.1-geoarrow, 2.0, parquet-geo-only)
+        geoparquet_version: GeoParquet version to write (1.0, 1.1, 1.1-geoarrow, 2.0, parquet-geo-only).
+            1.1-geoarrow converts geometry from any input to native GeoArrow nested-coordinate
+            encoding and omits the bbox column; columns with incompatible mixed types fall back to WKB.
         repair_geometry: Repair invalid geometry with ST_MakeValid (default: True).
             When False, invalid geometry is preserved and a warning reports the count.
 

--- a/geoparquet_io/core/geoarrow_encoding.py
+++ b/geoparquet_io/core/geoarrow_encoding.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 from geoparquet_io.core.crs_utils import is_default_crs
 from geoparquet_io.core.logging_config import debug
 
-# GeoParquet geometry_types base name -> geoarrow.pyarrow factory attribute.
-# Maps GeoParquet base names (including Multi* types) to geoarrow factory attribute names.
-# geometry_type_common handles promotion and unification.
+# GeoParquet geometry_types base names (including Multi* types) -> geoarrow.pyarrow
+# factory attribute names. geometry_type_common handles promotion and unification.
 _BASE_NAME_TO_FACTORY = {
     "point": "point",
     "linestring": "linestring",

--- a/geoparquet_io/core/geoarrow_encoding.py
+++ b/geoparquet_io/core/geoarrow_encoding.py
@@ -10,8 +10,8 @@ from geoparquet_io.core.crs_utils import is_default_crs
 from geoparquet_io.core.logging_config import debug
 
 # GeoParquet geometry_types base name -> geoarrow.pyarrow factory attribute.
-# Multi* and collection types are constructed by promotion, not listed here;
-# geometry_type_common handles unification.
+# Maps GeoParquet base names (including Multi* types) to geoarrow factory attribute names.
+# geometry_type_common handles promotion and unification.
 _BASE_NAME_TO_FACTORY = {
     "point": "point",
     "linestring": "linestring",
@@ -27,7 +27,7 @@ def _normalize_base_name(geometry_type: str) -> str:
     return geometry_type.split(" ")[0].strip().lower()
 
 
-def determine_geoarrow_target_type(geometry_types, input_crs=None):
+def determine_geoarrow_target_type(geometry_types: list[str], input_crs: dict | None = None):
     """Determine the single GeoArrow target type for a dataset.
 
     Args:
@@ -51,7 +51,7 @@ def determine_geoarrow_target_type(geometry_types, input_crs=None):
 
     try:
         common = types[0] if len(types) == 1 else ga.geometry_type_common(types)
-    except Exception as exc:  # incompatible mix (e.g. point + polygon)
+    except (ValueError, TypeError) as exc:  # incompatible mix (e.g. point + polygon)
         debug(f"GeoArrow types not unifiable ({base_names}); falling back to WKB: {exc}")
         return None, "WKB"
 

--- a/geoparquet_io/core/geoarrow_encoding.py
+++ b/geoparquet_io/core/geoarrow_encoding.py
@@ -20,18 +20,62 @@ _BASE_NAME_TO_FACTORY = {
     "multipolygon": "multipolygon",
 }
 
+# geoarrow.types.Dimensions enum values (see Dimensions.value).
+_DIM_XY = 1
+# Dimension codes that map to a concrete native GeoArrow coordinate layout.
+_NATIVE_DIM_CODES = {1, 2, 3, 4}  # XY, XYZ, XYM, XYZM
+
 
 def _normalize_base_name(geometry_type: str) -> str:
     """Strip Z/M dimension suffixes and lowercase: 'MultiPolygon Z' -> 'multipolygon'."""
     return geometry_type.split(" ")[0].strip().lower()
 
 
-def determine_geoarrow_target_type(geometry_types: list[str], input_crs: dict | None = None):
+def _resolve_dimension(dimensions: set[int] | None):
+    """Resolve a set of geoarrow dimension codes to a single target dimension.
+
+    Native GeoArrow types carry one fixed coordinate layout, so a column must use
+    a single dimension. This avoids silently coercing Z/M ordinates away.
+
+    Args:
+        dimensions: geoarrow dimension codes present in the data (Dimensions.value),
+            or None/empty when the dimensionality is unknown.
+
+    Returns:
+        (dimension_enum, ok). ``ok`` is False when the data cannot be represented
+        by one native type (mixed dimensions, or an unknown/unspecified code) so the
+        caller must fall back to WKB. ``dimension_enum`` is None for plain XY (keep
+        the factory default) or a ``geoarrow.types.Dimensions`` member otherwise.
+    """
+    if not dimensions:
+        return None, True  # unknown -> keep default 2D layout
+    if not dimensions.issubset(_NATIVE_DIM_CODES):
+        return None, False  # unspecified/unknown dimension -> WKB
+    if len(dimensions) > 1:
+        return None, False  # mixed XY/XYZ/XYM/XYZM -> WKB (no lossless single type)
+
+    import geoarrow.types as gat
+
+    code = next(iter(dimensions))
+    if code == _DIM_XY:
+        return None, True
+    return gat.Dimensions(code), True
+
+
+def determine_geoarrow_target_type(
+    geometry_types: list[str],
+    input_crs: dict | None = None,
+    dimensions: set[int] | None = None,
+):
     """Determine the single GeoArrow target type for a dataset.
 
     Args:
         geometry_types: GeoParquet geometry_types strings, e.g. ["Polygon", "MultiPolygon"].
         input_crs: PROJJSON dict to attach to the type (skipped when default CRS).
+        dimensions: geoarrow dimension codes (Dimensions.value) present in the data.
+            Used to select a Z/M-aware native type so 3D/measured coordinates are not
+            dropped. When the data mixes dimensions (or has none representable as a
+            single native type), the result falls back to WKB.
 
     Returns:
         (geoarrow_type, encoding_name). geoarrow_type is None and encoding_name
@@ -41,6 +85,11 @@ def determine_geoarrow_target_type(geometry_types: list[str], input_crs: dict | 
 
     base_names = {_normalize_base_name(g) for g in geometry_types if g}
     if not base_names or not base_names.issubset(_BASE_NAME_TO_FACTORY):
+        return None, "WKB"
+
+    dimension_enum, dimension_ok = _resolve_dimension(dimensions)
+    if not dimension_ok:
+        debug(f"GeoArrow dimensions not representable as one native type ({dimensions}); using WKB")
         return None, "WKB"
 
     types = []
@@ -57,11 +106,36 @@ def determine_geoarrow_target_type(geometry_types: list[str], input_crs: dict | 
     if common.extension_name == "geoarrow.wkb":
         return None, "WKB"
 
+    if dimension_enum is not None:
+        common = common.with_dimensions(dimension_enum)
+
     if input_crs and not is_default_crs(input_crs):
         common = common.with_crs(input_crs)
 
     encoding = common.extension_name.replace("geoarrow.", "")
     return common, encoding
+
+
+def detect_wkb_dimensions(arr) -> set[int]:
+    """Detect the geoarrow dimension codes present in a WKB/binary/geoarrow array.
+
+    Returns a set of ``geoarrow.types.Dimensions`` values (1=XY, 2=XYZ, 3=XYM,
+    4=XYZM). Returns an empty set for empty/all-null input or on any detection
+    failure, in which case the caller treats the data as plain 2D.
+    """
+    import geoarrow.pyarrow as ga
+
+    try:
+        if len(arr) == 0:
+            return set()
+        arr = arr.drop_null()  # geoarrow errors on null geometries
+        if len(arr) == 0:
+            return set()
+        types_struct = ga.unique_geometry_types(ga.as_wkb(arr))
+        return {d for d in types_struct.field("dimensions").to_pylist() if d is not None}
+    except Exception as exc:  # geoarrow C++ errors, invalid WKB, etc.
+        debug(f"Could not detect WKB dimensions; assuming 2D: {exc}")
+        return set()
 
 
 def wkb_array_to_geoarrow(arr, target_type):

--- a/geoparquet_io/core/geoarrow_encoding.py
+++ b/geoparquet_io/core/geoarrow_encoding.py
@@ -1,0 +1,72 @@
+"""WKB-to-native GeoArrow conversion helpers for GeoParquet 1.1-geoarrow output.
+
+Pure pyarrow/geoarrow utilities (no DuckDB, no Click). Used by the
+arrow-streaming write strategy to emit nested-coordinate GeoArrow encoding.
+"""
+
+from __future__ import annotations
+
+from geoparquet_io.core.crs_utils import is_default_crs
+from geoparquet_io.core.logging_config import debug
+
+# GeoParquet geometry_types base name -> geoarrow.pyarrow factory attribute.
+# Multi* and collection types are constructed by promotion, not listed here;
+# geometry_type_common handles unification.
+_BASE_NAME_TO_FACTORY = {
+    "point": "point",
+    "linestring": "linestring",
+    "polygon": "polygon",
+    "multipoint": "multipoint",
+    "multilinestring": "multilinestring",
+    "multipolygon": "multipolygon",
+}
+
+
+def _normalize_base_name(geometry_type: str) -> str:
+    """Strip Z/M dimension suffixes and lowercase: 'MultiPolygon Z' -> 'multipolygon'."""
+    return geometry_type.split(" ")[0].strip().lower()
+
+
+def determine_geoarrow_target_type(geometry_types, input_crs=None):
+    """Determine the single GeoArrow target type for a dataset.
+
+    Args:
+        geometry_types: GeoParquet geometry_types strings, e.g. ["Polygon", "MultiPolygon"].
+        input_crs: PROJJSON dict to attach to the type (skipped when default CRS).
+
+    Returns:
+        (geoarrow_type, encoding_name). geoarrow_type is None and encoding_name
+        is "WKB" when the set is empty or cannot be unified into one native type.
+    """
+    import geoarrow.pyarrow as ga
+
+    base_names = {_normalize_base_name(g) for g in geometry_types if g}
+    if not base_names or not base_names.issubset(_BASE_NAME_TO_FACTORY):
+        return None, "WKB"
+
+    types = []
+    for name in base_names:
+        factory = getattr(ga, _BASE_NAME_TO_FACTORY[name])
+        types.append(factory())
+
+    try:
+        common = types[0] if len(types) == 1 else ga.geometry_type_common(types)
+    except Exception as exc:  # incompatible mix (e.g. point + polygon)
+        debug(f"GeoArrow types not unifiable ({base_names}); falling back to WKB: {exc}")
+        return None, "WKB"
+
+    if common.extension_name == "geoarrow.wkb":
+        return None, "WKB"
+
+    if input_crs and not is_default_crs(input_crs):
+        common = common.with_crs(input_crs)
+
+    encoding = common.extension_name.replace("geoarrow.", "")
+    return common, encoding
+
+
+def wkb_array_to_geoarrow(arr, target_type):
+    """Convert a WKB/binary Arrow array to the given native GeoArrow target type."""
+    import geoarrow.pyarrow as ga
+
+    return ga.as_geoarrow(ga.as_wkb(arr), type=target_type)

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -631,23 +631,30 @@ def get_preview_data(
 
         # Also detect geometry columns from GeoParquet metadata
         geo_meta = get_geo_metadata(parquet_file)
+        columns_meta = {}
         if geo_meta:
             columns_meta = geo_meta.get("columns", {})
             geo_columns.update(columns_meta.keys())
 
-        # Get all column names from the parquet file
+        # Get all column names and DuckDB types from the parquet file
         schema_result = con.execute(
-            f"SELECT column_name FROM (DESCRIBE SELECT * FROM read_parquet('{safe_url}'))"
+            f"SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('{safe_url}'))"
         ).fetchall()
         all_columns = [row[0] for row in schema_result]
+        col_types = {row[0]: row[1] for row in schema_result}
 
-        # Build column list, converting geometry columns to WKT
+        # Native GeoArrow geometry is exposed by DuckDB as a raw STRUCT/LIST, which
+        # ST_AsText cannot consume. Select those columns raw and convert them to WKT
+        # via geoarrow after the query. Serialized (WKB/GEOMETRY) columns keep ST_AsText.
+        native_geo_columns = {c for c in geo_columns if "STRUCT" in col_types.get(c, "").upper()}
+
+        # Build column list, converting serialized geometry columns to WKT in SQL
         column_expressions = []
         for col in all_columns:
             # Escape double quotes in column names for SQL identifiers
             escaped_col = col.replace('"', '""')
-            if col in geo_columns:
-                # Convert geometry to WKT for display
+            if col in geo_columns and col not in native_geo_columns:
+                # Convert serialized geometry to WKT for display
                 column_expressions.append(f'ST_AsText("{escaped_col}") AS "{escaped_col}"')
             else:
                 column_expressions.append(f'"{escaped_col}"')
@@ -672,10 +679,61 @@ def get_preview_data(
 
         # Execute query and convert to PyArrow table
         table = con.execute(query).arrow().read_all()
+
+        # Convert any native GeoArrow geometry columns to WKT strings for display.
+        if native_geo_columns:
+            table = _native_geoarrow_columns_to_wkt(table, native_geo_columns, columns_meta)
     finally:
         con.close()
 
     return table, mode
+
+
+def _native_geoarrow_columns_to_wkt(
+    table: pa.Table, native_columns: set[str], columns_meta: dict
+) -> pa.Table:
+    """Replace native GeoArrow geometry columns with WKT strings for display.
+
+    DuckDB returns native GeoArrow geometry as a raw STRUCT/LIST without the
+    geoarrow extension type. Re-wrap each column with the geoarrow type implied
+    by its GeoParquet ``encoding`` and render it to WKT. Columns that cannot be
+    converted (e.g. unexpected encoding or dimensionality) are left untouched.
+    """
+    import geoarrow.pyarrow as ga
+    import pyarrow as pa
+
+    from geoparquet_io.core.logging_config import debug
+
+    def _nullable_type(t):
+        """Rebuild an Arrow type with all nested fields/elements nullable.
+
+        DuckDB returns native geometry as large_list with nullable subfields, while
+        a geoarrow type's storage uses (non-nullable) list. Casting to a nullable
+        variant bridges both the large_list->list and nullability differences so
+        rows with NULL geometry survive the cast.
+        """
+        if pa.types.is_struct(t):
+            return pa.struct([pa.field(f.name, _nullable_type(f.type), nullable=True) for f in t])
+        if pa.types.is_list(t) or pa.types.is_large_list(t):
+            return pa.list_(pa.field(t.value_field.name, _nullable_type(t.value_type)))
+        return t
+
+    for col in native_columns:
+        encoding = (columns_meta.get(col) or {}).get("encoding", "")
+        if not encoding or encoding.lower() == "wkb":
+            continue
+        try:
+            ga_type = getattr(ga, encoding.lower())()
+            arr = table.column(col).combine_chunks()
+            wrapped = ga_type.wrap_array(arr.cast(_nullable_type(ga_type.storage_type)))
+            wkt = ga.as_wkt(wrapped)
+            storage = wkt.storage if hasattr(wkt, "storage") else wkt
+            idx = table.schema.get_field_index(col)
+            table = table.set_column(idx, col, storage)
+        except Exception as e:
+            debug(f"Could not render native GeoArrow column '{col}' as WKT: {e}")
+            continue
+    return table
 
 
 def get_column_statistics(

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -140,10 +140,15 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geoarrow_target_type = None
         geoarrow_encoding = None
         if geoarrow_native and should_add_geo_metadata:
+            from geoparquet_io.core.common import compute_geometry_dimensions_via_sql
             from geoparquet_io.core.geoarrow_encoding import determine_geoarrow_target_type
 
+            # Detect Z/M dimensionality so 3D/measured coordinates select a
+            # dimension-aware native type (or fall back to WKB) rather than being
+            # silently coerced down to 2D.
+            dimensions = compute_geometry_dimensions_via_sql(con, query, geometry_column)
             geoarrow_target_type, geoarrow_encoding = determine_geoarrow_target_type(
-                precomputed_geom_types, input_crs
+                precomputed_geom_types, input_crs, dimensions=dimensions
             )
             if verbose:
                 debug(f"1.1-geoarrow target encoding: {geoarrow_encoding}")
@@ -506,10 +511,17 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             geom_types = _compute_geometry_types(table, geometry_column, verbose)
 
             if geoarrow_native:
-                from geoparquet_io.core.geoarrow_encoding import determine_geoarrow_target_type
+                from geoparquet_io.core.geoarrow_encoding import (
+                    detect_wkb_dimensions,
+                    determine_geoarrow_target_type,
+                )
 
+                # Detect Z/M dimensionality from the actual geometry so 3D/measured
+                # coordinates select a dimension-aware native type (or fall back to
+                # WKB) instead of being silently coerced down to 2D.
+                dimensions = detect_wkb_dimensions(table.column(geometry_column))
                 geoarrow_target_type, geoarrow_encoding = determine_geoarrow_target_type(
-                    geom_types, input_crs
+                    geom_types, input_crs, dimensions=dimensions
                 )
                 if verbose:
                     debug(f"1.1-geoarrow target encoding: {geoarrow_encoding}")

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -127,11 +127,26 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         # Determine version flags
         use_native_geometry = geoparquet_version in ("2.0", "parquet-geo-only")
         should_add_geo_metadata = geoparquet_version != "parquet-geo-only"
+        geoarrow_native = geoparquet_version == "1.1-geoarrow"
 
         # Pre-compute metadata
         precomputed_bbox, precomputed_geom_types = self._precompute_metadata(
             con, query, geometry_column, verbose, should_add_geo_metadata, use_native_geometry
         )
+
+        # Compute the geoarrow target type once from whole-dataset geometry types.
+        # All batches will be coerced to this single physical type (schema is fixed
+        # from batch 1 and cannot change mid-stream).
+        geoarrow_target_type = None
+        geoarrow_encoding = None
+        if geoarrow_native and should_add_geo_metadata:
+            from geoparquet_io.core.geoarrow_encoding import determine_geoarrow_target_type
+
+            geoarrow_target_type, geoarrow_encoding = determine_geoarrow_target_type(
+                precomputed_geom_types, input_crs
+            )
+            if verbose:
+                debug(f"1.1-geoarrow target encoding: {geoarrow_encoding}")
 
         if verbose:
             debug(f"Executing query with batch size {batch_size:,}...")
@@ -158,6 +173,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             precomputed_geom_types,
             precomputed_bbox,
             geometry_info,
+            geoarrow_encoding=geoarrow_encoding,
         )
 
         # Prepare writer kwargs
@@ -181,6 +197,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             writer_kwargs,
             verbose,
             extra_kv_metadata=extra_kv_metadata,
+            geoarrow_target_type=geoarrow_target_type,
         )
 
     def _precompute_metadata(
@@ -220,6 +237,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         precomputed_geom_types: list[str],
         precomputed_bbox: list[float] | None,
         geometry_info: dict | None = None,
+        geoarrow_encoding: str | None = None,
     ) -> dict | None:
         """Build geo metadata for query results."""
         from geoparquet_io.core.crs_utils import apply_output_crs
@@ -244,6 +262,11 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         col_meta["geometry_types"] = precomputed_geom_types
         if precomputed_bbox is not None:
             col_meta["bbox"] = precomputed_bbox
+
+        # Override encoding when geoarrow_target_type resolved a native encoding.
+        # geoarrow_encoding is "WKB" when mixed/unconvertible — no override needed.
+        if geoarrow_encoding is not None and geoarrow_encoding != "WKB":
+            col_meta["encoding"] = geoarrow_encoding
 
         # Handle secondary geometry columns from geometry_info
         if geometry_info:
@@ -283,6 +306,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         writer_kwargs: dict,
         verbose: bool,
         extra_kv_metadata: dict[str, str] | None = None,
+        geoarrow_target_type=None,
     ) -> None:
         """Stream batches from reader to Parquet file."""
         first_batch = None
@@ -299,6 +323,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 writer_kwargs,
                 verbose,
                 extra_kv_metadata=extra_kv_metadata,
+                geoarrow_target_type=geoarrow_target_type,
             )
             return
 
@@ -311,6 +336,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             geom_types=precomputed_geom_types,
             verbose=verbose,
             extra_kv_metadata=extra_kv_metadata,
+            geoarrow_target_type=geoarrow_target_type,
         )
 
         geoarrow_type = None
@@ -328,6 +354,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             use_native_geometry,
             writer_kwargs,
             verbose,
+            geoarrow_target_type=geoarrow_target_type,
         )
 
         if verbose:
@@ -344,6 +371,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         writer_kwargs: dict,
         verbose: bool,
         extra_kv_metadata: dict[str, str] | None = None,
+        geoarrow_target_type=None,
     ) -> None:
         """Handle writing an empty result set."""
         schema_with_meta = self._build_streaming_schema(
@@ -355,6 +383,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             geom_types=[],
             verbose=verbose,
             extra_kv_metadata=extra_kv_metadata,
+            geoarrow_target_type=geoarrow_target_type,
         )
         with pq.ParquetWriter(output_path, schema_with_meta, **writer_kwargs):
             pass
@@ -372,6 +401,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         use_native_geometry: bool,
         writer_kwargs: dict,
         verbose: bool,
+        geoarrow_target_type=None,
     ) -> tuple[int, int]:
         """Write all batches to Parquet file. Returns (rows_written, batches_written)."""
         rows_written = 0
@@ -383,6 +413,10 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 first_batch = self._convert_batch_to_geoarrow(
                     first_batch, geometry_column, geoarrow_type, schema_with_meta
                 )
+            elif geoarrow_target_type is not None:
+                first_batch = self._convert_batch_to_native_geoarrow(
+                    first_batch, geometry_column, geoarrow_target_type, schema_with_meta
+                )
             table_batch = pa.Table.from_batches([first_batch], schema=schema_with_meta)
             writer.write_table(table_batch)
             rows_written += first_batch.num_rows
@@ -393,6 +427,10 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 if use_native_geometry:
                     batch = self._convert_batch_to_geoarrow(
                         batch, geometry_column, geoarrow_type, schema_with_meta
+                    )
+                elif geoarrow_target_type is not None:
+                    batch = self._convert_batch_to_native_geoarrow(
+                        batch, geometry_column, geoarrow_target_type, schema_with_meta
                     )
                 table_batch = pa.Table.from_batches([batch], schema=schema_with_meta)
                 writer.write_table(table_batch)
@@ -535,6 +573,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geom_types: list[str],
         verbose: bool,
         extra_kv_metadata: dict[str, str] | None = None,
+        geoarrow_target_type=None,
     ) -> pa.Schema:
         """Build the output schema for streaming write."""
         from geoparquet_io.core.crs_utils import is_default_crs
@@ -557,6 +596,15 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                     new_fields.append(pa.field(geometry_column, geoarrow_type))
                 else:
                     new_fields.append(field)
+            schema = pa.schema(new_fields)
+        elif geoarrow_target_type is not None:
+            # 1.1-geoarrow path: replace geometry field with the native GeoArrow extension type.
+            # Only triggers when geometry is WKB (binary); already-native inputs are not
+            # routed here (Task 3 keeps them on duckdb-kv).
+            new_fields = [
+                pa.field(geometry_column, geoarrow_target_type) if f.name == geometry_column else f
+                for f in schema
+            ]
             schema = pa.schema(new_fields)
 
         if geo_meta is not None:
@@ -601,6 +649,45 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 new_columns.append(batch.column(i))
 
         return pa.RecordBatch.from_arrays(new_columns, schema=schema_with_geoarrow)
+
+    def _convert_batch_to_native_geoarrow(
+        self,
+        batch: pa.RecordBatch,
+        geometry_column: str,
+        geoarrow_target_type,
+        schema_with_meta: pa.Schema,
+    ) -> pa.RecordBatch:
+        """Convert WKB binary geometry column to native GeoArrow nested type (1.1-geoarrow path).
+
+        Only converts when the incoming column is binary/large_binary (WKB) or a
+        geoarrow.wkb extension type. If it is already a nested GeoArrow type, it is
+        left untouched — though this path should not normally be reached because Task 3
+        routing sends already-native inputs to the duckdb-kv strategy instead.
+        """
+        from geoparquet_io.core.geoarrow_encoding import wkb_array_to_geoarrow
+
+        col_index = batch.schema.get_field_index(geometry_column)
+        geom_col = batch.column(col_index)
+
+        col_type = batch.schema.field(geometry_column).type
+        is_wkb_binary = pa.types.is_binary(col_type) or pa.types.is_large_binary(col_type)
+        is_wkb_extension = (
+            isinstance(col_type, pa.ExtensionType)
+            and getattr(col_type, "extension_name", "") == "geoarrow.wkb"
+        )
+
+        if is_wkb_binary or is_wkb_extension:
+            converted = wkb_array_to_geoarrow(geom_col, geoarrow_target_type)
+            cols = [
+                converted if i == col_index else batch.column(i) for i in range(batch.num_columns)
+            ]
+            return pa.RecordBatch.from_arrays(cols, schema=schema_with_meta)
+
+        # Already native or unexpected type — leave untouched but cast schema
+        return pa.RecordBatch.from_arrays(
+            [batch.column(i) for i in range(batch.num_columns)],
+            schema=schema_with_meta,
+        )
 
     def _write_plain_parquet_from_table(
         self,

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -493,11 +493,26 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
 
         use_native_geometry = effective_version in ("2.0", "parquet-geo-only")
         should_add_geo_metadata = effective_version != "parquet-geo-only"
+        geoarrow_native = effective_version == "1.1-geoarrow"
+
+        # Compute the geoarrow target type once from the whole-table geometry types,
+        # so every batch is coerced to one physical type (schema is fixed up front).
+        geoarrow_target_type = None
+        geoarrow_encoding = None
 
         geo_meta = None
         if should_add_geo_metadata:
             bbox_info = {"has_bbox_column": False, "bbox_column_name": None}
             geom_types = _compute_geometry_types(table, geometry_column, verbose)
+
+            if geoarrow_native:
+                from geoparquet_io.core.geoarrow_encoding import determine_geoarrow_target_type
+
+                geoarrow_target_type, geoarrow_encoding = determine_geoarrow_target_type(
+                    geom_types, input_crs
+                )
+                if verbose:
+                    debug(f"1.1-geoarrow target encoding: {geoarrow_encoding}")
 
             geo_meta = create_geo_metadata(
                 original_metadata=None,
@@ -512,6 +527,11 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
 
             apply_output_crs(geo_meta["columns"][geometry_column], input_crs)
 
+            # Override encoding when geoarrow_target_type resolved a native encoding.
+            # geoarrow_encoding is "WKB" for mixed/unconvertible geometry — no override.
+            if geoarrow_encoding is not None and geoarrow_encoding != "WKB":
+                geo_meta["columns"][geometry_column]["encoding"] = geoarrow_encoding
+
         schema_with_meta = self._build_streaming_schema(
             schema=table.schema,
             geometry_column=geometry_column,
@@ -520,6 +540,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             input_crs=input_crs,
             geom_types=geo_meta["columns"][geometry_column]["geometry_types"] if geo_meta else [],
             verbose=verbose,
+            geoarrow_target_type=geoarrow_target_type,
         )
 
         writer_kwargs = {"compression": validated_compression or "NONE"}
@@ -539,6 +560,10 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 if use_native_geometry:
                     batch = self._convert_batch_to_geoarrow(
                         batch, geometry_column, geoarrow_type, schema_with_meta
+                    )
+                elif geoarrow_target_type is not None:
+                    batch = self._convert_batch_to_native_geoarrow(
+                        batch, geometry_column, geoarrow_target_type, schema_with_meta
                     )
                 table_batch = pa.Table.from_batches([batch], schema=schema_with_meta)
                 writer.write_table(table_batch)

--- a/tests/test_geoarrow_encoding.py
+++ b/tests/test_geoarrow_encoding.py
@@ -3,6 +3,7 @@ import shapely.wkb
 from shapely.geometry import Point, Polygon
 
 from geoparquet_io.core.geoarrow_encoding import (
+    detect_wkb_dimensions,
     determine_geoarrow_target_type,
     wkb_array_to_geoarrow,
 )
@@ -65,3 +66,54 @@ def test_wkb_array_preserves_nulls():
     out = wkb_array_to_geoarrow(arr, target)
     assert out.type.extension_name == "geoarrow.point"
     assert out.null_count == 1
+
+
+def test_z_dimension_selects_xyz_native_type():
+    """A Z-coordinate column must select an XYZ native type, not 2D (no data loss)."""
+    import geoarrow.types as gat
+
+    target, encoding = determine_geoarrow_target_type(["Point"], dimensions={2})  # 2 = XYZ
+    assert encoding == "point"
+    assert target.dimensions == gat.Dimensions.XYZ
+
+
+def test_mixed_dimensions_fall_back_to_wkb():
+    """Mixing 2D and 3D in one column cannot map to a single native type -> WKB."""
+    target, encoding = determine_geoarrow_target_type(["Point"], dimensions={1, 2})
+    assert target is None
+    assert encoding == "WKB"
+
+
+def test_unspecified_dimension_falls_back_to_wkb():
+    """An unknown/unspecified dimension code must not be coerced to 2D."""
+    target, encoding = determine_geoarrow_target_type(["Point"], dimensions={0})
+    assert target is None
+    assert encoding == "WKB"
+
+
+def test_z_wkb_converts_without_dropping_z():
+    """End-to-end: 3D WKB -> XYZ native array preserves the Z ordinate."""
+    import geoarrow.pyarrow as ga
+
+    target, _ = determine_geoarrow_target_type(["Point"], dimensions={2})
+    arr = pa.array(
+        [shapely.wkb.dumps(Point(1, 2, 3)), shapely.wkb.dumps(Point(4, 5, 6))],
+        type=pa.binary(),
+    )
+    out = wkb_array_to_geoarrow(arr, target)
+    assert "POINT Z (1 2 3)" in ga.format_wkt(out)[0].as_py()
+
+
+def test_detect_wkb_dimensions_3d():
+    arr = pa.array([shapely.wkb.dumps(Point(1, 2, 3))], type=pa.binary())
+    assert detect_wkb_dimensions(arr) == {2}  # XYZ
+
+
+def test_detect_wkb_dimensions_2d():
+    arr = pa.array([shapely.wkb.dumps(Point(1, 2))], type=pa.binary())
+    assert detect_wkb_dimensions(arr) == {1}  # XY
+
+
+def test_detect_wkb_dimensions_empty():
+    arr = pa.array([], type=pa.binary())
+    assert detect_wkb_dimensions(arr) == set()

--- a/tests/test_geoarrow_encoding.py
+++ b/tests/test_geoarrow_encoding.py
@@ -37,6 +37,12 @@ def test_empty_geometry_types_falls_back_to_wkb():
     assert encoding == "WKB"
 
 
+def test_no_crs_attached_when_input_crs_default():
+    """Default path (no input_crs) must not attach a CRS to the target type."""
+    target, _ = determine_geoarrow_target_type(["Point"])
+    assert target.crs is None
+
+
 def test_crs_is_attached_to_target_type():
     crs = {"type": "GeographicCRS", "name": "Custom"}
     target, _ = determine_geoarrow_target_type(["Point"], input_crs=crs)

--- a/tests/test_geoarrow_encoding.py
+++ b/tests/test_geoarrow_encoding.py
@@ -1,0 +1,61 @@
+import pyarrow as pa
+import shapely.wkb
+from shapely.geometry import Point, Polygon
+
+from geoparquet_io.core.geoarrow_encoding import (
+    determine_geoarrow_target_type,
+    wkb_array_to_geoarrow,
+)
+
+
+def _wkb_array(*geoms):
+    return pa.array([shapely.wkb.dumps(g) for g in geoms], type=pa.binary())
+
+
+def test_single_type_maps_to_native_encoding():
+    target, encoding = determine_geoarrow_target_type(["Polygon"])
+    assert encoding == "polygon"
+    assert target is not None
+    assert target.extension_name == "geoarrow.polygon"
+
+
+def test_polygon_and_multipolygon_promote_to_multipolygon():
+    target, encoding = determine_geoarrow_target_type(["Polygon", "MultiPolygon"])
+    assert encoding == "multipolygon"
+    assert target.extension_name == "geoarrow.multipolygon"
+
+
+def test_incompatible_types_fall_back_to_wkb():
+    target, encoding = determine_geoarrow_target_type(["Point", "Polygon"])
+    assert target is None
+    assert encoding == "WKB"
+
+
+def test_empty_geometry_types_falls_back_to_wkb():
+    target, encoding = determine_geoarrow_target_type([])
+    assert target is None
+    assert encoding == "WKB"
+
+
+def test_crs_is_attached_to_target_type():
+    crs = {"type": "GeographicCRS", "name": "Custom"}
+    target, _ = determine_geoarrow_target_type(["Point"], input_crs=crs)
+    assert target.extension_name == "geoarrow.point"
+    # CRS round-trips through the geoarrow type metadata
+    assert "Custom" in str(target.crs)
+
+
+def test_wkb_array_converts_to_target_type():
+    target, _ = determine_geoarrow_target_type(["Polygon"])
+    arr = _wkb_array(Polygon([(0, 0), (1, 0), (1, 1), (0, 0)]))
+    out = wkb_array_to_geoarrow(arr, target)
+    assert out.type.extension_name == "geoarrow.polygon"
+    assert len(out) == 1
+
+
+def test_wkb_array_preserves_nulls():
+    target, _ = determine_geoarrow_target_type(["Point"])
+    arr = pa.array([shapely.wkb.dumps(Point(1, 2)), None], type=pa.binary())
+    out = wkb_array_to_geoarrow(arr, target)
+    assert out.type.extension_name == "geoarrow.point"
+    assert out.null_count == 1

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1448,3 +1448,50 @@ class TestGeoParquet11GeoArrow:
         geom_col = geo_meta["primary_column"]
         assert geo_meta["columns"][geom_col]["encoding"] != "WKB"
         assert str(pq.read_schema(output_file).field(geom_col).type) != "binary"
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        [
+            "buildings_test.geojson",
+            "buildings_test.shp",
+            "buildings_test.gpkg",
+            "buildings_test.parquet",
+        ],
+    )
+    def test_all_input_formats_produce_native_encoding(self, fixture_name, test_data_dir, tmp_path):
+        """Every input format must yield native GeoArrow encoding + valid GeoParquet under 1.1-geoarrow."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.common import check_bbox_structure
+        from geoparquet_io.core.convert import convert_to_geoparquet
+
+        input_file = str(test_data_dir / fixture_name)
+        output_file = str(tmp_path / "out.parquet")
+        convert_to_geoparquet(
+            input_file, output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        geo_meta = get_geo_metadata(output_file)
+        geom_col = geo_meta["primary_column"]
+        encoding = geo_meta["columns"][geom_col]["encoding"]
+        # all buildings_test fixtures contain only Polygon geometries (verified)
+        assert encoding == "polygon", f"{fixture_name}: expected polygon, got {encoding}"
+        assert str(pq.read_schema(output_file).field(geom_col).type) != "binary"
+        # bbox column must be skipped for 1.1-geoarrow
+        assert not check_bbox_structure(output_file)["has_bbox_column"]
+        assert get_geoparquet_version(output_file) == "1.1.0"
+
+    def test_mixed_geometry_falls_back_to_wkb(self, test_data_dir, tmp_path):
+        """A column mixing incompatible geometry types (Point + Polygon) stays WKB under 1.1-geoarrow."""
+        from geoparquet_io.core.convert import convert_to_geoparquet
+
+        # mixed_geometries.csv has a 'geometry' WKT column with Point and Polygon rows
+        input_file = str(test_data_dir / "mixed_geometries.csv")
+        output_file = str(tmp_path / "out.parquet")
+        convert_to_geoparquet(
+            input_file, output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        geo_meta = get_geo_metadata(output_file)
+        geom_col = geo_meta["primary_column"]
+        assert geo_meta["columns"][geom_col]["encoding"] == "WKB"

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1268,9 +1268,10 @@ class TestPartitionGeoParquetVersion:
 class TestGeoParquet11GeoArrow:
     """Tests for --geoparquet-version 1.1-geoarrow output.
 
-    This version writes GeoParquet 1.1 metadata but skips the bbox column,
-    keeping the geometry in its native Arrow encoding (no WKB blob conversion).
-    Useful for GeoArrow-native parquet files that don't benefit from bbox columns.
+    This version writes GeoParquet 1.1.0 metadata, skips the bbox column, and
+    encodes geometry using native GeoArrow nested-coordinate types. Native input
+    encoding is preserved; WKB/text inputs are converted to native GeoArrow
+    (falling back to WKB only for geometry-type mixes that cannot be unified).
     """
 
     def test_version_constant_exists(self):
@@ -1357,34 +1358,28 @@ class TestGeoParquet11GeoArrow:
             f"Expected 'multipolygon' encoding in metadata, got '{encoding}'"
         )
 
-    def test_wkb_input_writes_binary_geometry(self, geojson_input, temp_output_file):
-        """WKB-encoded input (GeoJSON) with 1.1-geoarrow must write binary WKB, not native type."""
+    def test_wkb_input_writes_native_geometry(self, geojson_input, temp_output_file):
+        """WKB-encoded input (GeoJSON) with 1.1-geoarrow is converted to native GeoArrow."""
         import pyarrow.parquet as pq
 
         convert_to_geoparquet(
             geojson_input, temp_output_file, geoparquet_version="1.1-geoarrow", verbose=False
         )
-
         geo_meta = get_geo_metadata(temp_output_file)
         geom_col = geo_meta["primary_column"]
-        schema = pq.read_schema(temp_output_file)
-        geom_field = schema.field(geom_col)
-        assert str(geom_field.type) == "binary", (
-            f"WKB input should remain binary blob, got {geom_field.type}"
+        geom_field = pq.read_schema(temp_output_file).field(geom_col)
+        assert str(geom_field.type) != "binary", (
+            f"WKB input should become native GeoArrow, got {geom_field.type}"
         )
 
-    def test_wkb_input_metadata_encoding_is_wkb(self, geojson_input, temp_output_file):
-        """WKB-encoded input with 1.1-geoarrow must record 'WKB' in geo metadata."""
+    def test_wkb_input_metadata_encoding_is_native(self, geojson_input, temp_output_file):
+        """WKB-encoded polygon input records a native encoding (not 'WKB')."""
         convert_to_geoparquet(
             geojson_input, temp_output_file, geoparquet_version="1.1-geoarrow", verbose=False
         )
-
         geo_meta = get_geo_metadata(temp_output_file)
         geom_col = geo_meta["primary_column"]
-        encoding = geo_meta["columns"][geom_col]["encoding"]
-        assert encoding == "WKB", (
-            f"Expected 'WKB' encoding in metadata for WKB input, got '{encoding}'"
-        )
+        assert geo_meta["columns"][geom_col]["encoding"] == "polygon"
 
     @pytest.mark.parametrize(
         "geom_type",

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1412,3 +1412,39 @@ class TestGeoParquet11GeoArrow:
         assert encoding == geom_type, (
             f"Expected '{geom_type}' encoding in metadata, got '{encoding}'"
         )
+
+    def test_wkb_query_via_arrow_streaming_produces_native(self, geojson_input, temp_output_file):
+        """arrow-streaming + 1.1-geoarrow must emit nested GeoArrow, not WKB binary."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.convert import convert_to_geoparquet
+
+        # buildings_test.geojson is polygons
+        convert_to_geoparquet(
+            geojson_input,
+            temp_output_file,
+            geoparquet_version="1.1-geoarrow",
+            verbose=False,
+        )
+        geo_meta = get_geo_metadata(temp_output_file)
+        geom_col = geo_meta["primary_column"]
+        schema = pq.read_schema(temp_output_file)
+        assert str(schema.field(geom_col).type) != "binary"
+        assert geo_meta["columns"][geom_col]["encoding"] == "polygon"
+
+    def test_wkb_parquet_input_converts_to_native(self, test_data_dir, tmp_path):
+        """A WKB-encoded GeoParquet input must become native GeoArrow under 1.1-geoarrow."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.convert import convert_to_geoparquet
+
+        input_file = str(test_data_dir / "buildings_test.parquet")  # WKB-encoded
+        output_file = str(tmp_path / "out.parquet")
+        convert_to_geoparquet(
+            input_file, output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+
+        geo_meta = get_geo_metadata(output_file)
+        geom_col = geo_meta["primary_column"]
+        assert geo_meta["columns"][geom_col]["encoding"] != "WKB"
+        assert str(pq.read_schema(output_file).field(geom_col).type) != "binary"

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -27,6 +27,21 @@ from tests.conftest import (
 )
 
 
+def _is_wkb_type(arrow_type) -> bool:
+    """True when an Arrow type is WKB (plain/large binary or a geoarrow.wkb extension).
+
+    Uses pyarrow type predicates rather than a string comparison so it also catches
+    large_binary and geoarrow.wkb, which a ``str(type) != "binary"`` check would miss.
+    """
+    import pyarrow as pa
+
+    return (
+        pa.types.is_binary(arrow_type)
+        or pa.types.is_large_binary(arrow_type)
+        or getattr(arrow_type, "extension_name", "") == "geoarrow.wkb"
+    )
+
+
 class TestGeoParquetVersionConstants:
     """Test version configuration constants."""
 
@@ -1341,7 +1356,7 @@ class TestGeoParquet11GeoArrow:
         schema = pq.read_schema(output_file)
         geom_field = schema.field("geometry")
         # Native geometry should NOT be a plain binary blob
-        assert str(geom_field.type) != "binary", "geometry should remain native, not WKB blob"
+        assert not _is_wkb_type(geom_field.type), "geometry should remain native, not WKB blob"
 
     def test_native_input_metadata_encoding_preserved(self, test_data_dir, tmp_path):
         """GeoParquet metadata must record the actual native encoding, not WKB."""
@@ -1368,7 +1383,7 @@ class TestGeoParquet11GeoArrow:
         geo_meta = get_geo_metadata(temp_output_file)
         geom_col = geo_meta["primary_column"]
         geom_field = pq.read_schema(temp_output_file).field(geom_col)
-        assert str(geom_field.type) != "binary", (
+        assert not _is_wkb_type(geom_field.type), (
             f"WKB input should become native GeoArrow, got {geom_field.type}"
         )
 
@@ -1398,7 +1413,7 @@ class TestGeoParquet11GeoArrow:
 
         schema = pq.read_schema(output_file)
         geom_field = schema.field("geometry")
-        assert str(geom_field.type) != "binary", (
+        assert not _is_wkb_type(geom_field.type), (
             f"{geom_type}: geometry should remain native, not WKB blob"
         )
 
@@ -1424,7 +1439,7 @@ class TestGeoParquet11GeoArrow:
         geo_meta = get_geo_metadata(temp_output_file)
         geom_col = geo_meta["primary_column"]
         schema = pq.read_schema(temp_output_file)
-        assert str(schema.field(geom_col).type) != "binary"
+        assert not _is_wkb_type(schema.field(geom_col).type)
         assert geo_meta["columns"][geom_col]["encoding"] == "polygon"
 
     def test_wkb_parquet_input_converts_to_native(self, test_data_dir, tmp_path):
@@ -1442,7 +1457,7 @@ class TestGeoParquet11GeoArrow:
         geo_meta = get_geo_metadata(output_file)
         geom_col = geo_meta["primary_column"]
         assert geo_meta["columns"][geom_col]["encoding"] != "WKB"
-        assert str(pq.read_schema(output_file).field(geom_col).type) != "binary"
+        assert not _is_wkb_type(pq.read_schema(output_file).field(geom_col).type)
 
     @pytest.mark.parametrize(
         "fixture_name",
@@ -1471,7 +1486,7 @@ class TestGeoParquet11GeoArrow:
         encoding = geo_meta["columns"][geom_col]["encoding"]
         # all buildings_test fixtures contain only Polygon geometries (verified)
         assert encoding == "polygon", f"{fixture_name}: expected polygon, got {encoding}"
-        assert str(pq.read_schema(output_file).field(geom_col).type) != "binary"
+        assert not _is_wkb_type(pq.read_schema(output_file).field(geom_col).type)
         # bbox column must be skipped for 1.1-geoarrow
         assert not check_bbox_structure(output_file)["has_bbox_column"]
         assert get_geoparquet_version(output_file) == "1.1.0"
@@ -1533,4 +1548,84 @@ class TestGeoParquet11GeoArrow:
         geo_meta = json.loads(schema.metadata[b"geo"])
         geom_col = geo_meta["primary_column"]
         assert geo_meta["columns"][geom_col]["encoding"] == "polygon"
-        assert str(schema.field(geom_col).type) != "binary"
+        assert not _is_wkb_type(schema.field(geom_col).type)
+
+    def test_3d_input_preserves_z(self, tmp_path):
+        """3D (Point Z) WKB input must keep its Z ordinate under 1.1-geoarrow.
+
+        Regression for silent Z/M data loss: the native target type was always 2D,
+        so a forced conversion dropped the Z. Either Z survives in a native XYZ type
+        or the column falls back to WKB — never a silent 2D coercion.
+        """
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+        import shapely.wkb
+        from shapely.geometry import Point
+
+        import geoparquet_io as gpio
+
+        arr = pa.array(
+            [shapely.wkb.dumps(Point(1, 2, 3)), shapely.wkb.dumps(Point(4, 5, 6))],
+            type=pa.binary(),
+        )
+        table = gpio.Table(pa.table({"geometry": arr}), geometry_column="geometry")
+
+        output_file = str(tmp_path / "out_3d.parquet")
+        table.write(output_file, geoparquet_version="1.1-geoarrow")
+
+        schema = pq.read_schema(output_file)
+        geom_type = schema.field("geometry").type
+        if _is_wkb_type(geom_type):
+            # WKB fallback is acceptable — Z is preserved verbatim in the WKB bytes.
+            return
+
+        # Native encoding must carry the Z ordinate (XYZ storage with a z field).
+        import geoarrow.pyarrow as ga
+
+        col = pq.read_table(output_file).column("geometry").combine_chunks()
+        wkt = ga.format_wkt(ga.as_geoarrow(col))[0].as_py()
+        assert "POINT Z" in wkt, f"Z ordinate dropped, got {wkt}"
+
+    def test_python_api_write_preserves_crs(self, tmp_path):
+        """A non-default CRS must survive Table.write(1.1-geoarrow) (no silent CRS84).
+
+        Regression for dropped CRS: write_from_table was never given self.crs, so the
+        native type and geo metadata both lost a non-default CRS.
+        """
+        import json
+
+        import pyarrow as pa
+        import shapely.wkb
+        from pyproj import CRS
+        from shapely.geometry import Point
+
+        import geoparquet_io as gpio
+
+        projjson = CRS.from_epsg(3857).to_json_dict()
+        arr = pa.array(
+            [shapely.wkb.dumps(Point(1, 2)), shapely.wkb.dumps(Point(3, 4))],
+            type=pa.binary(),
+        )
+        geo = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": ["Point"],
+                    "crs": projjson,
+                }
+            },
+        }
+        tbl = pa.table({"geometry": arr}).replace_schema_metadata(
+            {b"geo": json.dumps(geo).encode("utf-8")}
+        )
+        table = gpio.Table(tbl, geometry_column="geometry")
+
+        output_file = str(tmp_path / "out_crs.parquet")
+        table.write(output_file, geoparquet_version="1.1-geoarrow")
+
+        geo_out = get_geo_metadata(output_file)
+        crs_out = geo_out["columns"]["geometry"].get("crs")
+        assert crs_out is not None, "non-default CRS was dropped"
+        assert crs_out.get("id", {}).get("code") == 3857

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1513,3 +1513,24 @@ class TestGeoParquet11GeoArrow:
         gdf = gpd.read_parquet(temp_output_file)
         assert len(gdf) > 0
         assert gdf.geometry.notna().all()
+
+    def test_python_api_write_produces_native_encoding(self, geojson_input, temp_output_file):
+        """The public Python API (Table.write) must produce native GeoArrow, not WKB.
+
+        Drives the Table.write path (gpio.convert(...).write(...)), which is a
+        different code path from convert_to_geoparquet and was previously emitting WKB.
+        """
+        import json
+
+        import pyarrow.parquet as pq
+
+        import geoparquet_io as gpio
+
+        table = gpio.convert(geojson_input)
+        table.write(temp_output_file, geoparquet_version="1.1-geoarrow")
+
+        schema = pq.read_schema(temp_output_file)
+        geo_meta = json.loads(schema.metadata[b"geo"])
+        geom_col = geo_meta["primary_column"]
+        assert geo_meta["columns"][geom_col]["encoding"] == "polygon"
+        assert str(schema.field(geom_col).type) != "binary"

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1478,6 +1478,9 @@ class TestGeoParquet11GeoArrow:
 
     def test_mixed_geometry_falls_back_to_wkb(self, test_data_dir, tmp_path):
         """A column mixing incompatible geometry types (Point + Polygon) stays WKB under 1.1-geoarrow."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
         from geoparquet_io.core.convert import convert_to_geoparquet
 
         # mixed_geometries.csv has a 'geometry' WKT column with Point and Polygon rows
@@ -1490,6 +1493,13 @@ class TestGeoParquet11GeoArrow:
         geo_meta = get_geo_metadata(output_file)
         geom_col = geo_meta["primary_column"]
         assert geo_meta["columns"][geom_col]["encoding"] == "WKB"
+
+        # Verify the physical Arrow column type is binary/WKB (not native nested GeoArrow)
+        schema = pq.read_schema(output_file)
+        geom_type = schema.field(geom_col).type
+        assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type), (
+            f"mixed geometry should stay binary WKB, got {geom_type}"
+        )
 
     def test_native_output_is_valid_and_readable(self, geojson_input, temp_output_file):
         """1.1-geoarrow native output passes validation and round-trips through geopandas."""

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1495,3 +1495,16 @@ class TestGeoParquet11GeoArrow:
         geo_meta = get_geo_metadata(output_file)
         geom_col = geo_meta["primary_column"]
         assert geo_meta["columns"][geom_col]["encoding"] == "WKB"
+
+    def test_native_output_is_valid_and_readable(self, geojson_input, temp_output_file):
+        """1.1-geoarrow native output passes validation and round-trips through geopandas."""
+        import geopandas as gpd
+
+        from geoparquet_io.core.convert import convert_to_geoparquet
+
+        convert_to_geoparquet(
+            geojson_input, temp_output_file, geoparquet_version="1.1-geoarrow", verbose=False
+        )
+        gdf = gpd.read_parquet(temp_output_file)
+        assert len(gdf) > 0
+        assert gdf.geometry.notna().all()

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -427,6 +427,47 @@ def test_preview_data_returns_wkt():
     assert "POLYGON" in geom_value or "POINT" in geom_value or "LINESTRING" in geom_value
 
 
+def test_preview_data_returns_wkt_for_native_geoarrow():
+    """get_preview_data must convert native GeoArrow geometry to WKT (not crash).
+
+    Native GeoArrow geometry is exposed by DuckDB as a raw STRUCT/LIST, which
+    ST_AsText cannot handle. head/tail must detect this and convert via geoarrow.
+    """
+    test_file = os.path.join(
+        os.path.dirname(__file__), "data", "data-polygon-encoding_native.parquet"
+    )
+    table, mode = get_preview_data(test_file, head=1)
+
+    geom_value = table.column("geometry")[0].as_py()
+    assert isinstance(geom_value, str), f"Expected WKT str but got {type(geom_value)}"
+    assert "POLYGON" in geom_value
+
+
+@pytest.mark.parametrize(
+    "geom_type,wkt_prefix",
+    [
+        ("point", "POINT"),
+        ("linestring", "LINESTRING"),
+        ("polygon", "POLYGON"),
+        ("multipoint", "MULTIPOINT"),
+        ("multilinestring", "MULTILINESTRING"),
+        ("multipolygon", "MULTIPOLYGON"),
+    ],
+)
+def test_preview_native_geoarrow_all_types(geom_type, wkt_prefix):
+    """All native GeoArrow geometry types render to WKT in head, including NULLs."""
+    test_file = os.path.join(
+        os.path.dirname(__file__), "data", f"data-{geom_type}-encoding_native.parquet"
+    )
+    table, _ = get_preview_data(test_file, head=10)
+    values = table.column("geometry").to_pylist()
+    # Every non-null value is a WKT string of the expected type; NULLs pass through.
+    non_null = [v for v in values if v is not None]
+    assert non_null, "expected at least one non-null geometry"
+    assert all(isinstance(v, str) for v in non_null)
+    assert any(wkt_prefix in v for v in non_null)
+
+
 def test_format_markdown_output():
     """Test markdown output formatting function."""
     file_info = {

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -465,7 +465,9 @@ def test_preview_native_geoarrow_all_types(geom_type, wkt_prefix):
     non_null = [v for v in values if v is not None]
     assert non_null, "expected at least one non-null geometry"
     assert all(isinstance(v, str) for v in non_null)
-    assert any(wkt_prefix in v for v in non_null)
+    assert all(v.startswith(wkt_prefix) for v in non_null), (
+        f"every non-null value must render as {wkt_prefix} WKT, got {non_null}"
+    )
 
 
 def test_format_markdown_output():


### PR DESCRIPTION
## Summary

`--geoparquet-version 1.1-geoarrow` previously only *preserved* native GeoArrow encoding when the input was already native; for every other input format (GeoJSON, Shapefile, GeoPackage, CSV, WKB GeoParquet) it silently fell back to WKB — contradicting the documented "native GeoArrow encoding".

This PR makes `1.1-geoarrow` actually **produce** native GeoArrow nested-coordinate encoding (`point`/`linestring`/`polygon`/`multipoint`/`multilinestring`/`multipolygon`) from **any** input, via both the CLI (`gpio convert`) and the Python API (`Table.write` / `gpio.convert(...).write(...)`).

It also fixes a related read-side bug: `gpio inspect head`/`tail` crashed on native-GeoArrow files (the kind this feature now produces).

## What changed

- **New `core/geoarrow_encoding.py`** — pure pyarrow/geoarrow helper: determines a single dataset-wide GeoArrow target type from the geometry types and converts WKB arrays to it. Incompatible mixed-geometry columns fall back to WKB; compatible mixes promote (e.g. `polygon`+`multipolygon` → `multipolygon`).
- **`arrow-streaming` write strategy** — new geoarrow-native mode (separate from the 2.0 `use_native_geometry` path) wired into both `write_from_query` (CLI/core) and `write_from_table` (Python API). The target type is computed once and every batch is coerced to it (stable streaming schema).
- **Routing** — `1.1-geoarrow` WKB/text inputs are routed to the streaming strategy in both `core/common.py:write_parquet_with_metadata` and `api/table.py` (`duckdb-kv`/`COPY TO` cannot emit nested GeoArrow). Already-native inputs keep their existing preservation path.
- **`inspect head`/`tail`** — detect native-GeoArrow geometry (DuckDB exposes it as a raw `STRUCT`/`LIST`) and render it to WKT via geoarrow (null-safe), instead of blindly calling `ST_AsText` (which only accepts `GEOMETRY`/WKB).
- **Docs & help text** — updated to describe native-encoding production with the WKB fallback for mixed types.

## Behavior notes

- The bbox column is still skipped for `1.1-geoarrow` (unchanged).
- A column genuinely mixing *incompatible* geometry types (e.g. Point + Polygon) cannot be native GeoArrow and falls back to WKB — a hard constraint of the format, not a shortcut.
- The previously-deliberate "preserve-only" contract (and its two tests) was intentionally updated to the new "produce native encoding" contract.

## Testing

- New unit tests for the conversion helper; cross-format conversion tests (GeoJSON/Shapefile/GeoPackage/WKB-Parquet → native), mixed-geometry WKB fallback, geopandas round-trip, and a Python-API (`Table.write`) test.
- New `inspect head`/`tail` tests covering all six native geometry types incl. NULLs.
- Full fast suite: 3002 passed, coverage 72.58% (one pre-existing flaky `test_commitizen` timeout that passes in isolation, unrelated to this change). Complexity (xenon), import-linter, and doc-sync gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GeoParquet **`1.1-geoarrow`** option for writing/conversion (Python and CLI), producing **native GeoArrow nested-coordinate geometry**, **skipping the bbox column**, and handling mixed geometry inputs with safe fallbacks.
  * Streaming writes now consistently emit native GeoArrow geometry when `1.1-geoarrow` is selected.
* **Bug Fixes**
  * Improved preview generation to correctly display WKT for **native GeoArrow geometry** returned by DuckDB.
* **Documentation**
  * Expanded docs for `geoparquet_version` / `--geoparquet-version` with version-specific behavior and examples.
* **Tests**
  * Added and updated coverage for `1.1-geoarrow` encoding, conversion, and preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->