### PR TITLE
fix: adversarial review findings for the corpus audit stack (#591–#597)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -36,6 +36,10 @@ jobs:
           # No direct git push happens here (create-pull-request uses its own
           # token input), so don't leave GITHUB_TOKEN credentials in .git/config.
           persist-credentials: false
+          # The verification pytest run includes the corpus conformance suite,
+          # which lives in the geoparquet-testing submodule — without it those
+          # tests silently skip and an upgrade could be "verified" untested.
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,8 @@ jobs:
           persist-credentials: false
           # Full history so diff-cover can diff against the PR base branch.
           fetch-depth: 0
+          # geoparquet-testing corpus for the corpus conformance tests
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -232,6 +234,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # geoparquet-testing corpus for the corpus conformance tests
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/data/geoparquet-testing"]
+	path = tests/data/geoparquet-testing
+	url = https://github.com/geoparquet/geoparquet-testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **New spec-validation checks in `gpio check spec` (#586).** Validation now
+  fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;
+  on version/feature mismatches (1.0 metadata using GeoParquet 2.0 native geo
+  types or the 1.1-only `covering` key); on PROJJSON `crs` objects missing the
+  required `type` member or using an unknown PROJJSON CRS type; and on a `geo`
+  key containing invalid JSON or a non-object value (clean failure instead of
+  a crash). Epoch validation is now datum-aware via pyproj: a coordinate
+  `epoch` on a datum ensemble (e.g. EPSG:4326, or the CRS84 default) fails, on
+  a specific static frame (e.g. GDA2020) warns, and on a dynamic frame (e.g.
+  ITRF) passes; an explicit `"crs": null` plus epoch warns since the datum
+  cannot be verified.
+
 - **`gpio process aggregate a5`**, **`gpio process aggregate h3`**, and
   **`gpio process aggregate admin`**: aggregate large GeoParquet datasets into A5 grid
   cells, H3 hexagonal cells, or administrative regions with per-bucket `count`,
@@ -71,6 +83,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Changed
 
+- **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
+  `gpio check spec` heuristic that flags geographic-looking coordinates (values
+  within ±180/±90) under a projected CRS now reports a WARNING instead of
+  FAILED, so affected files exit with code `2` (warnings) instead of `1`.
+  Callers gating on exit codes should update. The deterministic CRS-consistency
+  check for GeoParquet 2.0 native geo statistics still fails on a real
+  mismatch.
+
+- **`--geoparquet-version` auto mode preserves the input version (#587,
+  #594).** When the flag is omitted, `gpio convert` and `gpio convert
+  reproject` now preserve GeoParquet 2.0 inputs (previously silently
+  downgraded to 1.1), upgrade bare native-geo Parquet (no `geo` metadata) to
+  2.0, and write 1.1 for 1.x inputs. An explicit `--geoparquet-version` always
+  wins. The Python API resolves auto the same way, so
+  `gpio.read('native.parquet').write('out.parquet')` writes true 2.0 native
+  output like the CLI.
+
 - **BREAKING**: Renamed `--profile` to `--aws-profile` for clarity
   - Only affects AWS S3 operations (convert, extract, upload commands)
   - Local operations no longer have this flag
@@ -91,6 +120,18 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Non-planar edges metadata survives rewrites (#588).** `"edges":
+  "spherical"` (e.g. from BigQuery GEOGRAPHY extracts) is now preserved across
+  `convert`, `extract`, `sort`, `convert reproject`, and `partition`
+  rewrites — including remote (S3/GCS/Azure) outputs — instead of being
+  silently demoted to planar. GeoParquet 2.0 ellipsoidal edges algorithms
+  (`vincenty`, `karney`, `andoyer`, `thomas`) are mapped to `"spherical"` with
+  a warning when writing 1.x output; 2.0 outputs keep the algorithm verbatim.
+- **Z/M geometry types written and validated dimension-aware (#583, #589).**
+  Written `geometry_types` metadata now carries the spec's dimension suffixes
+  (`"Point Z"`, `"LineString ZM"`), and `gpio check spec` matches declared
+  suffixes against the actual coordinate dimensions in both directions
+  (declared-but-absent and present-but-undeclared).
 - **`gpio partition … --auto` is now extent-aware (#524).** Auto-resolution
   previously assumed data was spread uniformly across the entire globe, so
   regional/national datasets got a far-too-coarse resolution — collapsing into a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ uv run pytest -n auto -m "not slow and not network"  # Fast tests
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 <!-- END GENERATED: test-markers -->
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,18 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **New spec-validation checks in `gpio check spec` (#586).** Validation now
+  fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;
+  on version/feature mismatches (1.0 metadata using GeoParquet 2.0 native geo
+  types or the 1.1-only `covering` key); on PROJJSON `crs` objects missing the
+  required `type` member or using an unknown PROJJSON CRS type; and on a `geo`
+  key containing invalid JSON or a non-object value (clean failure instead of
+  a crash). Epoch validation is now datum-aware via pyproj: a coordinate
+  `epoch` on a datum ensemble (e.g. EPSG:4326, or the CRS84 default) fails, on
+  a specific static frame (e.g. GDA2020) warns, and on a dynamic frame (e.g.
+  ITRF) passes; an explicit `"crs": null` plus epoch warns since the datum
+  cannot be verified.
+
 - **`gpio process aggregate a5`**, **`gpio process aggregate h3`**, and
   **`gpio process aggregate admin`**: aggregate large GeoParquet datasets into A5 grid
   cells, H3 hexagonal cells, or administrative regions with per-bucket `count`,
@@ -71,6 +83,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Changed
 
+- **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
+  `gpio check spec` heuristic that flags geographic-looking coordinates (values
+  within ±180/±90) under a projected CRS now reports a WARNING instead of
+  FAILED, so affected files exit with code `2` (warnings) instead of `1`.
+  Callers gating on exit codes should update. The deterministic CRS-consistency
+  check for GeoParquet 2.0 native geo statistics still fails on a real
+  mismatch.
+
+- **`--geoparquet-version` auto mode preserves the input version (#587,
+  #594).** When the flag is omitted, `gpio convert` and `gpio convert
+  reproject` now preserve GeoParquet 2.0 inputs (previously silently
+  downgraded to 1.1), upgrade bare native-geo Parquet (no `geo` metadata) to
+  2.0, and write 1.1 for 1.x inputs. An explicit `--geoparquet-version` always
+  wins. The Python API resolves auto the same way, so
+  `gpio.read('native.parquet').write('out.parquet')` writes true 2.0 native
+  output like the CLI.
+
 - **BREAKING**: Renamed `--profile` to `--aws-profile` for clarity
   - Only affects AWS S3 operations (convert, extract, upload commands)
   - Local operations no longer have this flag
@@ -91,6 +120,18 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Non-planar edges metadata survives rewrites (#588).** `"edges":
+  "spherical"` (e.g. from BigQuery GEOGRAPHY extracts) is now preserved across
+  `convert`, `extract`, `sort`, `convert reproject`, and `partition`
+  rewrites — including remote (S3/GCS/Azure) outputs — instead of being
+  silently demoted to planar. GeoParquet 2.0 ellipsoidal edges algorithms
+  (`vincenty`, `karney`, `andoyer`, `thomas`) are mapped to `"spherical"` with
+  a warning when writing 1.x output; 2.0 outputs keep the algorithm verbatim.
+- **Z/M geometry types written and validated dimension-aware (#583, #589).**
+  Written `geometry_types` metadata now carries the spec's dimension suffixes
+  (`"Point Z"`, `"LineString ZM"`), and `gpio check spec` matches declared
+  suffixes against the actual coordinate dimensions in both directions
+  (declared-but-absent and present-but-undeclared).
 - **`gpio partition … --auto` is now extent-aware (#524).** Auto-resolution
   previously assumed data was spread uniformly across the entire globe, so
   regional/national datasets got a far-too-coarse resolution — collapsing into a

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,6 +97,7 @@ Coverage gates (both enforced in CI):
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 <!-- END GENERATED: test-markers -->
 
 ## Code Quality

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -240,11 +240,39 @@ Validates file structure and metadata against the GeoParquet specification:
 - Auto-detects version unless `--geoparquet-version` is specified
 - Optional data validation against metadata claims
 
+**Metadata checks include:**
+
+- **Version sanity** — an unknown `geo` metadata version (e.g. `99.0.0`) fails
+  validation, even in auto mode. Version/feature mismatches also fail: a file
+  declaring version 1.0 while using GeoParquet 2.0 native Parquet geo types, or
+  the 1.1-only `covering` key, is flagged as inconsistent.
+- **CRS structure** — PROJJSON `crs` objects must carry the required `type`
+  member, and it must be a known PROJJSON CRS type.
+- **Datum-aware epoch validation** — a coordinate `epoch` on a datum ensemble
+  (e.g. EPSG:4326, or the OGC:CRS84 default when `crs` is omitted) fails; on a
+  specific static frame (e.g. GDA2020) it warns; on a dynamic frame (e.g. ITRF)
+  it passes. With an explicit `"crs": null` the datum cannot be verified, so an
+  epoch produces a warning.
+- **Malformed metadata** — a `geo` key containing invalid JSON or a non-object
+  value fails cleanly in auto mode instead of crashing.
+- **Dimension-aware geometry types** — `geometry_types` entries carry Z/M
+  suffixes (`"Point Z"`, `"LineString ZM"`), and validation matches declared
+  suffixes against the actual coordinate dimensions in both directions
+  (declared-but-absent and present-but-undeclared).
+
 **Exit codes:**
 
 - `0` - All checks passed
 - `1` - One or more checks failed
 - `2` - Warnings only (all required checks passed)
+
+!!! note "Coordinate/CRS mismatch heuristic is now a warning"
+    The heuristic that flags geographic-looking coordinates (values within
+    ±180/±90) under a projected CRS reports a **WARNING** instead of a failure,
+    so `gpio check spec` exits with code `2` instead of `1` for affected files.
+    Update CI pipelines that gate only on exit code `1`. The deterministic
+    CRS-consistency check for GeoParquet 2.0 native geo statistics still fails
+    on a real mismatch.
 
 ### STAC Validation
 

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -20,7 +20,8 @@ The `convert` command transforms between GeoParquet and other vector formats wit
     - 100,000 row groups
     - Bbox column with proper metadata
     - Hilbert spatial ordering
-    - GeoParquet 1.1.0 metadata
+    - GeoParquet metadata (version auto-detected — see
+      [GeoParquet Version](#geoparquet-version); 1.1 for non-GeoParquet inputs)
 
 === "Python"
 
@@ -298,6 +299,42 @@ GeoParquet files can use non-standard geometry column names (e.g., `the_geom`, `
     gpio.convert('input.parquet', geometry_column='the_geom').write('output.parquet')
     ```
 
+### Edges Metadata Preservation
+
+Non-planar edges metadata (`"edges": "spherical"`, e.g. from BigQuery
+GEOGRAPHY extracts) survives every rewrite: `convert`, `extract`, `sort`,
+`convert reproject`, and `partition` all carry it through to the output —
+including remote (S3/GCS/Azure) outputs.
+
+=== "CLI"
+
+    ```bash
+    # Input with edges: "spherical" keeps it in the output
+    gpio convert geography.parquet output.parquet
+    gpio sort hilbert geography.parquet sorted.parquet
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    # edges metadata is preserved through the pipeline
+    gpio.read('geography.parquet').sort_hilbert().write('output.parquet')
+    ```
+
+When a GeoParquet 2.0 input declares an ellipsoidal edges algorithm
+(`vincenty`, `karney`, `andoyer`, `thomas`) and the output is 1.x, the
+algorithm is mapped to `"spherical"` — the only non-planar value 1.x supports
+— with a warning. 2.0 outputs keep the algorithm verbatim.
+
+### Z and M Dimensions
+
+Geometries with Z (elevation) and/or M (measure) values are preserved, and the
+written `geometry_types` metadata carries the spec's dimension suffixes
+(`"Point Z"`, `"LineString ZM"`). `gpio check spec` validates these suffixes
+against the actual coordinate dimensions in both directions.
+
 ## Remote Files
 
 Read from cloud storage or HTTPS:
@@ -390,7 +427,50 @@ Available compression types:
 
 ### GeoParquet Version
 
-Control the GeoParquet encoding version written to output:
+Control the GeoParquet encoding version written to output.
+
+**Auto-detection (default):** when `--geoparquet-version` is not specified, the
+output version is resolved from the input:
+
+- **GeoParquet 2.0 input** → stays 2.0 (no silent downgrade to 1.1)
+- **Bare native geo types** (Parquet `GEOMETRY`/`GEOGRAPHY` columns without
+  `geo` metadata) → upgraded to 2.0
+- **GeoParquet 1.x input** → written as 1.1
+- **Non-GeoParquet input** (Shapefile, GeoJSON, ...) → written as 1.1
+
+Auto-detection applies to both `gpio convert` and `gpio convert reproject`. An
+explicit `--geoparquet-version` always wins. The Python API resolves the
+version the same way, so `gpio.read('native.parquet').write('out.parquet')`
+writes true 2.0 native output just like the CLI.
+
+=== "CLI"
+
+    ```bash
+    # Auto mode: a 2.0 input stays 2.0
+    gpio convert input_v2.parquet output.parquet
+
+    # Auto mode: reproject preserves the input version too
+    gpio convert reproject input_v2.parquet output.parquet --dst-crs EPSG:3857
+
+    # Explicit version always wins
+    gpio convert input_v2.parquet output.parquet --geoparquet-version 1.1
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    # Auto mode: a 2.0 or native-geo input stays/becomes 2.0
+    gpio.read('input_v2.parquet').write('output.parquet')
+
+    # Explicit version always wins
+    gpio.read('input_v2.parquet').write(
+        'output.parquet', geoparquet_version='1.1'
+    )
+    ```
+
+**Explicit versions:**
 
 === "CLI"
 
@@ -427,7 +507,7 @@ Control the GeoParquet encoding version written to output:
 
 Available versions:
 - `1.0` — GeoParquet 1.0 with WKB encoding
-- `1.1` — GeoParquet 1.1 with WKB encoding (default)
+- `1.1` — GeoParquet 1.1 with WKB encoding (default for 1.x and non-GeoParquet inputs)
 - `1.1-geoarrow` — GeoParquet 1.1 with native GeoArrow (nested-coordinate) encoding; no bbox
   column; compatible geometry type mixes are promoted (e.g. Polygon + MultiPolygon →
   MultiPolygon); incompatible mixes fall back to WKB

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -181,8 +181,15 @@ def read(path: str | Path, **kwargs) -> Table:
         >>> table = gpio.read('data.parquet')
         >>> table.add_bbox().write('output.parquet')
     """
+    from geoparquet_io.core.common import resolve_geoparquet_version_from_file
+
     arrow_table = pq.read_table(str(path), **kwargs)
-    return Table(arrow_table)
+    table = Table(arrow_table)
+    # CLI-parity auto-version hint (todo 043): remember the file-based decision
+    # so write() picks the same version the CLI would for this input, even when
+    # native geometry columns were demoted to plain binary by pq.read_table.
+    table._auto_version_hint = resolve_geoparquet_version_from_file(str(path))
+    return table
 
 
 def read_partition(
@@ -462,6 +469,11 @@ class Table:
         """
         self._table = table
         self._geometry_column = geometry_column or self._detect_geometry_column()
+        # Auto-version hint captured at read time (see read()): pq.read_table
+        # demotes native geometry columns to plain binary when geoarrow isn't
+        # registered, so the table alone can't always tell a native-geo-only
+        # source from generic WKB. None when the table wasn't read from a file.
+        self._auto_version_hint: str | None = None
 
     def _detect_geometry_column(self) -> str | None:
         """Detect geometry column from metadata or common names."""
@@ -955,6 +967,21 @@ class Table:
         from geoparquet_io.core.remote import is_remote_url, setup_aws_profile_if_needed
         from geoparquet_io.core.upload import upload
         from geoparquet_io.core.write_strategies import WriteStrategy, WriteStrategyFactory
+
+        # Auto mode: resolve to a concrete version with the same decision the
+        # CLI uses (native-geo-only → 2.0), falling back to the hint captured
+        # at read() time, then the default. Passing a concrete version keeps
+        # output self-consistent (a None version made duckdb-kv keep the native
+        # GEOMETRY logical type while stamping 1.1.0/WKB geo metadata).
+        if geoparquet_version is None:
+            from geoparquet_io.core.common import resolve_geoparquet_version_from_table
+            from geoparquet_io.core.geo_metadata import DEFAULT_GEOPARQUET_VERSION
+
+            geoparquet_version = (
+                resolve_geoparquet_version_from_table(self._table, verbose)
+                or self._auto_version_hint
+                or DEFAULT_GEOPARQUET_VERSION
+            )
 
         path_str = str(path)
         is_remote = is_remote_url(path_str)

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -270,16 +270,17 @@ def geoparquet_version_option(func):
     - 2.0: GeoParquet 2.0 with native Parquet geo types
     - parquet-geo-only: Native Parquet geo types without GeoParquet metadata
 
-    If not specified, auto-detects from input: preserves input version,
-    upgrades native geo types to 2.0, defaults to 1.1.
+    If not specified, auto-detects from input: preserves 2.0, writes 1.1 for
+    1.x inputs (1.0 upgrades to 1.1), upgrades bare native geo types to 2.0,
+    defaults to 1.1.
     """
     return click.option(
         "--geoparquet-version",
         type=click.Choice(["1.0", "1.1", "1.1-geoarrow", "2.0", "parquet-geo-only"]),
         default=None,
         help="GeoParquet version to write (1.0, 1.1, 1.1-geoarrow, 2.0, parquet-geo-only). "
-        "Auto-detects from input if not specified: preserves input version, "
-        "upgrades native geo types to 2.0, defaults to 1.1.",
+        "Auto-detects from input if not specified: preserves 2.0; 1.x inputs "
+        "write 1.1; bare native geo types upgrade to 2.0; defaults to 1.1.",
     )(func)
 
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1808,6 +1808,21 @@ def _ensure_v2_geo_metadata(
         # Release the read handle before rewriting (Windows requires it).
         del pf
 
+    _rewrite_file_with_geo_metadata(
+        output_path, geo_meta, compression, compression_level, row_group_rows
+    )
+    if verbose:
+        debug("Re-attached geo metadata (writer omitted it for M/ZM geometries)")
+
+
+def _rewrite_file_with_geo_metadata(
+    output_path: str,
+    geo_meta: dict,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    row_group_rows: int | None = None,
+) -> None:
+    """Rewrite a parquet file in place with the given geo metadata attached."""
     # geoarrow registration makes pyarrow round-trip the native GEOMETRY/
     # GEOGRAPHY logical types (and their CRS) instead of demoting to binary.
     import geoarrow.pyarrow  # noqa: F401
@@ -1825,7 +1840,7 @@ def _ensure_v2_geo_metadata(
         "UNCOMPRESSED": "none",
         "LZ4_RAW": "lz4",
     }
-    write_kwargs: dict = {"compression": codec_map.get(compression, "zstd")}
+    write_kwargs: dict = {"compression": codec_map.get(compression.upper(), "zstd")}
     if compression_level is not None and write_kwargs["compression"] in ("zstd", "gzip", "brotli"):
         write_kwargs["compression_level"] = compression_level
     if row_group_rows:
@@ -1834,8 +1849,85 @@ def _ensure_v2_geo_metadata(
     tmp_path = f"{output_path}.geometa.tmp"
     pq.write_table(table, tmp_path, **write_kwargs)
     os.replace(tmp_path, output_path)
-    if verbose:
-        debug("Re-attached geo metadata (writer omitted it for M/ZM geometries)")
+
+
+def collect_nonplanar_edges(input_file: str) -> dict[str, str]:
+    """Map geometry column -> non-planar edges value declared by the input.
+
+    Sources: the native GEOGRAPHY logical type's algorithm, and any non-planar
+    ``edges`` in the input's geo column metadata.
+    """
+    from geoparquet_io.core.duckdb_metadata import (
+        get_geo_metadata,
+        get_schema_info,
+        parse_geometry_logical_type,
+    )
+
+    edges_by_col: dict[str, str] = {}
+    try:
+        for col in get_schema_info(input_file):
+            logical = col.get("logical_type") or ""
+            if "GeographyType" in logical:
+                parsed = parse_geometry_logical_type(logical) or {}
+                edges_by_col[col["name"]] = parsed.get("algorithm") or "spherical"
+        geo_meta = get_geo_metadata(input_file) or {}
+        for name, col_meta in (geo_meta.get("columns") or {}).items():
+            edges = col_meta.get("edges") if isinstance(col_meta, dict) else None
+            if edges and edges != "planar":
+                edges_by_col.setdefault(name, edges)
+    except Exception:
+        return {}
+    return edges_by_col
+
+
+def preserve_nonplanar_edges(
+    input_file: str,
+    output_file: str,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    verbose: bool = False,
+) -> None:
+    """Carry non-planar edges declarations from input to output (#588).
+
+    DuckDB has no GEOGRAPHY type, so rewrites demote native GEOGRAPHY columns
+    to GEOMETRY and drop ``edges`` from regenerated metadata. Losing the edge
+    interpretation silently corrupts semantics (great-circle edges read as
+    planar), so re-attach it to the output's geo metadata.
+    """
+    edges_by_col = collect_nonplanar_edges(input_file)
+    if not edges_by_col:
+        return
+
+    pf = pq.ParquetFile(output_file)
+    try:
+        kv = pf.metadata.metadata or {}
+        if b"geo" not in kv:
+            warn(
+                "Input declares non-planar edges but output has no geo metadata "
+                f"to carry them ({', '.join(sorted(edges_by_col))}). Edge "
+                "interpretation is lost; avoid parquet-geo-only for geography data."
+            )
+            return
+        geo_meta = json.loads(kv[b"geo"].decode("utf-8"))
+    finally:
+        del pf
+
+    changed = False
+    for name, edges in edges_by_col.items():
+        col_meta = geo_meta.get("columns", {}).get(name)
+        if isinstance(col_meta, dict) and col_meta.get("edges") != edges:
+            col_meta["edges"] = edges
+            changed = True
+
+    if not changed:
+        return
+
+    _rewrite_file_with_geo_metadata(output_file, geo_meta, compression, compression_level)
+    warn(
+        "Native GEOGRAPHY is not preserved by the writer (DuckDB has no "
+        f"geography type); kept edges declaration in geo metadata for: "
+        f"{', '.join(sorted(edges_by_col))}"
+    )
 
 
 def _plain_copy_to(

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -844,6 +844,32 @@ def _cast_table_to_schema(table, target_schema, *, page_info: str | None = None)
     return pa.table(dict(zip([f.name for f in target_schema], new_columns, strict=True)))
 
 
+def resolve_geoparquet_version_from_file(parquet_file: str, verbose: bool = False) -> str | None:
+    """
+    Resolve the auto-mode GeoParquet write version from a parquet input file.
+
+    Implements the documented --geoparquet-version default: preserve the input
+    version (1.x normalizes to 1.1, matching extract_version_from_metadata),
+    upgrade native-geo-only inputs to 2.0, otherwise None (caller defaults).
+
+    Returns None when the file cannot be inspected (e.g., remote without
+    credentials) so callers fall back to the default.
+    """
+    try:
+        info = detect_geoparquet_file_type(parquet_file, verbose)
+    except Exception:
+        return None
+
+    file_type = info.get("file_type")
+    if file_type == "geoparquet_v2":
+        return "2.0"
+    if file_type == "parquet_geo_only":
+        return "2.0"
+    if file_type == "geoparquet_v1":
+        return "1.1"
+    return None
+
+
 def _detect_version_from_table(table, verbose: bool = False) -> str | None:
     """
     Detect GeoParquet version from table's schema metadata.

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -900,7 +900,8 @@ def resolve_geoparquet_version_from_file(parquet_file: str, verbose: bool = Fals
     """
     try:
         info = detect_geoparquet_file_type(parquet_file, verbose)
-    except Exception:
+    except Exception as e:
+        debug(f"Version auto-detect failed for {parquet_file}: {e}; falling back to default")
         return None
 
     detected = {
@@ -1788,18 +1789,80 @@ def _geo_code_to_type_name(code: int) -> str | None:
     return name + suffix
 
 
+def _geography_edges_from_logical(logical: str) -> str | None:
+    """Edges value implied by a native Geography logical type string.
+
+    Returns the declared algorithm (e.g. "spherical", "vincenty"), defaulting
+    to "spherical" (the Parquet spec default) when none is spelled out.
+    Returns None for non-Geography logical types.
+    """
+    if not logical.startswith("Geography"):
+        return None
+    match = re.search(r"algorithm=([A-Za-z_]+)", logical)
+    return match.group(1).lower() if match else "spherical"
+
+
+def _geo_col_meta_from_stats(pf, col_index: int, logical: str) -> dict:
+    """Build one geo column metadata dict from a column's native geo statistics."""
+    codes: set[int] = set()
+    bbox = None
+    zrange = None
+    for rg in range(pf.metadata.num_row_groups):
+        stats = pf.metadata.row_group(rg).column(col_index).geo_statistics
+        if stats is None:
+            continue
+        codes.update(stats.geospatial_types or [])
+        if stats.xmin is not None:
+            # Limitation: min/max-merging row-group extents assumes planar
+            # edges; geography data crossing the antimeridian can yield an
+            # over-wide (though never under-covering) bbox here.
+            if bbox is None:
+                bbox = [stats.xmin, stats.ymin, stats.xmax, stats.ymax]
+            else:
+                bbox = [
+                    min(bbox[0], stats.xmin),
+                    min(bbox[1], stats.ymin),
+                    max(bbox[2], stats.xmax),
+                    max(bbox[3], stats.ymax),
+                ]
+        if stats.zmin is not None:
+            if zrange is None:
+                zrange = [stats.zmin, stats.zmax]
+            else:
+                zrange = [min(zrange[0], stats.zmin), max(zrange[1], stats.zmax)]
+
+    geometry_types = sorted(t for t in (_geo_code_to_type_name(c) for c in codes) if t is not None)
+    col_meta: dict = {"encoding": "WKB", "geometry_types": geometry_types}
+    if bbox is not None:
+        # RFC 7946 order; 6 values when a Z range exists (M is never
+        # part of bbox per spec).
+        if zrange is not None:
+            col_meta["bbox"] = [bbox[0], bbox[1], zrange[0], bbox[2], bbox[3], zrange[1]]
+        else:
+            col_meta["bbox"] = bbox
+    # A Geography logical type carries edge semantics the geo metadata must
+    # not drop: synthesize the matching edges declaration (#588).
+    edges = _geography_edges_from_logical(logical)
+    if edges:
+        col_meta["edges"] = edges
+    return col_meta
+
+
 def _ensure_v2_geo_metadata(
     output_path: str,
     compression: str = "ZSTD",
     compression_level: int | None = None,
     row_group_rows: int | None = None,
     verbose: bool = False,
+    primary_column: str | None = None,
 ) -> None:
     """Attach GeoParquet 2.0 geo metadata if the writer omitted it (#589).
 
     DuckDB 1.5.4's V2 writer skips the geo KV metadata for M/ZM geometries.
     Rebuild it from the file's native geospatial statistics, mirroring the
     shape DuckDB writes for XY/XYZ data, and rewrite the file in place.
+    ``primary_column`` names the real geometry column for multi-geometry
+    files; without it the fallback is "geometry", then alphabetical.
     """
     pf = pq.ParquetFile(output_path)
     try:
@@ -1807,54 +1870,25 @@ def _ensure_v2_geo_metadata(
         if b"geo" in kv:
             return
         schema = pf.metadata.schema
-        geo_col_names = {}
+        geo_cols: dict[int, tuple[str, str]] = {}
         for i in range(len(schema)):
             logical = str(schema.column(i).logical_type)
             if logical.startswith(("Geometry", "Geography")):
-                geo_col_names[i] = schema.column(i).name
-        if not geo_col_names:
+                geo_cols[i] = (schema.column(i).name, logical)
+        if not geo_cols:
             return
 
-        columns = {}
-        for i, name in geo_col_names.items():
-            codes: set[int] = set()
-            bbox = None
-            zrange = None
-            for rg in range(pf.metadata.num_row_groups):
-                stats = pf.metadata.row_group(rg).column(i).geo_statistics
-                if stats is None:
-                    continue
-                codes.update(stats.geospatial_types or [])
-                if stats.xmin is not None:
-                    if bbox is None:
-                        bbox = [stats.xmin, stats.ymin, stats.xmax, stats.ymax]
-                    else:
-                        bbox = [
-                            min(bbox[0], stats.xmin),
-                            min(bbox[1], stats.ymin),
-                            max(bbox[2], stats.xmax),
-                            max(bbox[3], stats.ymax),
-                        ]
-                if stats.zmin is not None:
-                    if zrange is None:
-                        zrange = [stats.zmin, stats.zmax]
-                    else:
-                        zrange = [min(zrange[0], stats.zmin), max(zrange[1], stats.zmax)]
+        columns = {
+            name: _geo_col_meta_from_stats(pf, i, logical)
+            for i, (name, logical) in geo_cols.items()
+        }
 
-            geometry_types = sorted(
-                t for t in (_geo_code_to_type_name(c) for c in codes) if t is not None
-            )
-            col_meta: dict = {"encoding": "WKB", "geometry_types": geometry_types}
-            if bbox is not None:
-                # RFC 7946 order; 6 values when a Z range exists (M is never
-                # part of bbox per spec).
-                if zrange is not None:
-                    col_meta["bbox"] = [bbox[0], bbox[1], zrange[0], bbox[2], bbox[3], zrange[1]]
-                else:
-                    col_meta["bbox"] = bbox
-            columns[name] = col_meta
-
-        primary = "geometry" if "geometry" in columns else sorted(columns)[0]
+        if primary_column and primary_column in columns:
+            primary = primary_column
+        elif "geometry" in columns:
+            primary = "geometry"
+        else:
+            primary = sorted(columns)[0]
         geo_meta = {"version": "2.0.0", "primary_column": primary, "columns": columns}
     finally:
         # Release the read handle before rewriting (Windows requires it).
@@ -1954,7 +1988,8 @@ def collect_nonplanar_edges(input_file: str) -> dict[str, str]:
             edges = col_meta.get("edges") if isinstance(col_meta, dict) else None
             if edges and edges != "planar":
                 edges_by_col.setdefault(name, edges)
-    except Exception:
+    except Exception as e:
+        debug(f"Could not collect edges metadata from {input_file}: {e}")
         return {}
     return edges_by_col
 
@@ -2047,10 +2082,13 @@ def _apply_nonplanar_edges(
     _rewrite_file_with_geo_metadata(
         output_file, geo_meta, compression, compression_level, row_group_rows
     )
+    # Neutral wording: the input may have declared edges via metadata only,
+    # without ever having a native GEOGRAPHY logical type.
     warn(
-        "Native GEOGRAPHY is not preserved by the writer (DuckDB has no "
-        f"geography type); kept edges declaration in geo metadata for: "
-        f"{', '.join(sorted(edges_by_col))}"
+        "Preserved non-planar edges declaration in geo metadata for: "
+        f"{', '.join(sorted(edges_by_col))}. Note: DuckDB has no geography "
+        "type, so any native GEOGRAPHY input is rewritten as GEOMETRY (the "
+        "edges metadata carries the interpretation)."
     )
 
 
@@ -2142,6 +2180,7 @@ def _plain_copy_to(
             compression_level=compression_level,
             row_group_rows=row_group_rows,
             verbose=verbose,
+            primary_column=geometry_column,
         )
 
     if verbose:

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -448,6 +448,45 @@ def validate_compression_settings(compression, compression_level, verbose=False)
     return compression, compression_level, compression_desc
 
 
+def zm_suffix_sql(geom_expr: str, sep: str = " ") -> str:
+    """SQL fragment producing the dimension suffix (''/'{sep}Z'/'{sep}M'/'{sep}ZM').
+
+    The GeoParquet spec treats "LineString" and "LineString ZM" as distinct
+    geometry_types entries, so any SQL type scan must append this suffix to
+    ST_GeometryType() output instead of collapsing dimensions.
+    """
+    return (
+        f"CASE WHEN ST_HasZ({geom_expr}) AND ST_HasM({geom_expr}) THEN '{sep}ZM' "
+        f"WHEN ST_HasZ({geom_expr}) THEN '{sep}Z' "
+        f"WHEN ST_HasM({geom_expr}) THEN '{sep}M' "
+        f"ELSE '' END"
+    )
+
+
+def split_zm_suffix(name: str) -> tuple[str, str]:
+    """Split a spec geometry type into (base, suffix): 'Point ZM' -> ('Point', ' ZM').
+
+    Names without a dimension suffix (and non-string inputs) return ('' suffix).
+    """
+    if isinstance(name, str):
+        for suffix in (" ZM", " Z", " M"):
+            if name.endswith(suffix):
+                return name[: -len(suffix)], suffix
+    return name, ""
+
+
+# DuckDB ST_GeometryType names ("POINT") -> GeoParquet spec names ("Point").
+_DUCKDB_TO_SPEC_TYPE = {
+    "POINT": "Point",
+    "LINESTRING": "LineString",
+    "POLYGON": "Polygon",
+    "MULTIPOINT": "MultiPoint",
+    "MULTILINESTRING": "MultiLineString",
+    "MULTIPOLYGON": "MultiPolygon",
+    "GEOMETRYCOLLECTION": "GeometryCollection",
+}
+
+
 def compute_geometry_types_via_sql(
     con,
     query: str,
@@ -462,7 +501,8 @@ def compute_geometry_types_via_sql(
         geometry_column: Name of geometry column
 
     Returns:
-        List of geometry type names (e.g., ["Point", "Polygon"]) or empty list if column not in query
+        List of spec geometry type names with dimension suffixes
+        (e.g., ["Point", "LineString ZM"]) or empty list if column not in query
     """
     # Check if geometry column exists in query result
     try:
@@ -481,29 +521,21 @@ def compute_geometry_types_via_sql(
 
     # Escape column name for SQL (double any embedded quotes)
     escaped_col = geometry_column.replace('"', '""')
+    quoted_col = f'"{escaped_col}"'
+    typed_expr = f"ST_GeometryType({quoted_col}) || {zm_suffix_sql(quoted_col)}"
     types_query = f"""
-        SELECT DISTINCT ST_GeometryType("{escaped_col}") as geom_type
+        SELECT DISTINCT {typed_expr} as geom_type
         FROM ({query})
-        WHERE "{escaped_col}" IS NOT NULL
+        WHERE {quoted_col} IS NOT NULL
     """
     results = con.execute(types_query).fetchall()
-
-    # DuckDB returns types like "POINT", "POLYGON" - convert to GeoParquet format
-    type_map = {
-        "POINT": "Point",
-        "LINESTRING": "LineString",
-        "POLYGON": "Polygon",
-        "MULTIPOINT": "MultiPoint",
-        "MULTILINESTRING": "MultiLineString",
-        "MULTIPOLYGON": "MultiPolygon",
-        "GEOMETRYCOLLECTION": "GeometryCollection",
-    }
 
     types = []
     for (geom_type,) in results:
         if geom_type:
-            normalized = type_map.get(geom_type.upper(), geom_type)
-            types.append(normalized)
+            base, suffix = split_zm_suffix(geom_type)
+            normalized = _DUCKDB_TO_SPEC_TYPE.get(base.upper(), base)
+            types.append(normalized + suffix)
 
     return sorted(set(types))
 
@@ -1806,13 +1838,26 @@ def _ensure_v2_geo_metadata(
         geo_meta = {"version": "2.0.0", "primary_column": primary, "columns": columns}
     finally:
         # Release the read handle before rewriting (Windows requires it).
-        del pf
+        pf.close()
 
     _rewrite_file_with_geo_metadata(
         output_path, geo_meta, compression, compression_level, row_group_rows
     )
     if verbose:
         debug("Re-attached geo metadata (writer omitted it for M/ZM geometries)")
+
+
+def _infer_row_group_size(output_path: str) -> int | None:
+    """Max rows per existing row group, so a rewrite can mirror the file's layout."""
+    pf = pq.ParquetFile(output_path)
+    try:
+        num_groups = pf.metadata.num_row_groups
+        if num_groups == 0:
+            return None
+        return max(pf.metadata.row_group(i).num_rows for i in range(num_groups))
+    finally:
+        # Release the read handle before any rewrite (Windows requires it).
+        pf.close()
 
 
 def _rewrite_file_with_geo_metadata(
@@ -1827,17 +1872,26 @@ def _rewrite_file_with_geo_metadata(
     # GEOGRAPHY logical types (and their CRS) instead of demoting to binary.
     import geoarrow.pyarrow  # noqa: F401
 
+    # Preserve the file's own row-group layout when the caller didn't specify
+    # one — pyarrow's ~1Mi-row default would otherwise collapse the groups.
+    if not row_group_rows:
+        row_group_rows = _infer_row_group_size(output_path)
+
     table = pq.read_table(output_path)
     new_meta = dict(table.schema.metadata or {})
     new_meta[b"geo"] = json.dumps(geo_meta).encode()
     table = table.replace_schema_metadata(new_meta)
 
+    # Keys cover every normalized name callers can pass (DuckDB COPY names
+    # from _plain_copy_to's compression_map plus pyarrow-style variants).
     codec_map = {
         "ZSTD": "zstd",
         "GZIP": "gzip",
         "BROTLI": "brotli",
         "SNAPPY": "snappy",
         "UNCOMPRESSED": "none",
+        "NONE": "none",
+        "LZ4": "lz4",
         "LZ4_RAW": "lz4",
     }
     write_kwargs: dict = {"compression": codec_map.get(compression.upper(), "zstd")}
@@ -1847,8 +1901,13 @@ def _rewrite_file_with_geo_metadata(
         write_kwargs["row_group_size"] = row_group_rows
 
     tmp_path = f"{output_path}.geometa.tmp"
-    pq.write_table(table, tmp_path, **write_kwargs)
-    os.replace(tmp_path, output_path)
+    try:
+        pq.write_table(table, tmp_path, **write_kwargs)
+        os.replace(tmp_path, output_path)
+    finally:
+        # os.replace consumes the tmp file on success; clean it up on failure.
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
 
 
 def collect_nonplanar_edges(input_file: str) -> dict[str, str]:
@@ -1880,11 +1939,27 @@ def collect_nonplanar_edges(input_file: str) -> dict[str, str]:
     return edges_by_col
 
 
+def _edges_for_output_version(edges: str, geo_version: str) -> str:
+    """Map an edges value to one representable in the output's spec version.
+
+    GeoParquet 1.x only allows {"planar", "spherical"}; ellipsoidal algorithms
+    (vincenty/karney/andoyer/thomas) from 2.0/native inputs degrade to
+    "spherical" with a warning. 2.0 outputs keep the algorithm verbatim.
+    """
+    if not str(geo_version).startswith("1."):
+        return edges
+    if edges in ("planar", "spherical"):
+        return edges
+    warn(f"edges algorithm '{edges}' is not representable in GeoParquet 1.x; writing 'spherical'")
+    return "spherical"
+
+
 def preserve_nonplanar_edges(
     input_file: str,
     output_file: str,
     compression: str = "ZSTD",
     compression_level: int | None = None,
+    row_group_rows: int | None = None,
     verbose: bool = False,
 ) -> None:
     """Carry non-planar edges declarations from input to output (#588).
@@ -1910,10 +1985,13 @@ def preserve_nonplanar_edges(
             return
         geo_meta = json.loads(kv[b"geo"].decode("utf-8"))
     finally:
-        del pf
+        # Release the read handle before rewriting (Windows requires it).
+        pf.close()
 
+    geo_version = str(geo_meta.get("version") or "")
     changed = False
     for name, edges in edges_by_col.items():
+        edges = _edges_for_output_version(edges, geo_version)
         col_meta = geo_meta.get("columns", {}).get(name)
         if isinstance(col_meta, dict) and col_meta.get("edges") != edges:
             col_meta["edges"] = edges
@@ -1922,7 +2000,9 @@ def preserve_nonplanar_edges(
     if not changed:
         return
 
-    _rewrite_file_with_geo_metadata(output_file, geo_meta, compression, compression_level)
+    _rewrite_file_with_geo_metadata(
+        output_file, geo_meta, compression, compression_level, row_group_rows
+    )
     warn(
         "Native GEOGRAPHY is not preserved by the writer (DuckDB has no "
         f"geography type); kept edges declaration in geo metadata for: "

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1714,6 +1714,130 @@ def write_geoparquet_via_arrow(
             )
 
 
+_GEO_TYPE_CODE_BASES = {
+    1: "Point",
+    2: "LineString",
+    3: "Polygon",
+    4: "MultiPoint",
+    5: "MultiLineString",
+    6: "MultiPolygon",
+    7: "GeometryCollection",
+}
+_GEO_TYPE_CODE_SUFFIXES = {0: "", 1: " Z", 2: " M", 3: " ZM"}
+
+
+def _geo_code_to_type_name(code: int) -> str | None:
+    """Map a Parquet geospatial type code (e.g. 3002) to 'LineString ZM'."""
+    dim, base = divmod(code, 1000)
+    name = _GEO_TYPE_CODE_BASES.get(base)
+    suffix = _GEO_TYPE_CODE_SUFFIXES.get(dim)
+    if name is None or suffix is None:
+        return None
+    return name + suffix
+
+
+def _ensure_v2_geo_metadata(
+    output_path: str,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    row_group_rows: int | None = None,
+    verbose: bool = False,
+) -> None:
+    """Attach GeoParquet 2.0 geo metadata if the writer omitted it (#589).
+
+    DuckDB 1.5.4's V2 writer skips the geo KV metadata for M/ZM geometries.
+    Rebuild it from the file's native geospatial statistics, mirroring the
+    shape DuckDB writes for XY/XYZ data, and rewrite the file in place.
+    """
+    pf = pq.ParquetFile(output_path)
+    try:
+        kv = pf.metadata.metadata or {}
+        if b"geo" in kv:
+            return
+        schema = pf.metadata.schema
+        geo_col_names = {}
+        for i in range(len(schema)):
+            logical = str(schema.column(i).logical_type)
+            if logical.startswith(("Geometry", "Geography")):
+                geo_col_names[i] = schema.column(i).name
+        if not geo_col_names:
+            return
+
+        columns = {}
+        for i, name in geo_col_names.items():
+            codes: set[int] = set()
+            bbox = None
+            zrange = None
+            for rg in range(pf.metadata.num_row_groups):
+                stats = pf.metadata.row_group(rg).column(i).geo_statistics
+                if stats is None:
+                    continue
+                codes.update(stats.geospatial_types or [])
+                if stats.xmin is not None:
+                    if bbox is None:
+                        bbox = [stats.xmin, stats.ymin, stats.xmax, stats.ymax]
+                    else:
+                        bbox = [
+                            min(bbox[0], stats.xmin),
+                            min(bbox[1], stats.ymin),
+                            max(bbox[2], stats.xmax),
+                            max(bbox[3], stats.ymax),
+                        ]
+                if stats.zmin is not None:
+                    if zrange is None:
+                        zrange = [stats.zmin, stats.zmax]
+                    else:
+                        zrange = [min(zrange[0], stats.zmin), max(zrange[1], stats.zmax)]
+
+            geometry_types = sorted(
+                t for t in (_geo_code_to_type_name(c) for c in codes) if t is not None
+            )
+            col_meta: dict = {"encoding": "WKB", "geometry_types": geometry_types}
+            if bbox is not None:
+                # RFC 7946 order; 6 values when a Z range exists (M is never
+                # part of bbox per spec).
+                if zrange is not None:
+                    col_meta["bbox"] = [bbox[0], bbox[1], zrange[0], bbox[2], bbox[3], zrange[1]]
+                else:
+                    col_meta["bbox"] = bbox
+            columns[name] = col_meta
+
+        primary = "geometry" if "geometry" in columns else sorted(columns)[0]
+        geo_meta = {"version": "2.0.0", "primary_column": primary, "columns": columns}
+    finally:
+        # Release the read handle before rewriting (Windows requires it).
+        del pf
+
+    # geoarrow registration makes pyarrow round-trip the native GEOMETRY/
+    # GEOGRAPHY logical types (and their CRS) instead of demoting to binary.
+    import geoarrow.pyarrow  # noqa: F401
+
+    table = pq.read_table(output_path)
+    new_meta = dict(table.schema.metadata or {})
+    new_meta[b"geo"] = json.dumps(geo_meta).encode()
+    table = table.replace_schema_metadata(new_meta)
+
+    codec_map = {
+        "ZSTD": "zstd",
+        "GZIP": "gzip",
+        "BROTLI": "brotli",
+        "SNAPPY": "snappy",
+        "UNCOMPRESSED": "none",
+        "LZ4_RAW": "lz4",
+    }
+    write_kwargs: dict = {"compression": codec_map.get(compression, "zstd")}
+    if compression_level is not None and write_kwargs["compression"] in ("zstd", "gzip", "brotli"):
+        write_kwargs["compression_level"] = compression_level
+    if row_group_rows:
+        write_kwargs["row_group_size"] = row_group_rows
+
+    tmp_path = f"{output_path}.geometa.tmp"
+    pq.write_table(table, tmp_path, **write_kwargs)
+    os.replace(tmp_path, output_path)
+    if verbose:
+        debug("Re-attached geo metadata (writer omitted it for M/ZM geometries)")
+
+
 def _plain_copy_to(
     con,
     query: str,
@@ -1790,6 +1914,19 @@ def _plain_copy_to(
         debug(f"Executing plain COPY TO with {duckdb_compression} compression...")
 
     con.execute(copy_query)
+
+    # DuckDB 1.5.4's V2 writer omits the geo KV metadata for geometries with
+    # an M dimension (XY/XYZ are written correctly). Without it the output
+    # silently degrades to parquet-geo-only, so repair it from the file's own
+    # native geospatial statistics (#589).
+    if duckdb_version == "V2":
+        _ensure_v2_geo_metadata(
+            output_path,
+            compression=duckdb_compression,
+            compression_level=compression_level,
+            row_group_rows=row_group_rows,
+            verbose=verbose,
+        )
 
     if verbose:
         import pyarrow.parquet as pq

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -876,6 +876,17 @@ def _cast_table_to_schema(table, target_schema, *, page_info: str | None = None)
     return pa.table(dict(zip([f.name for f in target_schema], new_columns, strict=True)))
 
 
+def _resolve_auto_version(detected: str | None) -> str | None:
+    """Shared auto-mode decision for CLI and API write paths.
+
+    Preserve a detected 1.x/2.0 version; upgrade native-geo-only inputs to 2.0
+    (the documented --geoparquet-version default contract).
+    """
+    if detected == "parquet-geo-only":
+        return "2.0"
+    return detected
+
+
 def resolve_geoparquet_version_from_file(parquet_file: str, verbose: bool = False) -> str | None:
     """
     Resolve the auto-mode GeoParquet write version from a parquet input file.
@@ -892,14 +903,23 @@ def resolve_geoparquet_version_from_file(parquet_file: str, verbose: bool = Fals
     except Exception:
         return None
 
-    file_type = info.get("file_type")
-    if file_type == "geoparquet_v2":
-        return "2.0"
-    if file_type == "parquet_geo_only":
-        return "2.0"
-    if file_type == "geoparquet_v1":
-        return "1.1"
-    return None
+    detected = {
+        "geoparquet_v2": "2.0",
+        "parquet_geo_only": "parquet-geo-only",
+        "geoparquet_v1": "1.1",
+    }.get(info.get("file_type"))
+    return _resolve_auto_version(detected)
+
+
+def resolve_geoparquet_version_from_table(table, verbose: bool = False) -> str | None:
+    """
+    Resolve the auto-mode GeoParquet write version from an Arrow table.
+
+    API-side counterpart of resolve_geoparquet_version_from_file, sharing the
+    same decision (_resolve_auto_version) so ``gpio.read(f).write(out)`` picks
+    the same version the CLI would for the same input file (todo 043).
+    """
+    return _resolve_auto_version(_detect_version_from_table(table, verbose))
 
 
 def _detect_version_from_table(table, verbose: bool = False) -> str | None:
@@ -1954,22 +1974,46 @@ def _edges_for_output_version(edges: str, geo_version: str) -> str:
     return "spherical"
 
 
-def preserve_nonplanar_edges(
-    input_file: str,
+def _collect_nonplanar_edges_from_metadata(original_metadata: dict | None) -> dict[str, str]:
+    """Map geometry column -> non-planar edges declared in an input KV metadata dict.
+
+    Fallback for write paths that carry the input's KV metadata but not its
+    path (the native GEOGRAPHY logical-type half needs the file itself).
+    """
+    if not original_metadata:
+        return {}
+    geo_data = original_metadata.get("geo") or original_metadata.get(b"geo")
+    if not geo_data:
+        return {}
+    try:
+        if isinstance(geo_data, bytes):
+            geo_data = geo_data.decode("utf-8")
+        geo_meta = json.loads(geo_data) if isinstance(geo_data, str) else geo_data
+        edges_by_col: dict[str, str] = {}
+        for name, col_meta in (geo_meta.get("columns") or {}).items():
+            edges = col_meta.get("edges") if isinstance(col_meta, dict) else None
+            if edges and edges != "planar":
+                edges_by_col[name] = edges
+        return edges_by_col
+    except Exception:
+        return {}
+
+
+def _apply_nonplanar_edges(
+    edges_by_col: dict[str, str],
     output_file: str,
     compression: str = "ZSTD",
     compression_level: int | None = None,
     row_group_rows: int | None = None,
     verbose: bool = False,
 ) -> None:
-    """Carry non-planar edges declarations from input to output (#588).
+    """Re-attach non-planar edges declarations to an output's geo metadata (#588).
 
     DuckDB has no GEOGRAPHY type, so rewrites demote native GEOGRAPHY columns
     to GEOMETRY and drop ``edges`` from regenerated metadata. Losing the edge
     interpretation silently corrupts semantics (great-circle edges read as
     planar), so re-attach it to the output's geo metadata.
     """
-    edges_by_col = collect_nonplanar_edges(input_file)
     if not edges_by_col:
         return
 
@@ -2126,6 +2170,7 @@ def write_parquet_with_metadata(
     memory_limit: str | None = None,
     geometry_info: dict | None = None,
     extra_kv_metadata: dict[str, str] | None = None,
+    input_file: str | None = None,
 ):
     """
     Write a parquet file with proper compression and metadata handling.
@@ -2165,6 +2210,10 @@ def write_parquet_with_metadata(
             - "metadata": dict mapping column names to their metadata (crs, encoding, etc.)
         extra_kv_metadata: Additional Parquet file-level KV metadata as {key: json_string}.
             Written alongside the 'geo' key (e.g., for Vecorel collection metadata).
+        input_file: Path to the input parquet file, when the write rewrites an
+            existing file. Enables full-fidelity non-planar edges preservation
+            (native GEOGRAPHY logical types are only visible in the file's
+            schema); without it, edges still fall back to original_metadata.
 
     Returns:
         None
@@ -2308,6 +2357,20 @@ def write_parquet_with_metadata(
 
             strategy.write_from_query(**write_kwargs)
 
+        # Non-planar edges must survive every rewrite path (#588): DuckDB
+        # regenerates geo metadata without `edges`, silently demoting geography
+        # data to planar. Runs on the local temp file, so remote outputs are
+        # patched before upload.
+        _preserve_edges_after_write(
+            input_file,
+            original_metadata,
+            actual_output,
+            compression=compression,
+            compression_level=compression_level,
+            row_group_rows=row_group_rows,
+            verbose=verbose,
+        )
+
         # Auto-fix vecorel schema compliance when collection metadata is present
         if not is_remote:
             _auto_fix_vecorel_if_needed(actual_output, extra_kv_metadata, original_metadata)
@@ -2320,6 +2383,34 @@ def write_parquet_with_metadata(
                 is_directory=False,
                 verbose=verbose,
             )
+
+
+def _preserve_edges_after_write(
+    input_file: str | None,
+    original_metadata: dict | None,
+    output_path: str,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    row_group_rows: int | None = None,
+    verbose: bool = False,
+) -> None:
+    """Restore non-planar edges dropped by the writer, on any rewrite path.
+
+    Prefers the input file (sees native GEOGRAPHY logical types as well as geo
+    metadata); falls back to the input's KV metadata dict when only that is
+    available (e.g. partition staging rewrites).
+    """
+    edges_by_col = collect_nonplanar_edges(input_file) if input_file else {}
+    if not edges_by_col:
+        edges_by_col = _collect_nonplanar_edges_from_metadata(original_metadata)
+    _apply_nonplanar_edges(
+        edges_by_col,
+        output_path,
+        compression=compression,
+        compression_level=compression_level,
+        row_group_rows=row_group_rows,
+        verbose=verbose,
+    )
 
 
 def _auto_fix_vecorel_if_needed(

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1594,21 +1594,10 @@ def convert_to_geoparquet(
             geoparquet_version=geoparquet_version,
             input_crs=effective_crs,
             geometry_info=geometry_info,
+            # Geography inputs: DuckDB demotes GEOGRAPHY to GEOMETRY and drops
+            # the edges declaration; the shared write path restores it (#588).
+            input_file=input_file if is_parquet and has_geometry else None,
         )
-
-        # Geography inputs: DuckDB demotes GEOGRAPHY to GEOMETRY and drops
-        # the edges declaration from regenerated metadata; restore it (#588).
-        if is_parquet and has_geometry and not is_remote_url(output_file):
-            from geoparquet_io.core.common import preserve_nonplanar_edges
-
-            preserve_nonplanar_edges(
-                input_file,
-                output_file,
-                compression=compression,
-                compression_level=compression_level,
-                row_group_rows=row_group_rows,
-                verbose=verbose,
-            )
 
         _report_conversion_results(output_file, start_time, is_geo=has_geometry)
 

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1479,6 +1479,16 @@ def convert_to_geoparquet(
         require_single_file(input_file, "convert")
 
     try:
+        # Auto version mode: preserve a parquet input's GeoParquet version
+        # (and upgrade native-geo-only inputs to 2.0) instead of silently
+        # falling back to the 1.1 default and stripping native types (#587).
+        if geoparquet_version is None and is_parquet:
+            from geoparquet_io.core.common import resolve_geoparquet_version_from_file
+
+            geoparquet_version = resolve_geoparquet_version_from_file(input_file, verbose)
+            if verbose and geoparquet_version:
+                debug(f"Auto-detected GeoParquet version from input: {geoparquet_version}")
+
         effective_crs = _determine_effective_crs(
             input_file, input_url, crs, is_csv, is_parquet, con, verbose
         )

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1572,6 +1572,20 @@ def convert_to_geoparquet(
             input_crs=effective_crs,
             geometry_info=geometry_info,
         )
+
+        # Geography inputs: DuckDB demotes GEOGRAPHY to GEOMETRY and drops
+        # the edges declaration from regenerated metadata; restore it (#588).
+        if is_parquet and has_geometry and not is_remote_url(output_file):
+            from geoparquet_io.core.common import preserve_nonplanar_edges
+
+            preserve_nonplanar_edges(
+                input_file,
+                output_file,
+                compression=compression,
+                compression_level=compression_level,
+                verbose=verbose,
+            )
+
         _report_conversion_results(output_file, start_time, is_geo=has_geometry)
 
     except duckdb.IOException as e:

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1383,6 +1383,17 @@ def _determine_effective_crs(
     return detected
 
 
+def _validate_output_metadata(output_file: str):
+    """Cheap metadata-level validation of the final output; None if it can't run."""
+    from geoparquet_io.core.validate import validate_geoparquet
+
+    try:
+        return validate_geoparquet(output_file, validate_data=False)
+    except Exception as e:  # never let the report step fail the conversion
+        debug(f"Post-conversion validation could not run: {e}")
+        return None
+
+
 def _report_conversion_results(output_file: str, start_time: float, is_geo: bool = True) -> None:
     """Report conversion results with timing and file size."""
     elapsed = time.time() - start_time
@@ -1396,10 +1407,22 @@ def _report_conversion_results(output_file: str, start_time: float, is_geo: bool
         progress(f"Output: {output_file} ({format_size(file_size)})")
     else:
         progress(f"Output: {output_file}")
-    if is_geo:
-        success("✓ Output passes GeoParquet validation")
-    else:
+
+    if not is_geo:
         success("✓ Converted to optimized Parquet (no geometry)")
+        return
+
+    # Only claim a validation pass after actually validating the final output
+    # (post any metadata repairs). Remote outputs skip the extra fetch.
+    result = None if is_remote_url(output_file) else _validate_output_metadata(output_file)
+    if result is None:
+        progress("Conversion complete (run 'gpio check spec' to validate)")
+    elif result.is_valid:
+        success("✓ Output passes GeoParquet validation (metadata checks)")
+    else:
+        warn(
+            "Output did not pass GeoParquet metadata validation — run 'gpio check spec' for details"
+        )
 
 
 def convert_to_geoparquet(
@@ -1583,6 +1606,7 @@ def convert_to_geoparquet(
                 output_file,
                 compression=compression,
                 compression_level=compression_level,
+                row_group_rows=row_group_rows,
                 verbose=verbose,
             )
 

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1509,8 +1509,10 @@ def convert_to_geoparquet(
             from geoparquet_io.core.common import resolve_geoparquet_version_from_file
 
             geoparquet_version = resolve_geoparquet_version_from_file(input_file, verbose)
-            if verbose and geoparquet_version:
+            if geoparquet_version:
                 debug(f"Auto-detected GeoParquet version from input: {geoparquet_version}")
+            else:
+                debug("Could not detect input GeoParquet version; using writer default")
 
         effective_crs = _determine_effective_crs(
             input_file, input_url, crs, is_csv, is_parquet, con, verbose

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -16,6 +16,7 @@ import re
 from typing import Any
 
 import duckdb
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.exceptions import GeoParquetError
@@ -127,12 +128,13 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
 
         # Get schema info with proper type mapping
         for field in schema:
-            # First check Arrow schema for logical type (GeoArrow extension types)
-            logical_type = _get_pyarrow_logical_type(field)
-
-            # If not found in Arrow schema, check Parquet physical schema
-            # This handles native Parquet GEOMETRY/GEOGRAPHY logical types
-            if logical_type is None and field.name in parquet_col_map:
+            # Prefer the Parquet physical schema's native GEOMETRY/GEOGRAPHY
+            # logical type: it is stable, while the Arrow-level view of the
+            # same column flips to a geoarrow extension type (dropping the
+            # Geometry/Geography distinction) once geoarrow.pyarrow has been
+            # imported anywhere in the process.
+            logical_type = None
+            if field.name in parquet_col_map:
                 parquet_col = parquet_col_map[field.name]
                 if parquet_col.logical_type is not None:
                     logical_type_str = str(parquet_col.logical_type)
@@ -144,9 +146,22 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
                     elif logical_type_str.startswith("Geography("):
                         logical_type = "GeographyType" + logical_type_str[9:]
 
+            # Fall back to the Arrow schema (GeoArrow extension types, e.g.
+            # 1.1-geoarrow files with no native Parquet logical type)
+            if logical_type is None:
+                logical_type = _get_pyarrow_logical_type(field)
+
+            # Report the storage type for extension fields: whether pyarrow
+            # sees geoarrow.wkb here depends on process-global extension
+            # registration (importing geoarrow.pyarrow anywhere flips it), and
+            # schema info must not vary with import order.
+            field_type = field.type
+            if isinstance(field_type, pa.ExtensionType):
+                field_type = field_type.storage_type
+
             col_info = {
                 "name": field.name,
-                "type": str(field.type),
+                "type": str(field_type),
                 "type_length": None,
                 "repetition_type": "OPTIONAL" if field.nullable else "REQUIRED",
                 "num_children": 0,

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -156,7 +156,9 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
             # registration (importing geoarrow.pyarrow anywhere flips it), and
             # schema info must not vary with import order.
             field_type = field.type
-            if isinstance(field_type, pa.ExtensionType):
+            # BaseExtensionType also covers C++-defined extensions (e.g.
+            # pyarrow's built-in ones), which pa.ExtensionType would miss.
+            if isinstance(field_type, pa.BaseExtensionType):
                 field_type = field_type.storage_type
 
             col_info = {

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -1034,6 +1034,7 @@ def _execute_extraction(
             geoparquet_version=geoparquet_version,
             write_strategy=write_strategy,
             memory_limit=memory_limit,
+            input_file=input_parquet,
         )
 
         # Get extracted row count from output file metadata (fast - reads footer only)

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -369,61 +369,17 @@ def compute_geometry_types_via_sql(
     """
     Compute distinct geometry types from query using DuckDB.
 
-    Uses ST_GeometryType to get distinct types and normalizes them
-    to GeoParquet format (e.g., "POINT" -> "Point").
-
-    Args:
-        con: DuckDB connection with spatial extension loaded
-        query: SQL query containing geometry column
-        geometry_column: Name of geometry column
+    Delegates to the canonical dimension-aware implementation in
+    ``geoparquet_io.core.common`` (lazy import: common imports this module
+    at top level, so a module-level import here would be circular).
 
     Returns:
-        List of geometry type names (e.g., ["Point", "Polygon"])
-        or empty list if column not in query
+        List of spec geometry type names with dimension suffixes
+        (e.g., ["Point", "LineString ZM"]) or empty list if column not in query
     """
-    # Check if geometry column exists in query result
-    try:
-        columns = _get_query_columns(con, query)
-        if geometry_column not in columns:
-            return []
-    except (duckdb.Error, RuntimeError, ValueError, AttributeError):
-        # If we can't determine schema, return empty list rather than failing
-        return []
+    from geoparquet_io.core.common import compute_geometry_types_via_sql as _impl
 
-    # GeoArrow native types (STRUCT(x DOUBLE, y DOUBLE)[N]) can't use ST_GeometryType.
-    # For native encodings, geometry_types is already known from the encoding name;
-    # returning [] here is valid — GeoParquet allows omitting geometry_types.
-    col_type = _get_query_column_type(con, query, geometry_column) or ""
-    if "STRUCT" in col_type:
-        return []
-
-    # Escape column name for SQL (double any embedded quotes)
-    escaped_col = geometry_column.replace('"', '""')
-    types_query = f"""
-        SELECT DISTINCT ST_GeometryType("{escaped_col}") as geom_type
-        FROM ({query})
-        WHERE "{escaped_col}" IS NOT NULL
-    """
-    results = con.execute(types_query).fetchall()
-
-    # DuckDB returns types like "POINT", "POLYGON" - convert to GeoParquet format
-    type_map = {
-        "POINT": "Point",
-        "LINESTRING": "LineString",
-        "POLYGON": "Polygon",
-        "MULTIPOINT": "MultiPoint",
-        "MULTILINESTRING": "MultiLineString",
-        "MULTIPOLYGON": "MultiPolygon",
-        "GEOMETRYCOLLECTION": "GeometryCollection",
-    }
-
-    types = []
-    for (geom_type,) in results:
-        if geom_type:
-            normalized = type_map.get(geom_type.upper(), geom_type)
-            types.append(normalized)
-
-    return sorted(set(types))
+    return _impl(con, query, geometry_column)
 
 
 # =============================================================================

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -489,6 +489,7 @@ def _hilbert_order_file_based(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            input_file=input_parquet,
         )
         con.close()
         if temp_file_created and temp_file:
@@ -532,6 +533,7 @@ def _hilbert_order_file_based(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            input_file=input_parquet,
         )
         if verbose:
             debug("Hilbert ordering completed successfully")

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -528,6 +528,16 @@ def reproject_impl(
         # Read original metadata to preserve non-geo KV metadata (e.g., vecorel)
         original_metadata, _ = get_parquet_metadata(input_parquet, verbose)
 
+        # Auto version mode: match convert's contract (todo 040) — preserve the
+        # input's GeoParquet version and upgrade native-geo-only inputs to 2.0
+        # instead of silently stripping native types to 1.1 WKB.
+        if geoparquet_version is None:
+            from geoparquet_io.core.common import resolve_geoparquet_version_from_file
+
+            geoparquet_version = resolve_geoparquet_version_from_file(read_source, verbose)
+            if verbose and geoparquet_version:
+                debug(f"Auto-detected GeoParquet version from input: {geoparquet_version}")
+
         # Handle in-place overwrite
         is_overwrite = str(out_path) == str(Path(input_parquet).resolve())
 
@@ -551,6 +561,7 @@ def reproject_impl(
                     geoparquet_version=geoparquet_version,
                     input_crs=target_crs_projjson,
                     memory_limit=memory_limit,
+                    input_file=read_source,
                 )
                 # Replace original with temp file
                 shutil.move(str(tmp_path), str(out_path))
@@ -578,6 +589,7 @@ def reproject_impl(
                     geoparquet_version=geoparquet_version,
                     input_crs=target_crs_projjson,
                     memory_limit=memory_limit,
+                    input_file=read_source,
                 )
 
                 if is_remote:
@@ -707,6 +719,12 @@ def _reproject_streaming(
             from geoparquet_io.core.common import get_parquet_metadata
 
             metadata, _ = get_parquet_metadata(working_file, verbose=False)
+
+            # Auto version mode: same contract as the file-based path (todo 040).
+            if geoparquet_version is None:
+                from geoparquet_io.core.common import resolve_geoparquet_version_from_file
+
+                geoparquet_version = resolve_geoparquet_version_from_file(working_file, False)
 
             # Update metadata with target CRS
             if metadata and b"geo" in metadata:

--- a/geoparquet_io/core/sort_by_column.py
+++ b/geoparquet_io/core/sort_by_column.py
@@ -212,6 +212,7 @@ def sort_by_column(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            input_file=input_parquet,
         )
 
         success(f"Sorted by {', '.join(column_list)} to: {output_parquet}")

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -259,6 +259,7 @@ def sort_by_quadkey(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            input_file=input_parquet,
         )
 
         if remove_quadkey_column:

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -613,6 +613,11 @@ def extract_version_from_metadata(metadata: dict | None) -> str | None:
                     # Upgrade all 1.x versions to 1.1 (backwards compatible)
                     if major == "1":
                         return "1.1"
+                    # Flatten any 2.x to "2.0" — the highest 2.x this writer
+                    # knows — so this path agrees with its file-based twin,
+                    # resolve_geoparquet_version_from_file (common.py).
+                    if major == "2":
+                        return "2.0"
                     return f"{major}.{parts[1]}"
         return None
     except (json.JSONDecodeError, UnicodeDecodeError):

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -235,6 +235,26 @@ def _check_encoding_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     )
 
 
+def _strip_zm_suffix(geometry_type: str) -> str:
+    """Return the base geometry type without a spec " Z"/" M"/" ZM" suffix."""
+    if not isinstance(geometry_type, str):
+        return geometry_type
+    for suffix in (" ZM", " Z", " M"):
+        if geometry_type.endswith(suffix):
+            return geometry_type[: -len(suffix)]
+    return geometry_type
+
+
+def _zm_suffix_sql(geom_expr: str, sep: str = " ") -> str:
+    """SQL fragment producing the dimension suffix (''/'{sep}Z'/'{sep}M'/'{sep}ZM')."""
+    return (
+        f"CASE WHEN ST_HasZ({geom_expr}) AND ST_HasM({geom_expr}) THEN '{sep}ZM' "
+        f"WHEN ST_HasZ({geom_expr}) THEN '{sep}Z' "
+        f"WHEN ST_HasM({geom_expr}) THEN '{sep}M' "
+        f"ELSE '' END"
+    )
+
+
 def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck:
     """Check 8: column metadata must include a 'geometry_types' list."""
     geometry_types = col_meta.get("geometry_types")
@@ -248,8 +268,9 @@ def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck
             category="column_metadata",
         )
 
-    # Validate each type is a valid string
-    invalid_types = [t for t in geometry_types if t not in VALID_GEOMETRY_TYPES]
+    # Validate each type is a valid string; the spec adds a " Z"/" M"/" ZM"
+    # suffix for 3D/measured geometries (e.g. "Point Z").
+    invalid_types = [t for t in geometry_types if _strip_zm_suffix(t) not in VALID_GEOMETRY_TYPES]
     if invalid_types:
         return ValidationCheck(
             name=f"geometry_types_list_{col_name}",
@@ -628,16 +649,19 @@ def _check_geometry_types_match_data(
         else:
             geom_expr = f'ST_GeomFromWKB("{geom_col}")'
 
-        # Get both distinct types and total count in one query
+        # Get both distinct types and total count in one query. The dimension
+        # suffix matters: "LineString" and "LineString ZM" are distinct
+        # geometry_types per spec, so the scan must not collapse them.
+        typed_expr = f"ST_GeometryType({geom_expr}) || {_zm_suffix_sql(geom_expr)}"
         query = f"""
-            SELECT ST_GeometryType({geom_expr}) as geom_type, COUNT(*) as cnt
+            SELECT {typed_expr} as geom_type, COUNT(*) as cnt
             FROM (
                 SELECT "{geom_col}"
                 FROM read_parquet('{safe_url}')
                 WHERE "{geom_col}" IS NOT NULL
                 {limit_clause}
             )
-            GROUP BY ST_GeometryType({geom_expr})
+            GROUP BY {typed_expr}
         """
 
         result = con.execute(query).fetchall()
@@ -662,10 +686,17 @@ def _check_geometry_types_match_data(
         normalized_found = set()
         for t in found_types.keys():
             if t:
-                # Strip ST_ prefix if present, then map via explicit mapping
+                # Strip ST_ prefix if present, split off the dimension suffix,
+                # map the base name, then re-append the suffix ("Point Z").
                 clean_type = t.replace("ST_", "").upper()
+                suffix = ""
+                for candidate in (" ZM", " Z", " M"):
+                    if clean_type.endswith(candidate):
+                        suffix = candidate
+                        clean_type = clean_type[: -len(candidate)]
+                        break
                 normalized = geom_type_mapping.get(clean_type, t)
-                normalized_found.add(normalized)
+                normalized_found.add(normalized + suffix)
 
         declared_set = set(declared_types) if declared_types else set()
 
@@ -1675,18 +1706,22 @@ def _check_native_geo_types_match(
                 category="parquet_geo_types",
             )
 
-        # Sample actual geometry types from the data
+        # Sample actual geometry types from the data. DuckDB's geo_types
+        # naming is dimension-aware ("linestring_m"), so append the matching
+        # suffix from ST_HasZ/ST_HasM instead of comparing base names only.
+        quoted_col = f'"{geom_col}"'
+        typed_expr = f"ST_GeometryType({quoted_col}) || {_zm_suffix_sql(quoted_col, sep='_')}"
         if sample_size == 0:
             # Check all rows
             actual_result = con.execute(f"""
-                SELECT DISTINCT ST_GeometryType("{geom_col}") as geom_type
+                SELECT DISTINCT {typed_expr} as geom_type
                 FROM read_parquet('{safe_url}')
                 WHERE "{geom_col}" IS NOT NULL
             """).fetchall()
         else:
             # Sample rows
             actual_result = con.execute(f"""
-                SELECT DISTINCT ST_GeometryType("{geom_col}") as geom_type
+                SELECT DISTINCT {typed_expr} as geom_type
                 FROM (
                     SELECT "{geom_col}"
                     FROM read_parquet('{safe_url}')

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from rich.console import Console
 
+from geoparquet_io.core.common import split_zm_suffix, zm_suffix_sql
 from geoparquet_io.core.crs_utils import NULL_CRS_HINT, get_crs_display_name, is_geographic_crs
 from geoparquet_io.core.exceptions import GeoParquetError
 
@@ -237,22 +238,7 @@ def _check_encoding_valid(col_meta: dict, col_name: str) -> ValidationCheck:
 
 def _strip_zm_suffix(geometry_type: str) -> str:
     """Return the base geometry type without a spec " Z"/" M"/" ZM" suffix."""
-    if not isinstance(geometry_type, str):
-        return geometry_type
-    for suffix in (" ZM", " Z", " M"):
-        if geometry_type.endswith(suffix):
-            return geometry_type[: -len(suffix)]
-    return geometry_type
-
-
-def _zm_suffix_sql(geom_expr: str, sep: str = " ") -> str:
-    """SQL fragment producing the dimension suffix (''/'{sep}Z'/'{sep}M'/'{sep}ZM')."""
-    return (
-        f"CASE WHEN ST_HasZ({geom_expr}) AND ST_HasM({geom_expr}) THEN '{sep}ZM' "
-        f"WHEN ST_HasZ({geom_expr}) THEN '{sep}Z' "
-        f"WHEN ST_HasM({geom_expr}) THEN '{sep}M' "
-        f"ELSE '' END"
-    )
+    return split_zm_suffix(geometry_type)[0]
 
 
 def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck:
@@ -791,7 +777,7 @@ def _check_geometry_types_match_data(
         # Get both distinct types and total count in one query. The dimension
         # suffix matters: "LineString" and "LineString ZM" are distinct
         # geometry_types per spec, so the scan must not collapse them.
-        typed_expr = f"ST_GeometryType({geom_expr}) || {_zm_suffix_sql(geom_expr)}"
+        typed_expr = f"ST_GeometryType({geom_expr}) || {zm_suffix_sql(geom_expr)}"
         query = f"""
             SELECT {typed_expr} as geom_type, COUNT(*) as cnt
             FROM (
@@ -827,15 +813,8 @@ def _check_geometry_types_match_data(
             if t:
                 # Strip ST_ prefix if present, split off the dimension suffix,
                 # map the base name, then re-append the suffix ("Point Z").
-                clean_type = t.replace("ST_", "").upper()
-                suffix = ""
-                for candidate in (" ZM", " Z", " M"):
-                    if clean_type.endswith(candidate):
-                        suffix = candidate
-                        clean_type = clean_type[: -len(candidate)]
-                        break
-                normalized = geom_type_mapping.get(clean_type, t)
-                normalized_found.add(normalized + suffix)
+                base, suffix = split_zm_suffix(t.replace("ST_", "").upper())
+                normalized_found.add(geom_type_mapping.get(base, t) + suffix)
 
         declared_set = set(declared_types) if declared_types else set()
 
@@ -1849,7 +1828,7 @@ def _check_native_geo_types_match(
         # naming is dimension-aware ("linestring_m"), so append the matching
         # suffix from ST_HasZ/ST_HasM instead of comparing base names only.
         quoted_col = f'"{geom_col}"'
-        typed_expr = f"ST_GeometryType({quoted_col}) || {_zm_suffix_sql(quoted_col, sep='_')}"
+        typed_expr = f"ST_GeometryType({quoted_col}) || {zm_suffix_sql(quoted_col, sep='_')}"
         if sample_size == 0:
             # Check all rows
             actual_result = con.execute(f"""

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -14,6 +14,7 @@ from typing import Any
 from rich.console import Console
 
 from geoparquet_io.core.crs_utils import NULL_CRS_HINT, get_crs_display_name, is_geographic_crs
+from geoparquet_io.core.exceptions import GeoParquetError
 
 
 class CheckStatus(Enum):
@@ -334,8 +335,14 @@ def _check_orientation_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     )
 
 
-def _check_edges_valid(col_meta: dict, col_name: str) -> ValidationCheck:
-    """Check 11: optional 'edges' must be a valid string."""
+def _check_edges_valid(
+    col_meta: dict, col_name: str, geo_version: str = "1.0.0"
+) -> ValidationCheck:
+    """Check 11: optional 'edges' must be a valid string.
+
+    GeoParquet 2.0 widened the vocabulary from planar/spherical to include the
+    four ellipsoidal-geodesic algorithms; 1.x keeps the narrow set.
+    """
     edges = col_meta.get("edges")
 
     if edges is None:
@@ -346,13 +353,17 @@ def _check_edges_valid(col_meta: dict, col_name: str) -> ValidationCheck:
             category="column_metadata",
         )
 
-    is_valid = edges in VALID_EDGES_GEOPARQUET
+    valid_edges = list(VALID_EDGES_GEOPARQUET)
+    if (geo_version or "1.0.0") >= "2.0.0":
+        valid_edges += [e for e in VALID_EDGES_PARQUET_GEO if e not in valid_edges]
+
+    is_valid = edges in valid_edges
     return ValidationCheck(
         name=f"edges_valid_{col_name}",
         status=CheckStatus.PASSED if is_valid else CheckStatus.FAILED,
         message=f'column "{col_name}" has valid edges: {edges}'
         if is_valid
-        else f'column "{col_name}" edges must be one of {VALID_EDGES_GEOPARQUET}',
+        else f'column "{col_name}" edges must be one of {valid_edges}',
         category="column_metadata",
     )
 
@@ -738,6 +749,8 @@ def _build_bbox_query(
         geom_expr = geom_col
     else:
         geom_expr = f"ST_GeomFromWKB({geom_col})"
+    # Empties have no extent; the same expression filters them out pre-LIMIT.
+    geom_expr_filter = geom_expr
 
     return f"""
         SELECT COUNT(*) as total,
@@ -751,6 +764,7 @@ def _build_bbox_query(
             SELECT {geom_col}
             FROM read_parquet('{safe_url}')
             WHERE {geom_col} IS NOT NULL
+              AND NOT ST_IsEmpty({geom_expr_filter})
             {limit_clause}
         )
     """
@@ -1595,6 +1609,7 @@ def _check_native_geo_stats_contains_data(
                 SELECT "{geom_col}"
                 FROM read_parquet('{safe_url}')
                 WHERE "{geom_col}" IS NOT NULL
+                  AND NOT ST_IsEmpty("{geom_col}")
                 {limit_clause}
             )
         """
@@ -1769,6 +1784,16 @@ def _check_v2_crs_in_parquet_type(
             category="geoparquet_2_0",
         )
 
+    # Explicit CRS84-equivalent metadata is still the default: the native type
+    # may omit its crs (which the Parquet spec defines as OGC:CRS84).
+    if _is_crs84_equivalent(metadata_crs):
+        return ValidationCheck(
+            name=f"v2_crs_in_parquet_type_{geom_col}",
+            status=CheckStatus.PASSED,
+            message="metadata CRS is the default (OGC:CRS84), no inline CRS required",
+            category="geoparquet_2_0",
+        )
+
     # Find the Parquet schema CRS
     for col in schema_info:
         if col.get("name") == geom_col:
@@ -1816,17 +1841,20 @@ def _check_v2_crs_consistency(geo_meta: dict, schema_info: list, geom_col: str) 
                 schema_crs = parsed.get("crs")
             break
 
-    # Both None = both default = match
-    if metadata_crs is None and schema_crs is None:
+    # An absent CRS on either side means the default, OGC:CRS84. Resolve both
+    # sides before comparing so explicit-CRS84 vs absent doesn't false-fail.
+    metadata_is_default = metadata_crs is None or _is_crs84_equivalent(metadata_crs)
+    schema_is_default = schema_crs is None or _is_crs84_equivalent(_parse_crs_value(schema_crs))
+    if metadata_is_default and schema_is_default:
         return ValidationCheck(
             name=f"v2_crs_consistency_{geom_col}",
             status=CheckStatus.PASSED,
-            message="CRS matches: both default to OGC:CRS84",
+            message="CRS matches: both are OGC:CRS84 (explicit or default)",
             category="geoparquet_2_0",
         )
 
     # Compare CRS - simplified comparison
-    if _crs_equals(metadata_crs, schema_crs):
+    if _crs_equals(metadata_crs, _parse_crs_value(schema_crs)):
         return ValidationCheck(
             name=f"v2_crs_consistency_{geom_col}",
             status=CheckStatus.PASSED,
@@ -2020,6 +2048,50 @@ def _extract_epsg_code(crs: Any) -> int | None:
     if isinstance(crs, str):
         return _extract_epsg_from_string(crs)
     return None
+
+
+def _parse_crs_value(crs: Any) -> Any:
+    """Normalize a CRS that may arrive as a PROJJSON string (from a logical type)."""
+    if isinstance(crs, str):
+        stripped = crs.strip()
+        if stripped.startswith("{"):
+            try:
+                return json.loads(stripped)
+            except (ValueError, TypeError):
+                return crs
+    return crs
+
+
+def _is_crs84_equivalent(crs: Any) -> bool:
+    """True when a declared CRS is the spec default (OGC:CRS84) or its lon/lat twin.
+
+    GeoParquet fixes coordinate order to (x, y) regardless of the CRS's own
+    axis definition, so EPSG:4326 metadata describes the same coordinates as
+    the OGC:CRS84 default.
+    """
+    crs = _parse_crs_value(crs)
+    if _is_ogc_crs84(crs):
+        return True
+    if isinstance(crs, dict):
+        crs_id = crs.get("id", {})
+        if isinstance(crs_id, dict) and crs_id:
+            authority = str(crs_id.get("authority", "")).upper()
+            code = str(crs_id.get("code", "")).upper()
+            return authority == "EPSG" and code == "4326"
+        # No id member (allowed in PROJJSON): fall back to a semantic
+        # comparison. Axis order is ignored because GeoParquet fixes
+        # coordinate order to (x, y) regardless of the CRS definition.
+        try:
+            from pyproj import CRS as PyprojCRS
+
+            return PyprojCRS.from_json_dict(crs).equals(
+                PyprojCRS.from_user_input("OGC:CRS84"), ignore_axis_order=True
+            )
+        except Exception:
+            return False
+    if isinstance(crs, str):
+        return crs.upper() in ("OGC:CRS84", "EPSG:4326", "SRID:4326")
+    return False
 
 
 def _is_ogc_crs84(crs: Any) -> bool:
@@ -2380,8 +2452,26 @@ def validate_geoparquet(
 
     safe_url = safe_file_url(parquet_file, verbose=verbose)
 
-    # Auto-detect file type
-    file_type_info = detect_geoparquet_file_type(parquet_file, verbose)
+    # Auto-detect file type. Corrupt metadata (e.g. invalid UTF-8 in the geo
+    # value) must yield a FAILED report, never an exception.
+    try:
+        file_type_info = detect_geoparquet_file_type(parquet_file, verbose)
+    except (GeoParquetError, UnicodeDecodeError, ValueError) as e:
+        result = ValidationResult(
+            file_path=parquet_file,
+            detected_version="unknown",
+            target_version=target_version,
+        )
+        result.checks.append(
+            ValidationCheck(
+                name="geo_metadata_parse",
+                status=CheckStatus.FAILED,
+                message="file metadata is not readable (corrupt or invalid encoding)",
+                details=str(e),
+                category="core_metadata",
+            )
+        )
+        return result
 
     # Determine detected version (always from file, not target)
     detected_version = _determine_version(file_type_info)
@@ -2402,11 +2492,25 @@ def validate_geoparquet(
             if version_check.status == CheckStatus.FAILED:
                 return result
 
-    # Get metadata
-    kv_metadata = get_kv_metadata(safe_url)
-    geo_meta = get_geo_metadata(safe_url)
-    schema_info = get_schema_info(safe_url)
-    geo_columns = detect_geometry_columns(safe_url)
+    # Get metadata. Corrupt metadata (e.g. invalid UTF-8 in the geo value) must
+    # yield a FAILED report, never an exception — rejecting such files is this
+    # function's job.
+    try:
+        kv_metadata = get_kv_metadata(safe_url)
+        geo_meta = get_geo_metadata(safe_url)
+        schema_info = get_schema_info(safe_url)
+        geo_columns = detect_geometry_columns(safe_url)
+    except (GeoParquetError, UnicodeDecodeError, ValueError) as e:
+        result.checks.append(
+            ValidationCheck(
+                name="geo_metadata_parse",
+                status=CheckStatus.FAILED,
+                message="file metadata is not readable (corrupt or invalid encoding)",
+                details=str(e),
+                category="core_metadata",
+            )
+        )
+        return result
 
     # Get DuckDB connection for data validation
     con = None
@@ -2632,13 +2736,17 @@ def _run_geoparquet_checks(
 
     columns = geo_meta.get("columns", {})
 
+    # A missing version is reported by _check_version_present above; guard the
+    # string comparisons below against None so validation never crashes on it.
+    geo_version = file_type_info.get("geo_version") or "1.0.0"
+
     # Column metadata checks for each geometry column
     for col_name, col_meta in columns.items():
         checks.append(_check_encoding_valid(col_meta, col_name))
         checks.append(_check_geometry_types_list(col_meta, col_name))
         checks.append(_check_crs_valid(col_meta, col_name))
         checks.append(_check_orientation_valid(col_meta, col_name))
-        checks.append(_check_edges_valid(col_meta, col_name))
+        checks.append(_check_edges_valid(col_meta, col_name, geo_version))
         checks.append(_check_bbox_valid(col_meta, col_name))
         checks.append(_check_epoch_valid(col_meta, col_name))
 
@@ -2678,8 +2786,6 @@ def _run_geoparquet_checks(
             )
 
     # Version-specific checks
-    geo_version = file_type_info.get("geo_version", "1.0.0")
-
     # GeoParquet 1.1 checks - covering was removed in 2.0, so only run for 1.x
     is_v1_1 = geo_version >= "1.1.0" and geo_version < "2.0.0"
     if is_v1_1:

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -273,6 +273,29 @@ def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck
     )
 
 
+# CRS type values allowed by the PROJJSON v0.7 schema's "crs" definition.
+_PROJJSON_CRS_TYPES = frozenset(
+    {
+        "GeodeticCRS",
+        "GeographicCRS",
+        "ProjectedCRS",
+        "VerticalCRS",
+        "CompoundCRS",
+        "BoundCRS",
+        "EngineeringCRS",
+        "ParametricCRS",
+        "TemporalCRS",
+        "DerivedGeodeticCRS",
+        "DerivedGeographicCRS",
+        "DerivedProjectedCRS",
+        "DerivedVerticalCRS",
+        "DerivedEngineeringCRS",
+        "DerivedParametricCRS",
+        "DerivedTemporalCRS",
+    }
+)
+
+
 def _check_crs_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     """Check 9: optional 'crs' must be null or a PROJJSON object.
 
@@ -301,19 +324,28 @@ def _check_crs_valid(col_meta: dict, col_name: str) -> ValidationCheck:
         )
 
     # Check if it's a valid PROJJSON object. The PROJJSON schema requires a
-    # "type" member; JSON without it is not PROJJSON.
+    # "type" member drawn from its known CRS type set; JSON without it (or
+    # with a made-up type) is not PROJJSON.
     if isinstance(crs, dict):
-        if "type" in crs:
+        if "type" not in crs:
             return ValidationCheck(
                 name=f"crs_valid_{col_name}",
-                status=CheckStatus.PASSED,
-                message=f'column "{col_name}" has valid PROJJSON CRS',
+                status=CheckStatus.FAILED,
+                message=f'column "{col_name}" CRS is missing the required PROJJSON "type" member',
+                category="column_metadata",
+            )
+        if crs["type"] not in _PROJJSON_CRS_TYPES:
+            return ValidationCheck(
+                name=f"crs_valid_{col_name}",
+                status=CheckStatus.FAILED,
+                message=f'column "{col_name}" CRS has unknown PROJJSON type: {crs["type"]!r}',
+                details=f"Known PROJJSON CRS types: {', '.join(sorted(_PROJJSON_CRS_TYPES))}",
                 category="column_metadata",
             )
         return ValidationCheck(
             name=f"crs_valid_{col_name}",
-            status=CheckStatus.FAILED,
-            message=f'column "{col_name}" CRS is missing the required PROJJSON "type" member',
+            status=CheckStatus.PASSED,
+            message=f'column "{col_name}" has valid PROJJSON CRS',
             category="column_metadata",
         )
 
@@ -348,6 +380,26 @@ def _check_orientation_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     )
 
 
+def _version_at_least(version: Any, major: int, minor: int = 0) -> bool:
+    """True when a GeoParquet version string is >= major.minor.
+
+    Parses instead of comparing lexicographically (which breaks on "1.10.0"
+    vs "1.2.0"). Handles "2.0", "2.0.0", and pre-release forms like
+    "1.0.0-beta.1" (the pre-release tag is ignored). Non-string or
+    unparsable versions return False.
+    """
+    if not isinstance(version, str):
+        return False
+    core = version.split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    try:
+        v_major = int(parts[0])
+        v_minor = int(parts[1]) if len(parts) > 1 else 0
+    except (ValueError, IndexError):
+        return False
+    return (v_major, v_minor) >= (major, minor)
+
+
 def _check_edges_valid(
     col_meta: dict, col_name: str, geo_version: str = "1.0.0"
 ) -> ValidationCheck:
@@ -367,7 +419,7 @@ def _check_edges_valid(
         )
 
     valid_edges = list(VALID_EDGES_GEOPARQUET)
-    if (geo_version or "1.0.0") >= "2.0.0":
+    if _version_at_least(geo_version, 2, 0):
         valid_edges += [e for e in VALID_EDGES_PARQUET_GEO if e not in valid_edges]
 
     is_valid = edges in valid_edges
@@ -523,7 +575,19 @@ def _check_version_known(geo_meta: dict) -> ValidationCheck:
             message="no version to check",
             category="core_metadata",
         )
-    if isinstance(version, str) and version.startswith(_KNOWN_VERSION_MAJORS):
+    if not isinstance(version, str):
+        return ValidationCheck(
+            name="version_known",
+            status=CheckStatus.FAILED,
+            message=f"version must be a string (got {type(version).__name__}: {version!r})",
+            details="Known versions are 1.x and 2.x",
+            category="core_metadata",
+        )
+    # Policy: prefix-match known majors so any 1.x/2.x patch release passes
+    # (the corpus depends on this). Versions from a future major hard-FAIL:
+    # their semantics are unknown and must not silently validate against
+    # today's rules.
+    if version.startswith(_KNOWN_VERSION_MAJORS):
         return ValidationCheck(
             name="version_known",
             status=CheckStatus.PASSED,
@@ -539,15 +603,41 @@ def _check_version_known(geo_meta: dict) -> ValidationCheck:
     )
 
 
+def _columns_declaring_covering(geo_meta: dict) -> list[str]:
+    """Names of geometry columns whose metadata declares the 1.1-only 'covering' key."""
+    return sorted(
+        name
+        for name, col in (geo_meta.get("columns") or {}).items()
+        if isinstance(col, dict) and "covering" in col
+    )
+
+
 def _check_version_features(parquet_file: str, geo_meta: dict) -> ValidationCheck:
-    """1.x metadata must not be combined with 2.0-only features (native types)."""
-    version = geo_meta.get("version") or ""
-    if not (isinstance(version, str) and version.startswith("1.")):
+    """1.x metadata must not be combined with features from a newer version."""
+
+    def _result(status, message, details=None):
         return ValidationCheck(
             name="version_features_match",
-            status=CheckStatus.PASSED,
-            message="version permits declared features",
+            status=status,
+            message=message,
+            details=details,
             category="core_metadata",
+        )
+
+    version = geo_meta.get("version")
+    if not isinstance(version, str):
+        # version_known already FAILs a non-string version; a PASS here would
+        # contradict it, so decline to judge features instead.
+        return _result(CheckStatus.SKIPPED, "version is not a string; feature check not applicable")
+    if not version.startswith("1."):
+        return _result(CheckStatus.PASSED, "version permits declared features")
+    covering_cols = _columns_declaring_covering(geo_meta)
+    if covering_cols and not _version_at_least(version, 1, 1):
+        return _result(
+            CheckStatus.FAILED,
+            f"version {version} declared but columns use the 1.1-only "
+            f"'covering' key ({', '.join(covering_cols)})",
+            details="'covering' was introduced in GeoParquet 1.1",
         )
     try:
         import pyarrow.parquet as pq
@@ -558,28 +648,16 @@ def _check_version_features(parquet_file: str, geo_meta: dict) -> ValidationChec
             for i in range(len(schema))
             if str(schema.column(i).logical_type).startswith(("Geometry", "Geography"))
         ]
-    except Exception:
-        return ValidationCheck(
-            name="version_features_match",
-            status=CheckStatus.SKIPPED,
-            message="could not inspect Parquet schema",
-            category="core_metadata",
-        )
+    except Exception as e:
+        return _result(CheckStatus.SKIPPED, f"could not inspect Parquet schema: {e}")
     if native_cols:
-        return ValidationCheck(
-            name="version_features_match",
-            status=CheckStatus.FAILED,
-            message=f"version {version} declared but file uses native Parquet "
+        return _result(
+            CheckStatus.FAILED,
+            f"version {version} declared but file uses native Parquet "
             f"GEOMETRY/GEOGRAPHY types ({', '.join(native_cols)})",
             details="Native geospatial logical types require GeoParquet 2.0",
-            category="core_metadata",
         )
-    return ValidationCheck(
-        name="version_features_match",
-        status=CheckStatus.PASSED,
-        message="declared features match the declared version",
-        category="core_metadata",
-    )
+    return _result(CheckStatus.PASSED, "declared features match the declared version")
 
 
 # =============================================================================
@@ -753,6 +831,30 @@ def _check_encoding_matches_data(
     )
 
 
+# Uppercase DuckDB geometry type names -> expected GeoParquet casing.
+_GEOM_TYPE_DISPLAY = {
+    "POINT": "Point",
+    "LINESTRING": "LineString",
+    "POLYGON": "Polygon",
+    "MULTIPOINT": "MultiPoint",
+    "MULTILINESTRING": "MultiLineString",
+    "MULTIPOLYGON": "MultiPolygon",
+    "GEOMETRYCOLLECTION": "GeometryCollection",
+}
+
+
+def _normalize_found_geometry_type(raw: str) -> str:
+    """Map a DuckDB type + dimension suffix ("MULTIPOINT Z") to spec casing.
+
+    Strips any ST_ prefix, splits off the Z/M/ZM suffix, maps the base name,
+    then re-appends the suffix ("MultiPoint Z"). Unmapped base names keep the
+    uppercase base (never the raw string, which still carries the suffix and
+    would double it: "TRIANGLE Z Z").
+    """
+    base, suffix = split_zm_suffix(raw.replace("ST_", "").upper())
+    return _GEOM_TYPE_DISPLAY.get(base, base) + suffix
+
+
 def _check_geometry_types_match_data(
     parquet_file: str, geom_col: str, declared_types: list, con, sample_size: int
 ) -> ValidationCheck:
@@ -797,24 +899,7 @@ def _check_geometry_types_match_data(
                 found_types[row[0]] = row[1]
                 total_count += row[1]
 
-        # Normalize type names (DuckDB returns like "POINT", we want "Point")
-        # Explicit mapping from uppercase DuckDB names to expected GeoParquet names
-        geom_type_mapping = {
-            "POINT": "Point",
-            "LINESTRING": "LineString",
-            "POLYGON": "Polygon",
-            "MULTIPOINT": "MultiPoint",
-            "MULTILINESTRING": "MultiLineString",
-            "MULTIPOLYGON": "MultiPolygon",
-            "GEOMETRYCOLLECTION": "GeometryCollection",
-        }
-        normalized_found = set()
-        for t in found_types.keys():
-            if t:
-                # Strip ST_ prefix if present, split off the dimension suffix,
-                # map the base name, then re-append the suffix ("Point Z").
-                base, suffix = split_zm_suffix(t.replace("ST_", "").upper())
-                normalized_found.add(geom_type_mapping.get(base, t) + suffix)
+        normalized_found = {_normalize_found_geometry_type(t) for t in found_types.keys() if t}
 
         declared_set = set(declared_types) if declared_types else set()
 
@@ -931,6 +1016,15 @@ def _interpret_bbox_result(result: tuple | None, geom_col: str) -> ValidationChe
     """
     if result:
         total, within = result
+        if total == 0:
+            # All rows were NULL or EMPTY; claiming PASS "(0 checked)" would
+            # vouch for a bbox nothing was tested against.
+            return ValidationCheck(
+                name=f"bbox_contains_data_{geom_col}",
+                status=CheckStatus.SKIPPED,
+                message="no non-empty geometries to check against declared bbox",
+                category="data_validation",
+            )
         if total == within:
             return ValidationCheck(
                 name=f"bbox_contains_data_{geom_col}",
@@ -1766,6 +1860,15 @@ def _check_native_geo_stats_contains_data(
 
         if result:
             total, within = result
+            if total == 0:
+                # All rows were NULL or EMPTY; a PASS "(0 checked)" would
+                # vouch for statistics nothing was tested against.
+                return ValidationCheck(
+                    name=f"native_geo_stats_contains_data_{geom_col}",
+                    status=CheckStatus.SKIPPED,
+                    message="no non-empty geometries to check against geospatial statistics",
+                    category="parquet_geo_types",
+                )
             if total == within:
                 return ValidationCheck(
                     name=f"native_geo_stats_contains_data_{geom_col}",
@@ -2263,7 +2366,14 @@ def _is_crs84_equivalent(crs: Any) -> bool:
         except Exception:
             return False
     if isinstance(crs, str):
-        return crs.upper() in ("OGC:CRS84", "EPSG:4326", "SRID:4326")
+        return crs.strip().upper() in (
+            "OGC:CRS84",
+            "EPSG:4326",
+            "SRID:4326",
+            "URN:OGC:DEF:CRS:OGC:1.3:CRS84",
+            "URN:OGC:DEF:CRS:OGC::CRS84",
+            "URN:OGC:DEF:CRS:EPSG::4326",
+        )
     return False
 
 
@@ -2626,6 +2736,28 @@ def _crs_equals(crs1: Any, crs2: Any) -> bool:
 # =============================================================================
 
 
+def _is_read_failure(exc: BaseException | None) -> bool:
+    """True when an exception chain indicates an I/O/read failure.
+
+    Distinguishes "the file could not be fetched" (missing path, permissions,
+    network) from "the file's content is corrupt" so remote read failures are
+    not misreported as corruption. Walks __cause__/__context__ because
+    GeoParquetError wraps the underlying error.
+    """
+    import duckdb
+
+    io_types: tuple[type, ...] = (OSError, duckdb.IOException)
+    if hasattr(duckdb, "HTTPException"):
+        io_types = (*io_types, duckdb.HTTPException)
+    seen: set[int] = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        if isinstance(exc, io_types):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
+
+
 def validate_geoparquet(
     parquet_file: str,
     target_version: str | None = None,
@@ -2662,6 +2794,12 @@ def validate_geoparquet(
 
     safe_url = safe_file_url(parquet_file, verbose=verbose)
 
+    def _metadata_failure_message(exc: Exception) -> str:
+        """Honest failure text: an unreadable file is not evidence of corruption."""
+        if _is_read_failure(exc):
+            return "could not read file (I/O or network error)"
+        return "file metadata is not readable (corrupt or invalid encoding)"
+
     # Auto-detect file type. Corrupt metadata (e.g. invalid UTF-8 in the geo
     # value) must yield a FAILED report, never an exception.
     try:
@@ -2676,7 +2814,7 @@ def validate_geoparquet(
             ValidationCheck(
                 name="geo_metadata_parse",
                 status=CheckStatus.FAILED,
-                message="file metadata is not readable (corrupt or invalid encoding)",
+                message=_metadata_failure_message(e),
                 details=str(e),
                 category="core_metadata",
             )
@@ -2715,7 +2853,7 @@ def validate_geoparquet(
             ValidationCheck(
                 name="geo_metadata_parse",
                 status=CheckStatus.FAILED,
-                message="file metadata is not readable (corrupt or invalid encoding)",
+                message=_metadata_failure_message(e),
                 details=str(e),
                 category="core_metadata",
             )
@@ -3014,7 +3152,7 @@ def _run_geoparquet_checks(
 
     # Version-specific checks
     # GeoParquet 1.1 checks - covering was removed in 2.0, so only run for 1.x
-    is_v1_1 = geo_version >= "1.1.0" and geo_version < "2.0.0"
+    is_v1_1 = _version_at_least(geo_version, 1, 1) and not _version_at_least(geo_version, 2, 0)
     if is_v1_1:
         for col_name, col_meta in columns.items():
             checks.append(_check_covering_is_object(col_meta, col_name))
@@ -3028,7 +3166,7 @@ def _run_geoparquet_checks(
                 checks.append(_check_covering_bbox_field_types(col_meta, col_name, schema_info))
 
     # File extension check applies to 1.1+
-    if geo_version >= "1.1.0":
+    if _version_at_least(geo_version, 1, 1):
         checks.append(_check_file_extension(parquet_file))
 
     # GeoParquet 2.0 checks - run Parquet native geo type checks first

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -440,29 +440,11 @@ def _check_bbox_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     )
 
 
-def _check_epoch_valid(col_meta: dict, col_name: str) -> ValidationCheck:
-    """Check 13: optional 'epoch' must be a number."""
-    epoch = col_meta.get("epoch")
+_CRS_ABSENT = object()
 
-    if epoch is None:
-        return ValidationCheck(
-            name=f"epoch_valid_{col_name}",
-            status=CheckStatus.PASSED,
-            message=f'column "{col_name}" has no epoch',
-            category="column_metadata",
-        )
 
-    if not isinstance(epoch, (int, float)):
-        return ValidationCheck(
-            name=f"epoch_valid_{col_name}",
-            status=CheckStatus.FAILED,
-            message=f'column "{col_name}" epoch must be a number',
-            category="column_metadata",
-        )
-
-    # A coordinate epoch only makes sense for a dynamic CRS. The default
-    # (absent crs = OGC:CRS84) and static datums do not support one.
-    crs = col_meta.get("crs")
+def _resolve_datum_type(crs: Any) -> str | None:
+    """Resolve a CRS value's datum type name via pyproj; None when unresolvable."""
     try:
         from pyproj import CRS as PyprojCRS
 
@@ -477,41 +459,68 @@ def _check_epoch_valid(col_meta: dict, col_name: str) -> ValidationCheck:
                 )
         else:
             pyproj_crs = PyprojCRS.from_user_input("OGC:CRS84")
-        datum_type = pyproj_crs.datum.type_name if pyproj_crs.datum else ""
-        # Dynamic frames (ITRF...) fully support epochs. A datum ensemble
-        # (EPSG:4326, OGC:CRS84) cannot carry one — there is no single frame
-        # the epoch could refer to. A specific static frame (e.g. GDA2020) is
-        # tolerated with a warning: epochs are commonly attached there in
-        # practice (plate-motion workflows) even though the frame is static.
-        if "Ensemble" in datum_type:
-            return ValidationCheck(
-                name=f"epoch_valid_{col_name}",
-                status=CheckStatus.FAILED,
-                message=f'column "{col_name}" declares epoch {epoch} on a datum ensemble',
-                details=f"Datum type: {datum_type}. "
-                "Coordinate epochs apply to dynamic reference frames (e.g. ITRF).",
-                category="column_metadata",
-            )
-        if "Dynamic" not in datum_type:
-            return ValidationCheck(
-                name=f"epoch_valid_{col_name}",
-                status=CheckStatus.WARNING,
-                message=f'column "{col_name}" declares epoch {epoch} on a static CRS',
-                details=f"Datum type: {datum_type or 'unknown'}. "
-                "Epochs are only meaningful for dynamic reference frames.",
-                category="column_metadata",
-            )
+        return pyproj_crs.datum.type_name if pyproj_crs.datum else ""
     except Exception:
-        # CRS not resolvable (or explicit null): can't judge the datum; the
-        # numeric epoch itself is fine.
-        pass
+        return None
 
-    return ValidationCheck(
-        name=f"epoch_valid_{col_name}",
-        status=CheckStatus.PASSED,
-        message=f'column "{col_name}" has valid epoch: {epoch}',
-        category="column_metadata",
-    )
+
+def _check_epoch_valid(col_meta: dict, col_name: str) -> ValidationCheck:
+    """Check 13: optional 'epoch' must be a number on a dynamic CRS."""
+
+    def _result(status, message, details=None):
+        return ValidationCheck(
+            name=f"epoch_valid_{col_name}",
+            status=status,
+            message=message,
+            details=details,
+            category="column_metadata",
+        )
+
+    epoch = col_meta.get("epoch")
+    if epoch is None:
+        return _result(CheckStatus.PASSED, f'column "{col_name}" has no epoch')
+    if not isinstance(epoch, (int, float)):
+        return _result(CheckStatus.FAILED, f'column "{col_name}" epoch must be a number')
+
+    # A coordinate epoch only makes sense for a dynamic CRS. The default
+    # (absent crs = OGC:CRS84) and static datums do not support one. An
+    # explicit null crs is distinct from absent: there is no CRS to judge.
+    crs = col_meta.get("crs", _CRS_ABSENT)
+    if crs is None:
+        return _result(
+            CheckStatus.WARNING,
+            f'column "{col_name}" declares epoch {epoch} but CRS is null; cannot verify datum type',
+        )
+    if crs is _CRS_ABSENT:
+        crs = None  # resolves to the OGC:CRS84 default below
+
+    datum_type = _resolve_datum_type(crs)
+    if datum_type is None:
+        return _result(
+            CheckStatus.WARNING,
+            f'column "{col_name}" declares epoch {epoch} but the CRS datum '
+            "could not be resolved for epoch validation",
+        )
+    # Dynamic frames (ITRF...) fully support epochs. A datum ensemble
+    # (EPSG:4326, OGC:CRS84) cannot carry one — there is no single frame
+    # the epoch could refer to. A specific static frame (e.g. GDA2020) is
+    # tolerated with a warning: epochs are commonly attached there in
+    # practice (plate-motion workflows) even though the frame is static.
+    if "Ensemble" in datum_type:
+        return _result(
+            CheckStatus.FAILED,
+            f'column "{col_name}" declares epoch {epoch} on a datum ensemble',
+            details=f"Datum type: {datum_type}. "
+            "Coordinate epochs apply to dynamic reference frames (e.g. ITRF).",
+        )
+    if "Dynamic" not in datum_type:
+        return _result(
+            CheckStatus.WARNING,
+            f'column "{col_name}" declares epoch {epoch} on a static CRS',
+            details=f"Datum type: {datum_type or 'unknown'}. "
+            "Epochs are only meaningful for dynamic reference frames.",
+        )
+    return _result(CheckStatus.PASSED, f'column "{col_name}" has valid epoch: {epoch}')
 
 
 _KNOWN_VERSION_MAJORS = ("1.", "2.")
@@ -2036,29 +2045,49 @@ def _check_v2_crs_consistency(geo_meta: dict, schema_info: list, geom_col: str) 
     )
 
 
+def _edges_schema_facts(schema_info: list, geom_col: str) -> tuple[bool, bool, str | None]:
+    """Return (is_geography, is_planar_geometry, schema_algorithm) for a column."""
+    from geoparquet_io.core.duckdb_metadata import parse_geometry_logical_type
+
+    for col in schema_info:
+        if col.get("name") != geom_col:
+            continue
+        logical_type = col.get("logical_type") or ""
+        if "GeographyType" in logical_type:
+            parsed = parse_geometry_logical_type(logical_type)
+            algorithm = parsed.get("algorithm", "spherical") if parsed else None
+            return True, False, algorithm
+        return False, "GeometryType" in logical_type, None
+    return False, False, None
+
+
 def _check_v2_edges_consistency(
     geo_meta: dict, schema_info: list, geom_col: str
 ) -> ValidationCheck:
     """Check V2-5: edges in metadata must match algorithm in Parquet GEOGRAPHY type."""
-    from geoparquet_io.core.duckdb_metadata import parse_geometry_logical_type
-
     col_meta = geo_meta.get("columns", {}).get(geom_col, {})
     metadata_edges = col_meta.get("edges", "planar")  # Default is planar
 
-    # Find schema algorithm
-    schema_algorithm = None
-    is_geography = False
-    for col in schema_info:
-        if col.get("name") == geom_col:
-            logical_type = col.get("logical_type") or ""
-            if "GeographyType" in logical_type:
-                is_geography = True
-                parsed = parse_geometry_logical_type(logical_type)
-                if parsed:
-                    schema_algorithm = parsed.get("algorithm", "spherical")  # Default
-            break
+    is_geography, is_planar_geometry, schema_algorithm = _edges_schema_facts(schema_info, geom_col)
 
     if not is_geography:
+        # The Parquet GEOMETRY logical type is defined as planar; a metadata
+        # claim of spherical/ellipsoidal edges contradicts it for readers that
+        # only honor the logical type. The 2.0 metadata schema still permits
+        # this shape (most writers cannot emit the GEOGRAPHY logical type and
+        # carry edges in geo metadata instead — gpio's own convert does), so
+        # this is an interoperability warning, not a spec violation.
+        if is_planar_geometry and metadata_edges != "planar":
+            return ValidationCheck(
+                name=f"v2_edges_consistency_{geom_col}",
+                status=CheckStatus.WARNING,
+                message=f"metadata declares non-planar edges '{metadata_edges}' "
+                "but column has planar GEOMETRY logical type",
+                details="Readers honoring only the Parquet logical type will "
+                "treat edges as planar; the GEOGRAPHY logical type expresses "
+                "this natively in GeoParquet 2.0",
+                category="geoparquet_2_0",
+            )
         return ValidationCheck(
             name=f"v2_edges_consistency_{geom_col}",
             status=CheckStatus.SKIPPED,
@@ -2184,7 +2213,7 @@ def _extract_epsg_from_dict(crs: dict) -> int | None:
     crs_id = crs.get("id", {})
     if not isinstance(crs_id, dict):
         return None
-    if crs_id.get("authority", "").upper() != "EPSG":
+    if str(crs_id.get("authority", "")).upper() != "EPSG":
         return None
     try:
         return int(crs_id.get("code", 0))
@@ -2267,7 +2296,8 @@ def _is_ogc_crs84(crs: Any) -> bool:
     if isinstance(crs, dict):
         crs_id = crs.get("id", {})
         if isinstance(crs_id, dict):
-            authority = crs_id.get("authority", "").upper()
+            # str() guards against malformed metadata with non-string values
+            authority = str(crs_id.get("authority", "")).upper()
             code = str(crs_id.get("code", "")).upper()
             return authority == "OGC" and code == "CRS84"
 
@@ -2565,26 +2595,51 @@ def _get_crs_from_schema(schema_info: list, geom_col: str) -> Any:
     return None
 
 
+def _complete_crs_id(crs: dict) -> tuple[str, str] | None:
+    """Normalized (authority, code) when both are present and non-empty, else None."""
+    crs_id = crs.get("id")
+    if not isinstance(crs_id, dict):
+        return None
+    authority = str(crs_id.get("authority") or "").upper()
+    code = str(crs_id.get("code") or "").upper()
+    if authority and code:
+        return (authority, code)
+    return None
+
+
 def _crs_equals(crs1: Any, crs2: Any) -> bool:
     """Compare two CRS values for equality."""
     if crs1 is None and crs2 is None:
         return True
     if crs1 is None or crs2 is None:
         return False
+    if not (isinstance(crs1, dict) and isinstance(crs2, dict)):
+        # Direct comparison for strings
+        return crs1 == crs2
 
-    # If both are dicts, compare EPSG codes if available
-    if isinstance(crs1, dict) and isinstance(crs2, dict):
-        id1 = crs1.get("id", {})
-        id2 = crs2.get("id", {})
-        if isinstance(id1, dict) and isinstance(id2, dict):
-            if id1.get("authority") == id2.get("authority"):
-                return id1.get("code") == id2.get("code")
+    # When both sides carry a complete authority:code id, trust it (the spec
+    # treats the id as authoritative).
+    id1 = _complete_crs_id(crs1)
+    id2 = _complete_crs_id(crs2)
+    if id1 and id2:
+        return id1 == id2
 
-        # Fall back to comparing names
-        return crs1.get("name") == crs2.get("name")
+    # Structurally identical PROJJSON is equal even if pyproj can't parse it.
+    if crs1 == crs2:
+        return True
 
-    # Direct comparison for strings
-    return crs1 == crs2
+    # At least one side lacks a usable id: compare semantically. Axis order is
+    # ignored because GeoParquet fixes coordinate order to (x, y). Fail closed
+    # on pyproj errors — an unverifiable CRS must not satisfy a consistency
+    # check.
+    try:
+        from pyproj import CRS as PyprojCRS
+
+        return PyprojCRS.from_json_dict(crs1).equals(
+            PyprojCRS.from_json_dict(crs2), ignore_axis_order=True
+        )
+    except Exception:
+        return False
 
 
 # =============================================================================
@@ -2688,15 +2743,16 @@ def validate_geoparquet(
         )
         return result
 
-    # A geo key that exists but doesn't parse must fail in ANY mode; without
-    # this, auto-detect classifies the file as plain parquet-geo-only and a
-    # corrupt file passes validation.
-    if geo_meta is None and kv_metadata and b"geo" in kv_metadata:
+    # A geo key that exists but doesn't parse to a JSON object must fail in
+    # ANY mode; without this, auto-detect classifies the file as plain
+    # parquet-geo-only and a corrupt file passes validation — and valid-JSON
+    # non-object values (list, string, number) would crash downstream checks.
+    if not isinstance(geo_meta, dict) and kv_metadata and b"geo" in kv_metadata:
         result.checks.append(
             ValidationCheck(
                 name="geo_metadata_parse",
                 status=CheckStatus.FAILED,
-                message="'geo' metadata key exists but is not valid JSON",
+                message="'geo' metadata key exists but is not a valid JSON object",
                 category="core_metadata",
             )
         )
@@ -2907,12 +2963,12 @@ def _run_geoparquet_checks(
     # Core metadata checks (1.0+)
     checks.append(_check_geo_key_exists(kv_metadata))
 
-    if geo_meta is None:
+    if not isinstance(geo_meta, dict):
         checks.append(
             ValidationCheck(
                 name="geo_metadata_parse",
                 status=CheckStatus.FAILED,
-                message="failed to parse 'geo' metadata as JSON",
+                message="failed to parse 'geo' metadata as a JSON object",
                 category="core_metadata",
             )
         )

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -314,16 +314,22 @@ def _check_crs_valid(col_meta: dict, col_name: str) -> ValidationCheck:
             category="column_metadata",
         )
 
-    # Check if it's a valid PROJJSON object
+    # Check if it's a valid PROJJSON object. The PROJJSON schema requires a
+    # "type" member; JSON without it is not PROJJSON.
     if isinstance(crs, dict):
-        # PROJJSON should have $schema or at minimum type/name
-        if "$schema" in crs or "type" in crs or "name" in crs:
+        if "type" in crs:
             return ValidationCheck(
                 name=f"crs_valid_{col_name}",
                 status=CheckStatus.PASSED,
                 message=f'column "{col_name}" has valid PROJJSON CRS',
                 category="column_metadata",
             )
+        return ValidationCheck(
+            name=f"crs_valid_{col_name}",
+            status=CheckStatus.FAILED,
+            message=f'column "{col_name}" CRS is missing the required PROJJSON "type" member',
+            category="column_metadata",
+        )
 
     return ValidationCheck(
         name=f"crs_valid_{col_name}",
@@ -446,14 +452,138 @@ def _check_epoch_valid(col_meta: dict, col_name: str) -> ValidationCheck:
             category="column_metadata",
         )
 
-    is_valid = isinstance(epoch, (int, float))
+    if not isinstance(epoch, (int, float)):
+        return ValidationCheck(
+            name=f"epoch_valid_{col_name}",
+            status=CheckStatus.FAILED,
+            message=f'column "{col_name}" epoch must be a number',
+            category="column_metadata",
+        )
+
+    # A coordinate epoch only makes sense for a dynamic CRS. The default
+    # (absent crs = OGC:CRS84) and static datums do not support one.
+    crs = col_meta.get("crs")
+    try:
+        from pyproj import CRS as PyprojCRS
+
+        if isinstance(crs, dict):
+            try:
+                pyproj_crs = PyprojCRS.from_json_dict(crs)
+            except Exception:
+                # Partial PROJJSON: resolve via its authority:code id instead
+                crs_id = crs.get("id") or {}
+                pyproj_crs = PyprojCRS.from_user_input(
+                    f"{crs_id.get('authority')}:{crs_id.get('code')}"
+                )
+        else:
+            pyproj_crs = PyprojCRS.from_user_input("OGC:CRS84")
+        datum_type = pyproj_crs.datum.type_name if pyproj_crs.datum else ""
+        # Dynamic frames (ITRF...) fully support epochs. A datum ensemble
+        # (EPSG:4326, OGC:CRS84) cannot carry one — there is no single frame
+        # the epoch could refer to. A specific static frame (e.g. GDA2020) is
+        # tolerated with a warning: epochs are commonly attached there in
+        # practice (plate-motion workflows) even though the frame is static.
+        if "Ensemble" in datum_type:
+            return ValidationCheck(
+                name=f"epoch_valid_{col_name}",
+                status=CheckStatus.FAILED,
+                message=f'column "{col_name}" declares epoch {epoch} on a datum ensemble',
+                details=f"Datum type: {datum_type}. "
+                "Coordinate epochs apply to dynamic reference frames (e.g. ITRF).",
+                category="column_metadata",
+            )
+        if "Dynamic" not in datum_type:
+            return ValidationCheck(
+                name=f"epoch_valid_{col_name}",
+                status=CheckStatus.WARNING,
+                message=f'column "{col_name}" declares epoch {epoch} on a static CRS',
+                details=f"Datum type: {datum_type or 'unknown'}. "
+                "Epochs are only meaningful for dynamic reference frames.",
+                category="column_metadata",
+            )
+    except Exception:
+        # CRS not resolvable (or explicit null): can't judge the datum; the
+        # numeric epoch itself is fine.
+        pass
+
     return ValidationCheck(
         name=f"epoch_valid_{col_name}",
-        status=CheckStatus.PASSED if is_valid else CheckStatus.FAILED,
-        message=f'column "{col_name}" has valid epoch: {epoch}'
-        if is_valid
-        else f'column "{col_name}" epoch must be a number',
+        status=CheckStatus.PASSED,
+        message=f'column "{col_name}" has valid epoch: {epoch}',
         category="column_metadata",
+    )
+
+
+_KNOWN_VERSION_MAJORS = ("1.", "2.")
+
+
+def _check_version_known(geo_meta: dict) -> ValidationCheck:
+    """The declared version must be a known GeoParquet major version."""
+    version = geo_meta.get("version")
+    if version is None:
+        # _check_version_present reports the absence; nothing to judge here.
+        return ValidationCheck(
+            name="version_known",
+            status=CheckStatus.SKIPPED,
+            message="no version to check",
+            category="core_metadata",
+        )
+    if isinstance(version, str) and version.startswith(_KNOWN_VERSION_MAJORS):
+        return ValidationCheck(
+            name="version_known",
+            status=CheckStatus.PASSED,
+            message=f"version {version} is a known GeoParquet version",
+            category="core_metadata",
+        )
+    return ValidationCheck(
+        name="version_known",
+        status=CheckStatus.FAILED,
+        message=f"unknown GeoParquet version: {version!r}",
+        details="Known versions are 1.x and 2.x",
+        category="core_metadata",
+    )
+
+
+def _check_version_features(parquet_file: str, geo_meta: dict) -> ValidationCheck:
+    """1.x metadata must not be combined with 2.0-only features (native types)."""
+    version = geo_meta.get("version") or ""
+    if not (isinstance(version, str) and version.startswith("1.")):
+        return ValidationCheck(
+            name="version_features_match",
+            status=CheckStatus.PASSED,
+            message="version permits declared features",
+            category="core_metadata",
+        )
+    try:
+        import pyarrow.parquet as pq
+
+        schema = pq.ParquetFile(parquet_file).metadata.schema
+        native_cols = [
+            schema.column(i).name
+            for i in range(len(schema))
+            if str(schema.column(i).logical_type).startswith(("Geometry", "Geography"))
+        ]
+    except Exception:
+        return ValidationCheck(
+            name="version_features_match",
+            status=CheckStatus.SKIPPED,
+            message="could not inspect Parquet schema",
+            category="core_metadata",
+        )
+    if native_cols:
+        return ValidationCheck(
+            name="version_features_match",
+            status=CheckStatus.FAILED,
+            message=f"version {version} declared but file uses native Parquet "
+            f"GEOMETRY/GEOGRAPHY types ({', '.join(native_cols)})",
+            details="Native geospatial logical types require GeoParquet 2.0",
+            category="core_metadata",
+        )
+    return ValidationCheck(
+        name="version_features_match",
+        status=CheckStatus.PASSED,
+        message="declared features match the declared version",
+        category="core_metadata",
     )
 
 
@@ -2368,14 +2498,16 @@ def _check_coordinates_valid_for_crs(
         is_geo = is_geographic_crs(crs)
 
         # Check bounds based on CRS type
+        geo_warning = None
         if is_geo:
             issues = _check_geographic_bounds(actual, crs_bounds)
         else:
             issues = _check_projected_bounds(actual, crs_bounds)
-            # Also check for geographic coords in projected CRS
+            # Geographic-looking coords in a projected CRS is only a heuristic:
+            # small legitimate projected values (near the origin) look identical
+            # to misdeclared lon/lat, so it warns instead of failing. The
+            # deterministic mismatch detection is v2_crs_consistency.
             geo_warning = _detect_geographic_in_projected(actual)
-            if geo_warning:
-                issues.append(geo_warning)
 
         if issues:
             return ValidationCheck(
@@ -2383,6 +2515,15 @@ def _check_coordinates_valid_for_crs(
                 status=CheckStatus.FAILED,
                 message=f"coordinates outside valid range for CRS ({total} checked)",
                 details="; ".join(issues),
+                category="data_validation",
+            )
+
+        if geo_warning:
+            return ValidationCheck(
+                name=check_name,
+                status=CheckStatus.WARNING,
+                message=f"possible CRS mismatch ({total} checked)",
+                details=geo_warning,
                 category="data_validation",
             )
 
@@ -2542,6 +2683,20 @@ def validate_geoparquet(
                 status=CheckStatus.FAILED,
                 message="file metadata is not readable (corrupt or invalid encoding)",
                 details=str(e),
+                category="core_metadata",
+            )
+        )
+        return result
+
+    # A geo key that exists but doesn't parse must fail in ANY mode; without
+    # this, auto-detect classifies the file as plain parquet-geo-only and a
+    # corrupt file passes validation.
+    if geo_meta is None and kv_metadata and b"geo" in kv_metadata:
+        result.checks.append(
+            ValidationCheck(
+                name="geo_metadata_parse",
+                status=CheckStatus.FAILED,
+                message="'geo' metadata key exists but is not valid JSON",
                 category="core_metadata",
             )
         )
@@ -2765,6 +2920,8 @@ def _run_geoparquet_checks(
 
     checks.append(_check_metadata_is_json(geo_meta))
     checks.append(_check_version_present(geo_meta))
+    checks.append(_check_version_known(geo_meta))
+    checks.append(_check_version_features(parquet_file, geo_meta))
     checks.append(_check_primary_column_present(geo_meta))
     checks.append(_check_columns_present(geo_meta))
     checks.append(_check_primary_column_in_columns(geo_meta))

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -573,12 +573,18 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         try:
             con.register("input_table", table)
 
-            # Convert WKB bytes to GEOMETRY for proper spatial processing
-            escaped_geom = geometry_column.replace('"', '""')
-            query = f"""
-                SELECT * REPLACE (ST_GeomFromWKB("{escaped_geom}") AS "{escaped_geom}")
-                FROM input_table
-            """
+            # Convert WKB bytes to GEOMETRY for proper spatial processing.
+            # geoarrow.wkb extension columns already register as GEOMETRY in
+            # DuckDB, where ST_GeomFromWKB(GEOMETRY) is a binder error.
+            geom_type = table.schema.field(geometry_column).type
+            if getattr(geom_type, "extension_name", None) == "geoarrow.wkb":
+                query = "SELECT * FROM input_table"
+            else:
+                escaped_geom = geometry_column.replace('"', '""')
+                query = f"""
+                    SELECT * REPLACE (ST_GeomFromWKB("{escaped_geom}") AS "{escaped_geom}")
+                    FROM input_table
+                """
 
             self.write_from_query(
                 con=con,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,11 +132,14 @@ addopts = [
     "--cov=geoparquet_io",
     "--cov-report=term-missing",
     "--cov-fail-under=67",
+    # The geoparquet-testing submodule ships its own pytest suite; never collect it.
+    "--ignore=tests/data/geoparquet-testing",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
     "integration: marks end-to-end integration tests",
+    "corpus: tests against the official geoparquet-testing corpus (requires git submodule)",
 ]
 
 [tool.ruff]
@@ -323,7 +326,7 @@ verbose = false
 # site/ (mkdocs build) and mutants/ (mutmut working tree) are gitignored
 # build artifacts; scanning them made test_codespell_passes fail on any
 # machine that had built docs or run mutation testing locally.
-skip = ".git,*.lock,*.parquet,*.json,tests/data/*,.venv,uv.lock,site,mutants"
+skip = ".git,*.lock,*.parquet,*.json,tests/data/*,geoparquet-testing,.venv,uv.lock,site,mutants"
 ignore-words-list = "nd,ot,crs,inout,hel,bu"
 check-filenames = true
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,20 @@ The `data/` directory contains test GeoParquet files:
 - `places_test.parquet` - 766 rows with place data including bbox column
 - `buildings_test.parquet` - 42 rows with building geometries
 
+### geoparquet-testing corpus (submodule)
+
+`data/geoparquet-testing/` is a git submodule vendoring the official
+[geoparquet-testing](https://github.com/geoparquet/geoparquet-testing) corpus,
+used by `test_geoparquet_corpus.py` (marker: `corpus`). Initialize it with:
+
+```bash
+git submodule update --init
+```
+
+Without it those tests skip with a hint. The pin is a specific upstream commit;
+bump it deliberately (fixture changes can alter expected results — see the
+adjudication notes in `test_geoparquet_corpus.py`).
+
 ## Running Tests
 
 ### Run all tests

--- a/tests/test_api_version_parity.py
+++ b/tests/test_api_version_parity.py
@@ -1,0 +1,91 @@
+"""CLI and Python API must resolve "auto" GeoParquet version identically (todo 043).
+
+Before the fix, ``gpio.read(pgo_file).write(out)`` emitted geo metadata claiming
+``version: 1.1.0, encoding: WKB`` while the column kept the native GEOMETRY
+logical type — an internally inconsistent hybrid — and diverged from the CLI,
+which upgrades native-geo-only inputs to 2.0.
+"""
+
+import pytest
+
+import geoparquet_io as gpio
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.convert import convert_to_geoparquet
+from tests.conftest import get_geo_metadata, get_geoparquet_version, has_native_geo_types
+
+
+def _write_native(path, version_option):
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('POINT (30 10)')),
+            (2, ST_GeomFromText('POINT (40 40)'))
+          ) t(id, geometry)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION '{version_option}')
+    """)
+    con.close()
+
+
+@pytest.fixture
+def pgo_input(tmp_path):
+    path = tmp_path / "pgo.parquet"
+    _write_native(path, "NONE")
+    assert get_geoparquet_version(str(path)) is None
+    assert has_native_geo_types(str(path))
+    return path
+
+
+@pytest.fixture
+def v2_input(tmp_path):
+    path = tmp_path / "v2.parquet"
+    _write_native(path, "V2")
+    assert get_geoparquet_version(str(path)) == "2.0.0"
+    return path
+
+
+def _assert_self_consistent(path):
+    """Native logical types require 2.x metadata (or none); 1.x means WKB blobs."""
+    version = get_geoparquet_version(str(path))
+    native = has_native_geo_types(str(path))
+    if version and version.startswith("1."):
+        assert not native, f"1.x geo metadata ({version}) but native GEOMETRY logical type"
+    if native and version:
+        assert version.startswith("2."), f"native logical type but metadata claims {version}"
+
+
+def test_pgo_input_api_matches_cli(pgo_input, tmp_path):
+    cli_out = tmp_path / "cli.parquet"
+    convert_to_geoparquet(str(pgo_input), str(cli_out), skip_hilbert=True, geoparquet_version=None)
+
+    api_out = tmp_path / "api.parquet"
+    gpio.read(pgo_input).write(api_out)
+
+    assert get_geoparquet_version(str(cli_out)) == "2.0.0"
+    assert get_geoparquet_version(str(api_out)) == "2.0.0"
+    assert has_native_geo_types(str(api_out))
+    _assert_self_consistent(cli_out)
+    _assert_self_consistent(api_out)
+
+
+def test_v2_input_api_matches_cli(v2_input, tmp_path):
+    cli_out = tmp_path / "cli.parquet"
+    convert_to_geoparquet(str(v2_input), str(cli_out), skip_hilbert=True, geoparquet_version=None)
+
+    api_out = tmp_path / "api.parquet"
+    gpio.read(v2_input).write(api_out)
+
+    assert get_geoparquet_version(str(cli_out)) == "2.0.0"
+    assert get_geoparquet_version(str(api_out)) == "2.0.0"
+    _assert_self_consistent(cli_out)
+    _assert_self_consistent(api_out)
+
+
+def test_api_explicit_v1_1_is_true_wkb(pgo_input, tmp_path):
+    """Explicit 1.1 must produce a real 1.1 WKB file, not a hybrid."""
+    out = tmp_path / "api11.parquet"
+    gpio.read(pgo_input).write(out, geoparquet_version="1.1")
+    assert get_geoparquet_version(str(out)) == "1.1.0"
+    assert not has_native_geo_types(str(out))
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"]["encoding"] == "WKB"

--- a/tests/test_convert_validation_message.py
+++ b/tests/test_convert_validation_message.py
@@ -1,0 +1,68 @@
+"""The post-conversion success message must not claim validation that never ran (todo 044).
+
+`_report_conversion_results` now runs a metadata-level validation of the final
+output and only claims a pass when it actually passed.
+"""
+
+import json
+import time
+
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core import convert as convert_mod
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.convert import _report_conversion_results, convert_to_geoparquet
+
+
+@pytest.fixture
+def valid_output(tmp_path):
+    src = tmp_path / "src.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('POINT (1 2)'))
+          ) t(id, geometry)
+        ) TO '{src.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V1')
+    """)
+    con.close()
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="1.1")
+    return out
+
+
+@pytest.fixture
+def captured_messages(monkeypatch):
+    calls = {"success": [], "warn": [], "progress": []}
+    monkeypatch.setattr(convert_mod, "success", lambda m: calls["success"].append(m))
+    monkeypatch.setattr(convert_mod, "warn", lambda m: calls["warn"].append(m))
+    monkeypatch.setattr(convert_mod, "progress", lambda m: calls["progress"].append(m))
+    return calls
+
+
+def test_valid_output_gets_validation_success(valid_output, captured_messages):
+    _report_conversion_results(str(valid_output), time.time(), is_geo=True)
+    assert any("passes GeoParquet validation" in m for m in captured_messages["success"]), (
+        captured_messages
+    )
+    assert not any("check spec" in m for m in captured_messages["warn"])
+
+
+def test_invalid_output_gets_warning_not_success(valid_output, captured_messages):
+    # Corrupt the geo metadata (invalid encoding) so metadata validation fails.
+    import geoarrow.pyarrow  # noqa: F401
+
+    table = pq.read_table(str(valid_output))
+    meta = dict(table.schema.metadata)
+    geo = json.loads(meta[b"geo"])
+    for col in geo["columns"].values():
+        col["encoding"] = "bogus"
+    meta[b"geo"] = json.dumps(geo).encode()
+    pq.write_table(table.replace_schema_metadata(meta), str(valid_output))
+
+    _report_conversion_results(str(valid_output), time.time(), is_geo=True)
+    assert not any("passes GeoParquet validation" in m for m in captured_messages["success"]), (
+        captured_messages
+    )
+    assert any("check spec" in m for m in captured_messages["warn"]), captured_messages

--- a/tests/test_convert_version_preserve.py
+++ b/tests/test_convert_version_preserve.py
@@ -105,3 +105,27 @@ def test_reproject_explicit_version_still_wins(pgo_input, tmp_path):
     reproject(str(pgo_input), str(out), target_crs="EPSG:3857", geoparquet_version="1.1")
     assert get_geoparquet_version(str(out)) == "1.1.0"
     assert not has_native_geo_types(str(out))
+
+
+# --- 2.x normalization must agree across detection paths (todo 047-C2) ---
+
+
+def test_streaming_metadata_path_flattens_future_2x_to_2_0():
+    """extract_version_from_metadata must agree with the file-based twin
+    (resolve_geoparquet_version_from_file), which flattens any 2.x to "2.0"."""
+    import json
+
+    from geoparquet_io.core.streaming import extract_version_from_metadata
+
+    meta = {b"geo": json.dumps({"version": "2.1.0"}).encode()}
+    assert extract_version_from_metadata(meta) == "2.0"
+
+
+def test_streaming_metadata_path_known_versions_unchanged():
+    import json
+
+    from geoparquet_io.core.streaming import extract_version_from_metadata
+
+    for declared, expected in [("1.0.0", "1.1"), ("1.1.0", "1.1"), ("2.0.0", "2.0")]:
+        meta = {b"geo": json.dumps({"version": declared}).encode()}
+        assert extract_version_from_metadata(meta) == expected, declared

--- a/tests/test_convert_version_preserve.py
+++ b/tests/test_convert_version_preserve.py
@@ -1,0 +1,76 @@
+"""Auto version mode must preserve a parquet input's GeoParquet version (gpio #587).
+
+The --geoparquet-version help promises: "preserves the version of input files,
+upgrades native geo types to 2.0, defaults to 1.1". Before the fix, convert
+silently downgraded 2.0 inputs to 1.1, stripping native logical types and the
+schema-level CRS.
+"""
+
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.convert import convert_to_geoparquet
+from tests.conftest import get_geoparquet_version, has_native_geo_types
+
+
+def _write_native(path, version_option):
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('POINT (30 10)')),
+            (2, ST_GeomFromText('POINT (40 40)'))
+          ) t(id, geometry)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION '{version_option}')
+    """)
+    con.close()
+
+
+@pytest.fixture
+def v2_input(tmp_path):
+    path = tmp_path / "v2.parquet"
+    _write_native(path, "V2")
+    assert get_geoparquet_version(str(path)) == "2.0.0"
+    return path
+
+
+@pytest.fixture
+def pgo_input(tmp_path):
+    path = tmp_path / "pgo.parquet"
+    _write_native(path, "NONE")
+    assert get_geoparquet_version(str(path)) is None
+    assert has_native_geo_types(str(path))
+    return path
+
+
+def test_auto_preserves_v2(v2_input, tmp_path):
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(str(v2_input), str(out), skip_hilbert=True, geoparquet_version=None)
+    assert get_geoparquet_version(str(out)) == "2.0.0"
+    assert has_native_geo_types(str(out))
+
+
+def test_auto_upgrades_parquet_geo_only_to_v2(pgo_input, tmp_path):
+    """Documented behavior: native-geo inputs upgrade to 2.0 in auto mode."""
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(str(pgo_input), str(out), skip_hilbert=True, geoparquet_version=None)
+    assert get_geoparquet_version(str(out)) == "2.0.0"
+    assert has_native_geo_types(str(out))
+
+
+def test_auto_keeps_v1_1_at_1_1(v2_input, tmp_path):
+    v11 = tmp_path / "v11.parquet"
+    convert_to_geoparquet(str(v2_input), str(v11), skip_hilbert=True, geoparquet_version="1.1")
+    assert get_geoparquet_version(str(v11)) == "1.1.0"
+
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(str(v11), str(out), skip_hilbert=True, geoparquet_version=None)
+    assert get_geoparquet_version(str(out)) == "1.1.0"
+    assert not has_native_geo_types(str(out))
+
+
+def test_explicit_version_still_wins(v2_input, tmp_path):
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(str(v2_input), str(out), skip_hilbert=True, geoparquet_version="1.1")
+    assert get_geoparquet_version(str(out)) == "1.1.0"
+    assert not has_native_geo_types(str(out))

--- a/tests/test_convert_version_preserve.py
+++ b/tests/test_convert_version_preserve.py
@@ -74,3 +74,34 @@ def test_explicit_version_still_wins(v2_input, tmp_path):
     convert_to_geoparquet(str(v2_input), str(out), skip_hilbert=True, geoparquet_version="1.1")
     assert get_geoparquet_version(str(out)) == "1.1.0"
     assert not has_native_geo_types(str(out))
+
+
+# --- Reproject auto mode must match convert's contract (todo 040) ---
+
+
+def test_reproject_auto_upgrades_parquet_geo_only_to_v2(pgo_input, tmp_path):
+    """Auto + native-geo-only input must write 2.0, not strip to 1.1 WKB."""
+    from geoparquet_io.core.reproject import reproject
+
+    out = tmp_path / "out.parquet"
+    reproject(str(pgo_input), str(out), target_crs="EPSG:3857", geoparquet_version=None)
+    assert get_geoparquet_version(str(out)) == "2.0.0"
+    assert has_native_geo_types(str(out))
+
+
+def test_reproject_auto_preserves_v2(v2_input, tmp_path):
+    from geoparquet_io.core.reproject import reproject
+
+    out = tmp_path / "out.parquet"
+    reproject(str(v2_input), str(out), target_crs="EPSG:3857", geoparquet_version=None)
+    assert get_geoparquet_version(str(out)) == "2.0.0"
+    assert has_native_geo_types(str(out))
+
+
+def test_reproject_explicit_version_still_wins(pgo_input, tmp_path):
+    from geoparquet_io.core.reproject import reproject
+
+    out = tmp_path / "out.parquet"
+    reproject(str(pgo_input), str(out), target_crs="EPSG:3857", geoparquet_version="1.1")
+    assert get_geoparquet_version(str(out)) == "1.1.0"
+    assert not has_native_geo_types(str(out))

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -55,9 +55,6 @@ CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
 # tracking each fix. test_validates_clean xfails while a file's failures are
 # all covered here and fails hard on anything new. Remove entries as fixes land.
 KNOWN_VALIDATION_BUGS = {
-    "geometry_types_list": "#583 Z/M suffixed types rejected",
-    "geometry_types_match_data": "#583 data scan drops Z/M suffix",
-    "native_geo_types_match": "#583 native stats comparison drops Z/M suffix",
     "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
 }
 
@@ -286,7 +283,13 @@ BAD_DATA_EXPECTATIONS = {
     ),
     "wkb-with-srid-prefix.parquet": ("auto", [r"native_geo_type_present_"], None),
     "wkb-wrong-type-byte.parquet": ("auto", [r"native_geo_type_present_"], None),
-    "zm-declared-xy-actual-xyz.parquet": ("auto", [r"native_geo_types_match_"], None),
+    # Native stats (computed from data) agree with the data, so detection
+    # comes from the geo-metadata declaration disagreeing with the scan.
+    "zm-declared-xy-actual-xyz.parquet": (
+        "auto",
+        [r"geometry_types_match_data_", r"native_geo_types_match_"],
+        None,
+    ),
     "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
 }
 

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -379,12 +379,7 @@ class TestWritePath:
                     strict=True, reason="gpio #588: GEOGRAPHY rewritten as GEOMETRY, edges lost"
                 ),
             ),
-            pytest.param(
-                "data/zm/linestring-xyzm-native-geometry.parquet",
-                marks=pytest.mark.xfail(
-                    strict=True, reason="gpio #589: XYZM 2.0 write drops geo metadata"
-                ),
-            ),
+            "data/zm/linestring-xyzm-native-geometry.parquet",
         ],
     )
     def test_explicit_v2_rewrite_preserves(self, rel, tmp_path):

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -373,12 +373,9 @@ class TestWritePath:
         "rel",
         WRITE_SUBSET
         + [
-            pytest.param(
-                "data/encodings/point-native-geography.parquet",
-                marks=pytest.mark.xfail(
-                    strict=True, reason="gpio #588: GEOGRAPHY rewritten as GEOMETRY, edges lost"
-                ),
-            ),
+            # Geography input: the native type demotes to GEOMETRY (DuckDB has
+            # no geography type) but the edges declaration must survive (#588).
+            "data/encodings/point-native-geography.parquet",
             "data/zm/linestring-xyzm-native-geometry.parquet",
         ],
     )

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -426,9 +426,6 @@ class TestWritePath:
         assert parsed and parsed.get("crs"), "native CRS lost on rewrite"
         assert "3857" in str(parsed["crs"]) or "Pseudo-Mercator" in str(parsed["crs"])
 
-    @pytest.mark.xfail(
-        strict=True, reason="gpio #587: auto version mode silently downgrades 2.0 to 1.1"
-    )
     @pytest.mark.parametrize("rel", WRITE_SUBSET[:3])
     def test_auto_rewrite_preserves_v2(self, rel, tmp_path):
         src = CORPUS / rel

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -54,9 +54,9 @@ CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
 # Validation checks that misfire on valid corpus files, with the gpio issue
 # tracking each fix. test_validates_clean xfails while a file's failures are
 # all covered here and fails hard on anything new. Remove entries as fixes land.
-KNOWN_VALIDATION_BUGS = {
-    "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
-}
+# Empty since the #581-#586 fixes; kept so a regression re-adds an entry
+# instead of reshaping the tests.
+KNOWN_VALIDATION_BUGS: dict[str, str] = {}
 
 
 # Fixtures that themselves violate the spec (upstream geoparquet-testing bugs).
@@ -209,12 +209,7 @@ class TestValidFilesSpotChecks:
 # in each entry's comment).
 BAD_DATA_EXPECTATIONS = {
     "bbox-does-not-contain-geometry.parquet": ("auto", [r"bbox_contains_data_"], None),
-    # PROJJSON schema validation not implemented yet
-    "crs-invalid-projjson.parquet": (
-        "auto",
-        [r"crs_valid_", r"native_crs_format_"],
-        "#586 no PROJJSON schema validation",
-    ),
+    "crs-invalid-projjson.parquet": ("auto", [r"crs_valid_", r"native_crs_format_"], None),
     # Detected today by the coordinate heuristic; after #581/#586 the
     # deterministic metadata-vs-native comparison (v2_crs_consistency) carries it.
     "crs-mismatch-schema-vs-geo-metadata.parquet": (
@@ -227,18 +222,8 @@ BAD_DATA_EXPECTATIONS = {
         [r"edges"],
         "#586 no spherical-vs-planar data heuristic (may be wontfix)",
     ),
-    "epoch-on-unsupported-crs.parquet": (
-        "auto",
-        [r"epoch"],
-        "#586 no epoch-on-static-datum check",
-    ),
-    # Auto mode treats unparsable geo as "no metadata" and passes the file as
-    # parquet-geo-only; corrupt JSON should be flagged in any mode.
-    "geo-invalid-json.parquet": (
-        "auto",
-        [r"geo_metadata", r"geo_key"],
-        "#586 invalid geo JSON treated as no-metadata",
-    ),
+    "epoch-on-unsupported-crs.parquet": ("auto", [r"epoch"], None),
+    "geo-invalid-json.parquet": ("auto", [r"geo_metadata", r"geo_key"], None),
     "geo-invalid-utf8.parquet": ("auto", [r"geo_metadata", r"geo_key"], None),
     "geometry-types-mismatch-declared-point-actual-linestring.parquet": (
         "auto",
@@ -263,16 +248,8 @@ BAD_DATA_EXPECTATIONS = {
         "#586 no orientation-vs-data check",
     ),
     "primary-column-not-in-columns.parquet": ("auto", [r"primary_column_in_columns"], None),
-    "version-1-0-with-2-0-features.parquet": (
-        "auto",
-        [r"version"],
-        "#586 no version/feature gating check",
-    ),
-    "version-unknown.parquet": (
-        "auto",
-        [r"version"],
-        "#586 unknown geo version accepted in auto mode",
-    ),
+    "version-1-0-with-2-0-features.parquet": ("auto", [r"version_features"], None),
+    "version-unknown.parquet": ("auto", [r"version_known"], None),
     # The wkb-* fixtures carry no native logical type (writers refuse invalid
     # WKB), so 2.0-level detection fires on the missing native type rather
     # than on parsing the payload. A deterministic EWKB byte-probe is #586.

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -1,0 +1,483 @@
+"""
+Conformance tests against the official geoparquet-testing corpus.
+
+The corpus (https://github.com/geoparquet/geoparquet-testing) is vendored as a
+git submodule at tests/data/geoparquet-testing, pinned to a specific commit.
+Run ``git submodule update --init`` if these tests report SKIPPED.
+
+Three tiers:
+- data/ + samples/ (51 files): valid GeoParquet 2.0.0 — gpio must detect,
+  read, and validate them cleanly.
+- bad_data/ (22 files): deliberate spec violations with a manifest of expected
+  failure codes — gpio must reject each one for the right reason, and must
+  never crash on any of them.
+- Write tier: representative corpus files rewritten through gpio must keep
+  their GeoParquet 2.0 nature (native logical types, CRS, geo metadata).
+
+Adjudication policy: this suite was built from the corpus's first complete run
+against gpio (July 2026). Discrepancies were judged against the spec text, not
+assumed to be gpio bugs. Confirmed gpio bugs are tracked in GitHub issues and
+appear here as KNOWN_VALIDATION_BUGS entries or xfail marks referencing the
+issue; they turn into hard failures/XPASS as fixes land.
+
+One corpus bug was found (CORPUS_BUG_FILES): the data/zm/ fixtures declare
+geometry_types ["LineString"] without the " Z"/" M"/" ZM" suffix the spec
+mandates for 3D/measured data ("a ' Z' suffix gets added", "It is expected
+that this field is strictly correct") — the very violation bad_data/
+zm-declared-xy-actual-xyz.parquet exists to test. Reported upstream; these
+xfails are non-strict so a fixed corpus pin turns them green automatically.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.common import detect_geoparquet_file_type
+from geoparquet_io.core.convert import convert_to_geoparquet
+from geoparquet_io.core.duckdb_metadata import (
+    detect_geometry_columns,
+    get_schema_info,
+    parse_geometry_logical_type,
+)
+from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+from tests.conftest import get_geo_metadata, get_geoparquet_version, has_native_geo_types
+
+pytestmark = [pytest.mark.corpus, pytest.mark.integration]
+
+CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
+
+# Validation checks that misfire on valid corpus files, with the gpio issue
+# tracking each fix. test_validates_clean xfails while a file's failures are
+# all covered here and fails hard on anything new. Remove entries as fixes land.
+KNOWN_VALIDATION_BUGS = {
+    "v2_crs_in_parquet_type": "#581 CRS84-default equivalence",
+    "v2_crs_consistency": "#581 CRS84-default equivalence",
+    "edges_valid": "#582 missing 2.0 ellipsoidal edges values",
+    "geometry_types_list": "#583 Z/M suffixed types rejected",
+    "geometry_types_match_data": "#583 data scan drops Z/M suffix",
+    "native_geo_types_match": "#583 native stats comparison drops Z/M suffix",
+    "native_geo_stats_contains_data": "#584 POINT EMPTY counted as outside bbox",
+    "bbox_contains_data": "#584 POINT EMPTY counted as outside bbox",
+    "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
+}
+
+
+# Fixtures that themselves violate the spec (upstream geoparquet-testing bugs).
+# Non-strict xfail: they pass again once the corpus pin advances past the fix.
+CORPUS_BUG_FILES = {
+    "data/zm/linestring-xyz-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYZ data; spec requires 'LineString Z'"
+    ),
+    "data/zm/linestring-xym-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYM data; spec requires 'LineString M'"
+    ),
+    "data/zm/linestring-xyzm-native-geometry.parquet": (
+        "corpus bug: declares ['LineString'] for XYZM data; spec requires 'LineString ZM'"
+    ),
+}
+
+
+def _corpus_files(*subdirs):
+    """Parametrize over corpus files; one graceful skip if the submodule is absent."""
+    if not (CORPUS / "data").exists():
+        return [
+            pytest.param(
+                None,
+                id="submodule-missing",
+                marks=pytest.mark.skip(reason="run: git submodule update --init"),
+            )
+        ]
+    files = [f for d in subdirs for f in sorted((CORPUS / d).rglob("*.parquet"))]
+    return [pytest.param(f, id=f.relative_to(CORPUS).as_posix()) for f in files]
+
+
+def _failed_checks(result):
+    return [c.name for c in result.checks if c.status == CheckStatus.FAILED]
+
+
+def _known_bug_refs(failed_names):
+    """Issue refs covering the given failed check names, or None if any is uncovered."""
+    refs = set()
+    for name in failed_names:
+        for prefix, ref in KNOWN_VALIDATION_BUGS.items():
+            if name.startswith(prefix):
+                refs.add(ref)
+                break
+        else:
+            return None
+    return refs
+
+
+class TestValidFilesRead:
+    """Every data/ and samples/ file must be detected, readable, and valid."""
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_detected_as_v2(self, path):
+        info = detect_geoparquet_file_type(str(path))
+        assert info["file_type"] == "geoparquet_v2", info
+        assert info["geo_version"] == "2.0.0", info
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_schema_and_data_readable(self, path):
+        """Both engines must fully read every file (all codecs, GEOGRAPHY, Z/M)."""
+        import pyarrow.parquet as pq
+
+        geom_cols = detect_geometry_columns(str(path))
+        assert geom_cols, "no geometry column detected"
+
+        table = pq.read_table(str(path))
+        con = duckdb.connect()
+        try:
+            con.execute("INSTALL spatial; LOAD spatial;")
+            (rows,) = con.execute(
+                f"SELECT count(*) FROM read_parquet('{path.as_posix()}')"
+            ).fetchone()
+        finally:
+            con.close()
+        assert rows == table.num_rows
+
+    @pytest.mark.parametrize("path", _corpus_files("data", "samples"))
+    def test_validates_clean(self, path):
+        rel = path.relative_to(CORPUS).as_posix()
+        result = validate_geoparquet(str(path), validate_data=True)
+        failed = _failed_checks(result)
+        if rel in CORPUS_BUG_FILES:
+            # Spec-violating fixture: failing validation is the CORRECT outcome
+            # (today it fails for the wrong reason, gpio #583). Non-strict so a
+            # fixed corpus pin flips it green without editing this file.
+            if failed:
+                pytest.xfail(CORPUS_BUG_FILES[rel])
+            return
+        if not failed:
+            return
+        refs = _known_bug_refs(failed)
+        assert refs is not None, f"unexpected validation failures: {failed}"
+        pytest.xfail(f"known gpio validation bugs: {sorted(refs)}")
+
+
+class TestValidFilesSpotChecks:
+    """Targeted assertions on specific spec axes."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected_dim"),
+        [
+            ("linestring-xyz-native-geometry.parquet", "XYZ"),
+            ("linestring-xym-native-geometry.parquet", "XYM"),
+            ("linestring-xyzm-native-geometry.parquet", "XYZM"),
+        ],
+    )
+    @pytest.mark.xfail(
+        strict=False,
+        reason="corpus bug: gen_zm.py writes unsuffixed geometry_types (see CORPUS_BUG_FILES)",
+    )
+    def test_zm_dimensions_parsed(self, name, expected_dim):
+        """Spec: 'a \" Z\" suffix gets added' and geometry_types is 'strictly correct'."""
+        path = CORPUS / "data" / "zm" / name
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        geo = get_geo_metadata(str(path))
+        declared = geo["columns"]["geometry"]["geometry_types"]
+        suffix = expected_dim[2:]  # Z, M, or ZM
+        assert declared == [f"LineString {suffix}"], declared
+
+    def test_two_geometry_columns_different_crs(self):
+        path = CORPUS / "data" / "multi_geometry" / "two-geom-columns-different-crs.parquet"
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        crs_by_col = {}
+        for col in get_schema_info(str(path)):
+            parsed = parse_geometry_logical_type(col.get("logical_type") or "")
+            if parsed:
+                crs_by_col[col["name"]] = parsed.get("crs")
+        assert set(crs_by_col) == {"footprint", "centroid"}, crs_by_col
+        assert crs_by_col["footprint"] != crs_by_col["centroid"], crs_by_col
+
+    @pytest.mark.parametrize(
+        "edges", ["planar", "spherical", "vincenty", "thomas", "andoyer", "karney"]
+    )
+    def test_edges_metadata_preserved_on_read(self, edges):
+        path = CORPUS / "data" / "edges" / f"edges-{edges}.parquet"
+        if not path.exists():
+            pytest.skip("run: git submodule update --init")
+        geo = get_geo_metadata(str(path))
+        col = geo["columns"]["geometry"]
+        expected = None if edges == "planar" else edges
+        assert col.get("edges", None) in (expected, edges), col.get("edges")
+
+
+# filename -> (validate mode, regex patterns over failed check names, xfail reason).
+# A file is "detected" when validation reports invalid AND at least one FAILED
+# check matches a pattern. Mode "2.0" forces target_version="2.0" — used where
+# auto-detect legitimately classifies the file as something valid (adjudicated
+# in each entry's comment).
+BAD_DATA_EXPECTATIONS = {
+    "bbox-does-not-contain-geometry.parquet": ("auto", [r"bbox_contains_data_"], None),
+    # PROJJSON schema validation not implemented yet
+    "crs-invalid-projjson.parquet": (
+        "auto",
+        [r"crs_valid_", r"native_crs_format_"],
+        "#586 no PROJJSON schema validation",
+    ),
+    # Detected today by the coordinate heuristic; after #581/#586 the
+    # deterministic metadata-vs-native comparison (v2_crs_consistency) carries it.
+    "crs-mismatch-schema-vs-geo-metadata.parquet": (
+        "auto",
+        [r"v2_crs_consistency_", r"coordinates_valid_for_crs_"],
+        None,
+    ),
+    "edges-spherical-with-planar-antimeridian-line.parquet": (
+        "auto",
+        [r"edges"],
+        "#586 no spherical-vs-planar data heuristic (may be wontfix)",
+    ),
+    "epoch-on-unsupported-crs.parquet": (
+        "auto",
+        [r"epoch"],
+        "#586 no epoch-on-static-datum check",
+    ),
+    # Auto mode treats unparsable geo as "no metadata" and passes the file as
+    # parquet-geo-only; corrupt JSON should be flagged in any mode.
+    "geo-invalid-json.parquet": (
+        "auto",
+        [r"geo_metadata", r"geo_key"],
+        "#586 invalid geo JSON treated as no-metadata",
+    ),
+    "geo-invalid-utf8.parquet": (
+        "auto",
+        [r"geo_metadata", r"geo_key"],
+        "#585 validator crashes on invalid UTF-8 metadata",
+    ),
+    "geometry-types-mismatch-declared-point-actual-linestring.parquet": (
+        "auto",
+        [r"geometry_types_match_data_"],
+        None,
+    ),
+    "geometry-types-missing-actual-type.parquet": (
+        "auto",
+        [r"geometry_types_match_data_"],
+        None,
+    ),
+    "missing-columns.parquet": ("auto", [r"columns_present"], None),
+    # Adjudicated: with no geo metadata and native types, auto-detect correctly
+    # classifies this as valid parquet-geo-only; the corpus expectation holds
+    # only when GeoParquet 2.0 is explicitly demanded.
+    "missing-geo-metadata.parquet": ("2.0", [r"version_match"], None),
+    "missing-primary-column.parquet": ("auto", [r"primary_column_present"], None),
+    # Auto mode crashes on the None version (#585); 2.0 mode detects it.
+    "missing-version.parquet": ("2.0", [r"version_match", r"version_present"], None),
+    "orientation-ccw-declared-rings-cw.parquet": (
+        "auto",
+        [r"orientation"],
+        "#586 no orientation-vs-data check",
+    ),
+    "primary-column-not-in-columns.parquet": ("auto", [r"primary_column_in_columns"], None),
+    "version-1-0-with-2-0-features.parquet": (
+        "auto",
+        [r"version"],
+        "#586 no version/feature gating check",
+    ),
+    "version-unknown.parquet": (
+        "auto",
+        [r"version"],
+        "#586 unknown geo version accepted in auto mode",
+    ),
+    # The wkb-* fixtures carry no native logical type (writers refuse invalid
+    # WKB), so 2.0-level detection fires on the missing native type rather
+    # than on parsing the payload. A deterministic EWKB byte-probe is #586.
+    "wkb-truncated.parquet": (
+        "auto",
+        [r"native_geo_type_present_", r"geometry_types_match_data_"],
+        None,
+    ),
+    "wkb-with-srid-prefix.parquet": ("auto", [r"native_geo_type_present_"], None),
+    "wkb-wrong-type-byte.parquet": ("auto", [r"native_geo_type_present_"], None),
+    "zm-declared-xy-actual-xyz.parquet": ("auto", [r"native_geo_types_match_"], None),
+    "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
+}
+
+# Files where validate_geoparquet currently raises instead of reporting (#585).
+CRASHES_ON_VALIDATE = {
+    "geo-invalid-utf8.parquet": "#585 GeoParquetError on invalid UTF-8 geo metadata",
+    "missing-version.parquet": "#585 TypeError comparing None version in auto mode",
+}
+
+
+def _bad_data_params():
+    if not (CORPUS / "bad_data").exists():
+        return [
+            pytest.param(
+                None,
+                None,
+                None,
+                id="submodule-missing",
+                marks=pytest.mark.skip(reason="run: git submodule update --init"),
+            )
+        ]
+    params = []
+    for fname, (mode, patterns, gap) in sorted(BAD_DATA_EXPECTATIONS.items()):
+        marks = []
+        if gap:
+            marks.append(pytest.mark.xfail(strict=True, reason=f"gpio gap: {gap}"))
+        params.append(
+            pytest.param(CORPUS / "bad_data" / fname, mode, patterns, id=fname, marks=marks)
+        )
+    return params
+
+
+class TestBadData:
+    """Every bad_data/ file must be rejected for the manifest's reason."""
+
+    def test_manifest_covers_expectations(self):
+        """Guard: corpus updates adding/removing bad files must not go unnoticed."""
+        manifest_path = CORPUS / "bad_data" / "manifest.json"
+        if not manifest_path.exists():
+            pytest.skip("run: git submodule update --init")
+        manifest = set(json.loads(manifest_path.read_text()))
+        on_disk = {f.name for f in (CORPUS / "bad_data").glob("*.parquet")}
+        assert manifest == on_disk
+        assert set(BAD_DATA_EXPECTATIONS) == manifest
+
+    @pytest.mark.parametrize("path", _corpus_files("bad_data"))
+    def test_never_crashes(self, path):
+        """A validator must reject bad files, not raise on them."""
+        if path.name in CRASHES_ON_VALIDATE:
+            pytest.xfail(CRASHES_ON_VALIDATE[path.name])
+        result = validate_geoparquet(str(path), validate_data=True, sample_size=0)
+        assert result is not None
+
+    @pytest.mark.parametrize(("path", "mode", "patterns"), _bad_data_params())
+    def test_detected_for_right_reason(self, path, mode, patterns):
+        if path.name in CRASHES_ON_VALIDATE and mode == "auto":
+            pytest.xfail(CRASHES_ON_VALIDATE[path.name])
+        result = validate_geoparquet(
+            str(path),
+            target_version="2.0" if mode == "2.0" else None,
+            validate_data=True,
+            sample_size=0,
+        )
+        failed = _failed_checks(result)
+        assert not result.is_valid, "bad file passed validation"
+        matched = [n for n in failed if any(re.match(p, n) for p in patterns)]
+        assert matched, f"invalid, but not for the expected reason. Failed: {failed}"
+
+
+WRITE_SUBSET = [
+    "data/encodings/polygon-native-geometry.parquet",
+    "data/crs/crs-epsg-3857.parquet",
+    "data/geometry_types/geometrycollection.parquet",
+    "data/compression/compression-brotli.parquet",
+    "samples/us-states.parquet",
+]
+
+
+class TestWritePath:
+    """Rewriting corpus files through gpio must preserve their 2.0 nature."""
+
+    @pytest.mark.parametrize(
+        "rel",
+        WRITE_SUBSET
+        + [
+            pytest.param(
+                "data/encodings/point-native-geography.parquet",
+                marks=pytest.mark.xfail(
+                    strict=True, reason="gpio #588: GEOGRAPHY rewritten as GEOMETRY, edges lost"
+                ),
+            ),
+            pytest.param(
+                "data/zm/linestring-xyzm-native-geometry.parquet",
+                marks=pytest.mark.xfail(
+                    strict=True, reason="gpio #589: XYZM 2.0 write drops geo metadata"
+                ),
+            ),
+        ],
+    )
+    def test_explicit_v2_rewrite_preserves(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="2.0")
+
+        assert has_native_geo_types(str(out)), "native logical type lost"
+        assert get_geoparquet_version(str(out)) == "2.0.0"
+        # GEOGRAPHY inputs must keep geography semantics (native type or edges).
+        src_types = {c["name"]: c.get("logical_type") or "" for c in get_schema_info(str(src))}
+        out_types = {c["name"]: c.get("logical_type") or "" for c in get_schema_info(str(out))}
+        for col, lt in src_types.items():
+            if "GeographyType" in lt:
+                out_geo = get_geo_metadata(str(out))["columns"][col]
+                assert "GeographyType" in out_types.get(col, "") or out_geo.get("edges") in (
+                    "spherical",
+                    "vincenty",
+                    "thomas",
+                    "andoyer",
+                    "karney",
+                )
+
+    def test_explicit_v2_rewrite_preserves_native_crs(self, tmp_path):
+        """Non-default CRS on the native logical type must survive a rewrite."""
+        src = CORPUS / "data" / "crs" / "crs-epsg-3857.parquet"
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="2.0")
+        (geom_lt,) = [
+            c.get("logical_type") or ""
+            for c in get_schema_info(str(out))
+            if c["name"] == "geometry"
+        ]
+        parsed = parse_geometry_logical_type(geom_lt)
+        assert parsed and parsed.get("crs"), "native CRS lost on rewrite"
+        assert "3857" in str(parsed["crs"]) or "Pseudo-Mercator" in str(parsed["crs"])
+
+    @pytest.mark.xfail(
+        strict=True, reason="gpio #587: auto version mode silently downgrades 2.0 to 1.1"
+    )
+    @pytest.mark.parametrize("rel", WRITE_SUBSET[:3])
+    def test_auto_rewrite_preserves_v2(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        out = tmp_path / "out.parquet"
+        convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version=None)
+        assert get_geoparquet_version(str(out)) == "2.0.0"
+        assert has_native_geo_types(str(out))
+
+    @pytest.mark.parametrize("rel", ["samples/us-states.parquet"])
+    def test_roundtrip_2_0_to_1_1_to_2_0(self, rel, tmp_path):
+        src = CORPUS / rel
+        if not src.exists():
+            pytest.skip("run: git submodule update --init")
+        mid = tmp_path / "v11.parquet"
+        back = tmp_path / "v20.parquet"
+        convert_to_geoparquet(str(src), str(mid), skip_hilbert=True, geoparquet_version="1.1")
+        convert_to_geoparquet(str(mid), str(back), skip_hilbert=True, geoparquet_version="2.0")
+        assert get_geoparquet_version(str(mid)) == "1.1.0"
+        assert not has_native_geo_types(str(mid))
+        assert get_geoparquet_version(str(back)) == "2.0.0"
+        assert has_native_geo_types(str(back))
+
+
+class TestCliWiring:
+    """One CLI-level test; everything else goes through the Python API for speed."""
+
+    def test_check_spec_exit_codes(self):
+        good = CORPUS / "data" / "bbox" / "bbox-present.parquet"
+        bad = CORPUS / "bad_data" / "missing-columns.parquet"
+        if not good.exists():
+            pytest.skip("run: git submodule update --init")
+        runner = CliRunner()
+        good_result = runner.invoke(cli, ["check", "spec", str(good), "--json"])
+        # Exit 0 (pass) or 2 (warnings only); 1 would mean spec failures. The
+        # good file currently trips known validation bugs (#581 et al.), so
+        # accept 0/1/2 but require valid JSON output; tighten to {0, 2} when
+        # KNOWN_VALIDATION_BUGS empties.
+        assert good_result.exit_code in (0, 1, 2), good_result.output
+        json.loads(good_result.output)
+        bad_result = runner.invoke(cli, ["check", "spec", str(bad), "--json"])
+        assert bad_result.exit_code == 1, bad_result.output

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -55,9 +55,12 @@ CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
 # Validation checks that misfire on valid corpus files, with the gpio issue
 # tracking each fix. test_validates_clean xfails while a file's failures are
 # all covered here and fails hard on anything new. Remove entries as fixes land.
-# Empty since the #581-#586 fixes; kept so a regression re-adds an entry
-# instead of reshaping the tests.
-KNOWN_VALIDATION_BUGS: dict[str, str] = {}
+KNOWN_VALIDATION_BUGS: dict[str, str] = {
+    # Row-group geospatial statistics are misread on some platforms (all-zero
+    # bbox on Windows CI, so every geometry falls "outside"); also false
+    # positives on multi-row-group files whose per-group stats are correct.
+    "native_geo_stats_contains_data": "gpio #603",
+}
 
 
 # Floors just below the current per-tier corpus counts (data=42, samples=9,
@@ -462,9 +465,11 @@ class TestCliWiring:
         runner = CliRunner()
         good_result = runner.invoke(cli, ["check", "spec", str(good), "--json"])
         # Exit 0 (pass) or 2 (warnings only); 1 means spec failures, which a
-        # valid corpus file must never trip now that KNOWN_VALIDATION_BUGS is
-        # empty (#597).
-        assert good_result.exit_code in (0, 2), good_result.output
+        # valid corpus file must never trip unless a check is currently
+        # adjudicated as buggy in KNOWN_VALIDATION_BUGS (then exit 1 is the
+        # expected symptom of that bug on affected platforms).
+        allowed = (0, 1, 2) if KNOWN_VALIDATION_BUGS else (0, 2)
+        assert good_result.exit_code in allowed, good_result.output
         json.loads(good_result.output)
         bad_result = runner.invoke(cli, ["check", "spec", str(bad), "--json"])
         assert bad_result.exit_code == 1, bad_result.output

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -55,14 +55,9 @@ CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
 # tracking each fix. test_validates_clean xfails while a file's failures are
 # all covered here and fails hard on anything new. Remove entries as fixes land.
 KNOWN_VALIDATION_BUGS = {
-    "v2_crs_in_parquet_type": "#581 CRS84-default equivalence",
-    "v2_crs_consistency": "#581 CRS84-default equivalence",
-    "edges_valid": "#582 missing 2.0 ellipsoidal edges values",
     "geometry_types_list": "#583 Z/M suffixed types rejected",
     "geometry_types_match_data": "#583 data scan drops Z/M suffix",
     "native_geo_types_match": "#583 native stats comparison drops Z/M suffix",
-    "native_geo_stats_contains_data": "#584 POINT EMPTY counted as outside bbox",
-    "bbox_contains_data": "#584 POINT EMPTY counted as outside bbox",
     "coordinates_valid_for_crs": "#586 heuristic false positive on small projected coords",
 }
 
@@ -247,11 +242,7 @@ BAD_DATA_EXPECTATIONS = {
         [r"geo_metadata", r"geo_key"],
         "#586 invalid geo JSON treated as no-metadata",
     ),
-    "geo-invalid-utf8.parquet": (
-        "auto",
-        [r"geo_metadata", r"geo_key"],
-        "#585 validator crashes on invalid UTF-8 metadata",
-    ),
+    "geo-invalid-utf8.parquet": ("auto", [r"geo_metadata", r"geo_key"], None),
     "geometry-types-mismatch-declared-point-actual-linestring.parquet": (
         "auto",
         [r"geometry_types_match_data_"],
@@ -268,8 +259,7 @@ BAD_DATA_EXPECTATIONS = {
     # only when GeoParquet 2.0 is explicitly demanded.
     "missing-geo-metadata.parquet": ("2.0", [r"version_match"], None),
     "missing-primary-column.parquet": ("auto", [r"primary_column_present"], None),
-    # Auto mode crashes on the None version (#585); 2.0 mode detects it.
-    "missing-version.parquet": ("2.0", [r"version_match", r"version_present"], None),
+    "missing-version.parquet": ("auto", [r"version_present"], None),
     "orientation-ccw-declared-rings-cw.parquet": (
         "auto",
         [r"orientation"],
@@ -300,11 +290,9 @@ BAD_DATA_EXPECTATIONS = {
     "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
 }
 
-# Files where validate_geoparquet currently raises instead of reporting (#585).
-CRASHES_ON_VALIDATE = {
-    "geo-invalid-utf8.parquet": "#585 GeoParquetError on invalid UTF-8 geo metadata",
-    "missing-version.parquet": "#585 TypeError comparing None version in auto mode",
-}
+# Files where validate_geoparquet raises instead of reporting. Empty since the
+# #585 fixes; kept so a regression re-adds an entry instead of reshaping tests.
+CRASHES_ON_VALIDATE: dict[str, str] = {}
 
 
 def _bad_data_params():

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -24,8 +24,9 @@ One corpus bug was found (CORPUS_BUG_FILES): the data/zm/ fixtures declare
 geometry_types ["LineString"] without the " Z"/" M"/" ZM" suffix the spec
 mandates for 3D/measured data ("a ' Z' suffix gets added", "It is expected
 that this field is strictly correct") — the very violation bad_data/
-zm-declared-xy-actual-xyz.parquet exists to test. Reported upstream; these
-xfails are non-strict so a fixed corpus pin turns them green automatically.
+zm-declared-xy-actual-xyz.parquet exists to test. Reported upstream; once a
+fixed corpus pin lands, test_validates_clean fails loudly on each stale entry
+so CORPUS_BUG_FILES gets cleaned up instead of masking future regressions.
 """
 
 import json
@@ -59,8 +60,30 @@ CORPUS = Path(__file__).parent / "data" / "geoparquet-testing"
 KNOWN_VALIDATION_BUGS: dict[str, str] = {}
 
 
+# Floors just below the current per-tier corpus counts (data=42, samples=9,
+# bad_data=22 at the pinned commit). An empty or restructured submodule makes
+# rglob return [] and pytest's empty-parameter-set default silently SKIPs every
+# parametrized test; test_corpus_tier_minimum_files turns that into a loud
+# failure. Raise these floors when the corpus grows.
+CORPUS_TIER_MINIMUMS = {"data": 40, "samples": 8, "bad_data": 15}
+
+
+@pytest.mark.parametrize(("tier", "minimum"), sorted(CORPUS_TIER_MINIMUMS.items()))
+def test_corpus_tier_minimum_files(tier, minimum):
+    """Guard: a shrunken/missing tier must fail loudly, not skip everything silently."""
+    if not (CORPUS / "data").exists():
+        pytest.skip("run: git submodule update --init")
+    count = len(list((CORPUS / tier).rglob("*.parquet")))
+    assert count >= minimum, (
+        f"{tier}/ has {count} parquet files, expected >= {minimum} — the corpus "
+        "submodule pin changed or is incomplete; every missing file is a "
+        "conformance test that silently stopped running"
+    )
+
+
 # Fixtures that themselves violate the spec (upstream geoparquet-testing bugs).
-# Non-strict xfail: they pass again once the corpus pin advances past the fix.
+# test_validates_clean xfails while an entry still reproduces and fails hard
+# once it stops reproducing, forcing removal of stale entries after a pin bump.
 CORPUS_BUG_FILES = {
     "data/zm/linestring-xyz-native-geometry.parquet": (
         "corpus bug: declares ['LineString'] for XYZ data; spec requires 'LineString Z'"
@@ -140,11 +163,16 @@ class TestValidFilesRead:
         failed = _failed_checks(result)
         if rel in CORPUS_BUG_FILES:
             # Spec-violating fixture: failing validation is the CORRECT outcome
-            # (today it fails for the wrong reason, gpio #583). Non-strict so a
-            # fixed corpus pin flips it green without editing this file.
+            # (today it fails for the wrong reason, gpio #583). If validation is
+            # clean the fixture was fixed upstream — force removal of the stale
+            # entry so it cannot mask a future regression on this file.
             if failed:
                 pytest.xfail(CORPUS_BUG_FILES[rel])
-            return
+            pytest.fail(
+                f"CORPUS_BUG_FILES entry no longer needed for {rel} — validation "
+                "is clean at this corpus pin; remove the entry (and the matching "
+                "test_zm_dimensions_parsed xfail if it now XPASSes)"
+            )
         if not failed:
             return
         refs = _known_bug_refs(failed)
@@ -260,11 +288,12 @@ BAD_DATA_EXPECTATIONS = {
     ),
     "wkb-with-srid-prefix.parquet": ("auto", [r"native_geo_type_present_"], None),
     "wkb-wrong-type-byte.parquet": ("auto", [r"native_geo_type_present_"], None),
-    # Native stats (computed from data) agree with the data, so detection
-    # comes from the geo-metadata declaration disagreeing with the scan.
+    # Native stats are computed from the data itself, so native_geo_types_match_
+    # can never fire here — they always agree with the data. Detection comes
+    # solely from the geo-metadata declaration disagreeing with the scan.
     "zm-declared-xy-actual-xyz.parquet": (
         "auto",
-        [r"geometry_types_match_data_", r"native_geo_types_match_"],
+        [r"geometry_types_match_data_"],
         None,
     ),
     "zm-declared-xyz-actual-xy.parquet": ("auto", [r"geometry_types_match_data_"], None),
@@ -306,7 +335,9 @@ class TestBadData:
         if not manifest_path.exists():
             pytest.skip("run: git submodule update --init")
         manifest = set(json.loads(manifest_path.read_text()))
-        on_disk = {f.name for f in (CORPUS / "bad_data").glob("*.parquet")}
+        # rglob to mirror _corpus_files collection: a nested bad_data file must
+        # not dodge the guard just because it sits in a subdirectory.
+        on_disk = {f.name for f in (CORPUS / "bad_data").rglob("*.parquet")}
         assert manifest == on_disk
         assert set(BAD_DATA_EXPECTATIONS) == manifest
 
@@ -430,11 +461,10 @@ class TestCliWiring:
             pytest.skip("run: git submodule update --init")
         runner = CliRunner()
         good_result = runner.invoke(cli, ["check", "spec", str(good), "--json"])
-        # Exit 0 (pass) or 2 (warnings only); 1 would mean spec failures. The
-        # good file currently trips known validation bugs (#581 et al.), so
-        # accept 0/1/2 but require valid JSON output; tighten to {0, 2} when
-        # KNOWN_VALIDATION_BUGS empties.
-        assert good_result.exit_code in (0, 1, 2), good_result.output
+        # Exit 0 (pass) or 2 (warnings only); 1 means spec failures, which a
+        # valid corpus file must never trip now that KNOWN_VALIDATION_BUGS is
+        # empty (#597).
+        assert good_result.exit_code in (0, 2), good_result.output
         json.loads(good_result.output)
         bad_result = runner.invoke(cli, ["check", "spec", str(bad), "--json"])
         assert bad_result.exit_code == 1, bad_result.output

--- a/tests/test_preserve_geography_edges.py
+++ b/tests/test_preserve_geography_edges.py
@@ -109,3 +109,68 @@ def test_v2_keeps_ellipsoidal_edges_verbatim(vincenty_input, tmp_path):
     )
     geo = get_geo_metadata(str(out))
     assert geo["columns"]["geometry"].get("edges") == "vincenty", geo["columns"]["geometry"]
+
+
+# --- Edges preservation must cover every rewrite path, not just convert (todo 037) ---
+
+
+def test_extract_preserves_spherical_edges(spherical_input, tmp_path):
+    from geoparquet_io.core.extract import extract
+
+    out = tmp_path / "out.parquet"
+    extract(str(spherical_input), str(out))
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+def test_sort_hilbert_preserves_spherical_edges(spherical_input, tmp_path):
+    from geoparquet_io.core.hilbert_order import hilbert_order
+
+    out = tmp_path / "out.parquet"
+    hilbert_order(str(spherical_input), str(out), geoparquet_version="2.0")
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+def test_sort_by_column_preserves_spherical_edges(spherical_input, tmp_path):
+    from geoparquet_io.core.sort_by_column import sort_by_column
+
+    out = tmp_path / "out.parquet"
+    sort_by_column(str(spherical_input), str(out), columns="id")
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+def test_reproject_preserves_spherical_edges(spherical_input, tmp_path):
+    from geoparquet_io.core.reproject import reproject
+
+    out = tmp_path / "out.parquet"
+    reproject(str(spherical_input), str(out), target_crs="EPSG:3857")
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+def test_remote_output_preserves_spherical_edges(spherical_input, tmp_path, monkeypatch):
+    """Remote outputs are patched on the local temp file before upload."""
+    import shutil
+
+    import geoparquet_io.core.common as common
+
+    uploaded = {}
+
+    def fake_upload(local, _remote, **kwargs):
+        dest = tmp_path / "uploaded.parquet"
+        shutil.copy(str(local), str(dest))
+        uploaded["dest"] = dest
+
+    monkeypatch.setattr(common, "upload_if_remote", fake_upload)
+
+    convert_to_geoparquet(
+        str(spherical_input),
+        "s3://fake-bucket/out.parquet",
+        skip_hilbert=True,
+        geoparquet_version="2.0",
+    )
+    assert "dest" in uploaded, "upload hook was not invoked for the remote output"
+    geo = get_geo_metadata(str(uploaded["dest"]))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]

--- a/tests/test_preserve_geography_edges.py
+++ b/tests/test_preserve_geography_edges.py
@@ -174,3 +174,29 @@ def test_remote_output_preserves_spherical_edges(spherical_input, tmp_path, monk
     assert "dest" in uploaded, "upload hook was not invoked for the remote output"
     geo = get_geo_metadata(str(uploaded["dest"]))
     assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+# --- Geography edges synthesis in metadata repair (todo 047-C7) ---
+
+
+class TestGeographyEdgesFromLogical:
+    """_ensure_v2_geo_metadata must synthesize `edges` for Geography columns."""
+
+    def test_algorithm_extracted(self):
+        from geoparquet_io.core.common import _geography_edges_from_logical
+
+        assert (
+            _geography_edges_from_logical("Geography(crs=OGC:CRS84, algorithm=vincenty)")
+            == "vincenty"
+        )
+
+    def test_defaults_to_spherical_without_algorithm(self):
+        from geoparquet_io.core.common import _geography_edges_from_logical
+
+        assert _geography_edges_from_logical("Geography(crs=OGC:CRS84)") == "spherical"
+
+    def test_geometry_logical_type_yields_none(self):
+        from geoparquet_io.core.common import _geography_edges_from_logical
+
+        assert _geography_edges_from_logical("Geometry(crs=OGC:CRS84)") is None
+        assert _geography_edges_from_logical("") is None

--- a/tests/test_preserve_geography_edges.py
+++ b/tests/test_preserve_geography_edges.py
@@ -1,0 +1,74 @@
+"""Rewrites must not silently drop non-planar edges semantics (gpio #588).
+
+DuckDB has no GEOGRAPHY type, so a native-GEOGRAPHY input inevitably comes
+back as GEOMETRY — but the `edges` declaration (spherical/ellipsoidal edge
+interpretation) must survive in the geo metadata, or consumers will read
+great-circle edges as planar.
+"""
+
+import json
+
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.convert import convert_to_geoparquet
+from tests.conftest import get_geo_metadata
+
+
+@pytest.fixture
+def spherical_input(tmp_path):
+    """A 2.0 file whose geo metadata declares edges=spherical.
+
+    (Native GEOGRAPHY logical types can't be written locally — only sedonadb
+    does that — so this simulates the metadata half of a geography input; the
+    corpus suite covers the logical-type half.)
+    """
+    path = tmp_path / "src.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('LINESTRING (0 0, 10 10)')),
+            (2, ST_GeomFromText('LINESTRING (-179 0, 179 5)'))
+          ) t(id, geometry)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+
+    import geoarrow.pyarrow  # noqa: F401  (keep native types through rewrite)
+
+    table = pq.read_table(str(path))
+    meta = dict(table.schema.metadata)
+    geo = json.loads(meta[b"geo"])
+    geo["columns"]["geometry"]["edges"] = "spherical"
+    meta[b"geo"] = json.dumps(geo).encode()
+    pq.write_table(table.replace_schema_metadata(meta), str(path))
+    return path
+
+
+def test_v2_rewrite_preserves_spherical_edges(spherical_input, tmp_path):
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(
+        str(spherical_input), str(out), skip_hilbert=True, geoparquet_version="2.0"
+    )
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+def test_v1_1_rewrite_preserves_spherical_edges(spherical_input, tmp_path):
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(
+        str(spherical_input), str(out), skip_hilbert=True, geoparquet_version="1.1"
+    )
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+def test_auto_rewrite_preserves_spherical_edges(spherical_input, tmp_path):
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(
+        str(spherical_input), str(out), skip_hilbert=True, geoparquet_version=None
+    )
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]

--- a/tests/test_preserve_geography_edges.py
+++ b/tests/test_preserve_geography_edges.py
@@ -16,9 +16,8 @@ from geoparquet_io.core.convert import convert_to_geoparquet
 from tests.conftest import get_geo_metadata
 
 
-@pytest.fixture
-def spherical_input(tmp_path):
-    """A 2.0 file whose geo metadata declares edges=spherical.
+def _make_edges_input(tmp_path, edges):
+    """A 2.0 file whose geo metadata declares the given edges value.
 
     (Native GEOGRAPHY logical types can't be written locally — only sedonadb
     does that — so this simulates the metadata half of a geography input; the
@@ -41,10 +40,20 @@ def spherical_input(tmp_path):
     table = pq.read_table(str(path))
     meta = dict(table.schema.metadata)
     geo = json.loads(meta[b"geo"])
-    geo["columns"]["geometry"]["edges"] = "spherical"
+    geo["columns"]["geometry"]["edges"] = edges
     meta[b"geo"] = json.dumps(geo).encode()
     pq.write_table(table.replace_schema_metadata(meta), str(path))
     return path
+
+
+@pytest.fixture
+def spherical_input(tmp_path):
+    return _make_edges_input(tmp_path, "spherical")
+
+
+@pytest.fixture
+def vincenty_input(tmp_path):
+    return _make_edges_input(tmp_path, "vincenty")
 
 
 def test_v2_rewrite_preserves_spherical_edges(spherical_input, tmp_path):
@@ -72,3 +81,31 @@ def test_auto_rewrite_preserves_spherical_edges(spherical_input, tmp_path):
     )
     geo = get_geo_metadata(str(out))
     assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+
+def test_v1_1_maps_ellipsoidal_edges_to_spherical(vincenty_input, tmp_path):
+    """1.x only allows planar/spherical; ellipsoidal algorithms map to spherical (todo 039)."""
+    from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(
+        str(vincenty_input), str(out), skip_hilbert=True, geoparquet_version="1.1"
+    )
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
+
+    result = validate_geoparquet(str(out), validate_data=False)
+    edges_failures = [
+        c for c in result.checks if "edges" in c.name and c.status == CheckStatus.FAILED
+    ]
+    assert not edges_failures, [f"{c.name}: {c.message}" for c in edges_failures]
+
+
+def test_v2_keeps_ellipsoidal_edges_verbatim(vincenty_input, tmp_path):
+    """2.0 outputs support the full edges vocabulary; keep the algorithm as-is."""
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(
+        str(vincenty_input), str(out), skip_hilbert=True, geoparquet_version="2.0"
+    )
+    geo = get_geo_metadata(str(out))
+    assert geo["columns"]["geometry"].get("edges") == "vincenty", geo["columns"]["geometry"]

--- a/tests/test_v2_zm_geo_metadata.py
+++ b/tests/test_v2_zm_geo_metadata.py
@@ -1,0 +1,73 @@
+"""GeoParquet 2.0 writes of M/ZM data must not lose the geo metadata (gpio #589).
+
+DuckDB 1.5.4's V2 writer omits the `geo` key-value metadata when geometries
+have an M dimension (XY and XYZ are fine). gpio must guarantee the metadata
+regardless, or the output silently degrades to parquet-geo-only.
+"""
+
+import json
+
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.convert import convert_to_geoparquet
+from tests.conftest import get_geo_metadata, get_geoparquet_version, has_native_geo_types
+
+
+@pytest.fixture
+def zm_source(tmp_path):
+    path = tmp_path / "src.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('LINESTRING ZM (0 0 100 0, 1 1 110 10)')),
+            (2, ST_GeomFromText('LINESTRING ZM (5 5 50 0, 6 5 60 5)'))
+          ) t(id, geometry)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    return path
+
+
+@pytest.fixture
+def xym_source(tmp_path):
+    path = tmp_path / "src.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('LINESTRING M (0 0 0, 1 1 10)'))
+          ) t(id, geometry)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    return path
+
+
+@pytest.mark.parametrize("source", ["zm_source", "xym_source"])
+def test_v2_write_of_m_data_keeps_geo_metadata(source, tmp_path, request):
+    src = request.getfixturevalue(source)
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version="2.0")
+
+    assert get_geoparquet_version(str(out)) == "2.0.0", "geo metadata missing from 2.0 output"
+    assert has_native_geo_types(str(out)), "native logical type lost"
+
+    geo = get_geo_metadata(str(out))
+    col = geo["columns"][geo["primary_column"]]
+    assert col["encoding"] == "WKB"
+    suffix = "ZM" if source == "zm_source" else "M"
+    assert col["geometry_types"] == [f"LineString {suffix}"], col["geometry_types"]
+
+
+def test_repaired_metadata_matches_duckdb_shape(zm_source, tmp_path):
+    """The repaired geo block mirrors what DuckDB writes for XY/Z data."""
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(str(zm_source), str(out), skip_hilbert=True, geoparquet_version="2.0")
+    kv = pq.ParquetFile(str(out)).metadata.metadata
+    geo = json.loads(kv[b"geo"])
+    assert geo["version"] == "2.0.0"
+    assert geo["primary_column"] == "geometry"
+    assert set(geo["columns"]) == {"geometry"}

--- a/tests/test_v2_zm_geo_metadata.py
+++ b/tests/test_v2_zm_geo_metadata.py
@@ -71,3 +71,51 @@ def test_repaired_metadata_matches_duckdb_shape(zm_source, tmp_path):
     assert geo["version"] == "2.0.0"
     assert geo["primary_column"] == "geometry"
     assert set(geo["columns"]) == {"geometry"}
+
+
+def test_repair_preserves_lz4_codec_and_row_groups(zm_source, tmp_path):
+    """The metadata repair rewrite must not change codec or row-group layout (todo 041)."""
+    out = tmp_path / "out.parquet"
+    convert_to_geoparquet(
+        str(zm_source),
+        str(out),
+        skip_hilbert=True,
+        geoparquet_version="2.0",
+        compression="LZ4",
+        row_group_rows=1,
+    )
+    pf = pq.ParquetFile(str(out))
+    assert b"geo" in pf.metadata.metadata, "geo metadata missing after repair"
+    assert pf.metadata.num_row_groups == 2, "explicit row-group size not preserved"
+    codecs = {
+        pf.metadata.row_group(i).column(0).compression for i in range(pf.metadata.num_row_groups)
+    }
+    assert codecs <= {"LZ4", "LZ4_RAW"}, f"LZ4 silently rewritten: {codecs}"
+
+
+def test_rewrite_keeps_row_group_structure_when_unspecified(tmp_path):
+    """With row_group_rows=None the rewrite must mirror the file's own layout."""
+    import pyarrow as pa
+
+    from geoparquet_io.core.common import _rewrite_file_with_geo_metadata
+
+    path = tmp_path / "plain.parquet"
+    pq.write_table(pa.table({"a": list(range(30))}), str(path), row_group_size=10)
+    assert pq.ParquetFile(str(path)).metadata.num_row_groups == 3
+
+    _rewrite_file_with_geo_metadata(str(path), {"version": "2.0.0"}, "ZSTD", None, None)
+    assert pq.ParquetFile(str(path)).metadata.num_row_groups == 3
+
+
+def test_rewrite_preserves_lz4_codec_unit(tmp_path):
+    """codec_map must cover the normalized 'LZ4' name callers actually pass."""
+    import pyarrow as pa
+
+    from geoparquet_io.core.common import _rewrite_file_with_geo_metadata
+
+    path = tmp_path / "plain.parquet"
+    pq.write_table(pa.table({"a": [1, 2, 3]}), str(path), compression="lz4")
+
+    _rewrite_file_with_geo_metadata(str(path), {"version": "2.0.0"}, "LZ4", None, None)
+    codec = pq.ParquetFile(str(path)).metadata.row_group(0).column(0).compression
+    assert codec in ("LZ4", "LZ4_RAW"), codec

--- a/tests/test_v2_zm_geo_metadata.py
+++ b/tests/test_v2_zm_geo_metadata.py
@@ -119,3 +119,32 @@ def test_rewrite_preserves_lz4_codec_unit(tmp_path):
     _rewrite_file_with_geo_metadata(str(path), {"version": "2.0.0"}, "LZ4", None, None)
     codec = pq.ParquetFile(str(path)).metadata.row_group(0).column(0).compression
     assert codec in ("LZ4", "LZ4_RAW"), codec
+
+
+# --- Primary-column choice for multi-geometry repairs (todo 047-C6) ---
+
+
+def test_repair_uses_real_primary_column_not_alphabetical(tmp_path):
+    """With two geometry columns, the repair must honor the caller's primary
+    column instead of picking the alphabetically-first one."""
+    from geoparquet_io.core.common import _ensure_v2_geo_metadata
+
+    path = tmp_path / "two_geoms.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('LINESTRING M (0 0 0, 1 1 10)'),
+                ST_GeomFromText('POINT M (5 5 1)'))
+          ) t(id, a_geom, the_geom)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    # Precondition: the DuckDB M-dimension bug leaves the file without geo KV.
+    assert (pq.ParquetFile(str(path)).metadata.metadata or {}).get(b"geo") is None
+
+    _ensure_v2_geo_metadata(str(path), primary_column="the_geom")
+
+    geo = json.loads(pq.ParquetFile(str(path)).metadata.metadata[b"geo"])
+    assert set(geo["columns"]) == {"a_geom", "the_geom"}
+    assert geo["primary_column"] == "the_geom"

--- a/tests/test_validate_new_checks.py
+++ b/tests/test_validate_new_checks.py
@@ -29,7 +29,7 @@ class TestVersionKnown:
 
 
 class TestVersionFeatures:
-    def _write(self, tmp_path, version_option, geo_version):
+    def _write(self, tmp_path, version_option):
         from geoparquet_io.core.common import get_duckdb_connection
 
         path = tmp_path / "f.parquet"
@@ -42,12 +42,12 @@ class TestVersionFeatures:
         return path
 
     def test_v1_metadata_with_native_types_fails(self, tmp_path):
-        path = self._write(tmp_path, "V2", "1.0.0")
+        path = self._write(tmp_path, "V2")
         check = _check_version_features(str(path), {"version": "1.0.0"})
         assert check.status == CheckStatus.FAILED
 
     def test_v2_metadata_with_native_types_passes(self, tmp_path):
-        path = self._write(tmp_path, "V2", "2.0.0")
+        path = self._write(tmp_path, "V2")
         check = _check_version_features(str(path), {"version": "2.0.0"})
         assert check.status == CheckStatus.PASSED
 

--- a/tests/test_validate_new_checks.py
+++ b/tests/test_validate_new_checks.py
@@ -1,0 +1,106 @@
+"""Unit tests for detection gaps surfaced by bad_data corpus files (gpio #586)."""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_crs_valid,
+    _check_epoch_valid,
+    _check_version_features,
+    _check_version_known,
+    validate_geoparquet,
+)
+
+ITRF2014 = {"type": "GeographicCRS", "name": "ITRF2014", "id": {"authority": "EPSG", "code": 9989}}
+EPSG_4326 = {"type": "GeographicCRS", "name": "WGS 84", "id": {"authority": "EPSG", "code": 4326}}
+
+
+class TestVersionKnown:
+    def test_unknown_version_fails(self):
+        check = _check_version_known({"version": "99.0.0"})
+        assert check.status == CheckStatus.FAILED
+
+    @pytest.mark.parametrize("version", ["1.0.0", "1.1.0", "2.0.0"])
+    def test_known_versions_pass(self, version):
+        check = _check_version_known({"version": version})
+        assert check.status == CheckStatus.PASSED
+
+
+class TestVersionFeatures:
+    def _write(self, tmp_path, version_option, geo_version):
+        from geoparquet_io.core.common import get_duckdb_connection
+
+        path = tmp_path / "f.parquet"
+        con = get_duckdb_connection(load_spatial=True)
+        con.execute(
+            f"COPY (SELECT ST_GeomFromText('POINT (1 2)') AS geometry) "
+            f"TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION '{version_option}')"
+        )
+        con.close()
+        return path
+
+    def test_v1_metadata_with_native_types_fails(self, tmp_path):
+        path = self._write(tmp_path, "V2", "1.0.0")
+        check = _check_version_features(str(path), {"version": "1.0.0"})
+        assert check.status == CheckStatus.FAILED
+
+    def test_v2_metadata_with_native_types_passes(self, tmp_path):
+        path = self._write(tmp_path, "V2", "2.0.0")
+        check = _check_version_features(str(path), {"version": "2.0.0"})
+        assert check.status == CheckStatus.PASSED
+
+
+class TestCrsRequiresType:
+    def test_projjson_missing_type_fails(self):
+        crs = {"id": {"authority": "XYZ", "code": 999}, "name": "Not a real CRS"}
+        check = _check_crs_valid({"crs": crs}, "geometry")
+        assert check.status == CheckStatus.FAILED
+
+    def test_projjson_with_type_passes(self):
+        check = _check_crs_valid({"crs": EPSG_4326}, "geometry")
+        assert check.status == CheckStatus.PASSED
+
+
+class TestEpochRequiresDynamicDatum:
+    def test_epoch_on_datum_ensemble_fails(self):
+        """EPSG:4326 is a datum ensemble — no single frame an epoch can refer to."""
+        check = _check_epoch_valid({"epoch": 2020.0, "crs": EPSG_4326}, "geometry")
+        assert check.status == CheckStatus.FAILED
+
+    def test_epoch_on_dynamic_datum_passes(self):
+        check = _check_epoch_valid({"epoch": 2020.0, "crs": ITRF2014}, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_epoch_on_static_frame_warns(self):
+        """GDA2020 is a specific static frame: tolerated with a warning
+        (matches the corpus, which ships valid GDA2020+epoch samples)."""
+        gda2020 = {
+            "type": "GeographicCRS",
+            "name": "GDA2020",
+            "id": {"authority": "EPSG", "code": 7843},
+        }
+        check = _check_epoch_valid({"epoch": 2020.0, "crs": gda2020}, "geometry")
+        assert check.status == CheckStatus.WARNING, check.message
+
+    def test_epoch_on_default_crs84_fails(self):
+        """No crs key = OGC:CRS84 default = WGS 84 ensemble."""
+        check = _check_epoch_valid({"epoch": 2020.0}, "geometry")
+        assert check.status == CheckStatus.FAILED
+
+    def test_no_epoch_passes(self):
+        check = _check_epoch_valid({"crs": EPSG_4326}, "geometry")
+        assert check.status == CheckStatus.PASSED
+
+
+class TestInvalidJsonGeoDetectedInAutoMode:
+    def test_invalid_json_geo_fails_auto(self, tmp_path):
+        table = pa.table({"a": [1], "geometry": [b"\x01\x01" + b"\x00" * 20]})
+        table = table.replace_schema_metadata({b"geo": b'{"version": "2.0.0",}'})
+        out = tmp_path / "bad.parquet"
+        pq.write_table(table, out)
+        result = validate_geoparquet(str(out), validate_data=False)
+        assert not result.is_valid
+        failed = [c.name for c in result.checks if c.status == CheckStatus.FAILED]
+        assert any("geo_metadata" in n for n in failed), failed

--- a/tests/test_validate_review_fixes.py
+++ b/tests/test_validate_review_fixes.py
@@ -18,12 +18,21 @@ import pyarrow.parquet as pq
 import pytest
 from pyproj import CRS as PyprojCRS
 
+from geoparquet_io.core.exceptions import GeoParquetError
 from geoparquet_io.core.validate import (
     CheckStatus,
+    _check_crs_valid,
     _check_epoch_valid,
     _check_v2_edges_consistency,
+    _check_version_features,
+    _check_version_known,
     _crs_equals,
+    _interpret_bbox_result,
+    _is_crs84_equivalent,
     _is_ogc_crs84,
+    _is_read_failure,
+    _normalize_found_geometry_type,
+    _version_at_least,
     validate_geoparquet,
 )
 
@@ -199,3 +208,176 @@ class TestEpochCrsHandling:
         crs = {"id": {"authority": "XYZ", "code": 1}}
         check = _check_epoch_valid({"epoch": 2020.0, "crs": crs}, "geometry")
         assert check.status == CheckStatus.WARNING, check.message
+
+
+# =============================================================================
+# P3 polish batch (todos 046/047)
+# =============================================================================
+
+
+class TestVacuousBboxPass:
+    """046-V1: a 0-geometry check must SKIP, not vouch for the bbox."""
+
+    def test_zero_checked_is_skipped(self):
+        check = _interpret_bbox_result((0, 0), "geometry")
+        assert check.status == CheckStatus.SKIPPED, check.message
+        assert "no non-empty geometries" in check.message
+
+    def test_nonzero_pass_unchanged(self):
+        check = _interpret_bbox_result((3, 3), "geometry")
+        assert check.status == CheckStatus.PASSED
+
+    def test_failure_unchanged(self):
+        check = _interpret_bbox_result((3, 2), "geometry")
+        assert check.status == CheckStatus.FAILED
+
+
+class TestReadFailureVsCorruption:
+    """046-V2: I/O failures must not be reported as corruption."""
+
+    def test_io_error_in_chain_is_read_failure(self):
+        try:
+            raise GeoParquetError("Cannot read file: x") from FileNotFoundError("x")
+        except GeoParquetError as e:
+            assert _is_read_failure(e)
+
+    def test_unicode_error_in_chain_is_corruption(self):
+        try:
+            raise GeoParquetError("Cannot read file: x") from UnicodeDecodeError(
+                "utf-8", b"\xff", 0, 1, "invalid start byte"
+            )
+        except GeoParquetError as e:
+            assert not _is_read_failure(e)
+
+    def test_bare_value_error_is_corruption(self):
+        assert not _is_read_failure(ValueError("bad metadata"))
+
+
+class TestCrs84UrnEquivalence:
+    """046-V3: URN spellings of CRS84/EPSG:4326 must be recognized."""
+
+    @pytest.mark.parametrize(
+        "crs",
+        [
+            "urn:ogc:def:crs:OGC:1.3:CRS84",
+            "urn:ogc:def:crs:OGC::CRS84",
+            "urn:ogc:def:crs:EPSG::4326",
+        ],
+    )
+    def test_urn_forms_equivalent(self, crs):
+        assert _is_crs84_equivalent(crs)
+
+    def test_other_crs_still_not_equivalent(self):
+        assert not _is_crs84_equivalent("EPSG:3857")
+        assert not _is_crs84_equivalent("urn:ogc:def:crs:EPSG::3857")
+
+
+class TestVersionAtLeast:
+    """046-V4: version compares must parse, not compare lexicographically."""
+
+    def test_short_and_full_forms(self):
+        assert _version_at_least("2.0", 2, 0)
+        assert _version_at_least("2.0.0", 2, 0)
+        assert not _version_at_least("1.1.0", 2, 0)
+
+    def test_prerelease_tag_ignored(self):
+        assert _version_at_least("1.0.0-beta.1", 1, 0)
+        assert not _version_at_least("1.0.0-beta.1", 1, 1)
+
+    def test_not_lexicographic(self):
+        # "1.10.0" < "1.2.0" lexicographically; numerically it is greater.
+        assert _version_at_least("1.10.0", 1, 2)
+
+    def test_garbage_and_non_string_false(self):
+        assert not _version_at_least("banana", 1, 0)
+        assert not _version_at_least(None, 1, 0)
+        assert not _version_at_least(1.0, 1, 0)
+
+
+class TestVersionKnownNonString:
+    """046-V5: non-string versions get an honest message, not 'unknown 1.0'."""
+
+    def test_non_string_version_fails_with_type_message(self):
+        check = _check_version_known({"version": 1.0})
+        assert check.status == CheckStatus.FAILED
+        assert "must be a string" in check.message
+
+    def test_string_versions_unchanged(self):
+        assert _check_version_known({"version": "1.0.0"}).status == CheckStatus.PASSED
+        assert _check_version_known({"version": "99.0.0"}).status == CheckStatus.FAILED
+
+
+class TestVersionFeaturesPolish:
+    """046-V6: no contradictory PASS, 1.1-only 'covering' detection, skip reasons."""
+
+    def test_non_string_version_skips_instead_of_passing(self):
+        check = _check_version_features("does-not-exist.parquet", {"version": 1.0})
+        assert check.status == CheckStatus.SKIPPED
+        assert "not a string" in check.message
+
+    def test_1_0_with_covering_fails(self):
+        geo = {
+            "version": "1.0.0",
+            "columns": {"geometry": {"encoding": "WKB", "covering": {"bbox": {}}}},
+        }
+        # Returns before the schema read, so no file is needed.
+        check = _check_version_features("does-not-exist.parquet", geo)
+        assert check.status == CheckStatus.FAILED
+        assert "covering" in check.message
+
+    def test_1_1_with_covering_passes(self, tmp_path):
+        out = tmp_path / "plain.parquet"
+        pq.write_table(pa.table({"geometry": [WKB_POINT]}), out)
+        geo = {
+            "version": "1.1.0",
+            "columns": {"geometry": {"encoding": "WKB", "covering": {"bbox": {}}}},
+        }
+        check = _check_version_features(str(out), geo)
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_schema_read_error_reason_in_message(self, tmp_path):
+        check = _check_version_features(str(tmp_path / "missing.parquet"), {"version": "1.1.0"})
+        assert check.status == CheckStatus.SKIPPED
+        assert "could not inspect Parquet schema:" in check.message
+        # The reason itself must be included, not just the preamble.
+        assert check.message.split("could not inspect Parquet schema:")[1].strip()
+
+
+class TestProjjsonTypeMember:
+    """046-V7: the PROJJSON 'type' value must come from the schema's known set."""
+
+    def test_made_up_type_fails(self):
+        check = _check_crs_valid({"crs": {"type": "TotallyMadeUp"}}, "geometry")
+        assert check.status == CheckStatus.FAILED
+        assert "TotallyMadeUp" in check.message
+
+    @pytest.mark.parametrize(
+        "crs_type",
+        [
+            "GeographicCRS",
+            "GeodeticCRS",
+            "ProjectedCRS",
+            "CompoundCRS",
+            "BoundCRS",
+            "VerticalCRS",
+            "EngineeringCRS",
+            "DerivedGeographicCRS",
+            "DerivedProjectedCRS",
+        ],
+    )
+    def test_known_types_pass(self, crs_type):
+        check = _check_crs_valid({"crs": {"type": crs_type}}, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+
+class TestGeomTypeNormalization:
+    """046-V10: unmapped base types must not get their Z/M suffix doubled."""
+
+    def test_unmapped_base_no_double_suffix(self):
+        assert _normalize_found_geometry_type("TRIANGLE Z") == "TRIANGLE Z"
+
+    def test_mapped_with_suffix(self):
+        assert _normalize_found_geometry_type("MULTIPOINT ZM") == "MultiPoint ZM"
+
+    def test_st_prefix_stripped(self):
+        assert _normalize_found_geometry_type("ST_POINT") == "Point"

--- a/tests/test_validate_review_fixes.py
+++ b/tests/test_validate_review_fixes.py
@@ -1,0 +1,201 @@
+"""Unit tests for verified code-review fixes (todos 036, 038, 039, 042).
+
+Covers:
+- 036: _crs_equals must not report equality for arbitrary id-less PROJJSON pairs
+- 038: validator must not crash on malformed metadata (numeric crs.id authority,
+       valid-JSON non-object geo values)
+- 039: non-planar edges declared on a planar GEOMETRY column must be flagged
+       in 2.0 (WARNING — see TestEdgesOnPlanarGeometry for the adjudication)
+- 042: epoch check must distinguish explicit-null CRS, and never silently PASS
+       when the CRS datum cannot be resolved
+"""
+
+import json
+import struct
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from pyproj import CRS as PyprojCRS
+
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_epoch_valid,
+    _check_v2_edges_consistency,
+    _crs_equals,
+    _is_ogc_crs84,
+    validate_geoparquet,
+)
+
+WKB_POINT = struct.pack("<BIdd", 1, 1, 30.0, 10.0)
+
+
+def _idless_projjson(user_input) -> dict:
+    crs = PyprojCRS.from_user_input(user_input).to_json_dict()
+    crs.pop("id", None)
+    return crs
+
+
+class TestCrsEqualsIdless:
+    """036: id-less PROJJSON dicts must be compared semantically, not assumed equal."""
+
+    def test_idless_3857_vs_idless_utm32n_not_equal(self):
+        assert not _crs_equals(_idless_projjson("EPSG:3857"), _idless_projjson("EPSG:32632"))
+
+    def test_identical_idless_projjson_equal(self):
+        a = _idless_projjson("EPSG:3857")
+        b = json.loads(json.dumps(a))
+        assert _crs_equals(a, b)
+
+    def test_both_with_matching_id_equal(self):
+        a = {"type": "ProjectedCRS", "name": "A", "id": {"authority": "EPSG", "code": 3857}}
+        b = {"type": "ProjectedCRS", "name": "B", "id": {"authority": "EPSG", "code": 3857}}
+        assert _crs_equals(a, b)
+
+    def test_both_with_different_id_not_equal(self):
+        a = {"type": "ProjectedCRS", "name": "A", "id": {"authority": "EPSG", "code": 3857}}
+        b = {"type": "ProjectedCRS", "name": "A", "id": {"authority": "EPSG", "code": 32632}}
+        assert not _crs_equals(a, b)
+
+    def test_different_dicts_sharing_name_are_not_equal(self):
+        """The old name-only fallback made these equal; must fail closed now."""
+        assert not _crs_equals(
+            {"name": "whatever", "type": "GeographicCRS"},
+            {"name": "whatever", "type": "ProjectedCRS"},
+        )
+
+    def test_identical_unparsable_dicts_are_equal(self):
+        """Byte-identical declarations describe the same CRS even if unparsable."""
+        assert _crs_equals({"name": "whatever"}, {"name": "whatever"})
+
+    def test_string_forms_unchanged(self):
+        assert _crs_equals("EPSG:4326", "EPSG:4326")
+        assert not _crs_equals("EPSG:4326", "EPSG:3857")
+
+    def test_none_handling_unchanged(self):
+        assert _crs_equals(None, None)
+        assert not _crs_equals(None, {"name": "x"})
+
+
+class TestMalformedMetadataNoCrash:
+    """038: malformed metadata must yield FAILED results, never exceptions."""
+
+    def test_is_ogc_crs84_numeric_authority_no_crash(self):
+        assert _is_ogc_crs84({"id": {"authority": 6, "code": "CRS84"}}) is False
+
+    def test_is_ogc_crs84_non_dict_id_no_crash(self):
+        assert _is_ogc_crs84({"id": "EPSG:4326"}) is False
+
+    def _write_with_geo_bytes(self, tmp_path, geo_bytes):
+        table = pa.table({"a": [1], "geometry": [WKB_POINT]})
+        table = table.replace_schema_metadata({b"geo": geo_bytes})
+        out = tmp_path / "bad.parquet"
+        pq.write_table(table, out)
+        return out
+
+    def test_numeric_authority_in_crs_id_reports_failed(self, tmp_path):
+        geo = {
+            "version": "1.0.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": [],
+                    "crs": {"id": {"authority": 1234, "code": 5678}, "name": "weird"},
+                }
+            },
+        }
+        out = self._write_with_geo_bytes(tmp_path, json.dumps(geo).encode())
+        result = validate_geoparquet(str(out), validate_data=True)
+        assert not result.is_valid
+        assert any(c.status == CheckStatus.FAILED for c in result.checks)
+
+    @pytest.mark.parametrize("geo_bytes", [b'["1.0.0"]', b'"hello"'])
+    def test_non_object_geo_json_reports_failed_auto(self, tmp_path, geo_bytes):
+        out = self._write_with_geo_bytes(tmp_path, geo_bytes)
+        result = validate_geoparquet(str(out), validate_data=False)
+        assert not result.is_valid
+        failed = [c.name for c in result.checks if c.status == CheckStatus.FAILED]
+        assert any("geo_metadata" in n for n in failed), failed
+
+    @pytest.mark.parametrize("target", ["1.0", "1.1", "2.0"])
+    def test_non_object_geo_json_reports_failed_explicit_version(self, tmp_path, target):
+        out = self._write_with_geo_bytes(tmp_path, b'["1.0.0"]')
+        result = validate_geoparquet(str(out), target_version=target, validate_data=False)
+        assert not result.is_valid
+        assert any(c.status == CheckStatus.FAILED for c in result.checks)
+
+
+GEOMETRY_SCHEMA = [{"name": "geometry", "logical_type": "GeometryType()", "type": "binary"}]
+GEOGRAPHY_SCHEMA = [{"name": "geometry", "logical_type": "GeographyType()", "type": "binary"}]
+WKB_SCHEMA = [{"name": "geometry", "logical_type": "", "type": "binary"}]
+
+
+def _edges_meta(edges=None):
+    col: dict = {"encoding": "WKB"}
+    if edges is not None:
+        col["edges"] = edges
+    return {"columns": {"geometry": col}}
+
+
+class TestEdgesOnPlanarGeometry:
+    """039: non-planar edges claims on a planar GEOMETRY column must be flagged in 2.0.
+
+    Flagged as WARNING, not FAILED: the official 2.0.0 metadata schema permits
+    any edges value regardless of logical type, the geoparquet-testing corpus
+    ships data/edges/edges-{vincenty,thomas,andoyer,karney}.parquet as valid
+    files with planar GEOMETRY logical types, and gpio's own convert emits this
+    shape when demoting GEOGRAPHY (#588). The review's concern — the claim was
+    never surfaced at all — is met by the warning.
+    """
+
+    @pytest.mark.parametrize("edges", ["vincenty", "spherical", "thomas", "andoyer", "karney"])
+    def test_non_planar_edges_on_geometry_warns(self, edges):
+        check = _check_v2_edges_consistency(_edges_meta(edges), GEOMETRY_SCHEMA, "geometry")
+        assert check.status == CheckStatus.WARNING, check.message
+        assert edges in check.message
+
+    @pytest.mark.parametrize("edges", [None, "planar"])
+    def test_planar_or_absent_edges_on_geometry_not_flagged(self, edges):
+        check = _check_v2_edges_consistency(_edges_meta(edges), GEOMETRY_SCHEMA, "geometry")
+        assert check.status == CheckStatus.SKIPPED, check.message
+
+    def test_wkb_column_still_skipped(self):
+        """1.x-style WKB columns (no native logical type) keep the SKIP behavior."""
+        check = _check_v2_edges_consistency(_edges_meta("spherical"), WKB_SCHEMA, "geometry")
+        assert check.status == CheckStatus.SKIPPED
+
+    def test_geography_matching_edges_still_passes(self):
+        check = _check_v2_edges_consistency(_edges_meta("spherical"), GEOGRAPHY_SCHEMA, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_geography_mismatched_edges_still_fails(self):
+        check = _check_v2_edges_consistency(_edges_meta("vincenty"), GEOGRAPHY_SCHEMA, "geometry")
+        assert check.status == CheckStatus.FAILED
+
+
+class TestEpochCrsHandling:
+    """042: explicit-null CRS and unresolvable CRSs must surface as WARNING."""
+
+    def test_explicit_null_crs_with_epoch_warns(self):
+        check = _check_epoch_valid({"epoch": 2020.0, "crs": None}, "geometry")
+        assert check.status == CheckStatus.WARNING, check.message
+
+    def test_absent_crs_with_epoch_fails(self):
+        """Absent crs means the OGC:CRS84 default — a datum ensemble."""
+        check = _check_epoch_valid({"epoch": 2020.0}, "geometry")
+        assert check.status == CheckStatus.FAILED
+
+    def test_unresolvable_crs_with_epoch_warns_not_passes(self):
+        crs = {
+            "type": "EngineeringCRS",
+            "name": "Site grid",
+            "id": {"authority": "EPSG", "code": 5817},
+        }
+        check = _check_epoch_valid({"epoch": 2020.0, "crs": crs}, "geometry")
+        assert check.status == CheckStatus.WARNING, check.message
+
+    def test_garbage_crs_with_epoch_warns_not_passes(self):
+        crs = {"id": {"authority": "XYZ", "code": 1}}
+        check = _check_epoch_valid({"epoch": 2020.0, "crs": crs}, "geometry")
+        assert check.status == CheckStatus.WARNING, check.message

--- a/tests/test_validate_v2_fixes.py
+++ b/tests/test_validate_v2_fixes.py
@@ -136,7 +136,9 @@ class TestEmptyGeometryContainment:
             )
         finally:
             con.close()
-        assert check.status in (CheckStatus.PASSED, CheckStatus.SKIPPED), check.message
+        # Two non-empty points must be checked and pass; a loose
+        # PASSED-or-SKIPPED assertion could mask a containment regression.
+        assert check.status == CheckStatus.PASSED, check.message
 
 
 class TestSchemaInfoRegistrationIndependent:

--- a/tests/test_validate_v2_fixes.py
+++ b/tests/test_validate_v2_fixes.py
@@ -1,0 +1,194 @@
+"""Unit tests for validator bugs surfaced by the geoparquet-testing corpus.
+
+Covers gpio issues:
+- #581: V2-2/V2-3 must treat explicit-CRS84 metadata + absent native CRS as valid
+- #582: edges vocabulary includes the 2.0 ellipsoidal values
+- #584: empty geometries excluded from stats/bbox containment
+- #585: validator reports FAILED instead of crashing on corrupt metadata
+"""
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_edges_valid,
+    _check_native_geo_stats_contains_data,
+    _check_v2_crs_consistency,
+    _check_v2_crs_in_parquet_type,
+    validate_geoparquet,
+)
+
+CRS84_PROJJSON = {
+    "type": "GeographicCRS",
+    "name": "WGS 84 (CRS84)",
+    "id": {"authority": "OGC", "code": "CRS84"},
+}
+EPSG_4326_PROJJSON = {
+    "type": "GeographicCRS",
+    "name": "WGS 84",
+    "id": {"authority": "EPSG", "code": 4326},
+}
+EPSG_3857_PROJJSON = {
+    "type": "ProjectedCRS",
+    "name": "WGS 84 / Pseudo-Mercator",
+    "id": {"authority": "EPSG", "code": 3857},
+}
+
+SCHEMA_NO_CRS = [{"name": "geometry", "logical_type": "GeometryType()", "type": "binary"}]
+
+
+def _geo_meta(crs):
+    return {"columns": {"geometry": {"encoding": "WKB", "crs": crs}}}
+
+
+class TestV2CrsDefaultEquivalence:
+    """#581: explicit CRS84-equivalent metadata + absent native CRS is spec-valid."""
+
+    @pytest.mark.parametrize("crs", [CRS84_PROJJSON, EPSG_4326_PROJJSON])
+    def test_crs_in_parquet_type_passes_for_default_equivalent(self, crs):
+        check = _check_v2_crs_in_parquet_type(_geo_meta(crs), SCHEMA_NO_CRS, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_crs_in_parquet_type_fails_for_non_default(self):
+        check = _check_v2_crs_in_parquet_type(
+            _geo_meta(EPSG_3857_PROJJSON), SCHEMA_NO_CRS, "geometry"
+        )
+        assert check.status == CheckStatus.FAILED
+
+    @pytest.mark.parametrize("crs", [CRS84_PROJJSON, EPSG_4326_PROJJSON])
+    def test_consistency_passes_for_default_equivalent(self, crs):
+        check = _check_v2_crs_consistency(_geo_meta(crs), SCHEMA_NO_CRS, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_consistency_fails_for_genuine_mismatch(self):
+        """Metadata 3857 vs absent native CRS (=CRS84) is a real inconsistency."""
+        check = _check_v2_crs_consistency(_geo_meta(EPSG_3857_PROJJSON), SCHEMA_NO_CRS, "geometry")
+        assert check.status == CheckStatus.FAILED
+
+    def test_consistency_passes_when_both_declare_same_crs(self):
+        schema = [
+            {
+                "name": "geometry",
+                "logical_type": f"GeometryType(crs={json.dumps(EPSG_3857_PROJJSON)})",
+                "type": "binary",
+            }
+        ]
+        check = _check_v2_crs_consistency(_geo_meta(EPSG_3857_PROJJSON), schema, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+
+class TestEdgesVocabulary:
+    """#582: GeoParquet 2.0 allows the four ellipsoidal-geodesic edges values."""
+
+    @pytest.mark.parametrize("edges", ["vincenty", "thomas", "andoyer", "karney"])
+    def test_ellipsoidal_edges_valid_for_v2(self, edges):
+        check = _check_edges_valid({"edges": edges}, "geometry", geo_version="2.0.0")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize("edges", ["vincenty", "karney"])
+    def test_ellipsoidal_edges_invalid_for_v1_1(self, edges):
+        check = _check_edges_valid({"edges": edges}, "geometry", geo_version="1.1.0")
+        assert check.status == CheckStatus.FAILED
+
+    @pytest.mark.parametrize("version", ["1.1.0", "2.0.0"])
+    def test_planar_and_spherical_valid_everywhere(self, version):
+        for edges in ("planar", "spherical"):
+            check = _check_edges_valid({"edges": edges}, "geometry", geo_version=version)
+            assert check.status == CheckStatus.PASSED
+
+    @pytest.mark.parametrize("version", ["1.1.0", "2.0.0"])
+    def test_bogus_edges_always_invalid(self, version):
+        check = _check_edges_valid({"edges": "geodesic"}, "geometry", geo_version=version)
+        assert check.status == CheckStatus.FAILED
+
+
+@pytest.fixture
+def native_file_with_empty_point(tmp_path):
+    """Native-typed file whose geo statistics (correctly) exclude a POINT EMPTY."""
+    out = tmp_path / "empty.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (ST_GeomFromText('POINT (30 10)')),
+            (ST_GeomFromText('POINT (40 40)')),
+            (ST_GeomFromText('POINT EMPTY'))
+          ) t(geometry)
+        ) TO '{out.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    return out
+
+
+class TestEmptyGeometryContainment:
+    """#584: empties have no extent and must not count as outside the stats bbox."""
+
+    def test_native_stats_containment_ignores_empty(self, native_file_with_empty_point):
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_native_geo_stats_contains_data(
+                str(native_file_with_empty_point), "geometry", con, sample_size=100
+            )
+        finally:
+            con.close()
+        assert check.status in (CheckStatus.PASSED, CheckStatus.SKIPPED), check.message
+
+
+class TestSchemaInfoRegistrationIndependent:
+    """Schema info must not change when geoarrow extension types get registered.
+
+    Importing geoarrow.pyarrow anywhere in the process registers extension
+    types globally, after which pyarrow reads native-GEOMETRY columns as
+    extension fields. get_schema_info must keep reporting the storage type so
+    checks like geometry_byte_array don't fail depending on test order.
+    """
+
+    def test_native_geometry_type_stable_after_geoarrow_import(self, native_file_with_empty_point):
+        import geoarrow.pyarrow  # noqa: F401  (import registers extension types)
+
+        from geoparquet_io.core.duckdb_metadata import get_schema_info
+
+        (geom,) = [
+            c for c in get_schema_info(str(native_file_with_empty_point)) if c["name"] == "geometry"
+        ]
+        assert "binary" in geom["type"].lower() or "BYTE_ARRAY" in geom["type"], geom["type"]
+        assert (geom["logical_type"] or "").startswith("GeometryType"), geom["logical_type"]
+
+        result = validate_geoparquet(str(native_file_with_empty_point), validate_data=False)
+        byte_array_checks = [c for c in result.checks if c.name.startswith("geometry_byte_array")]
+        assert all(c.status == CheckStatus.PASSED for c in byte_array_checks), [
+            (c.name, c.message) for c in byte_array_checks
+        ]
+
+
+class TestValidatorNeverCrashes:
+    """#585: corrupt metadata must produce FAILED checks, not exceptions."""
+
+    def _write_with_geo_bytes(self, tmp_path, geo_bytes):
+        table = pa.table({"a": [1], "geometry": [b"\x01\x01" + b"\x00" * 20]})
+        table = table.replace_schema_metadata({b"geo": geo_bytes})
+        out = tmp_path / "corrupt.parquet"
+        pq.write_table(table, out)
+        return out
+
+    def test_invalid_utf8_geo_metadata_reports_failed(self, tmp_path):
+        out = self._write_with_geo_bytes(tmp_path, b'\xff\xfe{"version"')
+        result = validate_geoparquet(str(out), validate_data=False)
+        assert not result.is_valid
+        assert any(c.status == CheckStatus.FAILED for c in result.checks)
+
+    def test_missing_version_auto_mode_reports_failed(self, tmp_path):
+        geo = {
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": []}},
+        }
+        out = self._write_with_geo_bytes(tmp_path, json.dumps(geo).encode())
+        result = validate_geoparquet(str(out), validate_data=False)
+        assert not result.is_valid
+        failed = [c.name for c in result.checks if c.status == CheckStatus.FAILED]
+        assert any("version" in n for n in failed), failed

--- a/tests/test_validate_zm_types.py
+++ b/tests/test_validate_zm_types.py
@@ -1,0 +1,95 @@
+"""Unit tests for Z/M geometry_types handling (gpio #583).
+
+The spec mandates dimension suffixes ("Point Z", "LineString ZM", ...) and
+says geometry_types "is expected to be strictly correct". gpio must accept
+suffixed names as valid and detect dimensionality when scanning data.
+"""
+
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_geometry_types_list,
+    _check_geometry_types_match_data,
+    _check_native_geo_types_match,
+)
+
+
+class TestGeometryTypesListAcceptsSuffixes:
+    @pytest.mark.parametrize(
+        "types",
+        [
+            ["Point Z"],
+            ["LineString M"],
+            ["Polygon ZM"],
+            ["MultiPolygon Z", "Polygon Z"],
+            ["Point", "Point Z"],
+        ],
+    )
+    def test_suffixed_types_valid(self, types):
+        check = _check_geometry_types_list({"geometry_types": types}, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize(
+        "types",
+        [
+            ["Point X"],
+            ["LineString ZZ"],
+            ["Sphere"],
+            ["Point z"],  # lowercase suffix is not spec-valid
+            ["PointZ"],  # missing the space
+        ],
+    )
+    def test_invalid_types_still_rejected(self, types):
+        check = _check_geometry_types_list({"geometry_types": types}, "geometry")
+        assert check.status == CheckStatus.FAILED, check.message
+
+
+@pytest.fixture
+def zm_file(tmp_path):
+    """Native 2.0 file containing XYZM linestrings."""
+    out = tmp_path / "zm.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (ST_GeomFromText('LINESTRING ZM (0 0 100 0, 1 1 110 10)')),
+            (ST_GeomFromText('LINESTRING ZM (5 5 50 0, 6 5 60 5)'))
+          ) t(geometry)
+        ) TO '{out.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    return out
+
+
+class TestDataScansAreDimensionAware:
+    def test_match_data_passes_for_correct_zm_declaration(self, zm_file):
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_geometry_types_match_data(
+                str(zm_file), "geometry", ["LineString ZM"], con, sample_size=100
+            )
+        finally:
+            con.close()
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_match_data_fails_when_dimension_undeclared(self, zm_file):
+        """Declaring XY 'LineString' for ZM data is the corpus's zm_mismatch case."""
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_geometry_types_match_data(
+                str(zm_file), "geometry", ["LineString"], con, sample_size=100
+            )
+        finally:
+            con.close()
+        assert check.status == CheckStatus.FAILED, check.message
+
+    def test_native_geo_types_match_zm(self, zm_file):
+        """Native stats declare linestring_zm; the data scan must agree."""
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            check = _check_native_geo_types_match(str(zm_file), "geometry", 100, con)
+        finally:
+            con.close()
+        assert check.status == CheckStatus.PASSED, check.message

--- a/tests/test_write_zm_geometry_types.py
+++ b/tests/test_write_zm_geometry_types.py
@@ -1,0 +1,77 @@
+"""Writers must emit dimension-suffixed geometry_types for Z/M data (review todo 035).
+
+The GeoParquet spec treats "LineString" and "LineString ZM" as distinct
+geometry_types entries. The write-side SQL scan previously collapsed the
+dimension, so gpio's own converted Z/M output failed gpio's own spec check.
+"""
+
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection, split_zm_suffix
+from geoparquet_io.core.convert import convert_to_geoparquet
+from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+from tests.conftest import get_geo_metadata
+
+WKT_BY_DIM = {
+    "Z": ("LINESTRING Z (0 0 1, 1 1 2)", "LineString Z"),
+    "M": ("LINESTRING M (0 0 5, 1 1 6)", "LineString M"),
+    "ZM": ("LINESTRING ZM (0 0 1 5, 1 1 2 6)", "LineString ZM"),
+}
+
+
+def _make_source(tmp_path, wkt):
+    path = tmp_path / "src.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('{wkt}'))
+          ) t(id, geometry)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
+    """)
+    con.close()
+    return path
+
+
+def test_split_zm_suffix():
+    assert split_zm_suffix("Point") == ("Point", "")
+    assert split_zm_suffix("Point Z") == ("Point", " Z")
+    assert split_zm_suffix("MultiPolygon M") == ("MultiPolygon", " M")
+    assert split_zm_suffix("LineString ZM") == ("LineString", " ZM")
+
+
+def test_compute_geometry_types_via_sql_is_dimension_aware():
+    """Both copies (common + geo_metadata) must return spec-suffixed names."""
+    from geoparquet_io.core import common, geo_metadata
+
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        query = (
+            "SELECT ST_GeomFromText('LINESTRING ZM (0 0 1 5, 1 1 2 6)') AS geometry "
+            "UNION ALL SELECT ST_GeomFromText('LINESTRING (2 2, 3 3)')"
+        )
+        expected = ["LineString", "LineString ZM"]
+        assert common.compute_geometry_types_via_sql(con, query, "geometry") == expected
+        assert geo_metadata.compute_geometry_types_via_sql(con, query, "geometry") == expected
+    finally:
+        con.close()
+
+
+@pytest.mark.parametrize("dim", ["Z", "M", "ZM"])
+@pytest.mark.parametrize("version", ["1.1", "2.0"])
+def test_convert_emits_suffixed_geometry_types(tmp_path, dim, version):
+    """Round-trip: converted Z/M output declares suffixed types and self-validates."""
+    wkt, expected = WKT_BY_DIM[dim]
+    src = _make_source(tmp_path, wkt)
+    out = tmp_path / f"out_{dim}_{version.replace('.', '_')}.parquet"
+    convert_to_geoparquet(str(src), str(out), skip_hilbert=True, geoparquet_version=version)
+
+    geo = get_geo_metadata(str(out))
+    col = geo["columns"][geo["primary_column"]]
+    assert col["geometry_types"] == [expected], col["geometry_types"]
+
+    result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+    failures = [
+        c for c in result.checks if "geometry_types" in c.name and c.status == CheckStatus.FAILED
+    ]
+    assert not failures, [f"{c.name}: {c.message}" for c in failures]


### PR DESCRIPTION
Addresses all findings from the 9-agent adversarial review of the corpus audit stack (todos 034–048 in \`todos/\`). Stacked on #597; merges last in the chain.

## P1 fixes
- **Writers emit dimension-suffixed \`geometry_types\`** (todo 035): \`compute_geometry_types_via_sql\` (both copies) now returns \"LineString ZM\" etc. via shared \`zm_suffix_sql\`/\`split_zm_suffix\` helpers, consolidating the 3x-duplicated suffix logic. gpio's Z/M output now passes its own validator (end-to-end round-trip tests).
- **\`_crs_equals\` false PASS** (036): id-less PROJJSON pairs now compared semantically via pyproj instead of trivially equal; name-only fallback removed.
- **Edges preservation at the right altitude** (037): moved into \`write_parquet_with_metadata\`, covering convert/extract/sort/reproject/partition — and remote outputs are patched pre-upload rather than skipped.

## P2 fixes
- Validator crash hardening: numeric \`crs.id.authority\`, valid-JSON non-dict \`geo\` (038)
- Non-planar edges on planar GEOMETRY logical type → WARNING (039; adjudicated against corpus/schema, see commit 1ebeced)
- 2.0 edges algorithms mapped to \"spherical\" with warning on 1.x writes (039)
- Reproject honors auto-version contract; issue #600 filed for sort/extract/partition (040)
- Repair-rewrite fidelity: LZ4 preserved, row groups preserved, tmp cleanup, explicit close (041)
- Epoch check: explicit \`crs: null\` → WARN not FAIL; pyproj failures → visible WARNING, never silent PASS (042)
- CLI/API auto-version parity via shared resolver; no more hybrid native-type+WKB-metadata output (043)
- Convert success message now backed by real metadata-level validation (044)
- Corpus suite hardening: tier minimum-count guards, exit codes tightened to (0,2), stale \`CORPUS_BUG_FILES\` entries force cleanup, security-audit workflow inits submodule (045)

## P3 polish (046/047)
Vacuous \"(0 checked)\" passes → SKIPPED, I/O-vs-corruption message split, URN CRS84, semver-aware compares, PROJJSON type vocabulary, \`BaseExtensionType\` unwrap, geography edges synthesis, primary-column plumbing, help-text accuracy, debug logging on silent fallbacks. Issue #601 filed for reproject bbox/edges semantics.

## Docs (048)
docs/guide/check.md + convert.md + CHANGELOG: new checks, the coordinates-heuristic severity change (exit 2 vs 1), auto-version and edges behavior.

**Merge-order note for the stack**: the whole chain was rebased onto current main (picks up the geography-extension CI fixes). #591 and #592 should merge back-to-back — #591 alone leaves corpus tests order-dependent on geoarrow import until #592's \`duckdb_metadata\` fix lands.

Tests: 3513 passed on the full fast suite (only known test_commitizen xdist flake, passes serially). ~110 new tests across the fix commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter GeoParquet specification validation, including version, CRS, epoch, malformed metadata, and Z/M geometry checks.
  * Added automatic GeoParquet version detection that preserves compatible input versions across conversion and reprojection.
* **Bug Fixes**
  * Preserved spherical and ellipsoidal edge metadata across conversions, extraction, sorting, reprojection, partitioning, and remote outputs.
  * Repaired missing GeoParquet 2.0 metadata for dimensional geometries without altering compression or row-group layout.
  * Coordinate/CRS heuristic mismatches now produce warnings instead of failures.
* **Documentation**
  * Updated validation, conversion, changelog, and testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->