### PR TITLE
fix(validate): dimension-aware Z/M geometry_types handling (#583)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,8 @@ jobs:
           persist-credentials: false
           # Full history so diff-cover can diff against the PR base branch.
           fetch-depth: 0
+          # geoparquet-testing corpus for the corpus conformance tests
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -232,6 +234,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # geoparquet-testing corpus for the corpus conformance tests
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/data/geoparquet-testing"]
+	path = tests/data/geoparquet-testing
+	url = https://github.com/geoparquet/geoparquet-testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ uv run pytest -n auto -m "not slow and not network"  # Fast tests
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 <!-- END GENERATED: test-markers -->
 
 ---

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,6 +97,7 @@ Coverage gates (both enforced in CI):
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 <!-- END GENERATED: test-markers -->
 
 ## Code Quality

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -16,6 +16,7 @@ import re
 from typing import Any
 
 import duckdb
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.exceptions import GeoParquetError
@@ -127,12 +128,13 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
 
         # Get schema info with proper type mapping
         for field in schema:
-            # First check Arrow schema for logical type (GeoArrow extension types)
-            logical_type = _get_pyarrow_logical_type(field)
-
-            # If not found in Arrow schema, check Parquet physical schema
-            # This handles native Parquet GEOMETRY/GEOGRAPHY logical types
-            if logical_type is None and field.name in parquet_col_map:
+            # Prefer the Parquet physical schema's native GEOMETRY/GEOGRAPHY
+            # logical type: it is stable, while the Arrow-level view of the
+            # same column flips to a geoarrow extension type (dropping the
+            # Geometry/Geography distinction) once geoarrow.pyarrow has been
+            # imported anywhere in the process.
+            logical_type = None
+            if field.name in parquet_col_map:
                 parquet_col = parquet_col_map[field.name]
                 if parquet_col.logical_type is not None:
                     logical_type_str = str(parquet_col.logical_type)
@@ -144,9 +146,22 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
                     elif logical_type_str.startswith("Geography("):
                         logical_type = "GeographyType" + logical_type_str[9:]
 
+            # Fall back to the Arrow schema (GeoArrow extension types, e.g.
+            # 1.1-geoarrow files with no native Parquet logical type)
+            if logical_type is None:
+                logical_type = _get_pyarrow_logical_type(field)
+
+            # Report the storage type for extension fields: whether pyarrow
+            # sees geoarrow.wkb here depends on process-global extension
+            # registration (importing geoarrow.pyarrow anywhere flips it), and
+            # schema info must not vary with import order.
+            field_type = field.type
+            if isinstance(field_type, pa.ExtensionType):
+                field_type = field_type.storage_type
+
             col_info = {
                 "name": field.name,
-                "type": str(field.type),
+                "type": str(field_type),
                 "type_length": None,
                 "repetition_type": "OPTIONAL" if field.nullable else "REQUIRED",
                 "num_children": 0,

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -235,6 +235,26 @@ def _check_encoding_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     )
 
 
+def _strip_zm_suffix(geometry_type: str) -> str:
+    """Return the base geometry type without a spec " Z"/" M"/" ZM" suffix."""
+    if not isinstance(geometry_type, str):
+        return geometry_type
+    for suffix in (" ZM", " Z", " M"):
+        if geometry_type.endswith(suffix):
+            return geometry_type[: -len(suffix)]
+    return geometry_type
+
+
+def _zm_suffix_sql(geom_expr: str, sep: str = " ") -> str:
+    """SQL fragment producing the dimension suffix (''/'{sep}Z'/'{sep}M'/'{sep}ZM')."""
+    return (
+        f"CASE WHEN ST_HasZ({geom_expr}) AND ST_HasM({geom_expr}) THEN '{sep}ZM' "
+        f"WHEN ST_HasZ({geom_expr}) THEN '{sep}Z' "
+        f"WHEN ST_HasM({geom_expr}) THEN '{sep}M' "
+        f"ELSE '' END"
+    )
+
+
 def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck:
     """Check 8: column metadata must include a 'geometry_types' list."""
     geometry_types = col_meta.get("geometry_types")
@@ -248,8 +268,9 @@ def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck
             category="column_metadata",
         )
 
-    # Validate each type is a valid string
-    invalid_types = [t for t in geometry_types if t not in VALID_GEOMETRY_TYPES]
+    # Validate each type is a valid string; the spec adds a " Z"/" M"/" ZM"
+    # suffix for 3D/measured geometries (e.g. "Point Z").
+    invalid_types = [t for t in geometry_types if _strip_zm_suffix(t) not in VALID_GEOMETRY_TYPES]
     if invalid_types:
         return ValidationCheck(
             name=f"geometry_types_list_{col_name}",
@@ -628,16 +649,19 @@ def _check_geometry_types_match_data(
         else:
             geom_expr = f'ST_GeomFromWKB("{geom_col}")'
 
-        # Get both distinct types and total count in one query
+        # Get both distinct types and total count in one query. The dimension
+        # suffix matters: "LineString" and "LineString ZM" are distinct
+        # geometry_types per spec, so the scan must not collapse them.
+        typed_expr = f"ST_GeometryType({geom_expr}) || {_zm_suffix_sql(geom_expr)}"
         query = f"""
-            SELECT ST_GeometryType({geom_expr}) as geom_type, COUNT(*) as cnt
+            SELECT {typed_expr} as geom_type, COUNT(*) as cnt
             FROM (
                 SELECT "{geom_col}"
                 FROM read_parquet('{safe_url}')
                 WHERE "{geom_col}" IS NOT NULL
                 {limit_clause}
             )
-            GROUP BY ST_GeometryType({geom_expr})
+            GROUP BY {typed_expr}
         """
 
         result = con.execute(query).fetchall()
@@ -662,10 +686,17 @@ def _check_geometry_types_match_data(
         normalized_found = set()
         for t in found_types.keys():
             if t:
-                # Strip ST_ prefix if present, then map via explicit mapping
+                # Strip ST_ prefix if present, split off the dimension suffix,
+                # map the base name, then re-append the suffix ("Point Z").
                 clean_type = t.replace("ST_", "").upper()
+                suffix = ""
+                for candidate in (" ZM", " Z", " M"):
+                    if clean_type.endswith(candidate):
+                        suffix = candidate
+                        clean_type = clean_type[: -len(candidate)]
+                        break
                 normalized = geom_type_mapping.get(clean_type, t)
-                normalized_found.add(normalized)
+                normalized_found.add(normalized + suffix)
 
         declared_set = set(declared_types) if declared_types else set()
 
@@ -1675,18 +1706,22 @@ def _check_native_geo_types_match(
                 category="parquet_geo_types",
             )
 
-        # Sample actual geometry types from the data
+        # Sample actual geometry types from the data. DuckDB's geo_types
+        # naming is dimension-aware ("linestring_m"), so append the matching
+        # suffix from ST_HasZ/ST_HasM instead of comparing base names only.
+        quoted_col = f'"{geom_col}"'
+        typed_expr = f"ST_GeometryType({quoted_col}) || {_zm_suffix_sql(quoted_col, sep='_')}"
         if sample_size == 0:
             # Check all rows
             actual_result = con.execute(f"""
-                SELECT DISTINCT ST_GeometryType("{geom_col}") as geom_type
+                SELECT DISTINCT {typed_expr} as geom_type
                 FROM read_parquet('{safe_url}')
                 WHERE "{geom_col}" IS NOT NULL
             """).fetchall()
         else:
             # Sample rows
             actual_result = con.execute(f"""
-                SELECT DISTINCT ST_GeometryType("{geom_col}") as geom_type
+                SELECT DISTINCT {typed_expr} as geom_type
                 FROM (
                     SELECT "{geom_col}"
                     FROM read_parquet('{safe_url}')

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -14,6 +14,7 @@ from typing import Any
 from rich.console import Console
 
 from geoparquet_io.core.crs_utils import NULL_CRS_HINT, get_crs_display_name, is_geographic_crs
+from geoparquet_io.core.exceptions import GeoParquetError
 
 
 class CheckStatus(Enum):
@@ -334,8 +335,14 @@ def _check_orientation_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     )
 
 
-def _check_edges_valid(col_meta: dict, col_name: str) -> ValidationCheck:
-    """Check 11: optional 'edges' must be a valid string."""
+def _check_edges_valid(
+    col_meta: dict, col_name: str, geo_version: str = "1.0.0"
+) -> ValidationCheck:
+    """Check 11: optional 'edges' must be a valid string.
+
+    GeoParquet 2.0 widened the vocabulary from planar/spherical to include the
+    four ellipsoidal-geodesic algorithms; 1.x keeps the narrow set.
+    """
     edges = col_meta.get("edges")
 
     if edges is None:
@@ -346,13 +353,17 @@ def _check_edges_valid(col_meta: dict, col_name: str) -> ValidationCheck:
             category="column_metadata",
         )
 
-    is_valid = edges in VALID_EDGES_GEOPARQUET
+    valid_edges = list(VALID_EDGES_GEOPARQUET)
+    if (geo_version or "1.0.0") >= "2.0.0":
+        valid_edges += [e for e in VALID_EDGES_PARQUET_GEO if e not in valid_edges]
+
+    is_valid = edges in valid_edges
     return ValidationCheck(
         name=f"edges_valid_{col_name}",
         status=CheckStatus.PASSED if is_valid else CheckStatus.FAILED,
         message=f'column "{col_name}" has valid edges: {edges}'
         if is_valid
-        else f'column "{col_name}" edges must be one of {VALID_EDGES_GEOPARQUET}',
+        else f'column "{col_name}" edges must be one of {valid_edges}',
         category="column_metadata",
     )
 
@@ -738,6 +749,8 @@ def _build_bbox_query(
         geom_expr = geom_col
     else:
         geom_expr = f"ST_GeomFromWKB({geom_col})"
+    # Empties have no extent; the same expression filters them out pre-LIMIT.
+    geom_expr_filter = geom_expr
 
     return f"""
         SELECT COUNT(*) as total,
@@ -751,6 +764,7 @@ def _build_bbox_query(
             SELECT {geom_col}
             FROM read_parquet('{safe_url}')
             WHERE {geom_col} IS NOT NULL
+              AND NOT ST_IsEmpty({geom_expr_filter})
             {limit_clause}
         )
     """
@@ -1595,6 +1609,7 @@ def _check_native_geo_stats_contains_data(
                 SELECT "{geom_col}"
                 FROM read_parquet('{safe_url}')
                 WHERE "{geom_col}" IS NOT NULL
+                  AND NOT ST_IsEmpty("{geom_col}")
                 {limit_clause}
             )
         """
@@ -1769,6 +1784,16 @@ def _check_v2_crs_in_parquet_type(
             category="geoparquet_2_0",
         )
 
+    # Explicit CRS84-equivalent metadata is still the default: the native type
+    # may omit its crs (which the Parquet spec defines as OGC:CRS84).
+    if _is_crs84_equivalent(metadata_crs):
+        return ValidationCheck(
+            name=f"v2_crs_in_parquet_type_{geom_col}",
+            status=CheckStatus.PASSED,
+            message="metadata CRS is the default (OGC:CRS84), no inline CRS required",
+            category="geoparquet_2_0",
+        )
+
     # Find the Parquet schema CRS
     for col in schema_info:
         if col.get("name") == geom_col:
@@ -1816,17 +1841,20 @@ def _check_v2_crs_consistency(geo_meta: dict, schema_info: list, geom_col: str) 
                 schema_crs = parsed.get("crs")
             break
 
-    # Both None = both default = match
-    if metadata_crs is None and schema_crs is None:
+    # An absent CRS on either side means the default, OGC:CRS84. Resolve both
+    # sides before comparing so explicit-CRS84 vs absent doesn't false-fail.
+    metadata_is_default = metadata_crs is None or _is_crs84_equivalent(metadata_crs)
+    schema_is_default = schema_crs is None or _is_crs84_equivalent(_parse_crs_value(schema_crs))
+    if metadata_is_default and schema_is_default:
         return ValidationCheck(
             name=f"v2_crs_consistency_{geom_col}",
             status=CheckStatus.PASSED,
-            message="CRS matches: both default to OGC:CRS84",
+            message="CRS matches: both are OGC:CRS84 (explicit or default)",
             category="geoparquet_2_0",
         )
 
     # Compare CRS - simplified comparison
-    if _crs_equals(metadata_crs, schema_crs):
+    if _crs_equals(metadata_crs, _parse_crs_value(schema_crs)):
         return ValidationCheck(
             name=f"v2_crs_consistency_{geom_col}",
             status=CheckStatus.PASSED,
@@ -2020,6 +2048,50 @@ def _extract_epsg_code(crs: Any) -> int | None:
     if isinstance(crs, str):
         return _extract_epsg_from_string(crs)
     return None
+
+
+def _parse_crs_value(crs: Any) -> Any:
+    """Normalize a CRS that may arrive as a PROJJSON string (from a logical type)."""
+    if isinstance(crs, str):
+        stripped = crs.strip()
+        if stripped.startswith("{"):
+            try:
+                return json.loads(stripped)
+            except (ValueError, TypeError):
+                return crs
+    return crs
+
+
+def _is_crs84_equivalent(crs: Any) -> bool:
+    """True when a declared CRS is the spec default (OGC:CRS84) or its lon/lat twin.
+
+    GeoParquet fixes coordinate order to (x, y) regardless of the CRS's own
+    axis definition, so EPSG:4326 metadata describes the same coordinates as
+    the OGC:CRS84 default.
+    """
+    crs = _parse_crs_value(crs)
+    if _is_ogc_crs84(crs):
+        return True
+    if isinstance(crs, dict):
+        crs_id = crs.get("id", {})
+        if isinstance(crs_id, dict) and crs_id:
+            authority = str(crs_id.get("authority", "")).upper()
+            code = str(crs_id.get("code", "")).upper()
+            return authority == "EPSG" and code == "4326"
+        # No id member (allowed in PROJJSON): fall back to a semantic
+        # comparison. Axis order is ignored because GeoParquet fixes
+        # coordinate order to (x, y) regardless of the CRS definition.
+        try:
+            from pyproj import CRS as PyprojCRS
+
+            return PyprojCRS.from_json_dict(crs).equals(
+                PyprojCRS.from_user_input("OGC:CRS84"), ignore_axis_order=True
+            )
+        except Exception:
+            return False
+    if isinstance(crs, str):
+        return crs.upper() in ("OGC:CRS84", "EPSG:4326", "SRID:4326")
+    return False
 
 
 def _is_ogc_crs84(crs: Any) -> bool:
@@ -2380,8 +2452,26 @@ def validate_geoparquet(
 
     safe_url = safe_file_url(parquet_file, verbose=verbose)
 
-    # Auto-detect file type
-    file_type_info = detect_geoparquet_file_type(parquet_file, verbose)
+    # Auto-detect file type. Corrupt metadata (e.g. invalid UTF-8 in the geo
+    # value) must yield a FAILED report, never an exception.
+    try:
+        file_type_info = detect_geoparquet_file_type(parquet_file, verbose)
+    except (GeoParquetError, UnicodeDecodeError, ValueError) as e:
+        result = ValidationResult(
+            file_path=parquet_file,
+            detected_version="unknown",
+            target_version=target_version,
+        )
+        result.checks.append(
+            ValidationCheck(
+                name="geo_metadata_parse",
+                status=CheckStatus.FAILED,
+                message="file metadata is not readable (corrupt or invalid encoding)",
+                details=str(e),
+                category="core_metadata",
+            )
+        )
+        return result
 
     # Determine detected version (always from file, not target)
     detected_version = _determine_version(file_type_info)
@@ -2402,11 +2492,25 @@ def validate_geoparquet(
             if version_check.status == CheckStatus.FAILED:
                 return result
 
-    # Get metadata
-    kv_metadata = get_kv_metadata(safe_url)
-    geo_meta = get_geo_metadata(safe_url)
-    schema_info = get_schema_info(safe_url)
-    geo_columns = detect_geometry_columns(safe_url)
+    # Get metadata. Corrupt metadata (e.g. invalid UTF-8 in the geo value) must
+    # yield a FAILED report, never an exception — rejecting such files is this
+    # function's job.
+    try:
+        kv_metadata = get_kv_metadata(safe_url)
+        geo_meta = get_geo_metadata(safe_url)
+        schema_info = get_schema_info(safe_url)
+        geo_columns = detect_geometry_columns(safe_url)
+    except (GeoParquetError, UnicodeDecodeError, ValueError) as e:
+        result.checks.append(
+            ValidationCheck(
+                name="geo_metadata_parse",
+                status=CheckStatus.FAILED,
+                message="file metadata is not readable (corrupt or invalid encoding)",
+                details=str(e),
+                category="core_metadata",
+            )
+        )
+        return result
 
     # Get DuckDB connection for data validation
     con = None
@@ -2632,13 +2736,17 @@ def _run_geoparquet_checks(
 
     columns = geo_meta.get("columns", {})
 
+    # A missing version is reported by _check_version_present above; guard the
+    # string comparisons below against None so validation never crashes on it.
+    geo_version = file_type_info.get("geo_version") or "1.0.0"
+
     # Column metadata checks for each geometry column
     for col_name, col_meta in columns.items():
         checks.append(_check_encoding_valid(col_meta, col_name))
         checks.append(_check_geometry_types_list(col_meta, col_name))
         checks.append(_check_crs_valid(col_meta, col_name))
         checks.append(_check_orientation_valid(col_meta, col_name))
-        checks.append(_check_edges_valid(col_meta, col_name))
+        checks.append(_check_edges_valid(col_meta, col_name, geo_version))
         checks.append(_check_bbox_valid(col_meta, col_name))
         checks.append(_check_epoch_valid(col_meta, col_name))
 
@@ -2678,8 +2786,6 @@ def _run_geoparquet_checks(
             )
 
     # Version-specific checks
-    geo_version = file_type_info.get("geo_version", "1.0.0")
-
     # GeoParquet 1.1 checks - covering was removed in 2.0, so only run for 1.x
     is_v1_1 = geo_version >= "1.1.0" and geo_version < "2.0.0"
     if is_v1_1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,11 +132,14 @@ addopts = [
     "--cov=geoparquet_io",
     "--cov-report=term-missing",
     "--cov-fail-under=67",
+    # The geoparquet-testing submodule ships its own pytest suite; never collect it.
+    "--ignore=tests/data/geoparquet-testing",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
     "integration: marks end-to-end integration tests",
+    "corpus: tests against the official geoparquet-testing corpus (requires git submodule)",
 ]
 
 [tool.ruff]
@@ -323,7 +326,7 @@ verbose = false
 # site/ (mkdocs build) and mutants/ (mutmut working tree) are gitignored
 # build artifacts; scanning them made test_codespell_passes fail on any
 # machine that had built docs or run mutation testing locally.
-skip = ".git,*.lock,*.parquet,*.json,tests/data/*,.venv,uv.lock,site,mutants"
+skip = ".git,*.lock,*.parquet,*.json,tests/data/*,geoparquet-testing,.venv,uv.lock,site,mutants"
 ignore-words-list = "nd,ot,crs,inout,hel,bu"
 check-filenames = true
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,20 @@ The `data/` directory contains test GeoParquet files:
 - `places_test.parquet` - 766 rows with place data including bbox column
 - `buildings_test.parquet` - 42 rows with building geometries
 
+### geoparquet-testing corpus (submodule)
+
+`data/geoparquet-testing/` is a git submodule vendoring the official
+[geoparquet-testing](https://github.com/geoparquet/geoparquet-testing) corpus,
+used by `test_geoparquet_corpus.py` (marker: `corpus`). Initialize it with:
+
+```bash
+git submodule update --init
+```
+
+Without it those tests skip with a hint. The pin is a specific upstream commit;
+bump it deliberately (fixture changes can alter expected results — see the
+adjudication notes in `test_geoparquet_corpus.py`).
+
 ## Running Tests
 
 ### Run all tests

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -55,9 +55,6 @@ CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
 # tracking each fix. test_validates_clean xfails while a file's failures are
 # all covered here and fails hard on anything new. Remove entries as fixes land.
 KNOWN_VALIDATION_BUGS = {
-    "geometry_types_list": "#583 Z/M suffixed types rejected",
-    "geometry_types_match_data": "#583 data scan drops Z/M suffix",
-    "native_geo_types_match": "#583 native stats comparison drops Z/M suffix",
     "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
 }
 
@@ -286,7 +283,13 @@ BAD_DATA_EXPECTATIONS = {
     ),
     "wkb-with-srid-prefix.parquet": ("auto", [r"native_geo_type_present_"], None),
     "wkb-wrong-type-byte.parquet": ("auto", [r"native_geo_type_present_"], None),
-    "zm-declared-xy-actual-xyz.parquet": ("auto", [r"native_geo_types_match_"], None),
+    # Native stats (computed from data) agree with the data, so detection
+    # comes from the geo-metadata declaration disagreeing with the scan.
+    "zm-declared-xy-actual-xyz.parquet": (
+        "auto",
+        [r"geometry_types_match_data_", r"native_geo_types_match_"],
+        None,
+    ),
     "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
 }
 

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -1,0 +1,483 @@
+"""
+Conformance tests against the official geoparquet-testing corpus.
+
+The corpus (https://github.com/geoparquet/geoparquet-testing) is vendored as a
+git submodule at tests/data/geoparquet-testing, pinned to a specific commit.
+Run ``git submodule update --init`` if these tests report SKIPPED.
+
+Three tiers:
+- data/ + samples/ (51 files): valid GeoParquet 2.0.0 — gpio must detect,
+  read, and validate them cleanly.
+- bad_data/ (22 files): deliberate spec violations with a manifest of expected
+  failure codes — gpio must reject each one for the right reason, and must
+  never crash on any of them.
+- Write tier: representative corpus files rewritten through gpio must keep
+  their GeoParquet 2.0 nature (native logical types, CRS, geo metadata).
+
+Adjudication policy: this suite was built from the corpus's first complete run
+against gpio (July 2026). Discrepancies were judged against the spec text, not
+assumed to be gpio bugs. Confirmed gpio bugs are tracked in GitHub issues and
+appear here as KNOWN_VALIDATION_BUGS entries or xfail marks referencing the
+issue; they turn into hard failures/XPASS as fixes land.
+
+One corpus bug was found (CORPUS_BUG_FILES): the data/zm/ fixtures declare
+geometry_types ["LineString"] without the " Z"/" M"/" ZM" suffix the spec
+mandates for 3D/measured data ("a ' Z' suffix gets added", "It is expected
+that this field is strictly correct") — the very violation bad_data/
+zm-declared-xy-actual-xyz.parquet exists to test. Reported upstream; these
+xfails are non-strict so a fixed corpus pin turns them green automatically.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.common import detect_geoparquet_file_type
+from geoparquet_io.core.convert import convert_to_geoparquet
+from geoparquet_io.core.duckdb_metadata import (
+    detect_geometry_columns,
+    get_schema_info,
+    parse_geometry_logical_type,
+)
+from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+from tests.conftest import get_geo_metadata, get_geoparquet_version, has_native_geo_types
+
+pytestmark = [pytest.mark.corpus, pytest.mark.integration]
+
+CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
+
+# Validation checks that misfire on valid corpus files, with the gpio issue
+# tracking each fix. test_validates_clean xfails while a file's failures are
+# all covered here and fails hard on anything new. Remove entries as fixes land.
+KNOWN_VALIDATION_BUGS = {
+    "v2_crs_in_parquet_type": "#581 CRS84-default equivalence",
+    "v2_crs_consistency": "#581 CRS84-default equivalence",
+    "edges_valid": "#582 missing 2.0 ellipsoidal edges values",
+    "geometry_types_list": "#583 Z/M suffixed types rejected",
+    "geometry_types_match_data": "#583 data scan drops Z/M suffix",
+    "native_geo_types_match": "#583 native stats comparison drops Z/M suffix",
+    "native_geo_stats_contains_data": "#584 POINT EMPTY counted as outside bbox",
+    "bbox_contains_data": "#584 POINT EMPTY counted as outside bbox",
+    "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
+}
+
+
+# Fixtures that themselves violate the spec (upstream geoparquet-testing bugs).
+# Non-strict xfail: they pass again once the corpus pin advances past the fix.
+CORPUS_BUG_FILES = {
+    "data/zm/linestring-xyz-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYZ data; spec requires 'LineString Z'"
+    ),
+    "data/zm/linestring-xym-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYM data; spec requires 'LineString M'"
+    ),
+    "data/zm/linestring-xyzm-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYZM data; spec requires 'LineString ZM'"
+    ),
+}
+
+
+def _corpus_files(*subdirs):
+    """Parametrize over corpus files; one graceful skip if the submodule is absent."""
+    if not (CORPUS / "data").exists():
+        return [
+            pytest.param(
+                None,
+                id="submodule-missing",
+                marks=pytest.mark.skip(reason="run: git submodule update --init"),
+            )
+        ]
+    files = [f for d in subdirs for f in sorted((CORPUS / d).rglob("*.parquet"))]
+    return [pytest.param(f, id=f.relative_to(CORPUS).as_posix()) for f in files]
+
+
+def _failed_checks(result):
+    return [c.name for c in result.checks if c.status == CheckStatus.FAILED]
+
+
+def _known_bug_refs(failed_names):
+    """Issue refs covering the given failed check names, or None if any is uncovered."""
+    refs = set()
+    for name in failed_names:
+        for prefix, ref in KNOWN_VALIDATION_BUGS.items():
+            if name.startswith(prefix):
+                refs.add(ref)
+                break
+        else:
+            return None
+    return refs
+
+
+class TestValidFilesRead:
+    """Every data/ and samples/ file must be detected, readable, and valid."""
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_detected_as_v2(self, path):
+        info = detect_geoparquet_file_type(str(path))
+        assert info["file_type"] == "geoparquet_v2", info
+        assert info["geo_version"] == "2.0.0", info
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_schema_and_data_readable(self, path):
+        """Both engines must fully read every file (all codecs, GEOGRAPHY, Z/M)."""
+        import pyarrow.parquet as pq
+
+        geom_cols = detect_geometry_columns(str(path))
+        assert geom_cols, "no geometry column detected"
+
+        table = pq.read_table(str(path))
+        con = duckdb.connect()
+        try:
+            con.execute("INSTALL spatial; LOAD spatial;")
+            (rows,) = con.execute(
+                f"SELECT count(*) FROM read_parquet('{path.as_posix()}')"
+            ).fetchone()
+        finally:
+            con.close()
+        assert rows == table.num_rows
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_validates_clean(self, path):
+        rel = path.relative_to(CORPUS).as_posix()
+        result = validate_geoparquet(str(path), validate_data=True)
+        failed = _failed_checks(result)
+        if rel in CORPUS_BUG_FILES:
+            # Spec-violating fixture: failing validation is the CORRECT outcome
+            # (today it fails for the wrong reason, gpio #583). Non-strict so a
+            # fixed corpus pin flips it green without editing this file.
+            if failed:
+                pytest.xfail(CORPUS_BUG_FILES[rel])
+            return
+        if not failed:
+            return
+        refs = _known_bug_refs(failed)
+        assert refs is not None, f"unexpected validation failures: {failed}"
+        pytest.xfail(f"known gpio validation bugs: {sorted(refs)}")
+
+
+class TestValidFilesSpotChecks:
+    """Targeted assertions on specific spec axes."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected_dim"),
+        [
+            ("linestring-xyz-native-geometry.parquet", "XYZ"),
+            ("linestring-xym-native-geometry.parquet", "XYM"),
+            ("linestring-xyzm-native-geometry.parquet", "XYZM"),
+        ],
+    )
+    @pytest.mark.xfail(
+        strict=False,
+        reason="corpus bug: gen_zm.py writes unsuffixed geometry_types (see CORPUS_BUG_FILES)",
+    )
+    def test_zm_dimensions_parsed(self, name, expected_dim):
+        """Spec: 'a \" Z\" suffix gets added' and geometry_types is 'strictly correct'."""
+        path = CORPUS / "data" / "zm" / name
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        geo = get_geo_metadata(str(path))
+        declared = geo["columns"]["geometry"]["geometry_types"]
+        suffix = expected_dim[2:]  # Z, M, or ZM
+        assert declared == [f"LineString {suffix}"], declared
+
+    def test_two_geometry_columns_different_crs(self):
+        path = CORPUS / "data" / "multi_geometry" / "two-geom-columns-different-crs.parquet"
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        crs_by_col = {}
+        for col in get_schema_info(str(path)):
+            parsed = parse_geometry_logical_type(col.get("logical_type") or "")
+            if parsed:
+                crs_by_col[col["name"]] = parsed.get("crs")
+        assert set(crs_by_col) == {"footprint", "centroid"}, crs_by_col
+        assert crs_by_col["footprint"] != crs_by_col["centroid"], crs_by_col
+
+    @pytest.mark.parametrize(
+        "edges", ["planar", "spherical", "vincenty", "thomas", "andoyer", "karney"]
+    )
+    def test_edges_metadata_preserved_on_read(self, edges):
+        path = CORPUS / "data" / "edges" / f"edges-{edges}.parquet"
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        geo = get_geo_metadata(str(path))
+        col = geo["columns"]["geometry"]
+        expected = None if edges == "planar" else edges
+        assert col.get("edges", None) in (expected, edges), col.get("edges")
+
+
+# filename -> (validate mode, regex patterns over failed check names, xfail reason).
+# A file is "detected" when validation reports invalid AND at least one FAILED
+# check matches a pattern. Mode "2.0" forces target_version="2.0" — used where
+# auto-detect legitimately classifies the file as something valid (adjudicated
+# in each entry's comment).
+BAD_DATA_EXPECTATIONS = {
+    "bbox-does-not-contain-geometry.parquet": ("auto", [r"bbox_contains_data_"], None),
+    # PROJJSON schema validation not implemented yet
+    "crs-invalid-projjson.parquet": (
+        "auto",
+        [r"crs_valid_", r"native_crs_format_"],
+        "#586 no PROJJSON schema validation",
+    ),
+    # Detected today by the coordinate heuristic; after #581/#586 the
+    # deterministic metadata-vs-native comparison (v2_crs_consistency) carries it.
+    "crs-mismatch-schema-vs-geo-metadata.parquet": (
+        "auto",
+        [r"v2_crs_consistency_", r"coordinates_valid_for_crs_"],
+        None,
+    ),
+    "edges-spherical-with-planar-antimeridian-line.parquet": (
+        "auto",
+        [r"edges"],
+        "#586 no spherical-vs-planar data heuristic (may be wontfix)",
+    ),
+    "epoch-on-unsupported-crs.parquet": (
+        "auto",
+        [r"epoch"],
+        "#586 no epoch-on-static-datum check",
+    ),
+    # Auto mode treats unparsable geo as "no metadata" and passes the file as
+    # parquet-geo-only; corrupt JSON should be flagged in any mode.
+    "geo-invalid-json.parquet": (
+        "auto",
+        [r"geo_metadata", r"geo_key"],
+        "#586 invalid geo JSON treated as no-metadata",
+    ),
+    "geo-invalid-utf8.parquet": (
+        "auto",
+        [r"geo_metadata", r"geo_key"],
+        "#585 validator crashes on invalid UTF-8 metadata",
+    ),
+    "geometry-types-mismatch-declared-point-actual-linestring.parquet": (
+        "auto",
+        [r"geometry_types_match_data_"],
+        None,
+    ),
+    "geometry-types-missing-actual-type.parquet": (
+        "auto",
+        [r"geometry_types_match_data_"],
+        None,
+    ),
+    "missing-columns.parquet": ("auto", [r"columns_present"], None),
+    # Adjudicated: with no geo metadata and native types, auto-detect correctly
+    # classifies this as valid parquet-geo-only; the corpus expectation holds
+    # only when GeoParquet 2.0 is explicitly demanded.
+    "missing-geo-metadata.parquet": ("2.0", [r"version_match"], None),
+    "missing-primary-column.parquet": ("auto", [r"primary_column_present"], None),
+    # Auto mode crashes on the None version (#585); 2.0 mode detects it.
+    "missing-version.parquet": ("2.0", [r"version_match", r"version_present"], None),
+    "orientation-ccw-declared-rings-cw.parquet": (
+        "auto",
+        [r"orientation"],
+        "#586 no orientation-vs-data check",
+    ),
+    "primary-column-not-in-columns.parquet": ("auto", [r"primary_column_in_columns"], None),
+    "version-1-0-with-2-0-features.parquet": (
+        "auto",
+        [r"version"],
+        "#586 no version/feature gating check",
+    ),
+    "version-unknown.parquet": (
+        "auto",
+        [r"version"],
+        "#586 unknown geo version accepted in auto mode",
+    ),
+    # The wkb-* fixtures carry no native logical type (writers refuse invalid
+    # WKB), so 2.0-level detection fires on the missing native type rather
+    # than on parsing the payload. A deterministic EWKB byte-probe is #586.
+    "wkb-truncated.parquet": (
+        "auto",
+        [r"native_geo_type_present_", r"geometry_types_match_data_"],
+        None,
+    ),
+    "wkb-with-srid-prefix.parquet": ("auto", [r"native_geo_type_present_"], None),
+    "wkb-wrong-type-byte.parquet": ("auto", [r"native_geo_type_present_"], None),
+    "zm-declared-xy-actual-xyz.parquet": ("auto", [r"native_geo_types_match_"], None),
+    "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
+}
+
+# Files where validate_geoparquet currently raises instead of reporting (#585).
+CRASHES_ON_VALIDATE = {
+    "geo-invalid-utf8.parquet": "#585 GeoParquetError on invalid UTF-8 geo metadata",
+    "missing-version.parquet": "#585 TypeError comparing None version in auto mode",
+}
+
+
+def _bad_data_params():
+    if not (CORPUS / "bad_data").exists():
+        return [
+            pytest.param(
+                None,
+                None,
+                None,
+                id="submodule-missing",
+                marks=pytest.mark.skip(reason="run: git submodule update --init"),
+            )
+        ]
+    params = []
+    for fname, (mode, patterns, gap) in sorted(BAD_DATA_EXPECTATIONS.items()):
+        marks = []
+        if gap:
+            marks.append(pytest.mark.xfail(strict=True, reason=f"gpio gap: {gap}"))
+        params.append(
+            pytest.param(CORPUS / "bad_data" / fname, mode, patterns, id=fname, marks=marks)
+        )
+    return params
+
+
+class TestBadData:
+    """Every bad_data/ file must be rejected for the manifest's reason."""
+
+    def test_manifest_covers_expectations(self):
+        """Guard: corpus updates adding/removing bad files must not go unnoticed."""
+        manifest_path = CORPUS / "bad_data" / "manifest.json"
+        if not manifest_path.exists():
+            pytest.skip("run: git submodule update --init")
+        manifest = set(json.loads(manifest_path.read_text()))
+        on_disk = {f.name for f in (CORPUS / "bad_data").glob("*.parquet")}
+        assert manifest == on_disk
+        assert set(BAD_DATA_EXPECTATIONS) == manifest
+
+    @pytest.mark.parametrize("path", _corpus_files("bad_data"))
+    def test_never_crashes(self, path):
+        """A validator must reject bad files, not raise on them."""
+        if path.name in CRASHES_ON_VALIDATE:
+            pytest.xfail(CRASHES_ON_VALIDATE[path.name])
+        result = validate_geoparquet(str(path), validate_data=True, sample_size=0)
+        assert result is not None
+
+    @pytest.mark.parametrize(("path", "mode", "patterns"), _bad_data_params())
+    def test_detected_for_right_reason(self, path, mode, patterns):
+        if path.name in CRASHES_ON_VALIDATE and mode == "auto":
+            pytest.xfail(CRASHES_ON_VALIDATE[path.name])
+        result = validate_geoparquet(
+            str(path),
+            target_version="2.0" if mode == "2.0" else None,
+            validate_data=True,
+            sample_size=0,
+        )
+        failed = _failed_checks(result)
+        assert not result.is_valid, "bad file passed validation"
+        matched = [n for n in failed if any(re.match(p, n) for p in patterns)]
+        assert matched, f"invalid, but not for the expected reason. Failed: {failed}"
+
+
+WRITE_SUBSET = [
+    "data/encodings/polygon-native-geometry.parquet",
+    "data/crs/crs-epsg-3857.parquet",
+    "data/geometry_types/geometrycollection.parquet",
+    "data/compression/compression-brotli.parquet",
+    "samples/us-states.parquet",
+]
+
+
+class TestWritePath:
+    """Rewriting corpus files through gpio must preserve their 2.0 nature."""
+
+    @pytest.mark.parametrize(
+        "rel",
+        WRITE_SUBSET
+        + [
+            pytest.param(
+                "data/encodings/point-native-geography.parquet",
+                marks=pytest.mark.xfail(
+                    strict=True, reason="gpio #588: GEOGRAPHY rewritten as GEOMETRY, edges lost"
+                ),
+            ),
+            pytest.param(
+                "data/zm/linestring-xyzm-native-geometry.parquet",
+                marks=pytest.mark.xfail(
+                    strict=True, reason="gpio #589: XYZM 2.0 write drops geo metadata"
+                ),
+            ),
+        ],
+    )
+    def test_explicit_v2_rewrite_preserves(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="2.0")
+
+        assert has_native_geo_types(str(out)), "native logical type lost"
+        assert get_geoparquet_version(str(out)) == "2.0.0"
+        # GEOGRAPHY inputs must keep geography semantics (native type or edges).
+        src_types = {c["name"]: c.get("logical_type") or "" for c in get_schema_info(str(src))}
+        out_types = {c["name"]: c.get("logical_type") or "" for c in get_schema_info(str(out))}
+        for col, lt in src_types.items():
+            if "GeographyType" in lt:
+                out_geo = get_geo_metadata(str(out))["columns"][col]
+                assert "GeographyType" in out_types.get(col, "") or out_geo.get("edges") in (
+                    "spherical",
+                    "vincenty",
+                    "thomas",
+                    "andoyer",
+                    "karney",
+                )
+
+    def test_explicit_v2_rewrite_preserves_native_crs(self, tmp_path):
+        """Non-default CRS on the native logical type must survive a rewrite."""
+        src = CORPUS / "data" / "crs" / "crs-epsg-3857.parquet"
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="2.0")
+        (geom_lt,) = [
+            c.get("logical_type") or ""
+            for c in get_schema_info(str(out))
+            if c["name"] == "geometry"
+        ]
+        parsed = parse_geometry_logical_type(geom_lt)
+        assert parsed and parsed.get("crs"), "native CRS lost on rewrite"
+        assert "3857" in str(parsed["crs"]) or "Pseudo-Mercator" in str(parsed["crs"])
+
+    @pytest.mark.xfail(
+        strict=True, reason="gpio #587: auto version mode silently downgrades 2.0 to 1.1"
+    )
+    @pytest.mark.parametrize("rel", WRITE_SUBSET[:3])
+    def test_auto_rewrite_preserves_v2(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version=None)
+        assert get_geoparquet_version(str(out)) == "2.0.0"
+        assert has_native_geo_types(str(out))
+
+    @pytest.mark.parametrize("rel", ["samples/us-states.parquet"])
+    def test_roundtrip_2_0_to_1_1_to_2_0(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        mid = tmp_path / "v11.parquet"
+        back = tmp_path / "v20.parquet"
+        convert_to_geoparquet(str(src), str(mid), skip_hilbert=True, geoparquet_version="1.1")
+        convert_to_geoparquet(str(mid), str(back), skip_hilbert=True, geoparquet_version="2.0")
+        assert get_geoparquet_version(str(mid)) == "1.1.0"
+        assert not has_native_geo_types(str(mid))
+        assert get_geoparquet_version(str(back)) == "2.0.0"
+        assert has_native_geo_types(str(back))
+
+
+class TestCliWiring:
+    """One CLI-level test; everything else goes through the Python API for speed."""
+
+    def test_check_spec_exit_codes(self):
+        good = CORPUS / "data" / "bbox" / "bbox-present.parquet"
+        bad = CORPUS / "bad_data" / "missing-columns.parquet"
+        if not good.exists():
+            pytest.skip("run: git submodule update --init")
+        runner = CliRunner()
+        good_result = runner.invoke(cli, ["check", "spec", str(good), "--json"])
+        # Exit 0 (pass) or 2 (warnings only); 1 would mean spec failures. The
+        # good file currently trips known validation bugs (#581 et al.), so
+        # accept 0/1/2 but require valid JSON output; tighten to {0, 2} when
+        # KNOWN_VALIDATION_BUGS empties.
+        assert good_result.exit_code in (0, 1, 2), good_result.output
+        json.loads(good_result.output)
+        bad_result = runner.invoke(cli, ["check", "spec", str(bad), "--json"])
+        assert bad_result.exit_code == 1, bad_result.output

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -55,14 +55,9 @@ CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
 # tracking each fix. test_validates_clean xfails while a file's failures are
 # all covered here and fails hard on anything new. Remove entries as fixes land.
 KNOWN_VALIDATION_BUGS = {
-    "v2_crs_in_parquet_type": "#581 CRS84-default equivalence",
-    "v2_crs_consistency": "#581 CRS84-default equivalence",
-    "edges_valid": "#582 missing 2.0 ellipsoidal edges values",
     "geometry_types_list": "#583 Z/M suffixed types rejected",
     "geometry_types_match_data": "#583 data scan drops Z/M suffix",
     "native_geo_types_match": "#583 native stats comparison drops Z/M suffix",
-    "native_geo_stats_contains_data": "#584 POINT EMPTY counted as outside bbox",
-    "bbox_contains_data": "#584 POINT EMPTY counted as outside bbox",
     "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
 }
 
@@ -247,11 +242,7 @@ BAD_DATA_EXPECTATIONS = {
         [r"geo_metadata", r"geo_key"],
         "#586 invalid geo JSON treated as no-metadata",
     ),
-    "geo-invalid-utf8.parquet": (
-        "auto",
-        [r"geo_metadata", r"geo_key"],
-        "#585 validator crashes on invalid UTF-8 metadata",
-    ),
+    "geo-invalid-utf8.parquet": ("auto", [r"geo_metadata", r"geo_key"], None),
     "geometry-types-mismatch-declared-point-actual-linestring.parquet": (
         "auto",
         [r"geometry_types_match_data_"],
@@ -268,8 +259,7 @@ BAD_DATA_EXPECTATIONS = {
     # only when GeoParquet 2.0 is explicitly demanded.
     "missing-geo-metadata.parquet": ("2.0", [r"version_match"], None),
     "missing-primary-column.parquet": ("auto", [r"primary_column_present"], None),
-    # Auto mode crashes on the None version (#585); 2.0 mode detects it.
-    "missing-version.parquet": ("2.0", [r"version_match", r"version_present"], None),
+    "missing-version.parquet": ("auto", [r"version_present"], None),
     "orientation-ccw-declared-rings-cw.parquet": (
         "auto",
         [r"orientation"],
@@ -300,11 +290,9 @@ BAD_DATA_EXPECTATIONS = {
     "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
 }
 
-# Files where validate_geoparquet currently raises instead of reporting (#585).
-CRASHES_ON_VALIDATE = {
-    "geo-invalid-utf8.parquet": "#585 GeoParquetError on invalid UTF-8 geo metadata",
-    "missing-version.parquet": "#585 TypeError comparing None version in auto mode",
-}
+# Files where validate_geoparquet raises instead of reporting. Empty since the
+# #585 fixes; kept so a regression re-adds an entry instead of reshaping tests.
+CRASHES_ON_VALIDATE: dict[str, str] = {}
 
 
 def _bad_data_params():

--- a/tests/test_validate_v2_fixes.py
+++ b/tests/test_validate_v2_fixes.py
@@ -1,0 +1,194 @@
+"""Unit tests for validator bugs surfaced by the geoparquet-testing corpus.
+
+Covers gpio issues:
+- #581: V2-2/V2-3 must treat explicit-CRS84 metadata + absent native CRS as valid
+- #582: edges vocabulary includes the 2.0 ellipsoidal values
+- #584: empty geometries excluded from stats/bbox containment
+- #585: validator reports FAILED instead of crashing on corrupt metadata
+"""
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_edges_valid,
+    _check_native_geo_stats_contains_data,
+    _check_v2_crs_consistency,
+    _check_v2_crs_in_parquet_type,
+    validate_geoparquet,
+)
+
+CRS84_PROJJSON = {
+    "type": "GeographicCRS",
+    "name": "WGS 84 (CRS84)",
+    "id": {"authority": "OGC", "code": "CRS84"},
+}
+EPSG_4326_PROJJSON = {
+    "type": "GeographicCRS",
+    "name": "WGS 84",
+    "id": {"authority": "EPSG", "code": 4326},
+}
+EPSG_3857_PROJJSON = {
+    "type": "ProjectedCRS",
+    "name": "WGS 84 / Pseudo-Mercator",
+    "id": {"authority": "EPSG", "code": 3857},
+}
+
+SCHEMA_NO_CRS = [{"name": "geometry", "logical_type": "GeometryType()", "type": "binary"}]
+
+
+def _geo_meta(crs):
+    return {"columns": {"geometry": {"encoding": "WKB", "crs": crs}}}
+
+
+class TestV2CrsDefaultEquivalence:
+    """#581: explicit CRS84-equivalent metadata + absent native CRS is spec-valid."""
+
+    @pytest.mark.parametrize("crs", [CRS84_PROJJSON, EPSG_4326_PROJJSON])
+    def test_crs_in_parquet_type_passes_for_default_equivalent(self, crs):
+        check = _check_v2_crs_in_parquet_type(_geo_meta(crs), SCHEMA_NO_CRS, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_crs_in_parquet_type_fails_for_non_default(self):
+        check = _check_v2_crs_in_parquet_type(
+            _geo_meta(EPSG_3857_PROJJSON), SCHEMA_NO_CRS, "geometry"
+        )
+        assert check.status == CheckStatus.FAILED
+
+    @pytest.mark.parametrize("crs", [CRS84_PROJJSON, EPSG_4326_PROJJSON])
+    def test_consistency_passes_for_default_equivalent(self, crs):
+        check = _check_v2_crs_consistency(_geo_meta(crs), SCHEMA_NO_CRS, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_consistency_fails_for_genuine_mismatch(self):
+        """Metadata 3857 vs absent native CRS (=CRS84) is a real inconsistency."""
+        check = _check_v2_crs_consistency(_geo_meta(EPSG_3857_PROJJSON), SCHEMA_NO_CRS, "geometry")
+        assert check.status == CheckStatus.FAILED
+
+    def test_consistency_passes_when_both_declare_same_crs(self):
+        schema = [
+            {
+                "name": "geometry",
+                "logical_type": f"GeometryType(crs={json.dumps(EPSG_3857_PROJJSON)})",
+                "type": "binary",
+            }
+        ]
+        check = _check_v2_crs_consistency(_geo_meta(EPSG_3857_PROJJSON), schema, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+
+class TestEdgesVocabulary:
+    """#582: GeoParquet 2.0 allows the four ellipsoidal-geodesic edges values."""
+
+    @pytest.mark.parametrize("edges", ["vincenty", "thomas", "andoyer", "karney"])
+    def test_ellipsoidal_edges_valid_for_v2(self, edges):
+        check = _check_edges_valid({"edges": edges}, "geometry", geo_version="2.0.0")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize("edges", ["vincenty", "karney"])
+    def test_ellipsoidal_edges_invalid_for_v1_1(self, edges):
+        check = _check_edges_valid({"edges": edges}, "geometry", geo_version="1.1.0")
+        assert check.status == CheckStatus.FAILED
+
+    @pytest.mark.parametrize("version", ["1.1.0", "2.0.0"])
+    def test_planar_and_spherical_valid_everywhere(self, version):
+        for edges in ("planar", "spherical"):
+            check = _check_edges_valid({"edges": edges}, "geometry", geo_version=version)
+            assert check.status == CheckStatus.PASSED
+
+    @pytest.mark.parametrize("version", ["1.1.0", "2.0.0"])
+    def test_bogus_edges_always_invalid(self, version):
+        check = _check_edges_valid({"edges": "geodesic"}, "geometry", geo_version=version)
+        assert check.status == CheckStatus.FAILED
+
+
+@pytest.fixture
+def native_file_with_empty_point(tmp_path):
+    """Native-typed file whose geo statistics (correctly) exclude a POINT EMPTY."""
+    out = tmp_path / "empty.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (ST_GeomFromText('POINT (30 10)')),
+            (ST_GeomFromText('POINT (40 40)')),
+            (ST_GeomFromText('POINT EMPTY'))
+          ) t(geometry)
+        ) TO '{out.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    return out
+
+
+class TestEmptyGeometryContainment:
+    """#584: empties have no extent and must not count as outside the stats bbox."""
+
+    def test_native_stats_containment_ignores_empty(self, native_file_with_empty_point):
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_native_geo_stats_contains_data(
+                str(native_file_with_empty_point), "geometry", con, sample_size=100
+            )
+        finally:
+            con.close()
+        assert check.status in (CheckStatus.PASSED, CheckStatus.SKIPPED), check.message
+
+
+class TestSchemaInfoRegistrationIndependent:
+    """Schema info must not change when geoarrow extension types get registered.
+
+    Importing geoarrow.pyarrow anywhere in the process registers extension
+    types globally, after which pyarrow reads native-GEOMETRY columns as
+    extension fields. get_schema_info must keep reporting the storage type so
+    checks like geometry_byte_array don't fail depending on test order.
+    """
+
+    def test_native_geometry_type_stable_after_geoarrow_import(self, native_file_with_empty_point):
+        import geoarrow.pyarrow  # noqa: F401  (import registers extension types)
+
+        from geoparquet_io.core.duckdb_metadata import get_schema_info
+
+        (geom,) = [
+            c for c in get_schema_info(str(native_file_with_empty_point)) if c["name"] == "geometry"
+        ]
+        assert "binary" in geom["type"].lower() or "BYTE_ARRAY" in geom["type"], geom["type"]
+        assert (geom["logical_type"] or "").startswith("GeometryType"), geom["logical_type"]
+
+        result = validate_geoparquet(str(native_file_with_empty_point), validate_data=False)
+        byte_array_checks = [c for c in result.checks if c.name.startswith("geometry_byte_array")]
+        assert all(c.status == CheckStatus.PASSED for c in byte_array_checks), [
+            (c.name, c.message) for c in byte_array_checks
+        ]
+
+
+class TestValidatorNeverCrashes:
+    """#585: corrupt metadata must produce FAILED checks, not exceptions."""
+
+    def _write_with_geo_bytes(self, tmp_path, geo_bytes):
+        table = pa.table({"a": [1], "geometry": [b"\x01\x01" + b"\x00" * 20]})
+        table = table.replace_schema_metadata({b"geo": geo_bytes})
+        out = tmp_path / "corrupt.parquet"
+        pq.write_table(table, out)
+        return out
+
+    def test_invalid_utf8_geo_metadata_reports_failed(self, tmp_path):
+        out = self._write_with_geo_bytes(tmp_path, b'\xff\xfe{"version"')
+        result = validate_geoparquet(str(out), validate_data=False)
+        assert not result.is_valid
+        assert any(c.status == CheckStatus.FAILED for c in result.checks)
+
+    def test_missing_version_auto_mode_reports_failed(self, tmp_path):
+        geo = {
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": []}},
+        }
+        out = self._write_with_geo_bytes(tmp_path, json.dumps(geo).encode())
+        result = validate_geoparquet(str(out), validate_data=False)
+        assert not result.is_valid
+        failed = [c.name for c in result.checks if c.status == CheckStatus.FAILED]
+        assert any("version" in n for n in failed), failed

--- a/tests/test_validate_zm_types.py
+++ b/tests/test_validate_zm_types.py
@@ -1,0 +1,95 @@
+"""Unit tests for Z/M geometry_types handling (gpio #583).
+
+The spec mandates dimension suffixes ("Point Z", "LineString ZM", ...) and
+says geometry_types "is expected to be strictly correct". gpio must accept
+suffixed names as valid and detect dimensionality when scanning data.
+"""
+
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_geometry_types_list,
+    _check_geometry_types_match_data,
+    _check_native_geo_types_match,
+)
+
+
+class TestGeometryTypesListAcceptsSuffixes:
+    @pytest.mark.parametrize(
+        "types",
+        [
+            ["Point Z"],
+            ["LineString M"],
+            ["Polygon ZM"],
+            ["MultiPolygon Z", "Polygon Z"],
+            ["Point", "Point Z"],
+        ],
+    )
+    def test_suffixed_types_valid(self, types):
+        check = _check_geometry_types_list({"geometry_types": types}, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize(
+        "types",
+        [
+            ["Point X"],
+            ["LineString ZZ"],
+            ["Sphere"],
+            ["Point z"],  # lowercase suffix is not spec-valid
+            ["PointZ"],  # missing the space
+        ],
+    )
+    def test_invalid_types_still_rejected(self, types):
+        check = _check_geometry_types_list({"geometry_types": types}, "geometry")
+        assert check.status == CheckStatus.FAILED, check.message
+
+
+@pytest.fixture
+def zm_file(tmp_path):
+    """Native 2.0 file containing XYZM linestrings."""
+    out = tmp_path / "zm.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (ST_GeomFromText('LINESTRING ZM (0 0 100 0, 1 1 110 10)')),
+            (ST_GeomFromText('LINESTRING ZM (5 5 50 0, 6 5 60 5)'))
+          ) t(geometry)
+        ) TO '{out.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    return out
+
+
+class TestDataScansAreDimensionAware:
+    def test_match_data_passes_for_correct_zm_declaration(self, zm_file):
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_geometry_types_match_data(
+                str(zm_file), "geometry", ["LineString ZM"], con, sample_size=100
+            )
+        finally:
+            con.close()
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_match_data_fails_when_dimension_undeclared(self, zm_file):
+        """Declaring XY 'LineString' for ZM data is the corpus's zm_mismatch case."""
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_geometry_types_match_data(
+                str(zm_file), "geometry", ["LineString"], con, sample_size=100
+            )
+        finally:
+            con.close()
+        assert check.status == CheckStatus.FAILED, check.message
+
+    def test_native_geo_types_match_zm(self, zm_file):
+        """Native stats declare linestring_zm; the data scan must agree."""
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_native_geo_types_match(str(zm_file), "geometry", 100, con)
+        finally:
+            con.close()
+        assert check.status == CheckStatus.PASSED, check.message


### PR DESCRIPTION
Stacked on #592. Closes #583.

The spec mandates dimension suffixes ("a `" Z"` suffix gets added") and calls geometry_types "strictly correct", but gpio was dimension-blind in three places:

- `geometry_types_list` rejected `"Polygon Z"` / `"LineString ZM"` as invalid type names (hit `samples/buildings-3d.parquet` and friends)
- `geometry_types_match_data` scanned with plain `ST_GeometryType`, collapsing `LineString ZM` data to `LineString` — so a correct `["LineString ZM"]` declaration failed and a wrong `["LineString"]` declaration passed
- `native_geo_types_match` compared DuckDB's dimension-aware `geo_types` stats (`linestring_zm`) against the dimension-blind scan, false-failing every Z/M file

Fix: a shared `_zm_suffix_sql` fragment built on `ST_HasZ`/`ST_HasM` makes both scans dimension-aware, and `geometry_types_list` validates the base name after stripping a spec suffix.

Consequences on the corpus suite:
- the three `samples/` Z/M files now validate clean
- both `bad_data/zm-*` cases are detected for the right reason (metadata declaration vs data)
- the three `data/zm/` fixtures now fail validation **correctly** — they declare unsuffixed types, which is the upstream corpus bug geoparquet/geoparquet-testing#2 (fix: geoparquet/geoparquet-testing#3); they're non-strict xfails keyed to the submodule pin

13 new unit tests in `tests/test_validate_zm_types.py` (TDD). Corpus: 202 passed / 19 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)