### PR TITLE
feat(process): add --where row filter to process aggregate (#568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `--breakdown` pivots, and `--auto` resolution sizing all reflect only the
   matching rows. Semantics and safety validation match `gpio extract --where`;
   also available on the Python API (`aggregate_a5/h3/admin(..., where=...)`).
+  On a hive-partitioned input the clause can filter on partition columns
+  (`--where "year = 2025"`). A `;` statement separator outside a quoted string
+  is now rejected in every `--where` clause (`extract` included), since DuckDB
+  executes multi-statement strings.
 
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`--where` row filter on `gpio process aggregate` (#568).** All three
+  subcommands (`a5`, `h3`, `admin`) accept a DuckDB WHERE clause that filters
+  input rows before aggregation — slice a dataset by year, category, or
+  attribute in the same single-command pass, with no pre-filter rewrite.
+  The filter applies to the source scan, so counts, `--metric` rollups,
+  `--breakdown` pivots, and `--auto` resolution sizing all reflect only the
+  matching rows. Semantics and safety validation match `gpio extract --where`;
+  also available on the Python API (`aggregate_a5/h3/admin(..., where=...)`).
+
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;
   on version/feature mismatches (1.0 metadata using GeoParquet 2.0 native geo

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `--breakdown` pivots, and `--auto` resolution sizing all reflect only the
   matching rows. Semantics and safety validation match `gpio extract --where`;
   also available on the Python API (`aggregate_a5/h3/admin(..., where=...)`).
+  On a hive-partitioned input the clause can filter on partition columns
+  (`--where "year = 2025"`). A `;` statement separator outside a quoted string
+  is now rejected in every `--where` clause (`extract` included), since DuckDB
+  executes multi-statement strings.
 
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`--where` row filter on `gpio process aggregate` (#568).** All three
+  subcommands (`a5`, `h3`, `admin`) accept a DuckDB WHERE clause that filters
+  input rows before aggregation — slice a dataset by year, category, or
+  attribute in the same single-command pass, with no pre-filter rewrite.
+  The filter applies to the source scan, so counts, `--metric` rollups,
+  `--breakdown` pivots, and `--auto` resolution sizing all reflect only the
+  matching rows. Semantics and safety validation match `gpio extract --where`;
+  also available on the Python API (`aggregate_a5/h3/admin(..., where=...)`).
+
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;
   on version/feature mismatches (1.0 metadata using GeoParquet 2.0 native geo

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -884,7 +884,7 @@ stats = table.partition_by_admin('output/', vecorel=True)
 
 ### Aggregation Methods {#aggregation}
 
-#### `aggregate_a5(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon')`
+#### `aggregate_a5(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None)`
 
 Aggregate features into A5 grid cells with per-cell statistics for low-zoom visualization.
 
@@ -904,6 +904,13 @@ result = gpio.read('fields.parquet').aggregate_a5(
 )
 result.write('cells.parquet')
 
+# Aggregate only a subset of rows
+result = gpio.read('fields.parquet').aggregate_a5(
+    resolution=8,
+    where="\"crop:name\" = 'wheat'",
+)
+result.write('wheat_cells.parquet')
+
 # No geometry — plain Parquet (re-join a5_cell to geometry later)
 result = gpio.read('fields.parquet').aggregate_a5(
     resolution=8,
@@ -922,10 +929,11 @@ result.write('cells_stats.parquet')
 | `breakdown` | str | None | Categorical column to pivot into `count_<value>` columns |
 | `breakdown_limit` | int | 20 | Max categories; remainder goes into `count_other` |
 | `out_geometry` | str | `"polygon"` | Geometry per cell: `"polygon"`, `"centroid"`, `"both"`, or `"none"` |
+| `where` | str | None | DuckDB WHERE clause filtering input rows before aggregation |
 
 Every output row carries `a5_cell` (UBIGINT) as the bucket identifier.
 
-#### `aggregate_h3(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon')`
+#### `aggregate_h3(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None)`
 
 Aggregate features into H3 hexagonal grid cells. Same options as `aggregate_a5`,
 but the resolution range is **0–15** and the bucket id column is `h3_cell` (a
@@ -944,7 +952,7 @@ result.write('cells.parquet')
 
 Every output row carries `h3_cell` (string) as the bucket identifier.
 
-#### `aggregate_admin(level='country', metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon')`
+#### `aggregate_admin(level='country', metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None)`
 
 Aggregate features into administrative regions (Overture Maps) with per-region statistics.
 

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -981,6 +981,7 @@ result.write('by_region.parquet')
 | `breakdown` | str | None | Categorical column to pivot into `count_<value>` columns |
 | `breakdown_limit` | int | 20 | Max categories; remainder goes into `count_other` |
 | `out_geometry` | str | `"polygon"` | Geometry per region: `"polygon"`, `"centroid"`, `"both"`, or `"none"` |
+| `where` | str | None | DuckDB WHERE clause filtering input rows before aggregation |
 
 Every output row carries `admin_code` and `admin_name` bucket identifiers. Features outside all regions go into an `unassigned` bucket.
 

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1789,6 +1789,15 @@ gpio extract data.parquet output.parquet --where "population > 1000; DROP TABLE 
 # Error: WHERE clause contains potentially dangerous SQL keywords: DROP
 ```
 
+A `;` statement separator is rejected on its own, even when no blocked keyword follows it, because DuckDB executes multi-statement strings:
+
+```bash
+gpio extract data.parquet output.parquet --where "1=1; COPY (SELECT 42) TO 'x.csv'"
+# Error: WHERE clause contains a ';' statement separator outside a quoted string
+```
+
+Semicolons inside string literals or quoted identifiers are fine (`--where "name = 'a;b'"`).
+
 ## Large File Handling
 
 gpio efficiently handles larger-than-memory files using streaming write strategies. The default strategy uses constant memory regardless of file size.

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -146,6 +146,37 @@ Use `--breakdown` to pivot a categorical column into per-category count columns 
     result.write('cells.parquet')
     ```
 
+### Row Filtering
+
+Use `--where` to aggregate only a subset of rows — a year, a category, a confidence threshold — without a separate pre-filter/rewrite pass. The clause is standard DuckDB SQL and applies to the source scan, so counts, metrics, breakdowns, and `--auto` resolution sizing all reflect only the filtered rows. All three subcommands (`a5`, `h3`, `admin`) support it, with the same semantics as [`gpio extract --where`](extract.md).
+
+=== "CLI"
+
+    ```bash
+    # Only 2025 rows (column names with special characters need
+    # double quotes in SQL; shell escaping varies)
+    gpio process aggregate a5 fields.parquet cells.parquet --resolution 6 \
+        --where "year(\"determination:datetime\") = 2025"
+
+    # Category / attribute filters
+    gpio process aggregate h3 fields.parquet cells.parquet --resolution 8 \
+        --where "\"crop:name\" = 'wheat'"
+    gpio process aggregate admin fields.parquet by_country.parquet --level country \
+        --where "confidence >= 50"
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    result = gpio.read('fields.parquet').aggregate_a5(
+        resolution=6,
+        where="year(\"determination:datetime\") = 2025",
+    )
+    result.write('cells.parquet')
+    ```
+
 ### Output Geometry
 
 Control what geometry each output row carries with `--out-geometry`:
@@ -393,6 +424,7 @@ Regardless of the chosen bucket scheme, every output file contains:
 Both commands support the standard output options:
 
 ```bash
+--where "confidence >= 50"  # DuckDB WHERE clause filtering input rows
 --compression SNAPPY      # Output compression (default: ZSTD)
 --geoparquet-version 1.1  # GeoParquet spec version
 --show-sql                # Print the generated DuckDB SQL

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -163,6 +163,10 @@ Use `--where` to aggregate only a subset of rows — a year, a category, a confi
         --where "\"crop:name\" = 'wheat'"
     gpio process aggregate admin fields.parquet by_country.parquet --level country \
         --where "confidence >= 50"
+
+    # Hive partition columns are filterable too
+    gpio process aggregate h3 "fields/**/*.parquet" cells.parquet --resolution 8 \
+        --where "year = 2025"
     ```
 
 === "Python"
@@ -176,6 +180,10 @@ Use `--where` to aggregate only a subset of rows — a year, a category, a confi
     )
     result.write('cells.parquet')
     ```
+
+On a hive-partitioned input (`year=2025/...`), the partition columns are part of the scan, so `--where "year = 2025"` filters on them and DuckDB prunes the partitions it does not need. Partition columns never appear in the aggregated output.
+
+The clause must be a single filtering expression: a `;` statement separator outside a quoted string is rejected, as are keywords that modify data (`DROP`, `DELETE`, `INSERT`, ...).
 
 ### Output Geometry
 

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -271,6 +271,7 @@ def aggregate_a5(
     breakdown_limit: int = 20,
     out_geometry: str = "polygon",
     geometry_column: str | None = None,
+    where: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into A5 grid cells with per-cell statistics.
@@ -283,6 +284,7 @@ def aggregate_a5(
         breakdown_limit: Max number of breakdown categories (default: 20)
         out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
         geometry_column: Geometry column name (defaults to "geometry")
+        where: DuckDB WHERE clause filtering input rows before aggregation
 
     Returns:
         New PyArrow Table with one row per A5 cell
@@ -297,6 +299,7 @@ def aggregate_a5(
         breakdown_limit=breakdown_limit,
         out_geometry=out_geometry,
         geometry_column=geometry_column,
+        where=where,
     )
 
 
@@ -308,6 +311,7 @@ def aggregate_h3(
     breakdown_limit: int = 20,
     out_geometry: str = "polygon",
     geometry_column: str | None = None,
+    where: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into H3 grid cells with per-cell statistics.
@@ -320,6 +324,7 @@ def aggregate_h3(
         breakdown_limit: Max number of breakdown categories (default: 20)
         out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
         geometry_column: Geometry column name (defaults to "geometry")
+        where: DuckDB WHERE clause filtering input rows before aggregation
 
     Returns:
         New PyArrow Table with one row per H3 cell
@@ -334,6 +339,7 @@ def aggregate_h3(
         breakdown_limit=breakdown_limit,
         out_geometry=out_geometry,
         geometry_column=geometry_column,
+        where=where,
     )
 
 
@@ -344,6 +350,7 @@ def aggregate_admin(
     breakdown: str | None = None,
     breakdown_limit: int = 20,
     out_geometry: str = "polygon",
+    where: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into administrative regions with per-region statistics.
@@ -355,6 +362,7 @@ def aggregate_admin(
         breakdown: Column name to pivot into per-category count columns
         breakdown_limit: Max number of breakdown categories (default: 20)
         out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
+        where: DuckDB WHERE clause filtering input rows before aggregation
 
     Returns:
         New PyArrow Table with one row per admin region
@@ -374,6 +382,7 @@ def aggregate_admin(
         breakdown=breakdown,
         breakdown_limit=breakdown_limit,
         out_geometry=out_geometry,
+        where=where,
     )
 
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1380,6 +1380,7 @@ class Table:
         breakdown: str | None = None,
         breakdown_limit: int = 20,
         out_geometry: str = "polygon",
+        where: str | None = None,
     ) -> Table:
         """
         Aggregate features into A5 grid cells with per-cell statistics.
@@ -1390,6 +1391,7 @@ class Table:
             breakdown: Column name to pivot into per-category count columns
             breakdown_limit: Max number of breakdown categories (default: 20)
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
+            where: DuckDB WHERE clause filtering input rows before aggregation
 
         Returns:
             New Table with one row per A5 cell
@@ -1404,6 +1406,7 @@ class Table:
             breakdown_limit=breakdown_limit,
             out_geometry=out_geometry,
             geometry_column=self._geometry_column,
+            where=where,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 
@@ -1414,6 +1417,7 @@ class Table:
         breakdown: str | None = None,
         breakdown_limit: int = 20,
         out_geometry: str = "polygon",
+        where: str | None = None,
     ) -> Table:
         """
         Aggregate features into H3 grid cells with per-cell statistics.
@@ -1424,6 +1428,7 @@ class Table:
             breakdown: Column name to pivot into per-category count columns
             breakdown_limit: Max number of breakdown categories (default: 20)
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
+            where: DuckDB WHERE clause filtering input rows before aggregation
 
         Returns:
             New Table with one row per H3 cell
@@ -1438,6 +1443,7 @@ class Table:
             breakdown_limit=breakdown_limit,
             out_geometry=out_geometry,
             geometry_column=self._geometry_column,
+            where=where,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 
@@ -1448,6 +1454,7 @@ class Table:
         breakdown: str | None = None,
         breakdown_limit: int = 20,
         out_geometry: str = "polygon",
+        where: str | None = None,
     ) -> Table:
         """
         Aggregate features into administrative regions with per-region statistics.
@@ -1458,6 +1465,7 @@ class Table:
             breakdown: Column name to pivot into per-category count columns
             breakdown_limit: Max number of breakdown categories (default: 20)
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
+            where: DuckDB WHERE clause filtering input rows before aggregation
 
         Returns:
             New Table with one row per admin region
@@ -1471,6 +1479,7 @@ class Table:
             breakdown=breakdown,
             breakdown_limit=breakdown_limit,
             out_geometry=out_geometry,
+            where=where,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -353,6 +353,15 @@ def partition_options_base(func):
     return func
 
 
+def where_option(func):
+    """Add the ``--where`` row-filter option (same wording as `gpio extract`)."""
+    return click.option(
+        "--where",
+        help="DuckDB WHERE clause for filtering rows. Column names with special "
+        'characters need double quotes in SQL (e.g., "crop:name"). Shell escaping varies.',
+    )(func)
+
+
 def grid_aggregate_options(func):
     """Add the options shared by `gpio process aggregate <grid>` commands.
 
@@ -360,8 +369,9 @@ def grid_aggregate_options(func):
     valid range differs between grids):
     - --auto, --target-per-cell, --max-cells
     - --metric, --breakdown, --breakdown-limit
-    - --out-geometry
+    - --out-geometry, --where
     """
+    func = where_option(func)
     func = click.option(
         "--out-geometry",
         type=click.Choice(["polygon", "centroid", "both", "none"]),

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -30,6 +30,7 @@ from geoparquet_io.cli.decorators import (
     row_group_options,
     show_sql_option,
     verbose_option,
+    where_option,
     write_strategy_option,
 )
 from geoparquet_io.cli.fix_helpers import handle_fix_common
@@ -44,7 +45,7 @@ from geoparquet_io.core.check_parquet_structure import CheckProfile
 from geoparquet_io.core.check_parquet_structure import check_all as check_structure_impl
 from geoparquet_io.core.check_spatial_order import check_spatial_order as check_spatial_impl
 from geoparquet_io.core.convert import convert_to_geoparquet
-from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.exceptions import InvalidParameterError, ValidationError
 from geoparquet_io.core.extract import extract as extract_impl
 from geoparquet_io.core.file_utils import validate_parquet_extension
 from geoparquet_io.core.hilbert_order import hilbert_order as hilbert_impl
@@ -7044,6 +7045,7 @@ def process_aggregate_a5(
     breakdown,
     breakdown_limit,
     out_geometry,
+    where,
     compression,
     compression_level,
     verbose,
@@ -7057,6 +7059,8 @@ def process_aggregate_a5(
         gpio process aggregate a5 fields.parquet cells.parquet --resolution 8
         gpio process aggregate a5 fields.parquet cells.parquet --auto \\
             --metric "sum:area_ha" --breakdown crop_type
+        gpio process aggregate a5 fields.parquet cells.parquet --resolution 8 \\
+            --where "\\"crop:name\\" = 'wheat'"
         gpio process aggregate a5 fields.parquet cells.csv-like.parquet \\
             --resolution 8 --out-geometry none
     """
@@ -7078,8 +7082,9 @@ def process_aggregate_a5(
                 geoparquet_version=geoparquet_version,
                 verbose=verbose,
                 show_sql=show_sql,
+                where=where,
             )
-        except (InvalidParameterError, ValueError, duckdb.Error) as exc:
+        except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise click.ClickException(str(exc)) from exc
 
 
@@ -7110,6 +7115,7 @@ def process_aggregate_h3(
     breakdown,
     breakdown_limit,
     out_geometry,
+    where,
     compression,
     compression_level,
     verbose,
@@ -7123,6 +7129,8 @@ def process_aggregate_h3(
         gpio process aggregate h3 fields.parquet cells.parquet --resolution 8
         gpio process aggregate h3 fields.parquet cells.parquet --auto \\
             --metric "sum:area_ha" --breakdown crop_type
+        gpio process aggregate h3 fields.parquet cells.parquet --resolution 8 \\
+            --where "confidence >= 50"
         gpio process aggregate h3 fields.parquet cells.parquet \\
             --resolution 8 --out-geometry none
     """
@@ -7144,8 +7152,9 @@ def process_aggregate_h3(
                 geoparquet_version=geoparquet_version,
                 verbose=verbose,
                 show_sql=show_sql,
+                where=where,
             )
-        except (InvalidParameterError, ValueError, duckdb.Error) as exc:
+        except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise click.ClickException(str(exc)) from exc
 
 
@@ -7180,6 +7189,7 @@ def process_aggregate_h3(
     default="polygon",
     help="Output geometry per region (default: polygon).",
 )
+@where_option
 @compression_options
 @verbose_option
 @geoparquet_version_option
@@ -7194,6 +7204,7 @@ def process_aggregate_admin(
     breakdown,
     breakdown_limit,
     out_geometry,
+    where,
     compression,
     compression_level,
     verbose,
@@ -7207,6 +7218,8 @@ def process_aggregate_admin(
         gpio process aggregate admin fields.parquet by_country.parquet --level country
         gpio process aggregate admin fields.parquet by_region.parquet \\
             --level region --metric "sum:area_ha" --breakdown crop_type
+        gpio process aggregate admin fields.parquet by_country.parquet \\
+            --level country --where "confidence >= 50"
     """
     with _activate_s3(ctx):
         try:
@@ -7223,8 +7236,9 @@ def process_aggregate_admin(
                 geoparquet_version=geoparquet_version,
                 verbose=verbose,
                 show_sql=show_sql,
+                where=where,
             )
-        except (InvalidParameterError, ValueError, duckdb.Error) as exc:
+        except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise click.ClickException(str(exc)) from exc
 
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -6999,6 +6999,25 @@ def pmtiles_create(
 # =============================================================================
 
 
+def _aggregate_error(exc: Exception, where: str | None) -> click.ClickException:
+    """Turn an aggregation failure into a message a user can act on.
+
+    A bad ``--where`` clause surfaces as a raw DuckDB binder/parser error that
+    echoes the whole generated SQL, which buries the actual cause. Drop the SQL
+    echo and name ``--where`` as the likely culprit (gpio #612). Non-DuckDB
+    errors (validation, bad parameters) already read well and pass through.
+    """
+    if not isinstance(exc, duckdb.Error):
+        return click.ClickException(str(exc))
+    message = str(exc).split("\nLINE ")[0].strip()
+    if where:
+        message += (
+            f'\n\nThis is most likely caused by --where "{where}" '
+            "-- check the column names and SQL syntax."
+        )
+    return click.ClickException(message)
+
+
 @cli.group()
 @click.pass_context
 def process(ctx):
@@ -7085,7 +7104,7 @@ def process_aggregate_a5(
                 where=where,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
-            raise click.ClickException(str(exc)) from exc
+            raise _aggregate_error(exc, where) from exc
 
 
 @process_aggregate.command(name="h3")
@@ -7155,7 +7174,7 @@ def process_aggregate_h3(
                 where=where,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
-            raise click.ClickException(str(exc)) from exc
+            raise _aggregate_error(exc, where) from exc
 
 
 @process_aggregate.command(name="admin")
@@ -7239,7 +7258,7 @@ def process_aggregate_admin(
                 where=where,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
-            raise click.ClickException(str(exc)) from exc
+            raise _aggregate_error(exc, where) from exc
 
 
 if __name__ == "__main__":

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -126,13 +126,47 @@ DANGEROUS_SQL_KEYWORDS = [
 ]
 
 
+def _has_unquoted_semicolon(where_clause: str) -> bool:
+    """True if ``where_clause`` contains a ``;`` outside a quoted string/identifier.
+
+    Quote state is tracked so legitimate data (``name = 'a;b'``) and identifiers
+    (``"weird;col"``) are not flagged. A doubled quote inside a literal toggles
+    the state twice, which leaves the tracking correct.
+    """
+    in_single = False
+    in_double = False
+    for ch in where_clause:
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == ";" and not in_single and not in_double:
+            return True
+    return False
+
+
+def where_sql_fragment(where_clause: str | None) -> str:
+    """Return a `` WHERE (...)`` fragment for ``where_clause`` (empty if None).
+
+    A newline is placed before the closing paren so a trailing ``--`` comment in
+    the clause cannot swallow the paren -- or whatever the caller appends next
+    (``USING SAMPLE``, a JOIN, ...). Callers are responsible for validating the
+    clause with :func:`validate_where_clause` first.
+    """
+    if not where_clause:
+        return ""
+    return f" WHERE ({where_clause}\n)"
+
+
 def validate_where_clause(where_clause: str) -> None:
     """
     Validate WHERE clause for potentially dangerous SQL keywords.
 
     This is a basic safety check to prevent accidental or intentional
     SQL injection attacks. It checks for keywords that could modify
-    data or database structure.
+    data or database structure, and for statement separators: DuckDB's
+    ``execute()`` runs multi-statement strings, so a ``;`` in an interpolated
+    clause could append an entirely new statement (gpio #612).
 
     Note: This feature is intended for trusted users. For untrusted input,
     additional validation or parameterized queries would be required.
@@ -141,7 +175,7 @@ def validate_where_clause(where_clause: str) -> None:
         where_clause: The WHERE clause string to validate
 
     Raises:
-        ValidationError: If dangerous SQL keywords are found
+        ValidationError: If dangerous SQL keywords or a statement separator are found
     """
     from geoparquet_io.core.exceptions import ValidationError
 
@@ -160,6 +194,16 @@ def validate_where_clause(where_clause: str) -> None:
             f"WHERE clause contains potentially dangerous SQL keywords: {', '.join(found_keywords)}. "
             "Only SELECT-style filtering expressions are allowed in --where. "
             "If you need to perform data modifications, use DuckDB directly."
+        )
+
+    # The keyword blocklist cannot see every harmful statement (COPY, ATTACH,
+    # PRAGMA, ...), so reject the separator itself: without a ';' the clause
+    # cannot start a second statement whatever it contains (gpio #612).
+    if _has_unquoted_semicolon(where_clause):
+        raise ValidationError(
+            "WHERE clause contains a ';' statement separator outside a quoted string. "
+            "Only a single filtering expression is allowed in --where. "
+            "If you need to run multiple statements, use DuckDB directly."
         )
 
 

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -5,6 +5,7 @@ This module provides functions for creating and managing DuckDB connections
 with appropriate extensions loaded for GeoParquet operations.
 """
 
+import re
 import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -104,6 +105,62 @@ def quote_identifier(name: str) -> str:
     """
     escaped = name.replace('"', '""')
     return f'"{escaped}"'
+
+
+# SQL keywords that could be dangerous in a user-supplied WHERE clause.
+# These could modify data or database structure.
+DANGEROUS_SQL_KEYWORDS = [
+    "DROP",
+    "DELETE",
+    "INSERT",
+    "UPDATE",
+    "CREATE",
+    "ALTER",
+    "TRUNCATE",
+    "EXEC",
+    "EXECUTE",
+    "MERGE",
+    "REPLACE",
+    "GRANT",
+    "REVOKE",
+]
+
+
+def validate_where_clause(where_clause: str) -> None:
+    """
+    Validate WHERE clause for potentially dangerous SQL keywords.
+
+    This is a basic safety check to prevent accidental or intentional
+    SQL injection attacks. It checks for keywords that could modify
+    data or database structure.
+
+    Note: This feature is intended for trusted users. For untrusted input,
+    additional validation or parameterized queries would be required.
+
+    Args:
+        where_clause: The WHERE clause string to validate
+
+    Raises:
+        ValidationError: If dangerous SQL keywords are found
+    """
+    from geoparquet_io.core.exceptions import ValidationError
+
+    # Match dangerous keywords as whole words (case-insensitive); word boundaries
+    # avoid false positives (e.g. "UPDATED_AT" must not match).
+    upper_clause = where_clause.upper()
+    found_keywords = []
+
+    for keyword in DANGEROUS_SQL_KEYWORDS:
+        pattern = rf"\b{keyword}\b"
+        if re.search(pattern, upper_clause):
+            found_keywords.append(keyword)
+
+    if found_keywords:
+        raise ValidationError(
+            f"WHERE clause contains potentially dangerous SQL keywords: {', '.join(found_keywords)}. "
+            "Only SELECT-style filtering expressions are allowed in --where. "
+            "If you need to perform data modifications, use DuckDB directly."
+        )
 
 
 def build_spatial_join_condition(

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -11,7 +11,6 @@ Also supports Arrow IPC streaming for Unix-style piping:
 from __future__ import annotations
 
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -24,15 +23,16 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.crs_utils import get_crs_display_name
 from geoparquet_io.core.duckdb_utils import (
+    DANGEROUS_SQL_KEYWORDS,  # noqa: F401 - re-exported for backwards compatibility
     _escape_sql_string,
     get_duckdb_connection,
     get_duckdb_connection_for_s3,
+    validate_where_clause,
 )
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
     GeoParquetError,
     InvalidParameterError,
-    ValidationError,
 )
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import (
@@ -60,61 +60,6 @@ def get_parquet_row_count(parquet_file: str) -> int:
     from geoparquet_io.core.duckdb_metadata import get_row_count
 
     return get_row_count(parquet_file)
-
-
-# SQL keywords that could be dangerous in a WHERE clause
-# These could modify data or database structure
-DANGEROUS_SQL_KEYWORDS = [
-    "DROP",
-    "DELETE",
-    "INSERT",
-    "UPDATE",
-    "CREATE",
-    "ALTER",
-    "TRUNCATE",
-    "EXEC",
-    "EXECUTE",
-    "MERGE",
-    "REPLACE",
-    "GRANT",
-    "REVOKE",
-]
-
-
-def validate_where_clause(where_clause: str) -> None:
-    """
-    Validate WHERE clause for potentially dangerous SQL keywords.
-
-    This is a basic safety check to prevent accidental or intentional
-    SQL injection attacks. It checks for keywords that could modify
-    data or database structure.
-
-    Note: This feature is intended for trusted users. For untrusted input,
-    additional validation or parameterized queries would be required.
-
-    Args:
-        where_clause: The WHERE clause string to validate
-
-    Raises:
-        ValidationError: If dangerous SQL keywords are found
-    """
-    # Build pattern to match dangerous keywords as whole words (case-insensitive)
-    # Use word boundaries to avoid false positives (e.g., "UPDATED_AT" shouldn't match)
-    upper_clause = where_clause.upper()
-    found_keywords = []
-
-    for keyword in DANGEROUS_SQL_KEYWORDS:
-        # Match keyword as a whole word
-        pattern = rf"\b{keyword}\b"
-        if re.search(pattern, upper_clause):
-            found_keywords.append(keyword)
-
-    if found_keywords:
-        raise ValidationError(
-            f"WHERE clause contains potentially dangerous SQL keywords: {', '.join(found_keywords)}. "
-            "Only SELECT-style filtering expressions are allowed in --where. "
-            "If you need to perform data modifications, use DuckDB directly."
-        )
 
 
 def looks_like_latlong_bbox(bbox: tuple[float, float, float, float]) -> bool:

--- a/geoparquet_io/core/partition/auto_resolution.py
+++ b/geoparquet_io/core/partition/auto_resolution.py
@@ -36,7 +36,10 @@ _INDEX_EXTENSIONS = {
 
 
 def _get_total_row_count(
-    input_parquet: str, verbose: bool = False, profile: str | None = None
+    input_parquet: str,
+    verbose: bool = False,
+    profile: str | None = None,
+    where: str | None = None,
 ) -> int:
     """
     Get total row count from parquet file.
@@ -45,6 +48,8 @@ def _get_total_row_count(
         input_parquet: Input file path
         verbose: Print debug messages
         profile: AWS profile name for S3 authentication (optional)
+        where: Optional WHERE clause; the count then reflects only matching rows
+            so auto-resolution sizes the grid on the filtered data (#568)
 
     Returns:
         Total number of rows
@@ -62,7 +67,8 @@ def _get_total_row_count(
         if profile:
             setup_aws_profile_if_needed(profile, input_parquet)
 
-        query = f"SELECT COUNT(*) FROM '{input_url}'"
+        where_sql = f" WHERE ({where})" if where else ""
+        query = f"SELECT COUNT(*) FROM '{input_url}'{where_sql}"
         result = con.execute(query).fetchone()
         return result[0] if result else 0
     finally:
@@ -347,7 +353,13 @@ def _geom_sql(con, url: str, geom_col: str) -> str:
 
 
 def _probe_distinct_cell_counts(
-    con, url: str, index_type: str, geom_sql: str, sample_clause: str, resolutions: list[int]
+    con,
+    url: str,
+    index_type: str,
+    geom_sql: str,
+    sample_clause: str,
+    resolutions: list[int],
+    where: str | None = None,
 ) -> list[int]:
     """Count distinct non-empty cells per resolution over a bounded sample.
 
@@ -361,11 +373,15 @@ def _probe_distinct_cell_counts(
     The centroid mirrors the cell assignment in the ``add/`` modules
     (``ST_X/ST_Y(ST_Centroid(geom))``), so probe counts track real partitioning.
     It is computed once per sampled row and reused for lon and lat.
+
+    ``where`` filters rows before sampling (DuckDB applies USING SAMPLE after
+    the WHERE clause), so the probe sees the same rows the aggregation will.
     """
     centroid = f"ST_Centroid({geom_sql})"
+    where_sql = f" WHERE ({where})" if where else ""
     sample_cte = (
         f"SELECT ST_X(c) AS lon, ST_Y(c) AS lat "
-        f"FROM (SELECT {centroid} AS c FROM '{url}'{sample_clause})"
+        f"FROM (SELECT {centroid} AS c FROM '{url}'{where_sql}{sample_clause})"
     )
     if index_type == "quadkey":
         # A level-r quadkey is the length-r prefix of a finer one, so compute the
@@ -420,6 +436,7 @@ def _probe_extent_resolution(
     total_rows: int,
     verbose: bool = False,
     profile: str | None = None,
+    where: str | None = None,
 ) -> int | None:
     """Pick the resolution whose non-empty cell count best matches the target.
 
@@ -462,7 +479,7 @@ def _probe_extent_resolution(
         # budget; otherwise draw a uniform sample of sample_size rows.
         sample_clause = "" if sample_size >= total_rows else f" USING SAMPLE {sample_size} ROWS"
         counts = _probe_distinct_cell_counts(
-            con, url, spatial_index_type, geom_sql, sample_clause, resolutions
+            con, url, spatial_index_type, geom_sql, sample_clause, resolutions, where=where
         )
     except Exception as e:
         if verbose:
@@ -499,6 +516,7 @@ def calculate_auto_resolution(
     max_resolution: int | None = None,
     verbose: bool = False,
     profile: str | None = None,
+    where: str | None = None,
 ) -> int:
     """
     Calculate optimal spatial index resolution for target partition size.
@@ -515,6 +533,7 @@ def calculate_auto_resolution(
         max_resolution: Maximum resolution (None = use index default)
         verbose: Print debug messages
         profile: AWS profile name for S3 authentication (optional)
+        where: Optional WHERE clause; sizing then reflects only matching rows (#568)
 
     Returns:
         Optimal resolution for the specified spatial index
@@ -553,7 +572,7 @@ def calculate_auto_resolution(
         debug(f"Calculating auto-resolution for {spatial_index_type}...")
 
     # Get total row count
-    total_rows = _get_total_row_count(input_parquet, verbose, profile)
+    total_rows = _get_total_row_count(input_parquet, verbose, profile, where=where)
 
     if verbose:
         debug(f"Total rows: {total_rows:,}")
@@ -614,6 +633,7 @@ def calculate_auto_resolution(
         total_rows=total_rows,
         verbose=verbose,
         profile=profile,
+        where=where,
     )
     if probed is not None:
         return probed

--- a/geoparquet_io/core/partition/auto_resolution.py
+++ b/geoparquet_io/core/partition/auto_resolution.py
@@ -13,7 +13,11 @@ import math
 
 from geoparquet_io.core.common import get_duckdb_connection, needs_httpfs
 from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    quote_identifier,
+    validate_where_clause,
+    where_sql_fragment,
+)
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, warn
@@ -33,6 +37,20 @@ _INDEX_EXTENSIONS = {
     "s2": ["INSTALL geography FROM community", "LOAD geography"],
     "quadkey": [],
 }
+
+
+def _count_query(url: str, where: str | None) -> str:
+    """``COUNT(*)`` over ``url``, with any WHERE clause nested in a subquery.
+
+    The nesting is a safety boundary, not cosmetics: interpolated into a
+    top-level statement the clause sits at the end of the string, where a
+    separator could start a second statement (DuckDB's ``execute()`` runs
+    multi-statement strings). Inside the subquery it cannot reach the top level.
+    :func:`validate_where_clause` rejects separators as well (gpio #612).
+    """
+    if not where:
+        return f"SELECT COUNT(*) FROM '{url}'"
+    return f"SELECT COUNT(*) FROM (SELECT 1 FROM '{url}'{where_sql_fragment(where)}) AS __filtered"
 
 
 def _get_total_row_count(
@@ -67,9 +85,7 @@ def _get_total_row_count(
         if profile:
             setup_aws_profile_if_needed(profile, input_parquet)
 
-        where_sql = f" WHERE ({where})" if where else ""
-        query = f"SELECT COUNT(*) FROM '{input_url}'{where_sql}"
-        result = con.execute(query).fetchone()
+        result = con.execute(_count_query(input_url, where)).fetchone()
         return result[0] if result else 0
     finally:
         if con is not None:
@@ -374,15 +390,16 @@ def _probe_distinct_cell_counts(
     (``ST_X/ST_Y(ST_Centroid(geom))``), so probe counts track real partitioning.
     It is computed once per sampled row and reused for lon and lat.
 
-    ``where`` filters rows before sampling (DuckDB applies USING SAMPLE after
-    the WHERE clause), so the probe sees the same rows the aggregation will.
+    ``where`` restricts the probe to the rows the aggregation will see. The
+    filter is nested *beneath* the sample: a WHERE sitting next to ``USING
+    SAMPLE`` is planned as a FILTER *above* RESERVOIR_SAMPLE, so a selective
+    clause would leave only a fraction of the sample budget and the probe would
+    over-resolve (gpio #612). Nesting also keeps the clause away from the top
+    level of the statement, where it could otherwise chain a second one.
     """
     centroid = f"ST_Centroid({geom_sql})"
-    where_sql = f" WHERE ({where})" if where else ""
-    sample_cte = (
-        f"SELECT ST_X(c) AS lon, ST_Y(c) AS lat "
-        f"FROM (SELECT {centroid} AS c FROM '{url}'{where_sql}{sample_clause})"
-    )
+    filtered = f"(SELECT {centroid} AS c FROM '{url}'{where_sql_fragment(where)})"
+    sample_cte = f"SELECT ST_X(c) AS lon, ST_Y(c) AS lat FROM {filtered}{sample_clause}"
     if index_type == "quadkey":
         # A level-r quadkey is the length-r prefix of a finer one, so compute the
         # finest quadkey once per row and take substrings (avoids a UDF call per
@@ -568,6 +585,11 @@ def calculate_auto_resolution(
     if max_partitions <= 0:
         raise ValueError(f"max_partitions must be a positive integer, got {max_partitions}")
 
+    # Shared partition entry point: callers may pass a clause straight through,
+    # so validate here rather than trusting each of them to have done it (#612).
+    if where:
+        validate_where_clause(where)
+
     if verbose:
         debug(f"Calculating auto-resolution for {spatial_index_type}...")
 
@@ -578,6 +600,13 @@ def calculate_auto_resolution(
         debug(f"Total rows: {total_rows:,}")
 
     if total_rows == 0:
+        # Name the filter when there is one: the file may be full of rows and
+        # only the clause empty-handed, which "no rows" alone would misattribute.
+        if where:
+            raise ValueError(
+                f'No rows match the --where filter "{where}", so there is nothing to size '
+                "the resolution on. Check the clause, or pass an explicit resolution."
+            )
         raise ValueError("Input file has no rows")
 
     # Calculate resolution based on spatial index type

--- a/geoparquet_io/core/process/aggregate/by_a5.py
+++ b/geoparquet_io/core/process/aggregate/by_a5.py
@@ -49,6 +49,7 @@ def aggregate_by_a5(
     geoparquet_version: str | None = None,
     verbose: bool = False,
     show_sql: bool = False,
+    where: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into A5 cells. Writes the output file."""
     aggregate_grid_file(
@@ -69,6 +70,7 @@ def aggregate_by_a5(
         geoparquet_version=geoparquet_version,
         verbose=verbose,
         show_sql=show_sql,
+        where=where,
     )
 
 
@@ -81,6 +83,7 @@ def aggregate_a5_table(
     out_geometry: str = "polygon",
     a5_column_name: str = DEFAULT_A5_COLUMN_NAME,
     geometry_column: str | None = None,
+    where: str | None = None,
 ):
     """Aggregate an in-memory Arrow table by a5 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
@@ -93,4 +96,5 @@ def aggregate_a5_table(
         out_geometry=out_geometry,
         cell_column=a5_column_name,
         geometry_column=geometry_column,
+        where=where,
     )

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -13,6 +13,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
     validate_where_clause,
+    where_sql_fragment,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import safe_file_url
@@ -24,6 +25,7 @@ from geoparquet_io.core.partition.admin_hierarchical import (
 )
 from geoparquet_io.core.process.aggregate.common import (
     VALID_OUT_GEOMETRY,
+    aggregate_source_relation,
     build_breakdown_column_names,
     build_breakdown_select,
     build_metric_select,
@@ -73,7 +75,8 @@ def _build_joined_sql(
 
     ``where`` is applied to the inner input scan, so the spatial join, metrics,
     and breakdowns all see only the filtered rows (#568). The caller validates
-    the clause.
+    the clause. Hive partition columns are visible to it (#612); see
+    :func:`aggregate_source_relation`.
     """
     if admin_bbox_col:
         bbox_filter = (
@@ -84,7 +87,6 @@ def _build_joined_sql(
         )
     else:
         bbox_filter = ""
-    where_sql = f" WHERE ({where})" if where else ""
     return f"""
         SELECT s.*,
                b.{quote_identifier(code_col)} AS __admin_code,
@@ -92,8 +94,8 @@ def _build_joined_sql(
                ST_AsWKB(b.{quote_identifier(admin_geom_col)}) AS __admin_geom
         FROM (
             SELECT *, ST_Centroid({input_geom_expr}) AS __cen
-            FROM read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)
-            {where_sql}
+            FROM {aggregate_source_relation(input_url)}
+            {where_sql_fragment(where)}
         ) s
         LEFT JOIN {admin_ref} b
           ON {bbox_filter}ST_Intersects(b.{quote_identifier(admin_geom_col)}, s.__cen)
@@ -205,7 +207,7 @@ def aggregate_by_admin(
 
         admin_ref = _get_admin_ref(admin_dataset, con, level)
 
-        read_rel = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
+        read_rel = aggregate_source_relation(input_url)
         # Admin boundaries are OGC:CRS84; reproject a non-CRS84 input so ST_Intersects
         # does not fail on a CRS mismatch and the centroid lands correctly (#525).
         source_crs = extract_crs_from_parquet(input_parquet, verbose)

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -9,7 +9,11 @@ import pyarrow.parquet as pq
 
 from geoparquet_io.core.common import write_geoparquet_table
 from geoparquet_io.core.crs_utils import crs_transform_sql_expr, extract_crs_from_parquet
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    quote_identifier,
+    validate_where_clause,
+)
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -52,6 +56,7 @@ def _build_joined_sql(
     name_col: str,
     admin_geom_col: str,
     admin_bbox_col: str | None = None,
+    where: str | None = None,
 ) -> str:
     """Build the spatial-join SQL tagging each input feature with its admin region.
 
@@ -65,6 +70,10 @@ def _build_joined_sql(
     When admin_bbox_col is provided, a cheap bbox prefilter is added to the ON
     clause so ST_Intersects is only evaluated for admin polygons whose bounding
     box contains the feature centroid point.
+
+    ``where`` is applied to the inner input scan, so the spatial join, metrics,
+    and breakdowns all see only the filtered rows (#568). The caller validates
+    the clause.
     """
     if admin_bbox_col:
         bbox_filter = (
@@ -75,6 +84,7 @@ def _build_joined_sql(
         )
     else:
         bbox_filter = ""
+    where_sql = f" WHERE ({where})" if where else ""
     return f"""
         SELECT s.*,
                b.{quote_identifier(code_col)} AS __admin_code,
@@ -83,6 +93,7 @@ def _build_joined_sql(
         FROM (
             SELECT *, ST_Centroid({input_geom_expr}) AS __cen
             FROM read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)
+            {where_sql}
         ) s
         LEFT JOIN {admin_ref} b
           ON {bbox_filter}ST_Intersects(b.{quote_identifier(admin_geom_col)}, s.__cen)
@@ -138,6 +149,7 @@ def aggregate_by_admin(
     geoparquet_version: str | None = None,
     verbose: bool = False,
     show_sql: bool = False,
+    where: str | None = None,
 ) -> None:
     """Aggregate input features by administrative region.
 
@@ -160,6 +172,7 @@ def aggregate_by_admin(
         geoparquet_version: GeoParquet spec version to write.
         verbose: Enable verbose debug logging.
         show_sql: Log the final SQL query.
+        where: DuckDB WHERE clause filtering input rows before aggregation.
     """
     configure_verbose(verbose)
     if out_geometry not in VALID_OUT_GEOMETRY:
@@ -167,6 +180,8 @@ def aggregate_by_admin(
             "out_geometry",
             f"Invalid value '{out_geometry}'. Valid: {', '.join(sorted(VALID_OUT_GEOMETRY))}",
         )
+    if where:
+        validate_where_clause(where)
     metrics = parse_metrics(metric)
 
     admin_dataset, _boundary_columns = _setup_admin_dataset(dataset, verbose, [level])
@@ -205,6 +220,7 @@ def aggregate_by_admin(
             name_col,
             admin_geom_col,
             admin_bbox_col,
+            where=where,
         )
 
         # When a breakdown is requested, materialize the spatial join once so that

--- a/geoparquet_io/core/process/aggregate/by_h3.py
+++ b/geoparquet_io/core/process/aggregate/by_h3.py
@@ -49,6 +49,7 @@ def aggregate_by_h3(
     geoparquet_version: str | None = None,
     verbose: bool = False,
     show_sql: bool = False,
+    where: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into H3 cells. Writes the output file."""
     aggregate_grid_file(
@@ -69,6 +70,7 @@ def aggregate_by_h3(
         geoparquet_version=geoparquet_version,
         verbose=verbose,
         show_sql=show_sql,
+        where=where,
     )
 
 
@@ -81,6 +83,7 @@ def aggregate_h3_table(
     out_geometry: str = "polygon",
     h3_column_name: str = DEFAULT_H3_COLUMN_NAME,
     geometry_column: str | None = None,
+    where: str | None = None,
 ):
     """Aggregate an in-memory Arrow table by h3 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
@@ -93,4 +96,5 @@ def aggregate_h3_table(
         out_geometry=out_geometry,
         cell_column=h3_column_name,
         geometry_column=geometry_column,
+        where=where,
     )

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -13,6 +13,23 @@ VALID_METRIC_FUNCS = {"sum", "avg", "min", "max"}
 VALID_OUT_GEOMETRY = {"polygon", "centroid", "both", "none"}
 
 
+def aggregate_source_relation(input_url: str) -> str:
+    """``read_parquet`` expression for the input scan of an aggregation.
+
+    Hive partitioning is left to DuckDB's auto-detection (the default) rather
+    than forced off, so ``--where "year = 2025"`` can filter on a partition
+    column of a hive-style glob/directory -- the documented use case, which the
+    forced ``hive_partitioning=false`` broke with a Binder error while the
+    ``--auto`` row-count path (a bare ``FROM 'url'``, auto-detecting) accepted
+    it (gpio #612).
+
+    Partition columns cannot leak into the output: every aggregation projects a
+    fixed column list (bucket id, count, metrics, breakdown pivots, geometry),
+    so a passthrough column added by the scan is dropped by the GROUP BY.
+    """
+    return f"read_parquet('{input_url}', union_by_name=true)"
+
+
 def geometry_to_geom_expr(con, relation: str, geom_col: str) -> str:
     """Return a SQL expression yielding a GEOMETRY for ``geom_col`` in ``relation``.
 

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -21,7 +21,11 @@ from geoparquet_io.core.crs_utils import (
     extract_crs_from_parquet,
     extract_crs_from_table,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    quote_identifier,
+    validate_where_clause,
+)
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -82,17 +86,26 @@ def _exclude_reserved(con, relation: str, extra: tuple[str, ...] = ()) -> str:
     return f" EXCLUDE ({', '.join(quote_identifier(c) for c in drop)})" if drop else ""
 
 
-def read_grid_source_sql(con, input_url: str, geom_col: str, source_crs=None) -> str:
+def read_grid_source_sql(
+    con, input_url: str, geom_col: str, source_crs=None, where: str | None = None
+) -> str:
     """Source relation exposing the original columns plus a GEOMETRY ``__geom``.
 
     Detects whether the input geometry column is read as GEOMETRY (real GeoParquet)
     or BLOB (plain WKB) so it works on both. Grid keying expects lon/lat, so a
     non-CRS84 ``source_crs`` is reprojected to OGC:CRS84 before keying (#525); a
     CRS-less / already-CRS84 input is left untouched.
+
+    ``where`` is applied to this source scan, so keying, metrics, and breakdowns
+    all see only the filtered rows (#568). The caller validates the clause.
     """
     read_rel = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
     geom_expr = crs_transform_sql_expr(geometry_to_geom_expr(con, read_rel, geom_col), source_crs)
-    return f"SELECT *{_exclude_reserved(con, read_rel)}, {geom_expr} AS __geom FROM {read_rel}"
+    where_sql = f" WHERE ({where})" if where else ""
+    return (
+        f"SELECT *{_exclude_reserved(con, read_rel)}, {geom_expr} AS __geom "
+        f"FROM {read_rel}{where_sql}"
+    )
 
 
 def build_grid_query(
@@ -175,10 +188,14 @@ def wrap_grid_geometry(
 
 
 def _resolve_resolution(
-    scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose
+    scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose, where=None
 ):
-    """Resolve the explicit or auto resolution and validate against scheme bounds."""
-    from geoparquet_io.core.partition.auto_resolution import calculate_auto_resolution
+    """Resolve the explicit or auto resolution and validate against scheme bounds.
+
+    ``where`` is forwarded to the auto-resolution sizing so --auto picks the grid
+    from the *filtered* row count, not the raw file size (#568).
+    """
+    from geoparquet_io.core.partition import auto_resolution as _auto_resolution
 
     if auto and resolution is not None:
         raise InvalidParameterError("resolution", "Pass either --resolution or --auto, not both")
@@ -187,12 +204,13 @@ def _resolve_resolution(
             "resolution", f"{scheme.name.upper()} aggregation requires --resolution or --auto"
         )
     if auto:
-        resolution = calculate_auto_resolution(
+        resolution = _auto_resolution.calculate_auto_resolution(
             input_parquet,
             scheme.name,
             target_rows_per_partition=target_per_cell,
             max_partitions=max_cells,
             verbose=verbose,
+            where=where,
         )
         if verbose:
             debug(f"Auto-selected {scheme.name} resolution {resolution}")
@@ -232,13 +250,16 @@ def aggregate_grid_file(
     geoparquet_version: str | None = None,
     verbose: bool = False,
     show_sql: bool = False,
+    where: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into grid cells. Writes the output file."""
     configure_verbose(verbose)
     cell_column = cell_column or scheme.default_column
     _validate_out_geometry(out_geometry)
+    if where:
+        validate_where_clause(where)
     resolution = _resolve_resolution(
-        scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose
+        scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose, where=where
     )
 
     input_url = safe_file_url(input_parquet, verbose)
@@ -251,7 +272,7 @@ def aggregate_grid_file(
         con.execute(f"LOAD {scheme.extension}")
         con.execute("SET geometry_always_xy = true")
 
-        source_sql = read_grid_source_sql(con, input_url, geom_col, source_crs)
+        source_sql = read_grid_source_sql(con, input_url, geom_col, source_crs, where=where)
         final_sql = build_grid_query(
             con,
             scheme,
@@ -312,10 +333,13 @@ def aggregate_grid_table(
     out_geometry: str = "polygon",
     cell_column: str | None = None,
     geometry_column: str | None = None,
+    where: str | None = None,
 ):
     """Aggregate an in-memory Arrow table into grid cells. Returns a new Arrow table."""
     cell_column = cell_column or scheme.default_column
     _validate_out_geometry(out_geometry)
+    if where:
+        validate_where_clause(where)
     if not scheme.min_resolution <= resolution <= scheme.max_resolution:
         raise InvalidParameterError(
             "resolution",
@@ -334,9 +358,10 @@ def aggregate_grid_table(
         geom_expr = crs_transform_sql_expr(
             geometry_to_geom_expr(con, "__agg_input", geom_col), source_crs
         )
+        where_sql = f" WHERE ({where})" if where else ""
         source_sql = (
             f"SELECT *{_exclude_reserved(con, '__agg_input', (geom_col,))}, "
-            f"{geom_expr} AS __geom FROM __agg_input"
+            f"{geom_expr} AS __geom FROM __agg_input{where_sql}"
         )
         final_sql = build_grid_query(
             con,

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -25,6 +25,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
     validate_where_clause,
+    where_sql_fragment,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import safe_file_url
@@ -32,6 +33,7 @@ from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import configure_verbose, debug, info, success
 from geoparquet_io.core.process.aggregate.common import (
     VALID_OUT_GEOMETRY,
+    aggregate_source_relation,
     build_breakdown_column_names,
     build_breakdown_select,
     build_metric_select,
@@ -97,14 +99,15 @@ def read_grid_source_sql(
     CRS-less / already-CRS84 input is left untouched.
 
     ``where`` is applied to this source scan, so keying, metrics, and breakdowns
-    all see only the filtered rows (#568). The caller validates the clause.
+    all see only the filtered rows (#568). The caller validates the clause. Hive
+    partition columns are visible to it (#612); see
+    :func:`aggregate_source_relation`.
     """
-    read_rel = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
+    read_rel = aggregate_source_relation(input_url)
     geom_expr = crs_transform_sql_expr(geometry_to_geom_expr(con, read_rel, geom_col), source_crs)
-    where_sql = f" WHERE ({where})" if where else ""
     return (
         f"SELECT *{_exclude_reserved(con, read_rel)}, {geom_expr} AS __geom "
-        f"FROM {read_rel}{where_sql}"
+        f"FROM {read_rel}{where_sql_fragment(where)}"
     )
 
 
@@ -188,7 +191,14 @@ def wrap_grid_geometry(
 
 
 def _resolve_resolution(
-    scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose, where=None
+    scheme,
+    input_parquet,
+    resolution,
+    auto,
+    target_per_cell,
+    max_cells,
+    verbose,
+    where: str | None = None,
 ):
     """Resolve the explicit or auto resolution and validate against scheme bounds.
 
@@ -358,10 +368,9 @@ def aggregate_grid_table(
         geom_expr = crs_transform_sql_expr(
             geometry_to_geom_expr(con, "__agg_input", geom_col), source_crs
         )
-        where_sql = f" WHERE ({where})" if where else ""
         source_sql = (
             f"SELECT *{_exclude_reserved(con, '__agg_input', (geom_col,))}, "
-            f"{geom_expr} AS __geom FROM __agg_input{where_sql}"
+            f"{geom_expr} AS __geom FROM __agg_input{where_sql_fragment(where)}"
         )
         final_sql = build_grid_query(
             con,

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -214,6 +214,24 @@ class TestValidateWhereClause:
         assert "DROP" in error_msg
         assert "DELETE" in error_msg
 
+    def test_unquoted_semicolon_blocked(self):
+        """A statement separator outside string literals is rejected even when no
+        blocklisted keyword appears (e.g. COPY-based injection, gpio #612)."""
+        with pytest.raises(GeoParquetError) as exc_info:
+            validate_where_clause("1=1); COPY (SELECT 42 AS x) TO '/tmp/pwned.csv'; SELECT (1=1")
+        assert ";" in str(exc_info.value)
+
+    def test_bare_semicolon_blocked(self):
+        with pytest.raises(GeoParquetError):
+            validate_where_clause("1=1;")
+
+    def test_semicolon_inside_single_quoted_literal_allowed(self):
+        validate_where_clause("name = 'a;b'")
+        validate_where_clause("note = 'it''s; fine'")
+
+    def test_semicolon_inside_double_quoted_identifier_allowed(self):
+        validate_where_clause('"weird;col" = 5')
+
 
 class TestConvertGeojsonToWkt:
     """Tests for convert_geojson_to_wkt function."""

--- a/tests/test_process_aggregate_where.py
+++ b/tests/test_process_aggregate_where.py
@@ -65,7 +65,9 @@ def test_read_grid_source_sql_appends_where(tmp_path):
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
         sql = read_grid_source_sql(con, str(src), "geometry", where="area > 3")
-        assert "WHERE (area > 3)" in sql
+        # The clause is closed on its own line so a trailing `--` comment in it
+        # cannot swallow the paren (#612).
+        assert "WHERE (area > 3\n)" in sql
         count = con.execute(f"SELECT COUNT(*) FROM ({sql})").fetchone()[0]
         assert count == 2  # areas 4.0 and 6.0
         # No clause -> unchanged behavior
@@ -88,7 +90,7 @@ def test_build_joined_sql_injects_where_into_inner_scan():
         where="\"crop:name\" = 'wheat'",
     )
     inner = sql.split(") s")[0]  # the input-scan subquery
-    assert "WHERE (\"crop:name\" = 'wheat')" in inner
+    assert "WHERE (\"crop:name\" = 'wheat'\n)" in inner
 
 
 def test_where_validation_rejects_dangerous_keywords(tmp_path):
@@ -179,6 +181,64 @@ def test_aggregate_auto_threads_where_to_auto_resolution(tmp_path, monkeypatch):
     assert captured.get("where") == "area > 3"
 
 
+def test_count_query_nests_where_in_subquery():
+    """The clause must never trail a top-level statement (#612 injection)."""
+    from geoparquet_io.core.partition.auto_resolution import _count_query
+
+    sql = _count_query("f.parquet", "area > 3")
+    assert "FROM (SELECT 1 FROM 'f.parquet'" in sql
+    assert sql.rstrip().endswith("AS __filtered")
+    assert _count_query("f.parquet", None) == "SELECT COUNT(*) FROM 'f.parquet'"
+
+
+def test_auto_resolution_rejects_statement_separator(tmp_path):
+    """A ``;`` payload must be refused before any SQL runs (#612)."""
+    from geoparquet_io.core.partition.auto_resolution import calculate_auto_resolution
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    pwned = tmp_path / "pwned.csv"
+    payload = f"1=1); COPY (SELECT 42 AS x) TO '{pwned}'; SELECT COUNT(*) FROM '{src}' WHERE (1=1"
+    with pytest.raises(ValidationError):
+        calculate_auto_resolution(str(src), "quadkey", target_rows_per_partition=1, where=payload)
+    assert not pwned.exists()
+
+
+def test_cli_auto_where_injection_writes_no_file(tmp_path):
+    """End-to-end: --auto --where cannot be used to run a second statement (#612)."""
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    pwned = tmp_path / "pwned_cli.csv"
+    payload = f"1=1); COPY (SELECT 42 AS x) TO '{pwned}'; SELECT COUNT(*) FROM '{src}' WHERE (1=1"
+    result = CliRunner().invoke(
+        cli,
+        [
+            "process",
+            "aggregate",
+            "a5",
+            str(src),
+            str(tmp_path / "o.parquet"),
+            "--auto",
+            "--where",
+            payload,
+        ],
+    )
+    assert result.exit_code != 0, result.output
+    assert not pwned.exists()
+
+
+def test_auto_empty_filter_result_names_the_filter(tmp_path):
+    """An empty filter result must blame the filter, not the file (#612)."""
+    from geoparquet_io.core.partition.auto_resolution import calculate_auto_resolution
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    with pytest.raises(ValueError, match="--where"):
+        calculate_auto_resolution(
+            str(src), "quadkey", target_rows_per_partition=1, where="area > 1000"
+        )
+
+
 def test_probe_distinct_cell_counts_respects_where(tmp_path):
     from geoparquet_io.core.duckdb_utils import get_duckdb_connection
     from geoparquet_io.core.partition.auto_resolution import (
@@ -198,6 +258,172 @@ def test_probe_distinct_cell_counts_respects_where(tmp_path):
         )
         assert counts_all == [2]
         assert counts_filtered == [1]
+    finally:
+        con.close()
+
+
+def test_probe_filters_beneath_the_sample(tmp_path):
+    """The sample must be drawn from the *filtered* rows, not filtered afterwards.
+
+    DuckDB puts the FILTER above RESERVOIR_SAMPLE when the clause sits next to
+    ``USING SAMPLE``, so a selective filter left only a fraction of the sample
+    and --auto over-resolved (#612).
+    """
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.partition.auto_resolution import (
+        _probe_distinct_cell_counts,
+        _register_quadkey_udf,
+    )
+
+    src = tmp_path / "f.parquet"
+    # 100 wheat rows at 100 distinct locations + 900 corn rows stacked on one spot.
+    rows = [(-170.0 + 3.0 * i, 10.0 + (i % 20), "wheat", 1.0) for i in range(100)]
+    rows += [(10.0, 50.0, "corn", 1.0)] * 900
+    _write_points_geoparquet(src, rows)
+
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        _register_quadkey_udf(con)
+        counts = _probe_distinct_cell_counts(
+            con,
+            str(src),
+            "quadkey",
+            "geometry",
+            " USING SAMPLE 200 ROWS",
+            [8],
+            where="crop = 'wheat'",
+        )
+    finally:
+        con.close()
+    # All 100 matching rows fit the 200-row budget, so every distinct cell is seen.
+    assert counts == [100]
+
+
+def test_read_grid_source_sql_tolerates_trailing_sql_comment(tmp_path):
+    """A trailing ``--`` comment must not swallow what follows the clause (#612)."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(con, str(src), "geometry", where="area > 3 -- big only")
+        assert con.execute(f"SELECT COUNT(*) FROM ({sql})").fetchone()[0] == 2
+    finally:
+        con.close()
+
+
+def test_where_error_message_names_the_where_option():
+    """An invalid clause must point at --where, not dump the generated SQL (#612)."""
+    import duckdb as _duckdb
+
+    from geoparquet_io.cli.main import _aggregate_error
+
+    exc = _duckdb.Error(
+        'Binder Error: Referenced column "yr" not found in FROM clause!\n'
+        "LINE 1: SELECT * EXCLUDE (...) FROM read_parquet('x.parquet') WHERE (yr = 2025)"
+    )
+    err = _aggregate_error(exc, "yr = 2025")
+    assert "--where" in str(err)
+    assert "yr = 2025" in str(err)
+    assert "LINE 1" not in str(err)
+    # Non-DuckDB errors pass through untouched.
+    assert str(_aggregate_error(ValueError("plain"), "yr = 2025")) == "plain"
+
+
+# ---------------------------------------------------------------------------
+# Hive-partitioned input: --where must be able to filter on partition columns
+# ---------------------------------------------------------------------------
+
+
+def _write_hive_points(root):
+    """Write year=2024/ and year=2025/ partitions of two points each."""
+    for year, rows in (
+        (2024, [(10.0, 50.0, "wheat", 1.0), (10.001, 50.001, "corn", 2.0)]),
+        (2025, [(10.002, 50.002, "wheat", 3.0)]),
+    ):
+        part = root / f"year={year}"
+        part.mkdir(parents=True, exist_ok=True)
+        _write_points_geoparquet(part / "data.parquet", rows)
+    return str(root / "**" / "*.parquet")
+
+
+def test_read_grid_source_sql_can_filter_on_hive_partition_column(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    glob = _write_hive_points(tmp_path / "hive")
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(con, glob, "geometry", where="year = 2025")
+        assert con.execute(f"SELECT COUNT(*) FROM ({sql})").fetchone()[0] == 1
+        sql_all = read_grid_source_sql(con, glob, "geometry")
+        assert con.execute(f"SELECT COUNT(*) FROM ({sql_all})").fetchone()[0] == 3
+    finally:
+        con.close()
+
+
+def test_grid_aggregation_output_has_no_hive_partition_column(tmp_path):
+    """Enabling hive partitioning must not leak partition columns into the output."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import (
+        GridScheme,
+        build_grid_query,
+        read_grid_source_sql,
+    )
+
+    # A scheme keyed by plain SQL so the test needs no community extension.
+    scheme = GridScheme(
+        name="test",
+        extension="",
+        min_resolution=0,
+        max_resolution=10,
+        default_column="test_cell",
+        key_template="CAST(floor(ST_X({geom}) * {res}) AS VARCHAR)",
+        boundary_template="{cell}",
+        latlng_template="{cell}",
+        poly_wkb_template="ST_AsWKB(ST_Point(0, 0))",
+        centroid_wkb_template="ST_AsWKB(ST_Point(0, 0))",
+    )
+    glob = _write_hive_points(tmp_path / "hive")
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        source_sql = read_grid_source_sql(con, glob, "geometry")
+        sql = build_grid_query(con, scheme, source_sql, 1, "test_cell", None, "crop", 20, "polygon")
+        cols = set(con.execute(sql).arrow().read_all().column_names)
+        assert "year" not in cols
+        assert {"test_cell", "count", "geometry"} <= cols
+    finally:
+        con.close()
+
+
+def test_admin_joined_sql_can_filter_on_hive_partition_column(tmp_path):
+    """The admin input scan exposes hive partition columns to --where too."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.by_admin import _build_joined_sql
+
+    glob = _write_hive_points(tmp_path / "hive")
+    admin = tmp_path / "admin.parquet"
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        con.execute(
+            f"""
+            COPY (SELECT 'XX' AS country,
+                         ST_GeomFromText('POLYGON((0 0, 20 0, 20 60, 0 60, 0 0))') AS geometry)
+            TO '{admin}' (FORMAT PARQUET)
+            """
+        )
+        sql = _build_joined_sql(
+            glob,
+            "geometry",
+            f"read_parquet('{admin}')",
+            "country",
+            "country",
+            "geometry",
+            where="year = 2025",
+        )
+        assert con.execute(f"SELECT COUNT(*) FROM ({sql})").fetchone()[0] == 1
     finally:
         con.close()
 

--- a/tests/test_process_aggregate_where.py
+++ b/tests/test_process_aggregate_where.py
@@ -39,6 +39,18 @@ FOUR_POINTS = [
 ]
 
 
+def _points_arrow_table():
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    tbl = (
+        con.execute("SELECT ST_AsWKB(ST_Point(10.0, 50.0)) AS geometry, 'wheat' AS crop")
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    return tbl
+
+
 # ---------------------------------------------------------------------------
 # SQL construction units (no grid extension, no network)
 # ---------------------------------------------------------------------------
@@ -92,22 +104,47 @@ def test_cli_where_dangerous_keywords_fail_cleanly(tmp_path):
     src = tmp_path / "f.parquet"
     _write_points_geoparquet(src, FOUR_POINTS[:1])
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        [
-            "process",
-            "aggregate",
-            "a5",
-            str(src),
-            str(tmp_path / "o.parquet"),
-            "--resolution",
-            "5",
-            "--where",
-            "DROP TABLE x",
-        ],
-    )
-    assert result.exit_code != 0
-    assert "dangerous" in result.output.lower()
+    for sub, extra in (
+        ("a5", ["--resolution", "5"]),
+        ("h3", ["--resolution", "5"]),
+        ("admin", ["--level", "country"]),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "process",
+                "aggregate",
+                sub,
+                str(src),
+                str(tmp_path / f"o_{sub}.parquet"),
+                *extra,
+                "--where",
+                "DROP TABLE x",
+            ],
+        )
+        assert result.exit_code != 0, f"{sub} accepted a dangerous clause"
+        assert "dangerous" in result.output.lower(), f"{sub}: {result.output}"
+
+
+def test_admin_where_validation_rejects_dangerous_keywords(tmp_path):
+    """Core admin path validates the clause before any dataset setup."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS[:1])
+    with pytest.raises(ValidationError, match="dangerous"):
+        aggregate_by_admin(
+            str(src), str(tmp_path / "o.parquet"), level="country", where="DELETE FROM x"
+        )
+
+
+def test_table_where_validation_rejects_dangerous_keywords():
+    """In-memory table path validates the clause before touching DuckDB."""
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_a5_table
+
+    tbl = _points_arrow_table()
+    with pytest.raises(ValidationError, match="dangerous"):
+        aggregate_a5_table(tbl, resolution=5, where="TRUNCATE x")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_process_aggregate_where.py
+++ b/tests/test_process_aggregate_where.py
@@ -1,0 +1,300 @@
+"""Tests for --where row filtering on `gpio process aggregate` (issue #568).
+
+The clause must apply to the source scan feeding keying, metrics, breakdowns,
+and --auto resolution sizing, mirroring `gpio extract --where` semantics.
+"""
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.exceptions import ValidationError
+from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+from geoparquet_io.core.process.aggregate.by_h3 import aggregate_by_h3
+
+
+def _write_points_geoparquet(path, rows):
+    """rows: list of (lon, lat, crop, area). Writes a tiny GeoParquet of points."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(f"({lon}, {lat}, '{crop}', {area})" for lon, lat, crop, area in rows)
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry, crop, area
+            FROM (VALUES {values}) AS t(lon, lat, crop, area)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+FOUR_POINTS = [
+    (10.00, 50.00, "wheat", 4.0),
+    (10.001, 50.001, "wheat", 6.0),
+    (10.002, 50.002, "corn", 2.0),
+    (-120.0, 40.0, "wheat", 1.0),
+]
+
+
+# ---------------------------------------------------------------------------
+# SQL construction units (no grid extension, no network)
+# ---------------------------------------------------------------------------
+
+
+def test_read_grid_source_sql_appends_where(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(con, str(src), "geometry", where="area > 3")
+        assert "WHERE (area > 3)" in sql
+        count = con.execute(f"SELECT COUNT(*) FROM ({sql})").fetchone()[0]
+        assert count == 2  # areas 4.0 and 6.0
+        # No clause -> unchanged behavior
+        sql_all = read_grid_source_sql(con, str(src), "geometry")
+        assert "WHERE" not in sql_all
+    finally:
+        con.close()
+
+
+def test_build_joined_sql_injects_where_into_inner_scan():
+    from geoparquet_io.core.process.aggregate.by_admin import _build_joined_sql
+
+    sql = _build_joined_sql(
+        "in.parquet",
+        "geometry",
+        "read_parquet('admin.parquet')",
+        "country",
+        "country",
+        "geometry",
+        where="\"crop:name\" = 'wheat'",
+    )
+    inner = sql.split(") s")[0]  # the input-scan subquery
+    assert "WHERE (\"crop:name\" = 'wheat')" in inner
+
+
+def test_where_validation_rejects_dangerous_keywords(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS[:1])
+    with pytest.raises(ValidationError, match="dangerous"):
+        aggregate_by_a5(
+            str(src), str(tmp_path / "o.parquet"), resolution=5, where="1=1; DROP TABLE x"
+        )
+
+
+def test_cli_where_dangerous_keywords_fail_cleanly(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS[:1])
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "process",
+            "aggregate",
+            "a5",
+            str(src),
+            str(tmp_path / "o.parquet"),
+            "--resolution",
+            "5",
+            "--where",
+            "DROP TABLE x",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "dangerous" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# --auto integration: the filter must drive resolution sizing
+# ---------------------------------------------------------------------------
+
+
+def test_auto_row_count_respects_where(tmp_path):
+    from geoparquet_io.core.partition.auto_resolution import _get_total_row_count
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    assert _get_total_row_count(str(src)) == 4
+    assert _get_total_row_count(str(src), where="area > 3") == 2
+
+
+def test_aggregate_auto_threads_where_to_auto_resolution(tmp_path, monkeypatch):
+    """aggregate --auto must size the grid on the *filtered* row count (#568)."""
+    import geoparquet_io.core.partition.auto_resolution as auto_res
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    captured = {}
+
+    def fake_calc(input_parquet, spatial_index_type, **kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop-after-capture")
+
+    monkeypatch.setattr(auto_res, "calculate_auto_resolution", fake_calc)
+    with pytest.raises(RuntimeError, match="stop-after-capture"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), auto=True, where="area > 3")
+    assert captured.get("where") == "area > 3"
+
+
+def test_probe_distinct_cell_counts_respects_where(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.partition.auto_resolution import (
+        _probe_distinct_cell_counts,
+        _register_quadkey_udf,
+    )
+
+    src = tmp_path / "f.parquet"
+    # Two far-apart points -> 2 distinct quadkeys; filter selects one.
+    _write_points_geoparquet(src, [(10.0, 50.0, "wheat", 4.0), (-120.0, 40.0, "corn", 1.0)])
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        _register_quadkey_udf(con)
+        counts_all = _probe_distinct_cell_counts(con, str(src), "quadkey", "geometry", "", [5])
+        counts_filtered = _probe_distinct_cell_counts(
+            con, str(src), "quadkey", "geometry", "", [5], where="crop = 'wheat'"
+        )
+        assert counts_all == [2]
+        assert counts_filtered == [1]
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end per scheme (needs grid community extensions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_a5_where_filters_rows(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    out_all = tmp_path / "all.parquet"
+    out_filtered = tmp_path / "filtered.parquet"
+    aggregate_by_a5(str(src), str(out_all), resolution=5)
+    aggregate_by_a5(str(src), str(out_filtered), resolution=5, where="crop = 'wheat'")
+    total_all = sum(pq.read_table(out_all).column("count").to_pylist())
+    total_filtered = sum(pq.read_table(out_filtered).column("count").to_pylist())
+    assert total_all == 4
+    assert total_filtered == 3  # three wheat rows
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_a5_where_with_breakdown_and_metric(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    out = tmp_path / "o.parquet"
+    aggregate_by_a5(
+        str(src),
+        str(out),
+        resolution=5,
+        metric="sum:area",
+        breakdown="crop",
+        where="area > 1",
+    )
+    df = pq.read_table(out).to_pandas()
+    # The (-120, 40) wheat row (area=1) is filtered out entirely.
+    assert int(df["count"].sum()) == 3
+    assert float(df["sum_area"].sum()) == 12.0
+    assert int(df["count_wheat"].sum()) == 2
+    assert int(df["count_corn"].sum()) == 1
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_h3_where_filters_rows(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, FOUR_POINTS)
+    out = tmp_path / "o.parquet"
+    aggregate_by_h3(str(src), str(out), resolution=5, where="crop = 'corn'")
+    assert sum(pq.read_table(out).column("count").to_pylist()) == 1
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_cli_aggregate_a5_where_special_char_column(tmp_path):
+    src = tmp_path / "f.parquet"
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry, crop AS "crop:name"
+            FROM (VALUES (10.0, 50.0, 'wheat'), (10.001, 50.001, 'corn')) AS t(lon, lat, crop)
+        ) TO '{src}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    out = tmp_path / "o.parquet"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "process",
+            "aggregate",
+            "a5",
+            str(src),
+            str(out),
+            "--resolution",
+            "5",
+            "--where",
+            "\"crop:name\" = 'wheat'",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert sum(pq.read_table(out).column("count").to_pylist()) == 1
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_admin_where_filters_rows(tmp_path):
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "pts.parquet"
+    out = tmp_path / "by_country.parquet"
+    # Two points in France (one wheat, one corn), one ocean wheat point.
+    _write_points_geoparquet(
+        src,
+        [(2.35, 48.85, "wheat", 1.0), (4.85, 45.75, "corn", 2.0), (-30.0, 0.0, "wheat", 3.0)],
+    )
+    aggregate_by_admin(str(src), str(out), level="country", where="crop = 'wheat'")
+    df = pq.read_table(out).to_pandas()
+    assert int(df["count"].sum()) == 2  # corn row filtered out
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_table_aggregate_a5_where():
+    from geoparquet_io.api.table import Table
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    tbl = (
+        con.execute(
+            """
+            SELECT ST_AsWKB(ST_Point(lon, lat)) AS geometry, crop FROM (VALUES
+                (10.0, 50.0, 'wheat'), (10.001, 50.001, 'corn')
+            ) AS t(lon, lat, crop)
+            """
+        )
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    result = Table(tbl).aggregate_a5(resolution=5, where="crop = 'wheat'")
+    assert sum(result.table.column("count").to_pylist()) == 1
+
+
+def test_cli_help_has_where_option():
+    runner = CliRunner()
+    for sub in ("a5", "h3", "admin"):
+        result = runner.invoke(cli, ["process", "aggregate", sub, "--help"])
+        assert result.exit_code == 0
+        assert "--where" in result.output, f"--where missing from {sub} --help"


### PR DESCRIPTION
## Summary

Adds `--where` to all three `gpio process aggregate` subcommands (`a5`, `h3`, `admin`), closing #568. A DuckDB WHERE clause filters input rows in the same single-command pass — no pre-filter rewrite of hundreds of GB needed to aggregate, say, only the 2025 prediction year of a partitioned dataset.

## Where the filter applies

Per the issue's checklist, the clause is injected into the **source scan** so everything downstream sees only filtered rows:

- Grid path (`a5`/`h3`): `read_grid_source_sql()` (file/URL) and the inline source in `aggregate_grid_table()` (in-memory) — `grid_common.py`
- Admin path: the inner input-scan subquery in `_build_joined_sql()` — `by_admin.py`
- `--auto` sizing: `calculate_auto_resolution` → `_get_total_row_count` (COUNT) and `_probe_distinct_cell_counts` (extent probe) both take the filter, so the chosen resolution reflects the filtered data (the "easiest place to forget" from the issue — covered by tests)
- Breakdown top-N values resolve from the filtered source automatically (tested, no extra code path)

## Consistency with `extract --where`

- Option help text copied verbatim; same trust model (arbitrary DuckDB SQL, no parsing)
- Same dangerous-keyword validation: `validate_where_clause` moved from `core/extract.py` to `core/duckdb_utils.py` for shared use (re-exported from `extract` for backwards compatibility)

## API parity

`where=` added to `ops.aggregate_a5/h3/admin`, `Table.aggregate_a5/h3/admin`, and all core functions.

## Tests

14 new tests in `tests/test_process_aggregate_where.py`: SQL-construction units, dangerous-keyword rejection (core + CLI), `--auto` threading (row count, probe, capture test), and slow/network e2e per subcommand incl. `--where`+`--breakdown`+`--metric`, special-character column (`"crop:name"`), and Table API. Full run: 14/14 passed locally; fast suite green (3522 passed).

## Docs

- `docs/guide/process-aggregate.md`: new "Row Filtering" section (CLI + Python tabs)
- `docs/api/python-api.md`: signatures + parameter rows
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--where` filtering to A5, H3, and administrative aggregation commands.
  * Added matching `where` options to Python aggregation APIs.
  * Filters now affect counts, metrics, breakdowns, and automatic resolution sizing.
  * Added validation to reject unsafe filtering expressions.

* **Documentation**
  * Updated aggregation guides, API documentation, and changelogs with usage examples and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->