### PR TITLE
fix(mutmut): keep test suite CWD-stable so mutation stats phase passes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,6 +135,35 @@ repos:
         pass_filenames: false
         types: [python]
 
+      # mutmut's stats-phase trampoline resolves the relative source_paths
+      # (geoparquet_io/) against the process CWD on EVERY instrumented call, so
+      # any test that changes the working directory crashes stats collection
+      # with "FileNotFoundError: 'geoparquet_io'" and takes the nightly mutation
+      # job down (silently, until #552 hardened the exit-code handling). Keep the
+      # suite CWD-stable: use the tmp_path fixture + absolute paths, or
+      # os.path.relpath for relative-path coverage. Justify a rare, deliberate
+      # exception with a trailing "# allow-cwd-change" comment.
+      - id: no-cwd-change-in-tests
+        name: no-cwd-change-in-tests
+        description: Tests must not change the process CWD (breaks mutmut stats phase)
+        entry: bash
+        args:
+          - -c
+          - |
+            if grep -rnE '(isolated_filesystem\(|os\.chdir\(|monkeypatch\.chdir\()' tests/ --include="*.py" | grep -v 'allow-cwd-change'; then
+              echo "ERROR: Tests must not change the process CWD."
+              echo "       isolated_filesystem() / os.chdir() / monkeypatch.chdir() break"
+              echo "       mutmut's stats-phase trampoline (it resolves the relative"
+              echo "       source_paths against CWD) and take the nightly mutation job down."
+              echo "       Use the tmp_path fixture with absolute paths, or os.path.relpath"
+              echo "       for relative-path coverage. Justify a rare exception with a"
+              echo "       trailing '# allow-cwd-change' comment."
+              exit 1
+            fi
+        language: system
+        pass_filenames: false
+        types: [python]
+
       - id: check-api-for-cli
         name: check-api-for-cli
         description: Remind to add Python API for new CLI commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,11 @@ source_paths = ["geoparquet_io/"]
 # fatal to the run.
 pytest_add_cli_args = [
     "--no-cov",
-    "--tb=no",
+    # --tb=short (not --tb=no): a failure in mutmut's single-process stats
+    # phase must show WHERE it failed. --tb=no once hid a cwd-related crash
+    # (tests that chdir break mutmut's trampoline) and made nightly red with
+    # no diagnosable reason. See the tests/ chdir guard in .pre-commit-config.
+    "--tb=short",
     "-m", "not slow and not network",
     "--ignore=tests/test_codespell.py",
     "--ignore=tests/test_import_linter.py",

--- a/tests/test_format_writers.py
+++ b/tests/test_format_writers.py
@@ -585,124 +585,124 @@ class TestCLIConvertSubcommands:
         """Create Click test runner."""
         return CliRunner()
 
-    def test_convert_geopackage_subcommand(self, runner):
+    def test_convert_geopackage_subcommand(self, runner, tmp_path):
         """Test 'gpio convert geopackage' CLI command."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    "geopackage",
-                    str(PLACES_PARQUET),
-                    "output.gpkg",
-                ],
-            )
-            if result.exit_code != 0:
-                print(f"STDOUT: {result.stdout}")
-                print(f"Exception: {result.exception}")
-            assert result.exit_code == 0
-            assert Path("output.gpkg").exists()
+        output = tmp_path / "output.gpkg"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                "geopackage",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        if result.exit_code != 0:
+            print(f"STDOUT: {result.stdout}")
+            print(f"Exception: {result.exception}")
+        assert result.exit_code == 0
+        assert output.exists()
 
-    def test_convert_flatgeobuf_subcommand(self, runner):
+    def test_convert_flatgeobuf_subcommand(self, runner, tmp_path):
         """Test 'gpio convert flatgeobuf' CLI command."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    "flatgeobuf",
-                    str(PLACES_PARQUET),
-                    "output.fgb",
-                ],
-            )
-            assert result.exit_code == 0
-            assert Path("output.fgb").exists()
+        output = tmp_path / "output.fgb"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                "flatgeobuf",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
 
-    def test_convert_csv_subcommand(self, runner):
+    def test_convert_csv_subcommand(self, runner, tmp_path):
         """Test 'gpio convert csv' CLI command."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    "csv",
-                    str(PLACES_PARQUET),
-                    "output.csv",
-                ],
-            )
-            assert result.exit_code == 0
-            assert Path("output.csv").exists()
+        output = tmp_path / "output.csv"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                "csv",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
 
-    def test_convert_shapefile_subcommand(self, runner):
+    def test_convert_shapefile_subcommand(self, runner, tmp_path):
         """Test 'gpio convert shapefile' CLI command."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    "shapefile",
-                    str(PLACES_PARQUET),
-                    "output.shp",
-                ],
-            )
-            assert result.exit_code == 0
-            assert Path("output.shp").exists()
+        output = tmp_path / "output.shp"
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                "shapefile",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
 
-    def test_convert_auto_detect_geopackage(self, runner):
+    def test_convert_auto_detect_geopackage(self, runner, tmp_path):
         """Test auto-detection of GeoPackage format from extension."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    str(PLACES_PARQUET),
-                    "output.gpkg",  # Auto-detect from .gpkg extension
-                ],
-            )
-            assert result.exit_code == 0
-            assert Path("output.gpkg").exists()
+        output = tmp_path / "output.gpkg"  # Auto-detect from .gpkg extension
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
 
-    def test_convert_auto_detect_flatgeobuf(self, runner):
+    def test_convert_auto_detect_flatgeobuf(self, runner, tmp_path):
         """Test auto-detection of FlatGeobuf format from extension."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    str(PLACES_PARQUET),
-                    "output.fgb",  # Auto-detect from .fgb extension
-                ],
-            )
-            assert result.exit_code == 0
-            assert Path("output.fgb").exists()
+        output = tmp_path / "output.fgb"  # Auto-detect from .fgb extension
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
 
-    def test_convert_auto_detect_csv(self, runner):
+    def test_convert_auto_detect_csv(self, runner, tmp_path):
         """Test auto-detection of CSV format from extension."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    str(PLACES_PARQUET),
-                    "output.csv",  # Auto-detect from .csv extension
-                ],
-            )
-            assert result.exit_code == 0
-            assert Path("output.csv").exists()
+        output = tmp_path / "output.csv"  # Auto-detect from .csv extension
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
 
-    def test_convert_auto_detect_shapefile(self, runner):
+    def test_convert_auto_detect_shapefile(self, runner, tmp_path):
         """Test auto-detection of Shapefile format from extension."""
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                cli,
-                [
-                    "convert",
-                    str(PLACES_PARQUET),
-                    "output.shp",  # Auto-detect from .shp extension
-                ],
-            )
-            assert result.exit_code == 0
-            assert Path("output.shp").exists()
+        output = tmp_path / "output.shp"  # Auto-detect from .shp extension
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                str(PLACES_PARQUET),
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
 
 
 class TestShapefileZip:

--- a/tests/test_list_layers.py
+++ b/tests/test_list_layers.py
@@ -378,16 +378,14 @@ class TestListLayersEdgeCases:
         result = list_layers_core(str(unicode_file))
         assert result is not None
 
-    def test_relative_path_normalized(self, multilayer_gpkg, monkeypatch):
+    def test_relative_path_normalized(self, multilayer_gpkg):
         """Relative paths should be handled correctly."""
-        from pathlib import Path
-
-        # Change to the directory containing the test file
-        test_dir = Path(multilayer_gpkg).parent
-        monkeypatch.chdir(test_dir)
-
-        # Use relative path
-        relative_path = Path(multilayer_gpkg).name
+        # Exercise relative-path handling WITHOUT changing the process CWD.
+        # Changing CWD breaks mutmut's stats-phase trampoline, which resolves
+        # the relative source_paths (geoparquet_io/) against the working
+        # directory on every instrumented call.
+        relative_path = os.path.relpath(multilayer_gpkg)
+        assert not os.path.isabs(relative_path)
         result = list_layers_core(relative_path)
         assert result is not None
 


### PR DESCRIPTION
## Problem

Nightly **Mutation Testing** has failed deterministically since the CI-hardening PR #552 landed — red on 2026-07-07 and 07-08, both on `a80b830`; green on every prior day. The failing step is mutmut's stats collection:

```
FAILED tests/test_format_writers.py::TestCLIConvertSubcommands::test_convert_geopackage_subcommand
  → <Result FileNotFoundError(2, 'No such file or directory')>.exit_code == 1
failed to collect stats. runner returned 1
```

## Root cause

mutmut's stats-phase trampoline (`record_trampoline_hit`) runs, on **every** instrumented `geoparquet_io` call:

```python
source_paths = [p.resolve(strict=True) for p in Config.get().source_paths]
```

`source_paths = ["geoparquet_io/"]` is **relative**, so `resolve(strict=True)` is evaluated against the process CWD. Any test that changes the working directory makes it raise `FileNotFoundError: 'geoparquet_io'`. `test_convert_geopackage_subcommand` runs inside `runner.isolated_filesystem()` (which `chdir`s), so the convert call fires the trampoline from a temp dir and crashes stats collection.

This is **not** a bug in the app or the test logic — it's a mutmut-vs-`chdir` incompatibility. It was masked for months because the old nightly workflow read mutmut's exit code 2 as "OK"; #552 correctly made any nonzero exit a hard failure, which surfaced the pre-existing issue.

## Fix

- **`tests/test_format_writers.py`** — all 8 `TestCLIConvertSubcommands` tests use the `tmp_path` fixture + absolute output paths instead of `runner.isolated_filesystem()` (no `chdir`).
- **`tests/test_list_layers.py`** — `test_relative_path_normalized` exercises relative-path handling via `os.path.relpath()` instead of `monkeypatch.chdir()`.
- **`.pre-commit-config.yaml`** — new deterministic `no-cwd-change-in-tests` guard so this class can't silently return (escape hatch: `# allow-cwd-change`).
- **`pyproject.toml`** — mutmut `--tb=no` → `--tb=short`, so a future stats-phase failure shows its reason in CI instead of being invisible.

No test deselection, no weakening of the mutation gate; no source code changed, so the kill rate is unaffected.

## Verification

- Reproduced the exact CI failure locally with `uv run mutmut run` (`1 failed, 1636 passed`, identical to CI).
- After the fix, `uv run mutmut run` completes stats collection (writes `mutants/mutmut-stats.json`, 6 MB) and proceeds into mutation testing.
- Affected tests pass normally (`46 passed`).
- Nightly CI dispatched on this branch to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pre-commit check to prevent tests from changing the working directory unless explicitly allowed.
* **Bug Fixes**
  * Improved mutation-test output so failures show a shorter, more useful traceback.
  * Updated test coverage to use temporary paths and relative paths more reliably, reducing reliance on changing directories.
* **Tests**
  * Adjusted CLI and layer-listing tests to work with filesystem-safe paths and preserve expected output checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->