### PR TITLE
pmtiles create / extract streaming crashes in geoarrow as_geoarrow push_batch on large GeoParquet

### DIFF
--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -21,10 +21,23 @@ import json
 import sys
 
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.ipc as ipc
 
 # Marker for stdin/stdout in CLI arguments
 STREAM_MARKER = "-"
+
+# Arrow's plain ``binary`` type uses 32-bit offsets, so the cumulative value
+# bytes of a single array must stay below INT32_MAX (2,147,483,647). geoarrow's
+# ``as_wkb`` re-encodes each Arrow chunk into a 32-bit ``binary`` array, so a
+# chunk whose total WKB exceeds this ceiling overflows
+# (``GeoArrowKernel<as_geoarrow>::push_batch() failed (75)``). DuckDB exports
+# Arrow in ~1M-row batches with ``arrow_large_buffer_size=true`` (64-bit
+# ``large_binary``), and 1M detailed polygons can easily blow past 2 GB. We
+# re-chunk oversized batches under this byte budget before conversion so the
+# 32-bit output stays valid while remaining maximally compatible downstream.
+# The margin below 2 GB leaves headroom for per-value offset bookkeeping.
+_MAX_WKB_CHUNK_BYTES = 1_500_000_000
 
 
 def is_stdin(path: str | None) -> bool:
@@ -322,6 +335,69 @@ def read_stdin_to_temp_file(verbose: bool = False) -> str:
     return temp_path
 
 
+def _wkb_chunk_data_nbytes(arr: pa.Array) -> int:
+    """Return the total value bytes (excluding offsets/validity) of a binary array."""
+    if len(arr) == 0:
+        return 0
+    total = pc.sum(pc.binary_length(arr)).as_py()
+    return int(total or 0)
+
+
+def _split_array_under_byte_limit(arr: pa.Array, max_bytes: int) -> list[pa.Array]:
+    """
+    Split a binary array into slices whose cumulative value bytes stay under a limit.
+
+    Bounds on bytes rather than rows because per-row WKB size varies wildly
+    (a point is ~21 bytes, a detailed field-boundary polygon can be kilobytes).
+    A single value larger than ``max_bytes`` is emitted in its own slice; the
+    caller surfaces a clear error if even that one row overflows the 32-bit
+    ceiling on conversion.
+    """
+    lengths = pc.binary_length(arr).to_pylist()
+    slices: list[pa.Array] = []
+    start = 0
+    running = 0
+    for i, length in enumerate(lengths):
+        length = length or 0  # null geometries contribute no value bytes
+        if i > start and running + length > max_bytes:
+            slices.append(arr.slice(start, i - start))
+            start = i
+            running = 0
+        running += length
+    slices.append(arr.slice(start, len(arr) - start))
+    return slices
+
+
+def _rebatch_wkb_under_byte_limit(
+    geom_col: pa.ChunkedArray | pa.Array,
+    max_bytes: int | None = None,
+) -> pa.ChunkedArray | pa.Array:
+    """
+    Re-chunk a (chunked) binary array so no chunk exceeds the 32-bit offset ceiling.
+
+    Returns the input unchanged when every chunk already fits the budget, so the
+    common (small-batch) case is a no-op. Oversized chunks are split on byte
+    boundaries (see :func:`_split_array_under_byte_limit`) before geoarrow
+    re-encodes them into 32-bit ``binary`` WKB (issue #511).
+    """
+    if max_bytes is None:
+        max_bytes = _MAX_WKB_CHUNK_BYTES
+
+    chunks = geom_col.chunks if isinstance(geom_col, pa.ChunkedArray) else [geom_col]
+    rebatched: list[pa.Array] = []
+    needs_split = False
+    for chunk in chunks:
+        if _wkb_chunk_data_nbytes(chunk) > max_bytes:
+            needs_split = True
+            rebatched.extend(_split_array_under_byte_limit(chunk, max_bytes))
+        else:
+            rebatched.append(chunk)
+
+    if not needs_split:
+        return geom_col
+    return pa.chunked_array(rebatched, type=geom_col.type)
+
+
 def apply_geoarrow_extension_type(
     table: pa.Table,
     geometry_column: str,
@@ -340,6 +416,12 @@ def apply_geoarrow_extension_type(
 
     Returns:
         Table with geometry column converted to geoarrow extension type
+
+    Raises:
+        StreamingError: If the geometry column is WKB but cannot be encoded
+            (e.g. a single geometry above the 2 GB Arrow offset ceiling, or
+            malformed WKB). Surfacing this loudly avoids the misleading
+            downstream "No data received on stdin" (issue #511).
     """
     import geoarrow.pyarrow as ga
 
@@ -348,6 +430,13 @@ def apply_geoarrow_extension_type(
 
     try:
         geom_col = table.column(geometry_column)
+
+        # Keep each Arrow chunk under the 32-bit binary offset ceiling before
+        # geoarrow re-encodes it. DuckDB exports geometry as 64-bit
+        # large_binary batches that can exceed 2 GB, but ga.as_wkb produces
+        # 32-bit binary — so an oversized batch overflows without this guard
+        # (issue #511).
+        geom_col = _rebatch_wkb_under_byte_limit(geom_col)
 
         # Convert to geoarrow WKB extension type
         wkb_arr = ga.as_wkb(geom_col)
@@ -367,8 +456,23 @@ def apply_geoarrow_extension_type(
         return table.set_column(col_index, geometry_column, wkb_arr)
 
     except (TypeError, ValueError, AttributeError):
-        # If conversion fails, return original table
+        # The column isn't convertible WKB (e.g. already-native nested
+        # geometry); pass it through unchanged rather than failing the stream.
         return table
+    except Exception as e:
+        # Any other failure — notably geoarrow's GeoArrowCException (a
+        # RuntimeError subclass) for malformed WKB or a single value above the
+        # 2 GB offset ceiling — must surface with its true cause. Returning the
+        # table here would silently emit un-converted geometry, and letting the
+        # raw exception escape gets masked downstream as the misleading "No
+        # data received on stdin" (issue #511).
+        raise StreamingError(
+            f"Failed to convert geometry column '{geometry_column}' to GeoArrow "
+            f"WKB for streaming: {e}\n\n"
+            "If a single geometry's WKB exceeds 2 GB it cannot be encoded into "
+            "Arrow's 32-bit binary layout; simplify very large geometries before "
+            "streaming."
+        ) from e
 
 
 def extract_crs_from_table(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -19,7 +19,11 @@ import pytest
 from geoparquet_io.core.streaming import (
     STREAM_MARKER,
     StreamingError,
+    _rebatch_wkb_under_byte_limit,
+    _split_array_under_byte_limit,
+    _wkb_chunk_data_nbytes,
     apply_geo_metadata,
+    apply_geoarrow_extension_type,
     apply_metadata_to_table,
     extract_geo_metadata,
     find_geometry_column_from_metadata,
@@ -643,3 +647,176 @@ class TestVersionExtraction:
         assert detect_version_for_output(None, table) is None
         assert detect_version_for_output({}, table) is None
         assert detect_version_for_output(None, None) is None
+
+
+def _wkb_polygon(npts: int) -> bytes:
+    """Build a little-endian WKB Polygon with one ring of ``npts`` vertices.
+
+    Each vertex is 16 bytes, so the WKB size scales ~linearly with ``npts`` —
+    used to manufacture large geometry payloads in tests (issue #511).
+    """
+    import struct
+
+    hdr = struct.pack("<BII", 1, 3, 1) + struct.pack("<I", npts)
+    coords = bytearray()
+    for i in range(npts - 1):
+        coords += struct.pack("<dd", (i % 1000) * 1e-4, (i % 997) * 1e-4)
+    coords += struct.pack("<dd", 0.0, 0.0)  # close the ring
+    return hdr + bytes(coords)
+
+
+class TestWkbByteRebatching:
+    """Tests for the 32-bit WKB offset-overflow guard (issue #511)."""
+
+    def test_data_nbytes_sums_value_lengths(self):
+        """_wkb_chunk_data_nbytes counts value bytes, not offset/validity bytes."""
+        blobs = [b"abc", b"de", b""]
+        arr = pa.array(blobs, type=pa.large_binary())
+        assert _wkb_chunk_data_nbytes(arr) == 5
+
+    def test_data_nbytes_empty_array(self):
+        """An empty array has zero value bytes."""
+        arr = pa.array([], type=pa.large_binary())
+        assert _wkb_chunk_data_nbytes(arr) == 0
+
+    def test_split_respects_byte_budget(self):
+        """Each emitted slice stays within the byte budget and rows are preserved."""
+        blobs = [b"x" * 1000 for _ in range(10)]
+        arr = pa.array(blobs, type=pa.large_binary())
+
+        slices = _split_array_under_byte_limit(arr, max_bytes=2500)
+
+        # 2500-byte budget fits two 1000-byte values per slice.
+        assert all(_wkb_chunk_data_nbytes(s) <= 2500 for s in slices)
+        assert sum(len(s) for s in slices) == 10
+        # Reassembling yields the original values in order.
+        rejoined = pa.concat_arrays(slices)
+        assert rejoined.to_pylist() == arr.to_pylist()
+
+    def test_split_oversized_single_value(self):
+        """A single value above the budget is emitted alone (no empty slices)."""
+        arr = pa.array([b"y" * 100, b"z" * 5000, b"y" * 100], type=pa.large_binary())
+
+        slices = _split_array_under_byte_limit(arr, max_bytes=1000)
+
+        assert all(len(s) > 0 for s in slices)
+        assert sum(len(s) for s in slices) == 3
+        # The oversized value lands in a slice on its own.
+        assert any(len(s) == 1 and _wkb_chunk_data_nbytes(s) == 5000 for s in slices)
+
+    def test_rebatch_noop_when_under_limit(self):
+        """Arrays already under the limit are returned unchanged (identity)."""
+        arr = pa.chunked_array([pa.array([b"abc", b"def"], type=pa.large_binary())])
+        result = _rebatch_wkb_under_byte_limit(arr, max_bytes=1_000_000)
+        assert result is arr
+
+    def test_rebatch_splits_oversized_chunk(self):
+        """Oversized chunks are split while preserving row order and values."""
+        blobs = [b"q" * 1000 for _ in range(10)]
+        arr = pa.chunked_array([pa.array(blobs, type=pa.large_binary())])
+
+        result = _rebatch_wkb_under_byte_limit(arr, max_bytes=2500)
+
+        assert isinstance(result, pa.ChunkedArray)
+        assert result.num_chunks > 1
+        assert all(_wkb_chunk_data_nbytes(c) <= 2500 for c in result.chunks)
+        assert result.combine_chunks().to_pylist() == arr.combine_chunks().to_pylist()
+
+
+class TestApplyGeoArrowExtensionType:
+    """Tests for apply_geoarrow_extension_type, including the #511 overflow fix."""
+
+    def _wkb_table(self, n: int = 6, npts: int = 64):
+        """Build a table whose geometry column is large_binary WKB polygons."""
+        blob = _wkb_polygon(npts)
+        return pa.table(
+            {
+                "id": list(range(n)),
+                "geometry": pa.array([blob] * n, type=pa.large_binary()),
+            }
+        )
+
+    def test_converts_to_geoarrow_wkb(self):
+        """A normal WKB column becomes a geoarrow.wkb extension type."""
+        table = self._wkb_table()
+        result = apply_geoarrow_extension_type(table, "geometry")
+
+        geom_type = result.column("geometry").type
+        assert getattr(geom_type, "extension_name", "") == "geoarrow.wkb"
+        assert result.num_rows == table.num_rows
+
+    def test_missing_column_returns_table_unchanged(self):
+        """Absent geometry column is a no-op."""
+        table = pa.table({"id": [1, 2]})
+        assert apply_geoarrow_extension_type(table, "geometry") is table
+
+    def test_rebatches_when_chunk_exceeds_limit(self, monkeypatch):
+        """A chunk above the byte budget is split before conversion and survives.
+
+        Drives the #511 overflow path with a tiny budget so it runs without the
+        ~2.2 GB of RAM the real-size reproduction requires.
+        """
+        import geoparquet_io.core.streaming as streaming
+
+        table = self._wkb_table(n=8, npts=64)
+        blob_size = len(_wkb_polygon(64))
+        # Budget that holds ~2 polygons per chunk, forcing multiple sub-chunks.
+        monkeypatch.setattr(streaming, "_MAX_WKB_CHUNK_BYTES", blob_size * 2)
+
+        result = apply_geoarrow_extension_type(table, "geometry")
+
+        geom = result.column("geometry")
+        assert getattr(geom.type, "extension_name", "") == "geoarrow.wkb"
+        # The single oversized chunk was split into several before conversion.
+        assert geom.num_chunks > 1
+        assert result.num_rows == table.num_rows
+        # WKB values survive the split + re-encode unchanged.
+        storage = pa.chunked_array([c.storage for c in geom.chunks])
+        assert storage.to_pylist() == table.column("geometry").to_pylist()
+
+    def test_preserves_crs(self):
+        """A provided CRS is attached to the resulting geoarrow type."""
+        table = self._wkb_table()
+        result = apply_geoarrow_extension_type(table, "geometry", crs="EPSG:4326")
+
+        geom_type = result.column("geometry").type
+        assert getattr(geom_type, "extension_name", "") == "geoarrow.wkb"
+        assert geom_type.crs is not None
+
+    def test_conversion_failure_raises_clear_error(self, monkeypatch):
+        """A geoarrow failure surfaces as StreamingError, not a silent passthrough.
+
+        Regression guard for the masked "No data received on stdin" bug: a
+        forced conversion failure must raise with the true cause rather than
+        returning un-converted geometry (issue #511).
+        """
+        import geoarrow.pyarrow as ga
+
+        def _boom(_arr):
+            # Mimic geoarrow's GeoArrowCException (a RuntimeError subclass).
+            raise RuntimeError("push_batch() failed (75)")
+
+        monkeypatch.setattr(ga, "as_wkb", _boom)
+
+        table = self._wkb_table()
+        with pytest.raises(StreamingError, match="GeoArrow"):
+            apply_geoarrow_extension_type(table, "geometry")
+
+    @pytest.mark.slow
+    def test_real_overflow_succeeds(self):
+        """End-to-end: a >2 GB large_binary WKB batch converts without overflow.
+
+        Reproduces issue #511 at real scale: ga.as_wkb alone raises
+        GeoArrowCException on this input, but apply_geoarrow_extension_type
+        re-chunks it first and succeeds. Needs ~2.2 GB RAM, hence ``slow``.
+        """
+        blob = _wkb_polygon(65536)  # ~1 MB each
+        int32_max = 2_147_483_647
+        n = int32_max // len(blob) + 50  # push the batch just over 2 GB
+        table = pa.table({"geometry": pa.array([blob] * n, type=pa.large_binary())})
+
+        result = apply_geoarrow_extension_type(table, "geometry")
+
+        geom = result.column("geometry")
+        assert getattr(geom.type, "extension_name", "") == "geoarrow.wkb"
+        assert result.num_rows == n


### PR DESCRIPTION
## Summary

`gpio pmtiles create` (and any streaming pipeline) crashed on large inputs such
as the FTW France field-boundary partition with a misleading
`StreamingError: No data received on stdin` and tippecanoe's "Did not read any
valid geometries". The real cause was an **int32 offset overflow** when
re-encoding WKB to a GeoArrow extension type.

`apply_geoarrow_extension_type` (`core/streaming.py`) called `ga.as_wkb()`,
which re-encodes each Arrow batch into a 32-bit `binary` array. The cumulative
value bytes of such an array must stay below `INT32_MAX` (2,147,483,647).
DuckDB's Arrow export — with gpio's `arrow_large_buffer_size=true` — emits
~1M-row `large_binary` (64-bit) batches, and 1M detailed polygons easily exceed
2 GB. The conversion then overflowed with
`GeoArrowKernel<as_geoarrow>::push_batch() failed (75)` (`EOVERFLOW`). Because
that exception (a `RuntimeError` subclass) wasn't in the function's narrow
`except (TypeError, ValueError, AttributeError)`, it killed the upstream
streaming process, and the downstream stage reported the misleading empty-stdin
error.

## What changed

- **Byte-aware re-batching before conversion** (`core/streaming.py`): an
  oversized Arrow chunk is split into sub-chunks whose cumulative WKB stays
  under a `~1.5 GB` budget (`_MAX_WKB_CHUNK_BYTES`), then converted. Bounding on
  bytes — not rows — is required because per-row WKB size varies wildly (a point
  is ~21 bytes; a detailed polygon can be kilobytes). The output stays plain
  32-bit `geoarrow.wkb`, so every downstream consumer (Arrow IPC hop → DuckDB
  registration → tippecanoe GeoJSONSeq path) is unaffected. The common
  small-batch case is a no-op and returns the input unchanged.
- **No more masked failures**: a genuine conversion failure (malformed WKB, or a
  single geometry above the 2 GB ceiling that cannot be split) now raises a
  clear `StreamingError` naming the geometry column and the true cause, instead
  of silently emitting un-converted geometry or surfacing downstream as "No data
  received on stdin". The benign passthrough for non-WKB columns
  (`TypeError`/`ValueError`/`AttributeError`) is preserved.

## Implementation notes

- New helpers: `_wkb_chunk_data_nbytes`, `_split_array_under_byte_limit`,
  `_rebatch_wkb_under_byte_limit`. No new third-party dependency — byte
  accounting uses `pyarrow.compute.binary_length` (no numpy).
- The CRS-application block and the rest of the streaming path are unchanged;
  storage remains 32-bit `binary`, which `pa.ExtensionArray.from_storage`
  already handles.

## Testing

- `uv run ruff format --check .`, `uv run ruff check .`,
  `uv run mypy geoparquet_io` — all clean.
- `uv run pytest -m "not slow and not network"` — 3059 passed, 8 skipped,
  coverage 73%.
- New unit tests in `tests/test_streaming.py`:
  - byte-aware split respects the budget, preserves row order, and handles a
    single oversized value;
  - `_rebatch_wkb_under_byte_limit` is a no-op under the limit and splits over
    it;
  - `apply_geoarrow_extension_type` converts, re-batches oversized chunks (tiny
    budget via monkeypatch — no large RAM needed), preserves CRS, and **raises
    `StreamingError` on a forced conversion failure** (regression guard for the
    masked "No data received on stdin").
  - `@pytest.mark.slow` end-to-end test reproducing issue #511 at real scale: a
    >2 GB `large_binary` WKB batch — which `ga.as_wkb` alone overflows on — now
    converts successfully (~2.2 GB RAM, verified locally: passes in ~21s).

Closes #511

---
*Automated by agent-farm.*