### PR TITLE
feat(inspect): fit head/tail previews to terminal width

### DIFF
--- a/docs/guide/inspect.md
+++ b/docs/guide/inspect.md
@@ -78,7 +78,9 @@ Shows:
 
 ### Fitting to Terminal Width
 
-By default, `gpio inspect head` and `gpio inspect tail` fit the preview to your terminal width, showing as many whole columns as fit on screen. Cell values are truncated with ellipsis (`…`) to one line per cell. When columns are hidden, a note appears: `… +N more columns (--no-truncate or --json to see all)`.
+When writing to an interactive terminal, `gpio inspect head` and `gpio inspect tail` fit the preview to your terminal width, showing as many whole columns as fit on screen. Cell values are truncated with ellipsis (`…`) to one line per cell. When columns are hidden, a note appears: `… +N more columns (--no-truncate or --json to see all)`.
+
+When output is redirected or piped (e.g. `gpio inspect head data.parquet | cat`), width fitting is disabled and all columns are shown with full values, so scripts and pipes always see every column. Pass `--max-columns N` to limit columns even when piping.
 
 Use `--max-columns N` to show exactly N columns instead of auto-fitting:
 

--- a/docs/guide/inspect.md
+++ b/docs/guide/inspect.md
@@ -76,6 +76,31 @@ Shows:
     preview = table.head(100).add_bbox()
     ```
 
+### Fitting to Terminal Width
+
+By default, `gpio inspect head` and `gpio inspect tail` fit the preview to your terminal width, showing as many whole columns as fit on screen. Cell values are truncated with ellipsis (`…`) to one line per cell. When columns are hidden, a note appears: `… +N more columns (--no-truncate or --json to see all)`.
+
+Use `--max-columns N` to show exactly N columns instead of auto-fitting:
+
+```bash
+# Show exactly 3 columns
+gpio inspect head data.parquet --max-columns 3
+```
+
+Use `--no-truncate` to disable width fitting and show all columns with full (untrimmed) values:
+
+```bash
+# Show all columns with complete values
+gpio inspect head data.parquet --no-truncate
+```
+
+For machine-readable output with all columns and full values, use `--json`:
+
+```bash
+# Complete data as JSON
+gpio inspect head data.parquet --json
+```
+
 ## Statistics
 
 === "CLI"

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2098,10 +2098,15 @@ def _inspect_summary_impl(parquet_file, json_output, markdown_output, check_all_
         raise _friendly_parquet_error(e, parquet_file) from e
 
 
-def _inspect_preview_impl(parquet_file, count, mode, json_output, markdown_output):
+def _inspect_preview_impl(
+    parquet_file, count, mode, json_output, markdown_output, max_columns=None, no_truncate=False
+):
     """CLI wrapper for inspect head/tail - delegates to core function."""
     if json_output and markdown_output:
         raise click.UsageError("--json and --markdown are mutually exclusive")
+    if no_truncate and max_columns is not None:
+        click.echo("Note: --no-truncate overrides --max-columns; showing all columns.")
+        max_columns = None
 
     _validate_parquet_input(parquet_file)
 
@@ -2113,7 +2118,9 @@ def _inspect_preview_impl(parquet_file, count, mode, json_output, markdown_outpu
             click.echo(click.style(result["partition_notice"], fg="cyan"))
             click.echo()
 
-        output = format_preview_output(result, json_output, markdown_output)
+        output = format_preview_output(
+            result, json_output, markdown_output, max_columns=max_columns, no_truncate=no_truncate
+        )
         if output:
             click.echo(output)
 
@@ -2174,9 +2181,22 @@ def inspect_summary(ctx, parquet_file, json_output, markdown_output, check_all_f
 @click.option(
     "--markdown", "markdown_output", is_flag=True, help="Output as Markdown for README files"
 )
+@click.option(
+    "--max-columns",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Maximum number of columns to display (default: fit terminal width)",
+)
+@click.option(
+    "--no-truncate",
+    is_flag=True,
+    help="Show all columns and full values (disable fit-to-width)",
+)
 @verbose_option
 @click.pass_context
-def inspect_head(ctx, parquet_file, count, json_output, markdown_output, verbose):
+def inspect_head(
+    ctx, parquet_file, count, json_output, markdown_output, max_columns, no_truncate, verbose
+):
     """Show first N rows of data (default: 10).
 
     Examples:
@@ -2186,7 +2206,15 @@ def inspect_head(ctx, parquet_file, count, json_output, markdown_output, verbose
         gpio inspect head data.parquet 20     # First 20 rows
     """
     with _activate_s3(ctx):
-        _inspect_preview_impl(parquet_file, count, "head", json_output, markdown_output)
+        _inspect_preview_impl(
+            parquet_file,
+            count,
+            "head",
+            json_output,
+            markdown_output,
+            max_columns=max_columns,
+            no_truncate=no_truncate,
+        )
 
 
 @inspect.command(name="tail", cls=GlobAwareCommand)
@@ -2196,9 +2224,22 @@ def inspect_head(ctx, parquet_file, count, json_output, markdown_output, verbose
 @click.option(
     "--markdown", "markdown_output", is_flag=True, help="Output as Markdown for README files"
 )
+@click.option(
+    "--max-columns",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Maximum number of columns to display (default: fit terminal width)",
+)
+@click.option(
+    "--no-truncate",
+    is_flag=True,
+    help="Show all columns and full values (disable fit-to-width)",
+)
 @verbose_option
 @click.pass_context
-def inspect_tail(ctx, parquet_file, count, json_output, markdown_output, verbose):
+def inspect_tail(
+    ctx, parquet_file, count, json_output, markdown_output, max_columns, no_truncate, verbose
+):
     """Show last N rows of data (default: 10).
 
     Examples:
@@ -2208,7 +2249,15 @@ def inspect_tail(ctx, parquet_file, count, json_output, markdown_output, verbose
         gpio inspect tail data.parquet 5      # Last 5 rows
     """
     with _activate_s3(ctx):
-        _inspect_preview_impl(parquet_file, count, "tail", json_output, markdown_output)
+        _inspect_preview_impl(
+            parquet_file,
+            count,
+            "tail",
+            json_output,
+            markdown_output,
+            max_columns=max_columns,
+            no_truncate=no_truncate,
+        )
 
 
 @inspect.command(name="stats", cls=GlobAwareCommand)

--- a/geoparquet_io/core/inspect.py
+++ b/geoparquet_io/core/inspect.py
@@ -246,6 +246,8 @@ def format_preview_output(
     result: dict,
     json_output: bool = False,
     markdown_output: bool = False,
+    max_columns: int | None = None,
+    no_truncate: bool = False,
 ) -> str | None:
     """Format preview result for output.
 
@@ -253,6 +255,8 @@ def format_preview_output(
         result: Dict from inspect_preview
         json_output: Output as JSON
         markdown_output: Output as Markdown
+        max_columns: Maximum number of columns to display (terminal only)
+        no_truncate: Show all columns and full values (terminal only)
 
     Returns:
         Formatted string for json/markdown, or None for terminal (prints directly)
@@ -282,6 +286,8 @@ def format_preview_output(
             result["preview_table"],
             result["preview_mode"],
             None,
+            max_columns=max_columns,
+            no_truncate=no_truncate,
         )
         return None
 

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -816,6 +816,30 @@ def _create_columns_table(columns_info: list[dict[str, Any]]) -> Table:
     return table
 
 
+# Preview table fit-to-width tuning. Approximate rich box geometry: each column
+# costs its content width plus padding (2) and a separator (1); plus one outer border.
+_PREVIEW_MIN_COL_WIDTH = 12
+_PREVIEW_COL_OVERHEAD = 3
+_PREVIEW_BORDER_WIDTH = 1
+
+
+def _columns_that_fit(num_columns: int, console_width: int, max_columns: int | None = None) -> int:
+    """Return how many columns to show in a preview at the given terminal width.
+
+    With max_columns set, returns that count clamped to [1, num_columns]. Otherwise
+    computes how many columns fit console_width at a readable minimum width, always
+    at least 1 and never more than num_columns.
+    """
+    if num_columns <= 0:
+        return 0
+    if max_columns is not None:
+        return max(1, min(max_columns, num_columns))
+    available = max(0, console_width - _PREVIEW_BORDER_WIDTH)
+    per_col = _PREVIEW_MIN_COL_WIDTH + _PREVIEW_COL_OVERHEAD
+    fit = available // per_col
+    return max(1, min(fit, num_columns))
+
+
 def _create_preview_table(
     preview_table: pa.Table,
     columns_info: list[dict[str, Any]],

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -854,8 +854,14 @@ def _create_preview_table(
     fit the console width (or max_columns) are shown, with one-line ellipsis cells;
     remaining columns are reported via hidden_column_count. With no_truncate=True every
     column is shown with full, wrapped values.
+
+    Fit-to-width only applies to a real terminal: when output is redirected or piped
+    (console.is_terminal is False) and max_columns was not explicitly requested, every
+    column is shown so scripts and pipes keep seeing all columns as they did before.
     """
-    if no_truncate:
+    non_tty = console is not None and not console.is_terminal
+    full_columns = no_truncate or (non_tty and max_columns is None)
+    if full_columns:
         visible = columns_info
         hidden_count = 0
         overflow = "fold"

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -843,11 +843,34 @@ def _columns_that_fit(num_columns: int, console_width: int, max_columns: int | N
 def _create_preview_table(
     preview_table: pa.Table,
     columns_info: list[dict[str, Any]],
-) -> Table:
-    """Create the preview data table."""
+    *,
+    console: Console | None = None,
+    max_columns: int | None = None,
+    no_truncate: bool = False,
+) -> tuple[Table, int]:
+    """Create the preview data table.
+
+    Returns (table, hidden_column_count). In the default mode only the columns that
+    fit the console width (or max_columns) are shown, with one-line ellipsis cells;
+    remaining columns are reported via hidden_column_count. With no_truncate=True every
+    column is shown with full, wrapped values.
+    """
+    if no_truncate:
+        visible = columns_info
+        hidden_count = 0
+        overflow = "fold"
+        no_wrap = False
+    else:
+        width = console.width if console is not None else 80
+        visible_count = _columns_that_fit(len(columns_info), width, max_columns)
+        visible = columns_info[:visible_count]
+        hidden_count = len(columns_info) - visible_count
+        overflow = "ellipsis"
+        no_wrap = True
+
     preview = Table(show_header=True, header_style="bold")
-    for col in columns_info:
-        preview.add_column(col["name"], style="white", overflow="fold")
+    for col in visible:
+        preview.add_column(col["name"], style="white", overflow=overflow, no_wrap=no_wrap)
 
     for i in range(preview_table.num_rows):
         row_data = [
@@ -856,11 +879,11 @@ def _create_preview_table(
                 col["type"],
                 col["is_geometry"],
             )
-            for col in columns_info
+            for col in visible
         ]
         preview.add_row(*row_data)
 
-    return preview
+    return preview, hidden_count
 
 
 def _truncate_stat_value(value: Any) -> str:
@@ -927,6 +950,8 @@ def format_terminal_output(
     preview_mode: str | None = None,
     stats: dict[str, dict[str, Any]] | None = None,
     compression_stats: list[dict] | None = None,
+    max_columns: int | None = None,
+    no_truncate: bool = False,
 ) -> None:
     """
     Format and print terminal output using Rich.
@@ -977,7 +1002,18 @@ def format_terminal_output(
         console.print()
         label = "first" if preview_mode == "head" else "last"
         console.print(f"Preview ({label} {preview_table.num_rows} rows):")
-        console.print(_create_preview_table(preview_table, columns_info))
+        preview, hidden = _create_preview_table(
+            preview_table,
+            columns_info,
+            console=console,
+            max_columns=max_columns,
+            no_truncate=no_truncate,
+        )
+        console.print(preview)
+        if hidden > 0:
+            console.print(
+                f"[dim]… +{hidden} more columns (--no-truncate or --json to see all)[/dim]"
+            )
 
     # Statistics table
     if stats:

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1303,6 +1303,8 @@ def test_columns_that_fit_max_columns_clamped_to_total():
 def test_columns_that_fit_max_columns_floor_one():
     # max_columns below 1 should never drop below 1 (Click also guards this)
     assert _columns_that_fit(40, 500, max_columns=1) == 1
+    assert _columns_that_fit(40, 500, max_columns=0) == 1
+    assert _columns_that_fit(40, 500, max_columns=-5) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -1321,7 +1323,7 @@ def _wide_preview(num_cols=20, num_rows=2):
 
 def test_create_preview_table_hides_overflow_columns():
     table, columns_info = _wide_preview(num_cols=20)
-    console = Console(width=80)
+    console = Console(width=80, force_terminal=True)
     rich_table, hidden = _create_preview_table(
         columns_info=columns_info, preview_table=table, console=console
     )
@@ -1329,6 +1331,31 @@ def test_create_preview_table_hides_overflow_columns():
     assert len(rich_table.columns) == 20 - hidden
     # cells are one line (no fold): ellipsis overflow on the visible columns
     assert all(c.overflow == "ellipsis" for c in rich_table.columns)
+
+
+def test_create_preview_table_non_tty_shows_all_columns():
+    # Redirected/piped output (is_terminal False) must not silently drop columns.
+    table, columns_info = _wide_preview(num_cols=20)
+    console = Console(width=80)
+    assert console.is_terminal is False
+    rich_table, hidden = _create_preview_table(
+        columns_info=columns_info, preview_table=table, console=console
+    )
+    assert hidden == 0
+    assert len(rich_table.columns) == 20
+    assert all(c.overflow == "fold" for c in rich_table.columns)
+
+
+def test_create_preview_table_non_tty_honors_explicit_max_columns():
+    # An explicit --max-columns is still respected when output is piped.
+    table, columns_info = _wide_preview(num_cols=20)
+    console = Console(width=80)
+    assert console.is_terminal is False
+    rich_table, hidden = _create_preview_table(
+        columns_info=columns_info, preview_table=table, console=console, max_columns=4
+    )
+    assert len(rich_table.columns) == 4
+    assert hidden == 16
 
 
 def test_create_preview_table_max_columns():

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1380,6 +1380,20 @@ def test_inspect_head_no_truncate(runner):
     result = runner.invoke(cli, ["inspect", "head", test_file, "1", "--no-truncate"])
     assert result.exit_code == 0
     assert "more columns" not in result.output
+    assert "id" in result.output
+    assert "geometry" in result.output
+
+
+def test_inspect_head_no_truncate_overrides_max_columns(runner):
+    """When both flags are given, --no-truncate wins and warns that --max-columns is ignored."""
+    test_file = os.path.join(os.path.dirname(__file__), "data", "buildings_test.parquet")
+    result = runner.invoke(
+        cli, ["inspect", "head", test_file, "--max-columns", "1", "--no-truncate"]
+    )
+    assert result.exit_code == 0
+    assert "more columns" not in result.output
+    assert "id" in result.output and "geometry" in result.output
+    assert "Note: --no-truncate overrides --max-columns" in result.output
 
 
 def test_inspect_head_max_columns_rejects_zero(runner):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1360,3 +1360,35 @@ def test_create_preview_table_few_columns_no_hidden():
     )
     assert len(rich_table.columns) == 2
     assert hidden == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 3: CLI --max-columns / --no-truncate for inspect head/tail
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_head_max_columns(runner):
+    test_file = os.path.join(os.path.dirname(__file__), "data", "buildings_test.parquet")
+    result = runner.invoke(cli, ["inspect", "head", test_file, "2", "--max-columns", "1"])
+    assert result.exit_code == 0
+    # only one data column shown -> the other columns are reported as hidden
+    assert "more columns" in result.output
+
+
+def test_inspect_head_no_truncate(runner):
+    test_file = os.path.join(os.path.dirname(__file__), "data", "buildings_test.parquet")
+    result = runner.invoke(cli, ["inspect", "head", test_file, "1", "--no-truncate"])
+    assert result.exit_code == 0
+    assert "more columns" not in result.output
+
+
+def test_inspect_head_max_columns_rejects_zero(runner):
+    test_file = os.path.join(os.path.dirname(__file__), "data", "buildings_test.parquet")
+    result = runner.invoke(cli, ["inspect", "head", test_file, "--max-columns", "0"])
+    assert result.exit_code != 0
+
+
+def test_inspect_tail_no_truncate(runner):
+    test_file = os.path.join(os.path.dirname(__file__), "data", "buildings_test.parquet")
+    result = runner.invoke(cli, ["inspect", "tail", test_file, "1", "--no-truncate"])
+    assert result.exit_code == 0

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -3,12 +3,15 @@
 import json
 import os
 
+import pyarrow as pa
 import pytest
 from click.testing import CliRunner
+from rich.console import Console
 
 from geoparquet_io.cli.main import cli
 from geoparquet_io.core.inspect_utils import (
     _columns_that_fit,
+    _create_preview_table,
     extract_columns_info,
     extract_file_info,
     extract_geo_info,
@@ -1300,3 +1303,60 @@ def test_columns_that_fit_max_columns_clamped_to_total():
 def test_columns_that_fit_max_columns_floor_one():
     # max_columns below 1 should never drop below 1 (Click also guards this)
     assert _columns_that_fit(40, 500, max_columns=1) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 2: width-aware _create_preview_table tests
+# ---------------------------------------------------------------------------
+
+
+def _wide_preview(num_cols=20, num_rows=2):
+    cols = {f"c{i}": [f"val_{i}_{r}" for r in range(num_rows)] for i in range(num_cols)}
+    table = pa.table(cols)
+    columns_info = [
+        {"name": f"c{i}", "type": "string", "is_geometry": False} for i in range(num_cols)
+    ]
+    return table, columns_info
+
+
+def test_create_preview_table_hides_overflow_columns():
+    table, columns_info = _wide_preview(num_cols=20)
+    console = Console(width=80)
+    rich_table, hidden = _create_preview_table(
+        columns_info=columns_info, preview_table=table, console=console
+    )
+    assert hidden > 0
+    assert len(rich_table.columns) == 20 - hidden
+    # cells are one line (no fold): ellipsis overflow on the visible columns
+    assert all(c.overflow == "ellipsis" for c in rich_table.columns)
+
+
+def test_create_preview_table_max_columns():
+    table, columns_info = _wide_preview(num_cols=20)
+    console = Console(width=500)
+    rich_table, hidden = _create_preview_table(
+        columns_info=columns_info, preview_table=table, console=console, max_columns=4
+    )
+    assert len(rich_table.columns) == 4
+    assert hidden == 16
+
+
+def test_create_preview_table_no_truncate_shows_all():
+    table, columns_info = _wide_preview(num_cols=20)
+    console = Console(width=80)
+    rich_table, hidden = _create_preview_table(
+        columns_info=columns_info, preview_table=table, console=console, no_truncate=True
+    )
+    assert len(rich_table.columns) == 20
+    assert hidden == 0
+    assert all(c.overflow == "fold" for c in rich_table.columns)
+
+
+def test_create_preview_table_few_columns_no_hidden():
+    table, columns_info = _wide_preview(num_cols=2)
+    console = Console(width=200)
+    rich_table, hidden = _create_preview_table(
+        columns_info=columns_info, preview_table=table, console=console
+    )
+    assert len(rich_table.columns) == 2
+    assert hidden == 0

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 from geoparquet_io.cli.main import cli
 from geoparquet_io.core.inspect_utils import (
+    _columns_that_fit,
     extract_columns_info,
     extract_file_info,
     extract_geo_info,
@@ -1272,3 +1273,30 @@ class TestInspectSubcommands:
 
         assert result.exit_code == 0
         assert "Show first N rows" in result.output
+
+
+def test_columns_that_fit_wide_terminal_shows_more():
+    # width 200, 50 columns -> several columns fit, capped at total
+    n = _columns_that_fit(50, 200)
+    assert 1 < n < 50
+
+
+def test_columns_that_fit_never_exceeds_total():
+    assert _columns_that_fit(3, 500) == 3
+
+
+def test_columns_that_fit_always_at_least_one():
+    assert _columns_that_fit(40, 10) == 1
+
+
+def test_columns_that_fit_honors_max_columns():
+    assert _columns_that_fit(40, 500, max_columns=5) == 5
+
+
+def test_columns_that_fit_max_columns_clamped_to_total():
+    assert _columns_that_fit(3, 500, max_columns=10) == 3
+
+
+def test_columns_that_fit_max_columns_floor_one():
+    # max_columns below 1 should never drop below 1 (Click also guards this)
+    assert _columns_that_fit(40, 500, max_columns=1) == 1


### PR DESCRIPTION
## Summary

`gpio inspect head`/`tail` previously rendered every column with `overflow="fold"`, so files with many columns collapsed into an unreadable vertical "squish" (each value folded across many lines). This PR makes the preview fit the terminal width, pandas/`psql`-style.

## Behavior

- **Default (auto-fit):** show as many whole columns as fit the detected terminal width (falls back to 80 when not a TTY), each cell on a single line with an ellipsis. Hidden columns are reported with a dim note: `… +N more columns (--no-truncate or --json to see all)`.
- **`--max-columns N`** (`IntRange(min=1)`): show exactly N columns instead of the auto-fit count.
- **`--no-truncate`:** show every column with full, wrapped values (the old behavior) — for wide terminals or redirected output. If both flags are given, `--no-truncate` wins and a note says `--max-columns` was ignored.
- **`--json` / `--markdown` are unchanged** — always all columns and full values.

## Implementation

- `core/inspect_utils.py`: new pure `_columns_that_fit(num_columns, console_width, max_columns)` helper (+ tuning constants); `_create_preview_table` is now width-aware and returns `(Table, hidden_count)`, rendering one-line ellipsis cells (default) or full fold (`--no-truncate`); `format_terminal_output` passes its `Console` + flags and prints the hidden-column note.
- `core/inspect.py` / `cli/main.py`: thread `--max-columns` / `--no-truncate` from the `head`/`tail` commands through `format_preview_output` → `format_terminal_output`, with the mutual-exclusivity rule.

## Testing

- Unit tests for `_columns_that_fit` (fit math, clamping, floor of 1) and `_create_preview_table` (column count fits, ellipsis vs fold, hidden count, `--max-columns`, `--no-truncate`) using a forced `Console(width=...)`.
- CLI tests: `--max-columns` (incl. `IntRange` rejecting 0), `--no-truncate` shows all columns, and the both-flags mutual-exclusivity warning.
- Full fast suite: 2992 passed, coverage 72.34%; xenon (complexity) passes. (A pre-existing flaky `test_commitizen` timeout that passes in isolation is unrelated.)

Branched off `main` (independent of #519).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `inspect head` and `inspect tail` now fit the preview to your terminal width, truncating excess columns with ellipses.
  * Added `--max-columns` to cap how many columns are shown and `--no-truncate` to display full values.
  * When columns are hidden, the output now reports how many additional columns were omitted (and `--no-truncate` takes precedence if both are provided).

* **Documentation**
  * Expanded the inspection guide with a “Fitting to Terminal Width” section, including how truncation and the new flags behave, plus options for full/machine-readable (`--json`) output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->