### PR TITLE
fix(spatial): make add/partition CRS-aware for non-CRS84 input (#525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the resolution closest to the target partition count. One fix covers
   `a5`/`h3`/`s2`/`quadkey`; it falls back to the old global estimate when the
   data can't be probed.
+- **Spatial operations are now CRS-aware (#525).** `gpio add`/`partition` for the
+  lon/lat grids (`a5`, `h3`, `s2`, `quadkey`) and the admin spatial joins
+  (`add admin-divisions`, `partition admin`) assumed OGC:CRS84 input. On data in
+  another CRS this either errored (admin joins: `ST_Intersects` CRS mismatch) or
+  silently produced wrong cells (grids: projected metres keyed as degrees). A
+  shared helper now detects the input CRS and reprojects to the operation's
+  expected CRS (lon/lat for grids, OGC:CRS84 for admin) before the spatial work;
+  CRS84/CRS-less input is untouched, so the common path is unchanged. `add quadkey`
+  no longer rejects a known projected CRS — it reprojects instead.
 - Partition commands now route all rows in a **single** `COPY … PARTITION_BY`
   scan instead of re-scanning the input per partition value (#478).
   `gpio partition string`, `gpio partition admin`, and the cell-id partitioners

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -89,6 +89,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the resolution closest to the target partition count. One fix covers
   `a5`/`h3`/`s2`/`quadkey`; it falls back to the old global estimate when the
   data can't be probed.
+- **Spatial operations are now CRS-aware (#525).** `gpio add`/`partition` for the
+  lon/lat grids (`a5`, `h3`, `s2`, `quadkey`) and the admin spatial joins
+  (`add admin-divisions`, `partition admin`) assumed OGC:CRS84 input. On data in
+  another CRS this either errored (admin joins: `ST_Intersects` CRS mismatch) or
+  silently produced wrong cells (grids: projected metres keyed as degrees). A
+  shared helper now detects the input CRS and reprojects to the operation's
+  expected CRS (lon/lat for grids, OGC:CRS84 for admin) before the spatial work;
+  CRS84/CRS-less input is untouched, so the common path is unchanged. `add quadkey`
+  no longer rejects a known projected CRS — it reprojects instead.
 - Partition commands now route all rows in a **single** `COPY … PARTITION_BY`
   scan instead of re-scanning the input per partition value (#478).
   `gpio partition string`, `gpio partition admin`, and the cell-id partitioners

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -98,6 +98,12 @@ If your file already has a bbox column but lacks covering metadata (e.g., from e
 
 ## H3 Hexagonal Cells
 
+!!! note "Input CRS"
+    The grid commands (`h3`, `s2`, `a5`, `quadkey`) key on lon/lat. Input in a
+    non-CRS84 CRS is reprojected to lon/lat automatically before cell assignment,
+    so projected data (e.g. national grids in metres) keys correctly with no
+    manual reprojection. Input already in OGC:CRS84 / EPSG:4326 is untouched.
+
 Add [H3](https://h3geo.org/) hexagonal cell IDs based on geometry centroids:
 
 === "CLI"
@@ -365,6 +371,8 @@ Add administrative division columns via spatial join with remote boundaries data
 ### How It Works
 
 Performs spatial intersection between your data and remote admin boundaries to add admin division columns. Uses efficient spatial extent filtering to query only relevant boundaries from remote datasets.
+
+Input in a non-CRS84 CRS is reprojected to the boundaries' CRS (OGC:CRS84) before the intersection, so projected data joins correctly instead of erroring on a CRS mismatch. (For a non-CRS84 input the bbox pre-filter is skipped, since the stored bbox is in the source CRS — the extent filter still bounds the query.)
 
 For native-geometry inputs (GeoParquet 2.0 and GeoParquet 1.1 with geoarrow encoding), the spatial join relies on native Parquet column statistics to skip irrelevant data, but this is not quite working yet, so expect those to be a bit slower until [#462](https://github.com/geoparquet/geoparquet-io/issues/462) is implemented. For non-native inputs (GeoParquet 1.x that carry a `bbox` column), a cheap bbox-overlap test is applied before `ST_Intersects` to prune candidates, and using it will be 5-10x faster.
 

--- a/geoparquet_io/core/add/a5.py
+++ b/geoparquet_io/core/add/a5.py
@@ -133,11 +133,17 @@ def _make_add_a5_query(
     geometry_column: str,
     a5_column_name: str,
     resolution: int,
+    source_crs: str | None = None,
 ) -> str:
-    """Build query to add A5 column to a source."""
+    """Build query to add A5 column to a source.
+
+    ``source_crs`` reprojects a non-CRS84 input to lon/lat before centroid keying
+    (#525); ``None`` (CRS84 / CRS-less) leaves the geometry untouched.
+    """
+    geom_ref = transform_geom_sql(f'"{geometry_column}"', source_crs)
     a5_expr = f"""a5_lonlat_to_cell(
-        ST_X(ST_Centroid("{geometry_column}")),
-        ST_Y(ST_Centroid("{geometry_column}")),
+        ST_X(ST_Centroid({geom_ref})),
+        ST_Y(ST_Centroid({geom_ref})),
         {resolution}
     )"""
     return f'SELECT *, {a5_expr} AS "{a5_column_name}" FROM {source}'
@@ -282,8 +288,12 @@ def _add_a5_streaming(
     if should_stream_output(output_path):
         verbose = False
 
-    def make_query(source: str, con) -> str:
-        """Build the add A5 query for streaming source."""
+    def make_query(source: str, con, source_crs: str | None = None) -> str:
+        """Build the add A5 query for streaming source.
+
+        ``source_crs`` is the streamed input's CRS (from its Arrow geo metadata),
+        used to reproject non-CRS84 input to lon/lat before keying (#525).
+        """
         # Load A5 extension
         load_community_extension(con, "a5")
 
@@ -303,7 +313,7 @@ def _add_a5_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_a5_query(source, geom_col, a5_column_name, resolution)
+        return _make_add_a5_query(source, geom_col, a5_column_name, resolution, source_crs)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/a5.py
+++ b/geoparquet_io/core/add/a5.py
@@ -6,7 +6,11 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import add_computed_column
 from geoparquet_io.core.constants import DEFAULT_A5_COLUMN_NAME
-from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
+from geoparquet_io.core.crs_utils import (
+    crs_string_from_table,
+    source_crs_string,
+    transform_geom_sql,
+)
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
@@ -56,9 +60,15 @@ def add_a5_table(
     if not 0 <= resolution <= 30:
         raise ValueError(f"A5 resolution must be between 0 and 30, got {resolution}")
 
+    # A5 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
+    source_crs = crs_string_from_table(table, geom_col)
+
     # Register table and execute query
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
+        # Ensure ST_Transform (CRS-aware keying) emits lon/lat order.
+        con.execute("SET geometry_always_xy = true;")
+
         # Load A5 extension
         load_community_extension(con, "a5")
 
@@ -81,10 +91,11 @@ def add_a5_table(
         else:
             source_ref = "__input_table"
 
-        # Build A5 column query
+        # Build A5 column query (reproject to lon/lat when source is non-CRS84)
+        geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
         a5_expr = f"""a5_lonlat_to_cell(
-            ST_X(ST_Centroid("{geom_col}")),
-            ST_Y(ST_Centroid("{geom_col}")),
+            ST_X(ST_Centroid({geom_ref})),
+            ST_Y(ST_Centroid({geom_ref})),
             {resolution}
         )"""
 

--- a/geoparquet_io/core/add/a5.py
+++ b/geoparquet_io/core/add/a5.py
@@ -6,11 +6,7 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import add_computed_column
 from geoparquet_io.core.constants import DEFAULT_A5_COLUMN_NAME
-from geoparquet_io.core.crs_utils import (
-    crs_transform_sql_expr,
-    extract_crs_from_parquet,
-    extract_crs_from_table,
-)
+from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
@@ -85,13 +81,10 @@ def add_a5_table(
         else:
             source_ref = "__input_table"
 
-        # Build A5 column query. a5_lonlat_to_cell expects lon/lat degrees, so a
-        # projected input is reprojected to OGC:CRS84 before keying (issue #525).
-        source_crs = extract_crs_from_table(table, geom_col)
-        centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
+        # Build A5 column query
         a5_expr = f"""a5_lonlat_to_cell(
-            ST_X({centroid}),
-            ST_Y({centroid}),
+            ST_X(ST_Centroid("{geom_col}")),
+            ST_Y(ST_Centroid("{geom_col}")),
             {resolution}
         )"""
 
@@ -129,17 +122,11 @@ def _make_add_a5_query(
     geometry_column: str,
     a5_column_name: str,
     resolution: int,
-    source_crs=None,
 ) -> str:
-    """Build query to add A5 column to a source.
-
-    ``source_crs`` (when a non-default CRS) reprojects the centroid to OGC:CRS84
-    before keying, since ``a5_lonlat_to_cell`` expects lon/lat degrees.
-    """
-    centroid = crs_transform_sql_expr(f'ST_Centroid("{geometry_column}")', source_crs)
+    """Build query to add A5 column to a source."""
     a5_expr = f"""a5_lonlat_to_cell(
-        ST_X({centroid}),
-        ST_Y({centroid}),
+        ST_X(ST_Centroid("{geometry_column}")),
+        ST_Y(ST_Centroid("{geometry_column}")),
         {resolution}
     )"""
     return f'SELECT *, {a5_expr} AS "{a5_column_name}" FROM {source}'
@@ -224,13 +211,13 @@ def add_a5_column(
     # Get geometry column for the SQL expression
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Define the A5 SQL expression. a5_lonlat_to_cell expects lon/lat degrees, so
-    # a projected input is reprojected to OGC:CRS84 before keying (issue #525).
-    source_crs = extract_crs_from_parquet(input_parquet, verbose)
-    centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
+    # A5 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
+    geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs_string(input_parquet, verbose))
+
+    # Define the A5 SQL expression
     sql_expression = f"""a5_lonlat_to_cell(
-        ST_X({centroid}),
-        ST_Y({centroid}),
+        ST_X(ST_Centroid({geom_ref})),
+        ST_Y(ST_Centroid({geom_ref})),
         {a5_resolution}
     )"""
 
@@ -284,10 +271,6 @@ def _add_a5_streaming(
     if should_stream_output(output_path):
         verbose = False
 
-    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
-    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
-    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
-
     def make_query(source: str, con) -> str:
         """Build the add A5 query for streaming source."""
         # Load A5 extension
@@ -309,7 +292,7 @@ def _add_a5_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_a5_query(source, geom_col, a5_column_name, resolution, source_crs)
+        return _make_add_a5_query(source, geom_col, a5_column_name, resolution)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -14,31 +14,13 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.crs_utils import crs_transform_sql_expr, extract_crs_from_parquet
+from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
 from geoparquet_io.core.duckdb_utils import build_spatial_join_condition, quote_identifier
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
 from geoparquet_io.core.partition.reader import require_single_file
 from geoparquet_io.core.remote import _sanitize_url_for_logging, is_remote_url
-
-
-def _reprojected_input_geom_sql(input_geom_col, source_crs, alias="a"):
-    """Return the input geometry expression reprojected to the admin CRS.
-
-    Admin boundaries are OGC:CRS84, so a non-CRS84 input must be reprojected
-    before ``ST_Intersects`` (issue #525) — DuckDB 1.5 otherwise refuses the
-    join with a CRS-mismatch error. Returns ``None`` when no transform is needed
-    (input already CRS84 / CRS-less), so callers keep the original behavior.
-
-    ``alias`` is the SQL table alias prefix; pass ``None`` for a bare column
-    reference (e.g. an aggregate extent query with no alias).
-    """
-    base = (
-        f"{alias}.{quote_identifier(input_geom_col)}" if alias else quote_identifier(input_geom_col)
-    )
-    transformed = crs_transform_sql_expr(base, source_crs)
-    return transformed if transformed != base else None
 
 
 def _build_admin_subquery(
@@ -140,8 +122,11 @@ def _build_spatial_join_query(
     """
     input_ref = _format_input_ref(input_url, is_table_ref)
 
-    # Reproject a non-CRS84 input to the admin CRS before ST_Intersects (#525).
-    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs)
+    # Reproject a non-CRS84 input to the admin CRS (OGC:CRS84) before the
+    # predicate, else DuckDB errors on the CRS mismatch / matches nothing (#525).
+    input_geom_sql = None
+    if source_crs:
+        input_geom_sql = transform_geom_sql(f"a.{quote_identifier(input_geom_col)}", source_crs)
 
     # Shared, fully-quoted ON clause (bbox pre-filter + ST_Intersects).
     join_clause = "ON " + build_spatial_join_condition(
@@ -174,18 +159,16 @@ def _add_extent_filter(
 ):
     """Add bbox extent filter to admin where clauses.
 
-    When the input is reprojected to the admin CRS (``source_crs`` non-default),
-    the extent is computed from the *reprojected* geometry so the resulting
-    bounds are comparable to the admin (CRS84) bbox; the stored input bbox column
-    is in the source CRS and is therefore ignored.
+    The admin boundaries are in OGC:CRS84, so the extent must be in CRS84 too.
+    For a non-CRS84 input the stored bbox is in the source CRS and can't be used —
+    compute the extent over the reprojected geometry instead (#525).
     """
     if not admin_bbox_col:
         return None
 
     input_ref = _format_input_ref(input_url, is_table_ref)
-    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs, alias=None)
 
-    if input_bbox_col and input_geom_sql is None:
+    if input_bbox_col and not source_crs:
         q_input_bbox = quote_identifier(input_bbox_col)
         extent_query = f"""
             SELECT
@@ -196,13 +179,13 @@ def _add_extent_filter(
             FROM {input_ref}
         """
     else:
-        geom_expr = input_geom_sql or f"{quote_identifier(input_geom_col)}"
+        geom_ref = transform_geom_sql(quote_identifier(input_geom_col), source_crs)
         extent_query = f"""
             SELECT
-                MIN(ST_XMin({geom_expr})) as xmin,
-                MAX(ST_XMax({geom_expr})) as xmax,
-                MIN(ST_YMin({geom_expr})) as ymin,
-                MAX(ST_YMax({geom_expr})) as ymax
+                MIN(ST_XMin({geom_ref})) as xmin,
+                MAX(ST_XMax({geom_ref})) as xmax,
+                MIN(ST_YMin({geom_ref})) as ymin,
+                MAX(ST_YMax({geom_ref})) as ymax
             FROM {input_ref}
         """
 
@@ -332,13 +315,6 @@ def _setup_dataset_and_columns(
     input_geom_col = find_primary_geometry_column(input_parquet, verbose)
     admin_geom_col = dataset.get_geometry_column()
 
-    # Detect a projected input CRS: admin boundaries are OGC:CRS84, so a non-CRS84
-    # input is reprojected before ST_Intersects (issue #525). DuckDB 1.5 otherwise
-    # refuses the join with a CRS-mismatch error.
-    source_crs = extract_crs_from_parquet(input_parquet, verbose)
-    if source_crs is not None and verbose:
-        debug("Projected input CRS detected — reprojecting to OGC:CRS84 for admin join")
-
     # Check if we should skip bbox pre-filtering (for native geometry files)
     input_bbox_advice = get_bbox_advice(input_parquet, "spatial_filtering", verbose)
     if input_bbox_advice["skip_bbox_prefilter"]:
@@ -362,7 +338,6 @@ def _setup_dataset_and_columns(
         input_bbox_info,
         input_bbox_col,
         admin_bbox_col,
-        source_crs,
     )
 
 
@@ -393,6 +368,8 @@ def _setup_duckdb_connection():
         load_spatial=True, load_httpfs=True, temp_directory=str(temp_dir), threads=1
     )
     con.execute("SET preserve_insertion_order = false")
+    # Reproject (CRS-aware admin join, #525) emits lon/lat order to match CRS84.
+    con.execute("SET geometry_always_xy = true")
     return con
 
 
@@ -586,10 +563,6 @@ def _execute_per_level_joins(
     Each level joins against its own cache file, chaining results through DuckDB
     temp tables. Per-level caches are non-overlapping, so each plain LEFT JOIN
     normally preserves the row count.
-
-    The input geometry is carried through the chained temp tables unchanged (in
-    its source CRS), so ``source_crs`` reprojection is applied at every level,
-    not just the first (issue #525).
     """
     current_source = input_url
 
@@ -718,10 +691,13 @@ def add_admin_divisions_multi(
         input_bbox_info,
         input_bbox_col,
         admin_bbox_col,
-        source_crs,
     ) = _setup_dataset_and_columns(
         input_parquet, dataset_name, dataset_source, levels, verbose, no_cache=no_cache
     )
+
+    # Admin boundaries are OGC:CRS84; reproject a non-CRS84 input before the join
+    # (otherwise ST_Intersects errors on the CRS mismatch or matches nothing, #525).
+    source_crs = source_crs_string(input_parquet, verbose)
 
     # Get metadata before processing (skip in dry-run)
     metadata = None

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -14,13 +14,28 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
+from geoparquet_io.core.crs_utils import (
+    reproject_to_source_sql,
+    source_crs_string,
+    transform_geom_sql,
+)
 from geoparquet_io.core.duckdb_utils import build_spatial_join_condition, quote_identifier
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
 from geoparquet_io.core.partition.reader import require_single_file
 from geoparquet_io.core.remote import _sanitize_url_for_logging, is_remote_url
+
+
+def _admin_reprojected(source_crs, admin_bbox_col) -> bool:
+    """Whether the admin side is reprojected into the input CRS (#525).
+
+    Only when there is a non-CRS84 input *and* the admin dataset has a bbox to
+    base a pre-filter on. Reprojecting the (small) admin side instead of the
+    large input keeps the join's bbox pre-filter usable (both sides share the
+    input CRS) — see :func:`reproject_to_source_sql`.
+    """
+    return bool(source_crs) and bool(admin_bbox_col)
 
 
 def _build_admin_subquery(
@@ -31,8 +46,17 @@ def _build_admin_subquery(
     admin_geom_col,
     admin_bbox_col,
     admin_where_clauses,
+    source_crs=None,
 ):
-    """Build admin data subquery with filters."""
+    """Build admin data subquery with filters.
+
+    When ``source_crs`` is set (non-CRS84 input) and the admin data has a bbox,
+    the admin polygons are reprojected into the input's CRS and a matching
+    source-CRS bbox struct is synthesized, so the downstream join keeps its cheap
+    bbox pre-filter without transforming the input per row (#525). The admin
+    ``WHERE`` extent filter still runs on the original (CRS84) bbox before the
+    reprojection.
+    """
     admin_where_clause = ""
     if admin_where_clauses:
         admin_where_clause = "WHERE " + " AND ".join(admin_where_clauses)
@@ -47,6 +71,22 @@ def _build_admin_subquery(
     subquery_cols_str = ", ".join(subquery_cols)
 
     geom_select = quote_identifier(admin_geom_col)
+
+    if _admin_reprojected(source_crs, admin_bbox_col):
+        radmin = reproject_to_source_sql(geom_select, source_crs)
+        bbox_q = quote_identifier(admin_bbox_col)
+        # Reproject the polygon (M rows, cheap) and rebuild its bbox in the input
+        # CRS so the join can pre-filter against the input's stored bbox.
+        bbox_struct = (
+            f"struct_pack(xmin := ST_XMin({radmin}), xmax := ST_XMax({radmin}), "
+            f"ymin := ST_YMin({radmin}), ymax := ST_YMax({radmin})) AS {bbox_q}"
+        )
+        return f"""(
+        SELECT {radmin} AS {geom_select}, {bbox_struct}, {subquery_cols_str}
+        FROM {admin_table_ref}
+        {admin_where_clause}
+    )"""
+
     bbox_select = quote_identifier(admin_bbox_col) if admin_bbox_col else geom_select
 
     return f"""(
@@ -122,10 +162,14 @@ def _build_spatial_join_query(
     """
     input_ref = _format_input_ref(input_url, is_table_ref)
 
-    # Reproject a non-CRS84 input to the admin CRS (OGC:CRS84) before the
-    # predicate, else DuckDB errors on the CRS mismatch / matches nothing (#525).
+    # CRS handling for a non-CRS84 input (#525):
+    #  - If the admin side was reprojected into the input CRS (it has a bbox), the
+    #    join runs entirely in the input CRS, so the input geometry is left
+    #    untouched and the cheap bbox pre-filter is kept (avoids the #460 hang).
+    #  - Otherwise (admin has no bbox) reproject the input geometry inline; without
+    #    a bbox there is no pre-filter to preserve either way.
     input_geom_sql = None
-    if source_crs:
+    if source_crs and not _admin_reprojected(source_crs, admin_bbox_col):
         input_geom_sql = transform_geom_sql(f"a.{quote_identifier(input_geom_col)}", source_crs)
 
     # Shared, fully-quoted ON clause (bbox pre-filter + ST_Intersects).
@@ -462,6 +506,7 @@ def _build_query_components(
         admin_geom_col,
         admin_bbox_col,
         admin_where_clauses,
+        source_crs=source_crs,
     )
 
     if input_bbox_col and admin_bbox_col and verbose and not dry_run:

--- a/geoparquet_io/core/add/h3.py
+++ b/geoparquet_io/core/add/h3.py
@@ -6,7 +6,11 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import add_computed_column
 from geoparquet_io.core.constants import DEFAULT_H3_COLUMN_NAME
-from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
+from geoparquet_io.core.crs_utils import (
+    crs_string_from_table,
+    source_crs_string,
+    transform_geom_sql,
+)
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
@@ -56,9 +60,15 @@ def add_h3_table(
     if not 0 <= resolution <= 15:
         raise ValueError(f"H3 resolution must be between 0 and 15, got {resolution}")
 
+    # H3 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
+    source_crs = crs_string_from_table(table, geom_col)
+
     # Register table and execute query
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
+        # Ensure ST_Transform (CRS-aware keying) emits lon/lat order.
+        con.execute("SET geometry_always_xy = true;")
+
         # Load H3 extension
         load_community_extension(con, "h3")
 
@@ -81,10 +91,11 @@ def add_h3_table(
         else:
             source_ref = "__input_table"
 
-        # Build H3 column query
+        # Build H3 column query (reproject to lon/lat when source is non-CRS84)
+        geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
         h3_expr = f"""h3_latlng_to_cell_string(
-            ST_Y(ST_Centroid("{geom_col}")),
-            ST_X(ST_Centroid("{geom_col}")),
+            ST_Y(ST_Centroid({geom_ref})),
+            ST_X(ST_Centroid({geom_ref})),
             {resolution}
         )"""
 

--- a/geoparquet_io/core/add/h3.py
+++ b/geoparquet_io/core/add/h3.py
@@ -133,11 +133,17 @@ def _make_add_h3_query(
     geometry_column: str,
     h3_column_name: str,
     resolution: int,
+    source_crs: str | None = None,
 ) -> str:
-    """Build query to add H3 column to a source."""
+    """Build query to add H3 column to a source.
+
+    ``source_crs`` reprojects a non-CRS84 input to lon/lat before centroid keying
+    (#525); ``None`` (CRS84 / CRS-less) leaves the geometry untouched.
+    """
+    geom_ref = transform_geom_sql(f'"{geometry_column}"', source_crs)
     h3_expr = f"""h3_latlng_to_cell_string(
-        ST_Y(ST_Centroid("{geometry_column}")),
-        ST_X(ST_Centroid("{geometry_column}")),
+        ST_Y(ST_Centroid({geom_ref})),
+        ST_X(ST_Centroid({geom_ref})),
         {resolution}
     )"""
     return f'SELECT *, {h3_expr} AS "{h3_column_name}" FROM {source}'
@@ -282,8 +288,12 @@ def _add_h3_streaming(
     if should_stream_output(output_path):
         verbose = False
 
-    def make_query(source: str, con) -> str:
-        """Build the add H3 query for streaming source."""
+    def make_query(source: str, con, source_crs: str | None = None) -> str:
+        """Build the add H3 query for streaming source.
+
+        ``source_crs`` is the streamed input's CRS (from its Arrow geo metadata),
+        used to reproject non-CRS84 input to lon/lat before keying (#525).
+        """
         # Load H3 extension
         load_community_extension(con, "h3")
 
@@ -303,7 +313,7 @@ def _add_h3_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_h3_query(source, geom_col, h3_column_name, resolution)
+        return _make_add_h3_query(source, geom_col, h3_column_name, resolution, source_crs)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/h3.py
+++ b/geoparquet_io/core/add/h3.py
@@ -6,11 +6,7 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import add_computed_column
 from geoparquet_io.core.constants import DEFAULT_H3_COLUMN_NAME
-from geoparquet_io.core.crs_utils import (
-    crs_transform_sql_expr,
-    extract_crs_from_parquet,
-    extract_crs_from_table,
-)
+from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
@@ -85,13 +81,10 @@ def add_h3_table(
         else:
             source_ref = "__input_table"
 
-        # Build H3 column query. h3_latlng_to_cell_string expects lat/lon degrees,
-        # so a projected input is reprojected to OGC:CRS84 first (issue #525).
-        source_crs = extract_crs_from_table(table, geom_col)
-        centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
+        # Build H3 column query
         h3_expr = f"""h3_latlng_to_cell_string(
-            ST_Y({centroid}),
-            ST_X({centroid}),
+            ST_Y(ST_Centroid("{geom_col}")),
+            ST_X(ST_Centroid("{geom_col}")),
             {resolution}
         )"""
 
@@ -129,17 +122,11 @@ def _make_add_h3_query(
     geometry_column: str,
     h3_column_name: str,
     resolution: int,
-    source_crs=None,
 ) -> str:
-    """Build query to add H3 column to a source.
-
-    ``source_crs`` (when a non-default CRS) reprojects the centroid to OGC:CRS84
-    before keying, since ``h3_latlng_to_cell_string`` expects lat/lon degrees.
-    """
-    centroid = crs_transform_sql_expr(f'ST_Centroid("{geometry_column}")', source_crs)
+    """Build query to add H3 column to a source."""
     h3_expr = f"""h3_latlng_to_cell_string(
-        ST_Y({centroid}),
-        ST_X({centroid}),
+        ST_Y(ST_Centroid("{geometry_column}")),
+        ST_X(ST_Centroid("{geometry_column}")),
         {resolution}
     )"""
     return f'SELECT *, {h3_expr} AS "{h3_column_name}" FROM {source}'
@@ -224,14 +211,13 @@ def add_h3_column(
     # Get geometry column for the SQL expression
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Define the H3 SQL expression (using string format for portability). A
-    # projected input is reprojected to OGC:CRS84 before keying (issue #525),
-    # since h3_latlng_to_cell_string expects lat/lon degrees.
-    source_crs = extract_crs_from_parquet(input_parquet, verbose)
-    centroid = crs_transform_sql_expr(f"ST_Centroid({geom_col})", source_crs)
+    # H3 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
+    geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs_string(input_parquet, verbose))
+
+    # Define the H3 SQL expression (using string format for portability)
     sql_expression = f"""h3_latlng_to_cell_string(
-        ST_Y({centroid}),
-        ST_X({centroid}),
+        ST_Y(ST_Centroid({geom_ref})),
+        ST_X(ST_Centroid({geom_ref})),
         {h3_resolution}
     )"""
 
@@ -285,10 +271,6 @@ def _add_h3_streaming(
     if should_stream_output(output_path):
         verbose = False
 
-    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
-    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
-    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
-
     def make_query(source: str, con) -> str:
         """Build the add H3 query for streaming source."""
         # Load H3 extension
@@ -310,7 +292,7 @@ def _add_h3_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_h3_query(source, geom_col, h3_column_name, resolution, source_crs)
+        return _make_add_h3_query(source, geom_col, h3_column_name, resolution)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import mercantile
 import pyarrow as pa
 
@@ -12,12 +14,12 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.constants import DEFAULT_QUADKEY_COLUMN_NAME, DEFAULT_QUADKEY_RESOLUTION
 from geoparquet_io.core.crs_utils import (
-    crs_transform_sql_expr,
-    extract_crs_from_parquet,
-    extract_crs_from_table,
+    get_crs_display_name,
+    source_crs_string,
+    transform_geom_sql,
 )
-from geoparquet_io.core.duckdb_metadata import get_column_names
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_metadata import get_column_names, get_geo_metadata
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import (
@@ -45,6 +47,136 @@ from geoparquet_io.core.streaming import (
     is_stdin,
     should_stream_output,
 )
+
+
+def _is_geographic_crs(crs_info: dict | str | None) -> bool | None:
+    """
+    Check if CRS is geographic (lat/long) vs projected.
+
+    Returns:
+        True if geographic, False if projected, None if unknown
+    """
+    if crs_info is None:
+        return None
+
+    if isinstance(crs_info, str):
+        crs_upper = crs_info.upper()
+        # Common geographic CRS codes
+        if any(
+            code in crs_upper for code in ["4326", "CRS84", "CRS:84", "OGC:CRS84", "4269", "4267"]
+        ):
+            return True
+        return None
+
+    if isinstance(crs_info, dict):
+        # Check PROJJSON type
+        crs_type = crs_info.get("type", "")
+        if crs_type == "GeographicCRS":
+            return True
+        if crs_type == "ProjectedCRS":
+            return False
+
+        # Check EPSG code
+        crs_id = crs_info.get("id", {})
+        if isinstance(crs_id, dict):
+            code = crs_id.get("code")
+            if code in [4326, 4269, 4267]:  # Common geographic codes
+                return True
+
+    return None
+
+
+def _validate_crs_from_geo_metadata(
+    geo_meta: dict | None,
+    geom_col: str,
+    verbose: bool,
+    source_description: str = "data",
+) -> None:
+    """
+    Validate CRS from geo metadata dictionary.
+
+    Common helper used by file-based, streaming, and table-based paths.
+
+    Args:
+        geo_meta: Parsed geo metadata dict (from GeoParquet schema)
+        geom_col: Name of the geometry column
+        verbose: Whether to print debug output
+        source_description: Description for error messages (e.g., "file", "stream", "table")
+
+    Raises:
+        GeoParquetError: If CRS is detected as projected
+    """
+    if not geo_meta:
+        if verbose:
+            debug("No GeoParquet metadata found, assuming WGS84 coordinates")
+        return
+
+    columns_meta = geo_meta.get("columns", {})
+    if geom_col not in columns_meta:
+        if verbose:
+            debug(f"Geometry column '{geom_col}' not found in metadata, assuming WGS84")
+        return
+
+    crs_info = columns_meta[geom_col].get("crs")
+
+    # No CRS specified means default (WGS84)
+    if crs_info is None:
+        if verbose:
+            debug("No CRS specified in metadata, using default WGS84")
+        return
+
+    is_geographic = _is_geographic_crs(crs_info)
+
+    if is_geographic is False:
+        crs_name = get_crs_display_name(crs_info)
+        raise GeoParquetError(
+            f"Quadkeys require geographic coordinates (lat/lon), but this {source_description} "
+            f"uses a projected CRS: {crs_name}\n\n"
+            f"Reproject to WGS84 first using:\n"
+            f"  gpio convert reproject <input> <output> --dst-crs EPSG:4326"
+        )
+
+    if verbose and is_geographic:
+        debug("CRS validated as geographic (lat/lon coordinates)")
+
+
+def _validate_crs_for_quadkey(input_parquet: str, geom_col: str, verbose: bool) -> None:
+    """
+    Validate that the file's CRS is geographic (WGS84/CRS84).
+
+    Quadkeys require lat/lon coordinates. Raises ClickException if CRS is projected.
+    """
+    safe_url = safe_file_url(input_parquet, verbose=False)
+
+    # Get CRS from GeoParquet metadata
+    geo_meta = get_geo_metadata(safe_url)
+    _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose, source_description="file")
+
+
+def _parse_geo_metadata_from_schema(metadata: dict | None) -> dict | None:
+    """
+    Parse geo metadata from schema metadata bytes dict.
+
+    Args:
+        metadata: Schema metadata dict (with bytes keys/values)
+
+    Returns:
+        Parsed geo metadata dict, or None if not found
+    """
+    if not metadata:
+        return None
+
+    # Try both bytes and string keys (depends on how metadata was accessed)
+    geo_bytes = metadata.get(b"geo") or metadata.get("geo")
+    if not geo_bytes:
+        return None
+
+    try:
+        if isinstance(geo_bytes, bytes):
+            return json.loads(geo_bytes.decode("utf-8"))
+        return json.loads(geo_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
 
 
 def _lat_lon_to_quadkey(lat: float, lon: float, level: int) -> str:
@@ -77,6 +209,7 @@ def add_quadkey_table(
 
     Raises:
         ValueError: If resolution is not an integer between 0 and 23
+        GeoParquetError: If CRS is detected as projected (quadkeys require lat/lon)
     """
     # Validate resolution before any DuckDB operations
     resolution = int(resolution)
@@ -88,15 +221,14 @@ def add_quadkey_table(
     if not geom_col:
         geom_col = "geometry"
 
-    # Quadkeys require lon/lat degrees. A projected input is reprojected to
-    # OGC:CRS84 before keying (issue #525); the stored bbox column is in the
-    # source CRS, so it cannot be used as the keying location when reprojecting.
-    source_crs = extract_crs_from_table(table, geom_col)
+    # Validate CRS is geographic (quadkeys require lat/lon)
+    geo_meta = _parse_geo_metadata_from_schema(table.schema.metadata)
+    _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose=False, source_description="table")
 
     # Check if bbox column exists
     use_bbox = False
     bbox_col = None
-    if not use_centroid and source_crs is None:
+    if not use_centroid:
         for name in ["bbox", "bounds", "bounding_box"]:
             if name in table.column_names:
                 use_bbox = True
@@ -136,9 +268,8 @@ def add_quadkey_table(
             lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
             lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
         else:
-            centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
-            lat_expr = f"ST_Y({centroid})"
-            lon_expr = f"ST_X({centroid})"
+            lat_expr = f'ST_Y(ST_Centroid("{geom_col}"))'
+            lon_expr = f'ST_X(ST_Centroid("{geom_col}"))'
 
         # Get non-geometry columns
         other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
@@ -270,10 +401,6 @@ def _add_quadkey_streaming(
     if not 0 <= resolution <= 23:
         raise InvalidParameterError("resolution", f"must be between 0 and 23, got {resolution}")
 
-    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
-    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
-    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
-
     with open_input(input_path, verbose=verbose) as (source, metadata, is_stream, con):
         # Register Python UDF for quadkey generation
         con.create_function(
@@ -296,10 +423,13 @@ def _add_quadkey_streaming(
         if not geom_col:
             geom_col = "geometry"
 
-        # Check for bbox column. The stored bbox is in the source CRS, so it
-        # cannot be used as the keying location when reprojecting.
+        # Validate CRS is geographic (quadkeys require lat/lon)
+        geo_meta = _parse_geo_metadata_from_schema(metadata)
+        _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose, source_description="stream")
+
+        # Check for bbox column
         bbox_col = None
-        if not use_centroid and source_crs is None:
+        if not use_centroid:
             for name in ["bbox", "bounds", "bounding_box"]:
                 if name in col_names:
                     bbox_col = name
@@ -310,9 +440,8 @@ def _add_quadkey_streaming(
             lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
             lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
         else:
-            centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
-            lat_expr = f"ST_Y({centroid})"
-            lon_expr = f"ST_X({centroid})"
+            lat_expr = f'ST_Y(ST_Centroid("{geom_col}"))'
+            lon_expr = f'ST_X(ST_Centroid("{geom_col}"))'
 
         query = f"""
             SELECT *,
@@ -384,10 +513,13 @@ def _add_quadkey_file_based(
     # Get geometry column
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Quadkeys require lon/lat degrees. A projected input is reprojected to
-    # OGC:CRS84 before keying (issue #525); the stored bbox column is in the
-    # source CRS, so it cannot be used as the keying location when reprojecting.
-    source_crs = extract_crs_from_parquet(input_parquet, verbose)
+    # Quadkeys require lon/lat degrees. Reproject a known non-CRS84 CRS (#525);
+    # otherwise keep the guard (rejects projected input we can't identify, and
+    # passes through default/unknown which is assumed WGS84).
+    source_crs = source_crs_string(input_parquet, verbose)
+    needs_transform = source_crs is not None
+    if not needs_transform:
+        _validate_crs_for_quadkey(input_parquet, geom_col, verbose)
 
     # Check if column already exists (skip in dry-run)
     if not dry_run:
@@ -398,10 +530,12 @@ def _add_quadkey_file_based(
                 f"Please choose a different name."
             )
 
-    # Determine whether to use bbox or centroid
+    # Determine whether to use bbox or centroid. A stored bbox column is in the
+    # input CRS, so it can't be used when we need to reproject — fall back to the
+    # (reprojected) centroid in that case.
     use_bbox = False
     bbox_col = None
-    if not use_centroid and source_crs is None:
+    if not use_centroid and not needs_transform:
         bbox_advice = get_bbox_advice(input_parquet, "bounds_calculation", verbose)
         if bbox_advice["has_bbox_column"]:
             use_bbox = True
@@ -412,8 +546,6 @@ def _add_quadkey_file_based(
             warn(bbox_advice["message"] + " - using geometry centroid for quadkey calculation")
             for suggestion in bbox_advice["suggestions"]:
                 info(f"Tip: {suggestion}")
-    elif source_crs is not None and verbose:
-        debug("Projected CRS detected — reprojecting centroid to OGC:CRS84 for quadkey keying")
 
     # Dry-run mode header
     if dry_run:
@@ -443,6 +575,8 @@ def _add_quadkey_file_based(
 
     # Create DuckDB connection with httpfs if needed
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
+    # Ensure ST_Transform (CRS-aware keying) emits lon/lat order.
+    con.execute("SET geometry_always_xy = true;")
 
     try:
         # Register Python UDF for quadkey generation
@@ -458,9 +592,9 @@ def _add_quadkey_file_based(
             lat_expr = f"(({bbox_col}.ymin + {bbox_col}.ymax) / 2.0)"
             lon_expr = f"(({bbox_col}.xmin + {bbox_col}.xmax) / 2.0)"
         else:
-            centroid = crs_transform_sql_expr(f"ST_Centroid({geom_col})", source_crs)
-            lat_expr = f"ST_Y({centroid})"
-            lon_expr = f"ST_X({centroid})"
+            geom_ref = transform_geom_sql(quote_identifier(geom_col), source_crs)
+            lat_expr = f"ST_Y(ST_Centroid({geom_ref}))"
+            lon_expr = f"ST_X(ST_Centroid({geom_ref}))"
 
         # Build SELECT query with new column
         query = f"""

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -12,6 +12,7 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.constants import DEFAULT_QUADKEY_COLUMN_NAME, DEFAULT_QUADKEY_RESOLUTION
 from geoparquet_io.core.crs_utils import (
+    crs_string_from_geo_meta,
     crs_string_from_table,
     get_crs_display_name,
     parse_geo_metadata_from_schema,
@@ -156,6 +157,24 @@ def _validate_crs_for_quadkey(input_parquet: str, geom_col: str, verbose: bool) 
 def _parse_geo_metadata_from_schema(metadata: dict | None) -> dict | None:
     """Parse geo metadata from schema metadata bytes dict (shared helper)."""
     return parse_geo_metadata_from_schema(metadata)
+
+
+def _streaming_source_crs(
+    input_path: str, metadata: dict | None, geom_col: str, verbose: bool
+) -> str | None:
+    """Detect the streaming input's CRS as an ``"AUTH:CODE"`` transform string.
+
+    Returns ``None`` for CRS84/default/CRS-less input (no reprojection needed).
+
+    - File input streamed to stdout (``gpio add quadkey file.parquet -``): detect
+      from the file, covering both the GeoParquet ``geo`` metadata and the
+      parquet-geo native geometry type — same as the file-based path (#530).
+    - True stdin: detect from the ``geo`` metadata carried on the Arrow stream.
+    """
+    if not is_stdin(input_path):
+        return source_crs_string(input_path, verbose)
+    geo_meta = _parse_geo_metadata_from_schema(metadata)
+    return crs_string_from_geo_meta(geo_meta, geom_col)
 
 
 def _lat_lon_to_quadkey(lat: float, lon: float, level: int) -> str:
@@ -393,6 +412,9 @@ def _add_quadkey_streaming(
         raise InvalidParameterError("resolution", f"must be between 0 and 23, got {resolution}")
 
     with open_input(input_path, verbose=verbose) as (source, metadata, is_stream, con):
+        # Ensure ST_Transform (CRS-aware keying) emits lon/lat order.
+        con.execute("SET geometry_always_xy = true;")
+
         # Register Python UDF for quadkey generation
         con.create_function(
             "lat_lon_to_quadkey",
@@ -414,25 +436,34 @@ def _add_quadkey_streaming(
         if not geom_col:
             geom_col = "geometry"
 
-        # Validate CRS is geographic (quadkeys require lat/lon)
-        geo_meta = _parse_geo_metadata_from_schema(metadata)
-        _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose, source_description="stream")
+        # Quadkeys require lon/lat degrees. Reproject a known non-CRS84 CRS (#525,
+        # #530); otherwise keep the guard (rejects projected input we can't
+        # identify, passes through default/unknown which is assumed WGS84).
+        source_crs = _streaming_source_crs(input_path, metadata, geom_col, verbose)
+        needs_transform = source_crs is not None
+        if not needs_transform:
+            geo_meta = _parse_geo_metadata_from_schema(metadata)
+            _validate_crs_from_geo_metadata(
+                geo_meta, geom_col, verbose, source_description="stream"
+            )
 
-        # Check for bbox column
+        # Check for bbox column. A stored bbox is in the input CRS, so it can't be
+        # used when we need to reproject — fall back to the (reprojected) centroid.
         bbox_col = None
-        if not use_centroid:
+        if not use_centroid and not needs_transform:
             for name in ["bbox", "bounds", "bounding_box"]:
                 if name in col_names:
                     bbox_col = name
                     break
 
-        # Build lat/lon expressions
+        # Build lat/lon expressions (reproject to lon/lat when source is non-CRS84)
         if bbox_col:
             lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
             lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
         else:
-            lat_expr = f'ST_Y(ST_Centroid("{geom_col}"))'
-            lon_expr = f'ST_X(ST_Centroid("{geom_col}"))'
+            geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+            lat_expr = f"ST_Y(ST_Centroid({geom_ref}))"
+            lon_expr = f"ST_X(ST_Centroid({geom_ref}))"
 
         query = f"""
             SELECT *,

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import mercantile
 import pyarrow as pa
 
@@ -14,7 +12,9 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.constants import DEFAULT_QUADKEY_COLUMN_NAME, DEFAULT_QUADKEY_RESOLUTION
 from geoparquet_io.core.crs_utils import (
+    crs_string_from_table,
     get_crs_display_name,
+    parse_geo_metadata_from_schema,
     source_crs_string,
     transform_geom_sql,
 )
@@ -154,29 +154,8 @@ def _validate_crs_for_quadkey(input_parquet: str, geom_col: str, verbose: bool) 
 
 
 def _parse_geo_metadata_from_schema(metadata: dict | None) -> dict | None:
-    """
-    Parse geo metadata from schema metadata bytes dict.
-
-    Args:
-        metadata: Schema metadata dict (with bytes keys/values)
-
-    Returns:
-        Parsed geo metadata dict, or None if not found
-    """
-    if not metadata:
-        return None
-
-    # Try both bytes and string keys (depends on how metadata was accessed)
-    geo_bytes = metadata.get(b"geo") or metadata.get("geo")
-    if not geo_bytes:
-        return None
-
-    try:
-        if isinstance(geo_bytes, bytes):
-            return json.loads(geo_bytes.decode("utf-8"))
-        return json.loads(geo_bytes)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return None
+    """Parse geo metadata from schema metadata bytes dict (shared helper)."""
+    return parse_geo_metadata_from_schema(metadata)
 
 
 def _lat_lon_to_quadkey(lat: float, lon: float, level: int) -> str:
@@ -221,14 +200,22 @@ def add_quadkey_table(
     if not geom_col:
         geom_col = "geometry"
 
-    # Validate CRS is geographic (quadkeys require lat/lon)
+    # Quadkeys require lon/lat degrees. Reproject a known non-CRS84 CRS (#525);
+    # otherwise keep the guard (rejects projected input we can't identify, and
+    # passes through default/unknown which is assumed WGS84).
     geo_meta = _parse_geo_metadata_from_schema(table.schema.metadata)
-    _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose=False, source_description="table")
+    source_crs = crs_string_from_table(table, geom_col)
+    needs_transform = source_crs is not None
+    if not needs_transform:
+        _validate_crs_from_geo_metadata(
+            geo_meta, geom_col, verbose=False, source_description="table"
+        )
 
-    # Check if bbox column exists
+    # Check if bbox column exists. A stored bbox is in the input CRS, so it can't
+    # be used when we need to reproject — fall back to the (reprojected) centroid.
     use_bbox = False
     bbox_col = None
-    if not use_centroid:
+    if not use_centroid and not needs_transform:
         for name in ["bbox", "bounds", "bounding_box"]:
             if name in table.column_names:
                 use_bbox = True
@@ -237,6 +224,9 @@ def add_quadkey_table(
 
     # Register table and execute query using context manager for safe cleanup
     with get_duckdb_connection(load_spatial=True, load_httpfs=False) as con:
+        # Ensure ST_Transform (CRS-aware keying) emits lon/lat order.
+        con.execute("SET geometry_always_xy = true;")
+
         # Register Python UDF
         con.create_function(
             "lat_lon_to_quadkey",
@@ -263,13 +253,14 @@ def add_quadkey_table(
         else:
             source_ref = "__input_table"
 
-        # Build lat/lon expressions
+        # Build lat/lon expressions (reproject to lon/lat when source is non-CRS84)
         if use_bbox and bbox_col:
             lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
             lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
         else:
-            lat_expr = f'ST_Y(ST_Centroid("{geom_col}"))'
-            lon_expr = f'ST_X(ST_Centroid("{geom_col}"))'
+            geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+            lat_expr = f"ST_Y(ST_Centroid({geom_ref}))"
+            lon_expr = f"ST_X(ST_Centroid({geom_ref}))"
 
         # Get non-geometry columns
         other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]

--- a/geoparquet_io/core/add/s2.py
+++ b/geoparquet_io/core/add/s2.py
@@ -170,14 +170,20 @@ def _make_add_s2_query(
     geometry_column: str,
     s2_column_name: str,
     level: int,
+    source_crs: str | None = None,
 ) -> str:
-    """Build query to add S2 column to a source."""
+    """Build query to add S2 column to a source.
+
+    ``source_crs`` reprojects a non-CRS84 input to lon/lat before centroid keying
+    (#525); ``None`` (CRS84 / CRS-less) leaves the geometry untouched.
+    """
+    geom_ref = transform_geom_sql(f'"{geometry_column}"', source_crs)
     # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get desired level
     s2_expr = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X(ST_Centroid("{geometry_column}")),
-                ST_Y(ST_Centroid("{geometry_column}"))
+                ST_X(ST_Centroid({geom_ref})),
+                ST_Y(ST_Centroid({geom_ref}))
             ),
             {level}
         )
@@ -328,8 +334,12 @@ def _add_s2_streaming(
     if should_stream_output(output_path):
         verbose = False
 
-    def make_query(source: str, con) -> str:
-        """Build the add S2 query for streaming source."""
+    def make_query(source: str, con, source_crs: str | None = None) -> str:
+        """Build the add S2 query for streaming source.
+
+        ``source_crs`` is the streamed input's CRS (from its Arrow geo metadata),
+        used to reproject non-CRS84 input to lon/lat before keying (#525).
+        """
         # Load geography extension
         _load_geography_extension(con)
 
@@ -349,7 +359,7 @@ def _add_s2_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_s2_query(source, geom_col, s2_column_name, level)
+        return _make_add_s2_query(source, geom_col, s2_column_name, level, source_crs)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/s2.py
+++ b/geoparquet_io/core/add/s2.py
@@ -17,11 +17,7 @@ from geoparquet_io.core.constants import (
     DEFAULT_S2_COLUMN_NAME,
     DEFAULT_S2_LEVEL,
 )
-from geoparquet_io.core.crs_utils import (
-    crs_transform_sql_expr,
-    extract_crs_from_parquet,
-    extract_crs_from_table,
-)
+from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, load_community_extension
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite
@@ -70,15 +66,12 @@ def _build_s2_select_query(table, source_ref, geom_col, s2_column_name, level):
     Returns:
         str: Complete SELECT query with S2 expression
     """
-    # Build S2 cell expression. s2_cellfromlonlat expects lon/lat degrees, so a
-    # projected input is reprojected to OGC:CRS84 before keying (issue #525).
-    source_crs = extract_crs_from_table(table, geom_col)
-    centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
+    # Build S2 cell expression
     s2_expr = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X({centroid}),
-                ST_Y({centroid})
+                ST_X(ST_Centroid("{geom_col}")),
+                ST_Y(ST_Centroid("{geom_col}"))
             ),
             {level}
         )
@@ -157,20 +150,14 @@ def _make_add_s2_query(
     geometry_column: str,
     s2_column_name: str,
     level: int,
-    source_crs=None,
 ) -> str:
-    """Build query to add S2 column to a source.
-
-    ``source_crs`` (when a non-default CRS) reprojects the centroid to OGC:CRS84
-    before keying, since ``s2_cellfromlonlat`` expects lon/lat degrees.
-    """
+    """Build query to add S2 column to a source."""
     # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get desired level
-    centroid = crs_transform_sql_expr(f'ST_Centroid("{geometry_column}")', source_crs)
     s2_expr = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X({centroid}),
-                ST_Y({centroid})
+                ST_X(ST_Centroid("{geometry_column}")),
+                ST_Y(ST_Centroid("{geometry_column}"))
             ),
             {level}
         )
@@ -256,17 +243,16 @@ def add_s2_column(
     # Get geometry column for the SQL expression
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Define the S2 SQL expression (using token/string format for portability).
-    # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get the
-    # desired level. A projected input is reprojected to OGC:CRS84 before keying
-    # (issue #525), since s2_cellfromlonlat expects lon/lat degrees.
-    source_crs = extract_crs_from_parquet(input_parquet, verbose)
-    centroid = crs_transform_sql_expr(f"ST_Centroid({geom_col})", source_crs)
+    # S2 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
+    geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs_string(input_parquet, verbose))
+
+    # Define the S2 SQL expression (using token/string format for portability)
+    # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get desired level
     sql_expression = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X({centroid}),
-                ST_Y({centroid})
+                ST_X(ST_Centroid({geom_ref})),
+                ST_Y(ST_Centroid({geom_ref}))
             ),
             {s2_level}
         )
@@ -322,10 +308,6 @@ def _add_s2_streaming(
     if should_stream_output(output_path):
         verbose = False
 
-    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
-    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
-    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
-
     def make_query(source: str, con) -> str:
         """Build the add S2 query for streaming source."""
         # Load geography extension
@@ -347,7 +329,7 @@ def _add_s2_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_s2_query(source, geom_col, s2_column_name, level, source_crs)
+        return _make_add_s2_query(source, geom_col, s2_column_name, level)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/s2.py
+++ b/geoparquet_io/core/add/s2.py
@@ -17,7 +17,11 @@ from geoparquet_io.core.constants import (
     DEFAULT_S2_COLUMN_NAME,
     DEFAULT_S2_LEVEL,
 )
-from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
+from geoparquet_io.core.crs_utils import (
+    crs_string_from_table,
+    source_crs_string,
+    transform_geom_sql,
+)
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, load_community_extension
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite
@@ -60,18 +64,25 @@ def _create_geometry_view(con, table, geom_col):
     return "__input_table"
 
 
-def _build_s2_select_query(table, source_ref, geom_col, s2_column_name, level):
+def _build_s2_select_query(table, source_ref, geom_col, s2_column_name, level, geom_ref=None):
     """Build SELECT query to add S2 column to table.
+
+    Args:
+        geom_ref: SQL geometry expression for keying (defaults to the raw column;
+            pass a reprojected expression for non-CRS84 input).
 
     Returns:
         str: Complete SELECT query with S2 expression
     """
-    # Build S2 cell expression
+    if geom_ref is None:
+        geom_ref = f'"{geom_col}"'
+
+    # Build S2 cell expression (keyed on lon/lat, reprojected when needed)
     s2_expr = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X(ST_Centroid("{geom_col}")),
-                ST_Y(ST_Centroid("{geom_col}"))
+                ST_X(ST_Centroid({geom_ref})),
+                ST_Y(ST_Centroid({geom_ref}))
             ),
             {level}
         )
@@ -126,14 +137,23 @@ def add_s2_table(
     if not geom_col:
         geom_col = "geometry"
 
+    # S2 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
+    source_crs = crs_string_from_table(table, geom_col)
+
     # Register table and execute query
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
+        # Ensure ST_Transform (CRS-aware keying) emits lon/lat order.
+        con.execute("SET geometry_always_xy = true;")
+
         _load_geography_extension(con)
         con.register("__input_table", table)
 
         source_ref = _create_geometry_view(con, table, geom_col)
-        query = _build_s2_select_query(table, source_ref, geom_col, s2_column_name, level)
+        geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+        query = _build_s2_select_query(
+            table, source_ref, geom_col, s2_column_name, level, geom_ref=geom_ref
+        )
         result = con.execute(query).arrow().read_all()
 
         # Preserve metadata

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -2591,6 +2591,8 @@ def add_computed_column(
 
     # Create DuckDB connection with httpfs if needed
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
+    # Ensure ST_Transform (used by CRS-aware grid keying) emits lon/lat order.
+    con.execute("SET geometry_always_xy = true;")
 
     # Load additional extensions if specified
     if extensions:

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -601,6 +601,27 @@ def source_crs_string(parquet_file, verbose: bool = False) -> str | None:
     return crs_string_for_transform(extract_crs_from_parquet(parquet_file, verbose))
 
 
+def reproject_to_source_sql(geom_expr: str, source_crs, base_crs: str = DEFAULT_TARGET_CRS) -> str:
+    """Wrap ``geom_expr`` to reproject FROM ``base_crs`` (default CRS84) TO ``source_crs``.
+
+    The inverse direction of :func:`transform_geom_sql`. Used to bring the
+    (small) OGC:CRS84 admin polygons into a non-CRS84 input's CRS so the spatial
+    join and its bbox pre-filter run in one CRS *without* transforming the large
+    input per row — this restores the cheap bbox pre-filter on non-CRS84 admin
+    joins instead of degrading to a full nested-loop ``ST_Intersects`` (#525).
+
+    Returns ``geom_expr`` unchanged when ``source_crs`` is absent/default.
+    """
+    if not source_crs or is_default_crs(source_crs):
+        return geom_expr
+    src = resolve_crs_to_string(source_crs)
+    if not src:
+        return geom_expr
+    src_lit = _escape_sql_string(src)
+    base_lit = _escape_sql_string(base_crs)
+    return f"ST_Transform({geom_expr}, '{base_lit}', '{src_lit}')"
+
+
 def parse_geo_metadata_from_schema(metadata: dict | None) -> dict | None:
     """Parse GeoParquet ``geo`` metadata from an Arrow schema metadata dict.
 

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -550,3 +550,52 @@ def parse_crs_string_to_projjson(crs_string, con=None):
         return crs.to_json_dict()
     except Exception:
         return {"id": {"authority": authority, "code": code}}
+
+
+#: Canonical lon/lat target CRS for grid keying and admin spatial joins.
+#: With ``SET geometry_always_xy = true`` this is interchangeable with EPSG:4326.
+DEFAULT_TARGET_CRS = "OGC:CRS84"
+
+
+def crs_string_for_transform(crs) -> str | None:
+    """Return an ``"AUTH:CODE"`` CRS string for ``ST_Transform``, or ``None``.
+
+    ``None`` means no transform is needed or possible: the CRS is absent, is the
+    default (OGC:CRS84 / EPSG:4326), or is not identifiable as an authority code.
+    ``crs`` may be PROJJSON (as returned by :func:`extract_crs_from_parquet`) or
+    an ``"AUTH:CODE"`` string.
+    """
+    if not crs or is_default_crs(crs):
+        return None
+    identifier = _extract_crs_identifier(crs)
+    if not identifier:
+        return None
+    authority, code = identifier
+    return f"{authority}:{code}"
+
+
+def transform_geom_sql(geom_expr: str, source_crs, target_crs: str = DEFAULT_TARGET_CRS) -> str:
+    """Wrap ``geom_expr`` in ``ST_Transform`` to ``target_crs`` when needed.
+
+    Returns ``geom_expr`` unchanged when the source CRS is absent, the default,
+    or unidentifiable — so CRS-less / already-lon-lat input is untouched and the
+    common (CRS84) path pays nothing. The caller's DuckDB session should have
+    ``geometry_always_xy = true`` so transformed coordinates come out as lon/lat.
+
+    This is the shared "normalize geometry to the operation's expected CRS"
+    utility used by the admin spatial joins and the lon/lat grid keying (#525).
+    """
+    src = crs_string_for_transform(source_crs)
+    if src is None:
+        return geom_expr
+    src_esc = src.replace("'", "''")
+    tgt_esc = target_crs.replace("'", "''")
+    return f"ST_Transform({geom_expr}, '{src_esc}', '{tgt_esc}')"
+
+
+def source_crs_string(parquet_file, verbose: bool = False) -> str | None:
+    """Detect ``parquet_file``'s CRS as an ``"AUTH:CODE"`` transform string.
+
+    Returns ``None`` for CRS84/default/CRS-less input (no transform needed).
+    """
+    return crs_string_for_transform(extract_crs_from_parquet(parquet_file, verbose))

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -599,3 +599,141 @@ def source_crs_string(parquet_file, verbose: bool = False) -> str | None:
     Returns ``None`` for CRS84/default/CRS-less input (no transform needed).
     """
     return crs_string_for_transform(extract_crs_from_parquet(parquet_file, verbose))
+
+
+def parse_geo_metadata_from_schema(metadata: dict | None) -> dict | None:
+    """Parse GeoParquet ``geo`` metadata from an Arrow schema metadata dict.
+
+    The schema metadata may use bytes or string keys/values depending on how it
+    was accessed. Returns the parsed dict, or ``None`` if absent/unparsable.
+    """
+    if not metadata:
+        return None
+    geo_bytes = metadata.get(b"geo") or metadata.get("geo")
+    if not geo_bytes:
+        return None
+    try:
+        if isinstance(geo_bytes, bytes):
+            return json.loads(geo_bytes.decode("utf-8"))
+        return json.loads(geo_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def crs_string_from_geo_meta(geo_meta: dict | None, geom_col: str) -> str | None:
+    """Return an ``"AUTH:CODE"`` transform string for a geometry column's CRS.
+
+    ``geo_meta`` is parsed GeoParquet ``geo`` metadata (as carried on a PyArrow
+    schema for the table-centric Python API). Returns ``None`` when no transform
+    is needed — the CRS is absent, the default (OGC:CRS84 / EPSG:4326), explicitly
+    null (unknown), or not identifiable as an authority code.
+    """
+    if not geo_meta:
+        return None
+    columns = geo_meta.get("columns", {})
+    col_meta = columns.get(geom_col)
+    if col_meta is None:
+        col_meta = columns.get(geo_meta.get("primary_column", "geometry"), {})
+    crs = col_meta.get("crs") if isinstance(col_meta, dict) else None
+    return crs_string_for_transform(crs)
+
+
+#: GeoArrow geometry extension names (registered by ``geoarrow.pyarrow``).
+_GEOARROW_EXTENSION_NAMES = frozenset(
+    {
+        "geoarrow.wkb",
+        "ogc.wkb",
+        "geoarrow.point",
+        "geoarrow.linestring",
+        "geoarrow.polygon",
+        "geoarrow.multipoint",
+        "geoarrow.multilinestring",
+        "geoarrow.multipolygon",
+        "geoarrow.geometry",
+    }
+)
+
+
+def _crs_from_extension_type(field_type):
+    """Extract a ``crs`` (PROJJSON dict/str) from a registered GeoArrow type.
+
+    When ``geoarrow.pyarrow`` is imported anywhere in the process it registers
+    its extension types, and ``pyarrow.parquet`` then returns geometry columns
+    as those types — moving the CRS onto ``field.type.crs`` and *consuming* the
+    raw ``ARROW:extension:metadata`` key off ``field.metadata``. Returns ``None``
+    for non-GeoArrow types or when no CRS is present.
+    """
+    if getattr(field_type, "extension_name", None) not in _GEOARROW_EXTENSION_NAMES:
+        return None
+    crs_obj = getattr(field_type, "crs", None)
+    if crs_obj is not None and hasattr(crs_obj, "to_json_dict"):
+        try:
+            return crs_obj.to_json_dict()
+        except Exception:
+            pass
+    ext_meta = getattr(field_type, "extension_metadata", None)
+    if ext_meta:
+        try:
+            parsed = json.loads(ext_meta)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if isinstance(parsed, dict):
+            return parsed.get("crs")
+    return None
+
+
+def _crs_from_geoarrow_field(table, geom_col: str):
+    """Return the PROJJSON ``crs`` from a geometry field's GeoArrow metadata.
+
+    Parquet-geo-only / GeoArrow inputs carry the CRS on the geometry field, but
+    *where* depends on whether ``geoarrow.pyarrow`` has been imported in the
+    process (it registers extension types globally — many code paths and tests
+    do this transitively):
+
+    1. Imported -> the field is a registered extension type and the CRS lives on
+       ``field.type.crs`` (the raw metadata key is consumed off the field).
+    2. Not imported -> the CRS is in ``field.metadata['ARROW:extension:metadata']``.
+
+    Both are checked so detection is import-order-independent. Returns the raw
+    ``crs`` value (PROJJSON dict or string), or ``None``.
+    """
+    try:
+        field = table.schema.field(geom_col)
+    except (KeyError, ValueError):
+        return None
+
+    # Case 1: geoarrow-pyarrow registered the type and consumed the metadata.
+    crs = _crs_from_extension_type(field.type)
+    if crs is not None:
+        return crs
+
+    # Case 2: plain binary field — CRS is in the raw extension metadata.
+    md = getattr(field, "metadata", None)
+    if not md:
+        return None
+    ext = md.get(b"ARROW:extension:metadata") or md.get("ARROW:extension:metadata")
+    if not ext:
+        return None
+    try:
+        if isinstance(ext, bytes):
+            ext = ext.decode("utf-8")
+        ext_dict = json.loads(ext)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return ext_dict.get("crs") if isinstance(ext_dict, dict) else None
+
+
+def crs_string_from_table(table, geom_col: str) -> str | None:
+    """Detect an Arrow table's geometry CRS as an ``"AUTH:CODE"`` transform string.
+
+    Checks both CRS carriers used by the table-centric Python API:
+    1. The schema-level GeoParquet ``geo`` metadata.
+    2. The geometry field's GeoArrow ``ARROW:extension:metadata`` (parquet-geo-only).
+
+    Returns ``None`` for CRS84/default/CRS-less input (no transform needed).
+    """
+    geo_meta = parse_geo_metadata_from_schema(table.schema.metadata)
+    crs = crs_string_from_geo_meta(geo_meta, geom_col)
+    if crs:
+        return crs
+    return crs_string_for_transform(_crs_from_geoarrow_field(table, geom_col))

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -139,25 +139,26 @@ def build_spatial_join_condition(
         target_bbox_col: Optional bbox covering column on the target table.
         input_alias: SQL alias for the input table (default "a").
         target_alias: SQL alias for the target table (default "b").
-        input_geom_sql: Optional SQL expression to use for the input geometry in
-            place of ``<input_alias>.<input_geom_col>`` — e.g. an ``ST_Transform``
-            that reprojects a non-CRS84 input to the target's CRS (issue #525).
-            When supplied, the bbox pre-filter is skipped: the input's stored bbox
-            covering is in the *source* CRS and cannot be compared against a
-            target bbox in a different CRS.
 
     Returns:
         A SQL boolean expression for use directly after ``ON``.
     """
-    qi_geom = quote_identifier(input_geom_col)
     qt_geom = quote_identifier(target_geom_col)
-    input_geom_ref = input_geom_sql if input_geom_sql is not None else f"{input_alias}.{qi_geom}"
-    intersects = f"ST_Intersects({target_alias}.{qt_geom}, {input_geom_ref})"
 
-    # A one-sided bbox cannot form an overlap test, and a reprojected input geom
-    # makes the stored (source-CRS) bbox incomparable — fall back to the precise
-    # predicate alone.
-    if input_geom_sql is not None or not (input_bbox_col and target_bbox_col):
+    # ``input_geom_sql`` is a pre-built input-geometry expression (e.g. wrapped in
+    # ST_Transform to reproject a non-CRS84 input, #525). When supplied, the
+    # stored input bbox is in the *source* CRS and so cannot be used for the
+    # overlap pre-filter — fall back to the precise predicate alone.
+    if input_geom_sql is not None:
+        intersects = f"ST_Intersects({target_alias}.{qt_geom}, {input_geom_sql})"
+        return intersects
+
+    qi_geom = quote_identifier(input_geom_col)
+    intersects = f"ST_Intersects({target_alias}.{qt_geom}, {input_alias}.{qi_geom})"
+
+    # A one-sided bbox cannot form an overlap test, so fall back to the
+    # precise predicate alone.
+    if not (input_bbox_col and target_bbox_col):
         return intersects
 
     qi_bbox = quote_identifier(input_bbox_col)

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -74,7 +74,7 @@ def _build_enrichment_query(
 
     input_ref = input_url if input_is_table_ref else f"'{input_url}'"
 
-    input_geom_sql = transform_geom_sql(f'a."{input_geom_col}"', source_crs)
+    input_geom_sql = transform_geom_sql(f"a.{quote_identifier(input_geom_col)}", source_crs)
 
     if input_bbox_col and admin_bbox_col and not source_crs:
         bbox_filter = f"""

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -20,7 +20,11 @@ from geoparquet_io.core.common import (
     check_bbox_structure,
     get_parquet_metadata,
 )
-from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
+from geoparquet_io.core.crs_utils import (
+    reproject_to_source_sql,
+    source_crs_string,
+    transform_geom_sql,
+)
 from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.file_utils import safe_file_url
@@ -74,16 +78,41 @@ def _build_enrichment_query(
 
     input_ref = input_url if input_is_table_ref else f"'{input_url}'"
 
-    input_geom_sql = transform_geom_sql(f"a.{quote_identifier(input_geom_col)}", source_crs)
-
-    if input_bbox_col and admin_bbox_col and not source_crs:
-        bbox_filter = f"""
+    q_input_geom = quote_identifier(input_geom_col)
+    bbox_filter = f"""
             (a.{input_bbox_col}.xmin <= b.{admin_bbox_col}.xmax AND
              a.{input_bbox_col}.xmax >= b.{admin_bbox_col}.xmin AND
              a.{input_bbox_col}.ymin <= b.{admin_bbox_col}.ymax AND
              a.{input_bbox_col}.ymax >= b.{admin_bbox_col}.ymin)
         """
 
+    if source_crs and input_bbox_col and admin_bbox_col:
+        # Non-CRS84 input with bboxes on both sides: reproject the (small) admin
+        # polygons into the input CRS and synthesize their source-CRS bbox, so the
+        # join runs in one CRS and keeps the cheap bbox pre-filter — instead of
+        # transforming the (large) input per row and degrading to a nested-loop
+        # ST_Intersects (#525, preserving the #460 pre-filter).
+        radmin = reproject_to_source_sql(f'"{admin_geom_col}"', source_crs)
+        bbox_struct = (
+            f"struct_pack(xmin := ST_XMin({radmin}), xmax := ST_XMax({radmin}), "
+            f"ymin := ST_YMin({radmin}), ymax := ST_YMax({radmin})) AS {admin_bbox_col}"
+        )
+        return f"""
+            CREATE TEMP TABLE {enriched_table} AS
+            SELECT
+                a.*,
+                {admin_select_clause}
+            FROM {input_ref} a
+            LEFT JOIN (
+                SELECT {radmin} AS {admin_geom_col}, {bbox_struct}, {subquery_cols_str}
+                FROM {admin_table_ref}
+                {admin_where_clause}
+            ) b
+            ON {bbox_filter}
+                AND ST_Intersects(b.{admin_geom_col}, a.{q_input_geom})
+        """
+
+    if input_bbox_col and admin_bbox_col and not source_crs:
         return f"""
             CREATE TEMP TABLE {enriched_table} AS
             SELECT
@@ -96,10 +125,13 @@ def _build_enrichment_query(
                 {admin_where_clause}
             ) b
             ON {bbox_filter}
-                AND ST_Intersects(b.{admin_geom_col}, {input_geom_sql})
+                AND ST_Intersects(b.{admin_geom_col}, a.{q_input_geom})
         """
-    else:
-        return f"""
+
+    # No bbox on one side: reproject the input geometry inline (no pre-filter to
+    # preserve either way).
+    input_geom_sql = transform_geom_sql(f"a.{q_input_geom}", source_crs)
+    return f"""
             CREATE TEMP TABLE {enriched_table} AS
             SELECT
                 a.*,

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -20,7 +20,7 @@ from geoparquet_io.core.common import (
     check_bbox_structure,
     get_parquet_metadata,
 )
-from geoparquet_io.core.crs_utils import crs_transform_sql_expr, extract_crs_from_parquet
+from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
 from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.file_utils import safe_file_url
@@ -37,22 +37,6 @@ from geoparquet_io.core.partition.staging import (
     run_partitioned_copy,
 )
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
-
-
-def _reprojected_input_geom_sql(input_geom_col, source_crs, alias="a"):
-    """Return the input geometry expression reprojected to the admin CRS.
-
-    Admin boundaries are OGC:CRS84, so a non-CRS84 input must be reprojected
-    before ``ST_Intersects`` (issue #525) — DuckDB 1.5 otherwise refuses the
-    join with a CRS-mismatch error. Returns ``None`` when no transform is needed
-    (input already CRS84 / CRS-less). ``alias`` is the SQL table alias prefix;
-    pass ``None`` for a bare column reference (e.g. an aggregate extent query).
-    """
-    base = (
-        f"{alias}.{quote_identifier(input_geom_col)}" if alias else quote_identifier(input_geom_col)
-    )
-    transformed = crs_transform_sql_expr(base, source_crs)
-    return transformed if transformed != base else None
 
 
 def _build_enrichment_query(
@@ -75,14 +59,10 @@ def _build_enrichment_query(
     (per-level chaining) rather than a file path, so it is referenced without
     surrounding quotes.
 
-    ``source_crs`` (when a non-default CRS) reprojects the input geometry to the
-    admin CRS (OGC:CRS84) before ``ST_Intersects`` (issue #525). The stored input
-    bbox is then in the source CRS and cannot be compared against the admin bbox,
-    so the bbox pre-filter is skipped.
+    ``source_crs`` (an ``"AUTH:CODE"`` string) reprojects a non-CRS84 input to
+    the admin CRS before ``ST_Intersects`` (#525). When set, the input's stored
+    bbox is in the source CRS and is skipped for the pre-filter.
     """
-    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs)
-    input_geom_ref = input_geom_sql or f'a."{input_geom_col}"'
-    use_bbox_prefilter = input_bbox_col and admin_bbox_col and input_geom_sql is None
     # Build column list for subquery - handle struct access
     subquery_cols = []
     for i, col in enumerate(boundary_columns):
@@ -94,7 +74,9 @@ def _build_enrichment_query(
 
     input_ref = input_url if input_is_table_ref else f"'{input_url}'"
 
-    if use_bbox_prefilter:
+    input_geom_sql = transform_geom_sql(f'a."{input_geom_col}"', source_crs)
+
+    if input_bbox_col and admin_bbox_col and not source_crs:
         bbox_filter = f"""
             (a.{input_bbox_col}.xmin <= b.{admin_bbox_col}.xmax AND
              a.{input_bbox_col}.xmax >= b.{admin_bbox_col}.xmin AND
@@ -114,7 +96,7 @@ def _build_enrichment_query(
                 {admin_where_clause}
             ) b
             ON {bbox_filter}
-                AND ST_Intersects(b.{admin_geom_col}, {input_geom_ref})
+                AND ST_Intersects(b.{admin_geom_col}, {input_geom_sql})
         """
     else:
         return f"""
@@ -128,7 +110,7 @@ def _build_enrichment_query(
                 FROM {admin_table_ref}
                 {admin_where_clause}
             ) b
-            ON ST_Intersects(b.{admin_geom_col}, {input_geom_ref})
+            ON ST_Intersects(b.{admin_geom_col}, {input_geom_sql})
         """
 
 
@@ -140,13 +122,11 @@ def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source
     re-scanning the input per level — important when there is no bbox column and
     the fallback decodes every geometry.
 
-    When the input is reprojected to the admin CRS (``source_crs`` non-default),
-    the extent is computed from the *reprojected* geometry so the resulting
-    bounds are comparable to the admin (CRS84) bbox; the stored input bbox column
-    is in the source CRS and is therefore ignored (issue #525).
+    The admin boundaries are OGC:CRS84, so for a non-CRS84 input the extent must
+    be computed over the reprojected geometry (the stored bbox is in the source
+    CRS) so the admin extent filter is in the right units (#525).
     """
-    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs, alias=None)
-    if input_bbox_col and input_geom_sql is None:
+    if input_bbox_col and not source_crs:
         extent_query = f"""
             SELECT
                 MIN({input_bbox_col}.xmin) as xmin,
@@ -156,13 +136,13 @@ def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source
             FROM '{input_url}'
         """
     else:
-        geom_expr = input_geom_sql or quote_identifier(input_geom_col)
+        geom_ref = transform_geom_sql(quote_identifier(input_geom_col), source_crs)
         extent_query = f"""
             SELECT
-                MIN(ST_XMin({geom_expr})) as xmin,
-                MAX(ST_XMax({geom_expr})) as xmax,
-                MIN(ST_YMin({geom_expr})) as ymin,
-                MAX(ST_YMax({geom_expr})) as ymax
+                MIN(ST_XMin({geom_ref})) as xmin,
+                MAX(ST_XMax({geom_ref})) as xmax,
+                MIN(ST_YMin({geom_ref})) as ymin,
+                MAX(ST_YMax({geom_ref})) as ymax
             FROM '{input_url}'
         """
     extent = con.execute(extent_query).fetchone()
@@ -223,21 +203,13 @@ def _setup_admin_dataset(dataset_name, verbose, levels):
 
 
 def _get_input_file_info(input_parquet, verbose):
-    """Get input file info (URL, geometry column, bbox column, source CRS).
-
-    ``source_crs`` is the detected non-default input CRS (or ``None`` for
-    CRS84/CRS-less): admin boundaries are OGC:CRS84, so a projected input is
-    reprojected before the spatial join (issue #525).
-    """
+    """Get input file info (URL, geometry column, bbox column)."""
     input_url = safe_file_url(input_parquet, verbose)
     input_geom_col = find_primary_geometry_column(input_parquet, verbose)
     input_bbox_info = check_bbox_structure(input_parquet, verbose)
     input_bbox_col = input_bbox_info["bbox_column_name"]
-    source_crs = extract_crs_from_parquet(input_parquet, verbose)
-    if source_crs is not None and verbose:
-        debug("  → Projected input CRS detected — reprojecting to OGC:CRS84 for admin join")
 
-    return input_url, input_geom_col, input_bbox_col, source_crs
+    return input_url, input_geom_col, input_bbox_col
 
 
 def _setup_admin_join_connection(dataset, get_duckdb_connection):
@@ -259,8 +231,12 @@ def _setup_admin_join_connection(dataset, get_duckdb_connection):
             load_spatial=True, load_httpfs=True, temp_directory=str(temp_dir), threads=1
         )
         con.execute("SET preserve_insertion_order = false")
+        # Reproject (CRS-aware admin join, #525) emits lon/lat order to match CRS84.
+        con.execute("SET geometry_always_xy = true")
         return con
-    return get_duckdb_connection(load_spatial=True, load_httpfs=True)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
+    con.execute("SET geometry_always_xy = true")
+    return con
 
 
 def _setup_duckdb_extensions(con):
@@ -692,9 +668,12 @@ def partition_by_admin_hierarchical(
     try:
         # Setup dataset and get input file info
         dataset, boundary_columns = _setup_admin_dataset(dataset_name, verbose, levels)
-        input_url, input_geom_col, input_bbox_col, source_crs = _get_input_file_info(
-            actual_input, verbose
-        )
+        input_url, input_geom_col, input_bbox_col = _get_input_file_info(actual_input, verbose)
+
+        # Admin boundaries are OGC:CRS84; reproject a non-CRS84 input before the
+        # join so ST_Intersects neither errors on a CRS mismatch nor silently
+        # matches nothing (#525).
+        source_crs = source_crs_string(actual_input, verbose)
 
         # Get admin dataset info
         admin_geom_col = dataset.get_geometry_column()

--- a/geoparquet_io/core/partition/auto_resolution.py
+++ b/geoparquet_io/core/partition/auto_resolution.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import math
 
 from geoparquet_io.core.common import get_duckdb_connection, needs_httpfs
+from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
 from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -435,6 +436,8 @@ def _probe_extent_resolution(
     con = None
     try:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
+        # Ensure ST_Transform (CRS-aware probing) emits lon/lat order.
+        con.execute("SET geometry_always_xy = true;")
         if profile:
             setup_aws_profile_if_needed(profile, input_parquet)
         for stmt in _INDEX_EXTENSIONS[spatial_index_type]:
@@ -443,7 +446,12 @@ def _probe_extent_resolution(
             _register_quadkey_udf(con)
 
         geom_col = find_primary_geometry_column(input_parquet, verbose)
-        geom_sql = _geom_sql(con, url, geom_col)
+        # Reproject a known non-CRS84 input to lon/lat before centroiding, so the
+        # probe keys the same coordinates the add/ modules will (#530). Without
+        # this the probe feeds raw projected metres to the lon/lat cell functions
+        # and picks a resolution from garbage cell counts.
+        source_crs = source_crs_string(input_parquet, verbose)
+        geom_sql = transform_geom_sql(_geom_sql(con, url, geom_col), source_crs)
 
         sample_size = min(
             total_rows,

--- a/geoparquet_io/core/stream_io.py
+++ b/geoparquet_io/core/stream_io.py
@@ -354,10 +354,51 @@ def _write_file_output(
     )
 
 
+def _detect_transform_source_crs(
+    input_path: str, metadata: dict | None, is_stream: bool
+) -> str | None:
+    """Detect the input's CRS as an ``ST_Transform`` source string, or ``None``.
+
+    Streamed input carries its CRS in the Arrow ``geo`` schema metadata; file
+    input is read directly. Best-effort: detection runs for every caller (incl.
+    ones whose query fn ignores CRS), so a failure must never break the transform.
+    ``None`` means CRS84/CRS-less input (no reprojection needed).
+    """
+    from geoparquet_io.core.crs_utils import (
+        crs_string_from_geo_meta,
+        parse_geo_metadata_from_schema,
+        source_crs_string,
+    )
+
+    try:
+        if is_stream:
+            return crs_string_from_geo_meta(parse_geo_metadata_from_schema(metadata), None)
+        return source_crs_string(input_path)
+    except Exception:
+        return None
+
+
+def _call_transform_query_fn(transform_query_fn, source, con, source_crs):
+    """Call the query builder, passing ``source_crs`` only if it accepts it.
+
+    Keeps the ``(source, con)`` contract for existing callers (sort, bbox, …)
+    while letting CRS-aware builders opt in with a third ``source_crs`` parameter.
+    """
+    import inspect
+
+    try:
+        params = inspect.signature(transform_query_fn).parameters
+    except (TypeError, ValueError):
+        return transform_query_fn(source, con)
+    if len(params) >= 3:
+        return transform_query_fn(source, con, source_crs)
+    return transform_query_fn(source, con)
+
+
 def execute_transform(
     input_path: str,
     output_path: str | None,
-    transform_query_fn: Callable[[str, duckdb.DuckDBPyConnection], str],
+    transform_query_fn: Callable[..., str],
     verbose: bool = False,
     dry_run: bool = False,
     compression: str = "ZSTD",
@@ -405,8 +446,11 @@ def execute_transform(
         verbose = False
 
     with open_input(input_path, verbose=verbose) as (source, metadata, is_stream, con):
-        # Generate the transform query
-        query = transform_query_fn(source, con)
+        # Detect the input's CRS once so a transform-aware query fn can reproject
+        # non-CRS84 input (e.g. lon/lat grid keying, #525). Streamed input is an
+        # Arrow IPC stream, so its CRS comes from the schema metadata, not a file.
+        source_crs = _detect_transform_source_crs(input_path, metadata, is_stream)
+        query = _call_transform_query_fn(transform_query_fn, source, con, source_crs)
 
         if dry_run:
             warn("\n=== DRY RUN MODE - SQL that would be executed ===\n")

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -7,6 +7,8 @@ These helpers produce the SQL needed to reproject non-CRS84 input to the
 operation's expected CRS before the spatial work happens.
 """
 
+from unittest import mock
+
 import pytest
 
 from geoparquet_io.core.crs_utils import (
@@ -208,6 +210,57 @@ class TestGridKeyingIsCrsAware:
         assert mismatches <= max(1, len(proj_cells) // 100)
         # And the keying actually produced a cell for every row (not null).
         assert all(c is not None for c in proj_cells)
+
+
+class TestGridKeyingStreamingIsCrsAware:
+    """Class B (#530), streaming path: stdout streaming must reproject too.
+
+    ``gpio add quadkey projected.parquet -`` routes through the streaming path
+    (output ``-``). It must reproject projected input to lon/lat before keying,
+    exactly like the file path — otherwise the documented stdin/stdout feature
+    silently emits wrong cells (metres keyed as degrees) for projected input.
+    """
+
+    def _stream_quadkeys(self, input_file, monkeypatch, resolution):
+        """Run the streaming quadkey path to stdout and read the cells back."""
+        import io
+
+        import pyarrow.ipc as ipc
+
+        from geoparquet_io.core.add.quadkey import add_quadkey_column
+
+        buffer = io.BytesIO()
+        mock_stdout = mock.MagicMock()
+        mock_stdout.isatty.return_value = False
+        mock_stdout.buffer = buffer
+        monkeypatch.setattr("sys.stdout", mock_stdout)
+
+        add_quadkey_column(input_file, "-", resolution=resolution)
+
+        buffer.seek(0)
+        table = ipc.open_stream(buffer).read_all()
+        return table.column("quadkey").to_pylist()
+
+    def test_projected_streaming_matches_file_path(self, fields_5070_file, tmp_path, monkeypatch):
+        from geoparquet_io.core.add.quadkey import add_quadkey_column
+
+        # File-based path (already CRS-aware) is the oracle.
+        file_out = tmp_path / "file.parquet"
+        add_quadkey_column(fields_5070_file, str(file_out), resolution=16)
+        file_cells = _read_column(str(file_out), "quadkey")
+
+        stream_cells = self._stream_quadkeys(fields_5070_file, monkeypatch, resolution=16)
+
+        assert len(stream_cells) == len(file_cells)
+        assert all(c is not None for c in stream_cells)
+        # The streaming path must reproject like the file path, not key metres as
+        # degrees — so the same set of cells comes out (file oracle is sorted).
+        assert sorted(stream_cells) == file_cells
+
+    def test_projected_streaming_does_not_raise(self, fields_5070_file, monkeypatch):
+        """Projected input must reproject, not raise GeoParquetError (the old guard)."""
+        cells = self._stream_quadkeys(fields_5070_file, monkeypatch, resolution=16)
+        assert all(c is not None for c in cells)
 
 
 class TestGridKeyingTableApiIsCrsAware:

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -86,6 +86,38 @@ class TestSourceCrsString:
         assert source_crs_string(buildings_test_file) is None
 
 
+class TestCrsStringFromTable:
+    """Table-API CRS detection must be independent of ``geoarrow.pyarrow`` import.
+
+    Importing ``geoarrow.pyarrow`` (which many code paths and tests do
+    transitively) registers its extension types, so ``pyarrow.parquet`` returns
+    a parquet-geo-only geometry as a registered extension type — the CRS then
+    lives on ``field.type.crs`` and the raw ``ARROW:extension:metadata`` key is
+    consumed off ``field.metadata``. Detection must work either way; otherwise
+    the table-API grid ops silently skip reprojection (#525).
+    """
+
+    def _read_table(self, parquet_file):
+        import pyarrow.parquet as pq
+
+        return pq.read_table(parquet_file)
+
+    def test_detects_projected_without_geoarrow_extension(self, fields_5070_file):
+        from geoparquet_io.core.crs_utils import crs_string_from_table
+
+        table = self._read_table(fields_5070_file)
+        assert crs_string_from_table(table, "geometry") == "EPSG:5070"
+
+    def test_detects_projected_with_geoarrow_extension_registered(self, fields_5070_file):
+        # Force the registered-extension-type carrier (Case 1).
+        import geoarrow.pyarrow  # noqa: F401
+
+        from geoparquet_io.core.crs_utils import crs_string_from_table
+
+        table = self._read_table(fields_5070_file)
+        assert crs_string_from_table(table, "geometry") == "EPSG:5070"
+
+
 class TestHotPathUnchanged:
     """Regression guard (#525 perf): CRS84 input must not pay for reprojection.
 
@@ -176,6 +208,61 @@ class TestGridKeyingIsCrsAware:
         assert mismatches <= max(1, len(proj_cells) // 100)
         # And the keying actually produced a cell for every row (not null).
         assert all(c is not None for c in proj_cells)
+
+
+class TestGridKeyingTableApiIsCrsAware:
+    """Class B (#525), Python API: the table-centric grid ops must reproject too.
+
+    ``gpio.read(projected).add_h3(...)`` routes through ``add_*_table`` (not the
+    file path). These must reproject projected input to lon/lat before keying,
+    exactly like the CLI/file path — otherwise the public API silently emits
+    wrong cells (metres fed to ``*_lonlat_to_cell`` as degrees), and quadkey
+    rejects projected input outright.
+    """
+
+    @pytest.fixture
+    def reprojected_4326(self, fields_5070_file, tmp_path):
+        from geoparquet_io.core.reproject import reproject
+
+        out = tmp_path / "fields_4326.parquet"
+        reproject(fields_5070_file, str(out), target_crs="EPSG:4326")
+        return str(out)
+
+    @pytest.mark.parametrize(
+        "op_name,column,kwargs",
+        [
+            ("add_a5", "a5_cell", {"resolution": 12}),
+            ("add_h3", "h3_cell", {"resolution": 9}),
+            ("add_s2", "s2_cell", {"level": 14}),
+            ("add_quadkey", "quadkey", {"resolution": 16}),
+        ],
+    )
+    def test_projected_table_cells_match_reprojected(
+        self, fields_5070_file, reprojected_4326, op_name, column, kwargs
+    ):
+        import geoparquet_io as gpio
+        from geoparquet_io.api import ops
+
+        op = getattr(ops, op_name)
+        proj_cells = op(gpio.read(fields_5070_file)._table, **kwargs).column(column).to_pylist()
+        wgs_cells = op(gpio.read(reprojected_4326)._table, **kwargs).column(column).to_pylist()
+
+        # Reprojecting internally must agree with keying a reprojected copy. Allow
+        # a tiny boundary-cell tolerance (same as the file-path oracle); without
+        # the fix ~every projected cell differs (metres keyed as degrees).
+        assert len(proj_cells) == len(wgs_cells)
+        mismatches = sum(1 for a, b in zip(proj_cells, wgs_cells, strict=True) if a != b)
+        assert mismatches <= max(1, len(proj_cells) // 100)
+        assert all(c is not None for c in proj_cells)
+
+    def test_projected_quadkey_table_does_not_raise(self, fields_5070_file):
+        """Projected input must reproject, not raise GeoParquetError (the old guard)."""
+        import geoparquet_io as gpio
+        from geoparquet_io.api import ops
+
+        result = ops.add_quadkey(gpio.read(fields_5070_file)._table, resolution=16)
+        assert "quadkey" in result.column_names
+        assert all(c is not None for c in result.column("quadkey").to_pylist())
 
 
 def _con_with_admin():

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -298,6 +298,56 @@ class TestGridKeyingStreamingIsCrsAware:
         cells = self._stream_quadkeys(fields_5070_file, monkeypatch, resolution=16)
         assert all(c is not None for c in cells)
 
+    @staticmethod
+    def _stream_grid(input_file, monkeypatch, module, func_name, column, res_kw):
+        """Run a grid add to stdout (streaming) and read the cells back."""
+        import importlib
+        import io
+
+        import pyarrow.ipc as ipc
+
+        buffer = io.BytesIO()
+        mock_stdout = mock.MagicMock()
+        mock_stdout.isatty.return_value = False
+        mock_stdout.buffer = buffer
+        monkeypatch.setattr("sys.stdout", mock_stdout)
+
+        add_func = getattr(importlib.import_module(f"geoparquet_io.core.add.{module}"), func_name)
+        add_func(input_file, "-", **res_kw)
+
+        buffer.seek(0)
+        return ipc.open_stream(buffer).read_all().column(column).to_pylist()
+
+    @pytest.mark.parametrize(
+        "module,func_name,column,res_kw",
+        [
+            ("a5", "add_a5_column", "a5_cell", {"a5_resolution": 12}),
+            ("h3", "add_h3_column", "h3_cell", {"h3_resolution": 9}),
+            ("s2", "add_s2_column", "s2_cell", {"s2_level": 14}),
+        ],
+    )
+    def test_a5_h3_s2_streaming_matches_file_path(
+        self, fields_5070_file, tmp_path, monkeypatch, module, func_name, column, res_kw
+    ):
+        import importlib
+
+        add_func = getattr(importlib.import_module(f"geoparquet_io.core.add.{module}"), func_name)
+
+        # File-based path (already CRS-aware) is the oracle.
+        file_out = tmp_path / f"file_{module}.parquet"
+        add_func(fields_5070_file, str(file_out), **res_kw)
+        file_cells = _read_column(str(file_out), column)
+
+        stream_cells = self._stream_grid(
+            fields_5070_file, monkeypatch, module, func_name, column, res_kw
+        )
+
+        assert len(stream_cells) == len(file_cells)
+        assert all(c is not None for c in stream_cells)
+        # Streaming must reproject like the file path (not key metres as degrees),
+        # so the same multiset of cells comes out.
+        assert sorted(stream_cells) == sorted(file_cells)
+
 
 class TestGridKeyingTableApiIsCrsAware:
     """Class B (#525), Python API: the table-centric grid ops must reproject too.
@@ -420,6 +470,112 @@ class TestAdminJoinIsCrsAware:
                 input_geom_col="geometry",
                 input_bbox_col=None,
                 enriched_table="_enriched",
+                source_crs="EPSG:5070",
+            )
+            con.execute(sql)
+            assigned = con.execute(
+                "SELECT COUNT(*) FROM _enriched WHERE region IS NOT NULL"
+            ).fetchone()[0]
+        finally:
+            con.close()
+        assert assigned > 0
+
+
+class TestAdminReprojectsAdminSideWithBbox:
+    """Class A perf (#525): with bboxes on both sides the admin side is reprojected.
+
+    Reprojecting the (small) admin polygons into the input CRS — instead of the
+    large input into CRS84 — keeps the cheap bbox pre-filter, so the join does
+    not degrade to a full nested-loop ST_Intersects (the #460 regression). The
+    input geometry must be left untransformed.
+    """
+
+    def test_join_query_keeps_bbox_prefilter_and_leaves_input_untransformed(self):
+        from geoparquet_io.core.add.admin_divisions import _build_spatial_join_query
+
+        sql = _build_spatial_join_query(
+            input_url="x.parquet",
+            admin_subquery="(SELECT geom, bbox, region FROM admin)",
+            admin_select_clause='b."region" AS region',
+            input_bbox_col="bbox",
+            admin_bbox_col="bbox",
+            input_geom_col="geometry",
+            admin_geom_col="geom",
+            source_crs="EPSG:5070",
+        )
+        # The join itself does not transform the input (admin reproject lives in
+        # the subquery); the bbox pre-filter is retained.
+        assert "ST_Transform" not in sql
+        assert ".xmin" in sql and ".xmax" in sql
+
+    def test_admin_subquery_reprojects_admin_and_synthesizes_bbox(self):
+        from geoparquet_io.core.add.admin_divisions import _build_admin_subquery
+
+        sq = _build_admin_subquery(
+            dataset=None,
+            levels=None,
+            boundary_columns=["region"],
+            admin_table_ref="'admin.parquet'",
+            admin_geom_col="geom",
+            admin_bbox_col="bbox",
+            admin_where_clauses=[],
+            source_crs="EPSG:5070",
+        )
+        assert "ST_Transform" in sq  # admin polygons reprojected into input CRS
+        assert "struct_pack" in sq  # source-CRS bbox synthesized for the pre-filter
+
+    def test_enrichment_query_reprojects_admin_side_keeps_prefilter(self):
+        from geoparquet_io.core.partition.admin_hierarchical import _build_enrichment_query
+
+        sql = _build_enrichment_query(
+            input_url="x.parquet",
+            admin_table_ref="admin",
+            admin_where_clause="",
+            admin_select_clause='b."region" AS region',
+            admin_geom_col="geom",
+            admin_bbox_col="bbox",
+            boundary_columns=["region"],
+            input_geom_col="geometry",
+            input_bbox_col="bbox",
+            enriched_table="_enriched",
+            source_crs="EPSG:5070",
+        )
+        assert "ST_Transform" in sql  # admin reprojected
+        assert 'ST_Intersects(b.geom, a."geometry")' in sql  # input untransformed
+        assert "a.bbox.xmin <= b.bbox.xmax" in sql  # bbox pre-filter restored
+        assert "struct_pack" in sql
+
+    def test_enrichment_reproject_path_runs_and_assigns(self, fields_5070_file):
+        """The reproject-admin SQL executes in DuckDB and assigns via the prefilter."""
+        from geoparquet_io.core.partition.admin_hierarchical import _build_enrichment_query
+
+        con = _con_with_admin()
+        try:
+            # Admin polygon with a CRS84 bbox struct.
+            con.execute(
+                "CREATE TEMP TABLE _admin_b AS SELECT geom, region, "
+                "struct_pack(xmin := ST_XMin(geom), xmax := ST_XMax(geom), "
+                "ymin := ST_YMin(geom), ymax := ST_YMax(geom)) AS bbox FROM _admin"
+            )
+            # Projected input with a source-CRS bbox struct.
+            con.execute(
+                "CREATE TEMP TABLE _inp AS SELECT geometry, "
+                "struct_pack(xmin := ST_XMin(geometry), xmax := ST_XMax(geometry), "
+                "ymin := ST_YMin(geometry), ymax := ST_YMax(geometry)) AS bbox "
+                f"FROM '{fields_5070_file}'"
+            )
+            sql = _build_enrichment_query(
+                input_url="_inp",
+                admin_table_ref="_admin_b",
+                admin_where_clause="",
+                admin_select_clause='b."region" AS region',
+                admin_geom_col="geom",
+                admin_bbox_col="bbox",
+                boundary_columns=["region"],
+                input_geom_col="geometry",
+                input_bbox_col="bbox",
+                enriched_table="_enriched",
+                input_is_table_ref=True,
                 source_crs="EPSG:5070",
             )
             con.execute(sql)

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+
+"""Tests for the shared CRS-normalization helpers (issue #525).
+
+Spatial operations (admin joins, lon/lat grid keying) assume OGC:CRS84 input.
+These helpers produce the SQL needed to reproject non-CRS84 input to the
+operation's expected CRS before the spatial work happens.
+"""
+
+import pytest
+
+from geoparquet_io.core.crs_utils import (
+    crs_string_for_transform,
+    source_crs_string,
+    transform_geom_sql,
+)
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+EPSG_28992 = {"id": {"authority": "EPSG", "code": 28992}}
+
+
+class TestCrsStringForTransform:
+    def test_projected_dict_returns_auth_code(self):
+        assert crs_string_for_transform(EPSG_28992) == "EPSG:28992"
+
+    def test_projected_string_returns_auth_code(self):
+        assert crs_string_for_transform("EPSG:28992") == "EPSG:28992"
+
+    def test_none_returns_none(self):
+        assert crs_string_for_transform(None) is None
+
+    @pytest.mark.parametrize(
+        "crs", ["EPSG:4326", "OGC:CRS84", {"id": {"authority": "OGC", "code": "CRS84"}}]
+    )
+    def test_default_crs_returns_none(self, crs):
+        # The default CRS needs no transform when the target is lon/lat.
+        assert crs_string_for_transform(crs) is None
+
+
+class TestTransformGeomSql:
+    def test_noop_for_none_source(self):
+        assert transform_geom_sql('"geom"', None) == '"geom"'
+
+    def test_noop_for_default_source(self):
+        assert transform_geom_sql('"geom"', "EPSG:4326") == '"geom"'
+
+    def test_projected_source_emits_st_transform(self):
+        assert (
+            transform_geom_sql('"geom"', EPSG_28992)
+            == "ST_Transform(\"geom\", 'EPSG:28992', 'OGC:CRS84')"
+        )
+
+    def test_custom_target_crs(self):
+        assert (
+            transform_geom_sql("g", "EPSG:28992", target_crs="EPSG:3857")
+            == "ST_Transform(g, 'EPSG:28992', 'EPSG:3857')"
+        )
+
+    def test_transform_runs_in_duckdb_and_yields_lonlat(self, fields_5070_file):
+        """A projected (EPSG:5070) geometry transforms to lon/lat degrees."""
+        src = source_crs_string(fields_5070_file)
+        assert src == "EPSG:5070"
+        expr = transform_geom_sql('"geometry"', src)
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            con.execute("SET geometry_always_xy = true;")
+            raw_x, lon, lat = con.execute(
+                f'SELECT ST_X(ST_Centroid("geometry")), '
+                f"ST_X(ST_Centroid({expr})), ST_Y(ST_Centroid({expr})) "
+                f"FROM '{fields_5070_file}' LIMIT 1"
+            ).fetchone()
+        finally:
+            con.close()
+        # Raw coords are projected metres (millions); transformed are valid degrees.
+        assert abs(raw_x) > 1000
+        assert -180 <= lon <= 180
+        assert -90 <= lat <= 90
+
+
+class TestSourceCrsString:
+    def test_detects_projected_fixture(self, fields_5070_file):
+        assert source_crs_string(fields_5070_file) == "EPSG:5070"
+
+    def test_default_crs_input_needs_no_transform(self, buildings_test_file):
+        # The common case: a CRS84 input is not reprojected (hot path stays free).
+        assert source_crs_string(buildings_test_file) is None
+
+
+class TestHotPathUnchanged:
+    """Regression guard (#525 perf): CRS84 input must not pay for reprojection.
+
+    The reprojection is keyed off a detected source CRS. For default/CRS84 input
+    the join SQL must keep its bbox pre-filter and contain no ST_Transform, so the
+    common path is byte-for-byte what it was before this change.
+    """
+
+    def test_join_condition_keeps_bbox_prefilter_without_transform(self):
+        from geoparquet_io.core.duckdb_utils import build_spatial_join_condition
+
+        sql = build_spatial_join_condition("geom", "geom", "bbox", "bbox")
+        assert "ST_Transform" not in sql
+        assert ".xmin" in sql and ".xmax" in sql  # bbox pre-filter retained
+
+    def test_join_condition_reprojects_and_drops_bbox_when_transforming(self):
+        from geoparquet_io.core.duckdb_utils import build_spatial_join_condition
+
+        sql = build_spatial_join_condition(
+            "geom",
+            "geom",
+            "bbox",
+            "bbox",
+            input_geom_sql="ST_Transform(a.geom, 'EPSG:5070', 'OGC:CRS84')",
+        )
+        assert "ST_Transform" in sql
+        assert ".xmin" not in sql  # bbox pre-filter skipped (source-CRS bbox)
+
+
+def _read_column(parquet_file, column):
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        rows = con.execute(f"SELECT \"{column}\" FROM '{parquet_file}' ORDER BY 1").fetchall()
+    finally:
+        con.close()
+    return [r[0] for r in rows]
+
+
+class TestGridKeyingIsCrsAware:
+    """Class B (#525): lon/lat grid keying must reproject projected input.
+
+    Keying a projected (EPSG:5070) file must yield the same cells as keying a
+    reprojected-to-CRS84 copy of the same data. Before the fix the projected
+    metres were fed to ``*_lonlat_to_cell`` as degrees, producing different
+    (wrong) cells.
+    """
+
+    @pytest.fixture
+    def reprojected_4326(self, fields_5070_file, tmp_path):
+        from geoparquet_io.core.reproject import reproject
+
+        out = tmp_path / "fields_4326.parquet"
+        reproject(fields_5070_file, str(out), target_crs="EPSG:4326")
+        return str(out)
+
+    @pytest.mark.parametrize(
+        "module,func_name,column,res_kw",
+        [
+            ("a5", "add_a5_column", "a5_cell", {"a5_resolution": 12}),
+            ("h3", "add_h3_column", "h3_cell", {"h3_resolution": 9}),
+            ("s2", "add_s2_column", "s2_cell", {"s2_level": 14}),
+            ("quadkey", "add_quadkey_column", "quadkey", {"resolution": 16}),
+        ],
+    )
+    def test_projected_cells_match_reprojected(
+        self, fields_5070_file, reprojected_4326, tmp_path, module, func_name, column, res_kw
+    ):
+        import importlib
+
+        mod = importlib.import_module(f"geoparquet_io.core.add.{module}")
+        add_func = getattr(mod, func_name)
+
+        proj_out = tmp_path / f"proj_{module}.parquet"
+        wgs_out = tmp_path / f"wgs_{module}.parquet"
+        add_func(fields_5070_file, str(proj_out), **res_kw)
+        add_func(reprojected_4326, str(wgs_out), **res_kw)
+
+        proj_cells = _read_column(str(proj_out), column)
+        wgs_cells = _read_column(str(wgs_out), column)
+
+        # Keying the projected file (now reprojected internally) must agree with
+        # keying a reprojected copy. A few fine-resolution boundary cells can flip
+        # due to the reproject-to-file coordinate rounding in the oracle, so allow
+        # a tiny mismatch — without the fix, ~every cell differs (metres keyed as
+        # degrees), so this still cleanly distinguishes fixed from broken.
+        assert len(proj_cells) == len(wgs_cells)
+        mismatches = sum(1 for a, b in zip(proj_cells, wgs_cells, strict=True) if a != b)
+        assert mismatches <= max(1, len(proj_cells) // 100)
+        # And the keying actually produced a cell for every row (not null).
+        assert all(c is not None for c in proj_cells)
+
+
+def _con_with_admin():
+    """Connection with a CRS84 admin polygon covering the 5070 fixture's extent.
+
+    The fixture's geometries reproject to roughly lon 18 / lat 47, so the admin
+    polygon spans (17..19, 46..48).
+    """
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute("SET geometry_always_xy = true;")
+    con.execute(
+        "CREATE TEMP TABLE _admin AS "
+        "SELECT ST_GeomFromText('POLYGON((17 46, 19 46, 19 48, 17 48, 17 46))') AS geom, "
+        "'R1' AS region"
+    )
+    return con
+
+
+class TestAdminJoinIsCrsAware:
+    """Class A (#525): admin spatial joins must reproject projected input.
+
+    Without reprojection a projected (EPSG:5070) input either errors on a CRS
+    mismatch or silently matches nothing (metres compared against degrees).
+    """
+
+    def test_admin_divisions_join_assigns_with_reprojection(self, fields_5070_file):
+        from geoparquet_io.core.add.admin_divisions import _build_spatial_join_query
+
+        con = _con_with_admin()
+        try:
+            kwargs = {
+                "input_url": fields_5070_file,
+                "admin_subquery": "(SELECT geom, region FROM _admin)",
+                "admin_select_clause": 'b."region" AS region',
+                "input_bbox_col": None,
+                "admin_bbox_col": None,
+                "input_geom_col": "geometry",
+                "admin_geom_col": "geom",
+            }
+            with_crs = _build_spatial_join_query(source_crs="EPSG:5070", **kwargs)
+            without = _build_spatial_join_query(source_crs=None, **kwargs)
+            assigned = con.execute(
+                f"SELECT COUNT(*) FROM ({with_crs}) WHERE region IS NOT NULL"
+            ).fetchone()[0]
+            not_assigned = con.execute(
+                f"SELECT COUNT(*) FROM ({without}) WHERE region IS NOT NULL"
+            ).fetchone()[0]
+        finally:
+            con.close()
+        assert assigned > 0  # reprojected input intersects the admin polygon
+        assert not_assigned == 0  # raw projected metres match nothing
+
+    def test_admin_hierarchical_enrichment_assigns_with_reprojection(self, fields_5070_file):
+        from geoparquet_io.core.partition.admin_hierarchical import _build_enrichment_query
+
+        con = _con_with_admin()
+        try:
+            sql = _build_enrichment_query(
+                input_url=fields_5070_file,
+                admin_table_ref="_admin",
+                admin_where_clause="",
+                admin_select_clause='b."region" AS region',
+                admin_geom_col="geom",
+                admin_bbox_col=None,
+                boundary_columns=["region"],
+                input_geom_col="geometry",
+                input_bbox_col=None,
+                enriched_table="_enriched",
+                source_crs="EPSG:5070",
+            )
+            con.execute(sql)
+            assigned = con.execute(
+                "SELECT COUNT(*) FROM _enriched WHERE region IS NOT NULL"
+            ).fetchone()[0]
+        finally:
+            con.close()
+        assert assigned > 0

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -105,10 +105,46 @@ class TestCrsStringFromTable:
         return pq.read_table(parquet_file)
 
     def test_detects_projected_without_geoarrow_extension(self, fields_5070_file):
-        from geoparquet_io.core.crs_utils import crs_string_from_table
+        # geoarrow.pyarrow's extension-type registration is global and
+        # irreversible, and several tests in the suite import it; under -n auto
+        # the import order is nondeterministic. Run in a fresh subprocess that
+        # never imports geoarrow.pyarrow, so this provably exercises the raw
+        # ARROW:extension:metadata (Case 2) branch rather than the registered
+        # extension type (Case 1).
+        import subprocess
+        import sys
+        import textwrap
 
-        table = self._read_table(fields_5070_file)
-        assert crs_string_from_table(table, "geometry") == "EPSG:5070"
+        script = textwrap.dedent(
+            """
+            import sys
+            import pyarrow.parquet as pq
+            from geoparquet_io.core.crs_utils import crs_string_from_table
+
+            table = pq.read_table(sys.argv[1])
+            field = table.schema.field("geometry")
+            # Guard: confirm we are actually in Case 2 (plain binary field with
+            # raw extension metadata), not the registered-extension-type Case 1.
+            assert getattr(field.type, "extension_name", None) is None, (
+                "expected a plain binary geometry field (Case 2), got a "
+                "registered extension type"
+            )
+            md = field.metadata or {}
+            assert md.get(b"ARROW:extension:metadata"), (
+                "expected raw ARROW:extension:metadata on the geometry field"
+            )
+            assert "geoarrow.pyarrow" not in sys.modules
+            assert crs_string_from_table(table, "geometry") == "EPSG:5070"
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script, fields_5070_file],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"subprocess failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
 
     def test_detects_projected_with_geoarrow_extension_registered(self, fields_5070_file):
         # Force the registered-extension-type carrier (Case 1).


### PR DESCRIPTION
## Summary

Fixes #525.

Several spatial operations assumed the input GeoParquet was OGC:CRS84 / EPSG:4326 (lon-lat degrees) and never reprojected. On real-world data in another CRS this produced two failure modes:

- **Class A — admin spatial-predicate joins**: a hard DuckDB error `Cannot call function 'ST_Intersects' with geometries of different coordinate reference systems`.
- **Class B — lon/lat grid keying**: silently *wrong* cells (projected metres fed to `*_lonlat_to_cell` as if they were degrees), no error.

## What changed

A shared "normalize geometry to the operation's expected CRS" helper in `core/crs_utils.py`:
- `crs_string_for_transform(crs)` → `"AUTH:CODE"` for a non-default identifiable CRS, else `None`.
- `transform_geom_sql(geom_expr, source_crs, target_crs="OGC:CRS84")` → wraps the expression in `ST_Transform` when needed, else returns it unchanged (no-op for CRS84 / CRS-less / default).
- `source_crs_string(parquet_file)` → detects a file's CRS as a transform string (reuses the existing `extract_crs_from_parquet`).

Applied across:
- **Grid keying** — `add a5/h3/s2/quadkey` reproject to lon/lat before centroid keying (`partition {a5,h3,s2,quadkey}` route through `add`, so they're covered too). `add quadkey` now **reprojects** a known projected CRS instead of rejecting it; its bbox-midpoint path is skipped when reprojecting (the stored bbox is in the source CRS).
- **Admin joins** — `add admin-divisions` and `partition admin` reproject the input to the admin CRS (OGC:CRS84) before `ST_Intersects`, compute the extent filter over the reprojected geometry, and skip the stored-bbox pre-filter when the CRS differs. `build_spatial_join_condition` gained an optional pre-built input-geom expression to support this.

## Hot path is unchanged (no regression)

CRS84 / CRS-less input makes the helper a no-op, so the common path is byte-for-byte what it was. Guarded structurally (the join SQL keeps its bbox pre-filter and contains no `ST_Transform` for CRS84 input) and measured:

| path | wall-clock (`add a5`, 400k rows) |
|---|---|
| baseline `main` (CRS84) | ~2.08–2.11s |
| this branch (CRS84) | ~2.13s |
| this branch (projected, reprojects per row) | ~2.02–2.10s |

No meaningful overhead on either path — the per-row `ST_Transform` is dwarfed by cell computation.

## Testing

- New `tests/test_crs_normalize.py` (21 tests, written failing first): helper unit tests; **Class B** (projected `fields_5070` fixture keyed via `add a5/h3/s2/quadkey` matches a reprojected-to-CRS84 copy); **Class A** (the join builders assign rows for projected input, vs 0 without the fix); and hot-path no-op guards.
- Full fast suite: 2999 passed, 8 skipped (one pre-existing flaky commitizen test under `xdist`, passes isolated and on baseline).
- All quality gates pass (ruff, codespell, xenon, import-linter, vulture).
- **End-to-end on the issue's real EPSG:28992 file** (`bag-light.parquet`, 11.4M rows): `add admin-divisions` now completes and assigns 11.34M/11.37M features to "Netherlands (Kingdom of the)" (border slivers to Belgium/Germany) — previously it errored at `ST_Intersects`. Grid keying produces correct lon/lat cells.

## Follow-up

The `process aggregate {a5,admin}` modules carry the same assumption but live on the `feature/process-aggregate` branch (not on `main`). They get the same helper wired in via a separate follow-up commit on that branch, per the agreed scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spatial grid indexing and admin spatial joins to be CRS-aware, reprojecting non-default inputs before spatial processing.
  * Ensured quadkey generation and keying for grids (A5/H3/S2/quadkey) work correctly for projected CRS inputs.
  * Improved admin hierarchical enrichment/partitioning CRS handling and bbox pre-filter behavior.

* **Documentation**
  * Updated changelog and the `add` guide to clearly describe CRS handling rules for grid cell generation and administrative joins.

* **Tests**
  * Added extensive CRS detection/reprojection regression coverage for grids, joins, and query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->