### PR TITLE
feat(ci): harden CI and code-trust machinery — deterministic gates, green main, bots open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    # Wait before adopting fresh releases: compromised versions are usually
+    # yanked within days of publication (zizmor dependabot-cooldown).
+    cooldown:
+      default-days: 7
 
   # Python dependencies (uv lockfile-aware)
   - package-ecosystem: "uv"
@@ -19,6 +25,13 @@ updates:
       - "dependencies"
       - "python"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    # Wait before adopting fresh releases: compromised versions are usually
+    # yanked within days of publication (zizmor dependabot-cooldown).
+    cooldown:
+      default-days: 7
     # Group minor and patch updates together
     groups:
       development-dependencies:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 Write a clear, action-oriented title. This will be used for changelog and release notes.
 Examples: "Add `gpio publish stac` command for STAC generation" or "Fix H3 indexing for polar regions"
 
+<!-- New here? See the Contributing Guide: https://geoparquet.io/contributing/ -->
+
 ## Description
 <!-- Concise summary of what changed and why. This may be used in release notes. -->
 
@@ -17,6 +19,10 @@ Examples: "Add `gpio publish stac` command for STAC generation" or "Fix H3 index
 - #
 
 ## Checklist
-- [ ] Tests added/updated
+See ["What a finished PR looks like"](https://geoparquet.io/contributing/#what-a-finished-pr-looks-like) for details on each item.
+- [ ] Tests added/updated, run against real data where feasible
+- [ ] Integration tests for changes that cross module/format/service boundaries
 - [ ] All tests pass (`uv run pytest`)
+- [ ] At least one adversarial review (AI counts, rubber stamps don't)
+- [ ] CodeRabbit comments fixed or answered
 - [ ] Documentation updated (README, guides, CLI reference)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,28 +31,39 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   check-trigger:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
       - id: check
+        env:
+          # Pass attacker-controllable label name via env, not template expansion,
+          # to avoid shell injection.
+          EVENT_NAME: ${{ github.event_name }}
+          LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.label.name }}" == "benchmark" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$LABEL_NAME" == "benchmark" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
   benchmark:
     needs: check-trigger
     if: needs.check-trigger.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Only the benchmark job posts PR comments, so scope the write here rather
+    # than at the top level (least privilege).
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       # Use environment variables to safely pass user inputs to shell commands
       ITERATIONS: ${{ inputs.iterations || '3' }}
@@ -60,7 +71,9 @@ jobs:
       OPS: ${{ inputs.ops || 'full' }}
       COMPARE_VERSION: ${{ inputs.compare_version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Validate inputs
         run: |
@@ -85,7 +98,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -166,19 +179,19 @@ jobs:
 
           echo "$COMPARISON_OUTPUT"
 
-          # Check if there are significant regressions (naive check for demonstration)
-          # In production, you'd parse the JSON or use a more sophisticated check
+          # A detected regression is now a hard gate. The PR-comment step runs
+          # with `if: always()` so results still post even when this step fails.
           if echo "$COMPARISON_OUTPUT" | grep -E "\+[0-9]{2,}%|regression" > /dev/null; then
-            echo "⚠️  Regression detected - profiling would run here in production"
+            echo "::error::Performance regression detected (>=10% on at least one operation)"
             echo ""
-            echo "To enable profiling:"
+            echo "To diagnose, run profiling locally:"
             echo "  gpio benchmark suite --files <file> --profile --profile-dir ./profiles"
-            echo ""
-            echo "Note: Profiling integration available but not auto-enabled to minimize CI time"
+            exit 1
           fi
 
       - name: Upload results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: always()
         with:
           name: benchmark-results-${{ github.sha }}
           path: |
@@ -187,11 +200,19 @@ jobs:
           retention-days: 30
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        # Run even when the regression gate above fails, so benchmark numbers
+        # still get posted to the PR alongside the failure.
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
+            // With `always()`, this step can run even if benchmarks never produced
+            // results (e.g. an earlier hard failure). Bail out quietly in that case.
+            if (!fs.existsSync('results_current.json')) {
+              core.warning('results_current.json not found — skipping PR comment.');
+              return;
+            }
             const results = JSON.parse(fs.readFileSync('results_current.json', 'utf8'));
 
             let body = '## Benchmark Results\n\n';

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -152,23 +152,27 @@ jobs:
           git checkout ${{ github.sha }}
           uv sync --all-extras
 
-          echo "## Benchmark Comparison" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          uv run python scripts/version_benchmark.py \
-            --compare results_baseline.json results_current.json >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Benchmark Comparison"
+            echo ""
+            echo "\`\`\`"
+            uv run python scripts/version_benchmark.py \
+              --compare results_baseline.json results_current.json
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate summary (no comparison)
         if: inputs.compare_version == ''
         run: |
-          echo "## Benchmark Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Version: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
-          cat results_current.json >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Benchmark Results"
+            echo ""
+            echo "Version: ${{ github.sha }}"
+            echo ""
+            echo "\`\`\`json"
+            cat results_current.json
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check for regressions and run profiling
         if: inputs.compare_version != ''

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -185,8 +185,15 @@ jobs:
 
           # A detected regression is now a hard gate. The PR-comment step runs
           # with `if: always()` so results still post even when this step fails.
-          if echo "$COMPARISON_OUTPUT" | grep -E "\+[0-9]{2,}%|regression" > /dev/null; then
-            echo "::error::Performance regression detected (>=10% on at least one operation)"
+          # compare_results() prints per-operation deltas as "+{delta:.1f}% slower";
+          # extract the largest and fail when it reaches 10%.
+          MAX_REGRESSION=$(echo "$COMPARISON_OUTPUT" \
+            | grep -oE '\+[0-9]+\.[0-9]+% slower' \
+            | grep -oE '[0-9]+\.[0-9]+' \
+            | sort -rn | head -1)
+
+          if [ -n "$MAX_REGRESSION" ] && awk "BEGIN { exit !($MAX_REGRESSION >= 10) }"; then
+            echo "::error::Performance regression detected: ${MAX_REGRESSION}% slower (threshold: 10%)"
             echo ""
             echo "To diagnose, run profiling locally:"
             echo "  gpio benchmark suite --files <file> --profile --profile-dir ./profiles"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,41 @@
+# Auto-merge Dependabot PRs for patch and minor updates.
+#
+# This is safe because the branch protection rulesets require the full
+# check matrix (tests, security-audit, docs, etc.) to pass before
+# auto-merge fires. Auto-merge only queues the PR; GitHub still blocks
+# the merge until every required status check is green.
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    # PR author, not github.actor: the actor context is spoofable via
+    # re-runs; the PR author is not (zizmor bot-conditions).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+
+      # Majors are deliberately left for a human to review and merge.
+      - name: Approve and enable auto-merge for patch/minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        # The approve step is belt-and-suspenders for the review-required
+        # ruleset; auto-merge then waits for required status checks.
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -21,16 +19,19 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -42,7 +43,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./site
 
@@ -50,10 +51,14 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,16 +6,24 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   mutation:
     name: Mutation Testing
     runs-on: ubuntu-latest
-    timeout-minutes: 120  # Mutation testing can be slow
+    # Mutation now actually runs (it was silently a no-op under mutmut 2's CLI)
+    # and its wall-clock duration is unknown, so give it plenty of headroom.
+    # GitHub's hard cap is 360.
+    timeout-minutes: 300
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -25,52 +33,93 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      - name: Pre-install DuckDB extensions
+        shell: bash
+        run: |
+          # DuckDB extension downloads (extensions.duckdb.org) occasionally fail
+          # with a transient network error, which broke otherwise-green builds.
+          # The mutation test suite exercises spatial/httpfs/h3, so install them
+          # up front with retry/backoff before giving up.
+          install="import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial'); con.execute('INSTALL httpfs'); con.execute('INSTALL h3 FROM community')"
+          for attempt in 1 2 3 4 5; do
+            if uv run python -c "$install"; then
+              echo "DuckDB extensions installed (attempt $attempt)."
+              exit 0
+            fi
+            echo "Extension install failed (attempt $attempt). Retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
+          echo "Failed to install DuckDB extensions after 5 attempts." >&2
+          exit 1
+
       - name: Run mutation testing
         run: |
-          # Allow mutmut to exit non-zero (exit code 2 = surviving mutants)
-          # but fail on actual errors (exit code 1 = crash)
-          EXIT_CODE=0
-          uv run mutmut run --no-progress --CI || EXIT_CODE=$?
-          if [ "$EXIT_CODE" -eq 1 ]; then
-            echo "::error::mutmut crashed during execution"
+          # mutmut 3's `run` takes no --CI/--no-progress flags. Under mutmut 3 a
+          # nonzero exit means a REAL failure (surviving mutants no longer get a
+          # special exit code), so any nonzero exit is a hard failure here. Do NOT
+          # reintroduce exit-code-2 tolerance — that semantic died with mutmut 2
+          # and its silent no-op is exactly what this workflow now guards against.
+          if ! uv run mutmut run; then
+            echo "::error::mutmut run failed (nonzero exit) — mutation testing did not complete"
             exit 1
           fi
-          uv run mutmut results
 
       - name: Check kill rate
         run: |
-          # Extract stats from mutmut results
-          RESULTS=$(uv run mutmut results 2>&1)
+          # Per-mutant status lines: "    <mutant_name>: <status>".
+          # Count killed/survived directly; grep exits 1 on zero matches, so
+          # tolerate that with `|| true`.
+          RESULTS=$(uv run mutmut results --all true)
           echo "$RESULTS"
 
-          # Parse killed and survived counts using POSIX-compatible patterns
-          # mutmut 3.x outputs lines like "Killed: 42" or "Survived: 5"
-          KILLED=$(echo "$RESULTS" | sed -n 's/.*[Kk]illed[: ]*\([0-9]*\).*/\1/p' | head -1)
-          SURVIVED=$(echo "$RESULTS" | sed -n 's/.*[Ss]urvived[: ]*\([0-9]*\).*/\1/p' | head -1)
-
-          # Default to 0 if parsing fails
+          KILLED=$(echo "$RESULTS" | grep -c ': killed$' || true)
+          SURVIVED=$(echo "$RESULTS" | grep -c ': survived$' || true)
           KILLED=${KILLED:-0}
           SURVIVED=${SURVIVED:-0}
           TOTAL=$((KILLED + SURVIVED))
 
-          if [ "$TOTAL" -gt 0 ]; then
-            RATE=$((KILLED * 100 / TOTAL))
-            echo "Mutation kill rate: $RATE% ($KILLED/$TOTAL)"
+          # A zero total means no mutants were generated/parsed. This EXACT silent
+          # no-op shipped before (mutmut 2's `--CI` flag errored instantly, the
+          # old logic read that as "0 survivors, all good"), so treat it as a hard
+          # failure rather than a warning.
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "::error::No mutants were generated/parsed — mutation testing is silently broken"
+            exit 1
+          fi
 
-            # Fail if kill rate is below threshold (start with 50%, increase over time)
-            if [ "$RATE" -lt 50 ]; then
-              echo "::warning::Mutation kill rate below 50% threshold"
-              # Don't fail initially - just warn
-              # exit 1
-            fi
-          else
-            echo "::warning::No mutations generated or could not parse mutmut output"
+          RATE=$((KILLED * 100 / TOTAL))
+
+          # Floor comes from .mutation-baseline (first non-comment, non-blank line).
+          FLOOR=$(grep -vE '^\s*#' .mutation-baseline | grep -vE '^\s*$' | head -1)
+          if ! [[ "$FLOOR" =~ ^[0-9]+$ ]]; then
+            echo "::error::.mutation-baseline floor is not an integer: '$FLOOR'"
+            exit 1
+          fi
+
+          echo "Mutation kill rate: ${RATE}% (floor ${FLOOR}%)"
+          echo "Killed: $KILLED  Survived: $SURVIVED  Total: $TOTAL"
+
+          {
+            echo "## Mutation Testing"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Kill rate | ${RATE}% |"
+            echo "| Floor | ${FLOOR}% |"
+            echo "| Killed | $KILLED |"
+            echo "| Survived | $SURVIVED |"
+            echo "| Total | $TOTAL |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$RATE" -lt "$FLOOR" ]; then
+            echo "::error::Mutation kill rate ${RATE}% is below the ${FLOOR}% floor from .mutation-baseline"
+            exit 1
           fi
 
       - name: Upload mutation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: mutation-report
-          path: .mutmut-cache/
+          path: mutants/**/*.meta
           retention-days: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,8 +59,8 @@ jobs:
           # 1. [project].version (the package version - what we want)
           # 2. [tool.commitizen].version (kept in sync by cz bump)
           VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected version: $VERSION (tag: v$VERSION)"
 
       - name: Check release status
@@ -74,17 +74,17 @@ jobs:
           # Check if GitHub Release exists (the real indicator of a completed release)
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, nothing to do"
-            echo "release_exists=true" >> $GITHUB_OUTPUT
-            echo "tag_exists=true" >> $GITHUB_OUTPUT
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "release_exists=false" >> $GITHUB_OUTPUT
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
             # Check if tag exists (may need to skip tag creation but still publish)
             if git rev-parse "$TAG" >/dev/null 2>&1; then
               echo "Tag $TAG exists but no release - recovery mode"
-              echo "tag_exists=true" >> $GITHUB_OUTPUT
+              echo "tag_exists=true" >> "$GITHUB_OUTPUT"
             else
               echo "Tag $TAG does not exist, full release"
-              echo "tag_exists=false" >> $GITHUB_OUTPUT
+              echo "tag_exists=false" >> "$GITHUB_OUTPUT"
             fi
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,22 +19,32 @@ on:
     branches: [main]
   workflow_dispatch:  # Manual trigger for recovery scenarios
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Run if: push with bump commit OR manual trigger (workflow_dispatch)
     if: startsWith(github.event.head_commit.message, 'bump:') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write  # Required for creating tags and releases
       id-token: write  # Required for trusted PyPI publishing
     steps:
-      - uses: actions/checkout@v7
+      # Credentials must persist here: the "Create git tag" step pushes the
+      # release tag with the checkout token.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0  # Full history for tag creation
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          # No cache in the publish path: a poisoned cache must never be able
+          # to influence artifacts shipped to PyPI (zizmor cache-poisoning).
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.11
@@ -55,8 +65,11 @@ jobs:
 
       - name: Check release status
         id: release_check
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
 
           # Check if GitHub Release exists (the real indicator of a completed release)
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -74,16 +87,16 @@ jobs:
               echo "tag_exists=false" >> $GITHUB_OUTPUT
             fi
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create git tag
         if: steps.release_check.outputs.tag_exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
 
       - name: Build package
         if: steps.release_check.outputs.release_exists == 'false'
@@ -91,16 +104,18 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.release_check.outputs.release_exists == 'false'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           print-hash: true
 
       - name: Create GitHub Release
         if: steps.release_check.outputs.release_exists == 'false'
-        run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "${{ steps.version.outputs.tag }}" \
-            --notes "See [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details." \
-            dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "See [CHANGELOG](https://github.com/$REPO/blob/main/CHANGELOG.md) for details." \
+            dist/*

--- a/.github/workflows/release-benchmark.yml
+++ b/.github/workflows/release-benchmark.yml
@@ -20,17 +20,24 @@ on:
         required: true
         default: 'v0.9.0'
 
+permissions:
+  contents: read
+
 jobs:
   benchmark-comparison:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write  # "Update release notes" edits the GitHub release body
     env:
       # Use environment variables to safely pass user inputs to shell commands
       INPUT_CURRENT: ${{ inputs.current_version }}
       INPUT_BASELINE: ${{ inputs.baseline_version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0  # Need full history for tags
+          persist-credentials: false
 
       - name: Validate inputs
         if: github.event_name == 'workflow_dispatch'
@@ -46,18 +53,25 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
-          enable-cache: true
+          # No cache in release-triggered runs: this job edits release notes
+          # and stores 400-day baselines (zizmor cache-poisoning).
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.11
 
       - name: Determine versions
         id: versions
+        env:
+          # env indirection, not inline templating: a crafted tag name must
+          # never expand into shell code (zizmor template-injection).
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            CURRENT="${{ github.event.release.tag_name }}"
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            CURRENT="$RELEASE_TAG"
             # Get the previous tag (skip current tag, get next one)
             TAGS=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
             TAG_COUNT=$(echo "$TAGS" | wc -l)
@@ -100,6 +114,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ steps.versions.outputs.current }}
         run: |
           # Create directory for historical baselines
           mkdir -p baselines
@@ -111,7 +126,7 @@ jobs:
           BASELINE_COUNT=0
           for TAG in $TAGS; do
             # Skip current version
-            if [[ "$TAG" == "${{ steps.versions.outputs.current }}" ]]; then
+            if [[ "$TAG" == "$CURRENT_VERSION" ]]; then
               continue
             fi
 
@@ -333,7 +348,7 @@ jobs:
           fi
 
       - name: Upload results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: release-benchmark-${{ steps.versions.outputs.current }}
           path: |
@@ -344,12 +359,17 @@ jobs:
 
       - name: Update release notes
         if: github.event_name == 'release'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # env indirection, not inline templating into JS source
+          # (zizmor template-injection).
+          REGRESSIONS: ${{ steps.comparison.outputs.regressions }}
+          BASELINE_VERSION: ${{ steps.versions.outputs.baseline }}
         with:
           script: |
             const fs = require('fs');
             const comparison = fs.readFileSync('comparison.txt', 'utf8');
-            const regressions = '${{ steps.comparison.outputs.regressions }}';
+            const regressions = process.env.REGRESSIONS;
 
             let benchmarkSection = '\n\n---\n\n## Performance\n\n';
 
@@ -357,7 +377,7 @@ jobs:
             if (regressions !== 'none') {
               benchmarkSection += '⚠️ **Regressions detected:**\n```\n' + regressions + '\n```\n\n';
             } else {
-              benchmarkSection += '✅ No significant performance regressions compared to ${{ steps.versions.outputs.baseline }}\n\n';
+              benchmarkSection += `✅ No significant performance regressions compared to ${process.env.BASELINE_VERSION}\n\n`;
             }
 
             // Add trend analysis if available
@@ -408,10 +428,14 @@ jobs:
 
       - name: Warn on regressions
         if: steps.comparison.outputs.regressions != 'none'
+        env:
+          REGRESSIONS: ${{ steps.comparison.outputs.regressions }}
         run: |
-          echo "::warning::Performance regressions detected: ${{ steps.comparison.outputs.regressions }}"
+          echo "::warning::Performance regressions detected: $REGRESSIONS"
 
       - name: Warn on trend degradation
         if: steps.trends.outputs.warnings != '' && steps.trends.outputs.warnings != 'none'
+        env:
+          TREND_WARNINGS: ${{ steps.trends.outputs.warnings }}
         run: |
-          echo "::warning::Gradual performance degradation detected across releases: ${{ steps.trends.outputs.warnings }}"
+          echo "::warning::Gradual performance degradation detected across releases: $TREND_WARNINGS"

--- a/.github/workflows/release-benchmark.yml
+++ b/.github/workflows/release-benchmark.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 120
     permissions:
       contents: write  # "Update release notes" edits the GitHub release body
+      actions: read  # "Download previous baselines" reads the Actions artifacts API
     env:
       # Use environment variables to safely pass user inputs to shell commands
       INPUT_CURRENT: ${{ inputs.current_version }}
@@ -141,7 +142,7 @@ jobs:
               --jq ".artifacts[] | select(.name == \"$ARTIFACT_NAME\") | .id" > /tmp/artifact_id.txt || true
 
             if [ -s /tmp/artifact_id.txt ]; then
-              ARTIFACT_ID=$(cat /tmp/artifact_id.txt | head -1)
+              ARTIFACT_ID=$(head -1 /tmp/artifact_id.txt)
               echo "  Found artifact ID: $ARTIFACT_ID"
 
               # Download the artifact

--- a/.github/workflows/release-benchmark.yml
+++ b/.github/workflows/release-benchmark.yml
@@ -85,8 +85,8 @@ jobs:
             CURRENT="$INPUT_CURRENT"
             BASELINE="$INPUT_BASELINE"
           fi
-          echo "current=$CURRENT" >> $GITHUB_OUTPUT
-          echo "baseline=$BASELINE" >> $GITHUB_OUTPUT
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
           if [[ -n "$BASELINE" ]]; then
             echo "Comparing $CURRENT against $BASELINE"
           else
@@ -145,21 +145,21 @@ jobs:
               echo "  Found artifact ID: $ARTIFACT_ID"
 
               # Download the artifact
-              gh api repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip > /tmp/${TAG}.zip || {
+              gh api "repos/${{ github.repository }}/actions/artifacts/${ARTIFACT_ID}/zip" > "/tmp/${TAG}.zip" || {
                 echo "  Failed to download artifact"
                 continue
               }
 
               # Extract just the results JSON
-              unzip -q -o /tmp/${TAG}.zip -d /tmp/${TAG}/ || {
+              unzip -q -o "/tmp/${TAG}.zip" -d "/tmp/${TAG}/" || {
                 echo "  Failed to extract artifact"
                 continue
               }
 
               # Find the results file
-              RESULTS_FILE=$(find /tmp/${TAG}/ -name "results_*.json" | head -1)
+              RESULTS_FILE=$(find "/tmp/${TAG}/" -name "results_*.json" | head -1)
               if [ -n "$RESULTS_FILE" ]; then
-                cp "$RESULTS_FILE" baselines/results_${TAG}.json
+                cp "$RESULTS_FILE" "baselines/results_${TAG}.json"
                 echo "  ✓ Downloaded baseline for $TAG"
                 BASELINE_COUNT=$((BASELINE_COUNT + 1))
               else
@@ -175,7 +175,7 @@ jobs:
             fi
           done
 
-          echo "baseline_count=$BASELINE_COUNT" >> $GITHUB_OUTPUT
+          echo "baseline_count=$BASELINE_COUNT" >> "$GITHUB_OUTPUT"
           echo "Downloaded $BASELINE_COUNT historical baselines"
 
       - name: Run current benchmarks
@@ -250,30 +250,38 @@ jobs:
             echo "regressions<<EOF"
             cat regressions.txt
             echo "EOF"
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
           # Create summary
-          echo "## Release Benchmark Comparison" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Current:** $CURRENT_VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "**Baseline:** $BASELINE_VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Release Benchmark Comparison"
+            echo ""
+            echo "**Current:** $CURRENT_VERSION"
+            echo "**Baseline:** $BASELINE_VERSION"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$REGRESSIONS" != "none" ]]; then
-            echo "### ⚠️ Performance Regressions Detected" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "$REGRESSIONS" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "### ⚠️ Performance Regressions Detected"
+              echo ""
+              echo "$REGRESSIONS"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "### ✅ No Significant Regressions" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "### ✅ No Significant Regressions"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          echo "### Detailed Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          cat comparison.txt >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Detailed Results"
+            echo ""
+            echo "\`\`\`"
+            cat comparison.txt
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Analyze trends across releases
         id: trends
@@ -281,16 +289,19 @@ jobs:
         env:
           CURRENT_VERSION: ${{ steps.versions.outputs.current }}
         run: |
-          # Create ordered list of baseline files (oldest to newest)
-          BASELINE_FILES=$(ls -t baselines/results_*.json | tac | tr '\n' ' ')
-          echo "Baseline files: $BASELINE_FILES"
+          # Create ordered list of baseline files (oldest to newest by mtime)
+          mapfile -t BASELINE_FILES < <(
+            find baselines -name 'results_*.json' -printf '%T@ %p\n' \
+              | sort -n | cut -d' ' -f2-
+          )
+          echo "Baseline files: ${BASELINE_FILES[*]}"
 
           # Add current results to the end
-          BASELINE_FILES="$BASELINE_FILES results_current.json"
+          BASELINE_FILES+=(results_current.json)
 
           # Run trend analysis
           uv run python scripts/version_benchmark.py \
-            --trend $BASELINE_FILES \
+            --trend "${BASELINE_FILES[@]}" \
             -o trend_analysis.json
 
           # Extract warnings for GitHub Actions
@@ -310,19 +321,20 @@ jobs:
           "
 
           # Set output
-          TREND_WARNINGS=$(cat trend_warnings.txt)
           {
             echo "warnings<<EOF"
             cat trend_warnings.txt
             echo "EOF"
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Add trend analysis to summary
         if: steps.trends.outputs.warnings != '' && steps.trends.outputs.warnings != 'none'
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📊 Performance Trends" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo ""
+            echo "### 📊 Performance Trends"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ -f trend_analysis.json ]]; then
             # Extract and display trend statistics
@@ -344,7 +356,7 @@ jobs:
                 print('**⚠️ Gradual Degradation Detected:**')
                 for w in trends['warnings']:
                     print(f\"- {w['message']}\")
-            " >> $GITHUB_STEP_SUMMARY
+            " >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload results

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -25,7 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: write
+      # The automated-fix PR is opened with BOT_PR_TOKEN, not GITHUB_TOKEN, so
+      # GITHUB_TOKEN needs no write to contents here — only issue management.
+      contents: read
       pull-requests: write
       issues: write
     steps:
@@ -95,7 +97,16 @@ jobs:
             uv lock --upgrade-package "$p"
           done
 
+          # Guard the sync explicitly: under `set +e` a failed resolution would
+          # otherwise fall through to the diff/test checks and could mark a fix
+          # verified against a broken environment. Bail to the issue path instead.
           uv sync --all-extras
+          SYNC_EXIT=$?
+          if [ $SYNC_EXIT -ne 0 ]; then
+            echo "uv sync failed after upgrade — cannot verify fix."
+            echo "fix_works=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # If the lockfile did not change, no upstream fix is available yet —
           # fall through to the issue path rather than opening an empty PR.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -51,26 +51,31 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          IGNORE_ARGS=$(uv run python scripts/pip_audit_ignores.py)
           # Machine-readable JSON for extracting vulnerable package names.
-          uv run pip-audit -f json -o audit.json $(uv run python scripts/pip_audit_ignores.py)
+          # word-splitting intended: emits repeated --ignore-vuln flags
+          # shellcheck disable=SC2086
+          uv run pip-audit -f json -o audit.json $IGNORE_ARGS
           # Human-readable output for the PR/issue body. This drives the
           # vulnerabilities_found decision via its exit code.
-          uv run pip-audit $(uv run python scripts/pip_audit_ignores.py) > audit-results.txt 2>&1
+          # word-splitting intended: emits repeated --ignore-vuln flags
+          # shellcheck disable=SC2086
+          uv run pip-audit $IGNORE_ARGS > audit-results.txt 2>&1
           EXIT_CODE=$?
 
           if [ $EXIT_CODE -ne 0 ]; then
-            echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
-            echo "## Vulnerabilities Found" >> $GITHUB_STEP_SUMMARY
-            cat audit-results.txt >> $GITHUB_STEP_SUMMARY
+            echo "vulnerabilities_found=true" >> "$GITHUB_OUTPUT"
+            echo "## Vulnerabilities Found" >> "$GITHUB_STEP_SUMMARY"
+            cat audit-results.txt >> "$GITHUB_STEP_SUMMARY"
             # Expose the human-readable report as a multiline output for the PR body.
             {
               echo "audit_output<<GPIO_AUDIT_EOF"
               cat audit-results.txt
               echo "GPIO_AUDIT_EOF"
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
-            echo "## ✅ No vulnerabilities found" >> $GITHUB_STEP_SUMMARY
+            echo "vulnerabilities_found=false" >> "$GITHUB_OUTPUT"
+            echo "## ✅ No vulnerabilities found" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Attempt automated fix
@@ -96,7 +101,7 @@ jobs:
           # fall through to the issue path rather than opening an empty PR.
           if git diff --quiet uv.lock; then
             echo "uv.lock unchanged — no upstream fix available."
-            echo "fix_works=false" >> $GITHUB_OUTPUT
+            echo "fix_works=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -106,10 +111,10 @@ jobs:
 
           if [ $TEST_EXIT -eq 0 ]; then
             echo "Tests pass with upgraded dependencies."
-            echo "fix_works=true" >> $GITHUB_OUTPUT
+            echo "fix_works=true" >> "$GITHUB_OUTPUT"
           else
             echo "Tests failed with upgraded dependencies — not opening a PR."
-            echo "fix_works=false" >> $GITHUB_OUTPUT
+            echo "fix_works=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Open automated fix pull request

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,7 +1,16 @@
 name: Security Audit
 
-# Proactive security scanning - creates issues instead of blocking CI
-# This catches CVEs BEFORE they fail your regular CI
+# Proactive security scanning — PR-first, issue-as-fallback.
+#
+# Runs pip-audit daily against the locked dependency tree (honoring the
+# self-expiring ignore list in .pip-audit-ignores). When vulnerabilities are
+# found it does NOT just file an issue: it first tries to fix them
+# automatically by upgrading the vulnerable packages in uv.lock and running
+# the fast test suite. If the upgrade actually changes the lockfile and tests
+# still pass, it opens (or updates) a pull request with the fix so a human can
+# review and merge. Only when no upstream fix is available (the lockfile does
+# not change) or the upgraded tests fail does it fall back to opening a
+# tracking issue. This catches CVEs BEFORE they fail regular CI.
 
 on:
   schedule:
@@ -10,16 +19,24 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # No direct git push happens here (create-pull-request uses its own
+          # token input), so don't leave GITHUB_TOKEN credentials in .git/config.
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -34,21 +51,106 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          uv run pip-audit > audit-results.txt 2>&1
+          # Machine-readable JSON for extracting vulnerable package names.
+          uv run pip-audit -f json -o audit.json $(uv run python scripts/pip_audit_ignores.py)
+          # Human-readable output for the PR/issue body. This drives the
+          # vulnerabilities_found decision via its exit code.
+          uv run pip-audit $(uv run python scripts/pip_audit_ignores.py) > audit-results.txt 2>&1
           EXIT_CODE=$?
 
           if [ $EXIT_CODE -ne 0 ]; then
             echo "vulnerabilities_found=true" >> $GITHUB_OUTPUT
             echo "## Vulnerabilities Found" >> $GITHUB_STEP_SUMMARY
             cat audit-results.txt >> $GITHUB_STEP_SUMMARY
+            # Expose the human-readable report as a multiline output for the PR body.
+            {
+              echo "audit_output<<GPIO_AUDIT_EOF"
+              cat audit-results.txt
+              echo "GPIO_AUDIT_EOF"
+            } >> $GITHUB_OUTPUT
           else
             echo "vulnerabilities_found=false" >> $GITHUB_OUTPUT
             echo "## ✅ No vulnerabilities found" >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Create or update issue
+      - name: Attempt automated fix
+        id: fix
         if: steps.audit.outputs.vulnerabilities_found == 'true'
-        uses: actions/github-script@v9
+        run: |
+          set +e
+
+          # Extract the names of packages that actually have vulnerabilities.
+          PACKAGES=$(jq -r '.dependencies[] | select(.vulns | length > 0) | .name' audit.json | sort -u)
+          echo "Vulnerable packages:"
+          echo "$PACKAGES"
+
+          # Upgrade each vulnerable package to its latest compatible release.
+          for p in $PACKAGES; do
+            echo "Upgrading $p ..."
+            uv lock --upgrade-package "$p"
+          done
+
+          uv sync --all-extras
+
+          # If the lockfile did not change, no upstream fix is available yet —
+          # fall through to the issue path rather than opening an empty PR.
+          if git diff --quiet uv.lock; then
+            echo "uv.lock unchanged — no upstream fix available."
+            echo "fix_works=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Run the fast suite to confirm the upgrade didn't break anything.
+          uv run pytest -n 4 -m "not slow and not network" -q --tb=short --no-cov -p no:cacheprovider
+          TEST_EXIT=$?
+
+          if [ $TEST_EXIT -eq 0 ]; then
+            echo "Tests pass with upgraded dependencies."
+            echo "fix_works=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tests failed with upgraded dependencies — not opening a PR."
+            echo "fix_works=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Open automated fix pull request
+        if: steps.fix.outputs.fix_works == 'true'
+        # Use a dedicated bot token (not the default GITHUB_TOKEN): PRs opened
+        # with GITHUB_TOKEN never trigger further workflow runs, so CI would
+        # not run on the fix PR. BOT_PR_TOKEN lets the PR exercise CI normally.
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.9
+        with:
+          token: ${{ secrets.BOT_PR_TOKEN }}
+          branch: bot/security-dependency-upgrades
+          delete-branch: true
+          add-paths: uv.lock
+          commit-message: 'fix(deps): upgrade vulnerable dependencies (automated)'
+          title: 'fix(deps): upgrade vulnerable dependencies (automated)'
+          labels: |
+            security
+            automated
+            dependencies
+          body: |
+            ## Automated Security Fix
+
+            This pull request was opened automatically by the daily security
+            audit workflow. It upgrades the vulnerable dependencies detected by
+            `pip-audit` and has been verified against the fast test suite.
+
+            Please review the lockfile change and merge if CI passes.
+
+            ### Vulnerabilities Addressed
+
+            ```
+            ${{ steps.audit.outputs.audit_output }}
+            ```
+
+            ### Audit Details
+
+            - **Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Create or update issue
+        if: steps.audit.outputs.vulnerabilities_found == 'true' && steps.fix.outputs.fix_works != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -59,6 +161,8 @@ jobs:
               '## Automated Security Audit',
               '',
               'This issue was automatically created by the daily security audit workflow.',
+              'An automated fix was attempted but no upstream fix is available, or the',
+              'upgraded dependencies failed the test suite, so this needs manual attention.',
               '',
               '### Vulnerabilities Found',
               '',
@@ -70,7 +174,8 @@ jobs:
               '',
               '1. **Quick fix**: Run `uv lock --upgrade-package <package>` for the affected package',
               '2. **Full update**: Run `uv lock --upgrade && uv sync`',
-              '3. **If no fix available**: Add to ignore list in `.github/workflows/tests.yml`',
+              '3. **If no fix available**: Add the vulnerability to `.pip-audit-ignores`',
+              '   using the self-expiring format `VULN-ID EXPIRES(YYYY-MM-DD) REASON`',
               '',
               '### Audit Details',
               '',
@@ -112,7 +217,7 @@ jobs:
 
       - name: Close issue if no vulnerabilities
         if: steps.audit.outputs.vulnerabilities_found == 'false'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = '🔒 Security: Dependency vulnerabilities detected';

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,11 @@ jobs:
       - name: Dependency audit
         # Ignore list lives in .pip-audit-ignores (single source of truth,
         # shared with security-audit.yml). Entries auto-expire; see the file.
-        run: uv run pip-audit $(uv run python scripts/pip_audit_ignores.py)
+        run: |
+          IGNORE_ARGS=$(uv run python scripts/pip_audit_ignores.py)
+          # word-splitting intended: emits repeated --ignore-vuln flags
+          # shellcheck disable=SC2086
+          uv run pip-audit $IGNORE_ARGS
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,14 +15,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -32,49 +38,39 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Check code formatting
-        run: uv run ruff format --check .
+      # .pre-commit-config.yaml is the single source of truth for lint/quality
+      # rules. CI runs the exact same hooks contributors run locally, so a rule
+      # can never exist in only one place and drift (that gap previously let
+      # unhooked clones merge house-rule violations).
+      - name: Run pre-commit hooks (commit stage)
+        env:
+          # doc-sync mutates files (the --check step below covers it);
+          # sync-dependencies runs `uv sync` against the staged diff, which is
+          # meaningless in CI.
+          SKIP: doc-sync,sync-dependencies
+        run: uv run pre-commit run --all-files --show-diff-on-failure
 
-      - name: Run linter
-        run: uv run ruff check .
+      - name: Run pre-commit hooks (pre-push stage)
+        run: >-
+          uv run pre-commit run --all-files --hook-stage pre-push
+          --show-diff-on-failure
 
-      - name: Type check
-        run: uv run mypy geoparquet_io/
-
-      - name: Check architecture
-        run: uv run lint-imports
-
-      - name: Check CLAUDE.md sections are current
+      - name: Check generated doc sections are current
         run: uv run python scripts/doc_sync.py --check
-
-      - name: Check code complexity (informational)
-        run: uv run xenon --max-absolute=E --max-modules=D --max-average=C geoparquet_io tests
-        continue-on-error: true
-
-      - name: Check for dead code (informational)
-        run: uv run vulture
-        continue-on-error: true
-
-      - name: Check freshness markers (menard)
-        run: uv run menard audit --exit-code
-        continue-on-error: true
-
-      - name: Check spelling
-        run: uv run codespell
-
-      - name: Validate CLAUDE.md
-        run: uv run python scripts/validate_claude_md.py
 
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # On scheduled runs, don't fail the workflow for new CVEs - the security-audit
     # workflow handles those proactively. On PRs, we want to block vulnerable code.
     continue-on-error: ${{ github.event_name == 'schedule' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -88,17 +84,13 @@ jobs:
         run: uv run bandit -r geoparquet_io/ -c pyproject.toml
 
       - name: Dependency audit
-        # PYSEC-2026-196: pip 26.1.1 vulnerability. Fix in pip 26.1.2.
-        run: |
-          PIP_VERSION=$(uv run pip --version | awk '{print $2}')
-          if [[ "$PIP_VERSION" == "26.1.2"* ]] || [[ "$(printf '%s\n' "26.1.2" "$PIP_VERSION" | sort -V | head -n1)" == "26.1.2" ]]; then
-            uv run pip-audit
-          else
-            uv run pip-audit --ignore-vuln PYSEC-2026-196
-          fi
+        # Ignore list lives in .pip-audit-ignores (single source of truth,
+        # shared with security-audit.yml). Entries auto-expire; see the file.
+        run: uv run pip-audit $(uv run python scripts/pip_audit_ignores.py)
 
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -110,10 +102,14 @@ jobs:
           - os: windows-latest
             python-version: '3.10'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so diff-cover can diff against the PR base branch.
+          fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -165,20 +161,37 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
 
+      - name: Diff coverage gate (changed lines >= 90% covered)
+        if: >-
+          github.event_name == 'pull_request' &&
+          matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        # Coverage comes from the fast suite, so changed lines must be covered
+        # by fast tests specifically — intended pressure: new code ships with
+        # tests that run on every PR, not only in the post-merge slow suite.
+        run: |
+          git fetch origin "$BASE_REF"
+          uv run diff-cover coverage.xml \
+            --compare-branch "origin/$BASE_REF" --fail-under=90
+
   notebooks:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -196,6 +209,8 @@ jobs:
     # Slow tests run on merge to main, schedule, and manual dispatch. They do NOT
     # run on every PR (too slow), but can be opted in per-PR by adding the
     # "run-slow-tests" label, so risky changes can be verified before merge.
+    # Network-marked tests are deliberately excluded: they hit live third-party
+    # servers and live in the non-blocking network-tests job below.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
@@ -203,16 +218,19 @@ jobs:
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'run-slow-tests'))
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.11']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -261,7 +279,7 @@ jobs:
             brew install tippecanoe
           fi
 
-      - name: Run slow and network tests (parallel)
+      - name: Run slow tests (parallel)
         shell: bash
         run: |
           # Security tests (the live pip-audit) are owned by the dedicated
@@ -272,18 +290,166 @@ jobs:
 
           if [ "$RUNNER_OS" == "Windows" ]; then
             # Use loadfile distribution on Windows to reduce DuckDB extension conflicts
-            uv run pytest -n 4 --dist=loadfile -m "slow or network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0
+            uv run pytest -n 4 --dist=loadfile -m "slow and not network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            uv run pytest -n 3 -m "slow or network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0
+            uv run pytest -n 3 -m "slow and not network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0
           else
-            uv run pytest -n 4 -m "slow or network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0
+            uv run pytest -n 4 -m "slow and not network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0
           fi
 
       - name: Upload slow test coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           file: ./coverage.xml
           flags: slowtests
           name: codecov-slow
           fail_ci_if_error: false
+
+  network-tests:
+    # Live third-party services (ArcGIS, WFS, Carto, BigQuery, ...). A remote
+    # server's flakiness is not something a PR author can fix, so this job is
+    # non-blocking: the failing STEP is continue-on-error (workflow stays
+    # green) and failures open/update a single tracking issue instead —
+    # mirroring the security-audit.yml pattern. It is intentionally NOT in the
+    # required-checks list.
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install GDAL
+        run: sudo apt-get update && sudo apt-get install -y gdal-bin
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Pre-install DuckDB extensions
+        shell: bash
+        run: |
+          # DuckDB extension downloads (extensions.duckdb.org) occasionally fail
+          # with a transient network error, which broke otherwise-green builds.
+          # Retry with backoff before giving up.
+          install="import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial'); con.execute('INSTALL httpfs'); con.execute('INSTALL h3 FROM community')"
+          for attempt in 1 2 3 4 5; do
+            if uv run python -c "$install"; then
+              echo "DuckDB extensions installed (attempt $attempt)."
+              exit 0
+            fi
+            echo "Extension install failed (attempt $attempt). Retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
+          echo "Failed to install DuckDB extensions after 5 attempts." >&2
+          exit 1
+
+      - name: Install tippecanoe
+        run: sudo apt-get install -y tippecanoe
+
+      - name: Run network tests (serial, forked)
+        id: nettests
+        continue-on-error: true
+        run: |
+          # Serial (no xdist): a live-fetch segfault (see the Vermont ArcGIS
+          # test for #334) kills an xdist worker and poisons every sibling
+          # test's verdict. --forked confines a crash to the one test that
+          # crashed; --timeout caps a hung remote; --reruns absorbs transient
+          # network errors.
+          uv run pytest -p no:xdist --forked -m network \
+            --ignore=tests/test_security.py \
+            --timeout=180 --timeout-method=thread \
+            --reruns 2 --reruns-delay 10 \
+            -v --tb=short --no-cov
+
+      - name: Open or update tracking issue on failure
+        if: steps.nettests.outcome == 'failure'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = '🌐 Network tests failing against live services';
+            const body = [
+              '## Automated network-test report',
+              '',
+              'The non-blocking `network-tests` job failed. These tests hit',
+              'live third-party services, so this usually means a remote',
+              'endpoint changed, broke, or throttled us — but it can also be',
+              'a real regression in our extractors.',
+              '',
+              `- **Run**: [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+              `- **Date**: ${new Date().toISOString().split('T')[0]}`,
+              '',
+              '---',
+              '*Opened/updated automatically by the network-tests job; it will*',
+              '*be closed automatically when the suite passes again.*'
+            ].join('\n');
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'network-tests,automated',
+              per_page: 100
+            });
+            const existing = issues.data.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['network-tests', 'automated']
+              });
+            }
+
+      - name: Close tracking issue on success
+        if: steps.nettests.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = '🌐 Network tests failing against live services';
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'network-tests,automated',
+              per_page: 100
+            });
+            const existing = issues.data.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: '✅ Network tests passing again. Closing automatically.'
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ cython_debug/
 
 # Internal agentic dev planning artifacts
 docs/superpowers/
+
+# mutmut mutation-testing working tree
+mutants/

--- a/.mutation-baseline
+++ b/.mutation-baseline
@@ -1,0 +1,4 @@
+# Minimum mutation kill rate (%) enforced by nightly.yml.
+# Ratchet UP as test quality improves; lowering requires justification in the PR.
+# Rate = killed / (killed + survived) from `mutmut results --all true`.
+50

--- a/.pip-audit-ignores
+++ b/.pip-audit-ignores
@@ -1,0 +1,11 @@
+# pip-audit ignore list — single source of truth, consumed by the tests.yml
+# security job and the security-audit.yml workflow via:
+#     uv run pip-audit $(uv run python scripts/pip_audit_ignores.py)
+#
+# Format: VULN-ID  EXPIRES(YYYY-MM-DD)  REASON
+# Entries past their expiry are dropped automatically: if the vulnerability is
+# fixed upstream by then, the audit stays green; if not, it goes red and
+# demands a conscious decision (extend the date with a reason, or pin/replace
+# the dependency). Never leave an entry without an expiry rationale.
+
+PYSEC-2026-196  2026-08-15  pip 26.1.1 vulnerability; fixed in pip 26.1.2 — remove once uv-managed pip updates

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,21 @@ repos:
         additional_dependencies:
           - tomli
 
+  # Lint GitHub Actions workflow syntax/semantics
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  # Audit GitHub Actions workflows for security issues (unpinned actions,
+  # missing permissions, template injection, ...). Offline mode keeps it
+  # deterministic and token-free.
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor
+        args: [--no-online-audits]
+
   # -------------------------------------------------------------------------
   # Local hooks - commit stage (fast, <10s total)
   # -------------------------------------------------------------------------
@@ -187,18 +202,26 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      - id: mypy
+        name: mypy
+        description: Static type check (same gate as CI)
+        entry: uv run mypy geoparquet_io/
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
       - id: vulture
         name: vulture
-        description: Find unused code
-        entry: uv run vulture geoparquet_io/ --min-confidence 80
+        description: Find unused code (paths/confidence from [tool.vulture])
+        entry: uv run vulture
         language: system
         pass_filenames: false
         stages: [pre-push]
 
       - id: xenon
         name: xenon
-        description: Monitor code complexity
-        entry: uv run xenon --max-absolute=E --max-modules=D --max-average=C geoparquet_io/
+        description: Monitor code complexity (same scope as CI)
+        entry: uv run xenon --max-absolute=E --max-modules=D --max-average=C geoparquet_io tests
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,53 @@
 # Contributing
 
+Thanks for contributing! This guide explains how we work, what a finished
+pull request looks like, and how to get set up. The short version: send a
+PR, test it against real data, get it reviewed hard, and let CI do its job.
+
+## How we work
+
+**Prefer pull requests to issues.** If you can describe a problem clearly,
+you can usually also open a PR that fixes it. Open an issue instead only
+when the change genuinely needs discussion first (a design decision, a
+breaking change, a new dependency) or when you can't attempt the fix
+yourself.
+
+**Start from a reproducible example.** A failing test that demonstrates a
+bug is a better bug report than any amount of prose. If you hit a bug, try
+to capture it as a small test case first. From there, an AI coding
+assistant (Claude, Copilot, or similar) can often carry you the rest of the
+way to a working PR — we encourage that. AI-assisted PRs are welcome here;
+they're held to the same bar as any other PR, and the CI is built so we can
+trust them.
+
+**The CI is strict on purpose.** Every gate described below exists so that
+maintainers don't have to manually re-verify each change. Strict, automated
+checks are what make it safe for us to accept fast, autonomous
+contributions — including ones written largely by AI. The guardrails aren't
+there to slow you down; they're what let us say yes quickly.
+
+## What a finished PR looks like
+
+Before you ask for a merge, check that your PR clears this bar:
+
+- [ ] **Tests run against real data.** This project reads and writes real
+      GeoParquet files, so tests should too. Use actual (small) files
+      rather than mocks or toy fixtures wherever that's feasible.
+- [ ] **Integration tests for anything that crosses a boundary.** If your
+      change spans modules, file formats, or an external service, add a
+      test that exercises the whole path — unit tests alone aren't enough.
+- [ ] **At least one adversarial review.** Someone (or something) whose job
+      is to *break* the change: feed it wrong data, hit the edge cases,
+      probe the failure modes. An AI review counts, but it has to be
+      adversarial in intent, not a rubber stamp.
+- [ ] **All CI checks green.** The required checks are the contract. A red
+      check blocks the merge, by design — fix it rather than working around
+      it.
+- [ ] **CodeRabbit comments addressed.** Every automated review comment is
+      either fixed or answered with a reason. Silence isn't an answer.
+- [ ] **Docs updated** if you changed user-facing behavior (guides, CLI
+      reference, Python API docs).
+
 ## Prerequisites
 
 - Python 3.10+
@@ -74,9 +122,33 @@ Two ratchet/ignore files gate quality over time:
 - `.mutation-baseline` — minimum mutation kill rate enforced by the nightly
   mutation-testing run. Ratchet it up as test quality improves.
 
-Branch protection is code too: `scripts/apply_branch_protection.sh` declares
-the required status checks and review rules as GitHub rulesets (run once by an
-admin after changes).
+## How the CI is set up (and why)
+
+Merging to `main` requires these status checks to pass: `lint`, `security`,
+`notebooks`, and the `test` matrix (Ubuntu on Python 3.10–3.13, macOS and
+Windows on 3.11–3.13). That list lives in code —
+`scripts/apply_branch_protection.sh` declares the required checks and review
+rules as GitHub rulesets, and an admin re-runs it whenever the list changes.
+If your PR is blocked on a check, that's the system working as intended:
+fix the check.
+
+Two heavier gates exist but don't run on every PR, so they won't slow down
+day-to-day contributions:
+
+- **Benchmark regression** — label-triggered; fails if performance drops
+  10% or more against the baseline.
+- **Mutation testing** — nightly; enforces the kill-rate floor in
+  `.mutation-baseline`.
+
+The repository also maintains itself where it can:
+
+- The **daily security audit** opens an automated fix PR when a dependency
+  vulnerability has a clean upgrade path.
+- **Dependabot PRs auto-merge** once all required checks pass.
+
+Bot-opened PRs go through the exact same required checks as human ones.
+That's the deal across the board: nothing merges without the checks, and
+because of that, a lot can merge without a human bottleneck.
 
 ## Documentation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,24 @@ uv run pytest tests/test_yourfile.py -v               # Single file
 uv run pytest -m "not slow and not network"           # Fast tests only
 ```
 
-Coverage minimum: 67% (enforced in CI).
+CI runs three test tiers:
+
+- **Fast tests** (`not slow and not network`) — run on every PR across the full
+  OS/Python matrix and **block merging**.
+- **Slow tests** (`slow and not network`) — run after merge to main and nightly;
+  opt in on a PR by adding the `run-slow-tests` label.
+- **Network tests** (`network`) — hit live third-party services (ArcGIS, WFS,
+  Carto, ...). They are **non-blocking**: failures open/update a tracking issue
+  instead of failing CI, because a remote server's behavior is not something a
+  PR author can fix. They run serially with per-test timeouts, retries, and
+  process isolation (`--forked`).
+
+Coverage gates (both enforced in CI):
+
+- Global floor: 67% total coverage.
+- **Changed lines: 90%** — `diff-cover` checks that the lines your PR touches
+  are covered *by fast tests*. New code ships with tests that run on every PR,
+  not only in the post-merge slow suite.
 
 <!-- BEGIN GENERATED: test-markers -->
 ### Test Markers
@@ -36,11 +53,30 @@ Coverage minimum: 67% (enforced in CI).
 
 ## Code Quality
 
-All handled by pre-commit:
+`.pre-commit-config.yaml` is the **single source of truth** for every quality
+rule. CI runs the exact same hooks (`pre-commit run --all-files`, plus the
+pre-push stage), so a check can never pass locally and fail in CI for a
+different rule set — and skipping local hook install just moves the same
+failure to CI.
 
 ```bash
-uv run pre-commit run --all-files
+uv run pre-commit run --all-files                        # commit-stage hooks
+uv run pre-commit run --all-files --hook-stage pre-push  # deptry, vulture,
+                                                         # xenon, mypy,
+                                                         # import-linter, menard
 ```
+
+Two ratchet/ignore files gate quality over time:
+
+- `.pip-audit-ignores` — self-expiring CVE ignore list shared by the CI
+  security job and the daily security audit. Each entry needs an expiry date
+  and a reason; expired entries automatically re-fail CI.
+- `.mutation-baseline` — minimum mutation kill rate enforced by the nightly
+  mutation-testing run. Ratchet it up as test quality improves.
+
+Branch protection is code too: `scripts/apply_branch_protection.sh` declares
+the required status checks and review rules as GitHub rulesets (run once by an
+admin after changes).
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ dev = [
     "pytest>=9.0.3",  # CVE-2025-71176 fix
     "pytest-cov>=4.0.0",
     "pytest-xdist>=3.5.0",
+    "pytest-timeout>=2.3",  # per-test caps for live-network tests in CI
+    "pytest-rerunfailures>=14",  # retry transient network failures in CI
+    "pytest-forked>=1.6",  # isolate segfault-prone live-service tests
+    "diff-cover>=9.0",  # changed-lines coverage gate in CI
     "nbmake>=1.5.0",
     "ruff>=0.8.0",
     "pre-commit>=4.3.0",
@@ -243,8 +247,36 @@ ignore_errors = true
 
 [tool.mutmut]
 source_paths = ["geoparquet_io/"]
-runner = "python -m pytest -x -q --tb=no"
+# Fast tests only: slow/network tests are nondeterministic (live third-party
+# servers) and far too slow to run once per mutant. --no-cov drops the
+# coverage overhead and the global --cov-fail-under gate from addopts.
+# NOTE: mutmut 3 runs pytest in-process and IGNORES a `runner` setting;
+# extra args must go in pytest_add_cli_args.
+# The --ignore'd files are tooling meta-tests that spawn `uv run ...`
+# subprocesses against the project; from mutmut's mutants/ cwd that would
+# resolve/install the MUTATED package — meaningless for mutation score and
+# fatal to the run.
+pytest_add_cli_args = [
+    "--no-cov",
+    "--tb=no",
+    "-m", "not slow and not network",
+    "--ignore=tests/test_codespell.py",
+    "--ignore=tests/test_import_linter.py",
+    "--ignore=tests/test_security.py",
+    "--ignore=tests/test_validate_claude_md.py",
+]
 pytest_add_cli_args_test_selection = ["tests/"]
+# Everything the test suite reads relative to the repo root must also exist
+# inside mutmut's mutants/ tree (tests import scripts.*, and the meta-tests
+# validate ADRs, CLAUDE.md, workflows, and config files).
+also_copy = [
+    "scripts/",
+    "context/",
+    ".github/",
+    ".pre-commit-config.yaml",
+    ".pip-audit-ignores",
+    "CLAUDE.md",
+]
 
 [tool.bandit]
 exclude_dirs = ["tests", ".venv", "docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,10 @@ sort_by_size = true
 verbose = false
 
 [tool.codespell]
-skip = ".git,*.lock,*.parquet,*.json,tests/data/*,.venv,uv.lock"
+# site/ (mkdocs build) and mutants/ (mutmut working tree) are gitignored
+# build artifacts; scanning them made test_codespell_passes fail on any
+# machine that had built docs or run mutation testing locally.
+skip = ".git,*.lock,*.parquet,*.json,tests/data/*,.venv,uv.lock,site,mutants"
 ignore-words-list = "nd,ot,crs,inout,hel,bu"
 check-filenames = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,8 +368,9 @@ dev = [
 [tool.deptry]
 # DEP002: unused dependencies - skip because optional/benchmark extras aren't always used
 ignore = ["DEP002"]
-# Exclude virtual env, tests, and benchmarks from analysis
-exclude = [".venv", "tests", "geoparquet_io/benchmarks"]
+# Exclude virtual env, tests, benchmarks, plugin packages (own dependency
+# definitions), and mutmut's mutants/ working tree from analysis
+exclude = [".venv", "tests", "geoparquet_io/benchmarks", "plugins", "mutants"]
 # Known transitive dependencies that appear unused but are required
 per_rule_ignores = {DEP003 = ["tomli"]}
 

--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -42,6 +42,15 @@ set -euo pipefail
 #   and store it as the repository Actions secret named BOT_PR_TOKEN.
 #   (A fine-grained PAT is preferred over a classic PAT so the grant stays
 #   limited to geoparquet/geoparquet-io.)
+#
+#   NOTE: a fine-grained PAT must name the geoparquet ORG as its resource
+#   owner, which requires the org to have opted in to fine-grained PAT
+#   access (org owners: Settings -> Third-party Access -> Personal access
+#   tokens). If the org does not appear in your resource-owner dropdown,
+#   fall back to a classic PAT with the `repo` scope - it works with plain
+#   repo write access, at the cost of covering every repo your account can
+#   reach. Either way, store it with:
+#       gh secret set BOT_PR_TOKEN --repo geoparquet/geoparquet-io
 # =============================================================================
 
 REPO="geoparquet/geoparquet-io"
@@ -232,4 +241,5 @@ gh api "repos/${REPO}" --jq .allow_auto_merge
 
 echo ""
 echo ">> Done. Remember to create the BOT_PR_TOKEN repo secret (fine-grained"
-echo "   PAT, contents+PRs write, this repo only) for the security-audit bot."
+echo "   PAT, contents+PRs write, this repo only; or a classic PAT with the"
+echo "   'repo' scope if the org hasn't enabled fine-grained PAT access)."

--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# apply_branch_protection.sh
+#
+# WHAT THIS DOES
+#   Migrates geoparquet/geoparquet-io from legacy "classic" branch protection
+#   to GitHub repository rulesets, and enables repo-level auto-merge.
+#
+#   It is a one-shot admin task: run it ONCE after the CI-hardening PR merges.
+#
+#   Concretely it:
+#     1. Enables auto-merge on the repository.
+#     2. Deletes the classic branch-protection rule on `main` (if present).
+#     3. Creates (or updates) TWO branch rulesets targeting `main`:
+#          A. "main: PR + green checks" - forces PR + passing status checks
+#             for EVERYONE (no bypass actors, including admins).
+#          B. "main: review required"  - requires 1 approving review, but the
+#             repository-admin role can bypass it (so admin merges and
+#             auto-approved bot PRs don't get blocked on human review).
+#     4. Prints a verification summary.
+#
+# REQUIREMENTS
+#   - `gh` CLI authenticated as a user with ADMIN permission on the repo.
+#     (Ruleset + branch-protection + repo-settings writes all require admin.)
+#   - `jq` on PATH (used to build/validate the JSON payloads and parse output).
+#
+# SAFE TO RE-RUN
+#   Idempotent. Rulesets are matched by NAME via a GET, then updated with PUT
+#   if they already exist, or created with POST if they don't. Re-running
+#   converges the live config to what this script declares - it will not create
+#   duplicate rulesets. Enabling auto-merge and deleting classic protection are
+#   likewise no-ops on a second run.
+#
+# RELATED MANUAL STEP (NOT done by this script)
+#   The security-audit bot opens/updates PRs and needs a token that can bypass
+#   the rulesets' identity. Create a fine-grained Personal Access Token scoped
+#   to THIS repository only, with:
+#       - Contents:      Read and write
+#       - Pull requests: Read and write
+#   and store it as the repository Actions secret named BOT_PR_TOKEN.
+#   (A fine-grained PAT is preferred over a classic PAT so the grant stays
+#   limited to geoparquet/geoparquet-io.)
+# =============================================================================
+
+REPO="geoparquet/geoparquet-io"
+
+# -----------------------------------------------------------------------------
+# 1. Enable repository auto-merge.
+# -----------------------------------------------------------------------------
+echo ">> Enabling auto-merge on ${REPO} ..."
+gh api -X PATCH "repos/${REPO}" -F allow_auto_merge=true >/dev/null
+
+# -----------------------------------------------------------------------------
+# 2. Delete classic branch protection on main (tolerate 404 = already gone).
+# -----------------------------------------------------------------------------
+echo ">> Removing classic branch protection on main (if present) ..."
+if gh api "repos/${REPO}/branches/main/protection" >/dev/null 2>&1; then
+  gh api -X DELETE "repos/${REPO}/branches/main/protection" >/dev/null
+  echo "   classic protection deleted."
+else
+  echo "   no classic protection found (nothing to delete)."
+fi
+
+# -----------------------------------------------------------------------------
+# Helper: create-or-update a ruleset by name.
+#   $1 = ruleset name
+#   $2 = full ruleset JSON payload (must contain matching "name")
+# Looks the name up in the existing rulesets; PUTs to update if found,
+# POSTs to create otherwise. This name-keyed lookup is the idempotency
+# mechanism that makes the whole script safe to re-run.
+# -----------------------------------------------------------------------------
+apply_ruleset() {
+  local name="$1"
+  local payload="$2"
+  local existing_id
+
+  existing_id="$(
+    gh api "repos/${REPO}/rulesets" \
+      --jq ".[] | select(.name == \"${name}\") | .id" 2>/dev/null || true
+  )"
+
+  if [[ -n "${existing_id}" ]]; then
+    echo ">> Updating ruleset '${name}' (id ${existing_id}) ..."
+    printf '%s' "${payload}" \
+      | gh api -X PUT "repos/${REPO}/rulesets/${existing_id}" \
+          --input - >/dev/null
+  else
+    echo ">> Creating ruleset '${name}' ..."
+    printf '%s' "${payload}" \
+      | gh api -X POST "repos/${REPO}/rulesets" \
+          --input - >/dev/null
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# 3a. Ruleset A: "main: PR + green checks"
+#
+#     enforcement: active, NO bypass actors -> applies to EVERYONE, admins
+#     included. Requires a PR (0 approvals) and all 13 status checks green,
+#     and blocks force-pushes / deletion of main.
+#
+#     integration_id is intentionally omitted from each required check so a
+#     check with that name counts no matter which app/source reports it.
+#     strict_required_status_checks_policy=false: PR branch need not be
+#     up-to-date with main before merging.
+# -----------------------------------------------------------------------------
+RULESET_A_NAME="main: PR + green checks"
+RULESET_A_PAYLOAD="$(
+  jq -n --arg name "${RULESET_A_NAME}" '
+  {
+    name: $name,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [],
+    conditions: {
+      ref_name: {
+        include: ["~DEFAULT_BRANCH"],
+        exclude: []
+      }
+    },
+    rules: [
+      {
+        type: "pull_request",
+        parameters: {
+          required_approving_review_count: 0,
+          dismiss_stale_reviews_on_push: false,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_review_thread_resolution: false
+        }
+      },
+      {
+        type: "required_status_checks",
+        parameters: {
+          strict_required_status_checks_policy: false,
+          required_status_checks: [
+            {context: "lint"},
+            {context: "security"},
+            {context: "notebooks"},
+            {context: "test (ubuntu-latest, 3.10)"},
+            {context: "test (ubuntu-latest, 3.11)"},
+            {context: "test (ubuntu-latest, 3.12)"},
+            {context: "test (ubuntu-latest, 3.13)"},
+            {context: "test (macos-latest, 3.11)"},
+            {context: "test (macos-latest, 3.12)"},
+            {context: "test (macos-latest, 3.13)"},
+            {context: "test (windows-latest, 3.11)"},
+            {context: "test (windows-latest, 3.12)"},
+            {context: "test (windows-latest, 3.13)"}
+          ]
+        }
+      },
+      { type: "non_fast_forward" },
+      { type: "deletion" }
+    ]
+  }'
+)"
+
+# -----------------------------------------------------------------------------
+# 3b. Ruleset B: "main: review required"
+#
+#     enforcement: active, with a bypass actor for the repository-admin role
+#     (actor_id 5 = the built-in "admin" RepositoryRole, bypass_mode always).
+#     Requires 1 approving review from everyone EXCEPT admins.
+# -----------------------------------------------------------------------------
+RULESET_B_NAME="main: review required"
+RULESET_B_PAYLOAD="$(
+  jq -n --arg name "${RULESET_B_NAME}" '
+  {
+    name: $name,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [
+      {
+        actor_id: 5,
+        actor_type: "RepositoryRole",
+        bypass_mode: "always"
+      }
+    ],
+    conditions: {
+      ref_name: {
+        include: ["~DEFAULT_BRANCH"],
+        exclude: []
+      }
+    },
+    rules: [
+      {
+        type: "pull_request",
+        parameters: {
+          required_approving_review_count: 1,
+          dismiss_stale_reviews_on_push: false,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_review_thread_resolution: false
+        }
+      }
+    ]
+  }'
+)"
+
+# -----------------------------------------------------------------------------
+# NET EFFECT of A + B together
+#   * Ruleset A has NO bypass, so absolutely everyone - contributors AND
+#     admins - must open a PR and get all 13 checks green before merging to
+#     main. Nobody can push straight to main or force-push/delete it.
+#   * Ruleset B additionally demands 1 approving review, but the admin role
+#     bypasses B. So:
+#       - regular collaborators: PR + green checks + 1 approval;
+#       - repo admins and the auto-approved security-audit bot PRs (merged by
+#         an admin / with the admin-bypass token): PR + green checks, no
+#         second human approval required.
+#   Because rulesets are additive, the strictest applicable rule wins for each
+#   actor - exactly the layered policy we want.
+# -----------------------------------------------------------------------------
+
+apply_ruleset "${RULESET_A_NAME}" "${RULESET_A_PAYLOAD}"
+apply_ruleset "${RULESET_B_NAME}" "${RULESET_B_PAYLOAD}"
+
+# -----------------------------------------------------------------------------
+# 4. Verification.
+# -----------------------------------------------------------------------------
+echo ""
+echo ">> Rulesets now on ${REPO}:"
+gh api "repos/${REPO}/rulesets" \
+  --jq '.[] | "   id=\(.id)  name=\(.name)  enforcement=\(.enforcement)"'
+
+echo ""
+echo -n ">> allow_auto_merge = "
+gh api "repos/${REPO}" --jq .allow_auto_merge
+
+echo ""
+echo ">> Done. Remember to create the BOT_PR_TOKEN repo secret (fine-grained"
+echo "   PAT, contents+PRs write, this repo only) for the security-audit bot."

--- a/scripts/pip_audit_ignores.py
+++ b/scripts/pip_audit_ignores.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Emit pip-audit --ignore-vuln args from the .pip-audit-ignores file.
+
+Single source of truth for pip-audit ignores, consumed by both the tests.yml
+security job and the security-audit.yml workflow:
+
+    uv run pip-audit $(uv run python scripts/pip_audit_ignores.py)
+
+File format (whitespace-separated, ``#`` starts a comment line):
+
+    VULN-ID  EXPIRES(YYYY-MM-DD)  REASON...
+
+Entries past their expiry date are dropped, so a still-present vulnerability
+starts failing CI again automatically instead of being ignored forever.
+Malformed lines fail loudly — a broken ignore file must never silently
+disable auditing.
+"""
+
+import datetime
+import sys
+from pathlib import Path
+
+DEFAULT_PATH = Path(__file__).parent.parent / ".pip-audit-ignores"
+
+
+class IgnoreFileError(ValueError):
+    """Raised when .pip-audit-ignores contains a malformed line."""
+
+
+def active_ignores(path: Path, today: datetime.date) -> list[str]:
+    """Return non-expired vulnerability IDs from the ignore file."""
+    ids: list[str] = []
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(maxsplit=2)
+        if len(parts) < 3:
+            raise IgnoreFileError(
+                f"{path.name} line {lineno}: expected 'VULN-ID EXPIRES REASON', got: {raw!r}"
+            )
+        vuln_id, expires_str = parts[0], parts[1]
+        try:
+            expires = datetime.date.fromisoformat(expires_str)
+        except ValueError as exc:
+            raise IgnoreFileError(
+                f"{path.name} line {lineno}: expiry must be YYYY-MM-DD, got: {expires_str!r}"
+            ) from exc
+        if today <= expires:
+            ids.append(vuln_id)
+    return ids
+
+
+def format_args(ids: list[str]) -> str:
+    """Format vulnerability IDs as pip-audit --ignore-vuln arguments."""
+    return " ".join(f"--ignore-vuln {vuln_id}" for vuln_id in ids)
+
+
+def main() -> int:
+    try:
+        ids = active_ignores(DEFAULT_PATH, today=datetime.date.today())
+    except (OSError, IgnoreFileError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    output = format_args(ids)
+    if output:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -2483,7 +2483,7 @@ class TestEsriJsonPageToTable:
 class TestConvertOutputCrs:
     @patch("geoparquet_io.core.arcgis.write_geoparquet_table")
     @patch("geoparquet_io.core.arcgis.arcgis_to_table")
-    def test_convert_forwards_output_crs(self, mock_to_table, mock_write, tmp_path):
+    def test_convert_forwards_output_crs(self, mock_to_table, _mock_write, tmp_path):
         from geoparquet_io.core.arcgis import convert_arcgis_to_geoparquet
 
         mock_to_table.return_value = pa.table({"geometry": pa.array([], type=pa.binary())})

--- a/tests/test_hilbert_order_helpers.py
+++ b/tests/test_hilbert_order_helpers.py
@@ -95,7 +95,7 @@ class TestHilbertRgSizeGuidance:
     """Tests for row group size guidance when Hilbert sorting with v2.0."""
 
     @patch("geoparquet_io.core.hilbert_order._hilbert_order_file_based")
-    def test_large_rg_with_v20_shows_guidance(self, mock_file_based, caplog):
+    def test_large_rg_with_v20_shows_guidance(self, _mock_file_based, caplog):
         """Large RG size + v2.0 should show spatial guidance."""
         from geoparquet_io.core.hilbert_order import hilbert_order
 
@@ -110,7 +110,7 @@ class TestHilbertRgSizeGuidance:
         assert "50000" in caplog.text or "50,000" in caplog.text
 
     @patch("geoparquet_io.core.hilbert_order._hilbert_order_file_based")
-    def test_large_rg_with_pgo_shows_guidance(self, mock_file_based, caplog):
+    def test_large_rg_with_pgo_shows_guidance(self, _mock_file_based, caplog):
         """Large RG size + parquet-geo-only should show spatial guidance."""
         from geoparquet_io.core.hilbert_order import hilbert_order
 
@@ -124,7 +124,7 @@ class TestHilbertRgSizeGuidance:
         assert "row group" in caplog.text.lower() or "row-group" in caplog.text.lower()
 
     @patch("geoparquet_io.core.hilbert_order._hilbert_order_file_based")
-    def test_small_rg_with_v20_no_guidance(self, mock_file_based, caplog):
+    def test_small_rg_with_v20_no_guidance(self, _mock_file_based, caplog):
         """Small RG size + v2.0 should NOT show guidance."""
         from geoparquet_io.core.hilbert_order import hilbert_order
 
@@ -138,7 +138,7 @@ class TestHilbertRgSizeGuidance:
         assert "spatial filter pushdown" not in caplog.text
 
     @patch("geoparquet_io.core.hilbert_order._hilbert_order_file_based")
-    def test_large_rg_with_v11_no_guidance(self, mock_file_based, caplog):
+    def test_large_rg_with_v11_no_guidance(self, _mock_file_based, caplog):
         """Large RG size + v1.1 should NOT show RG guidance (v1.1 has no geo stats anyway)."""
         from geoparquet_io.core.hilbert_order import hilbert_order
 
@@ -154,7 +154,7 @@ class TestHilbertRgSizeGuidance:
         assert "Smaller row groups" not in caplog.text
 
     @patch("geoparquet_io.core.hilbert_order._hilbert_order_file_based")
-    def test_no_rg_rows_specified_no_guidance(self, mock_file_based, caplog):
+    def test_no_rg_rows_specified_no_guidance(self, _mock_file_based, caplog):
         """No row_group_rows specified should NOT show guidance."""
         from geoparquet_io.core.hilbert_order import hilbert_order
 

--- a/tests/test_mutmut.py
+++ b/tests/test_mutmut.py
@@ -90,10 +90,36 @@ class TestMutmutConfig:
             assert full_path.exists(), f"Tests directory does not exist: {test_path}"
             assert full_path.is_dir(), f"Tests path is not a directory: {test_path}"
 
-    def test_mutmut_runner_uses_pytest(self, mutmut_config: dict[str, Any]):
-        """Verify runner config uses pytest."""
-        runner = mutmut_config.get("runner", "")
-        assert "pytest" in runner, "mutmut runner should use pytest"
+    def test_mutmut_excludes_slow_and_network_tests(self, mutmut_config: dict[str, Any]):
+        """Verify per-mutant pytest runs are fast-suite only.
+
+        mutmut 3 runs pytest in-process and ignores a `runner` string, so the
+        marker filter must live in pytest_add_cli_args. Without it, every
+        mutant would run slow/network tests (nondeterministic and far too
+        slow).
+        """
+        args = mutmut_config.get("pytest_add_cli_args", [])
+        assert "not slow and not network" in args, (
+            "mutmut pytest_add_cli_args must filter to fast tests"
+        )
+        assert "--no-cov" in args, (
+            "mutmut pytest_add_cli_args must disable coverage (per-mutant "
+            "overhead, and the global --cov-fail-under gate would misfire)"
+        )
+
+    def test_mutmut_also_copies_test_prerequisites(self, mutmut_config: dict[str, Any]):
+        """Verify everything tests read relative to the repo root is copied.
+
+        Tests run from mutmut's mutants/ tree; anything missing from
+        also_copy fails there while passing in a normal checkout.
+        """
+        also_copy = mutmut_config.get("also_copy", [])
+        for required in ("scripts/", "context/"):
+            assert required in also_copy, f"mutmut also_copy must include {required}"
+        for entry in also_copy:
+            assert (PROJECT_ROOT / entry.rstrip("/")).exists(), (
+                f"also_copy entry does not exist: {entry}"
+            )
 
     def test_mutmut_dev_dependency(self, pyproject_config: dict[str, Any]):
         """Verify mutmut is in dev optional-dependencies."""

--- a/tests/test_pip_audit_ignores.py
+++ b/tests/test_pip_audit_ignores.py
@@ -1,0 +1,81 @@
+"""Tests for scripts/pip_audit_ignores.py — the centralized pip-audit ignore list.
+
+The ignore list lives in .pip-audit-ignores at the repo root and is consumed by
+both the tests.yml security job and the security-audit.yml workflow, replacing
+the inline bash version-compare hack that previously drifted between the two.
+"""
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.pip_audit_ignores import IgnoreFileError, active_ignores, format_args
+
+REPO_ROOT = Path(__file__).parent.parent
+TODAY = datetime.date(2026, 7, 3)
+
+
+def write(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / ".pip-audit-ignores"
+    path.write_text(content)
+    return path
+
+
+class TestActiveIgnores:
+    def test_valid_line_parses(self, tmp_path):
+        path = write(tmp_path, "PYSEC-2026-196 2026-08-15 pip 26.1.1; fixed in 26.1.2\n")
+        assert active_ignores(path, today=TODAY) == ["PYSEC-2026-196"]
+
+    def test_comments_and_blank_lines_skipped(self, tmp_path):
+        path = write(
+            tmp_path,
+            "# vuln-id  expires  reason\n"
+            "\n"
+            "   \n"
+            "# another comment\n"
+            "GHSA-abcd-1234-efgh 2099-01-01 some reason here\n",
+        )
+        assert active_ignores(path, today=TODAY) == ["GHSA-abcd-1234-efgh"]
+
+    def test_expired_entries_dropped(self, tmp_path):
+        path = write(
+            tmp_path,
+            "PYSEC-2020-001 2020-01-01 long expired\nPYSEC-2026-196 2026-08-15 still active\n",
+        )
+        assert active_ignores(path, today=TODAY) == ["PYSEC-2026-196"]
+
+    def test_entry_active_on_expiry_date_itself(self, tmp_path):
+        path = write(tmp_path, "PYSEC-2026-001 2026-07-03 expires today, still active\n")
+        assert active_ignores(path, today=TODAY) == ["PYSEC-2026-001"]
+
+    def test_missing_reason_rejected(self, tmp_path):
+        path = write(tmp_path, "PYSEC-2026-196 2026-08-15\n")
+        with pytest.raises(IgnoreFileError, match="line 1"):
+            active_ignores(path, today=TODAY)
+
+    def test_malformed_date_rejected(self, tmp_path):
+        path = write(tmp_path, "PYSEC-2026-196 15-08-2026 bad date format\n")
+        with pytest.raises(IgnoreFileError, match="line 1"):
+            active_ignores(path, today=TODAY)
+
+    def test_empty_file_yields_no_ignores(self, tmp_path):
+        path = write(tmp_path, "# only comments\n")
+        assert active_ignores(path, today=TODAY) == []
+
+
+class TestFormatArgs:
+    def test_formats_ignore_vuln_flags(self):
+        assert format_args(["A", "B"]) == "--ignore-vuln A --ignore-vuln B"
+
+    def test_empty_list_formats_to_empty_string(self):
+        assert format_args([]) == ""
+
+
+class TestRepoIgnoreFile:
+    def test_repo_ignore_file_parses_cleanly(self):
+        """The committed .pip-audit-ignores must always parse."""
+        path = REPO_ROOT / ".pip-audit-ignores"
+        assert path.exists()
+        # Must not raise, regardless of what is currently listed or expired.
+        active_ignores(path, today=datetime.date.today())

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -56,11 +56,13 @@ class TestSecurityToolAvailability:
 
 # NOTE: The live dependency audit ("does pip-audit pass?") intentionally does
 # NOT live here as a pytest test. It runs in the dedicated `security` job in
-# .github/workflows/tests.yml, which owns the self-expiring CVE-ignore list,
-# blocks PRs on new vulnerabilities, and is non-blocking on nightly schedules.
-# A duplicate copy used to live here and drifted out of sync with the workflow's
-# ignore list (PYSEC-2026-196), silently breaking `main` on every push. Keep the
-# audit in exactly one place — the workflow.
+# .github/workflows/tests.yml, which blocks PRs on new vulnerabilities and is
+# non-blocking on nightly schedules. The self-expiring CVE-ignore list lives in
+# .pip-audit-ignores at the repo root (parsed by scripts/pip_audit_ignores.py)
+# and is shared with security-audit.yml. A duplicate audit used to live here
+# and its ignore list drifted out of sync with the workflow's (PYSEC-2026-196),
+# silently breaking `main` on every push. Keep the audit in exactly one place —
+# the workflow — and the ignore list in exactly one file.
 
 
 class TestBanditConfiguration:

--- a/tests/test_version_benchmark.py
+++ b/tests/test_version_benchmark.py
@@ -1,16 +1,14 @@
 """Tests for version_benchmark.py trend analysis."""
 
 import json
-
-# Import the functions we want to test
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-from version_benchmark import analyze_trends
+# Import via the scripts package (not a sys.path hack) so this also works from
+# mutmut's mutants/ copy of the tree, where relative-path insertion breaks.
+from scripts.version_benchmark import analyze_trends
 
 
 @pytest.fixture

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -3728,7 +3728,7 @@ class TestFetchWithSpatialTiles:
             ),
             patch(
                 "geoparquet_io.core.wfs._refine_tiles_adaptive",
-                side_effect=lambda tiles, *a, **kw: tiles,
+                side_effect=lambda tiles, *a, **_kw: tiles,
             ),
             patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", side_effect=mock_fetch),
         ):

--- a/uv.lock
+++ b/uv.lock
@@ -488,6 +488,49 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/1b/7f73766c119a1344eb69e31890ede7c5825ce03d69a9d29292d1bd1cfa1b/chardet-7.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0c79b13c9908ac7dfe0a74116ebc9a0f28b2319d23c32f3dfcdfbe1279c7eaf", size = 874121, upload-time = "2026-04-13T21:32:47.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/02/b677c8203d34dad6c2af48287bb1f8c5dff63db2094636fbe634b555b7fb/chardet-7.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bba8bea1b28d927b3e99e47deafe53658d34497c0a891d95ff1ba8ff6663f01c", size = 856900, upload-time = "2026-04-13T21:32:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/4b/1361a485a999d97cac4c895e615326f69a639532a52ef365a468bd09bad1/chardet-7.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23163921dccf3103ce59540b0443c106d2c0a0ff2e0503e05196f5e6fdea453f", size = 876634, upload-time = "2026-04-13T21:32:50.238Z" },
+    { url = "https://files.pythonhosted.org/packages/87/23/e31c8ad33aa448f0845fd58af5fc22da1626407616d09df4973b2b34f477/chardet-7.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfb54563fe5f130da17c44c6a4e2e8052ba628e5ab4eab7ef8190f736f0f8f72", size = 886497, upload-time = "2026-04-13T21:32:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ef/ea4edec8c87f7e6eda02673acc68fe48725e564fc5a1865782efb53d5598/chardet-7.4.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3990fffcc6a6045f2234ab72752ad037e3b2d48c72037f244d42738db397eb75", size = 881061, upload-time = "2026-04-13T21:32:53.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/fc10600da98541777d720ad9e6bc040c0e0af1adb92e27142e35158957cb/chardet-7.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c7116b0452994734ccff35e154b44240090eb0f4f74b9106292668133557c175", size = 942533, upload-time = "2026-04-13T21:32:55.134Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/505c207f334d51e937cbaa27ff95776e16e2d120e13cbe491cd7b3a70b50/chardet-7.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:25a862cddc6a9ac07023e808aedd297115345fbaabc2690479481ddc0f980e09", size = 870747, upload-time = "2026-04-13T21:32:56.916Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4b/d3c79495dee4831b8bebca2790e72cb90f0c5849c940570a7c7e5b70b952/chardet-7.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7005c88da26fd95d8abb8acbe6281d833e9a9181b03cf49b4546c4555389bd97", size = 853210, upload-time = "2026-04-13T21:32:58.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/99/f6a822ad1bde25a4c38dc3e770485e78e0893dfd871cd6e18ed3ea3a795e/chardet-7.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc50f28bad067393cce0af9091052c3b8df7a23115afd8ba7b2e0947f0cef1f8", size = 873625, upload-time = "2026-04-13T21:32:59.606Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/10/31932775c94a86814f76b41c4a772b52abfb0e6125324f32c6da1196c297/chardet-7.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3da294de1a681097848ab58bd3f2771a674f8039d2d87a5538b28856b815e9", size = 883436, upload-time = "2026-04-13T21:33:01.351Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/63/0f43e3acf2c436fdb32a0f904aeb03a2904d2126eed34a042a194d235926/chardet-7.4.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:93c45e116dd51b66226a53ade3f9f635e870de5399b90e00ce45dcc311093bf4", size = 876589, upload-time = "2026-04-13T21:33:02.636Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a6/e9b8f8a3e99602792b01fa7d0a731737615ab56d8bfd0b52935a0ef88b85/chardet-7.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:ccc1f83ab4bcfb901cf39e0c4ba6bc6e726fc6264735f10e24ceb5cb47387578", size = 941866, upload-time = "2026-04-13T21:33:04.282Z" },
+    { url = "https://files.pythonhosted.org/packages/61/33/29de185079e6675c3f375546e30a559b7ddc75ce972f18d6e566cd9ea4eb/chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971", size = 874870, upload-time = "2026-04-13T21:33:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/4c5af01fd1a7506a1d5375403d68925eac70289229492db5aa68b58103d8/chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a", size = 854859, upload-time = "2026-04-13T21:33:07.381Z" },
+    { url = "https://files.pythonhosted.org/packages/36/21/edb36ad5dfa48d7f8eed97ab43931ecdaa8c15166c21b1d614967e49d681/chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235", size = 875032, upload-time = "2026-04-13T21:33:08.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/a32a241d861cf180853a11c8e5a67641cb1b2af13c3a5ccce83ec07e2c9f/chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb", size = 888283, upload-time = "2026-04-13T21:33:10.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/e1ee6a77abf3782c00e05b89c4d4328c8353bf9500661c4348df1dd68614/chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f", size = 879974, upload-time = "2026-04-13T21:33:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/32/60/fca69c534602a7ced04280c952a246ad1edde2a6ca3a164f65d32ac41fe7/chardet-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101", size = 943973, upload-time = "2026-04-13T21:33:12.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/79ac9b4db5bc87020c9dbc419125371d80882d1d197e9c4765ba8682b605/chardet-7.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9", size = 873769, upload-time = "2026-04-13T21:33:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/25bdec773905bff0ff6cf35ca73b17bd05593b4f87bd8c5fa43705f7167d/chardet-7.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a", size = 853991, upload-time = "2026-04-13T21:33:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/a29380ee0b215d23d77733b5ad60c5c0c7969650e080c667acdf9462040d/chardet-7.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357", size = 874024, upload-time = "2026-04-13T21:33:16.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b1/3338e121cbd4c8a126b8ccb1061170c2ce51a53f678c502793ea49c6fd6d/chardet-7.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d", size = 887410, upload-time = "2026-04-13T21:33:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1c/44a9a9e0c59c185a5d307ceaeee8768afa1558f0a24f7a4b5fa11b67586b/chardet-7.4.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb", size = 879269, upload-time = "2026-04-13T21:33:20.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/5d0e77ea774bd3224321c248880ea0c0379000ac5c2bb6d77609549de247/chardet-7.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131", size = 944155, upload-time = "2026-04-13T21:33:21.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -912,6 +955,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/21/057e816125c162662d2a2cc2ebcd72dd333e78e51678298d07dd3146011a/diff_cover-10.3.0.tar.gz", hash = "sha256:474dbc63e815fbb7567d7b7ca5b104123e96129f25426ebdbc9a1bdbb935b2c6", size = 106546, upload-time = "2026-05-30T14:17:14.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/0a/a96e57a7a3fca419cd5ceff0d13dee2166520fa67103fb82624ad64700fb/diff_cover-10.3.0-py3-none-any.whl", hash = "sha256:2e47d5ab3868d1e92131c11f364f3f4a8583c97123d3bbc6b6cc8ce0a4cc2202", size = 58989, upload-time = "2026-05-30T14:17:12.858Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1320,6 +1378,7 @@ dev = [
     { name = "codespell" },
     { name = "commitizen" },
     { name = "deptry" },
+    { name = "diff-cover" },
     { name = "import-linter" },
     { name = "menard" },
     { name = "mutmut" },
@@ -1330,6 +1389,9 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-forked" },
+    { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "radon" },
@@ -1362,6 +1424,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.2" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.25.0" },
+    { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "fiona", marker = "extra == 'benchmark'", specifier = ">=1.9.0" },
     { name = "fsspec", specifier = ">=2023.9.0" },
@@ -1395,6 +1458,9 @@ requires-dist = [
     { name = "pystac", specifier = ">=1.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pytest-forked", marker = "extra == 'dev'", specifier = ">=1.6" },
+    { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=14" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0.1" },
@@ -3539,6 +3605,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3849,6 +3924,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-forked"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/c9/93ad2ba2413057ee694884b88cf7467a46c50c438977720aeac26e73fdb7/pytest-forked-1.6.0.tar.gz", hash = "sha256:4dafd46a9a600f65d822b8f605133ecf5b3e1941ebb3588e943b4e3eb71a5a3f", size = 9977, upload-time = "2023-02-12T23:22:27.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/af/9c0bda43e486a3c9bf1e0f876d0f241bc3f229d7d65d09331a0868db9629/pytest_forked-1.6.0-py3-none-any.whl", hash = "sha256:810958f66a91afb1a1e2ae83089d8dc1cd2437ac96b12963042fbb9fb4d16af0", size = 4897, upload-time = "2023-02-12T23:22:26.022Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

One PR that makes green mean green and turns every quality signal into a deterministic, auditable gate — with machines fixing what machines can fix.

### Why main was red

`slow-tests` ran `-m "slow or network"` on every push; the live Vermont ArcGIS fetch (#334 regression test) kept segfaulting the xdist worker. Live third-party servers should never decide main's status.

### What this PR changes

**Green main / test tiers**
- `slow-tests` now runs `slow and not network`.
- New non-blocking `network-tests` job: serial + `--forked` (segfault isolation), per-test `--timeout=180`, `--reruns 2`. Failures open/update a single tracking issue and auto-close on recovery (same pattern as the security audit). The workflow stays green.

**One rule source**
- The lint job now runs `pre-commit run --all-files` (commit + pre-push stages). House rules (DuckDB antipatterns, no-click-echo, schema-reconciliation guard) finally run in CI; local hooks and CI can no longer drift.
- New hooks: `actionlint`, `zizmor --no-online-audits`, and `mypy` (pre-push). Xenon/vulture scopes unified with CI; both are now blocking (the 7 vulture findings are fixed here).

**Per-PR test quality**
- `diff-cover` gate: changed lines need ≥90% coverage **from fast tests** on the ubuntu/3.11 cell.

**Mutation testing actually runs now**
- The nightly `mutmut run --no-progress --CI` invocation has errored instantly since mutmut 3 (flags removed); exit 2 was read as "surviving mutants" and the parse failure was warn-only — so mutation testing has silently never run. Fixed the invocation (`pytest_add_cli_args`, `also_copy`, meta-test excludes), and the kill-rate check now hard-fails on zero mutants, parse failure, or a rate below the committed `.mutation-baseline` floor (50%).
- ⚠️ Known follow-up: mutmut's stats pass runs the whole fast suite in one pytest process, which surfaces a pre-existing test-order pollution (`test_format_writers.py::test_convert_geopackage_subcommand` fails after ~1,600 tests, passes in isolation). Tracked for a follow-up fix; until then the first nightly run may flag it — that is real signal, not mutation noise.

**Security: PRs, not tickets**
- `.pip-audit-ignores` — single, self-expiring CVE ignore list (ID + expiry + reason), parsed by `scripts/pip_audit_ignores.py` (unit-tested), consumed by both the CI security job and the daily audit. Replaces the inline pip-version bash hack that previously drifted and broke main.
- `security-audit.yml` now tries `uv lock --upgrade-package` + fast suite on any CVE and opens an auto-fix PR (`bot/security-dependency-upgrades`); it files an issue only when no upstream fix exists or tests fail.

**Dependency automation**
- `dependabot-automerge.yml`: approves + enables auto-merge (squash) for Dependabot patch/minor PRs; majors stay human-reviewed. Non-spoofable author check per zizmor.
- Dependabot: commitizen-compliant commit prefixes, 7-day cooldown before adopting fresh releases.

**Supply chain / hygiene (all 8 workflows)**
- Top-level `permissions: contents: read` with job-level widening only where needed; `timeout-minutes` on every job; every action SHA-pinned with version comments (Dependabot maintains pins); template expansions moved to env indirection; release paths run cache-disabled; `persist-credentials: false` everywhere except the tag-pushing release checkout (inline-ignored with justification). `actionlint` + `zizmor` pass clean and now guard all of this in CI.

**Branch protection as code**
- `scripts/apply_branch_protection.sh` (admin, run once after merge): migrates main from classic protection to two rulesets — (A) PR required + 13 required status checks for everyone including admins, no bypass; (B) 1 approval required, bypassed by repo admins and satisfied by the bot's auto-approve for Dependabot. Also enables repo auto-merge.

### Post-merge admin steps (once)

1. Run `scripts/apply_branch_protection.sh` (needs admin).
2. Create the fine-grained PAT secret `BOT_PR_TOKEN` (this repo only; contents + pull-requests write) so security auto-fix PRs trigger CI. No existing PAT secret was found.
3. `gh workflow run` the Security Audit and Nightly CI workflows once to validate the new paths.

## Technical Details

- Required-check contexts (13): `lint`, `security`, `notebooks`, `test (ubuntu-latest, 3.10–3.13)`, `test (macos-latest, 3.11–3.13)`, `test (windows-latest, 3.11–3.13)`. `slow-tests`/`network-tests` are conditional jobs and deliberately not required (would deadlock PRs).
- mutmut 3 facts verified against installed 3.6.0 source: `runner` config is ignored (in-process `pytest.main`), results live in `mutants/**/*.meta`, survivors no longer exit 2.
- diff-cover uses the fast-suite `coverage.xml`; changed lines covered only by slow tests fail the gate by design (documented in contributing.md).

## Breaking Changes

None at runtime. Process changes: xenon/vulture/menard/mypy now block; new contributors' PRs must pass diff coverage on changed lines.

## Related Issue(s)

Supersedes the recurring red-main churn from live-network flakes (see #544, #334 history).

## Checklist

- [x] Tests added/updated (`tests/test_pip_audit_ignores.py`; vulture fixes keep behavior identical)
- [x] Docs updated (`docs/contributing.md`)
- [x] actionlint + zizmor clean; pre-commit both stages green locally
- [x] Commitizen-formatted commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / CI**
  * Hardened GitHub Actions with stricter permissions, pinned action versions, and more deterministic benchmark execution/reporting (including hard-fail on significant regressions).
  * Added Dependabot auto-merge for eligible patch/minor updates and introduced automation to migrate branch protection to rulesets with auto-merge enabled.
  * Implemented PR-first dependency remediation for security audits using a centralized, self-expiring ignore list.
* **New Features**
  * Added `.mutation-baseline` to enforce a minimum mutation kill rate.
* **Documentation**
  * Expanded contributing guidance for CI tiers, coverage gates, and mutation/security requirements.
* **Tests**
  * Added validation coverage for the centralized ignore list and for benchmark/mutation-related CI configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->