### PR TITLE
test(corpus): add official geoparquet-testing conformance suite (GeoParquet 2.0 audit)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,8 @@ jobs:
           persist-credentials: false
           # Full history so diff-cover can diff against the PR base branch.
           fetch-depth: 0
+          # geoparquet-testing corpus for the corpus conformance tests
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -232,6 +234,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # geoparquet-testing corpus for the corpus conformance tests
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/data/geoparquet-testing"]
+	path = tests/data/geoparquet-testing
+	url = https://github.com/geoparquet/geoparquet-testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ uv run pytest -n auto -m "not slow and not network"  # Fast tests
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 <!-- END GENERATED: test-markers -->
 
 ---

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,6 +97,7 @@ Coverage gates (both enforced in CI):
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 <!-- END GENERATED: test-markers -->
 
 ## Code Quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,11 +132,14 @@ addopts = [
     "--cov=geoparquet_io",
     "--cov-report=term-missing",
     "--cov-fail-under=67",
+    # The geoparquet-testing submodule ships its own pytest suite; never collect it.
+    "--ignore=tests/data/geoparquet-testing",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
     "integration: marks end-to-end integration tests",
+    "corpus: tests against the official geoparquet-testing corpus (requires git submodule)",
 ]
 
 [tool.ruff]
@@ -323,7 +326,7 @@ verbose = false
 # site/ (mkdocs build) and mutants/ (mutmut working tree) are gitignored
 # build artifacts; scanning them made test_codespell_passes fail on any
 # machine that had built docs or run mutation testing locally.
-skip = ".git,*.lock,*.parquet,*.json,tests/data/*,.venv,uv.lock,site,mutants"
+skip = ".git,*.lock,*.parquet,*.json,tests/data/*,geoparquet-testing,.venv,uv.lock,site,mutants"
 ignore-words-list = "nd,ot,crs,inout,hel,bu"
 check-filenames = true
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,20 @@ The `data/` directory contains test GeoParquet files:
 - `places_test.parquet` - 766 rows with place data including bbox column
 - `buildings_test.parquet` - 42 rows with building geometries
 
+### geoparquet-testing corpus (submodule)
+
+`data/geoparquet-testing/` is a git submodule vendoring the official
+[geoparquet-testing](https://github.com/geoparquet/geoparquet-testing) corpus,
+used by `test_geoparquet_corpus.py` (marker: `corpus`). Initialize it with:
+
+```bash
+git submodule update --init
+```
+
+Without it those tests skip with a hint. The pin is a specific upstream commit;
+bump it deliberately (fixture changes can alter expected results — see the
+adjudication notes in `test_geoparquet_corpus.py`).
+
 ## Running Tests
 
 ### Run all tests

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -1,0 +1,483 @@
+"""
+Conformance tests against the official geoparquet-testing corpus.
+
+The corpus (https://github.com/geoparquet/geoparquet-testing) is vendored as a
+git submodule at tests/data/geoparquet-testing, pinned to a specific commit.
+Run ``git submodule update --init`` if these tests report SKIPPED.
+
+Three tiers:
+- data/ + samples/ (51 files): valid GeoParquet 2.0.0 — gpio must detect,
+  read, and validate them cleanly.
+- bad_data/ (22 files): deliberate spec violations with a manifest of expected
+  failure codes — gpio must reject each one for the right reason, and must
+  never crash on any of them.
+- Write tier: representative corpus files rewritten through gpio must keep
+  their GeoParquet 2.0 nature (native logical types, CRS, geo metadata).
+
+Adjudication policy: this suite was built from the corpus's first complete run
+against gpio (July 2026). Discrepancies were judged against the spec text, not
+assumed to be gpio bugs. Confirmed gpio bugs are tracked in GitHub issues and
+appear here as KNOWN_VALIDATION_BUGS entries or xfail marks referencing the
+issue; they turn into hard failures/XPASS as fixes land.
+
+One corpus bug was found (CORPUS_BUG_FILES): the data/zm/ fixtures declare
+geometry_types ["LineString"] without the " Z"/" M"/" ZM" suffix the spec
+mandates for 3D/measured data ("a ' Z' suffix gets added", "It is expected
+that this field is strictly correct") — the very violation bad_data/
+zm-declared-xy-actual-xyz.parquet exists to test. Reported upstream; these
+xfails are non-strict so a fixed corpus pin turns them green automatically.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.common import detect_geoparquet_file_type
+from geoparquet_io.core.convert import convert_to_geoparquet
+from geoparquet_io.core.duckdb_metadata import (
+    detect_geometry_columns,
+    get_schema_info,
+    parse_geometry_logical_type,
+)
+from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+from tests.conftest import get_geo_metadata, get_geoparquet_version, has_native_geo_types
+
+pytestmark = [pytest.mark.corpus, pytest.mark.integration]
+
+CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
+
+# Validation checks that misfire on valid corpus files, with the gpio issue
+# tracking each fix. test_validates_clean xfails while a file's failures are
+# all covered here and fails hard on anything new. Remove entries as fixes land.
+KNOWN_VALIDATION_BUGS = {
+    "v2_crs_in_parquet_type": "#581 CRS84-default equivalence",
+    "v2_crs_consistency": "#581 CRS84-default equivalence",
+    "edges_valid": "#582 missing 2.0 ellipsoidal edges values",
+    "geometry_types_list": "#583 Z/M suffixed types rejected",
+    "geometry_types_match_data": "#583 data scan drops Z/M suffix",
+    "native_geo_types_match": "#583 native stats comparison drops Z/M suffix",
+    "native_geo_stats_contains_data": "#584 POINT EMPTY counted as outside bbox",
+    "bbox_contains_data": "#584 POINT EMPTY counted as outside bbox",
+    "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
+}
+
+
+# Fixtures that themselves violate the spec (upstream geoparquet-testing bugs).
+# Non-strict xfail: they pass again once the corpus pin advances past the fix.
+CORPUS_BUG_FILES = {
+    "data/zm/linestring-xyz-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYZ data; spec requires 'LineString Z'"
+    ),
+    "data/zm/linestring-xym-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYM data; spec requires 'LineString M'"
+    ),
+    "data/zm/linestring-xyzm-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYZM data; spec requires 'LineString ZM'"
+    ),
+}
+
+
+def _corpus_files(*subdirs):
+    """Parametrize over corpus files; one graceful skip if the submodule is absent."""
+    if not (CORPUS / "data").exists():
+        return [
+            pytest.param(
+                None,
+                id="submodule-missing",
+                marks=pytest.mark.skip(reason="run: git submodule update --init"),
+            )
+        ]
+    files = [f for d in subdirs for f in sorted((CORPUS / d).rglob("*.parquet"))]
+    return [pytest.param(f, id=f.relative_to(CORPUS).as_posix()) for f in files]
+
+
+def _failed_checks(result):
+    return [c.name for c in result.checks if c.status == CheckStatus.FAILED]
+
+
+def _known_bug_refs(failed_names):
+    """Issue refs covering the given failed check names, or None if any is uncovered."""
+    refs = set()
+    for name in failed_names:
+        for prefix, ref in KNOWN_VALIDATION_BUGS.items():
+            if name.startswith(prefix):
+                refs.add(ref)
+                break
+        else:
+            return None
+    return refs
+
+
+class TestValidFilesRead:
+    """Every data/ and samples/ file must be detected, readable, and valid."""
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_detected_as_v2(self, path):
+        info = detect_geoparquet_file_type(str(path))
+        assert info["file_type"] == "geoparquet_v2", info
+        assert info["geo_version"] == "2.0.0", info
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_schema_and_data_readable(self, path):
+        """Both engines must fully read every file (all codecs, GEOGRAPHY, Z/M)."""
+        import pyarrow.parquet as pq
+
+        geom_cols = detect_geometry_columns(str(path))
+        assert geom_cols, "no geometry column detected"
+
+        table = pq.read_table(str(path))
+        con = duckdb.connect()
+        try:
+            con.execute("INSTALL spatial; LOAD spatial;")
+            (rows,) = con.execute(
+                f"SELECT count(*) FROM read_parquet('{path.as_posix()}')"
+            ).fetchone()
+        finally:
+            con.close()
+        assert rows == table.num_rows
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_validates_clean(self, path):
+        rel = path.relative_to(CORPUS).as_posix()
+        result = validate_geoparquet(str(path), validate_data=True)
+        failed = _failed_checks(result)
+        if rel in CORPUS_BUG_FILES:
+            # Spec-violating fixture: failing validation is the CORRECT outcome
+            # (today it fails for the wrong reason, gpio #583). Non-strict so a
+            # fixed corpus pin flips it green without editing this file.
+            if failed:
+                pytest.xfail(CORPUS_BUG_FILES[rel])
+            return
+        if not failed:
+            return
+        refs = _known_bug_refs(failed)
+        assert refs is not None, f"unexpected validation failures: {failed}"
+        pytest.xfail(f"known gpio validation bugs: {sorted(refs)}")
+
+
+class TestValidFilesSpotChecks:
+    """Targeted assertions on specific spec axes."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected_dim"),
+        [
+            ("linestring-xyz-native-geometry.parquet", "XYZ"),
+            ("linestring-xym-native-geometry.parquet", "XYM"),
+            ("linestring-xyzm-native-geometry.parquet", "XYZM"),
+        ],
+    )
+    @pytest.mark.xfail(
+        strict=False,
+        reason="corpus bug: gen_zm.py writes unsuffixed geometry_types (see CORPUS_BUG_FILES)",
+    )
+    def test_zm_dimensions_parsed(self, name, expected_dim):
+        """Spec: 'a \" Z\" suffix gets added' and geometry_types is 'strictly correct'."""
+        path = CORPUS / "data" / "zm" / name
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        geo = get_geo_metadata(str(path))
+        declared = geo["columns"]["geometry"]["geometry_types"]
+        suffix = expected_dim[2:]  # Z, M, or ZM
+        assert declared == [f"LineString {suffix}"], declared
+
+    def test_two_geometry_columns_different_crs(self):
+        path = CORPUS / "data" / "multi_geometry" / "two-geom-columns-different-crs.parquet"
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        crs_by_col = {}
+        for col in get_schema_info(str(path)):
+            parsed = parse_geometry_logical_type(col.get("logical_type") or "")
+            if parsed:
+                crs_by_col[col["name"]] = parsed.get("crs")
+        assert set(crs_by_col) == {"footprint", "centroid"}, crs_by_col
+        assert crs_by_col["footprint"] != crs_by_col["centroid"], crs_by_col
+
+    @pytest.mark.parametrize(
+        "edges", ["planar", "spherical", "vincenty", "thomas", "andoyer", "karney"]
+    )
+    def test_edges_metadata_preserved_on_read(self, edges):
+        path = CORPUS / "data" / "edges" / f"edges-{edges}.parquet"
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        geo = get_geo_metadata(str(path))
+        col = geo["columns"]["geometry"]
+        expected = None if edges == "planar" else edges
+        assert col.get("edges", None) in (expected, edges), col.get("edges")
+
+
+# filename -> (validate mode, regex patterns over failed check names, xfail reason).
+# A file is "detected" when validation reports invalid AND at least one FAILED
+# check matches a pattern. Mode "2.0" forces target_version="2.0" — used where
+# auto-detect legitimately classifies the file as something valid (adjudicated
+# in each entry's comment).
+BAD_DATA_EXPECTATIONS = {
+    "bbox-does-not-contain-geometry.parquet": ("auto", [r"bbox_contains_data_"], None),
+    # PROJJSON schema validation not implemented yet
+    "crs-invalid-projjson.parquet": (
+        "auto",
+        [r"crs_valid_", r"native_crs_format_"],
+        "#586 no PROJJSON schema validation",
+    ),
+    # Detected today by the coordinate heuristic; after #581/#586 the
+    # deterministic metadata-vs-native comparison (v2_crs_consistency) carries it.
+    "crs-mismatch-schema-vs-geo-metadata.parquet": (
+        "auto",
+        [r"v2_crs_consistency_", r"coordinates_valid_for_crs_"],
+        None,
+    ),
+    "edges-spherical-with-planar-antimeridian-line.parquet": (
+        "auto",
+        [r"edges"],
+        "#586 no spherical-vs-planar data heuristic (may be wontfix)",
+    ),
+    "epoch-on-unsupported-crs.parquet": (
+        "auto",
+        [r"epoch"],
+        "#586 no epoch-on-static-datum check",
+    ),
+    # Auto mode treats unparsable geo as "no metadata" and passes the file as
+    # parquet-geo-only; corrupt JSON should be flagged in any mode.
+    "geo-invalid-json.parquet": (
+        "auto",
+        [r"geo_metadata", r"geo_key"],
+        "#586 invalid geo JSON treated as no-metadata",
+    ),
+    "geo-invalid-utf8.parquet": (
+        "auto",
+        [r"geo_metadata", r"geo_key"],
+        "#585 validator crashes on invalid UTF-8 metadata",
+    ),
+    "geometry-types-mismatch-declared-point-actual-linestring.parquet": (
+        "auto",
+        [r"geometry_types_match_data_"],
+        None,
+    ),
+    "geometry-types-missing-actual-type.parquet": (
+        "auto",
+        [r"geometry_types_match_data_"],
+        None,
+    ),
+    "missing-columns.parquet": ("auto", [r"columns_present"], None),
+    # Adjudicated: with no geo metadata and native types, auto-detect correctly
+    # classifies this as valid parquet-geo-only; the corpus expectation holds
+    # only when GeoParquet 2.0 is explicitly demanded.
+    "missing-geo-metadata.parquet": ("2.0", [r"version_match"], None),
+    "missing-primary-column.parquet": ("auto", [r"primary_column_present"], None),
+    # Auto mode crashes on the None version (#585); 2.0 mode detects it.
+    "missing-version.parquet": ("2.0", [r"version_match", r"version_present"], None),
+    "orientation-ccw-declared-rings-cw.parquet": (
+        "auto",
+        [r"orientation"],
+        "#586 no orientation-vs-data check",
+    ),
+    "primary-column-not-in-columns.parquet": ("auto", [r"primary_column_in_columns"], None),
+    "version-1-0-with-2-0-features.parquet": (
+        "auto",
+        [r"version"],
+        "#586 no version/feature gating check",
+    ),
+    "version-unknown.parquet": (
+        "auto",
+        [r"version"],
+        "#586 unknown geo version accepted in auto mode",
+    ),
+    # The wkb-* fixtures carry no native logical type (writers refuse invalid
+    # WKB), so 2.0-level detection fires on the missing native type rather
+    # than on parsing the payload. A deterministic EWKB byte-probe is #586.
+    "wkb-truncated.parquet": (
+        "auto",
+        [r"native_geo_type_present_", r"geometry_types_match_data_"],
+        None,
+    ),
+    "wkb-with-srid-prefix.parquet": ("auto", [r"native_geo_type_present_"], None),
+    "wkb-wrong-type-byte.parquet": ("auto", [r"native_geo_type_present_"], None),
+    "zm-declared-xy-actual-xyz.parquet": ("auto", [r"native_geo_types_match_"], None),
+    "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
+}
+
+# Files where validate_geoparquet currently raises instead of reporting (#585).
+CRASHES_ON_VALIDATE = {
+    "geo-invalid-utf8.parquet": "#585 GeoParquetError on invalid UTF-8 geo metadata",
+    "missing-version.parquet": "#585 TypeError comparing None version in auto mode",
+}
+
+
+def _bad_data_params():
+    if not (CORPUS / "bad_data").exists():
+        return [
+            pytest.param(
+                None,
+                None,
+                None,
+                id="submodule-missing",
+                marks=pytest.mark.skip(reason="run: git submodule update --init"),
+            )
+        ]
+    params = []
+    for fname, (mode, patterns, gap) in sorted(BAD_DATA_EXPECTATIONS.items()):
+        marks = []
+        if gap:
+            marks.append(pytest.mark.xfail(strict=True, reason=f"gpio gap: {gap}"))
+        params.append(
+            pytest.param(CORPUS / "bad_data" / fname, mode, patterns, id=fname, marks=marks)
+        )
+    return params
+
+
+class TestBadData:
+    """Every bad_data/ file must be rejected for the manifest's reason."""
+
+    def test_manifest_covers_expectations(self):
+        """Guard: corpus updates adding/removing bad files must not go unnoticed."""
+        manifest_path = CORPUS / "bad_data" / "manifest.json"
+        if not manifest_path.exists():
+            pytest.skip("run: git submodule update --init")
+        manifest = set(json.loads(manifest_path.read_text()))
+        on_disk = {f.name for f in (CORPUS / "bad_data").glob("*.parquet")}
+        assert manifest == on_disk
+        assert set(BAD_DATA_EXPECTATIONS) == manifest
+
+    @pytest.mark.parametrize("path", _corpus_files("bad_data"))
+    def test_never_crashes(self, path):
+        """A validator must reject bad files, not raise on them."""
+        if path.name in CRASHES_ON_VALIDATE:
+            pytest.xfail(CRASHES_ON_VALIDATE[path.name])
+        result = validate_geoparquet(str(path), validate_data=True, sample_size=0)
+        assert result is not None
+
+    @pytest.mark.parametrize(("path", "mode", "patterns"), _bad_data_params())
+    def test_detected_for_right_reason(self, path, mode, patterns):
+        if path.name in CRASHES_ON_VALIDATE and mode == "auto":
+            pytest.xfail(CRASHES_ON_VALIDATE[path.name])
+        result = validate_geoparquet(
+            str(path),
+            target_version="2.0" if mode == "2.0" else None,
+            validate_data=True,
+            sample_size=0,
+        )
+        failed = _failed_checks(result)
+        assert not result.is_valid, "bad file passed validation"
+        matched = [n for n in failed if any(re.match(p, n) for p in patterns)]
+        assert matched, f"invalid, but not for the expected reason. Failed: {failed}"
+
+
+WRITE_SUBSET = [
+    "data/encodings/polygon-native-geometry.parquet",
+    "data/crs/crs-epsg-3857.parquet",
+    "data/geometry_types/geometrycollection.parquet",
+    "data/compression/compression-brotli.parquet",
+    "samples/us-states.parquet",
+]
+
+
+class TestWritePath:
+    """Rewriting corpus files through gpio must preserve their 2.0 nature."""
+
+    @pytest.mark.parametrize(
+        "rel",
+        WRITE_SUBSET
+        + [
+            pytest.param(
+                "data/encodings/point-native-geography.parquet",
+                marks=pytest.mark.xfail(
+                    strict=True, reason="gpio #588: GEOGRAPHY rewritten as GEOMETRY, edges lost"
+                ),
+            ),
+            pytest.param(
+                "data/zm/linestring-xyzm-native-geometry.parquet",
+                marks=pytest.mark.xfail(
+                    strict=True, reason="gpio #589: XYZM 2.0 write drops geo metadata"
+                ),
+            ),
+        ],
+    )
+    def test_explicit_v2_rewrite_preserves(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="2.0")
+
+        assert has_native_geo_types(str(out)), "native logical type lost"
+        assert get_geoparquet_version(str(out)) == "2.0.0"
+        # GEOGRAPHY inputs must keep geography semantics (native type or edges).
+        src_types = {c["name"]: c.get("logical_type") or "" for c in get_schema_info(str(src))}
+        out_types = {c["name"]: c.get("logical_type") or "" for c in get_schema_info(str(out))}
+        for col, lt in src_types.items():
+            if "GeographyType" in lt:
+                out_geo = get_geo_metadata(str(out))["columns"][col]
+                assert "GeographyType" in out_types.get(col, "") or out_geo.get("edges") in (
+                    "spherical",
+                    "vincenty",
+                    "thomas",
+                    "andoyer",
+                    "karney",
+                )
+
+    def test_explicit_v2_rewrite_preserves_native_crs(self, tmp_path):
+        """Non-default CRS on the native logical type must survive a rewrite."""
+        src = CORPUS / "data" / "crs" / "crs-epsg-3857.parquet"
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="2.0")
+        (geom_lt,) = [
+            c.get("logical_type") or ""
+            for c in get_schema_info(str(out))
+            if c["name"] == "geometry"
+        ]
+        parsed = parse_geometry_logical_type(geom_lt)
+        assert parsed and parsed.get("crs"), "native CRS lost on rewrite"
+        assert "3857" in str(parsed["crs"]) or "Pseudo-Mercator" in str(parsed["crs"])
+
+    @pytest.mark.xfail(
+        strict=True, reason="gpio #587: auto version mode silently downgrades 2.0 to 1.1"
+    )
+    @pytest.mark.parametrize("rel", WRITE_SUBSET[:3])
+    def test_auto_rewrite_preserves_v2(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version=None)
+        assert get_geoparquet_version(str(out)) == "2.0.0"
+        assert has_native_geo_types(str(out))
+
+    @pytest.mark.parametrize("rel", ["samples/us-states.parquet"])
+    def test_roundtrip_2_0_to_1_1_to_2_0(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        mid = tmp_path / "v11.parquet"
+        back = tmp_path / "v20.parquet"
+        convert_to_geoparquet(str(src), str(mid), skip_hilbert=True, geoparquet_version="1.1")
+        convert_to_geoparquet(str(mid), str(back), skip_hilbert=True, geoparquet_version="2.0")
+        assert get_geoparquet_version(str(mid)) == "1.1.0"
+        assert not has_native_geo_types(str(mid))
+        assert get_geoparquet_version(str(back)) == "2.0.0"
+        assert has_native_geo_types(str(back))
+
+
+class TestCliWiring:
+    """One CLI-level test; everything else goes through the Python API for speed."""
+
+    def test_check_spec_exit_codes(self):
+        good = CORPUS / "data" / "bbox" / "bbox-present.parquet"
+        bad = CORPUS / "bad_data" / "missing-columns.parquet"
+        if not good.exists():
+            pytest.skip("run: git submodule update --init")
+        runner = CliRunner()
+        good_result = runner.invoke(cli, ["check", "spec", str(good), "--json"])
+        # Exit 0 (pass) or 2 (warnings only); 1 would mean spec failures. The
+        # good file currently trips known validation bugs (#581 et al.), so
+        # accept 0/1/2 but require valid JSON output; tighten to {0, 2} when
+        # KNOWN_VALIDATION_BUGS empties.
+        assert good_result.exit_code in (0, 1, 2), good_result.output
+        json.loads(good_result.output)
+        bad_result = runner.invoke(cli, ["check", "spec", str(bad), "--json"])
+        assert bad_result.exit_code == 1, bad_result.output


### PR DESCRIPTION
Adds the official [geoparquet-testing](https://github.com/geoparquet/geoparquet-testing) corpus as a git submodule (`tests/data/geoparquet-testing`, pinned to `5799448`) and a conformance suite (`tests/test_geoparquet_corpus.py`) that runs gpio's read, validate, and write paths against all 73 files. This was the corpus's **first complete run against gpio** (or, as far as we know, any full implementation), so every discrepancy was adjudicated against the spec text rather than assumed to be a gpio bug.

## Results at a glance

| Tier | Files | Outcome |
|---|---|---|
| data/ + samples/ read | 51 | **All 51 read perfectly** — detection as v2, pyarrow + DuckDB full reads, all 6 codecs, native GEOGRAPHY, XYZ/XYM/XYZM, GeometryCollection, multi-geometry-column |
| data/ + samples/ validate | 51 | 6 clean; 42 xfail on known validator bugs (#581–#586); 3 xfail as **corpus bugs** (see below) |
| bad_data/ detection | 22 | 13 detected for the manifest's reason; 2 crash the validator (#585); 7 detection gaps (#586) |
| write (rewrite/roundtrip) | subset | Explicit `--geoparquet-version 2.0` preserves native types + CRS; auto mode silently downgrades (#587); GEOGRAPHY loses spherical semantics (#588); XYZM drops geo metadata (#589) |

`pytest tests/test_geoparquet_corpus.py -rx` is the living gap report: every xfail carries its issue number and flips loudly when a fix lands (strict where a gpio fix is expected; non-strict where a corpus fix is expected).

## gpio issues filed from adjudication

- #581 V2-2/V2-3 fail valid files: explicit CRS84 metadata + absent native CRS is spec-valid (hits 44/51 files)
- #582 `edges` vocabulary missing 2.0 ellipsoidal values (vincenty/thomas/andoyer/karney)
- #583 Z/M geometry_types: `"Polygon Z"` rejected as invalid; data scans drop the dimension suffix
- #584 `POINT EMPTY` counted as "outside bbox" in stats/bbox containment checks
- #585 validator crashes (invalid-UTF-8 `geo` metadata; `None` version comparison) instead of reporting FAILED
- #586 missing checks: unknown version, 1.0-metadata-with-2.0-features, orientation-vs-data, epoch-on-static-datum, PROJJSON schema validation, invalid-JSON `geo`, EWKB probe, spherical-antimeridian heuristic; plus `coordinates_valid_for_crs` false positive on small projected coords
- #587 auto version mode silently downgrades 2.0 input to 1.1 (native types + schema CRS stripped)
- #588 native GEOGRAPHY rewritten as GEOMETRY, `edges: spherical` lost
- #589 XYZM written with `--geoparquet-version 2.0` drops all `geo` metadata

Fixes land in separate PRs per cluster; each will flip its xfails here (TDD: the corpus tests are the failing tests).

## Corpus bug found (upstream)

`data/zm/*` fixtures declare `geometry_types: ["LineString"]` for Z/M/ZM data. The spec mandates the `" Z"`/`" M"`/`" ZM"` suffix and calls the field "strictly correct" — and this is exactly the violation `bad_data/zm-declared-xy-actual-xyz.parquet` tests. Root cause: `scripts/gen_zm.py` hardcodes the unsuffixed list (the `samples/` files do it correctly). Upstream issue to be filed; the three files are non-strict xfails keyed to the corpus pin.

## Adjudications of note (not bugs)

- `bad_data/missing-geo-metadata.parquet`: gpio classifies native-types-without-metadata as valid *parquet-geo-only* — defensible; the corpus expectation only holds when GeoParquet 2.0 is explicitly demanded, so the test forces `target_version="2.0"`.
- `bad_data/wkb-*.parquet`: fixtures carry no native logical type (writers refuse invalid WKB), so gpio detects them via the missing native type rather than by parsing the payload — legitimate 2.0-level rejection.
- `bad_data/crs-mismatch-schema-vs-geo-metadata.parquet` vs `data/crs/crs-epsg-3857.parquet`: coordinate-range heuristics cannot distinguish these two files (both have small coords with a projected CRS); the deterministic detection is the metadata-vs-native CRS comparison (#581's fixed V2-3).

## Wiring

- `corpus` pytest marker; suite skips gracefully (with a hint) when the submodule isn't initialized
- `tests.yml`: `submodules: true` on the `test` and `slow-tests` checkouts
- pytest `--ignore` + codespell `skip` for the submodule (it ships its own test suite)
- Suite runs in ~11s (51+22 files, Python API calls, one CliRunner smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive GeoParquet 2.0 corpus conformance tests covering validation, reading, writing, metadata, CRS, dimensionality, and CLI behavior.
  * Added coverage for invalid fixtures, expected validation failures, and round-trip conversions.
  * Tests now use the official testing corpus and skip gracefully when it is unavailable.
* **Documentation**
  * Documented corpus test setup and added the new `corpus` test marker.
* **Chores**
  * Added and pinned the GeoParquet testing corpus as a test resource.
  * Updated automated test workflows to initialize required submodules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->