### PR TITLE
fix(ci): drop self-approval from Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -27,14 +27,15 @@ jobs:
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
 
       # Majors are deliberately left for a human to review and merge.
-      - name: Approve and enable auto-merge for patch/minor updates
+      - name: Enable auto-merge for patch/minor updates
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        # The approve step is belt-and-suspenders for the review-required
-        # ruleset; auto-merge then waits for required status checks.
+        # No self-approval: the default GITHUB_TOKEN is not permitted to
+        # approve PRs, and main's branch protection requires zero approving
+        # reviews anyway. Auto-merge queues the PR; GitHub still blocks the
+        # merge until every required status check is green.
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Problem

Every patch/minor Dependabot PR fails the auto-merge job:

```
Run gh pr review --approve "$PR_URL"
failed to create review: GraphQL: GitHub Actions is not permitted to
approve pull requests. (addPullRequestReview)
Error: Process completed with exit code 1.
```

## Cause

The default `GITHUB_TOKEN` is **not permitted to approve pull requests** — this is a hard GitHub restriction, and the repo setting `can_approve_pull_request_reviews` is `false`. So `gh pr review --approve` can never succeed with the built-in token.

The step's own comment called it "belt-and-suspenders for the review-required ruleset" — but no such requirement exists. `main`'s branch protection reports:

```
required_approving_review_count: 0
```

So the approval was never needed to merge in the first place.

## Fix

Drop the `gh pr review --approve` line and rely on `gh pr merge --auto --squash` alone. Auto-merge queues the PR; GitHub still blocks the merge until the full required status-check matrix (tests, security-audit, docs, …) is green — so this remains safe.

No new secrets/PAT/App token needed, since nothing requires an approval.

## After merge

Once this lands and Dependabot rebases #571 / #572 onto the updated `main`, their auto-merge jobs will pick up the fixed workflow and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency updates to merge eligible patch and minor releases without requiring an approval step.
  * Dependency updates remain subject to required status checks before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->