### PR TITLE
Spatial operations are not CRS-aware: admin joins error and grid keying silently wrong for non-CRS84 input

### DIFF
--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -2,6 +2,15 @@
 
 The `add` commands enhance GeoParquet files with spatial indices, geometry metrics, and administrative metadata.
 
+!!! note "Coordinate Reference Systems"
+    The grid-index commands (`h3`, `s2`, `a5`, `quadkey`) and `admin-divisions` are
+    **CRS-aware**. If your input declares a projected CRS (e.g. EPSG:5070 or
+    EPSG:28992), the geometry centroid is reprojected to OGC:CRS84 (lon/lat
+    degrees) before the cell is computed, and the input is reprojected to the
+    admin boundaries' CRS before the spatial join — so you no longer need to run
+    `gpio convert reproject` first. Inputs without a declared CRS are treated as
+    OGC:CRS84 per the GeoParquet spec.
+
 ## Bounding Boxes
 
 Add precomputed bounding boxes for faster spatial queries:

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -55,9 +55,11 @@ datasets — collapsing them into a handful of giant partitions. If the sample
 probe can't run (for example, the file has no geometry column), gpio falls back
 to the uniform-coverage estimate.
 
-> **Note:** cell assignment currently assumes lon/lat (EPSG:4326-family) input.
-> Projected-CRS data should be reprojected before partitioning so cells — and
-> the auto-resolution probe — line up with the data's real geography.
+> **Note:** cell assignment is CRS-aware — a projected input (e.g. EPSG:5070) is
+> reprojected to OGC:CRS84 before the grid cell is computed, and `partition admin`
+> reprojects the input to the admin boundaries' CRS before the spatial join. The
+> auto-resolution probe still samples the input's own coordinates, so its
+> estimate is most accurate for lon/lat data.
 
 ## By String Column
 

--- a/geoparquet_io/core/add/a5.py
+++ b/geoparquet_io/core/add/a5.py
@@ -6,6 +6,11 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import add_computed_column
 from geoparquet_io.core.constants import DEFAULT_A5_COLUMN_NAME
+from geoparquet_io.core.crs_utils import (
+    crs_transform_sql_expr,
+    extract_crs_from_parquet,
+    extract_crs_from_table,
+)
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
@@ -80,10 +85,13 @@ def add_a5_table(
         else:
             source_ref = "__input_table"
 
-        # Build A5 column query
+        # Build A5 column query. a5_lonlat_to_cell expects lon/lat degrees, so a
+        # projected input is reprojected to OGC:CRS84 before keying (issue #525).
+        source_crs = extract_crs_from_table(table, geom_col)
+        centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
         a5_expr = f"""a5_lonlat_to_cell(
-            ST_X(ST_Centroid("{geom_col}")),
-            ST_Y(ST_Centroid("{geom_col}")),
+            ST_X({centroid}),
+            ST_Y({centroid}),
             {resolution}
         )"""
 
@@ -121,11 +129,17 @@ def _make_add_a5_query(
     geometry_column: str,
     a5_column_name: str,
     resolution: int,
+    source_crs=None,
 ) -> str:
-    """Build query to add A5 column to a source."""
+    """Build query to add A5 column to a source.
+
+    ``source_crs`` (when a non-default CRS) reprojects the centroid to OGC:CRS84
+    before keying, since ``a5_lonlat_to_cell`` expects lon/lat degrees.
+    """
+    centroid = crs_transform_sql_expr(f'ST_Centroid("{geometry_column}")', source_crs)
     a5_expr = f"""a5_lonlat_to_cell(
-        ST_X(ST_Centroid("{geometry_column}")),
-        ST_Y(ST_Centroid("{geometry_column}")),
+        ST_X({centroid}),
+        ST_Y({centroid}),
         {resolution}
     )"""
     return f'SELECT *, {a5_expr} AS "{a5_column_name}" FROM {source}'
@@ -210,10 +224,13 @@ def add_a5_column(
     # Get geometry column for the SQL expression
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Define the A5 SQL expression
+    # Define the A5 SQL expression. a5_lonlat_to_cell expects lon/lat degrees, so
+    # a projected input is reprojected to OGC:CRS84 before keying (issue #525).
+    source_crs = extract_crs_from_parquet(input_parquet, verbose)
+    centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
     sql_expression = f"""a5_lonlat_to_cell(
-        ST_X(ST_Centroid("{geom_col}")),
-        ST_Y(ST_Centroid("{geom_col}")),
+        ST_X({centroid}),
+        ST_Y({centroid}),
         {a5_resolution}
     )"""
 
@@ -267,6 +284,10 @@ def _add_a5_streaming(
     if should_stream_output(output_path):
         verbose = False
 
+    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
+    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
+    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
+
     def make_query(source: str, con) -> str:
         """Build the add A5 query for streaming source."""
         # Load A5 extension
@@ -288,7 +309,7 @@ def _add_a5_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_a5_query(source, geom_col, a5_column_name, resolution)
+        return _make_add_a5_query(source, geom_col, a5_column_name, resolution, source_crs)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -14,12 +14,31 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
+from geoparquet_io.core.crs_utils import crs_transform_sql_expr, extract_crs_from_parquet
 from geoparquet_io.core.duckdb_utils import build_spatial_join_condition, quote_identifier
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
 from geoparquet_io.core.partition.reader import require_single_file
 from geoparquet_io.core.remote import _sanitize_url_for_logging, is_remote_url
+
+
+def _reprojected_input_geom_sql(input_geom_col, source_crs, alias="a"):
+    """Return the input geometry expression reprojected to the admin CRS.
+
+    Admin boundaries are OGC:CRS84, so a non-CRS84 input must be reprojected
+    before ``ST_Intersects`` (issue #525) — DuckDB 1.5 otherwise refuses the
+    join with a CRS-mismatch error. Returns ``None`` when no transform is needed
+    (input already CRS84 / CRS-less), so callers keep the original behavior.
+
+    ``alias`` is the SQL table alias prefix; pass ``None`` for a bare column
+    reference (e.g. an aggregate extent query with no alias).
+    """
+    base = (
+        f"{alias}.{quote_identifier(input_geom_col)}" if alias else quote_identifier(input_geom_col)
+    )
+    transformed = crs_transform_sql_expr(base, source_crs)
+    return transformed if transformed != base else None
 
 
 def _build_admin_subquery(
@@ -101,6 +120,7 @@ def _build_spatial_join_query(
     admin_geom_col,
     *,
     is_table_ref=False,
+    source_crs=None,
 ):
     """Build the per-level admin spatial join query.
 
@@ -120,9 +140,16 @@ def _build_spatial_join_query(
     """
     input_ref = _format_input_ref(input_url, is_table_ref)
 
+    # Reproject a non-CRS84 input to the admin CRS before ST_Intersects (#525).
+    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs)
+
     # Shared, fully-quoted ON clause (bbox pre-filter + ST_Intersects).
     join_clause = "ON " + build_spatial_join_condition(
-        input_geom_col, admin_geom_col, input_bbox_col, admin_bbox_col
+        input_geom_col,
+        admin_geom_col,
+        input_bbox_col,
+        admin_bbox_col,
+        input_geom_sql=input_geom_sql,
     )
 
     return f"""
@@ -136,15 +163,29 @@ def _build_spatial_join_query(
 
 
 def _add_extent_filter(
-    con, input_url, input_bbox_col, input_geom_col, admin_bbox_col, verbose, is_table_ref=False
+    con,
+    input_url,
+    input_bbox_col,
+    input_geom_col,
+    admin_bbox_col,
+    verbose,
+    is_table_ref=False,
+    source_crs=None,
 ):
-    """Add bbox extent filter to admin where clauses."""
+    """Add bbox extent filter to admin where clauses.
+
+    When the input is reprojected to the admin CRS (``source_crs`` non-default),
+    the extent is computed from the *reprojected* geometry so the resulting
+    bounds are comparable to the admin (CRS84) bbox; the stored input bbox column
+    is in the source CRS and is therefore ignored.
+    """
     if not admin_bbox_col:
         return None
 
     input_ref = _format_input_ref(input_url, is_table_ref)
+    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs, alias=None)
 
-    if input_bbox_col:
+    if input_bbox_col and input_geom_sql is None:
         q_input_bbox = quote_identifier(input_bbox_col)
         extent_query = f"""
             SELECT
@@ -155,13 +196,13 @@ def _add_extent_filter(
             FROM {input_ref}
         """
     else:
-        q_input_geom = quote_identifier(input_geom_col)
+        geom_expr = input_geom_sql or f"{quote_identifier(input_geom_col)}"
         extent_query = f"""
             SELECT
-                MIN(ST_XMin({q_input_geom})) as xmin,
-                MAX(ST_XMax({q_input_geom})) as xmax,
-                MIN(ST_YMin({q_input_geom})) as ymin,
-                MAX(ST_YMax({q_input_geom})) as ymax
+                MIN(ST_XMin({geom_expr})) as xmin,
+                MAX(ST_XMax({geom_expr})) as xmax,
+                MIN(ST_YMin({geom_expr})) as ymin,
+                MAX(ST_YMax({geom_expr})) as ymax
             FROM {input_ref}
         """
 
@@ -291,6 +332,13 @@ def _setup_dataset_and_columns(
     input_geom_col = find_primary_geometry_column(input_parquet, verbose)
     admin_geom_col = dataset.get_geometry_column()
 
+    # Detect a projected input CRS: admin boundaries are OGC:CRS84, so a non-CRS84
+    # input is reprojected before ST_Intersects (issue #525). DuckDB 1.5 otherwise
+    # refuses the join with a CRS-mismatch error.
+    source_crs = extract_crs_from_parquet(input_parquet, verbose)
+    if source_crs is not None and verbose:
+        debug("Projected input CRS detected — reprojecting to OGC:CRS84 for admin join")
+
     # Check if we should skip bbox pre-filtering (for native geometry files)
     input_bbox_advice = get_bbox_advice(input_parquet, "spatial_filtering", verbose)
     if input_bbox_advice["skip_bbox_prefilter"]:
@@ -314,6 +362,7 @@ def _setup_dataset_and_columns(
         input_bbox_info,
         input_bbox_col,
         admin_bbox_col,
+        source_crs,
     )
 
 
@@ -358,6 +407,7 @@ def _build_admin_where_clauses_list(
     verbose,
     dry_run,
     is_table_ref=False,
+    source_crs=None,
 ):
     """Build WHERE clauses for admin boundaries."""
     admin_where_clauses = []
@@ -375,6 +425,7 @@ def _build_admin_where_clauses_list(
         admin_bbox_col,
         verbose and not dry_run,
         is_table_ref=is_table_ref,
+        source_crs=source_crs,
     )
     if extent_filter:
         admin_where_clauses.append(extent_filter)
@@ -397,6 +448,7 @@ def _build_query_components(
     dry_run,
     prefix=None,
     is_table_ref=False,
+    source_crs=None,
 ):
     """Build all query components."""
     # Use provided admin_source (may be cached local path or remote URL)
@@ -419,6 +471,7 @@ def _build_query_components(
         verbose,
         dry_run,
         is_table_ref=is_table_ref,
+        source_crs=source_crs,
     )
 
     admin_select_clause = _build_admin_select_clause(
@@ -448,6 +501,7 @@ def _build_query_components(
         input_geom_col,
         admin_geom_col,
         is_table_ref=is_table_ref,
+        source_crs=source_crs,
     )
 
     return query, admin_source
@@ -525,12 +579,17 @@ def _execute_per_level_joins(
     prefix,
     no_cache,
     extra_kv=None,
+    source_crs=None,
 ):
     """Run separate spatial joins per admin level for per-level-source datasets.
 
     Each level joins against its own cache file, chaining results through DuckDB
     temp tables. Per-level caches are non-overlapping, so each plain LEFT JOIN
     normally preserves the row count.
+
+    The input geometry is carried through the chained temp tables unchanged (in
+    its source CRS), so ``source_crs`` reprojection is applied at every level,
+    not just the first (issue #525).
     """
     current_source = input_url
 
@@ -555,6 +614,7 @@ def _execute_per_level_joins(
             dry_run,
             prefix=prefix,
             is_table_ref=is_table_ref,
+            source_crs=source_crs,
         )
 
         if dry_run:
@@ -658,6 +718,7 @@ def add_admin_divisions_multi(
         input_bbox_info,
         input_bbox_col,
         admin_bbox_col,
+        source_crs,
     ) = _setup_dataset_and_columns(
         input_parquet, dataset_name, dataset_source, levels, verbose, no_cache=no_cache
     )
@@ -719,6 +780,7 @@ def add_admin_divisions_multi(
                     effective_prefix,
                     no_cache,
                     extra_kv=extra_kv,
+                    source_crs=source_crs,
                 )
                 if dry_run:
                     return
@@ -737,6 +799,7 @@ def add_admin_divisions_multi(
                     verbose,
                     dry_run,
                     prefix=effective_prefix,
+                    source_crs=source_crs,
                 )
 
                 if _handle_dry_run_mode(

--- a/geoparquet_io/core/add/h3.py
+++ b/geoparquet_io/core/add/h3.py
@@ -6,6 +6,11 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import add_computed_column
 from geoparquet_io.core.constants import DEFAULT_H3_COLUMN_NAME
+from geoparquet_io.core.crs_utils import (
+    crs_transform_sql_expr,
+    extract_crs_from_parquet,
+    extract_crs_from_table,
+)
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
@@ -80,10 +85,13 @@ def add_h3_table(
         else:
             source_ref = "__input_table"
 
-        # Build H3 column query
+        # Build H3 column query. h3_latlng_to_cell_string expects lat/lon degrees,
+        # so a projected input is reprojected to OGC:CRS84 first (issue #525).
+        source_crs = extract_crs_from_table(table, geom_col)
+        centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
         h3_expr = f"""h3_latlng_to_cell_string(
-            ST_Y(ST_Centroid("{geom_col}")),
-            ST_X(ST_Centroid("{geom_col}")),
+            ST_Y({centroid}),
+            ST_X({centroid}),
             {resolution}
         )"""
 
@@ -121,11 +129,17 @@ def _make_add_h3_query(
     geometry_column: str,
     h3_column_name: str,
     resolution: int,
+    source_crs=None,
 ) -> str:
-    """Build query to add H3 column to a source."""
+    """Build query to add H3 column to a source.
+
+    ``source_crs`` (when a non-default CRS) reprojects the centroid to OGC:CRS84
+    before keying, since ``h3_latlng_to_cell_string`` expects lat/lon degrees.
+    """
+    centroid = crs_transform_sql_expr(f'ST_Centroid("{geometry_column}")', source_crs)
     h3_expr = f"""h3_latlng_to_cell_string(
-        ST_Y(ST_Centroid("{geometry_column}")),
-        ST_X(ST_Centroid("{geometry_column}")),
+        ST_Y({centroid}),
+        ST_X({centroid}),
         {resolution}
     )"""
     return f'SELECT *, {h3_expr} AS "{h3_column_name}" FROM {source}'
@@ -210,10 +224,14 @@ def add_h3_column(
     # Get geometry column for the SQL expression
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Define the H3 SQL expression (using string format for portability)
+    # Define the H3 SQL expression (using string format for portability). A
+    # projected input is reprojected to OGC:CRS84 before keying (issue #525),
+    # since h3_latlng_to_cell_string expects lat/lon degrees.
+    source_crs = extract_crs_from_parquet(input_parquet, verbose)
+    centroid = crs_transform_sql_expr(f"ST_Centroid({geom_col})", source_crs)
     sql_expression = f"""h3_latlng_to_cell_string(
-        ST_Y(ST_Centroid({geom_col})),
-        ST_X(ST_Centroid({geom_col})),
+        ST_Y({centroid}),
+        ST_X({centroid}),
         {h3_resolution}
     )"""
 
@@ -267,6 +285,10 @@ def _add_h3_streaming(
     if should_stream_output(output_path):
         verbose = False
 
+    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
+    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
+    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
+
     def make_query(source: str, con) -> str:
         """Build the add H3 query for streaming source."""
         # Load H3 extension
@@ -288,7 +310,7 @@ def _add_h3_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_h3_query(source, geom_col, h3_column_name, resolution)
+        return _make_add_h3_query(source, geom_col, h3_column_name, resolution, source_crs)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import mercantile
 import pyarrow as pa
 
@@ -13,8 +11,12 @@ from geoparquet_io.core.common import (
     write_parquet_with_metadata,
 )
 from geoparquet_io.core.constants import DEFAULT_QUADKEY_COLUMN_NAME, DEFAULT_QUADKEY_RESOLUTION
-from geoparquet_io.core.crs_utils import get_crs_display_name
-from geoparquet_io.core.duckdb_metadata import get_column_names, get_geo_metadata
+from geoparquet_io.core.crs_utils import (
+    crs_transform_sql_expr,
+    extract_crs_from_parquet,
+    extract_crs_from_table,
+)
+from geoparquet_io.core.duckdb_metadata import get_column_names
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
@@ -82,99 +84,6 @@ def _is_geographic_crs(crs_info: dict | str | None) -> bool | None:
     return None
 
 
-def _validate_crs_from_geo_metadata(
-    geo_meta: dict | None,
-    geom_col: str,
-    verbose: bool,
-    source_description: str = "data",
-) -> None:
-    """
-    Validate CRS from geo metadata dictionary.
-
-    Common helper used by file-based, streaming, and table-based paths.
-
-    Args:
-        geo_meta: Parsed geo metadata dict (from GeoParquet schema)
-        geom_col: Name of the geometry column
-        verbose: Whether to print debug output
-        source_description: Description for error messages (e.g., "file", "stream", "table")
-
-    Raises:
-        GeoParquetError: If CRS is detected as projected
-    """
-    if not geo_meta:
-        if verbose:
-            debug("No GeoParquet metadata found, assuming WGS84 coordinates")
-        return
-
-    columns_meta = geo_meta.get("columns", {})
-    if geom_col not in columns_meta:
-        if verbose:
-            debug(f"Geometry column '{geom_col}' not found in metadata, assuming WGS84")
-        return
-
-    crs_info = columns_meta[geom_col].get("crs")
-
-    # No CRS specified means default (WGS84)
-    if crs_info is None:
-        if verbose:
-            debug("No CRS specified in metadata, using default WGS84")
-        return
-
-    is_geographic = _is_geographic_crs(crs_info)
-
-    if is_geographic is False:
-        crs_name = get_crs_display_name(crs_info)
-        raise GeoParquetError(
-            f"Quadkeys require geographic coordinates (lat/lon), but this {source_description} "
-            f"uses a projected CRS: {crs_name}\n\n"
-            f"Reproject to WGS84 first using:\n"
-            f"  gpio convert reproject <input> <output> --dst-crs EPSG:4326"
-        )
-
-    if verbose and is_geographic:
-        debug("CRS validated as geographic (lat/lon coordinates)")
-
-
-def _validate_crs_for_quadkey(input_parquet: str, geom_col: str, verbose: bool) -> None:
-    """
-    Validate that the file's CRS is geographic (WGS84/CRS84).
-
-    Quadkeys require lat/lon coordinates. Raises ClickException if CRS is projected.
-    """
-    safe_url = safe_file_url(input_parquet, verbose=False)
-
-    # Get CRS from GeoParquet metadata
-    geo_meta = get_geo_metadata(safe_url)
-    _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose, source_description="file")
-
-
-def _parse_geo_metadata_from_schema(metadata: dict | None) -> dict | None:
-    """
-    Parse geo metadata from schema metadata bytes dict.
-
-    Args:
-        metadata: Schema metadata dict (with bytes keys/values)
-
-    Returns:
-        Parsed geo metadata dict, or None if not found
-    """
-    if not metadata:
-        return None
-
-    # Try both bytes and string keys (depends on how metadata was accessed)
-    geo_bytes = metadata.get(b"geo") or metadata.get("geo")
-    if not geo_bytes:
-        return None
-
-    try:
-        if isinstance(geo_bytes, bytes):
-            return json.loads(geo_bytes.decode("utf-8"))
-        return json.loads(geo_bytes)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return None
-
-
 def _lat_lon_to_quadkey(lat: float, lon: float, level: int) -> str:
     """Convert latitude and longitude to a quadkey string using mercantile."""
     tile = mercantile.tile(lon, lat, level)
@@ -205,7 +114,6 @@ def add_quadkey_table(
 
     Raises:
         ValueError: If resolution is not an integer between 0 and 23
-        GeoParquetError: If CRS is detected as projected (quadkeys require lat/lon)
     """
     # Validate resolution before any DuckDB operations
     resolution = int(resolution)
@@ -217,14 +125,15 @@ def add_quadkey_table(
     if not geom_col:
         geom_col = "geometry"
 
-    # Validate CRS is geographic (quadkeys require lat/lon)
-    geo_meta = _parse_geo_metadata_from_schema(table.schema.metadata)
-    _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose=False, source_description="table")
+    # Quadkeys require lon/lat degrees. A projected input is reprojected to
+    # OGC:CRS84 before keying (issue #525); the stored bbox column is in the
+    # source CRS, so it cannot be used as the keying location when reprojecting.
+    source_crs = extract_crs_from_table(table, geom_col)
 
     # Check if bbox column exists
     use_bbox = False
     bbox_col = None
-    if not use_centroid:
+    if not use_centroid and source_crs is None:
         for name in ["bbox", "bounds", "bounding_box"]:
             if name in table.column_names:
                 use_bbox = True
@@ -264,8 +173,9 @@ def add_quadkey_table(
             lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
             lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
         else:
-            lat_expr = f'ST_Y(ST_Centroid("{geom_col}"))'
-            lon_expr = f'ST_X(ST_Centroid("{geom_col}"))'
+            centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
+            lat_expr = f"ST_Y({centroid})"
+            lon_expr = f"ST_X({centroid})"
 
         # Get non-geometry columns
         other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
@@ -397,6 +307,10 @@ def _add_quadkey_streaming(
     if not 0 <= resolution <= 23:
         raise InvalidParameterError("resolution", f"must be between 0 and 23, got {resolution}")
 
+    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
+    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
+    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
+
     with open_input(input_path, verbose=verbose) as (source, metadata, is_stream, con):
         # Register Python UDF for quadkey generation
         con.create_function(
@@ -419,13 +333,10 @@ def _add_quadkey_streaming(
         if not geom_col:
             geom_col = "geometry"
 
-        # Validate CRS is geographic (quadkeys require lat/lon)
-        geo_meta = _parse_geo_metadata_from_schema(metadata)
-        _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose, source_description="stream")
-
-        # Check for bbox column
+        # Check for bbox column. The stored bbox is in the source CRS, so it
+        # cannot be used as the keying location when reprojecting.
         bbox_col = None
-        if not use_centroid:
+        if not use_centroid and source_crs is None:
             for name in ["bbox", "bounds", "bounding_box"]:
                 if name in col_names:
                     bbox_col = name
@@ -436,8 +347,9 @@ def _add_quadkey_streaming(
             lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
             lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
         else:
-            lat_expr = f'ST_Y(ST_Centroid("{geom_col}"))'
-            lon_expr = f'ST_X(ST_Centroid("{geom_col}"))'
+            centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
+            lat_expr = f"ST_Y({centroid})"
+            lon_expr = f"ST_X({centroid})"
 
         query = f"""
             SELECT *,
@@ -509,8 +421,10 @@ def _add_quadkey_file_based(
     # Get geometry column
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Validate CRS is geographic (quadkeys require lat/lon)
-    _validate_crs_for_quadkey(input_parquet, geom_col, verbose)
+    # Quadkeys require lon/lat degrees. A projected input is reprojected to
+    # OGC:CRS84 before keying (issue #525); the stored bbox column is in the
+    # source CRS, so it cannot be used as the keying location when reprojecting.
+    source_crs = extract_crs_from_parquet(input_parquet, verbose)
 
     # Check if column already exists (skip in dry-run)
     if not dry_run:
@@ -524,7 +438,7 @@ def _add_quadkey_file_based(
     # Determine whether to use bbox or centroid
     use_bbox = False
     bbox_col = None
-    if not use_centroid:
+    if not use_centroid and source_crs is None:
         bbox_advice = get_bbox_advice(input_parquet, "bounds_calculation", verbose)
         if bbox_advice["has_bbox_column"]:
             use_bbox = True
@@ -535,6 +449,8 @@ def _add_quadkey_file_based(
             warn(bbox_advice["message"] + " - using geometry centroid for quadkey calculation")
             for suggestion in bbox_advice["suggestions"]:
                 info(f"Tip: {suggestion}")
+    elif source_crs is not None and verbose:
+        debug("Projected CRS detected — reprojecting centroid to OGC:CRS84 for quadkey keying")
 
     # Dry-run mode header
     if dry_run:
@@ -579,8 +495,9 @@ def _add_quadkey_file_based(
             lat_expr = f"(({bbox_col}.ymin + {bbox_col}.ymax) / 2.0)"
             lon_expr = f"(({bbox_col}.xmin + {bbox_col}.xmax) / 2.0)"
         else:
-            lat_expr = f"ST_Y(ST_Centroid({geom_col}))"
-            lon_expr = f"ST_X(ST_Centroid({geom_col}))"
+            centroid = crs_transform_sql_expr(f"ST_Centroid({geom_col})", source_crs)
+            lat_expr = f"ST_Y({centroid})"
+            lon_expr = f"ST_X({centroid})"
 
         # Build SELECT query with new column
         query = f"""

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -47,43 +47,6 @@ from geoparquet_io.core.streaming import (
 )
 
 
-def _is_geographic_crs(crs_info: dict | str | None) -> bool | None:
-    """
-    Check if CRS is geographic (lat/long) vs projected.
-
-    Returns:
-        True if geographic, False if projected, None if unknown
-    """
-    if crs_info is None:
-        return None
-
-    if isinstance(crs_info, str):
-        crs_upper = crs_info.upper()
-        # Common geographic CRS codes
-        if any(
-            code in crs_upper for code in ["4326", "CRS84", "CRS:84", "OGC:CRS84", "4269", "4267"]
-        ):
-            return True
-        return None
-
-    if isinstance(crs_info, dict):
-        # Check PROJJSON type
-        crs_type = crs_info.get("type", "")
-        if crs_type == "GeographicCRS":
-            return True
-        if crs_type == "ProjectedCRS":
-            return False
-
-        # Check EPSG code
-        crs_id = crs_info.get("id", {})
-        if isinstance(crs_id, dict):
-            code = crs_id.get("code")
-            if code in [4326, 4269, 4267]:  # Common geographic codes
-                return True
-
-    return None
-
-
 def _lat_lon_to_quadkey(lat: float, lon: float, level: int) -> str:
     """Convert latitude and longitude to a quadkey string using mercantile."""
     tile = mercantile.tile(lon, lat, level)

--- a/geoparquet_io/core/add/s2.py
+++ b/geoparquet_io/core/add/s2.py
@@ -17,6 +17,11 @@ from geoparquet_io.core.constants import (
     DEFAULT_S2_COLUMN_NAME,
     DEFAULT_S2_LEVEL,
 )
+from geoparquet_io.core.crs_utils import (
+    crs_transform_sql_expr,
+    extract_crs_from_parquet,
+    extract_crs_from_table,
+)
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, load_community_extension
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite
@@ -65,12 +70,15 @@ def _build_s2_select_query(table, source_ref, geom_col, s2_column_name, level):
     Returns:
         str: Complete SELECT query with S2 expression
     """
-    # Build S2 cell expression
+    # Build S2 cell expression. s2_cellfromlonlat expects lon/lat degrees, so a
+    # projected input is reprojected to OGC:CRS84 before keying (issue #525).
+    source_crs = extract_crs_from_table(table, geom_col)
+    centroid = crs_transform_sql_expr(f'ST_Centroid("{geom_col}")', source_crs)
     s2_expr = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X(ST_Centroid("{geom_col}")),
-                ST_Y(ST_Centroid("{geom_col}"))
+                ST_X({centroid}),
+                ST_Y({centroid})
             ),
             {level}
         )
@@ -149,14 +157,20 @@ def _make_add_s2_query(
     geometry_column: str,
     s2_column_name: str,
     level: int,
+    source_crs=None,
 ) -> str:
-    """Build query to add S2 column to a source."""
+    """Build query to add S2 column to a source.
+
+    ``source_crs`` (when a non-default CRS) reprojects the centroid to OGC:CRS84
+    before keying, since ``s2_cellfromlonlat`` expects lon/lat degrees.
+    """
     # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get desired level
+    centroid = crs_transform_sql_expr(f'ST_Centroid("{geometry_column}")', source_crs)
     s2_expr = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X(ST_Centroid("{geometry_column}")),
-                ST_Y(ST_Centroid("{geometry_column}"))
+                ST_X({centroid}),
+                ST_Y({centroid})
             ),
             {level}
         )
@@ -242,13 +256,17 @@ def add_s2_column(
     # Get geometry column for the SQL expression
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    # Define the S2 SQL expression (using token/string format for portability)
-    # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get desired level
+    # Define the S2 SQL expression (using token/string format for portability).
+    # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get the
+    # desired level. A projected input is reprojected to OGC:CRS84 before keying
+    # (issue #525), since s2_cellfromlonlat expects lon/lat degrees.
+    source_crs = extract_crs_from_parquet(input_parquet, verbose)
+    centroid = crs_transform_sql_expr(f"ST_Centroid({geom_col})", source_crs)
     sql_expression = f"""s2_cell_token(
         s2_cell_parent(
             s2_cellfromlonlat(
-                ST_X(ST_Centroid({geom_col})),
-                ST_Y(ST_Centroid({geom_col}))
+                ST_X({centroid}),
+                ST_Y({centroid})
             ),
             {s2_level}
         )
@@ -304,6 +322,10 @@ def _add_s2_streaming(
     if should_stream_output(output_path):
         verbose = False
 
+    # Detect a projected source CRS so the centroid is reprojected to OGC:CRS84
+    # before keying. stdin carries no readable CRS, so it is treated as CRS84.
+    source_crs = None if is_stdin(input_path) else extract_crs_from_parquet(input_path, verbose)
+
     def make_query(source: str, con) -> str:
         """Build the add S2 query for streaming source."""
         # Load geography extension
@@ -325,7 +347,7 @@ def _add_s2_streaming(
         if verbose:
             debug(f"Using geometry column: {geom_col}")
 
-        return _make_add_s2_query(source, geom_col, s2_column_name, level)
+        return _make_add_s2_query(source, geom_col, s2_column_name, level, source_crs)
 
     execute_transform(
         input_path,

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -214,6 +214,107 @@ def _wrap_query_with_crs(
     """
 
 
+#: Default target CRS for lon/lat operations (grid keying, admin joins). The
+#: GeoParquet default; lon/lat axis order is guaranteed by the session-level
+#: ``geometry_always_xy = true`` that ``get_duckdb_connection`` sets.
+WGS84_TRANSFORM_TARGET = "OGC:CRS84"
+
+
+def resolve_crs_to_string(crs_info) -> str | None:
+    """Resolve CRS info (PROJJSON dict or string) to a CRS string for ST_Transform.
+
+    Tries the authority identifier first, then pyproj resolution, then the raw
+    PROJJSON. Returns None if ``crs_info`` is falsy or unresolvable.
+    """
+    if not crs_info:
+        return None
+
+    identifier = _extract_crs_identifier(crs_info)
+    if identifier:
+        authority, code = identifier
+        return f"{authority}:{code}"
+
+    if isinstance(crs_info, dict):
+        try:
+            from pyproj import CRS
+
+            authority = CRS.from_json_dict(crs_info).to_authority()
+            if authority:
+                return f"{authority[0]}:{authority[1]}"
+        except Exception:
+            pass
+        return json.dumps(crs_info)
+
+    return None
+
+
+def crs_transform_sql_expr(
+    geom_sql: str,
+    source_crs,
+    target_crs: str = WGS84_TRANSFORM_TARGET,
+) -> str:
+    """Return a SQL expression yielding ``geom_sql`` in ``target_crs``.
+
+    Wraps ``geom_sql`` in ``ST_Transform(..., '<src>', '<target>')`` only when
+    the source CRS is known and differs from the target; otherwise returns
+    ``geom_sql`` unchanged. This is the single source of truth for making the
+    CRS-blind spatial operations (grid keying, admin joins) CRS-aware.
+
+    The rules mirror the GeoParquet/DuckDB contract:
+
+    - A missing/``None`` or default (OGC:CRS84 / EPSG:4326) source is treated as
+      already being the target — no transform. A CRS-less geometry (e.g. from an
+      in-memory Arrow table via ``ST_GeomFromWKB``) is therefore accepted as-is,
+      and ``ST_Intersects`` accepts a CRS-less geometry against a CRS-bearing one.
+    - An unresolvable source CRS is left untransformed rather than guessed.
+
+    Relies on the session-level ``geometry_always_xy = true`` so the transformed
+    coordinates come out as lon/lat (x/y) for the ``*_lonlat_to_cell`` keying.
+
+    Args:
+        geom_sql: A SQL geometry expression (e.g. a quoted column name or
+            ``ST_Centroid("geometry")``).
+        source_crs: The source CRS as a PROJJSON dict, an ``AUTH:CODE`` string,
+            or ``None``.
+        target_crs: The target CRS string (default OGC:CRS84).
+    """
+    if not source_crs or is_default_crs(source_crs):
+        return geom_sql
+
+    src = resolve_crs_to_string(source_crs)
+    if not src:
+        return geom_sql
+
+    src_literal = _escape_sql_string(src)
+    target_literal = _escape_sql_string(target_crs)
+    return f"ST_Transform({geom_sql}, '{src_literal}', '{target_literal}')"
+
+
+def extract_crs_from_table(table, geometry_column: str | None = None):
+    """Return the CRS of ``geometry_column`` from a pyarrow table's geo metadata.
+
+    Returns the CRS value (PROJJSON dict or string) when present and non-default,
+    else ``None``. ``geometry_column`` defaults to the geo metadata's declared
+    primary column. Used by the table-centric (Python API) operations to detect
+    a projected input before grid keying.
+    """
+    metadata = table.schema.metadata
+    if not metadata or b"geo" not in metadata:
+        return None
+    try:
+        geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    columns = geo_meta.get("columns", {})
+    if not isinstance(columns, dict):
+        return None
+    col = geometry_column or geo_meta.get("primary_column", "geometry")
+    crs = columns.get(col, {}).get("crs")
+    if crs and not is_default_crs(crs):
+        return crs
+    return None
+
+
 def extract_crs_from_parquet(parquet_file, verbose=False):
     """
     Extract CRS (as PROJJSON dict) from a Parquet file.

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -113,6 +113,7 @@ def build_spatial_join_condition(
     target_bbox_col: str | None = None,
     input_alias: str = "a",
     target_alias: str = "b",
+    input_geom_sql: str | None = None,
 ) -> str:
     """Build the ON-clause condition for a spatial join between two tables.
 
@@ -138,17 +139,25 @@ def build_spatial_join_condition(
         target_bbox_col: Optional bbox covering column on the target table.
         input_alias: SQL alias for the input table (default "a").
         target_alias: SQL alias for the target table (default "b").
+        input_geom_sql: Optional SQL expression to use for the input geometry in
+            place of ``<input_alias>.<input_geom_col>`` — e.g. an ``ST_Transform``
+            that reprojects a non-CRS84 input to the target's CRS (issue #525).
+            When supplied, the bbox pre-filter is skipped: the input's stored bbox
+            covering is in the *source* CRS and cannot be compared against a
+            target bbox in a different CRS.
 
     Returns:
         A SQL boolean expression for use directly after ``ON``.
     """
     qi_geom = quote_identifier(input_geom_col)
     qt_geom = quote_identifier(target_geom_col)
-    intersects = f"ST_Intersects({target_alias}.{qt_geom}, {input_alias}.{qi_geom})"
+    input_geom_ref = input_geom_sql if input_geom_sql is not None else f"{input_alias}.{qi_geom}"
+    intersects = f"ST_Intersects({target_alias}.{qt_geom}, {input_geom_ref})"
 
-    # A one-sided bbox cannot form an overlap test, so fall back to the
-    # precise predicate alone.
-    if not (input_bbox_col and target_bbox_col):
+    # A one-sided bbox cannot form an overlap test, and a reprojected input geom
+    # makes the stored (source-CRS) bbox incomparable — fall back to the precise
+    # predicate alone.
+    if input_geom_sql is not None or not (input_bbox_col and target_bbox_col):
         return intersects
 
     qi_bbox = quote_identifier(input_bbox_col)

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -20,6 +20,7 @@ from geoparquet_io.core.common import (
     check_bbox_structure,
     get_parquet_metadata,
 )
+from geoparquet_io.core.crs_utils import crs_transform_sql_expr, extract_crs_from_parquet
 from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.file_utils import safe_file_url
@@ -38,6 +39,22 @@ from geoparquet_io.core.partition.staging import (
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
 
+def _reprojected_input_geom_sql(input_geom_col, source_crs, alias="a"):
+    """Return the input geometry expression reprojected to the admin CRS.
+
+    Admin boundaries are OGC:CRS84, so a non-CRS84 input must be reprojected
+    before ``ST_Intersects`` (issue #525) — DuckDB 1.5 otherwise refuses the
+    join with a CRS-mismatch error. Returns ``None`` when no transform is needed
+    (input already CRS84 / CRS-less). ``alias`` is the SQL table alias prefix;
+    pass ``None`` for a bare column reference (e.g. an aggregate extent query).
+    """
+    base = (
+        f"{alias}.{quote_identifier(input_geom_col)}" if alias else quote_identifier(input_geom_col)
+    )
+    transformed = crs_transform_sql_expr(base, source_crs)
+    return transformed if transformed != base else None
+
+
 def _build_enrichment_query(
     input_url,
     admin_table_ref,
@@ -50,13 +67,22 @@ def _build_enrichment_query(
     input_bbox_col,
     enriched_table,
     input_is_table_ref=False,
+    source_crs=None,
 ):
     """Build enrichment query for spatial join.
 
     ``input_is_table_ref`` marks ``input_url`` as a DuckDB temp-table name
     (per-level chaining) rather than a file path, so it is referenced without
     surrounding quotes.
+
+    ``source_crs`` (when a non-default CRS) reprojects the input geometry to the
+    admin CRS (OGC:CRS84) before ``ST_Intersects`` (issue #525). The stored input
+    bbox is then in the source CRS and cannot be compared against the admin bbox,
+    so the bbox pre-filter is skipped.
     """
+    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs)
+    input_geom_ref = input_geom_sql or f'a."{input_geom_col}"'
+    use_bbox_prefilter = input_bbox_col and admin_bbox_col and input_geom_sql is None
     # Build column list for subquery - handle struct access
     subquery_cols = []
     for i, col in enumerate(boundary_columns):
@@ -68,7 +94,7 @@ def _build_enrichment_query(
 
     input_ref = input_url if input_is_table_ref else f"'{input_url}'"
 
-    if input_bbox_col and admin_bbox_col:
+    if use_bbox_prefilter:
         bbox_filter = f"""
             (a.{input_bbox_col}.xmin <= b.{admin_bbox_col}.xmax AND
              a.{input_bbox_col}.xmax >= b.{admin_bbox_col}.xmin AND
@@ -88,7 +114,7 @@ def _build_enrichment_query(
                 {admin_where_clause}
             ) b
             ON {bbox_filter}
-                AND ST_Intersects(b.{admin_geom_col}, a."{input_geom_col}")
+                AND ST_Intersects(b.{admin_geom_col}, {input_geom_ref})
         """
     else:
         return f"""
@@ -102,19 +128,25 @@ def _build_enrichment_query(
                 FROM {admin_table_ref}
                 {admin_where_clause}
             ) b
-            ON ST_Intersects(b.{admin_geom_col}, a."{input_geom_col}")
+            ON ST_Intersects(b.{admin_geom_col}, {input_geom_ref})
         """
 
 
-def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col):
+def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source_crs=None):
     """Compute the input's (xmin, xmax, ymin, ymax) extent in one scan.
 
     The extent does not change across admin levels, so callers compute it once
     and reuse it for every level's WHERE clause (issue #480) rather than
     re-scanning the input per level — important when there is no bbox column and
     the fallback decodes every geometry.
+
+    When the input is reprojected to the admin CRS (``source_crs`` non-default),
+    the extent is computed from the *reprojected* geometry so the resulting
+    bounds are comparable to the admin (CRS84) bbox; the stored input bbox column
+    is in the source CRS and is therefore ignored (issue #525).
     """
-    if input_bbox_col:
+    input_geom_sql = _reprojected_input_geom_sql(input_geom_col, source_crs, alias=None)
+    if input_bbox_col and input_geom_sql is None:
         extent_query = f"""
             SELECT
                 MIN({input_bbox_col}.xmin) as xmin,
@@ -124,13 +156,13 @@ def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col):
             FROM '{input_url}'
         """
     else:
-        qgeom = quote_identifier(input_geom_col)
+        geom_expr = input_geom_sql or quote_identifier(input_geom_col)
         extent_query = f"""
             SELECT
-                MIN(ST_XMin({qgeom})) as xmin,
-                MAX(ST_XMax({qgeom})) as xmax,
-                MIN(ST_YMin({qgeom})) as ymin,
-                MAX(ST_YMax({qgeom})) as ymax
+                MIN(ST_XMin({geom_expr})) as xmin,
+                MAX(ST_XMax({geom_expr})) as xmax,
+                MIN(ST_YMin({geom_expr})) as ymin,
+                MAX(ST_YMax({geom_expr})) as ymax
             FROM '{input_url}'
         """
     extent = con.execute(extent_query).fetchone()
@@ -191,13 +223,21 @@ def _setup_admin_dataset(dataset_name, verbose, levels):
 
 
 def _get_input_file_info(input_parquet, verbose):
-    """Get input file info (URL, geometry column, bbox column)."""
+    """Get input file info (URL, geometry column, bbox column, source CRS).
+
+    ``source_crs`` is the detected non-default input CRS (or ``None`` for
+    CRS84/CRS-less): admin boundaries are OGC:CRS84, so a projected input is
+    reprojected before the spatial join (issue #525).
+    """
     input_url = safe_file_url(input_parquet, verbose)
     input_geom_col = find_primary_geometry_column(input_parquet, verbose)
     input_bbox_info = check_bbox_structure(input_parquet, verbose)
     input_bbox_col = input_bbox_info["bbox_column_name"]
+    source_crs = extract_crs_from_parquet(input_parquet, verbose)
+    if source_crs is not None and verbose:
+        debug("  → Projected input CRS detected — reprojecting to OGC:CRS84 for admin join")
 
-    return input_url, input_geom_col, input_bbox_col
+    return input_url, input_geom_col, input_bbox_col, source_crs
 
 
 def _setup_admin_join_connection(dataset, get_duckdb_connection):
@@ -287,6 +327,7 @@ def _perform_enrichment_join(
     boundary_columns,
     input_geom_col,
     input_bbox_col,
+    source_crs=None,
 ):
     """Perform spatial join enrichment."""
     enrichment_query = _build_enrichment_query(
@@ -300,6 +341,7 @@ def _perform_enrichment_join(
         input_geom_col,
         input_bbox_col,
         enriched_table,
+        source_crs=source_crs,
     )
     con.execute(enrichment_query)
 
@@ -317,6 +359,7 @@ def _perform_per_level_enrichment_join(
     input_bbox_col,
     vecorel,
     verbose,
+    source_crs=None,
 ):
     """Enrich by chaining one LEFT JOIN per level against its own land cache.
 
@@ -339,7 +382,7 @@ def _perform_per_level_enrichment_join(
 
     # The data extent does not change across levels, so compute it once and reuse
     # it for every level's WHERE clause rather than re-scanning per level (#480).
-    extent = _compute_input_extent(con, input_url, input_bbox_col, input_geom_col)
+    extent = _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source_crs)
 
     for i, (level, col) in enumerate(zip(levels, boundary_columns, strict=True)):
         level_source = dataset.get_source_for_level(level)
@@ -371,6 +414,7 @@ def _perform_per_level_enrichment_join(
                 input_bbox_col,
                 target,
                 input_is_table_ref=current_is_table_ref,
+                source_crs=source_crs,
             )
         )
         if not is_last:
@@ -648,7 +692,9 @@ def partition_by_admin_hierarchical(
     try:
         # Setup dataset and get input file info
         dataset, boundary_columns = _setup_admin_dataset(dataset_name, verbose, levels)
-        input_url, input_geom_col, input_bbox_col = _get_input_file_info(actual_input, verbose)
+        input_url, input_geom_col, input_bbox_col, source_crs = _get_input_file_info(
+            actual_input, verbose
+        )
 
         # Get admin dataset info
         admin_geom_col = dataset.get_geometry_column()
@@ -686,6 +732,7 @@ def partition_by_admin_hierarchical(
                     input_bbox_col,
                     vecorel,
                     verbose,
+                    source_crs=source_crs,
                 )
             else:
                 admin_source = dataset.prepare_data_source(con)
@@ -693,7 +740,9 @@ def partition_by_admin_hierarchical(
                     levels, boundary_columns, dataset=dataset, vecorel=vecorel
                 )
                 admin_table_ref = _build_admin_table_reference(dataset, admin_source)
-                extent = _compute_input_extent(con, input_url, input_bbox_col, input_geom_col)
+                extent = _compute_input_extent(
+                    con, input_url, input_bbox_col, input_geom_col, source_crs
+                )
                 admin_where_clause = _build_admin_where_clause(
                     dataset, levels, admin_bbox_col, extent, verbose
                 )
@@ -709,6 +758,7 @@ def partition_by_admin_hierarchical(
                     boundary_columns,
                     input_geom_col,
                     input_bbox_col,
+                    source_crs=source_crs,
                 )
 
             # Verify enrichment results

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -21,12 +21,12 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.crs_utils import (
     NULL_CRS_NO_FLAG_ERROR,
-    _extract_crs_identifier,
     apply_target_crs_to_geo_meta,
     crs_is_explicitly_null,
     extract_crs_from_parquet,
     geoparquet_crs_is_null,
     parse_crs_string_to_projjson,
+    resolve_crs_to_string,
 )
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 from geoparquet_io.core.file_utils import safe_file_url
@@ -78,31 +78,10 @@ def _detect_geometry_column_from_table(table: pa.Table) -> str:
 def _resolve_crs_to_string(crs_info) -> str | None:
     """Resolve CRS info (PROJJSON dict or string) to a CRS string for ST_Transform.
 
-    Tries authority identifier first, then pyproj resolution, then raw PROJJSON.
-
-    Returns:
-        CRS string like "EPSG:4326" or PROJJSON string, or None if unresolvable
+    Thin wrapper over :func:`crs_utils.resolve_crs_to_string` (single source of
+    truth) kept for the module-local callers below.
     """
-    if not crs_info:
-        return None
-
-    identifier = _extract_crs_identifier(crs_info)
-    if identifier:
-        authority, code = identifier
-        return f"{authority}:{code}"
-
-    if isinstance(crs_info, dict):
-        try:
-            from pyproj import CRS
-
-            authority = CRS.from_json_dict(crs_info).to_authority()
-            if authority:
-                return f"{authority[0]}:{authority[1]}"
-        except Exception:
-            pass
-        return json.dumps(crs_info)
-
-    return None
+    return resolve_crs_to_string(crs_info)
 
 
 def _detect_crs_from_table(table: pa.Table, geom_col: str) -> str:

--- a/tests/test_add_quadkey.py
+++ b/tests/test_add_quadkey.py
@@ -8,7 +8,6 @@ import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.core.add.quadkey import (
-    _is_geographic_crs,
     _lat_lon_to_quadkey,
 )
 from geoparquet_io.core.crs_utils import get_crs_display_name
@@ -40,64 +39,6 @@ class TestLatLonToQuadkey:
         assert len(qk_high) == 15
         # Higher resolution should start with the lower resolution key
         assert qk_high.startswith(qk_low)
-
-
-class TestIsGeographicCrs:
-    """Tests for _is_geographic_crs function."""
-
-    def test_none_crs(self):
-        """Test with None CRS."""
-        assert _is_geographic_crs(None) is None
-
-    def test_epsg_4326_string(self):
-        """Test WGS84 EPSG:4326 string."""
-        assert _is_geographic_crs("EPSG:4326") is True
-        assert _is_geographic_crs("epsg:4326") is True
-
-    def test_crs84_string(self):
-        """Test CRS84 string."""
-        assert _is_geographic_crs("OGC:CRS84") is True
-        assert _is_geographic_crs("CRS:84") is True
-
-    def test_unknown_string(self):
-        """Test unknown CRS string."""
-        assert _is_geographic_crs("EPSG:3857") is None  # Web Mercator
-
-    def test_geographic_crs_dict(self):
-        """Test GeographicCRS type in dict."""
-        crs_dict = {"type": "GeographicCRS", "name": "WGS 84"}
-        assert _is_geographic_crs(crs_dict) is True
-
-    def test_projected_crs_dict(self):
-        """Test ProjectedCRS type in dict."""
-        crs_dict = {"type": "ProjectedCRS", "name": "Web Mercator"}
-        assert _is_geographic_crs(crs_dict) is False
-
-    def test_crs_dict_with_epsg_code(self):
-        """Test CRS dict with EPSG code."""
-        crs_dict = {"id": {"authority": "EPSG", "code": 4326}}
-        assert _is_geographic_crs(crs_dict) is True
-
-
-class TestValidateCrsForQuadkey:
-    """Tests for CRS validation."""
-
-    def test_none_crs_returns_true(self):
-        """Test with None CRS (assumes WGS84)."""
-        assert _is_geographic_crs(None) is None
-
-    def test_epsg_4269_is_geographic(self):
-        """Test EPSG:4269 (NAD83) is recognized as geographic."""
-        assert _is_geographic_crs("EPSG:4269") is True
-
-    def test_epsg_4267_is_geographic(self):
-        """Test EPSG:4267 (NAD27) is recognized as geographic."""
-        assert _is_geographic_crs("EPSG:4267") is True
-
-    def test_dict_with_epsg_4269(self):
-        """Test dict with NAD83 code."""
-        crs_dict = {"id": {"authority": "EPSG", "code": 4269}}
-        assert _is_geographic_crs(crs_dict) is True
 
 
 class TestGetCrsDisplayName:

--- a/tests/test_crs_aware_operations.py
+++ b/tests/test_crs_aware_operations.py
@@ -1,0 +1,282 @@
+"""CRS-awareness of spatial operations (issue #525).
+
+Several spatial operations assumed the input was OGC:CRS84 (lon/lat degrees):
+
+- Grid keying (``add a5``/``h3``/``s2``/``quadkey`` and the ``partition``
+  equivalents that build on them) fed projected metres straight into
+  ``*_lonlat_to_cell``, producing silently-wrong cells.
+- Admin joins (``add admin-divisions``, ``partition admin``) ran
+  ``ST_Intersects`` between a projected input and CRS84 admin boundaries, which
+  DuckDB 1.5 refuses with a CRS-mismatch error.
+
+These tests exercise the shared reprojection on the projected (EPSG:5070) test
+fixtures, which are the same fields as the CRS84 fixture in a different CRS.
+"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.add.a5 import add_a5_column, add_a5_table
+from geoparquet_io.core.add.admin_divisions import add_admin_divisions_multi
+from geoparquet_io.core.add.h3 import add_h3_column, add_h3_table
+from geoparquet_io.core.add.quadkey import add_quadkey_column, add_quadkey_table
+from geoparquet_io.core.add.s2 import add_s2_column, add_s2_table
+from geoparquet_io.core.common import add_bbox
+from geoparquet_io.core.crs_utils import (
+    crs_transform_sql_expr,
+    extract_crs_from_table,
+    parse_crs_string_to_projjson,
+)
+from geoparquet_io.core.duckdb_utils import build_spatial_join_condition
+from geoparquet_io.core.reproject import reproject
+
+
+def _column(parquet_file: str, column: str) -> list:
+    con = duckdb.connect()
+    con.execute("LOAD spatial")
+    try:
+        rows = con.execute(f"SELECT \"{column}\" FROM read_parquet('{parquet_file}')").fetchall()
+    finally:
+        con.close()
+    return [r[0] for r in rows]
+
+
+def _agreement(a: list, b: list) -> float:
+    assert len(a) == len(b)
+    return sum(1 for x, y in zip(a, b, strict=True) if x == y) / len(a)
+
+
+# --------------------------------------------------------------------------- #
+# Shared helper
+# --------------------------------------------------------------------------- #
+
+
+class TestCrsTransformSqlExpr:
+    """Unit tests for the shared ``crs_transform_sql_expr`` helper."""
+
+    def test_none_crs_is_untransformed(self):
+        assert crs_transform_sql_expr('"geometry"', None) == '"geometry"'
+
+    def test_default_crs_is_untransformed(self):
+        # EPSG:4326 / OGC:CRS84 are the target — never transformed.
+        assert crs_transform_sql_expr('"g"', "EPSG:4326") == '"g"'
+        assert crs_transform_sql_expr('"g"', "OGC:CRS84") == '"g"'
+        assert crs_transform_sql_expr('"g"', {"id": {"authority": "EPSG", "code": 4326}}) == '"g"'
+
+    def test_projected_crs_wraps_in_transform(self):
+        expr = crs_transform_sql_expr('ST_Centroid("g")', "EPSG:5070")
+        assert expr == "ST_Transform(ST_Centroid(\"g\"), 'EPSG:5070', 'OGC:CRS84')"
+
+    def test_projjson_dict_is_resolved(self):
+        crs = parse_crs_string_to_projjson("EPSG:5070")
+        expr = crs_transform_sql_expr('"g"', crs)
+        assert "ST_Transform" in expr and "EPSG:5070" in expr
+
+    def test_custom_target(self):
+        expr = crs_transform_sql_expr('"g"', "EPSG:4326", target_crs="EPSG:3857")
+        # 4326 source is the default and is skipped regardless of target.
+        assert expr == '"g"'
+        expr = crs_transform_sql_expr('"g"', "EPSG:5070", target_crs="EPSG:3857")
+        assert expr == "ST_Transform(\"g\", 'EPSG:5070', 'EPSG:3857')"
+
+
+# --------------------------------------------------------------------------- #
+# Class B — grid keying must reproject projected input before keying
+# --------------------------------------------------------------------------- #
+
+_GRID_FILE_CASES = [
+    ("a5", add_a5_column, "a5_cell", {"a5_resolution": 12}),
+    ("h3", add_h3_column, "h3_cell", {"h3_resolution": 9}),
+    ("s2", add_s2_column, "s2_cell", {"s2_level": 15}),
+    ("quadkey", add_quadkey_column, "quadkey", {"resolution": 14, "use_centroid": True}),
+]
+
+
+@pytest.fixture
+def crs84_reference(fields_5070_file, tmp_path):
+    """The projected fixture reprojected to OGC:CRS84 (the keying baseline)."""
+    ref = str(tmp_path / "ref_crs84.parquet")
+    reproject(fields_5070_file, ref, target_crs="EPSG:4326", verbose=False)
+    return ref
+
+
+@pytest.mark.parametrize(("name", "fn", "col", "kwargs"), _GRID_FILE_CASES)
+def test_grid_keying_reprojects_projected_file(
+    name, fn, col, kwargs, fields_5070_file, crs84_reference, tmp_path
+):
+    """Keying a projected file matches keying it after reprojection to CRS84."""
+    out_proj = str(tmp_path / f"{name}_proj.parquet")
+    out_ref = str(tmp_path / f"{name}_ref.parquet")
+    fn(fields_5070_file, out_proj, **kwargs)
+    fn(crs84_reference, out_ref, **kwargs)
+
+    proj_cells = _column(out_proj, col)
+    ref_cells = _column(out_ref, col)
+
+    assert all(c is not None for c in proj_cells)
+    # Centroid-then-transform vs transform-then-centroid differ for a few cells
+    # near grid boundaries; the overwhelming majority must agree.
+    assert _agreement(proj_cells, ref_cells) >= 0.97
+
+
+def test_grid_keying_is_load_bearing(fields_5070_file, tmp_path):
+    """The reprojection genuinely changes the cells for a projected input.
+
+    Compares the CRS-aware output against the pre-fix behaviour — feeding the
+    raw projected centroid (metres) straight into ``a5_lonlat_to_cell`` as if it
+    were lon/lat — and asserts none of the cells agree.
+    """
+    out = str(tmp_path / "aware.parquet")
+    add_a5_column(fields_5070_file, out, a5_resolution=12)
+    aware_cells = _column(out, "a5_cell")
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; INSTALL a5 FROM community; LOAD a5")
+    con.execute("SET geometry_always_xy = true")
+    blind_cells = [
+        r[0]
+        for r in con.execute(
+            f"""
+            SELECT a5_lonlat_to_cell(
+                ST_X(ST_Centroid(geometry)), ST_Y(ST_Centroid(geometry)), 12
+            )
+            FROM read_parquet('{fields_5070_file}')
+            """
+        ).fetchall()
+    ]
+    con.close()
+
+    assert _agreement(aware_cells, blind_cells) == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Grid keying — table (Python API) path
+# --------------------------------------------------------------------------- #
+
+_GRID_TABLE_CASES = [
+    ("a5", add_a5_table, "a5_cell", {"resolution": 12}),
+    ("h3", add_h3_table, "h3_cell", {"resolution": 9}),
+    ("s2", add_s2_table, "s2_cell", {"level": 15}),
+    ("quadkey", add_quadkey_table, "quadkey", {"resolution": 14, "use_centroid": True}),
+]
+
+
+def _projected_table(crs84_file: str, target: str = "EPSG:5070"):
+    """Build an in-memory table in ``target`` CRS with explicit geo metadata."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial")
+    con.execute("SET geometry_always_xy = true")
+    table = (
+        con.execute(
+            f"""
+        SELECT * EXCLUDE(geometry),
+               ST_AsWKB(ST_Transform(geometry, 'OGC:CRS84', '{target}')) AS geometry
+        FROM read_parquet('{crs84_file}')
+        """
+        )
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    geo_meta = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "crs": parse_crs_string_to_projjson(target)}},
+    }
+    return table.replace_schema_metadata({b"geo": json.dumps(geo_meta).encode("utf-8")})
+
+
+@pytest.mark.parametrize(("name", "fn", "col", "kwargs"), _GRID_TABLE_CASES)
+def test_grid_keying_table_reprojects(name, fn, col, kwargs, fields_geom_type_only_file):
+    """The table API detects a projected CRS in geo metadata and reprojects."""
+    table84 = pq.read_table(fields_geom_type_only_file)
+    table_proj = _projected_table(fields_geom_type_only_file)
+    assert extract_crs_from_table(table_proj, "geometry") is not None
+
+    cells84 = fn(table84, **kwargs).column(col).to_pylist()
+    cells_proj = fn(table_proj, **kwargs).column(col).to_pylist()
+
+    assert all(c is not None for c in cells_proj)
+    assert _agreement(cells84, cells_proj) >= 0.97
+
+
+def test_quadkey_no_longer_errors_on_projected_input(fields_5070_file, tmp_path):
+    """Quadkey used to raise on a projected CRS; it now reprojects instead."""
+    out = str(tmp_path / "qk.parquet")
+    add_quadkey_column(fields_5070_file, out, resolution=12)
+    cells = _column(out, "quadkey")
+    assert len(cells) == 100
+    assert all(isinstance(c, str) and len(c) == 12 for c in cells)
+
+
+# --------------------------------------------------------------------------- #
+# Class A — admin joins must reproject input to the admin (CRS84) before join
+# --------------------------------------------------------------------------- #
+
+
+class TestSpatialJoinConditionCrs:
+    """``build_spatial_join_condition`` honours a reprojected input geom."""
+
+    def test_default_uses_plain_column(self):
+        cond = build_spatial_join_condition("geom", "geometry", "bbox", "bbox")
+        assert "ST_Transform" not in cond
+        assert 'a."geom"' in cond
+        # bbox pre-filter present when both sides have bbox.
+        assert ".xmin" in cond
+
+    def test_reprojected_input_skips_bbox_prefilter(self):
+        transformed = "ST_Transform(a.\"geom\", 'EPSG:5070', 'OGC:CRS84')"
+        cond = build_spatial_join_condition(
+            "geom", "geometry", "bbox", "bbox", input_geom_sql=transformed
+        )
+        assert transformed in cond
+        # The source-CRS bbox cannot be compared cross-CRS, so it is dropped.
+        assert ".xmin" not in cond
+        assert cond.startswith("ST_Intersects(")
+
+
+@pytest.fixture
+def local_admin_dataset(tmp_path):
+    """A single-polygon CRS84 admin dataset covering the test fields' extent."""
+    admin = str(tmp_path / "admin.parquet")
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial")
+    con.execute(
+        f"""
+        COPY (
+            SELECT 'XX' AS country,
+                   ST_GeomFromText('POLYGON((16 45, 20 45, 20 49, 16 49, 16 45))') AS geometry
+        ) TO '{admin}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    # Add the bbox covering column + GeoParquet metadata the join expects.
+    add_bbox(admin, "bbox", False)
+    return admin
+
+
+def test_admin_divisions_reprojects_projected_input(
+    fields_5070_file, local_admin_dataset, tmp_path
+):
+    """``add admin-divisions`` joins a projected input against CRS84 boundaries.
+
+    Without reprojection DuckDB 1.5 raises a CRS-mismatch Binder error; with it
+    every feature falls inside the covering admin polygon.
+    """
+    out = str(tmp_path / "enriched.parquet")
+    add_admin_divisions_multi(
+        input_parquet=fields_5070_file,
+        output_parquet=out,
+        dataset_name="current",
+        levels=["country"],
+        dataset_source=local_admin_dataset,
+        verbose=False,
+    )
+    countries = _column(out, "current_country")
+    assert len(countries) == 100
+    assert all(c == "XX" for c in countries)

--- a/tests/test_crs_aware_operations.py
+++ b/tests/test_crs_aware_operations.py
@@ -16,6 +16,7 @@ fixtures, which are the same fields as the CRS84 fixture in a different CRS.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import duckdb
 import pyarrow.parquet as pq
@@ -280,3 +281,113 @@ def test_admin_divisions_reprojects_projected_input(
     countries = _column(out, "current_country")
     assert len(countries) == 100
     assert all(c == "XX" for c in countries)
+
+
+def test_partition_admin_reprojects_projected_input_single_source(
+    fields_5070_file, local_admin_dataset, tmp_path, monkeypatch
+):
+    """``partition admin`` joins a projected input against CRS84 boundaries.
+
+    Exercises the single-source enrichment path (``_perform_enrichment_join``):
+    without reprojecting the projected (EPSG:5070) input to the admin CRS the
+    join raises a CRS-mismatch error; with it every feature falls inside the
+    covering ``XX`` polygon and lands in a single partition.
+    """
+    from geoparquet_io.core.admin_datasets import CurrentAdminDataset
+    from geoparquet_io.core.partition.admin_hierarchical import (
+        partition_by_admin_hierarchical,
+    )
+
+    def fake_create(dataset_name, source_path=None, verbose=False):
+        return CurrentAdminDataset(source_path=local_admin_dataset, verbose=verbose)
+
+    monkeypatch.setattr(
+        "geoparquet_io.core.partition.admin_hierarchical.AdminDatasetFactory.create",
+        staticmethod(fake_create),
+    )
+
+    out_dir = str(tmp_path / "out_single")
+    count = partition_by_admin_hierarchical(
+        fields_5070_file,
+        out_dir,
+        dataset_name="current",
+        levels=["country"],
+        hive=True,
+    )
+
+    assert count == 1
+    files = list(Path(out_dir).rglob("*.parquet"))
+    assert len(files) == 1
+    assert "country=XX" in str(files[0])
+    assert pq.ParquetFile(str(files[0])).metadata.num_rows == 100
+
+
+def test_partition_admin_reprojects_projected_input_per_level(
+    fields_5070_file, tmp_path, monkeypatch
+):
+    """``partition admin`` reprojects a projected input on the per-level path.
+
+    Exercises the chained temp-table enrichment path
+    (``_perform_per_level_enrichment_join``) used by Overture-shaped datasets:
+    each level's join must see the input reprojected to the admin (CRS84) CRS.
+    The fields fixture lies within lon 16-20 / lat 45-49 (in CRS84), split here
+    into two regions; every feature must be attributed to the covering country
+    and one of the two regions.
+    """
+    import duckdb
+
+    from geoparquet_io.core.admin_datasets import OvertureAdminDataset
+    from geoparquet_io.core.partition.admin_hierarchical import (
+        partition_by_admin_hierarchical,
+    )
+
+    admin_file = str(tmp_path / "overture_admin.parquet")
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    con.execute(
+        f"""
+        COPY (
+            SELECT subtype, country, region, geometry,
+                {{'xmin': ST_XMin(geometry), 'xmax': ST_XMax(geometry),
+                  'ymin': ST_YMin(geometry), 'ymax': ST_YMax(geometry)}} AS bbox
+            FROM (VALUES
+                ('country', 'XX', NULL,
+                 ST_GeomFromText('POLYGON((16 45, 20 45, 20 49, 16 49, 16 45))')),
+                ('region', 'XX', 'XX-W',
+                 ST_GeomFromText('POLYGON((16 45, 18 45, 18 49, 16 49, 16 45))')),
+                ('region', 'XX', 'XX-E',
+                 ST_GeomFromText('POLYGON((18 45, 20 45, 20 49, 18 49, 18 45))'))
+            ) AS t(subtype, country, region, geometry)
+        ) TO '{admin_file}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+    def fake_create(dataset_name, source_path=None, verbose=False):
+        return OvertureAdminDataset(source_path=admin_file, verbose=verbose)
+
+    monkeypatch.setattr(
+        "geoparquet_io.core.partition.admin_hierarchical.AdminDatasetFactory.create",
+        staticmethod(fake_create),
+    )
+
+    out_dir = str(tmp_path / "out_per_level")
+    count = partition_by_admin_hierarchical(
+        fields_5070_file,
+        out_dir,
+        dataset_name="overture",
+        levels=["country", "region"],
+        hive=True,
+    )
+
+    files = list(Path(out_dir).rglob("*.parquet"))
+    assert files, "no partitions were created"
+    assert count == len(files)
+    # No row multiplication: per-level chaining emits one row per input feature.
+    assert sum(pq.ParquetFile(str(f)).metadata.num_rows for f in files) == 100
+    # Every feature attributed to the covering country and a known region.
+    assert all("country=XX" in str(f) for f in files)
+    assert {p.name for f in files for p in Path(f).parents if p.name.startswith("region=")} <= {
+        "region=XX-W",
+        "region=XX-E",
+    }


### PR DESCRIPTION
## Summary

Several spatial operations assumed the input GeoParquet was in OGC:CRS84
(lon/lat degrees) and did not reproject. On data in another CRS this produced
two failure modes (issue #525):

- **Class A — admin joins**: `ST_Intersects` between a projected input and the
  CRS84 admin boundaries raised a hard CRS-mismatch `Binder Error` in DuckDB 1.5.
- **Class B — grid keying**: projected metres were fed straight into
  `*_lonlat_to_cell`, which expects degrees, producing silently-wrong cells with
  no error.

This PR introduces a single shared "reproject geometry to the operation's
expected CRS" helper and applies it across every affected path.

## What changed

**Shared helper** (`core/crs_utils.py`):
- `crs_transform_sql_expr(geom_sql, source_crs, target_crs="OGC:CRS84")` — wraps a
  SQL geometry expression in `ST_Transform` only when the source CRS is known and
  differs from the target; a missing/default/CRS-less source is left untouched
  (and `ST_Intersects` accepts a CRS-less geom against a CRS-bearing one). Relies
  on the session-level `geometry_always_xy = true`.
- `resolve_crs_to_string` (moved here so `reproject.py` shares one implementation)
  and `extract_crs_from_table` (detect a projected CRS from an Arrow table's geo
  metadata for the Python-API paths).

**Grid keying — `add a5` / `h3` / `s2` / `quadkey`** (file, streaming, and table
paths): the centroid is reprojected to OGC:CRS84 before the `*_lonlat_to_cell`
call. `quadkey` previously *errored* on a projected CRS; it now reprojects
instead (the dead validation helpers were removed). The `partition a5/h3/s2/
quadkey` commands inherit the fix because they build on `add_*_column`.

**Admin joins — `add admin-divisions` and `partition admin`**: the input geometry
is reprojected to the admin (CRS84) CRS before `ST_Intersects`. When reprojecting,
the bbox pre-filter is skipped (the stored input bbox is in the source CRS and is
not comparable to the admin bbox) and the admin extent filter is computed from the
*reprojected* geometry. `build_spatial_join_condition` gained an optional
`input_geom_sql` override to drive this.

## Notes

- `process aggregate {a5,admin}` referenced in the issue does not exist on this
  branch, so it is not part of this change.
- Inputs without a declared CRS continue to be treated as OGC:CRS84 per the spec.

## Testing

New `tests/test_crs_aware_operations.py`:
- Unit tests for `crs_transform_sql_expr` and the `build_spatial_join_condition`
  reprojection/bbox-skip behaviour.
- Grid keying (file + table API, all four index types) on the projected EPSG:5070
  fixture matches keying the same data after reprojection to CRS84, and a
  load-bearing test shows the result differs from the pre-fix metres-as-degrees
  output.
- `quadkey` no longer raises on a projected input.
- End-to-end `add admin-divisions` on the projected fixture against a local CRS84
  admin polygon attributes all 100 features (previously a CRS-mismatch error).

Local gate (all green): `ruff format --check .`, `ruff check .`,
`mypy geoparquet_io`, and `pytest -m 'not slow and not network'`
(3021 passed, 8 skipped, 72.7% coverage).

Closes #525

---
*Automated by agent-farm.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spatial indexing and admin partitioning now handle projected coordinate systems correctly.
  * Grid cell and quadkey outputs are computed from lon/lat coordinates when needed, and inputs without CRS metadata are treated as CRS84.
  * Spatial joins and extent checks now work across CRS boundaries without requiring a manual reprojection step first.

* **Documentation**
  * Updated guidance to explain CRS-aware behavior for add and partition workflows.

* **Tests**
  * Added coverage for CRS-aware spatial indexing, joins, and partitioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->