### PR TITLE
Fix misleading 'Batch size 0 too large' on non-paged ArcGIS requests

### DIFF
--- a/geoparquet_io/core/http_retry.py
+++ b/geoparquet_io/core/http_retry.py
@@ -150,13 +150,27 @@ def make_request_with_retry(
                 try:
                     return cast(dict[str, Any], response.json())
                 except json.JSONDecodeError as e:
-                    # Server returned non-JSON (likely HTML error page)
+                    # Server returned non-JSON (likely HTML error page).
+                    # Don't include response content in error - may contain
+                    # sensitive tokens; the status code and Content-Type are
+                    # safe and make a WAF/proxy block page distinguishable
+                    # from a genuine payload-size truncation.
+                    content_type = response.headers.get("content-type", "unknown")
+                    detail = (
+                        f"Server returned non-JSON response "
+                        f"(Content-Type: {content_type}, HTTP {response.status_code}), "
+                        f"likely an HTML error or block page"
+                    )
+                    if batch_size is None:
+                        # No batch was requested (e.g. a feature-count or
+                        # layer-info query), so reducing the batch size cannot
+                        # help and BatchTooLargeError would be misleading.
+                        raise RemoteAccessError(url, detail) from e
                     # This is NOT retryable with same params - batch is too large
-                    # Don't include response content in error - may contain sensitive tokens
                     raise BatchTooLargeError(
                         url=url,
-                        batch_size=batch_size or 0,
-                        reason="Server returned non-JSON response (likely HTML error page)",
+                        batch_size=batch_size,
+                        reason=detail,
                     ) from e
             else:
                 return bytes(response.content)

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -442,6 +442,53 @@ class TestTimeout:
 
         assert mock_client.get.call_args.kwargs["timeout"] == 300.0
 
+    def test_non_json_without_batch_size_is_remote_access_error(self):
+        """A non-paged request that gets HTML must not report a batch problem.
+
+        Regression test for #485: the count and layer-info queries carry no
+        batch size, so a WAF/proxy block page was reported as
+        "Batch size 0 too large", hiding the real cause.
+        """
+        from geoparquet_io.core.exceptions import BatchTooLargeError, RemoteAccessError
+        from geoparquet_io.core.http_retry import make_request_with_retry
+
+        mock_client = MagicMock()
+        mock_response = Mock()
+        mock_response.json.side_effect = json.JSONDecodeError("x", "<html>", 0)
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_client.get.return_value = mock_response
+
+        with patch("geoparquet_io.core.http_retry.get_shared_http_client") as mock_get_client:
+            mock_get_client.return_value = mock_client
+            with pytest.raises(RemoteAccessError) as exc_info:
+                make_request_with_retry("GET", "https://example.com/count")
+
+        assert not isinstance(exc_info.value, BatchTooLargeError)
+        assert "Batch size" not in str(exc_info.value)
+        assert "text/html" in str(exc_info.value)
+
+    def test_non_json_with_batch_size_keeps_batch_error(self):
+        """A paged request that gets HTML still raises BatchTooLargeError."""
+        from geoparquet_io.core.exceptions import BatchTooLargeError
+        from geoparquet_io.core.http_retry import make_request_with_retry
+
+        mock_client = MagicMock()
+        mock_response = Mock()
+        mock_response.json.side_effect = json.JSONDecodeError("x", "<html>", 0)
+        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_client.get.return_value = mock_response
+
+        with patch("geoparquet_io.core.http_retry.get_shared_http_client") as mock_get_client:
+            mock_get_client.return_value = mock_client
+            with pytest.raises(BatchTooLargeError) as exc_info:
+                make_request_with_retry("GET", "https://example.com/query", batch_size=1000)
+
+        assert exc_info.value.batch_size == 1000
+
 
 class TestCrsParsing:
     """Tests for output-crs parsing helpers."""


### PR DESCRIPTION
Closes #485

## Description

The ArcGIS count and layer-info queries call `make_request_with_retry` without a `batch_size`, so any non-JSON body (WAF block page, proxy error page, HTML 500) raised `BatchTooLargeError` with `batch_size=0` and printed `Batch size 0 too large for <url>`. There is no batch on those requests, so the adaptive batch fallback can never apply and the message points at the wrong cause.

## Technical Details

`make_request_with_retry` now raises `RemoteAccessError` on a non-JSON response when `batch_size is None`; the paged feature fetch keeps raising `BatchTooLargeError` with its real batch size. Both messages now include the response Content-Type and HTTP status, which makes a block page distinguishable from genuine payload truncation. Response bodies are still not included.

Scope note: this PR covers suggestions 1 and 2 from the issue. The User-Agent header (3) and the retry-on-non-JSON change (4) are behavioural changes to every outbound request and are left as follow-ups.

## Breaking Changes
**Does this PR introduce breaking changes?** No

## Related Issue(s)
- #485

## Checklist
- [x] Tests added/updated, run against real data where feasible
- [ ] Integration tests for changes that cross module/format/service boundaries — N/A, unit-level error mapping
- [x] All tests pass (`uv run pytest`) — `tests/test_arcgis.py` error/retry/timeout tests pass; new test fails without the fix and passes with it
- [x] At least one adversarial review (AI counts, rubber stamps don't)
- [ ] CodeRabbit comments fixed or answered — none yet
- [ ] Documentation updated (README, guides, CLI reference) — N/A, error message only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for non-JSON responses from remote services.
  - Reports clearer details, including response type and HTTP status.
  - Prevents non-paged requests from being incorrectly treated as oversized batches.
  - Preserves the requested batch size when reporting paged request failures.

- **Tests**
  - Added regression coverage for HTML and other non-JSON responses in both request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->