### PR TITLE
duckdb.IOException (GeoJSON too complex) not caught — batch-size fallback ladder never fires for large polygon layers

### DIFF
--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -84,6 +84,21 @@ class ArcGISLayerInfo:
 BATCH_SIZE_FALLBACKS = [1000, 500, 100, 50, 10, 1]
 
 
+def _disable_gdal_geojson_size_limit() -> None:
+    """Lift GDAL's per-feature GeoJSON object size limit before ST_Read.
+
+    GDAL's GeoJSON/ESRIJSON drivers cap a single feature object at 200 MB by
+    default (``OGR_GEOJSON_MAX_OBJ_SIZE``, in megabytes) and raise an
+    ``IOException`` ("GeoJSON object too complex/large") when a feature exceeds
+    it. Large, complex polygon layers — e.g. national admin boundaries with
+    detailed coastlines — blow past this even at ``batch_size=1``, so the
+    batch-size fallback ladder cannot recover. GDAL reads the option from the
+    process environment; "0" removes the limit. Idempotent and harmless to call
+    on every page conversion. See issue #517.
+    """
+    os.environ["OGR_GEOJSON_MAX_OBJ_SIZE"] = "0"
+
+
 def _get_reduced_batch_size(current_batch: int) -> int | None:
     """
     Get the next smaller batch size from the fallback sequence.
@@ -953,6 +968,10 @@ def _json_doc_to_table(doc: dict, exclude: str, suffix: str, con=None) -> pa.Tab
     try:
         with open(temp_file, "w") as f:
             json.dump(doc, f)
+
+        # Allow arbitrarily large/complex single features through GDAL's parser
+        # (issue #517) — must be in effect before ST_Read reads the temp file.
+        _disable_gdal_geojson_size_limit()
 
         query = f"""
             SELECT

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1280,6 +1280,38 @@ class TestStreamingConversion:
         result = _geojson_page_to_table([])
         assert result is None
 
+    def test_disable_gdal_geojson_size_limit_sets_env(self, monkeypatch):
+        """Helper removes GDAL's per-feature GeoJSON size limit (issue #517)."""
+        import os
+
+        from geoparquet_io.core.arcgis import _disable_gdal_geojson_size_limit
+
+        monkeypatch.delenv("OGR_GEOJSON_MAX_OBJ_SIZE", raising=False)
+        _disable_gdal_geojson_size_limit()
+        assert os.environ["OGR_GEOJSON_MAX_OBJ_SIZE"] == "0"
+
+    def test_disable_gdal_geojson_size_limit_overrides_existing(self, monkeypatch):
+        """A prior nonzero limit is lifted unconditionally (issue #517)."""
+        import os
+
+        from geoparquet_io.core.arcgis import _disable_gdal_geojson_size_limit
+
+        monkeypatch.setenv("OGR_GEOJSON_MAX_OBJ_SIZE", "200")
+        _disable_gdal_geojson_size_limit()
+        assert os.environ["OGR_GEOJSON_MAX_OBJ_SIZE"] == "0"
+
+    def test_geojson_page_to_table_lifts_size_limit(self, monkeypatch):
+        """Converting a page sets the GDAL size limit before ST_Read (#517)."""
+        import os
+
+        from geoparquet_io.core.arcgis import _geojson_page_to_table
+
+        monkeypatch.delenv("OGR_GEOJSON_MAX_OBJ_SIZE", raising=False)
+        table = _geojson_page_to_table(MOCK_FEATURES_PAGE["features"])
+
+        assert table is not None
+        assert os.environ["OGR_GEOJSON_MAX_OBJ_SIZE"] == "0"
+
     @patch("geoparquet_io.core.arcgis.fetch_all_features")
     def test_stream_features_to_parquet_single_page(self, mock_fetch, output_file):
         """Test streaming a single page to parquet."""


### PR DESCRIPTION
## Summary

Fixes #517. Extracting FeatureServer layers with very large/complex polygon
geometries (e.g. Philippines admin boundaries) failed permanently with:

```
duckdb.IOException: IO Error: At line 1, character ...: GeoJSON object too
complex/large. You may define the OGR_GEOJSON_MAX_OBJ_SIZE configuration option
to a value in megabytes to allow for larger features, or 0 to remove any size limit.
```

GDAL's GeoJSON/ESRIJSON drivers cap a single feature object at 200 MB by default
(`OGR_GEOJSON_MAX_OBJ_SIZE`, in MB). When any one feature's serialized geometry
exceeds that, DuckDB's `ST_Read` raises an `IOException`. Because this is a
*per-feature* size problem rather than a *page-payload* problem, the existing
`BatchTooLargeError` fallback ladder can't help — the error fires even at
`batch_size=1` (e.g. an admin0 layer with a single national boundary).

## What changed

- Added `_disable_gdal_geojson_size_limit()` in `core/arcgis.py`, which sets
  `OGR_GEOJSON_MAX_OBJ_SIZE=0` (no limit) in the process environment where GDAL
  reads it.
- Call it inside `_json_doc_to_table()` immediately before `ST_Read`, so it
  applies to both the GeoJSON and EsriJSON conversion paths and is always in
  effect before the parser runs. The call is idempotent and cheap.

This makes `extract_arcgis` handle the case transparently — callers no longer
need to set `OGR_GEOJSON_MAX_OBJ_SIZE=0` themselves.

## Testing

Added unit tests in `tests/test_arcgis.py`:

- `test_disable_gdal_geojson_size_limit_sets_env` — sets the limit to `0` when unset.
- `test_disable_gdal_geojson_size_limit_overrides_existing` — lifts a prior nonzero limit.
- `test_geojson_page_to_table_lifts_size_limit` — page conversion sets the limit before `ST_Read`.

Gate run locally and green:

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy geoparquet_io`
- `uv run pytest -m 'not slow and not network'`

Closes #517

---
*Automated by agent-farm.*