### PR TITLE
test(arcgis): shrink live #334 regression fetch to curb worker crashes

### DIFF
--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -2190,32 +2190,43 @@ class TestRealWorldSchemaMismatch:
         "FS_VCGI_OPENDATA_Cadastral_PTTR_point_WM_v1_view/FeatureServer/0"
     )
 
-    @pytest.fixture
-    def output_file(self, tmp_path):
-        """Create a temporary output file path."""
-        output = tmp_path / f"vt_property_{uuid.uuid4()}.parquet"
-        yield str(output)
-        safe_unlink(output)
-
-    def test_vermont_property_transfers_issue_334(self, output_file):
+    def test_vermont_property_transfers_issue_334(self):
         """Test extraction from VT property transfer dataset that triggered #334.
 
         This dataset has the TownGlValu field (esriFieldTypeDouble) which caused
         schema mismatches when some batches only had integer values.
-        """
-        import geoparquet_io as gpio
 
-        # Extract a subset to keep test fast but still exercise multiple batches
-        table = gpio.extract_arcgis(
+        The #334 regression lives in the per-page schema reconciliation inside
+        ``_stream_features_to_parquet``; what actually exercises it is crossing
+        *multiple batches* over that Double field, not the total row count. We
+        drive the core extractor with a small ``batch_size`` (3 pages of 50 =
+        150 rows) rather than pulling 5000 rows through the server's 2000-row
+        pages. That hits the identical code path with ~30x less live data,
+        keeping this live third-party fetch fast and far less prone to the
+        transient worker crashes that a large multi-page fetch under parallel
+        CI can trigger. (``batch_size`` isn't exposed on the public
+        ``extract_arcgis`` API, so we call the core ``arcgis_to_table``, which
+        the public API wraps and which owns the #334 fix.)
+        """
+        from geoparquet_io.core.arcgis import arcgis_to_table
+
+        # 3 small pages (50 each) still span the TownGlValu Double field across
+        # batches, which is exactly what triggered the schema mismatch in #334.
+        table = arcgis_to_table(
             self.VT_PROPERTY_SERVICE,
-            limit=5000,  # Multiple pages to trigger potential schema issues
+            limit=150,
+            batch_size=50,
         )
 
         assert table.num_rows > 0
         assert "geometry" in table.column_names
 
-        # Verify the schema is consistent (no schema mismatch error occurred)
-        # If we got here without error, the fix is working
+        # TownGlValu is the esriFieldTypeDouble field from #334; its presence
+        # confirms we actually crossed the batches that used to mismatch.
+        assert "TownGlValu" in table.column_names
+
+        # Verify the schema is consistent (no schema mismatch error occurred).
+        # If we got here without error, the fix is working.
         assert table.schema is not None
 
 


### PR DESCRIPTION
## Problem

The slow/network CI failed with:

\`\`\`
FAILED tests/test_arcgis.py::TestRealWorldSchemaMismatch::test_vermont_property_transfers_issue_334
  - worker 'gw1' crashed while running '...'
\`\`\`

This is a **worker process crash** (native death), not an assertion failure:

- The test's Python assertions never ran — the worker *process* died mid-test.
- No \`pytest-timeout\` is configured, so this is **not** a hang being killed; it's a genuine abnormal exit (native segfault / OOM-kill).
- Under \`pytest-xdist\`, a crashed worker marks the in-flight test failed and restarts the worker — it does **not** re-run the crashed test, and \`pytest-rerunfailures\` can't rescue a dead process. One crash ⇒ one red build.

## Root cause

\`test_vermont_property_transfers_issue_334\` is a \`@pytest.mark.network\` test that hits a **live third-party ArcGIS service** (Vermont state GIS) and pulls **5000 features** — 3 pages of up to 2000, 102 fields each. It's the heaviest live fetch in the whole slow/network suite, run under \`-n 4\` parallelism against a server we don't control.

Verified against the live service: it passes **4/4 in isolation**, ~320 MB peak RSS (runner has ~16 GB), and the HTTP body is JSON-parsed in Python before GDAL/DuckDB touch it (so a truncated response raises a catchable error, not a segfault). Concurrent DuckDB \`INSTALL\` races are already guarded. **Conclusion: external-service/native flakiness on the largest live fetch, not a code bug.**

## Fix

Issue #334 is about *schema mismatch across paginated batches* for the \`TownGlValu\` Double field — that needs **multiple batches**, not 5000 rows. Drive the core \`arcgis_to_table\` with \`batch_size=50, limit=150\` (3 pages of 50) so the identical per-page reconciliation path in \`_stream_features_to_parquet\` runs with **~30× less live data**.

- Runtime: large slice of the ~8-min suite → **~3.5s** locally.
- Coverage preserved: still crosses multiple batches over \`TownGlValu\` (now asserted present).
- \`batch_size\` isn't on the public \`extract_arcgis\` API, so the test calls the core \`arcgis_to_table\` that the public API wraps and that owns the #334 fix.
- Drops the unused \`output_file\` fixture the test never referenced.

## Why not xfail

\`xfail\` can't catch a worker crash (pytest never regains control to evaluate the marker), and the test normally passes — marking it \`xfail\` would just produce \`XPASS\` on every healthy run and hide real #334 regressions. True immunity to this flake class would be CI isolation (a non-gating "real-world live services" job), which is out of scope here.

## Testing

- \`test_vermont_property_transfers_issue_334\` passes against the live service in ~3.5s.
- Full non-network arcgis suite: 104 passed.
- \`ruff check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage for a Vermont property transfer data issue, helping ensure imports continue to handle schema changes reliably.
  * Updated the test scenario to use smaller batches, better reflecting how large datasets are processed and reducing the chance of hidden schema mismatches.
  * Added validation for an additional property field and stronger checks that the output schema remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->