### PR TITLE
partition string leaks internal __gpio_part alias column into output (compounds on re-partition)

### DIFF
--- a/tests/test_partition_quadkey.py
+++ b/tests/test_partition_quadkey.py
@@ -129,6 +129,11 @@ class TestPartitionByQuadkeyFunction:
         assert output_path.exists()
         parquet_files = list(output_path.glob("*.parquet"))
         assert len(parquet_files) > 0
+        # Regression #490: the shared finalize must not leak the internal
+        # __gpio_part alias into cell-id partition outputs.
+        for f in parquet_files:
+            names = pq.ParquetFile(f).schema_arrow.names
+            assert not any(n.startswith("__gpio_part") for n in names), names
 
     def test_partition_hive_style(self, places_file, output_folder):
         """Test Hive-style partitioning."""

--- a/tests/test_partition_single_pass.py
+++ b/tests/test_partition_single_pass.py
@@ -359,3 +359,69 @@ class TestOverwrite:
         for f, mtime in mtimes.items():
             assert os.path.exists(f)
             assert os.path.getmtime(f) == mtime  # untouched
+
+
+def _write_two_column(path, rows):
+    """Write a GeoParquet with two partitionable columns from ``rows`` of
+    (country, subdivision, x, y)."""
+    from geoparquet_io.core.common import write_parquet_with_metadata
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    con.execute("CREATE TABLE t (country VARCHAR, subdivision VARCHAR, geometry GEOMETRY)")
+    for country, subdivision, x, y in rows:
+        con.execute("INSERT INTO t VALUES (?, ?, ST_Point(?, ?))", [country, subdivision, x, y])
+    write_parquet_with_metadata(con, "SELECT * FROM t", path)
+    con.close()
+    return path
+
+
+class TestRepartitionNoLeak:
+    """Regression for #490: the internal ``__gpio_part`` alias must never leak
+    into output files, and re-partitioning a partition must not compound it
+    (``__gpio_part``, then ``__gpio_part_1``, …)."""
+
+    def test_repartition_of_partition_has_no_alias_column(self, temp_output_dir):
+        src = _write_two_column(
+            os.path.join(temp_output_dir, "src.parquet"),
+            [
+                ("US", "US-NY", 1, 1),
+                ("US", "US-NY", 2, 2),
+                ("US", "US-CA", 3, 3),
+                ("CA", "CA-ON", 4, 4),
+            ],
+        )
+
+        # Pass 1: partition by country.
+        out1 = os.path.join(temp_output_dir, "out1")
+        partition_by_column(
+            input_parquet=src,
+            output_folder=out1,
+            column_name="country",
+            keep_partition_column=True,
+            skip_analysis=True,
+        )
+        first_files = _rglob_parquet(out1)
+        for f in first_files:
+            names = pq.ParquetFile(f).schema_arrow.names
+            assert not any(n.startswith("__gpio_part") for n in names), names
+
+        # Pass 2: re-partition the US output (carried via SELECT *) by subdivision.
+        us_file = os.path.join(out1, "US.parquet")
+        assert us_file in first_files
+        out2 = os.path.join(temp_output_dir, "out2")
+        partition_by_column(
+            input_parquet=us_file,
+            output_folder=out2,
+            column_name="subdivision",
+            keep_partition_column=True,
+            skip_analysis=True,
+        )
+        second_files = _rglob_parquet(out2)
+        assert second_files
+        for f in second_files:
+            names = pq.ParquetFile(f).schema_arrow.names
+            # No alias from either pass: __gpio_part, __gpio_part_1, …
+            assert not any(n.startswith("__gpio_part") for n in names), names
+        # Rows reconcile across the re-partition (only the 3 US rows).
+        assert sum(_row_count(f) for f in second_files) == 3


### PR DESCRIPTION
## Summary

Fixes #490 — the internal `__gpio_part` partition-key alias leaking into
`gpio partition` output files, and compounding (`__gpio_part`, `__gpio_part_1`,
…) when an already-partitioned file is re-partitioned.

The code fix already landed on `main` as part of #480: the per-partition
finalize step in `core/partition/staging.py` re-reads each staging file with
`hive_partitioning=false`, so DuckDB no longer re-materializes the dropped
`__gpio_part` column from the `__gpio_part=<value>/` staging directory name.
The `_build_staging_select` helper also drops/excludes the alias via
`PARTITION_BY` and a collision-safe alias generator.

What was missing was a **regression test for the compounding re-partition
case** that the issue specifically calls out, plus coverage of the shared
finalize path through a cell-id partitioner. This PR adds those.

## Changes

- `tests/test_partition_single_pass.py`: new `TestRepartitionNoLeak` class.
  It partitions a two-column input by `country`, then re-partitions a resulting
  file by `subdivision`, and asserts no output column starts with `__gpio_part`
  on either pass (so neither `__gpio_part` nor `__gpio_part_1` leaks), and that
  rows reconcile across the re-partition.
- `tests/test_partition_quadkey.py`: added the same `__gpio_part` leak
  assertion to `test_partition_basic`, guarding the shared `finalize_partition_file`
  path used by all cell-id partitioners (a5/h3/s2/quadkey/kdtree).

## Testing

- `uv run ruff format --check .`, `uv run ruff check .`, `uv run mypy geoparquet_io` — all clean.
- `uv run pytest -m 'not slow and not network'` — 3049 passed, 8 skipped, coverage 73%.
- Verified the new tests are meaningful: temporarily flipping
  `hive_partitioning=false` → `true` in `core/partition/staging.py` makes both
  new assertions fail; reverting makes them pass.

Closes #490

---
*Automated by agent-farm.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where partitioned GeoParquet/Parquet outputs could expose internal placeholder alias columns in the schema (including suffixed variants).
  * Re-partitioning now preserves only expected data fields and avoids schema alias leakage.
* **Tests**
  * Added/extended regression tests to validate schema cleanliness across partitioning and re-partitioning scenarios, including row count reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->