### PR TITLE
Add `gpio publish partition-index` command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ geoparquet_io/
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or statistics |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files |
 | `gpio pmtiles` | create | PMTiles generation commands |
-| `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata, cloud uploads) |
+| `gpio publish` | partition-index, stac, upload | Commands for publishing GeoParquet data (STAC metadata, cloud uploads) |
 | `gpio skills` |  | List and access LLM skills for gpio |
 | `gpio sort` | column, hilbert, quadkey | Commands for sorting GeoParquet files |
 <!-- END GENERATED: cli-commands -->

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1224,6 +1224,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |
 | `ops.explain_analyze(file_path, query=None)` | DuckDB EXPLAIN ANALYZE query plan |
+| `ops.build_partition_index(input_glob, output, partition_key=None, profile=None)` | File→bbox index from footers |
 
 ## Pipeline Composition
 

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -687,6 +687,42 @@ gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place
 
 See [Sub-Partitioning Large Files](sub-partitioning.md) for details.
 
+## Partition bbox Index
+
+Once a dataset is split into one file per partition, build a small
+`file → bbox` index so a client (e.g. a browser tiler) can pick the 1–2 files
+that overlap a query region **without reading the data files**. The index is
+built from parquet footers only (no data scan) and aggregates per-file bounds
+from the bbox covering column.
+
+=== "CLI"
+
+    ```bash
+    # One row per file, with its bounding box
+    gpio publish partition-index 'output/*.parquet' output/_partitions.parquet
+
+    # Extract a hive partition key into its own column
+    gpio publish partition-index 's3://bucket/ds/data/*.parquet' index.parquet \
+      --partition-key provincia
+    ```
+
+=== "Python"
+
+    ```python
+    from geoparquet_io.api import ops
+
+    ops.build_partition_index(
+        'output/*.parquet',
+        'output/_partitions.parquet',
+        partition_key='provincia',
+    )
+    ```
+
+The files must carry a bbox covering — either a `bbox` struct (see
+[`gpio add bbox`](add.md)) or top-level `xmin/ymin/xmax/ymax` columns. The output
+has one row per file: `file_name`, the optional partition key, and
+`xmin/ymin/xmax/ymax`.
+
 ## See Also
 
 - [CLI Reference](../cli/overview.md) - Full command reference

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -27,6 +27,7 @@ from geoparquet_io.core.add.quadkey import add_quadkey_table
 from geoparquet_io.core.add.s2 import add_s2_table
 from geoparquet_io.core.extract import extract_table
 from geoparquet_io.core.hilbert_order import hilbert_order_table
+from geoparquet_io.core.partition_index import build_partition_index as _build_partition_index
 from geoparquet_io.core.reproject import reproject_table
 from geoparquet_io.core.sort_by_column import sort_by_column_table
 from geoparquet_io.core.sort_quadkey import sort_by_quadkey_table
@@ -408,6 +409,34 @@ def reproject(
         source_crs=source_crs,
         geometry_column=geometry_column,
         assume_crs84=assume_crs84,
+    )
+
+
+def build_partition_index(
+    input_glob: str,
+    output: str,
+    partition_key: str | None = None,
+    profile: str | None = None,
+) -> int:
+    """Build a file->bbox index over partitioned GeoParquet files (footers only).
+
+    Reads parquet footers (no data scan), aggregates per-file bounds from the bbox
+    covering column, and writes a small index Parquet to ``output``.
+
+    Args:
+        input_glob: File, glob, directory, or remote URL of partitioned GeoParquet.
+        output: Path to write the index Parquet to.
+        partition_key: Hive key to extract from each file path into a column.
+        profile: AWS profile for remote (S3) reads.
+
+    Returns:
+        Number of files indexed.
+    """
+    return _build_partition_index(
+        input_glob,
+        output,
+        partition_key=partition_key,
+        profile=profile,
     )
 
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -74,6 +74,7 @@ from geoparquet_io.core.partition.by_s2 import partition_by_s2 as partition_by_s
 from geoparquet_io.core.partition.by_string import (
     partition_by_string as partition_by_string_impl,
 )
+from geoparquet_io.core.partition_index import build_partition_index as build_partition_index_impl
 from geoparquet_io.core.reproject import reproject as reproject_core
 from geoparquet_io.core.sort_by_column import sort_by_column as sort_by_column_impl
 from geoparquet_io.core.sort_quadkey import sort_by_quadkey as sort_by_quadkey_impl
@@ -6021,6 +6022,34 @@ def publish_stac(input, output, bucket, public_url, collection_id, item_id, over
         --public-url https://data.example.com/roads/
     """
     _stac_impl(input, output, bucket, public_url, collection_id, item_id, overwrite, verbose)
+
+
+@publish.command(name="partition-index")
+@handle_geoparquet_errors
+@click.argument("input")
+@click.argument("output", type=click.Path())
+@click.option(
+    "--partition-key",
+    default=None,
+    help="Hive key to extract from each file path into a column (e.g. 'provincia').",
+)
+@aws_profile_option
+@verbose_option
+def publish_partition_index(input, output, partition_key, aws_profile, verbose):
+    """Build a file->bbox index (_partitions.parquet) from parquet footers.
+
+    Reads footers only (no data scan) and writes one row per file with its
+    bounding box, so a tiler can pick the partition files that overlap a tile.
+    Requires a bbox covering column (run 'gpio add bbox' on the files if missing).
+
+    \b
+    Examples:
+      gpio publish partition-index 'data/*.parquet' _partitions.parquet
+      gpio publish partition-index 's3://bkt/v3/ds/data/*.parquet' idx.parquet --partition-key provincia
+    """
+    build_partition_index_impl(
+        input, output, partition_key=partition_key, profile=aws_profile, verbose=verbose
+    )
 
 
 @publish.command(name="upload")

--- a/geoparquet_io/core/partition_index.py
+++ b/geoparquet_io/core/partition_index.py
@@ -1,0 +1,157 @@
+"""Build a file->bbox index over a set of partitioned GeoParquet files.
+
+Reads parquet **footers only** (DuckDB's ``parquet_metadata`` — no data scan) and
+aggregates per-file bounds from the bbox covering column's row-group statistics.
+The result is a small ``_partitions.parquet`` that a browser tiler (or any
+client) can intersect with a tile to pick the 1-2 partition files that overlap,
+without reading the data files themselves.
+
+Bounds are taken from a bbox covering column, in either layout:
+
+* a ``bbox`` STRUCT with ``xmin/ymin/xmax/ymax`` fields (gpio ``add bbox``), or
+* top-level ``xmin/ymin/xmax/ymax`` DOUBLE columns.
+
+Files without a bbox covering raise a clear error (run ``gpio add bbox`` first).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.logging_config import configure_verbose, debug, success
+from geoparquet_io.core.remote import (
+    needs_httpfs,
+    setup_aws_profile_if_needed,
+    validate_profile_for_urls,
+)
+
+#: bbox covering fields, in canonical order.
+_BBOX_FIELDS = ("xmin", "ymin", "xmax", "ymax")
+_VALID_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _sql_str(value: str) -> str:
+    """Escape a value for use inside a single-quoted SQL string literal."""
+    return value.replace("'", "''")
+
+
+def _resolve_glob(input_path: str) -> str:
+    """Expand a local directory to a ``*.parquet`` glob; pass files/globs/URLs through."""
+    if os.path.isdir(input_path):
+        return os.path.join(input_path, "*.parquet")
+    return input_path
+
+
+def _struct_bbox_paths(paths: set[str]) -> dict[str, str] | None:
+    """If a STRUCT covering's four fields are present (e.g. ``"bbox, xmin"``), map them."""
+    for path in paths:
+        if path.endswith(", xmin"):
+            prefix = path[: -len(", xmin")]
+            candidate = {f: f"{prefix}, {f}" for f in _BBOX_FIELDS}
+            if set(candidate.values()) <= paths:
+                return candidate
+    return None
+
+
+def _detect_bbox_paths(con, glob_sql: str) -> dict[str, str] | None:
+    """Map each bbox field to its ``path_in_schema``, or None if no covering is present.
+
+    Handles top-level ``xmin`` columns and ``bbox`` STRUCT subfields (whose path
+    DuckDB renders as ``"bbox, xmin"``).
+    """
+    paths = {
+        row[0]
+        for row in con.execute(
+            f"SELECT DISTINCT path_in_schema FROM parquet_metadata({glob_sql})"
+        ).fetchall()
+    }
+    if set(_BBOX_FIELDS) <= paths:
+        return {f: f for f in _BBOX_FIELDS}
+    return _struct_bbox_paths(paths)
+
+
+def _index_query(glob_sql: str, bbox_paths: dict[str, str], partition_key: str | None) -> str:
+    """Build the per-file bbox aggregation query from footer row-group stats."""
+    wanted = ", ".join(f"'{_sql_str(p)}'" for p in bbox_paths.values())
+    select_cols = ["file_name"]
+    if partition_key:
+        select_cols.append(
+            f"regexp_extract(file_name, '{partition_key}=([^/]+)', 1) AS {partition_key}"
+        )
+    aggs = {
+        "xmin": f"min(lo) FILTER (WHERE p = '{_sql_str(bbox_paths['xmin'])}') AS xmin",
+        "ymin": f"min(lo) FILTER (WHERE p = '{_sql_str(bbox_paths['ymin'])}') AS ymin",
+        "xmax": f"max(hi) FILTER (WHERE p = '{_sql_str(bbox_paths['xmax'])}') AS xmax",
+        "ymax": f"max(hi) FILTER (WHERE p = '{_sql_str(bbox_paths['ymax'])}') AS ymax",
+    }
+    select_cols.extend(aggs.values())
+    return f"""
+        WITH m AS (
+            SELECT file_name, path_in_schema AS p,
+                   stats_min_value::DOUBLE AS lo, stats_max_value::DOUBLE AS hi
+            FROM parquet_metadata({glob_sql})
+            WHERE path_in_schema IN ({wanted})
+        )
+        SELECT {", ".join(select_cols)}
+        FROM m GROUP BY file_name ORDER BY file_name
+    """
+
+
+def build_partition_index(
+    input_glob: str,
+    output: str,
+    partition_key: str | None = None,
+    profile: str | None = None,
+    verbose: bool = False,
+) -> int:
+    """Build a file->bbox index and write it to ``output`` as Parquet.
+
+    Args:
+        input_glob: File, glob, directory, or remote URL of partitioned GeoParquet.
+        output: Path to write the index parquet to.
+        partition_key: If given, extract this hive key's value from each file path
+            into a column (e.g. ``provincia`` -> column ``provincia`` = ``"28"``).
+        profile: AWS profile for remote (S3) reads.
+        verbose: Verbose logging.
+
+    Returns:
+        Number of files indexed.
+
+    Raises:
+        ValueError: If ``partition_key`` is not a valid identifier, or the inputs
+            have no bbox covering column to read bounds from.
+    """
+    configure_verbose(verbose)
+    if partition_key is not None and not _VALID_KEY.match(partition_key):
+        raise ValueError(
+            f"Invalid partition key {partition_key!r}: must be a valid identifier "
+            "(letters, digits, underscore; not starting with a digit)."
+        )
+
+    resolved = _resolve_glob(input_glob)
+    validate_profile_for_urls(profile, resolved, output)
+    setup_aws_profile_if_needed(profile, resolved, output)
+
+    con = get_duckdb_connection(
+        load_spatial=False,
+        load_httpfs=needs_httpfs(resolved) or needs_httpfs(output),
+    )
+    try:
+        glob_sql = f"'{_sql_str(resolved)}'"
+        bbox_paths = _detect_bbox_paths(con, glob_sql)
+        if bbox_paths is None:
+            raise ValueError(
+                "No bbox covering column found (looked for a 'bbox' struct or "
+                "top-level xmin/ymin/xmax/ymax). Run 'gpio add bbox' on the files first."
+            )
+        debug(f"Using bbox columns: {bbox_paths}")
+        query = _index_query(glob_sql, bbox_paths, partition_key)
+        con.execute(f"COPY ({query}) TO '{_sql_str(output)}' (FORMAT PARQUET)")
+        count = con.execute(f"SELECT COUNT(*) FROM ({query})").fetchone()[0]
+    finally:
+        con.close()
+
+    success(f"Wrote partition index for {count} file(s) to: {output}")
+    return count

--- a/geoparquet_io/core/partition_index.py
+++ b/geoparquet_io/core/partition_index.py
@@ -77,8 +77,11 @@ def _index_query(glob_sql: str, bbox_paths: dict[str, str], partition_key: str |
     wanted = ", ".join(f"'{_sql_str(p)}'" for p in bbox_paths.values())
     select_cols = ["file_name"]
     if partition_key:
+        # Normalize Windows backslash separators to '/' before extracting, so the
+        # hive value stops at the path separator on every platform.
+        normalized = "replace(file_name, '\\', '/')"
         select_cols.append(
-            f"regexp_extract(file_name, '{partition_key}=([^/]+)', 1) AS {partition_key}"
+            f"regexp_extract({normalized}, '{partition_key}=([^/]+)', 1) AS {partition_key}"
         )
     aggs = {
         "xmin": f"min(lo) FILTER (WHERE p = '{_sql_str(bbox_paths['xmin'])}') AS xmin",
@@ -149,7 +152,7 @@ def build_partition_index(
         debug(f"Using bbox columns: {bbox_paths}")
         query = _index_query(glob_sql, bbox_paths, partition_key)
         con.execute(f"COPY ({query}) TO '{_sql_str(output)}' (FORMAT PARQUET)")
-        count = con.execute(f"SELECT COUNT(*) FROM ({query})").fetchone()[0]
+        count = int(con.execute(f"SELECT COUNT(*) FROM ({query})").fetchone()[0])
     finally:
         con.close()
 

--- a/geoparquet_io/skills/geoparquet.md
+++ b/geoparquet_io/skills/geoparquet.md
@@ -37,7 +37,7 @@ Be proactive - analyze the data and make recommendations rather than waiting to 
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or... |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files. |
 | `gpio pmtiles` | create | PMTiles generation commands. Generate PMTiles from... |
-| `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata,... |
+| `gpio publish` | partition-index, stac, upload | Commands for publishing GeoParquet data (STAC metadata,... |
 | `gpio skills` |  | List and access LLM skills for gpio. Skills are markdown... |
 | `gpio sort` | column, hilbert, quadkey | Commands for sorting GeoParquet files. |
 <!-- END GENERATED: skill-commands -->

--- a/tests/test_partition_index.py
+++ b/tests/test_partition_index.py
@@ -1,0 +1,146 @@
+"""Tests for the partition file->bbox index builder (core, CLI, Python API).
+
+The index is built from parquet footers only (``parquet_metadata`` — no data
+scan): per-file bounds aggregated from the bbox covering column's row-group
+stats, written to a small ``_partitions.parquet`` a tiler can use to route tiles
+to the 1-2 files that overlap.
+"""
+
+from __future__ import annotations
+
+import os
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+
+def _con() -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    return con
+
+
+def _write_file(path: str, wkts: list[str], layout: str = "struct") -> None:
+    """Write a small parquet file with geometry + a bbox covering in ``layout``.
+
+    layout: "struct" (gpio bbox struct), "top" (top-level xmin/.. doubles),
+    or "none" (no bbox covering at all).
+    """
+    con = _con()
+    rows = ", ".join(f"({i}, ST_GeomFromText('{w}'))" for i, w in enumerate(wkts))
+    con.execute(f"CREATE TABLE t AS SELECT id, geom FROM (VALUES {rows}) v(id, geom)")
+    if layout == "struct":
+        sel = (
+            "id, ST_AsWKB(geom) AS geometry, "
+            "STRUCT_PACK(xmin := ST_XMin(geom), ymin := ST_YMin(geom), "
+            "xmax := ST_XMax(geom), ymax := ST_YMax(geom)) AS bbox"
+        )
+    elif layout == "top":
+        sel = (
+            "id, ST_AsWKB(geom) AS geometry, ST_XMin(geom) AS xmin, ST_YMin(geom) AS ymin, "
+            "ST_XMax(geom) AS xmax, ST_YMax(geom) AS ymax"
+        )
+    else:
+        sel = "id, ST_AsWKB(geom) AS geometry"
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    con.execute(f"COPY (SELECT {sel} FROM t) TO '{path}' (FORMAT PARQUET)")
+    con.close()
+
+
+def _rows(path: str) -> list[dict]:
+    return pq.read_table(path).to_pylist()
+
+
+# Two boxes per file so the aggregated file bbox is non-trivial.
+FILE_A = ["POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", "POLYGON((5 5, 20 5, 20 20, 5 20, 5 5))"]
+FILE_B = ["POLYGON((100 100, 110 100, 110 110, 100 110, 100 100))"]
+
+
+class TestBuildPartitionIndexCore:
+    def test_aggregates_per_file_bounds(self, tmp_path):
+        from geoparquet_io.core.partition_index import build_partition_index
+
+        _write_file(str(tmp_path / "a.parquet"), FILE_A)
+        _write_file(str(tmp_path / "b.parquet"), FILE_B)
+        out = str(tmp_path / "_partitions.parquet")
+        build_partition_index(str(tmp_path / "*.parquet"), out)
+
+        rows = {os.path.basename(r["file_name"]): r for r in _rows(out)}
+        assert set(rows) == {"a.parquet", "b.parquet"}
+        a = rows["a.parquet"]
+        assert (a["xmin"], a["ymin"], a["xmax"], a["ymax"]) == (0.0, 0.0, 20.0, 20.0)
+        b = rows["b.parquet"]
+        assert (b["xmin"], b["ymin"], b["xmax"], b["ymax"]) == (100.0, 100.0, 110.0, 110.0)
+
+    def test_top_level_bbox_layout(self, tmp_path):
+        from geoparquet_io.core.partition_index import build_partition_index
+
+        _write_file(str(tmp_path / "a.parquet"), FILE_A, layout="top")
+        out = str(tmp_path / "_partitions.parquet")
+        build_partition_index(str(tmp_path / "*.parquet"), out)
+        a = _rows(out)[0]
+        assert (a["xmin"], a["ymin"], a["xmax"], a["ymax"]) == (0.0, 0.0, 20.0, 20.0)
+
+    def test_partition_key_extracted_from_path(self, tmp_path):
+        from geoparquet_io.core.partition_index import build_partition_index
+
+        _write_file(str(tmp_path / "provincia=28" / "data.parquet"), FILE_A)
+        _write_file(str(tmp_path / "provincia=08" / "data.parquet"), FILE_B)
+        out = str(tmp_path / "_partitions.parquet")
+        build_partition_index(str(tmp_path / "**" / "*.parquet"), out, partition_key="provincia")
+        provincias = sorted(r["provincia"] for r in _rows(out))
+        assert provincias == ["08", "28"]
+
+    def test_errors_without_bbox_columns(self, tmp_path):
+        from geoparquet_io.core.partition_index import build_partition_index
+
+        _write_file(str(tmp_path / "a.parquet"), FILE_A, layout="none")
+        with pytest.raises(ValueError, match="bbox"):
+            build_partition_index(str(tmp_path / "*.parquet"), str(tmp_path / "out.parquet"))
+
+    def test_rejects_bad_partition_key(self, tmp_path):
+        from geoparquet_io.core.partition_index import build_partition_index
+
+        _write_file(str(tmp_path / "a.parquet"), FILE_A)
+        with pytest.raises(ValueError):
+            build_partition_index(
+                str(tmp_path / "*.parquet"),
+                str(tmp_path / "out.parquet"),
+                partition_key="bad key; DROP",
+            )
+
+
+class TestPartitionIndexCLI:
+    def test_cli_builds_index(self, tmp_path):
+        from geoparquet_io.cli.main import cli
+
+        _write_file(str(tmp_path / "a.parquet"), FILE_A)
+        _write_file(str(tmp_path / "b.parquet"), FILE_B)
+        out = str(tmp_path / "_partitions.parquet")
+        result = CliRunner().invoke(
+            cli, ["publish", "partition-index", str(tmp_path / "*.parquet"), out]
+        )
+        assert result.exit_code == 0, result.output
+        assert len(_rows(out)) == 2
+
+    def test_cli_errors_without_bbox(self, tmp_path):
+        from geoparquet_io.cli.main import cli
+
+        _write_file(str(tmp_path / "a.parquet"), FILE_A, layout="none")
+        out = str(tmp_path / "out.parquet")
+        result = CliRunner().invoke(
+            cli, ["publish", "partition-index", str(tmp_path / "*.parquet"), out]
+        )
+        assert result.exit_code != 0
+
+
+class TestPartitionIndexPythonAPI:
+    def test_ops_function(self, tmp_path):
+        from geoparquet_io.api import ops
+
+        _write_file(str(tmp_path / "a.parquet"), FILE_A)
+        out = str(tmp_path / "_partitions.parquet")
+        ops.build_partition_index(str(tmp_path / "*.parquet"), out)
+        assert len(_rows(out)) == 1


### PR DESCRIPTION
## Description

Adds `gpio publish partition-index`, which builds a small `file → bbox` index over a set of partitioned GeoParquet files. A client (e.g. a browser vector tiler) can intersect a tile with this index to pick the 1–2 partition files that overlap — without opening the data files. Useful for any partitioned dataset, not just tiling.

## Technical Details

The index is built from parquet **footers only** (DuckDB's `parquet_metadata` — no data scan). Per-file bounds are aggregated from the bbox covering column's row-group statistics:

- Supports both layouts: a `bbox` STRUCT (paths render as `"bbox, xmin"`) and top-level `xmin/ymin/xmax/ymax` DOUBLE columns.
- `stats_min_value`/`stats_max_value` are cast to DOUBLE only *after* filtering to the four bbox paths, so non-numeric stats (e.g. id columns) never hit the cast.
- `--partition-key NAME` extracts a hive key from each file path into its own column (e.g. `provincia=28` → `provincia` = `"28"`).
- Files without a bbox covering raise a clear error pointing at `gpio add bbox`.

Output is one row per file: `file_name`, optional partition key, `xmin/ymin/xmax/ymax`. Works on local paths, globs, directories, and remote (S3) URLs.

- Core: `core/partition_index.py` — `build_partition_index()`.
- CLI: `gpio publish partition-index INPUT OUTPUT`.
- Python API: `ops.build_partition_index()` (file-set operation, so functional rather than a `Table` method).

Complexity grade A; module coverage 98%; import-linter clean.

## Breaking Changes
**Does this PR introduce breaking changes?** No

## Related Issue(s)
- N/A

## Checklist
- [x] Tests added/updated
- [x] All tests pass (`uv run pytest`)
- [x] Documentation updated (README, guides, CLI reference)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building a lightweight partition-to-bounding-box index from GeoParquet files.
  * Introduced a new `gpio publish partition-index` command and a matching Python API for generating the index.
  * Added documentation and examples showing how to create and use the index with local or remote data.

* **Bug Fixes**
  * Improved validation and error handling when required bounding box information is missing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->