### PR TITLE
fix(geometry): summarize geo metadata in verbose output instead of full dump

### DIFF
--- a/geoparquet_io/core/geometry_detection.py
+++ b/geoparquet_io/core/geometry_detection.py
@@ -70,6 +70,40 @@ def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> 
     return None
 
 
+def _crs_short(crs) -> str:
+    """Short CRS label (e.g. 'EPSG:28992') for verbose output, avoiding full PROJJSON."""
+    if crs is None:
+        return "none"
+    if isinstance(crs, str):
+        return crs
+    if isinstance(crs, dict):
+        cid = crs.get("id")
+        if isinstance(cid, dict):
+            return f"{cid.get('authority', '?')}:{cid.get('code', '?')}"
+        return crs.get("name", "custom")
+    return "custom"
+
+
+def _summarize_geo_metadata(geo_meta) -> str:
+    """One-line geo-metadata summary for verbose output (no full CRS dump)."""
+    if not isinstance(geo_meta, dict):
+        return str(geo_meta)
+    columns = geo_meta.get("columns", {})
+    cols = (
+        "; ".join(
+            f"{name}(encoding={col.get('encoding', '?')}, crs={_crs_short(col.get('crs'))}, "
+            f"types={col.get('geometry_types', [])})"
+            for name, col in columns.items()
+        )
+        if isinstance(columns, dict)
+        else ""
+    )
+    return (
+        f"version={geo_meta.get('version', '?')}, "
+        f"primary_column={geo_meta.get('primary_column', '?')}, columns=[{cols}]"
+    )
+
+
 def find_primary_geometry_column(parquet_file: str, verbose: bool = False) -> str:
     """
     Find the primary geometry column from GeoParquet metadata.
@@ -86,8 +120,6 @@ def find_primary_geometry_column(parquet_file: str, verbose: bool = False) -> st
     Returns:
         str: Name of the primary geometry column (defaults to 'geometry')
     """
-    import json
-
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
     from geoparquet_io.core.file_utils import safe_file_url
 
@@ -95,7 +127,7 @@ def find_primary_geometry_column(parquet_file: str, verbose: bool = False) -> st
     geo_meta = get_geo_metadata(safe_url)
 
     if verbose and geo_meta:
-        debug(f"\nGeo metadata: {json.dumps(geo_meta, indent=2)}")
+        debug(f"Geo metadata: {_summarize_geo_metadata(geo_meta)}")
 
     if geo_meta:
         if isinstance(geo_meta, dict):

--- a/tests/test_geometry_detection.py
+++ b/tests/test_geometry_detection.py
@@ -9,7 +9,9 @@ import pytest
 
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
+    _crs_short,
     _detect_geometry_from_query,
+    _summarize_geo_metadata,
     detect_parquet_geometry_column,
     find_primary_geometry_column,
 )
@@ -329,3 +331,43 @@ class TestGeometryDetectionEdgeCases:
         result = find_primary_geometry_column(output_path)
         # Falls back to 'geometry' since no valid detection possible
         assert result == "geometry"
+
+
+class TestGeoMetadataSummary:
+    """Verbose geo-metadata output is a concise one-liner, not a full CRS dump."""
+
+    def test_summary_is_concise_single_line(self):
+        meta = {
+            "version": "1.1.0",
+            "primary_column": "geom",
+            "columns": {
+                "geom": {
+                    "encoding": "WKB",
+                    "crs": {
+                        "name": "Amersfoort / RD New",
+                        "id": {"authority": "EPSG", "code": 28992},
+                    },
+                    "geometry_types": ["Polygon"],
+                }
+            },
+        }
+        summary = _summarize_geo_metadata(meta)
+        assert "\n" not in summary
+        assert "version=1.1.0" in summary
+        assert "primary_column=geom" in summary
+        assert "encoding=WKB" in summary
+        assert "EPSG:28992" in summary
+        assert "Polygon" in summary
+        # The verbose CRS internals must not leak into the summary.
+        assert "projjson" not in summary.lower()
+        assert "ellipsoid" not in summary.lower()
+
+    def test_crs_short_handles_variants(self):
+        assert _crs_short(None) == "none"
+        assert _crs_short("OGC:CRS84") == "OGC:CRS84"
+        assert _crs_short({"id": {"authority": "EPSG", "code": 4326}}) == "EPSG:4326"
+        assert _crs_short({"name": "Custom CRS"}) == "Custom CRS"
+
+    def test_summary_handles_non_dict_metadata(self):
+        # Older/list-form metadata should not raise.
+        assert _summarize_geo_metadata([{"name": "geometry"}])


### PR DESCRIPTION
## Summary

`find_primary_geometry_column()` logged the **entire** geo metadata at verbose level via `json.dumps(geo_meta, indent=2)` — including the full CRS PROJJSON. On any `gpio partition … --auto --verbose` run this dumps ~150 lines of CRS definition (ellipsoid params, conversion parameters, etc.) before the actual probe output.

## What changed

- Replace the full-JSON dump with a concise one-line summary: version, primary column, and per-column `encoding` / CRS code / geometry types.
- Add `_crs_short()` to render a CRS as `EPSG:<code>` (or its name, or `none`) instead of full PROJJSON.
- Drop the now-unused `json` import.

Example, for a Netherlands RD New (EPSG:28992) file, verbose now prints:

```
Geo metadata: version=1.1.0, primary_column=geom, columns=[geom(encoding=WKB, crs=EPSG:28992, types=['Polygon'])]
```

instead of ~150 lines of PROJJSON.

## Testing

New `TestGeoMetadataSummary` covers the concise summary, CRS-shortening variants (none / string / EPSG id / name), and non-dict (list-form) metadata. Full `tests/test_geometry_detection.py`: 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verbose GeoParquet metadata logging to show a compact, single-line summary instead of a large indented dump.
  * Made metadata display more readable by shortening CRS details and handling older or unusual metadata formats more safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->