### PR TITLE
fix(partition): make --auto resolution extent-aware (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **`gpio partition … --auto` is now extent-aware (#524).** Auto-resolution
+  previously assumed data was spread uniformly across the entire globe, so
+  regional/national datasets got a far-too-coarse resolution — collapsing into a
+  handful of giant partitions instead of the requested `--target-rows`-sized
+  ones (off by ~2 orders of magnitude). It now probes a bounded sample of the
+  actual data, counts non-empty cells at each candidate resolution, and picks
+  the resolution closest to the target partition count. One fix covers
+  `a5`/`h3`/`s2`/`quadkey`; it falls back to the old global estimate when the
+  data can't be probed.
 - Partition commands now route all rows in a **single** `COPY … PARTITION_BY`
   scan instead of re-scanning the input per partition value (#478).
   `gpio partition string`, `gpio partition admin`, and the cell-id partitioners

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,6 +80,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **`gpio partition … --auto` is now extent-aware (#524).** Auto-resolution
+  previously assumed data was spread uniformly across the entire globe, so
+  regional/national datasets got a far-too-coarse resolution — collapsing into a
+  handful of giant partitions instead of the requested `--target-rows`-sized
+  ones (off by ~2 orders of magnitude). It now probes a bounded sample of the
+  actual data, counts non-empty cells at each candidate resolution, and picks
+  the resolution closest to the target partition count. One fix covers
+  `a5`/`h3`/`s2`/`quadkey`; it falls back to the old global estimate when the
+  data can't be probed.
 - Partition commands now route all rows in a **single** `COPY … PARTITION_BY`
   scan instead of re-scanning the input per partition value (#478).
   `gpio partition string`, `gpio partition admin`, and the cell-id partitioners

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -41,16 +41,23 @@ gpio partition quadkey input.parquet output/ --auto --max-partitions 1000
 gpio partition a5 input.parquet --auto --preview
 ```
 
-### Resolution Formulas
+### How auto-resolution is chosen
 
-The auto-resolution calculation uses these cell count formulas:
+Auto-resolution is **extent-aware**: gpio probes a bounded sample of your data
+and counts how many cells are actually non-empty at each candidate resolution,
+then picks the resolution whose non-empty cell count is closest to your target
+partition count (`total rows ÷ --target-rows`, capped by `--max-partitions`).
 
-| Index | Formula | Notes |
-|-------|---------|-------|
-| **H3** | `cells ≈ 122 × 7^resolution` | Hexagonal cells |
-| **S2** | `cells = 6 × 4^level` | Spherical cells |
-| **A5** | `cells = 6 × 4^resolution` | Equal-area cells |
-| **Quadkey** | `tiles = 4^zoom` | Square tiles |
+This sizes partitions to where your data actually is. A globally-uniform
+formula (e.g. `cells = 6 × 4^resolution` for A5) assumes the data is spread
+evenly across the whole planet, which badly under-resolves regional or national
+datasets — collapsing them into a handful of giant partitions. If the sample
+probe can't run (for example, the file has no geometry column), gpio falls back
+to the uniform-coverage estimate.
+
+> **Note:** cell assignment currently assumes lon/lat (EPSG:4326-family) input.
+> Projected-CRS data should be reprojected before partitioning so cells — and
+> the auto-resolution probe — line up with the data's real geography.
 
 ## By String Column
 
@@ -176,7 +183,7 @@ Use `--auto` to let gpio calculate the optimal H3 resolution:
 !!! note "CLI-Only Feature"
     Auto-resolution is currently CLI-only. For Python, use `partition_by_h3()` with an explicit `resolution` parameter (see examples above).
 
-Auto-resolution calculates the optimal H3 resolution using the formula: `cells ≈ 122 × 7^resolution`. The algorithm targets your specified rows per partition while respecting the `--max-partitions` constraint.
+Auto-resolution probes your data's actual extent (see [How auto-resolution is chosen](#how-auto-resolution-is-chosen)) to pick the H3 resolution that targets your specified rows per partition, while respecting the `--max-partitions` constraint.
 
 ## By S2 Cells
 
@@ -255,7 +262,7 @@ Use `--auto` to let gpio calculate the optimal S2 level:
 !!! note "CLI-Only Feature"
     Auto-resolution is currently CLI-only. For Python, use `partition_by_s2()` with an explicit `level` parameter (see examples above).
 
-Auto-resolution calculates the optimal S2 level using the formula: `cells = 6 × 4^level`. The algorithm targets your specified rows per partition while respecting the `--max-partitions` constraint.
+Auto-resolution probes your data's actual extent (see [How auto-resolution is chosen](#how-auto-resolution-is-chosen)) to pick the S2 level that targets your specified rows per partition, while respecting the `--max-partitions` constraint.
 
 ## By A5 Cells
 
@@ -322,7 +329,7 @@ Use `--auto` to let gpio calculate the optimal A5 resolution:
 !!! note "CLI-Only Feature"
     Auto-resolution is currently CLI-only. A5 partitioning in Python is not yet available.
 
-Auto-resolution calculates the optimal A5 resolution using the formula: `cells = 6 × 4^resolution`. The algorithm targets your specified rows per partition while respecting the `--max-partitions` constraint.
+Auto-resolution probes your data's actual extent (see [How auto-resolution is chosen](#how-auto-resolution-is-chosen)) to pick the A5 resolution that targets your specified rows per partition, while respecting the `--max-partitions` constraint.
 
 ## By Quadkey Cells
 
@@ -403,7 +410,7 @@ Use `--auto` to let gpio calculate the optimal quadkey zoom level:
 !!! note "CLI-Only Feature"
     Auto-resolution is currently CLI-only. For Python, use `partition_by_quadkey()` with an explicit `partition_resolution` parameter (see examples above).
 
-Auto-resolution calculates the optimal quadkey zoom level using the formula: `tiles = 4^zoom`. The algorithm targets your specified rows per partition while respecting the `--max-partitions` constraint.
+Auto-resolution probes your data's actual extent (see [How auto-resolution is chosen](#how-auto-resolution-is-chosen)) to pick the quadkey zoom level that targets your specified rows per partition, while respecting the `--max-partitions` constraint.
 
 ## By KD-Tree
 

--- a/geoparquet_io/core/partition/auto_resolution.py
+++ b/geoparquet_io/core/partition/auto_resolution.py
@@ -11,10 +11,27 @@ from __future__ import annotations
 
 import math
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, warn
 from geoparquet_io.core.remote import needs_httpfs
+
+# Tuning for the extent-aware probe (issue #524). Sampling a multiple of the
+# target partition count keeps cells near the target resolution well-populated,
+# so the sampled distinct-cell count is a good estimate of the true non-empty
+# count. The floor stabilizes coarse counts; the ceiling bounds probe cost.
+_PROBE_OVERSAMPLE = 100
+_PROBE_MIN_SAMPLE = 50_000
+_PROBE_MAX_SAMPLE = 500_000
+
+# DuckDB extension setup required before each index's cell function is callable.
+_INDEX_EXTENSIONS = {
+    "a5": ["INSTALL a5 FROM community", "LOAD a5"],
+    "h3": ["INSTALL h3 FROM community", "LOAD h3"],
+    "s2": ["INSTALL geography FROM community", "LOAD geography"],
+    "quadkey": [],
+}
 
 
 def _get_total_row_count(
@@ -286,6 +303,160 @@ def _calculate_a5_resolution(
     return resolution
 
 
+def _cell_expr(index_type: str, lon: str, lat: str, resolution: int) -> str:
+    """SQL expression assigning a cell at ``resolution`` (mirrors add/ modules)."""
+    if index_type == "a5":
+        return f"a5_lonlat_to_cell({lon}, {lat}, {resolution})"
+    if index_type == "s2":
+        return f"s2_cell_token(s2_cell_parent(s2_cellfromlonlat({lon}, {lat}), {resolution}))"
+    if index_type == "h3":
+        return f"h3_latlng_to_cell_string({lat}, {lon}, {resolution})"
+    if index_type == "quadkey":
+        return f"lat_lon_to_quadkey({lat}, {lon}, {resolution})"
+    raise ValueError(f"Unsupported spatial index type: {index_type}")
+
+
+def _register_quadkey_udf(con) -> None:
+    """Register the mercantile-based quadkey UDF used by the add-quadkey path."""
+    import mercantile
+
+    def lat_lon_to_quadkey(lat: float, lon: float, level: int) -> str:
+        return mercantile.quadkey(mercantile.tile(lon, lat, level))
+
+    con.create_function(
+        "lat_lon_to_quadkey",
+        lat_lon_to_quadkey,
+        ["DOUBLE", "DOUBLE", "INTEGER"],
+        "VARCHAR",
+    )
+
+
+def _geom_sql(con, url: str, geom_col: str) -> str:
+    """Return a GEOMETRY-typed SQL expression for ``geom_col`` in ``url``.
+
+    DuckDB reads a GeoParquet geometry column as GEOMETRY; WKB-blob columns come
+    back as BLOB and must be decoded. Raises if the column is absent.
+    """
+    qcol = quote_identifier(geom_col)
+    desc = con.execute(f"DESCRIBE SELECT {qcol} FROM '{url}'").fetchall()
+    col_type = (desc[0][1] if desc else "").upper()
+    if "GEOMETRY" in col_type:
+        return qcol
+    return f"ST_GeomFromWKB({qcol})"
+
+
+def _probe_distinct_cell_counts(
+    con, url: str, index_type: str, geom_sql: str, sample_size: int, resolutions: list[int]
+) -> list[int]:
+    """Count distinct non-empty cells per resolution over a bounded sample."""
+    lon = f"ST_X(ST_Centroid({geom_sql}))"
+    lat = f"ST_Y(ST_Centroid({geom_sql}))"
+    sample_cte = f"SELECT {lon} AS lon, {lat} AS lat FROM '{url}' USING SAMPLE {sample_size} ROWS"
+    if index_type == "quadkey":
+        # A level-r quadkey is the length-r prefix of a finer one, so compute the
+        # finest quadkey once per row and take substrings (avoids a UDF call per
+        # resolution per row).
+        max_res = resolutions[-1]
+        cols = ", ".join(
+            f"COUNT(DISTINCT substr(qk, 1, {r})) AS c{i}" for i, r in enumerate(resolutions)
+        )
+        query = (
+            f"WITH sample AS ({sample_cte}), "
+            f"keyed AS (SELECT lat_lon_to_quadkey(lat, lon, {max_res}) AS qk "
+            f"FROM sample WHERE lon IS NOT NULL AND lat IS NOT NULL) "
+            f"SELECT {cols} FROM keyed"
+        )
+    else:
+        cols = ", ".join(
+            f"COUNT(DISTINCT {_cell_expr(index_type, 'lon', 'lat', r)}) AS c{i}"
+            for i, r in enumerate(resolutions)
+        )
+        query = (
+            f"WITH sample AS ({sample_cte}) SELECT {cols} FROM sample "
+            f"WHERE lon IS NOT NULL AND lat IS NOT NULL"
+        )
+    return list(con.execute(query).fetchone())
+
+
+def _select_closest_resolution(
+    resolutions: list[int], counts: list[int], target_partitions: float
+) -> int:
+    """Resolution whose distinct cell count is closest to the target.
+
+    Counts are monotonic non-decreasing in resolution; the strict comparison
+    keeps the coarsest resolution among ties (avoids over-resolving on plateaus).
+    """
+    best_res = resolutions[0]
+    best_diff: float | None = None
+    for res, count in zip(resolutions, counts, strict=False):
+        diff = abs(count - target_partitions)
+        if best_diff is None or diff < best_diff:
+            best_diff = diff
+            best_res = res
+    return best_res
+
+
+def _probe_extent_resolution(
+    input_parquet: str,
+    spatial_index_type: str,
+    target_partitions: float,
+    min_resolution: int,
+    max_resolution: int,
+    total_rows: int,
+    verbose: bool = False,
+    profile: str | None = None,
+) -> int | None:
+    """Pick the resolution whose non-empty cell count best matches the target.
+
+    Probes distinct cell counts over a bounded sample of the actual data so the
+    chosen resolution reflects the data's real extent rather than global uniform
+    coverage (issue #524). Returns None if the data can't be probed (e.g. no
+    geometry column, sampling error), so the caller can fall back to the global
+    estimate.
+    """
+    from geoparquet_io.core.remote import setup_aws_profile_if_needed
+
+    url = safe_file_url(input_parquet, verbose)
+    resolutions = list(range(min_resolution, max_resolution + 1))
+    con = None
+    try:
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
+        if profile:
+            setup_aws_profile_if_needed(con, profile)
+        for stmt in _INDEX_EXTENSIONS[spatial_index_type]:
+            con.execute(stmt)
+        if spatial_index_type == "quadkey":
+            _register_quadkey_udf(con)
+
+        geom_col = find_primary_geometry_column(input_parquet, verbose)
+        geom_sql = _geom_sql(con, url, geom_col)
+
+        sample_size = min(
+            total_rows,
+            _PROBE_MAX_SAMPLE,
+            max(int(target_partitions * _PROBE_OVERSAMPLE), _PROBE_MIN_SAMPLE),
+        )
+        counts = _probe_distinct_cell_counts(
+            con, url, spatial_index_type, geom_sql, sample_size, resolutions
+        )
+    except Exception as e:
+        if verbose:
+            warn(f"Extent-aware probe unavailable ({e}); using global estimate")
+        return None
+    finally:
+        if con is not None:
+            con.close()
+
+    resolution = _select_closest_resolution(resolutions, counts, target_partitions)
+    if verbose:
+        cell_count = counts[resolutions.index(resolution)]
+        info(
+            f"{spatial_index_type} extent-aware resolution: {resolution} "
+            f"(~{cell_count} non-empty cells, target ~{target_partitions:.0f} partitions)"
+        )
+    return resolution
+
+
 def calculate_auto_resolution(
     input_parquet: str,
     spatial_index_type: str,
@@ -397,7 +568,24 @@ def calculate_auto_resolution(
     if max_resolution is None:
         max_resolution = default_max
 
-    # Calculate optimal resolution
+    # Extent-aware probe (issue #524): size the resolution to the data's actual
+    # extent instead of assuming uniform global coverage. Falls back to the
+    # global-formula estimate below if the data can't be probed.
+    target_partitions = min(total_rows / target_rows_per_partition, max_partitions)
+    probed = _probe_extent_resolution(
+        input_parquet=input_parquet,
+        spatial_index_type=spatial_index_type,
+        target_partitions=target_partitions,
+        min_resolution=min_resolution,
+        max_resolution=max_resolution,
+        total_rows=total_rows,
+        verbose=verbose,
+        profile=profile,
+    )
+    if probed is not None:
+        return probed
+
+    # Fallback: global-formula estimate
     kwargs = {
         "total_rows": total_rows,
         "target_rows_per_partition": target_rows_per_partition,

--- a/geoparquet_io/core/partition/auto_resolution.py
+++ b/geoparquet_io/core/partition/auto_resolution.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 
 import math
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.common import get_duckdb_connection, needs_httpfs
+from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, warn
-from geoparquet_io.core.remote import needs_httpfs
 
 # Tuning for the extent-aware probe (issue #524). Sampling a multiple of the
 # target partition count keeps cells near the target resolution well-populated,
@@ -59,7 +59,7 @@ def _get_total_row_count(
 
         # Setup S3 authentication if profile specified
         if profile:
-            setup_aws_profile_if_needed(con, profile)
+            setup_aws_profile_if_needed(profile, input_parquet)
 
         query = f"SELECT COUNT(*) FROM '{input_url}'"
         result = con.execute(query).fetchone()
@@ -422,7 +422,7 @@ def _probe_extent_resolution(
     try:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
         if profile:
-            setup_aws_profile_if_needed(con, profile)
+            setup_aws_profile_if_needed(profile, input_parquet)
         for stmt in _INDEX_EXTENSIONS[spatial_index_type]:
             con.execute(stmt)
         if spatial_index_type == "quadkey":
@@ -446,6 +446,14 @@ def _probe_extent_resolution(
     finally:
         if con is not None:
             con.close()
+
+    # All-zero counts mean the sample held no usable geometries (NULL/invalid).
+    # Treat that like a probe failure so the global estimate is used instead of
+    # silently selecting the coarsest resolution.
+    if not any(counts):
+        if verbose:
+            warn("Extent-aware probe found no non-empty cells; using global estimate")
+        return None
 
     resolution = _select_closest_resolution(resolutions, counts, target_partitions)
     if verbose:

--- a/geoparquet_io/core/partition/auto_resolution.py
+++ b/geoparquet_io/core/partition/auto_resolution.py
@@ -346,12 +346,26 @@ def _geom_sql(con, url: str, geom_col: str) -> str:
 
 
 def _probe_distinct_cell_counts(
-    con, url: str, index_type: str, geom_sql: str, sample_size: int, resolutions: list[int]
+    con, url: str, index_type: str, geom_sql: str, sample_clause: str, resolutions: list[int]
 ) -> list[int]:
-    """Count distinct non-empty cells per resolution over a bounded sample."""
-    lon = f"ST_X(ST_Centroid({geom_sql}))"
-    lat = f"ST_Y(ST_Centroid({geom_sql}))"
-    sample_cte = f"SELECT {lon} AS lon, {lat} AS lat FROM '{url}' USING SAMPLE {sample_size} ROWS"
+    """Count distinct non-empty cells per resolution over a bounded sample.
+
+    ``sample_clause`` is reservoir sampling (``USING SAMPLE n ROWS``) or empty
+    when the whole file fits the budget. Reservoir is deliberate: it draws a
+    uniform random sample regardless of row order. Block/percentage sampling
+    (``TABLESAMPLE``) would be cheaper but, on spatially-sorted data, would only
+    see a contiguous slice of the extent and badly underestimate the non-empty
+    cell count -- the exact failure mode this probe exists to prevent (#524).
+
+    The centroid mirrors the cell assignment in the ``add/`` modules
+    (``ST_X/ST_Y(ST_Centroid(geom))``), so probe counts track real partitioning.
+    It is computed once per sampled row and reused for lon and lat.
+    """
+    centroid = f"ST_Centroid({geom_sql})"
+    sample_cte = (
+        f"SELECT ST_X(c) AS lon, ST_Y(c) AS lat "
+        f"FROM (SELECT {centroid} AS c FROM '{url}'{sample_clause})"
+    )
     if index_type == "quadkey":
         # A level-r quadkey is the length-r prefix of a finer one, so compute the
         # finest quadkey once per row and take substrings (avoids a UDF call per
@@ -436,8 +450,11 @@ def _probe_extent_resolution(
             _PROBE_MAX_SAMPLE,
             max(int(target_partitions * _PROBE_OVERSAMPLE), _PROBE_MIN_SAMPLE),
         )
+        # Skip the reservoir sample (a full scan) when the file already fits the
+        # budget; otherwise draw a uniform sample of sample_size rows.
+        sample_clause = "" if sample_size >= total_rows else f" USING SAMPLE {sample_size} ROWS"
         counts = _probe_distinct_cell_counts(
-            con, url, spatial_index_type, geom_sql, sample_size, resolutions
+            con, url, spatial_index_type, geom_sql, sample_clause, resolutions
         )
     except Exception as e:
         if verbose:

--- a/tests/test_partition_auto_resolution.py
+++ b/tests/test_partition_auto_resolution.py
@@ -582,3 +582,167 @@ class TestVerboseOutput:
                 verbose=True,
             )
         assert "Quadkey auto-resolution" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Extent-aware resolution (issue #524)
+# ---------------------------------------------------------------------------
+
+
+def _make_clustered_geoparquet(path, n=8000, seed=42):
+    """Write a regionally-clustered point GeoParquet (lon/lat, EPSG:4326).
+
+    Points are confined to a small bbox (roughly the Netherlands) so the data
+    occupies a tiny fraction of the globe. A globally-uniform resolution formula
+    badly under-resolves data like this; this is the core of issue #524.
+    """
+    import geopandas as gpd
+    import numpy as np
+    from shapely.geometry import Point
+
+    rng = np.random.default_rng(seed)
+    lons = rng.uniform(4.0, 7.0, n)
+    lats = rng.uniform(51.0, 53.5, n)
+    gdf = gpd.GeoDataFrame(
+        {"id": range(n), "geometry": [Point(x, y) for x, y in zip(lons, lats, strict=False)]},
+        crs="EPSG:4326",
+    )
+    gdf.to_parquet(path)
+    return str(path)
+
+
+def _count_distinct_cells(parquet_file, index_type, resolution):
+    """Count distinct non-empty cells over the data at a given resolution.
+
+    Independent of the implementation under test: builds the cell expression
+    directly via DuckDB spatial/h3/quadkey functions.
+    """
+    import mercantile
+
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        lon = "ST_X(ST_Centroid(geometry))"
+        lat = "ST_Y(ST_Centroid(geometry))"
+        if index_type == "a5":
+            con.execute("INSTALL a5 FROM community")
+            con.execute("LOAD a5")
+            expr = f"a5_lonlat_to_cell({lon}, {lat}, {resolution})"
+        elif index_type == "s2":
+            con.execute("INSTALL geography FROM community")
+            con.execute("LOAD geography")
+            expr = f"s2_cell_token(s2_cell_parent(s2_cellfromlonlat({lon}, {lat}), {resolution}))"
+        elif index_type == "h3":
+            con.execute("INSTALL h3 FROM community")
+            con.execute("LOAD h3")
+            expr = f"h3_latlng_to_cell_string({lat}, {lon}, {resolution})"
+        elif index_type == "quadkey":
+            con.create_function(
+                "lat_lon_to_quadkey",
+                lambda la, lo, lv: mercantile.quadkey(mercantile.tile(lo, la, lv)),
+                ["DOUBLE", "DOUBLE", "INTEGER"],
+                "VARCHAR",
+            )
+            expr = f"lat_lon_to_quadkey({lat}, {lon}, {resolution})"
+        else:
+            raise ValueError(index_type)
+        row = con.execute(f"SELECT COUNT(DISTINCT {expr}) FROM '{parquet_file}'").fetchone()
+        return row[0]
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def clustered_file(tmp_path):
+    """A regionally-clustered point GeoParquet for extent-aware tests."""
+    return _make_clustered_geoparquet(tmp_path / "clustered.parquet")
+
+
+class TestExtentAwareResolution:
+    """Auto-resolution should be sized to the data's actual extent (issue #524).
+
+    A globally-uniform formula picks a far-too-coarse resolution for
+    regional/national data, collapsing it into a handful of giant partitions.
+    These tests pin the extent-aware behavior.
+    """
+
+    @pytest.mark.parametrize("index_type", ["a5", "s2", "h3", "quadkey"])
+    def test_finer_than_global_formula(self, clustered_file, index_type):
+        """Extent-aware resolution must exceed the old global-formula choice."""
+        total_rows = 8000
+        target_rows = 80  # ~100 target partitions
+
+        if index_type in ("a5", "s2"):
+            global_res = _calculate_a5_resolution(total_rows, target_rows)
+        elif index_type == "h3":
+            global_res = _calculate_h3_resolution(total_rows, target_rows)
+        else:
+            global_res = _calculate_quadkey_resolution(total_rows, target_rows)
+
+        extent_res = calculate_auto_resolution(
+            input_parquet=clustered_file,
+            spatial_index_type=index_type,
+            target_rows_per_partition=target_rows,
+        )
+
+        assert extent_res > global_res, (
+            f"{index_type}: extent-aware res {extent_res} should be finer than "
+            f"global-formula res {global_res} for clustered data"
+        )
+
+    @pytest.mark.parametrize("index_type", ["a5", "s2", "h3", "quadkey"])
+    def test_chosen_resolution_near_target_partitions(self, clustered_file, index_type):
+        """The chosen resolution's non-empty cell count is near the target."""
+        total_rows = 8000
+        target_rows = 80
+        target_partitions = total_rows / target_rows  # 100
+
+        res = calculate_auto_resolution(
+            input_parquet=clustered_file,
+            spatial_index_type=index_type,
+            target_rows_per_partition=target_rows,
+        )
+        cells = _count_distinct_cells(clustered_file, index_type, res)
+
+        # Should be within a 4x band of the target partition count, and far
+        # better than the 1-3 partitions the global formula would yield.
+        assert target_partitions / 4 <= cells <= target_partitions * 4, (
+            f"{index_type}: res {res} gave {cells} cells, target ~{target_partitions:.0f}"
+        )
+
+    def test_respects_max_resolution(self, clustered_file):
+        """Probe must not exceed the max_resolution bound."""
+        res = calculate_auto_resolution(
+            input_parquet=clustered_file,
+            spatial_index_type="a5",
+            target_rows_per_partition=1,  # would want a very fine resolution
+            max_resolution=5,
+        )
+        assert res <= 5
+
+    def test_respects_min_resolution(self, clustered_file):
+        """Probe must not go below the min_resolution bound."""
+        res = calculate_auto_resolution(
+            input_parquet=clustered_file,
+            spatial_index_type="a5",
+            target_rows_per_partition=10_000_000,  # would want a coarse resolution
+            min_resolution=4,
+        )
+        assert res >= 4
+
+    def test_falls_back_when_no_geometry(self, tmp_path):
+        """A parquet with no geometry column falls back to the global formula."""
+        import pandas as pd
+
+        non_geo = tmp_path / "non_geo.parquet"
+        pd.DataFrame({"a": range(8000)}).to_parquet(non_geo)
+
+        res = calculate_auto_resolution(
+            input_parquet=str(non_geo),
+            spatial_index_type="a5",
+            target_rows_per_partition=80,
+        )
+        # Falls back to the pure-math global formula for the same row count.
+        expected = _calculate_a5_resolution(8000, 80)
+        assert res == expected

--- a/tests/test_partition_auto_resolution.py
+++ b/tests/test_partition_auto_resolution.py
@@ -619,7 +619,7 @@ def _count_distinct_cells(parquet_file, index_type, resolution):
     """
     import mercantile
 
-    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.common import get_duckdb_connection
 
     con = get_duckdb_connection(load_spatial=True)
     try:
@@ -659,6 +659,7 @@ def clustered_file(tmp_path):
     return _make_clustered_geoparquet(tmp_path / "clustered.parquet")
 
 
+@pytest.mark.network
 class TestExtentAwareResolution:
     """Auto-resolution should be sized to the data's actual extent (issue #524).
 
@@ -746,3 +747,25 @@ class TestExtentAwareResolution:
         # Falls back to the pure-math global formula for the same row count.
         expected = _calculate_a5_resolution(8000, 80)
         assert res == expected
+
+    def test_falls_back_when_all_geometries_null(self, tmp_path):
+        """All-NULL geometries probe to zero cells and fall back, not min_resolution."""
+        import geopandas as gpd
+
+        all_null = tmp_path / "all_null.parquet"
+        gdf = gpd.GeoDataFrame(
+            {"id": range(8000), "geometry": [None] * 8000},
+            crs="EPSG:4326",
+        )
+        gdf.to_parquet(all_null)
+
+        res = calculate_auto_resolution(
+            input_parquet=str(all_null),
+            spatial_index_type="a5",
+            target_rows_per_partition=80,
+        )
+        # The probe finds no non-empty cells, so the global formula is used
+        # instead of silently collapsing to the coarsest (min) resolution.
+        expected = _calculate_a5_resolution(8000, 80)
+        assert res == expected
+        assert res > 0

--- a/tests/test_partition_auto_resolution.py
+++ b/tests/test_partition_auto_resolution.py
@@ -348,8 +348,14 @@ class TestS2ResolutionCalculation:
 class TestAutoResolutionIntegration:
     """Test the main calculate_auto_resolution function with real files."""
 
+    @pytest.mark.network
     def test_calculate_auto_resolution_h3_with_real_file(self, fields_5070_file):
-        """Test auto-resolution calculation with a real GeoParquet file (H3)."""
+        """Test auto-resolution calculation with a real GeoParquet file (H3).
+
+        Network-marked: the extent-aware probe runs ``INSTALL h3 FROM community``
+        + ``LOAD``, which a cold-cache runner must download. The quadkey
+        integration test below covers the probe's success path offline.
+        """
         resolution = calculate_auto_resolution(
             input_parquet=fields_5070_file,
             spatial_index_type="h3",
@@ -361,7 +367,12 @@ class TestAutoResolutionIntegration:
         assert 0 <= resolution <= 15
 
     def test_calculate_auto_resolution_quadkey_with_real_file(self, fields_5070_file):
-        """Test auto-resolution calculation with a real GeoParquet file (quadkey)."""
+        """Test auto-resolution calculation with a real GeoParquet file (quadkey).
+
+        Intentionally *not* network-marked: quadkey's probe needs only mercantile
+        (no ``INSTALL ... FROM community``), so this exercises the extent-aware
+        probe's success path in the offline fast suite.
+        """
         resolution = calculate_auto_resolution(
             input_parquet=fields_5070_file,
             spatial_index_type="quadkey",
@@ -372,8 +383,12 @@ class TestAutoResolutionIntegration:
         # Should return a valid quadkey zoom level
         assert 0 <= resolution <= 23
 
+    @pytest.mark.network
     def test_calculate_auto_resolution_a5_with_real_file(self, fields_5070_file):
-        """Test auto-resolution calculation with a real GeoParquet file (A5)."""
+        """Test auto-resolution calculation with a real GeoParquet file (A5).
+
+        Network-marked: the extent-aware probe runs ``INSTALL a5 FROM community``.
+        """
         resolution = calculate_auto_resolution(
             input_parquet=fields_5070_file,
             spatial_index_type="a5",
@@ -384,8 +399,13 @@ class TestAutoResolutionIntegration:
         # Should return a valid A5 resolution
         assert 0 <= resolution <= 30
 
+    @pytest.mark.network
     def test_calculate_auto_resolution_s2_with_real_file(self, fields_5070_file):
-        """Test auto-resolution calculation with a real GeoParquet file (S2)."""
+        """Test auto-resolution calculation with a real GeoParquet file (S2).
+
+        Network-marked: the extent-aware probe runs
+        ``INSTALL geography FROM community``.
+        """
         resolution = calculate_auto_resolution(
             input_parquet=fields_5070_file,
             spatial_index_type="s2",
@@ -422,8 +442,12 @@ class TestAutoResolutionIntegration:
                 target_rows_per_partition=100,
             )
 
+    @pytest.mark.network
     def test_calculate_auto_resolution_custom_bounds(self, fields_5070_file):
-        """Test custom min/max resolution bounds."""
+        """Test custom min/max resolution bounds.
+
+        Network-marked: uses H3, whose probe runs ``INSTALL h3 FROM community``.
+        """
         resolution = calculate_auto_resolution(
             input_parquet=fields_5070_file,
             spatial_index_type="h3",

--- a/tests/test_partition_auto_resolution.py
+++ b/tests/test_partition_auto_resolution.py
@@ -748,6 +748,33 @@ class TestExtentAwareResolution:
         expected = _calculate_a5_resolution(8000, 80)
         assert res == expected
 
+    def test_sampling_path_for_large_file(self, tmp_path):
+        """A file larger than the sample budget exercises the reservoir-sample path."""
+        import geopandas as gpd
+        import numpy as np
+        from shapely.geometry import Point
+
+        # 60k rows exceeds the 50k sample floor, so USING SAMPLE is applied
+        # (smaller files take the no-sample branch).
+        n = 60_000
+        rng = np.random.default_rng(7)
+        lons = rng.uniform(4.0, 7.0, n)
+        lats = rng.uniform(51.0, 53.5, n)
+        big = tmp_path / "big.parquet"
+        gpd.GeoDataFrame(
+            {"id": range(n), "geometry": [Point(x, y) for x, y in zip(lons, lats, strict=False)]},
+            crs="EPSG:4326",
+        ).to_parquet(big)
+
+        res = calculate_auto_resolution(
+            input_parquet=str(big),
+            spatial_index_type="a5",
+            target_rows_per_partition=600,  # ~100 target partitions
+        )
+        # Probe ran over a sample and chose a sane, non-degenerate resolution
+        # (not the coarse fallback the global formula would give for clustered data).
+        assert 0 < res <= 30
+
     def test_falls_back_when_all_geometries_null(self, tmp_path):
         """All-NULL geometries probe to zero cells and fall back, not min_resolution."""
         import geopandas as gpd


### PR DESCRIPTION
## Summary

Fixes #524.

`gpio partition {a5,h3,s2,quadkey} --auto` picked the spatial-index resolution by assuming the data was spread roughly **uniformly across the whole globe**. The per-index calculators solved `target_partitions = total_rows / target_rows` against a *global* cell-count formula (A5/S2 `6×4^res`, H3 `122×7^res`, quadkey `4^zoom`) — i.e. the number of cells covering the entire planet, not the number of **non-empty** cells over the data's real extent.

For regional/national datasets this was off by ~2 orders of magnitude (the issue's Netherlands example wanted ~114 partitions but got `res 2` → 1–3 giant partitions of millions of rows each, instead of `res 8` → ~110 partitions of ~100k rows).

## What changed

- `calculate_auto_resolution()` is now **extent-aware**: it probes a bounded sample of the actual data, counts non-empty cells at each candidate resolution (mirroring the cell expressions in the `add/` modules), and selects the resolution whose count is closest to the target partition count. One change in the shared `core/partition/auto_resolution.py` covers `a5`/`h3`/`s2`/`quadkey`.
- The existing pure-math `_calculate_*_resolution` functions are **kept as a fallback** for when the data can't be probed (e.g. no geometry column, sampling error).
- Sampling is sized to a multiple of the target partition count (floor 50k, ceiling 500k) so cells near the target resolution are well-populated and the sampled distinct-cell count is a good estimate.
- quadkey reuses the existing mercantile UDF, computing the finest quadkey once per row and taking substrings per level (avoids a UDF call per resolution per row).
- Docs (`docs/guide/partition.md`) updated to describe the extent-aware behavior and replace the stale global-formula tables; CHANGELOG entry added.

## Out of scope

Cell assignment still assumes lon/lat (EPSG:4326-family) input. Projected-CRS reprojection is a separate concern (noted in #524). The probe deliberately mirrors the current lon/lat-assuming partitioner so the two stay consistent — when reprojection lands, both should adopt it together.

## Testing

- New `TestExtentAwareResolution` class in `tests/test_partition_auto_resolution.py` (TDD — written failing first): for a regionally-clustered lon/lat fixture, the chosen resolution is strictly finer than the old global formula across all four indices, its non-empty cell count lands within a 4× band of the target, and min/max bounds + the no-geometry fallback are pinned.
- Full suite: `tests/test_partition_auto_resolution.py` (56 passed) and all partition-related fast tests (225 passed, 1 skipped).
- Methodology validated end-to-end on the issue's real file (Netherlands buildings, 11.4M rows): after reprojecting to EPSG:4326 the probe reproduces the issue's cell-count table almost exactly (res 4→3, res 6→11, res 8→**105**, res 10→1196), so with the default target it selects **res 8** as expected. (On the raw file — which is EPSG:28992 — results reflect the separate projected-CRS issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `gpio partition … --auto` is now **extent-aware**: it samples the input to measure non-empty spatial index cells per candidate resolution and selects the resolution closest to the target partition count (bounded by limits).
  * When probing isn’t possible (e.g., missing/invalid geometry), it falls back to the prior estimation behavior.

* **Documentation**
  * Updated the partitioning guide and changelog with the new extent-aware auto-resolution approach, fallback behavior, and EPSG:4326-family guidance.

* **Tests**
  * Added coverage for extent-aware auto-resolution behavior, bounds enforcement, and fallback cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->