### PR TITLE
fix(ci): rename Codecov 'file' input to 'files' for v7 action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
@@ -305,7 +305,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: slowtests
           name: codecov-slow
           fail_ci_if_error: false


### PR DESCRIPTION
## Problem

CI workflow validation fails on both Codecov upload steps in `tests.yml`:

> ❌ Unexpected input(s) 'file', valid inputs are [...'files'...]

Failing run: https://github.com/geoparquet/geoparquet-io/actions/runs/28949926521/job/85893632217

## Cause

The `codecov/codecov-action` was bumped to **v7.0.0**, which removed the singular `file` input in favor of the plural `files`. The two upload steps still passed `file: ./coverage.xml`, so Actions rejected them at input-validation time (before the step even runs).

## Fix

Rename `file:` → `files:` in both Codecov upload steps:
- Upload coverage to Codecov (unit tests)
- Upload slow test coverage to Codecov (slow tests)

No behavior change — same single `coverage.xml` path, just the correct input name for the pinned action version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage report uploads for both fast and slow test suites.
  * Improved compatibility with the coverage reporting service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->