### PR TITLE
perf(add): lean on DuckDB SPATIAL_JOIN for admin-divisions/country-codes; fix misleading native-geometry message; re-evaluate bbox pre-filter (supersedes #462)

### DIFF
--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -460,15 +460,24 @@ def _build_admin_where_clauses_list(
     return admin_where_clauses
 
 
-def _report_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col, verbose):
+def _report_join_strategy(
+    has_native_geometry, input_bbox_col, admin_bbox_col, verbose, input_geom_rewritten=False
+):
     """Print a status line describing which spatial-join strategy will run.
 
     Native-geometry inputs take the bare-ST_Intersects SPATIAL_JOIN fast path, so
     the old "No bbox columns available, using full geometry intersection..." line
     misreported them as a degraded fallback (issue #538). Only 1.x files that
     genuinely lack a bbox column get that warning now.
+
+    A reprojected (non-CRS84) input also gets a bare ST_Intersects — its stored
+    bbox is in the source CRS and is dropped from the predicate (#525) — so
+    ``input_geom_rewritten`` keeps the message from claiming a bbox pre-filter
+    that the emitted SQL does not contain.
     """
-    strategy = spatial_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col)
+    strategy = spatial_join_strategy(
+        has_native_geometry, input_bbox_col, admin_bbox_col, input_geom_rewritten
+    )
     if strategy == SPATIAL_JOIN_NATIVE:
         progress("Using native geometry with DuckDB SPATIAL_JOIN...")
     elif strategy == SPATIAL_JOIN_BBOX_PREFILTER:
@@ -535,7 +544,14 @@ def _build_query_components(
     )
 
     if not dry_run:
-        _report_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col, verbose)
+        input_geom_rewritten = _reprojected_input_geom_sql(input_geom_col, source_crs) is not None
+        _report_join_strategy(
+            has_native_geometry,
+            input_bbox_col,
+            admin_bbox_col,
+            verbose,
+            input_geom_rewritten=input_geom_rewritten,
+        )
 
     query = _build_spatial_join_query(
         input_url,
@@ -565,6 +581,7 @@ def _handle_dry_run_mode(
     compression,
     compression_level,
     has_native_geometry=False,
+    input_geom_rewritten=False,
 ):
     """Handle dry-run mode output."""
     if not dry_run:
@@ -581,7 +598,9 @@ def _handle_dry_run_mode(
     )
 
     info("-- Main spatial join query")
-    strategy = spatial_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col)
+    strategy = spatial_join_strategy(
+        has_native_geometry, input_bbox_col, admin_bbox_col, input_geom_rewritten
+    )
     if strategy == SPATIAL_JOIN_NATIVE:
         info("-- Using native geometry with DuckDB SPATIAL_JOIN")
     elif strategy == SPATIAL_JOIN_BBOX_PREFILTER:
@@ -871,6 +890,9 @@ def add_admin_divisions_multi(
                     compression,
                     compression_level,
                     has_native_geometry=has_native_geometry,
+                    input_geom_rewritten=(
+                        _reprojected_input_geom_sql(input_geom_col, source_crs) is not None
+                    ),
                 ):
                     return
 

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -544,7 +544,9 @@ def _build_query_components(
     )
 
     if not dry_run:
-        input_geom_rewritten = _reprojected_input_geom_sql(input_geom_col, source_crs) is not None
+        input_geom_rewritten = bool(source_crs) and not _admin_reprojected(
+            source_crs, admin_bbox_col
+        )
         _report_join_strategy(
             has_native_geometry,
             input_bbox_col,
@@ -891,7 +893,7 @@ def add_admin_divisions_multi(
                     compression_level,
                     has_native_geometry=has_native_geometry,
                     input_geom_rewritten=(
-                        _reprojected_input_geom_sql(input_geom_col, source_crs) is not None
+                        bool(source_crs) and not _admin_reprojected(source_crs, admin_bbox_col)
                     ),
                 ):
                     return

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -19,7 +19,13 @@ from geoparquet_io.core.crs_utils import (
     source_crs_string,
     transform_geom_sql,
 )
-from geoparquet_io.core.duckdb_utils import build_spatial_join_condition, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    SPATIAL_JOIN_BBOX_PREFILTER,
+    SPATIAL_JOIN_NATIVE,
+    build_spatial_join_condition,
+    quote_identifier,
+    spatial_join_strategy,
+)
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
@@ -454,6 +460,24 @@ def _build_admin_where_clauses_list(
     return admin_where_clauses
 
 
+def _report_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col, verbose):
+    """Print a status line describing which spatial-join strategy will run.
+
+    Native-geometry inputs take the bare-ST_Intersects SPATIAL_JOIN fast path, so
+    the old "No bbox columns available, using full geometry intersection..." line
+    misreported them as a degraded fallback (issue #538). Only 1.x files that
+    genuinely lack a bbox column get that warning now.
+    """
+    strategy = spatial_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col)
+    if strategy == SPATIAL_JOIN_NATIVE:
+        progress("Using native geometry with DuckDB SPATIAL_JOIN...")
+    elif strategy == SPATIAL_JOIN_BBOX_PREFILTER:
+        if verbose:
+            debug("Using bbox columns for initial filtering...")
+    else:
+        progress("No bbox columns available, using full geometry intersection...")
+
+
 def _build_query_components(
     con,
     dataset,
@@ -470,6 +494,7 @@ def _build_query_components(
     prefix=None,
     is_table_ref=False,
     source_crs=None,
+    has_native_geometry=False,
 ):
     """Build all query components."""
     # Use provided admin_source (may be cached local path or remote URL)
@@ -509,10 +534,8 @@ def _build_query_components(
         source_crs=source_crs,
     )
 
-    if input_bbox_col and admin_bbox_col and verbose and not dry_run:
-        debug("Using bbox columns for initial filtering...")
-    elif not (input_bbox_col and admin_bbox_col) and not dry_run:
-        progress("No bbox columns available, using full geometry intersection...")
+    if not dry_run:
+        _report_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col, verbose)
 
     query = _build_spatial_join_query(
         input_url,
@@ -541,6 +564,7 @@ def _handle_dry_run_mode(
     query,
     compression,
     compression_level,
+    has_native_geometry=False,
 ):
     """Handle dry-run mode output."""
     if not dry_run:
@@ -557,7 +581,10 @@ def _handle_dry_run_mode(
     )
 
     info("-- Main spatial join query")
-    if input_bbox_col and admin_bbox_col:
+    strategy = spatial_join_strategy(has_native_geometry, input_bbox_col, admin_bbox_col)
+    if strategy == SPATIAL_JOIN_NATIVE:
+        info("-- Using native geometry with DuckDB SPATIAL_JOIN")
+    elif strategy == SPATIAL_JOIN_BBOX_PREFILTER:
         info("-- Using bbox columns for optimized spatial join")
     else:
         info("-- Using full geometry intersection (no bbox optimization)")
@@ -602,6 +629,7 @@ def _execute_per_level_joins(
     no_cache,
     extra_kv=None,
     source_crs=None,
+    has_native_geometry=False,
 ):
     """Run separate spatial joins per admin level for per-level-source datasets.
 
@@ -633,6 +661,7 @@ def _execute_per_level_joins(
             prefix=prefix,
             is_table_ref=is_table_ref,
             source_crs=source_crs,
+            has_native_geometry=has_native_geometry,
         )
 
         if dry_run:
@@ -756,6 +785,10 @@ def add_admin_divisions_multi(
         if verbose:
             debug(f"Using geometry columns: {input_geom_col} (input), {admin_geom_col} (admin)")
 
+    # Native-geometry inputs take the bare-ST_Intersects SPATIAL_JOIN fast path
+    # (issue #538); _setup_dataset_and_columns flags them via status == "native".
+    has_native_geometry = input_bbox_info.get("status") == "native"
+
     # Create DuckDB connection with ambient S3 config from dataset
     from geoparquet_io.core.duckdb_utils import s3_config_scope
 
@@ -802,6 +835,7 @@ def add_admin_divisions_multi(
                     no_cache,
                     extra_kv=extra_kv,
                     source_crs=source_crs,
+                    has_native_geometry=has_native_geometry,
                 )
                 if dry_run:
                     return
@@ -821,6 +855,7 @@ def add_admin_divisions_multi(
                     dry_run,
                     prefix=effective_prefix,
                     source_crs=source_crs,
+                    has_native_geometry=has_native_geometry,
                 )
 
                 if _handle_dry_run_mode(
@@ -835,6 +870,7 @@ def add_admin_divisions_multi(
                     query,
                     compression,
                     compression_level,
+                    has_native_geometry=has_native_geometry,
                 ):
                     return
 

--- a/geoparquet_io/core/add/country_codes.py
+++ b/geoparquet_io/core/add/country_codes.py
@@ -9,7 +9,13 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.duckdb_utils import build_spatial_join_condition, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    SPATIAL_JOIN_BBOX_PREFILTER,
+    SPATIAL_JOIN_NATIVE,
+    build_spatial_join_condition,
+    quote_identifier,
+    spatial_join_strategy,
+)
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -335,12 +341,16 @@ def _print_dry_run_query(
     using_default,
     input_bbox_col,
     countries_bbox_col,
+    has_native_geometry=False,
 ):
     """Print the dry-run query output."""
     final_step = "3" if using_default else "1"
     info(f"-- Step {final_step}: Main spatial join query")
 
-    if input_bbox_col and countries_bbox_col:
+    strategy = spatial_join_strategy(has_native_geometry, input_bbox_col, countries_bbox_col)
+    if strategy == SPATIAL_JOIN_NATIVE:
+        info("-- Using native geometry with DuckDB SPATIAL_JOIN")
+    elif strategy == SPATIAL_JOIN_BBOX_PREFILTER:
         info("-- Using bbox columns for optimized spatial join")
     else:
         info("-- Using full geometry intersection (no bbox optimization)")
@@ -418,6 +428,8 @@ def _prepare_bbox_columns(
     For GeoParquet 2.0 / parquet-geo files with native geometry types,
     skip bbox pre-filtering entirely as native geometry row group statistics
     are faster than manual bbox filtering.
+
+    Returns ``(input_bbox_col, countries_bbox_col, has_native_geometry)``.
     """
     # Check if input file has native geometry (2.0 / parquet-geo)
     input_bbox_advice = get_bbox_advice(input_parquet, "spatial_filtering", verbose)
@@ -426,7 +438,7 @@ def _prepare_bbox_columns(
     if input_bbox_advice["skip_bbox_prefilter"]:
         if verbose:
             debug("Input has native geometry - skipping bbox pre-filter (native stats are faster)")
-        return None, None
+        return None, None, True
 
     # For 1.x files, use bbox optimization if available
     input_bbox_info = check_bbox_structure(input_parquet, verbose)
@@ -460,7 +472,7 @@ def _prepare_bbox_columns(
             )
             countries_bbox_col = countries_bbox_info["bbox_column_name"]
 
-    return input_bbox_col, countries_bbox_col
+    return input_bbox_col, countries_bbox_col, False
 
 
 def _setup_countries_source(
@@ -509,13 +521,24 @@ def _create_duckdb_connection(using_default):
     return con
 
 
-def _print_bbox_status(input_bbox_col, countries_bbox_col, verbose, dry_run):
-    """Print bbox optimization status message."""
+def _print_bbox_status(
+    input_bbox_col, countries_bbox_col, verbose, dry_run, has_native_geometry=False
+):
+    """Print a status line describing which spatial-join strategy will run.
+
+    Native-geometry inputs take the bare-ST_Intersects SPATIAL_JOIN fast path, so
+    the old "No bbox columns available..." line misreported them as a degraded
+    fallback (issue #538). Only 1.x files genuinely lacking a bbox get that warning.
+    """
     if dry_run:
         return
-    if input_bbox_col and countries_bbox_col and verbose:
-        debug("Using bbox columns for initial filtering...")
-    elif not (input_bbox_col and countries_bbox_col):
+    strategy = spatial_join_strategy(has_native_geometry, input_bbox_col, countries_bbox_col)
+    if strategy == SPATIAL_JOIN_NATIVE:
+        progress("Using native geometry with DuckDB SPATIAL_JOIN...")
+    elif strategy == SPATIAL_JOIN_BBOX_PREFILTER:
+        if verbose:
+            debug("Using bbox columns for initial filtering...")
+    else:
         progress("No bbox columns available, using full geometry intersection...")
 
 
@@ -546,7 +569,7 @@ def add_country_codes(
         )
 
     input_geom_col = find_primary_geometry_column(input_parquet, verbose)
-    input_bbox_col, countries_bbox_col = _prepare_bbox_columns(
+    input_bbox_col, countries_bbox_col, has_native_geometry = _prepare_bbox_columns(
         input_parquet, countries_parquet, using_default, add_bbox_flag, dry_run, verbose
     )
 
@@ -591,7 +614,7 @@ def add_country_codes(
     )
 
     select_clause = _build_select_clause(country_code_col, subdivision_code_col, using_default)
-    _print_bbox_status(input_bbox_col, countries_bbox_col, verbose, dry_run)
+    _print_bbox_status(input_bbox_col, countries_bbox_col, verbose, dry_run, has_native_geometry)
 
     query = _build_spatial_join_query(
         input_url,
@@ -612,6 +635,7 @@ def add_country_codes(
             using_default,
             input_bbox_col,
             countries_bbox_col,
+            has_native_geometry,
         )
         return
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -2314,7 +2314,9 @@ def get_bbox_advice(
     Get version-aware bbox optimization advice.
 
     Provides context-aware recommendations based on file type and operation:
-    - For GeoParquet 2.0/parquet-geo with spatial_filtering: No bbox needed (native stats work)
+    - For GeoParquet 2.0/parquet-geo with spatial_filtering: No bbox pre-filter
+      needed -- a bare ST_Intersects ON clause lets DuckDB's SPATIAL_JOIN operator
+      engage, which is dramatically faster than a bbox-overlap NL join (issue #538).
     - For GeoParquet 2.0/parquet-geo with bounds_calculation: bbox still recommended (faster)
     - For GeoParquet 1.x without bbox: Suggest adding bbox OR upgrading to 2.0
 
@@ -2330,9 +2332,12 @@ def get_bbox_advice(
         dict with:
             - needs_warning: bool - Whether to show a warning to the user
             - skip_bbox_prefilter: bool - Whether to skip bbox pre-filtering in queries.
-              Only True for spatial_filtering with native geometry (where Parquet stats
-              are used automatically). For bounds_calculation, always False since bbox
-              column provides pre-computed values that are faster than geometry stats.
+              Only True for spatial_filtering with native geometry. There a bare
+              ST_Intersects ON clause is recognized by DuckDB's SPATIAL_JOIN operator
+              and is much faster than ANDing a bbox-overlap test in front of it, which
+              defeats SPATIAL_JOIN and forces a BLOCKWISE_NL_JOIN (issue #538). For
+              bounds_calculation, always False since the bbox column provides
+              pre-computed values that are faster than geometry stats.
             - has_native_geometry: bool - Whether file uses native Parquet geometry types
             - message: str - User-facing message (if needs_warning)
             - suggestions: list[str] - Suggested actions for the user
@@ -2363,9 +2368,10 @@ def get_bbox_advice(
 
     if operation == "spatial_filtering":
         if has_native_geo:
-            # Native geometry stats are used automatically - no warning needed
+            # Native geometry -> bare ST_Intersects ON clause engages DuckDB's
+            # SPATIAL_JOIN operator (the fast path, issue #538) - no warning needed.
             if verbose:
-                debug("Using native Parquet geometry statistics for spatial filtering")
+                debug("Native geometry: bare ST_Intersects engages DuckDB SPATIAL_JOIN")
         elif not has_bbox:
             # 1.x without bbox - warn and suggest options
             result["needs_warning"] = True

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -129,6 +129,17 @@ def build_spatial_join_condition(
     run a full ST_Intersects against every admin geometry, which effectively
     hangs. See PR #460.
 
+    Trade-off (issue #538): a *bare* ``ST_Intersects(...)`` ON clause is the
+    only shape DuckDB's ``SPATIAL_JOIN`` operator recognizes; the moment any
+    bbox-overlap test is ANDed in front, the plan drops to a ``BLOCKWISE_NL_JOIN``
+    (O(n·m)). On the cases benchmarked in #538 the bare-intersects SPATIAL_JOIN
+    was ~27-73x faster. The pre-filter is therefore retained *only* for the
+    explicit-bbox (1.x) path where #460 proved SPATIAL_JOIN does not reliably
+    trigger; native-geometry inputs deliberately get the bare predicate (see
+    below) and must NOT have a bbox derived from their geometry and ANDed in --
+    that was #462's proposed direction and it pessimizes the very path it meant
+    to speed up.
+
     All identifiers are passed through :func:`quote_identifier`, so column names
     sourced from untrusted file metadata cannot break out of the predicate.
 
@@ -174,6 +185,40 @@ def build_spatial_join_condition(
         "    -- Precise check only runs on the bbox matches\n"
         f"    AND {intersects}"
     )
+
+
+# Strategy labels returned by spatial_join_strategy(), kept in sync with the
+# predicate decision in build_spatial_join_condition().
+SPATIAL_JOIN_NATIVE = "native"
+SPATIAL_JOIN_BBOX_PREFILTER = "bbox_prefilter"
+SPATIAL_JOIN_NO_BBOX = "no_bbox"
+
+
+def spatial_join_strategy(
+    has_native_geometry: bool,
+    input_bbox_col: str | None,
+    target_bbox_col: str | None,
+) -> str:
+    """Classify which spatial-join strategy :func:`build_spatial_join_condition` uses.
+
+    Lets callers print a status message that matches the predicate that actually
+    runs (issue #538), instead of misreporting the native-geometry fast path as a
+    degraded "no bbox" fallback.
+
+    Returns:
+        - ``SPATIAL_JOIN_NATIVE``: native-geometry input. The ON clause is a bare
+          ``ST_Intersects``, which DuckDB's ``SPATIAL_JOIN`` operator recognizes
+          and accelerates. This is the fast path, not a fallback.
+        - ``SPATIAL_JOIN_BBOX_PREFILTER``: 1.x input with a bbox covering on both
+          sides; the cheap bbox-overlap test is ANDed in front of ``ST_Intersects``.
+        - ``SPATIAL_JOIN_NO_BBOX``: 1.x input without a bbox column; no pre-filter
+          is possible and the precise check runs against every candidate.
+    """
+    if has_native_geometry:
+        return SPATIAL_JOIN_NATIVE
+    if input_bbox_col and target_bbox_col:
+        return SPATIAL_JOIN_BBOX_PREFILTER
+    return SPATIAL_JOIN_NO_BBOX
 
 
 def get_duckdb_connection(

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -198,6 +198,7 @@ def spatial_join_strategy(
     has_native_geometry: bool,
     input_bbox_col: str | None,
     target_bbox_col: str | None,
+    input_geom_rewritten: bool = False,
 ) -> str:
     """Classify which spatial-join strategy :func:`build_spatial_join_condition` uses.
 
@@ -205,17 +206,34 @@ def spatial_join_strategy(
     runs (issue #538), instead of misreporting the native-geometry fast path as a
     degraded "no bbox" fallback.
 
+    Args:
+        has_native_geometry: True when the input exposes a native geometry type
+            (GeoParquet 2.x / geo-typed Parquet) rather than a 1.x bbox covering.
+        input_bbox_col: Input-side bbox covering column, or ``None``.
+        target_bbox_col: Target-side bbox covering column, or ``None``.
+        input_geom_rewritten: True when the input geometry is rewritten in the ON
+            clause (e.g. an ``ST_Transform`` reprojecting a non-CRS84 input, issue
+            #525). :func:`build_spatial_join_condition` then drops the bbox
+            pre-filter because the stored (source-CRS) input bbox is incomparable
+            to the target bbox, so the emitted predicate is a bare ``ST_Intersects``
+            even though ``input_bbox_col`` is populated. The classifier must mirror
+            that or it misreports a reprojected 1.x-with-bbox input as a
+            bbox-prefilter join (issue #538).
+
     Returns:
         - ``SPATIAL_JOIN_NATIVE``: native-geometry input. The ON clause is a bare
           ``ST_Intersects``, which DuckDB's ``SPATIAL_JOIN`` operator recognizes
           and accelerates. This is the fast path, not a fallback.
         - ``SPATIAL_JOIN_BBOX_PREFILTER``: 1.x input with a bbox covering on both
           sides; the cheap bbox-overlap test is ANDed in front of ``ST_Intersects``.
-        - ``SPATIAL_JOIN_NO_BBOX``: 1.x input without a bbox column; no pre-filter
-          is possible and the precise check runs against every candidate.
+        - ``SPATIAL_JOIN_NO_BBOX``: no bbox pre-filter is applied — either a 1.x
+          input without a bbox column, or a reprojected input whose stored bbox is
+          incomparable. The precise check runs against every candidate.
     """
     if has_native_geometry:
         return SPATIAL_JOIN_NATIVE
+    if input_geom_rewritten:
+        return SPATIAL_JOIN_NO_BBOX
     if input_bbox_col and target_bbox_col:
         return SPATIAL_JOIN_BBOX_PREFILTER
     return SPATIAL_JOIN_NO_BBOX

--- a/tests/test_country_code.py
+++ b/tests/test_country_code.py
@@ -2,6 +2,7 @@
 Tests for find_country_code_column function.
 """
 
+import logging
 import os
 import tempfile
 
@@ -10,7 +11,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
-from geoparquet_io.core.add.country_codes import find_country_code_column
+from geoparquet_io.core.add.country_codes import add_country_codes, find_country_code_column
 
 
 class TestFindCountryCodeColumn:
@@ -185,3 +186,38 @@ class TestFindCountryCodeColumn:
         finally:
             if os.path.exists(tmp_name):
                 os.unlink(tmp_name)
+
+
+class TestCountryCodesDryRun:
+    """Dry-run status-message regression tests for add_country_codes.
+
+    The country_codes module is reached via benchmarks/legacy paths rather than a
+    CLI command, so the dry-run flow is exercised by calling the core function
+    directly with a local countries file (no network).
+    """
+
+    def test_dry_run_native_geometry_uses_spatial_join(self, fields_v2_file, caplog):
+        """Native-geometry input reports the SPATIAL_JOIN fast path, not a fallback.
+
+        Mirrors ``test_dry_run_with_native_geometry_input`` for admin-divisions
+        (#538): a GeoParquet 2.0 / geo-typed input nulls the bbox columns, so the
+        ON clause is a bare ST_Intersects that DuckDB's SPATIAL_JOIN operator
+        accelerates. The dry-run note must say so rather than the misleading
+        "no bbox optimization" fallback message.
+        """
+        with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+            add_country_codes(
+                input_parquet=fields_v2_file,
+                countries_parquet=fields_v2_file,
+                output_parquet="output.parquet",
+                add_bbox_flag=False,
+                dry_run=True,
+                verbose=False,
+            )
+
+        output = caplog.text
+        # Native geometry is the fast SPATIAL_JOIN path, and the ON clause is a
+        # bare ST_Intersects (no bbox pre-filter).
+        assert "Using native geometry with DuckDB SPATIAL_JOIN" in output
+        assert "no bbox optimization" not in output
+        assert "ON ST_Intersects" in output

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -165,3 +165,35 @@ class TestDryRunCommands:
         # fallback — the misleading "no bbox optimization" note must be gone.
         assert "Using native geometry with DuckDB SPATIAL_JOIN" in result.output
         assert "no bbox optimization" not in result.output
+
+    def test_dry_run_with_reprojected_bbox_input(self, austria_bbox_covering_file):
+        """Reprojected (non-CRS84) 1.x-with-bbox input must not claim a bbox prefilter.
+
+        Regression for #538/#525: a projected 1.x input has a stored bbox column,
+        but admin boundaries are CRS84 so the input geometry is wrapped in
+        ST_Transform (#525). build_spatial_join_condition then drops the source-CRS
+        bbox pre-filter and emits a bare ST_Intersects — so the status message must
+        report "no bbox optimization", not "Using bbox columns for optimized
+        spatial join", which would mismatch the predicate that actually runs.
+        """
+        runner = CliRunner()
+        result = runner.invoke(
+            add,
+            [
+                "admin-divisions",
+                austria_bbox_covering_file,
+                "output.parquet",
+                "--dry-run",
+                "--no-cache",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "DRY RUN MODE" in result.output
+        # Input is reprojected to CRS84, so the ON clause is a bare ST_Intersects
+        # wrapping the input geometry in ST_Transform — no bbox-overlap pre-filter.
+        assert "ON ST_Intersects" in result.output
+        assert "ST_Transform" in result.output
+        # The message must match the bare predicate, not claim a bbox prefilter.
+        assert "Using full geometry intersection (no bbox optimization)" in result.output
+        assert "Using bbox columns for optimized spatial join" not in result.output

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -161,3 +161,7 @@ class TestDryRunCommands:
         assert "Bbox columns: none (input)" in result.output
         # No bbox pre-filter in the JOIN ON clause (only ST_Intersects)
         assert "ON ST_Intersects" in result.output
+        # #538: native geometry is the fast SPATIAL_JOIN path, not a degraded
+        # fallback — the misleading "no bbox optimization" note must be gone.
+        assert "Using native geometry with DuckDB SPATIAL_JOIN" in result.output
+        assert "no bbox optimization" not in result.output

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -167,14 +167,21 @@ class TestDryRunCommands:
         assert "no bbox optimization" not in result.output
 
     def test_dry_run_with_reprojected_bbox_input(self, austria_bbox_covering_file):
-        """Reprojected (non-CRS84) 1.x-with-bbox input must not claim a bbox prefilter.
+        """Reprojected (non-CRS84) input + admin-with-bbox keeps the bbox pre-filter.
 
-        Regression for #538/#525: a projected 1.x input has a stored bbox column,
-        but admin boundaries are CRS84 so the input geometry is wrapped in
-        ST_Transform (#525). build_spatial_join_condition then drops the source-CRS
-        bbox pre-filter and emits a bare ST_Intersects — so the status message must
-        report "no bbox optimization", not "Using bbox columns for optimized
-        spatial join", which would mismatch the predicate that actually runs.
+        Regression for #538/#540: the input is EPSG:31287 and the admin dataset
+        (GAUL) has a bbox column, so admin_divisions reprojects the *admin* side into
+        the input CRS (ST_Transform on the admin geometry) and keeps the cheap
+        bbox-overlap pre-filter on both sides — the input geometry is left untouched
+        (#525). build_spatial_join_condition therefore emits the bbox pre-filter
+        ANDed in front of ST_Intersects, so the status line must report the bbox
+        optimization, not "no bbox optimization".
+
+        This guards against the f2 mismatch: keying the reported strategy on
+        ``source_crs`` alone (ignoring admin_bbox_col) would misreport this join as
+        SPATIAL_JOIN_NO_BBOX while the emitted SQL still runs the bbox pre-filter.
+        The reported strategy must mirror the ``input_geom_sql is not None`` decision
+        in _build_spatial_join_query, i.e. ``source_crs and not _admin_reprojected``.
         """
         runner = CliRunner()
         result = runner.invoke(
@@ -190,10 +197,11 @@ class TestDryRunCommands:
 
         assert result.exit_code == 0
         assert "DRY RUN MODE" in result.output
-        # Input is reprojected to CRS84, so the ON clause is a bare ST_Intersects
-        # wrapping the input geometry in ST_Transform — no bbox-overlap pre-filter.
-        assert "ON ST_Intersects" in result.output
+        # Admin side is reprojected into the input CRS (ST_Transform on the admin
+        # geometry); the input geometry is left as-is so the bbox pre-filter stays.
         assert "ST_Transform" in result.output
-        # The message must match the bare predicate, not claim a bbox prefilter.
-        assert "Using full geometry intersection (no bbox optimization)" in result.output
-        assert "Using bbox columns for optimized spatial join" not in result.output
+        # The bbox-overlap pre-filter must be present in the emitted predicate.
+        assert ".xmin <=" in result.output
+        # The message must match the predicate that actually runs (bbox pre-filter).
+        assert "Using bbox columns for optimized spatial join" in result.output
+        assert "no bbox optimization" not in result.output

--- a/tests/test_duckdb_utils.py
+++ b/tests/test_duckdb_utils.py
@@ -4,6 +4,9 @@ import duckdb
 import pytest
 
 from geoparquet_io.core.duckdb_utils import (
+    SPATIAL_JOIN_BBOX_PREFILTER,
+    SPATIAL_JOIN_NATIVE,
+    SPATIAL_JOIN_NO_BBOX,
     _add_bucket_needing_auth,
     _bucket_needs_auth,
     _clear_s3_cache,
@@ -14,6 +17,7 @@ from geoparquet_io.core.duckdb_utils import (
     load_community_extension,
     quote_identifier,
     s3_config_scope,
+    spatial_join_strategy,
 )
 from geoparquet_io.core.exceptions import ExtensionUnavailableError
 
@@ -127,6 +131,56 @@ class TestBuildSpatialJoinCondition:
         cond = build_spatial_join_condition("geo m", 'g"x', "b b", "q")
         assert '"geo m"' in cond
         assert '"g""x"' in cond  # embedded double-quote doubled
+
+    def test_no_derived_bbox_from_geometry(self):
+        """Regression guard for #538: the ON clause must never derive a bbox from
+        the geometry (ST_XMin/XMax/...) and AND it in front of ST_Intersects.
+
+        #462 proposed exactly that for native geometry; the #538 benchmark showed
+        it defeats DuckDB's SPATIAL_JOIN and forces a ~73x slower BLOCKWISE_NL_JOIN.
+        The builder must only ever use *stored* bbox covering columns as a
+        pre-filter, never compute one inline.
+        """
+        for cond in (
+            build_spatial_join_condition("geometry", "geom"),
+            build_spatial_join_condition("geometry", "geom", "bbox", "geom_bbox"),
+            build_spatial_join_condition(
+                "geometry",
+                "geom",
+                "bbox",
+                "geom_bbox",
+                input_geom_sql="ST_Transform(a.\"geometry\", 'EPSG:5070', 'OGC:CRS84')",
+            ),
+        ):
+            assert "ST_XMin" not in cond
+            assert "ST_XMax" not in cond
+            assert "ST_YMin" not in cond
+            assert "ST_YMax" not in cond
+
+
+class TestSpatialJoinStrategy:
+    """Tests for spatial_join_strategy() (issue #538).
+
+    The classifier keeps the user-facing status message in sync with the
+    predicate build_spatial_join_condition actually emits, so native-geometry
+    inputs are no longer misreported as a degraded "no bbox" fallback.
+    """
+
+    def test_native_geometry_is_fast_path(self):
+        """Native geometry -> bare ST_Intersects SPATIAL_JOIN, regardless of bbox cols."""
+        assert spatial_join_strategy(True, None, None) == SPATIAL_JOIN_NATIVE
+        # Native wins even if bbox columns happen to be present.
+        assert spatial_join_strategy(True, "bbox", "bbox") == SPATIAL_JOIN_NATIVE
+
+    def test_explicit_bbox_both_sides_uses_prefilter(self):
+        """1.x input with bbox on both sides -> bbox-overlap pre-filter."""
+        assert spatial_join_strategy(False, "bbox", "bbox") == SPATIAL_JOIN_BBOX_PREFILTER
+
+    def test_missing_bbox_is_no_bbox_fallback(self):
+        """1.x input lacking a bbox column (either side) -> genuine no-bbox fallback."""
+        assert spatial_join_strategy(False, None, None) == SPATIAL_JOIN_NO_BBOX
+        assert spatial_join_strategy(False, "bbox", None) == SPATIAL_JOIN_NO_BBOX
+        assert spatial_join_strategy(False, None, "bbox") == SPATIAL_JOIN_NO_BBOX
 
 
 class TestGetDuckdbConnection:


### PR DESCRIPTION
## Summary

Implements the **safe, verifiable** scope of #538 for `gpio add admin-divisions` and `gpio add country-codes`:

1. **Fix the misleading native-geometry message.** For GeoParquet 2.0 / 1.1-geoarrow inputs the command printed `No bbox columns available, using full geometry intersection...`, framing the **fast** path as a degraded fallback. On DuckDB 1.5.1 a bare `ST_Intersects(...)` ON clause is exactly what DuckDB's `SPATIAL_JOIN` operator recognizes and accelerates. Native-geometry inputs now report `Using native geometry with DuckDB SPATIAL_JOIN...`; the `No bbox columns available...` warning is shown **only** for 1.x files that genuinely lack a bbox column.

2. **Reject #462's proposed direction.** #462 wanted to derive `ST_XMin/XMax/...` from native geometry and AND it in front of `ST_Intersects`. The #538 benchmark shows this defeats `SPATIAL_JOIN` and forces a ~73× slower `BLOCKWISE_NL_JOIN`. `build_spatial_join_condition` now documents this trade-off, and a regression test asserts the ON clause never computes a bbox from the geometry (for bare, explicit-bbox, and reprojected inputs).

3. **Update `get_bbox_advice` assumptions.** The docstring/comments now describe the actual mechanism — the `SPATIAL_JOIN` operator engaging on a bare `ST_Intersects` — instead of the vague "Parquet stats used automatically".

## Implementation notes

- New helper `spatial_join_strategy(has_native_geometry, input_bbox_col, target_bbox_col)` in `core/duckdb_utils.py` classifies the join into `native` / `bbox_prefilter` / `no_bbox`, kept in sync with the predicate `build_spatial_join_condition` actually emits. Both commands use it so the status line and dry-run comment match the join that runs.
- The native-geometry signal (`input_bbox_info["status"] == "native"` in admin-divisions; the `skip_bbox_prefilter` advice in country-codes) is threaded down to the runtime and dry-run message sites.
- **The bbox pre-filter itself is intentionally NOT removed.** Issue #538 §3 makes that conditional on reproducing the #457/#460 Overture hang on real ≥1M-feature data with `EXPLAIN ANALYZE`, which cannot be performed in this offline environment. The #460 history (`SPATIAL_JOIN` not triggering for the real Overture shape → run never finished) means removing it blindly is a known regression risk, so the explicit-bbox (1.x) path is left unchanged. The retained-pre-filter rationale and the #462 trade-off are now documented in `build_spatial_join_condition`.

## Testing

- `uv run ruff format --check .` — clean
- `uv run ruff check .` — clean
- `uv run mypy geoparquet_io` — no issues
- `uv run pytest -m 'not slow and not network'` — green
- New/updated tests:
  - `TestBuildSpatialJoinCondition::test_no_derived_bbox_from_geometry` — guards against re-introducing #462's inline-derived bbox.
  - `TestSpatialJoinStrategy` — covers the native / bbox-prefilter / no-bbox classification.
  - `test_dry_run_with_native_geometry_input` — now asserts the accurate `Using native geometry with DuckDB SPATIAL_JOIN` note appears and the old `no bbox optimization` text is gone.

Closes #538

---
*Automated by agent-farm.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved spatial-join status and dry-run messaging to reflect the actual join strategy (native geometry vs bbox-based paths).

* **Bug Fixes**
  * Fixed misleading “no bbox optimization” output for native-geometry inputs.
  * Ensured strategy reporting aligns with the generated join predicate and avoids deriving bbox bounds from native geometry.

* **Documentation**
  * Clarified native-geometry fast-path behavior for GeoParquet 2.0 spatial filtering.

* **Tests**
  * Added regression tests for dry-run messaging and verified join predicate correctness for native, reprojected, and bbox-based scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->