### PR TITLE
feat(process): add --metric-nodata sentinel handling to process aggregate (#566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,11 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   of building heights comes back at `-313 m`). All three subcommands (`a5`,
   `h3`, `admin`) now accept `--metric-nodata "-999"` (comma-separate multiple
   sentinels) to map those values to `NULL` before aggregation: `sum`/`avg`/
-  `min`/`max` ignore them while `count` still counts every feature. Also on
-  the Python API as `aggregate_a5/h3/admin(..., metric_nodata=...)`.
+  `min`/`max` ignore them while `count` still counts every feature. `nan` is
+  accepted for NaN-encoded nodata, and sentinels are compared at the metric
+  column's own precision so the classic float32 nodata `-3.4028235e+38`
+  matches `REAL` columns. Also on the Python API as
+  `aggregate_a5/h3/admin(..., metric_nodata=...)`.
 
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   is now rejected in every `--where` clause (`extract` included), since DuckDB
   executes multi-statement strings.
 
+- **`--metric-nodata` NoData sentinel handling in `gpio process aggregate` (#566).**
+  Real-world numeric columns often encode "no value" as a sentinel like `-999`
+  instead of SQL `NULL`, which silently poisons `--metric` rollups (an average
+  of building heights comes back at `-313 m`). All three subcommands (`a5`,
+  `h3`, `admin`) now accept `--metric-nodata "-999"` (comma-separate multiple
+  sentinels) to map those values to `NULL` before aggregation: `sum`/`avg`/
+  `min`/`max` ignore them while `count` still counts every feature. Also on
+  the Python API as `aggregate_a5/h3/admin(..., metric_nodata=...)`.
+
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;
   on version/feature mismatches (1.0 metadata using GeoParquet 2.0 native geo

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,8 +29,11 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   of building heights comes back at `-313 m`). All three subcommands (`a5`,
   `h3`, `admin`) now accept `--metric-nodata "-999"` (comma-separate multiple
   sentinels) to map those values to `NULL` before aggregation: `sum`/`avg`/
-  `min`/`max` ignore them while `count` still counts every feature. Also on
-  the Python API as `aggregate_a5/h3/admin(..., metric_nodata=...)`.
+  `min`/`max` ignore them while `count` still counts every feature. `nan` is
+  accepted for NaN-encoded nodata, and sentinels are compared at the metric
+  column's own precision so the classic float32 nodata `-3.4028235e+38`
+  matches `REAL` columns. Also on the Python API as
+  `aggregate_a5/h3/admin(..., metric_nodata=...)`.
 
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   is now rejected in every `--where` clause (`extract` included), since DuckDB
   executes multi-statement strings.
 
+- **`--metric-nodata` NoData sentinel handling in `gpio process aggregate` (#566).**
+  Real-world numeric columns often encode "no value" as a sentinel like `-999`
+  instead of SQL `NULL`, which silently poisons `--metric` rollups (an average
+  of building heights comes back at `-313 m`). All three subcommands (`a5`,
+  `h3`, `admin`) now accept `--metric-nodata "-999"` (comma-separate multiple
+  sentinels) to map those values to `NULL` before aggregation: `sum`/`avg`/
+  `min`/`max` ignore them while `count` still counts every feature. Also on
+  the Python API as `aggregate_a5/h3/admin(..., metric_nodata=...)`.
+
 - **New spec-validation checks in `gpio check spec` (#586).** Validation now
   fails on unknown `geo` metadata versions (e.g. `99.0.0`) even in auto mode;
   on version/feature mismatches (1.0 metadata using GeoParquet 2.0 native geo

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -930,7 +930,7 @@ result.write('cells_stats.parquet')
 | `breakdown_limit` | int | 20 | Max categories; remainder goes into `count_other` |
 | `out_geometry` | str | `"polygon"` | Geometry per cell: `"polygon"`, `"centroid"`, `"both"`, or `"none"` |
 | `where` | str | None | DuckDB WHERE clause filtering input rows before aggregation |
-| `metric_nodata` | str | None | NoData sentinel value(s) mapped to NULL in metric columns, e.g. `"-999"` or `"-999,-9999"` |
+| `metric_nodata` | str | None | NoData sentinel value(s) mapped to NULL in metric columns, e.g. `"-999"` or `"-999,-9999"` (`"nan"` matches NaN) |
 
 Every output row carries `a5_cell` (UBIGINT) as the bucket identifier.
 

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -884,7 +884,7 @@ stats = table.partition_by_admin('output/', vecorel=True)
 
 ### Aggregation Methods {#aggregation}
 
-#### `aggregate_a5(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None)`
+#### `aggregate_a5(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None)`
 
 Aggregate features into A5 grid cells with per-cell statistics for low-zoom visualization.
 
@@ -930,10 +930,11 @@ result.write('cells_stats.parquet')
 | `breakdown_limit` | int | 20 | Max categories; remainder goes into `count_other` |
 | `out_geometry` | str | `"polygon"` | Geometry per cell: `"polygon"`, `"centroid"`, `"both"`, or `"none"` |
 | `where` | str | None | DuckDB WHERE clause filtering input rows before aggregation |
+| `metric_nodata` | str | None | NoData sentinel value(s) mapped to NULL in metric columns, e.g. `"-999"` or `"-999,-9999"` |
 
 Every output row carries `a5_cell` (UBIGINT) as the bucket identifier.
 
-#### `aggregate_h3(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None)`
+#### `aggregate_h3(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None)`
 
 Aggregate features into H3 hexagonal grid cells. Same options as `aggregate_a5`,
 but the resolution range is **0–15** and the bucket id column is `h3_cell` (a
@@ -952,7 +953,7 @@ result.write('cells.parquet')
 
 Every output row carries `h3_cell` (string) as the bucket identifier.
 
-#### `aggregate_admin(level='country', metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None)`
+#### `aggregate_admin(level='country', metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None)`
 
 Aggregate features into administrative regions (Overture Maps) with per-region statistics.
 

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -48,7 +48,10 @@ Rules of thumb:
   sentinel drags `avg`/`sum` toward garbage and `min` reports the sentinel
   itself. Pass `--metric-nodata "-999"` (comma-separate multiple sentinels) to
   map them to `NULL` before aggregation — `sum`/`avg`/`min`/`max` then ignore
-  those values while `count` still counts every feature.
+  those values while `count` still counts every feature. `nan` is accepted for
+  NaN-encoded nodata, and sentinels are compared at the metric column's own
+  precision, so the classic float32 nodata `-3.4028235e+38` matches `REAL`
+  (float32) columns correctly. Sentinels apply only to numeric metric columns.
 
 === "CLI"
 

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -42,6 +42,33 @@ Rules of thumb:
 - **`avg` does *not* scale with count** — it isolates size/intensity, so a cell with 5 large fields is comparable to one with 5 000 small fields. Best for "typical value" maps.
 - **`min`/`max`** surface outliers; pair `min:year` with `max:year` to show the span of values in a cell.
 - The column must already exist and be numeric. To aggregate a **geometry-derived** value like area, compute it first with `gpio add geometry-metrics` (writes `metrics:area` in m²), then `--metric "sum:metrics:area"`.
+- **NoData sentinels skew every metric.** Real-world numeric columns frequently
+  encode "no value" as a sentinel like `-999` or `-9999` rather than SQL `NULL`
+  (e.g. GlobalBuildingAtlas heights use `-999`). Fed to `--metric` directly, the
+  sentinel drags `avg`/`sum` toward garbage and `min` reports the sentinel
+  itself. Pass `--metric-nodata "-999"` (comma-separate multiple sentinels) to
+  map them to `NULL` before aggregation — `sum`/`avg`/`min`/`max` then ignore
+  those values while `count` still counts every feature.
+
+=== "CLI"
+
+    ```bash
+    gpio process aggregate a5 buildings.parquet cells.parquet --auto \
+        --metric "avg:height,max:height" --metric-nodata "-999"
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    result = gpio.read('buildings.parquet').aggregate_a5(
+        resolution=10,
+        metric="avg:height,max:height",
+        metric_nodata="-999",
+    )
+    result.write('cells.parquet')
+    ```
 
 ### Which breakdown to use
 
@@ -433,6 +460,7 @@ Both commands support the standard output options:
 
 ```bash
 --where "confidence >= 50"  # DuckDB WHERE clause filtering input rows
+--metric-nodata "-999"    # NoData sentinel(s) mapped to NULL in --metric columns
 --compression SNAPPY      # Output compression (default: ZSTD)
 --geoparquet-version 1.1  # GeoParquet spec version
 --show-sql                # Print the generated DuckDB SQL

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -272,6 +272,7 @@ def aggregate_a5(
     out_geometry: str = "polygon",
     geometry_column: str | None = None,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into A5 grid cells with per-cell statistics.
@@ -285,6 +286,8 @@ def aggregate_a5(
         out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
         geometry_column: Geometry column name (defaults to "geometry")
         where: DuckDB WHERE clause filtering input rows before aggregation
+        metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns,
+            e.g. "-999" or "-999,-9999"
 
     Returns:
         New PyArrow Table with one row per A5 cell
@@ -300,6 +303,7 @@ def aggregate_a5(
         out_geometry=out_geometry,
         geometry_column=geometry_column,
         where=where,
+        metric_nodata=metric_nodata,
     )
 
 
@@ -312,6 +316,7 @@ def aggregate_h3(
     out_geometry: str = "polygon",
     geometry_column: str | None = None,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into H3 grid cells with per-cell statistics.
@@ -325,6 +330,8 @@ def aggregate_h3(
         out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
         geometry_column: Geometry column name (defaults to "geometry")
         where: DuckDB WHERE clause filtering input rows before aggregation
+        metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns,
+            e.g. "-999" or "-999,-9999"
 
     Returns:
         New PyArrow Table with one row per H3 cell
@@ -340,6 +347,7 @@ def aggregate_h3(
         out_geometry=out_geometry,
         geometry_column=geometry_column,
         where=where,
+        metric_nodata=metric_nodata,
     )
 
 
@@ -351,6 +359,7 @@ def aggregate_admin(
     breakdown_limit: int = 20,
     out_geometry: str = "polygon",
     where: str | None = None,
+    metric_nodata: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into administrative regions with per-region statistics.
@@ -363,6 +372,8 @@ def aggregate_admin(
         breakdown_limit: Max number of breakdown categories (default: 20)
         out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
         where: DuckDB WHERE clause filtering input rows before aggregation
+        metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns,
+            e.g. "-999" or "-999,-9999"
 
     Returns:
         New PyArrow Table with one row per admin region
@@ -383,6 +394,7 @@ def aggregate_admin(
         breakdown_limit=breakdown_limit,
         out_geometry=out_geometry,
         where=where,
+        metric_nodata=metric_nodata,
     )
 
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1381,6 +1381,7 @@ class Table:
         breakdown_limit: int = 20,
         out_geometry: str = "polygon",
         where: str | None = None,
+        metric_nodata: str | None = None,
     ) -> Table:
         """
         Aggregate features into A5 grid cells with per-cell statistics.
@@ -1392,6 +1393,7 @@ class Table:
             breakdown_limit: Max number of breakdown categories (default: 20)
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
             where: DuckDB WHERE clause filtering input rows before aggregation
+            metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns
 
         Returns:
             New Table with one row per A5 cell
@@ -1407,6 +1409,7 @@ class Table:
             out_geometry=out_geometry,
             geometry_column=self._geometry_column,
             where=where,
+            metric_nodata=metric_nodata,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 
@@ -1418,6 +1421,7 @@ class Table:
         breakdown_limit: int = 20,
         out_geometry: str = "polygon",
         where: str | None = None,
+        metric_nodata: str | None = None,
     ) -> Table:
         """
         Aggregate features into H3 grid cells with per-cell statistics.
@@ -1429,6 +1433,7 @@ class Table:
             breakdown_limit: Max number of breakdown categories (default: 20)
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
             where: DuckDB WHERE clause filtering input rows before aggregation
+            metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns
 
         Returns:
             New Table with one row per H3 cell
@@ -1444,6 +1449,7 @@ class Table:
             out_geometry=out_geometry,
             geometry_column=self._geometry_column,
             where=where,
+            metric_nodata=metric_nodata,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 
@@ -1455,6 +1461,7 @@ class Table:
         breakdown_limit: int = 20,
         out_geometry: str = "polygon",
         where: str | None = None,
+        metric_nodata: str | None = None,
     ) -> Table:
         """
         Aggregate features into administrative regions with per-region statistics.
@@ -1466,6 +1473,7 @@ class Table:
             breakdown_limit: Max number of breakdown categories (default: 20)
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
             where: DuckDB WHERE clause filtering input rows before aggregation
+            metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns
 
         Returns:
             New Table with one row per admin region
@@ -1480,6 +1488,7 @@ class Table:
             breakdown_limit=breakdown_limit,
             out_geometry=out_geometry,
             where=where,
+            metric_nodata=metric_nodata,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -367,8 +367,8 @@ def metric_nodata_option(func):
     return click.option(
         "--metric-nodata",
         default=None,
-        help='NoData sentinel value(s) in --metric columns, e.g. "-999" or "-999,-9999". '
-        "Mapped to NULL before sum/avg/min/max; count is unaffected.",
+        help='NoData sentinel value(s) in --metric columns, e.g. "-999" or "-999,-9999" '
+        '("nan" matches NaN). Mapped to NULL before sum/avg/min/max; count is unaffected.',
     )(func)
 
 

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -362,13 +362,23 @@ def where_option(func):
     )(func)
 
 
+def metric_nodata_option(func):
+    """Add the ``--metric-nodata`` NoData sentinel option for aggregate commands."""
+    return click.option(
+        "--metric-nodata",
+        default=None,
+        help='NoData sentinel value(s) in --metric columns, e.g. "-999" or "-999,-9999". '
+        "Mapped to NULL before sum/avg/min/max; count is unaffected.",
+    )(func)
+
+
 def grid_aggregate_options(func):
     """Add the options shared by `gpio process aggregate <grid>` commands.
 
     Adds (the per-scheme ``--resolution`` is declared on each command, since its
     valid range differs between grids):
     - --auto, --target-per-cell, --max-cells
-    - --metric, --breakdown, --breakdown-limit
+    - --metric, --metric-nodata, --breakdown, --breakdown-limit
     - --out-geometry, --where
     """
     func = where_option(func)
@@ -389,6 +399,7 @@ def grid_aggregate_options(func):
         default=None,
         help="Categorical column to pivot count by (one count_<value> column each).",
     )(func)
+    func = metric_nodata_option(func)
     func = click.option(
         "--metric",
         default=None,

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -20,6 +20,7 @@ from geoparquet_io.cli.decorators import (
     grid_aggregate_options,
     handle_directory_sub_partition,
     handle_geoparquet_errors,
+    metric_nodata_option,
     output_format_options,
     overwrite_option,
     parse_row_group_options,
@@ -7061,6 +7062,7 @@ def process_aggregate_a5(
     target_per_cell,
     max_cells,
     metric,
+    metric_nodata,
     breakdown,
     breakdown_limit,
     out_geometry,
@@ -7080,6 +7082,8 @@ def process_aggregate_a5(
             --metric "sum:area_ha" --breakdown crop_type
         gpio process aggregate a5 fields.parquet cells.parquet --resolution 8 \\
             --where "\\"crop:name\\" = 'wheat'"
+        gpio process aggregate a5 buildings.parquet cells.parquet --auto \\
+            --metric "avg:height,max:height" --metric-nodata "-999"
         gpio process aggregate a5 fields.parquet cells.csv-like.parquet \\
             --resolution 8 --out-geometry none
     """
@@ -7102,6 +7106,7 @@ def process_aggregate_a5(
                 verbose=verbose,
                 show_sql=show_sql,
                 where=where,
+                metric_nodata=metric_nodata,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise _aggregate_error(exc, where) from exc
@@ -7131,6 +7136,7 @@ def process_aggregate_h3(
     target_per_cell,
     max_cells,
     metric,
+    metric_nodata,
     breakdown,
     breakdown_limit,
     out_geometry,
@@ -7150,6 +7156,8 @@ def process_aggregate_h3(
             --metric "sum:area_ha" --breakdown crop_type
         gpio process aggregate h3 fields.parquet cells.parquet --resolution 8 \\
             --where "confidence >= 50"
+        gpio process aggregate h3 buildings.parquet cells.parquet --auto \\
+            --metric "avg:height" --metric-nodata "-999"
         gpio process aggregate h3 fields.parquet cells.parquet \\
             --resolution 8 --out-geometry none
     """
@@ -7172,6 +7180,7 @@ def process_aggregate_h3(
                 verbose=verbose,
                 show_sql=show_sql,
                 where=where,
+                metric_nodata=metric_nodata,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise _aggregate_error(exc, where) from exc
@@ -7191,6 +7200,7 @@ def process_aggregate_h3(
     default=None,
     help='Numeric rollups, e.g. "sum:area_ha,avg:yield". Bare column = sum.',
 )
+@metric_nodata_option
 @click.option(
     "--breakdown",
     default=None,
@@ -7220,6 +7230,7 @@ def process_aggregate_admin(
     output_parquet,
     level,
     metric,
+    metric_nodata,
     breakdown,
     breakdown_limit,
     out_geometry,
@@ -7239,6 +7250,8 @@ def process_aggregate_admin(
             --level region --metric "sum:area_ha" --breakdown crop_type
         gpio process aggregate admin fields.parquet by_country.parquet \\
             --level country --where "confidence >= 50"
+        gpio process aggregate admin buildings.parquet by_country.parquet \\
+            --level country --metric "avg:height" --metric-nodata "-999"
     """
     with _activate_s3(ctx):
         try:
@@ -7256,6 +7269,7 @@ def process_aggregate_admin(
                 verbose=verbose,
                 show_sql=show_sql,
                 where=where,
+                metric_nodata=metric_nodata,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise _aggregate_error(exc, where) from exc

--- a/geoparquet_io/core/process/aggregate/by_a5.py
+++ b/geoparquet_io/core/process/aggregate/by_a5.py
@@ -6,6 +6,8 @@ Thin scheme definition over the shared engine in ``grid_common``.
 
 from __future__ import annotations
 
+import pyarrow as pa
+
 from geoparquet_io.core.constants import DEFAULT_A5_COLUMN_NAME
 from geoparquet_io.core.process.aggregate.grid_common import (
     GridScheme,
@@ -87,7 +89,7 @@ def aggregate_a5_table(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
-):
+) -> pa.Table:
     """Aggregate an in-memory Arrow table by a5 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
         A5_SCHEME,

--- a/geoparquet_io/core/process/aggregate/by_a5.py
+++ b/geoparquet_io/core/process/aggregate/by_a5.py
@@ -50,6 +50,7 @@ def aggregate_by_a5(
     verbose: bool = False,
     show_sql: bool = False,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into A5 cells. Writes the output file."""
     aggregate_grid_file(
@@ -71,6 +72,7 @@ def aggregate_by_a5(
         verbose=verbose,
         show_sql=show_sql,
         where=where,
+        metric_nodata=metric_nodata,
     )
 
 
@@ -84,6 +86,7 @@ def aggregate_a5_table(
     a5_column_name: str = DEFAULT_A5_COLUMN_NAME,
     geometry_column: str | None = None,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ):
     """Aggregate an in-memory Arrow table by a5 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
@@ -97,4 +100,5 @@ def aggregate_a5_table(
         cell_column=a5_column_name,
         geometry_column=geometry_column,
         where=where,
+        metric_nodata=metric_nodata,
     )

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -30,6 +30,7 @@ from geoparquet_io.core.process.aggregate.common import (
     build_breakdown_select,
     build_metric_select,
     geometry_to_geom_expr,
+    parse_metric_nodata,
     parse_metrics,
     resolve_breakdown_values,
 )
@@ -102,7 +103,9 @@ def _build_joined_sql(
     """
 
 
-def _build_agg_sql(joined_sql: str, metrics, breakdown_select: str) -> str:
+def _build_agg_sql(
+    joined_sql: str, metrics, breakdown_select: str, nodata_values: list[str] | None = None
+) -> str:
     """Build the GROUP BY aggregation on top of the spatial join."""
     agg_parts = [
         "COALESCE(__admin_code, 'unassigned') AS admin_code",
@@ -110,7 +113,7 @@ def _build_agg_sql(joined_sql: str, metrics, breakdown_select: str) -> str:
         "ANY_VALUE(__admin_geom) AS __admin_geom",
         "COUNT(*) AS count",
     ]
-    metric_select = build_metric_select(metrics)
+    metric_select = build_metric_select(metrics, nodata_values=nodata_values)
     if metric_select:
         agg_parts.append(metric_select)
     if breakdown_select:
@@ -152,6 +155,7 @@ def aggregate_by_admin(
     verbose: bool = False,
     show_sql: bool = False,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ) -> None:
     """Aggregate input features by administrative region.
 
@@ -175,6 +179,7 @@ def aggregate_by_admin(
         verbose: Enable verbose debug logging.
         show_sql: Log the final SQL query.
         where: DuckDB WHERE clause filtering input rows before aggregation.
+        metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns.
     """
     configure_verbose(verbose)
     if out_geometry not in VALID_OUT_GEOMETRY:
@@ -185,6 +190,11 @@ def aggregate_by_admin(
     if where:
         validate_where_clause(where)
     metrics = parse_metrics(metric)
+    nodata_values = parse_metric_nodata(metric_nodata)
+    if nodata_values and not metrics:
+        raise InvalidParameterError(
+            "metric-nodata", "--metric-nodata requires --metric (it only affects metric columns)"
+        )
 
     admin_dataset, _boundary_columns = _setup_admin_dataset(dataset, verbose, [level])
     mapping = admin_dataset.get_level_column_mapping()
@@ -237,9 +247,9 @@ def aggregate_by_admin(
             )
             colmap = build_breakdown_column_names(top_values, reserved={"count_other"})
             breakdown_select = build_breakdown_select(breakdown, colmap, has_other)
-            agg_sql = _build_agg_sql(joined_ref, metrics, breakdown_select)
+            agg_sql = _build_agg_sql(joined_ref, metrics, breakdown_select, nodata_values)
         else:
-            agg_sql = _build_agg_sql(joined_sql, metrics, "")
+            agg_sql = _build_agg_sql(joined_sql, metrics, "", nodata_values)
         final_sql = _wrap_admin_geometry(agg_sql, out_geometry)
 
         if show_sql or verbose:

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -25,14 +25,15 @@ from geoparquet_io.core.partition.admin_hierarchical import (
 )
 from geoparquet_io.core.process.aggregate.common import (
     VALID_OUT_GEOMETRY,
+    MetricSpec,
     aggregate_source_relation,
     build_breakdown_column_names,
     build_breakdown_select,
     build_metric_select,
     geometry_to_geom_expr,
-    parse_metric_nodata,
-    parse_metrics,
     resolve_breakdown_values,
+    resolve_metric_column_types,
+    validate_metric_nodata,
 )
 
 
@@ -104,7 +105,11 @@ def _build_joined_sql(
 
 
 def _build_agg_sql(
-    joined_sql: str, metrics, breakdown_select: str, nodata_values: list[str] | None = None
+    joined_sql: str,
+    metrics: list[MetricSpec],
+    breakdown_select: str,
+    nodata_values: list[str] | None = None,
+    column_types: dict[str, str] | None = None,
 ) -> str:
     """Build the GROUP BY aggregation on top of the spatial join."""
     agg_parts = [
@@ -113,7 +118,9 @@ def _build_agg_sql(
         "ANY_VALUE(__admin_geom) AS __admin_geom",
         "COUNT(*) AS count",
     ]
-    metric_select = build_metric_select(metrics, nodata_values=nodata_values)
+    metric_select = build_metric_select(
+        metrics, nodata_values=nodata_values, column_types=column_types
+    )
     if metric_select:
         agg_parts.append(metric_select)
     if breakdown_select:
@@ -189,12 +196,7 @@ def aggregate_by_admin(
         )
     if where:
         validate_where_clause(where)
-    metrics = parse_metrics(metric)
-    nodata_values = parse_metric_nodata(metric_nodata)
-    if nodata_values and not metrics:
-        raise InvalidParameterError(
-            "metric-nodata", "--metric-nodata requires --metric (it only affects metric columns)"
-        )
+    metrics, nodata_values = validate_metric_nodata(metric, metric_nodata)
 
     admin_dataset, _boundary_columns = _setup_admin_dataset(dataset, verbose, [level])
     mapping = admin_dataset.get_level_column_mapping()
@@ -218,6 +220,14 @@ def aggregate_by_admin(
         admin_ref = _get_admin_ref(admin_dataset, con, level)
 
         read_rel = aggregate_source_relation(input_url)
+        # Resolve metric column types from the input so sentinel literals match the
+        # column's actual precision (REAL vs DOUBLE, #613) and non-numeric metric
+        # columns fail up-front instead of mid-query.
+        column_types = (
+            resolve_metric_column_types(con, f"SELECT * FROM {read_rel}", metrics)
+            if nodata_values
+            else None
+        )
         # Admin boundaries are OGC:CRS84; reproject a non-CRS84 input so ST_Intersects
         # does not fail on a CRS mismatch and the centroid lands correctly (#525).
         source_crs = extract_crs_from_parquet(input_parquet, verbose)
@@ -247,9 +257,11 @@ def aggregate_by_admin(
             )
             colmap = build_breakdown_column_names(top_values, reserved={"count_other"})
             breakdown_select = build_breakdown_select(breakdown, colmap, has_other)
-            agg_sql = _build_agg_sql(joined_ref, metrics, breakdown_select, nodata_values)
+            agg_sql = _build_agg_sql(
+                joined_ref, metrics, breakdown_select, nodata_values, column_types
+            )
         else:
-            agg_sql = _build_agg_sql(joined_sql, metrics, "", nodata_values)
+            agg_sql = _build_agg_sql(joined_sql, metrics, "", nodata_values, column_types)
         final_sql = _wrap_admin_geometry(agg_sql, out_geometry)
 
         if show_sql or verbose:

--- a/geoparquet_io/core/process/aggregate/by_h3.py
+++ b/geoparquet_io/core/process/aggregate/by_h3.py
@@ -6,6 +6,8 @@ Thin scheme definition over the shared engine in ``grid_common``.
 
 from __future__ import annotations
 
+import pyarrow as pa
+
 from geoparquet_io.core.constants import DEFAULT_H3_COLUMN_NAME
 from geoparquet_io.core.process.aggregate.grid_common import (
     GridScheme,
@@ -87,7 +89,7 @@ def aggregate_h3_table(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
-):
+) -> pa.Table:
     """Aggregate an in-memory Arrow table by h3 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
         H3_SCHEME,

--- a/geoparquet_io/core/process/aggregate/by_h3.py
+++ b/geoparquet_io/core/process/aggregate/by_h3.py
@@ -50,6 +50,7 @@ def aggregate_by_h3(
     verbose: bool = False,
     show_sql: bool = False,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into H3 cells. Writes the output file."""
     aggregate_grid_file(
@@ -71,6 +72,7 @@ def aggregate_by_h3(
         verbose=verbose,
         show_sql=show_sql,
         where=where,
+        metric_nodata=metric_nodata,
     )
 
 
@@ -84,6 +86,7 @@ def aggregate_h3_table(
     h3_column_name: str = DEFAULT_H3_COLUMN_NAME,
     geometry_column: str | None = None,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ):
     """Aggregate an in-memory Arrow table by h3 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
@@ -97,4 +100,5 @@ def aggregate_h3_table(
         cell_column=h3_column_name,
         geometry_column=geometry_column,
         where=where,
+        metric_nodata=metric_nodata,
     )

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 
@@ -11,6 +12,33 @@ from geoparquet_io.core.exceptions import InvalidParameterError
 
 VALID_METRIC_FUNCS = {"sum", "avg", "min", "max"}
 VALID_OUT_GEOMETRY = {"polygon", "centroid", "both", "none"}
+
+# Strict SQL-safe numeric literal: ASCII digits only (float() also accepts
+# Unicode digits, underscores, inf/Infinity -- none of which are valid SQL).
+_NUMERIC_TOKEN_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$", re.ASCII)
+_NAN_TOKEN_RE = re.compile(r"^[+-]?nan$", re.IGNORECASE | re.ASCII)
+
+# DuckDB numeric type names (DESCRIBE output). REAL columns report as FLOAT.
+_NUMERIC_SQL_TYPES = {
+    "TINYINT",
+    "SMALLINT",
+    "INTEGER",
+    "BIGINT",
+    "HUGEINT",
+    "UTINYINT",
+    "USMALLINT",
+    "UINTEGER",
+    "UBIGINT",
+    "UHUGEINT",
+    "FLOAT",
+    "REAL",
+    "DOUBLE",
+}
+
+
+def _is_numeric_sql_type(col_type: str) -> bool:
+    t = col_type.upper()
+    return t in _NUMERIC_SQL_TYPES or t.startswith(("DECIMAL", "NUMERIC"))
 
 
 def aggregate_source_relation(input_url: str) -> str:
@@ -96,10 +124,13 @@ def parse_metrics(metric_str: str | None) -> list[MetricSpec]:
 def parse_metric_nodata(nodata_str: str | None) -> list[str]:
     """Parse a --metric-nodata string into validated numeric literals.
 
-    Accepts comma-separated numbers (e.g. ``"-999"`` or ``"-999,-9999"``). Each
-    token must parse as a number; the original token is preserved verbatim in the
-    generated SQL so integer sentinels stay integer literals (no float coercion
-    of the compared column).
+    Accepts comma-separated finite numbers (e.g. ``"-999"`` or ``"-999,-9999"``)
+    plus the special token ``nan`` (a common float nodata encoding), which is
+    normalized to lowercase ``"nan"`` and rendered as a typed NaN literal at SQL
+    build time. Numeric tokens are validated against a strict ASCII literal
+    pattern (``float()`` alone also accepts Unicode digits, underscores and
+    inf/Infinity, none of which are safe to splice into SQL) and preserved
+    verbatim so integer sentinels stay integer literals.
     """
     if nodata_str is None:
         return []
@@ -108,14 +139,16 @@ def parse_metric_nodata(nodata_str: str | None) -> list[str]:
         token = raw.strip()
         if not token:
             continue
-        try:
-            float(token)
-        except ValueError:
+        if _NAN_TOKEN_RE.match(token):
+            values.append("nan")
+            continue
+        if not _NUMERIC_TOKEN_RE.match(token) or not math.isfinite(float(token)):
             raise InvalidParameterError(
                 "metric-nodata",
-                f"NoData sentinel '{token}' is not a number. "
-                'Pass comma-separated numeric values, e.g. "-999" or "-999,-9999".',
-            ) from None
+                f"NoData sentinel '{token}' is not a finite number. "
+                'Pass comma-separated numeric values (e.g. "-999" or "-999,-9999"); '
+                '"nan" is also accepted for NaN sentinels.',
+            )
         values.append(token)
     if not values:
         raise InvalidParameterError(
@@ -126,26 +159,100 @@ def parse_metric_nodata(nodata_str: str | None) -> list[str]:
     return values
 
 
-def _nodata_wrapped_column(column: str, nodata_values: list[str]) -> str:
+def validate_metric_nodata(
+    metric: str | None, metric_nodata: str | None
+) -> tuple[list[MetricSpec], list[str]]:
+    """Parse and cross-validate the metric and metric-nodata parameters together.
+
+    Shared by the grid and admin aggregation paths (CLI and Python API), so the
+    wording stays flag-neutral. Returns ``(metrics, nodata_values)``.
+    """
+    metrics = parse_metrics(metric)
+    nodata_values = parse_metric_nodata(metric_nodata)
+    if nodata_values and not metrics:
+        raise InvalidParameterError(
+            "metric-nodata",
+            "NoData sentinels require at least one metric (they only affect metric columns)",
+        )
+    return metrics, nodata_values
+
+
+def resolve_metric_column_types(con, select_sql: str, metrics: list[MetricSpec]) -> dict[str, str]:
+    """Resolve the DuckDB type of each metric column via a cheap DESCRIBE bind.
+
+    ``select_sql`` must be a SELECT statement exposing the metric columns.
+    Returns ``{column: TYPE}`` (uppercase). Resolution failures (e.g. a missing
+    column) return partial/empty info so the original error surfaces from the
+    real query instead of an opaque bind error here.
+    """
+    if not metrics:
+        return {}
+    columns = sorted({m.column for m in metrics})
+    col_list = ", ".join(quote_identifier(c) for c in columns)
+    try:
+        rows = con.execute(f"DESCRIBE SELECT {col_list} FROM ({select_sql})").fetchall()
+    except Exception:  # noqa: BLE001 - typing is best-effort; real query reports errors
+        return {}
+    return {row[0]: str(row[1]).upper() for row in rows}
+
+
+def _nodata_literal(token: str, col_type: str | None) -> str:
+    """Render one validated sentinel token as a SQL literal matched to ``col_type``.
+
+    - ``nan`` becomes a typed NaN cast (DuckDB evaluates ``NaN = NaN`` as TRUE,
+      so NULLIF/IN work).
+    - For REAL (float32) columns, the literal is cast to REAL so the comparison
+      happens at float32 precision; a bare DOUBLE literal like -3.4028235e+38
+      would never equal the widened REAL value (#613).
+    - Everything else keeps the validated token verbatim (integer sentinels stay
+      integer literals; fractional sentinels never round onto integer columns).
+    """
+    is_real = col_type in ("FLOAT", "REAL")
+    if token == "nan":
+        return f"CAST('nan' AS {'REAL' if is_real else 'DOUBLE'})"
+    if is_real:
+        return f"CAST({token} AS REAL)"
+    return token
+
+
+def _nodata_wrapped_column(
+    column: str, nodata_values: list[str], col_type: str | None = None
+) -> str:
     """SQL expression mapping sentinel values of ``column`` to NULL."""
     qcol = quote_identifier(column)
-    if len(nodata_values) == 1:
-        return f"NULLIF({qcol}, {nodata_values[0]})"
-    in_list = ", ".join(nodata_values)
+    literals = [_nodata_literal(tok, col_type) for tok in nodata_values]
+    if len(literals) == 1:
+        return f"NULLIF({qcol}, {literals[0]})"
+    in_list = ", ".join(literals)
     return f"CASE WHEN {qcol} IN ({in_list}) THEN NULL ELSE {qcol} END"
 
 
-def build_metric_select(metrics: list[MetricSpec], nodata_values: list[str] | None = None) -> str:
+def build_metric_select(
+    metrics: list[MetricSpec],
+    nodata_values: list[str] | None = None,
+    column_types: dict[str, str] | None = None,
+) -> str:
     """Build the comma-joined aggregate expressions for the SELECT (no leading comma).
 
     When ``nodata_values`` is given, each metric column is wrapped so sentinel
     values become NULL before aggregation (#566) -- sum/avg/min/max then ignore
     them, while the separate ``COUNT(*)`` still counts every feature.
+
+    ``column_types`` (from :func:`resolve_metric_column_types`) lets sentinel
+    literals be cast to the column's actual type and rejects sentinel use on
+    non-numeric metric columns up-front instead of mid-query.
     """
     parts = []
     for m in metrics:
         if nodata_values:
-            col_expr = _nodata_wrapped_column(m.column, nodata_values)
+            col_type = (column_types or {}).get(m.column)
+            if col_type is not None and not _is_numeric_sql_type(col_type):
+                raise InvalidParameterError(
+                    "metric-nodata",
+                    f"NoData sentinels apply only to numeric metric columns; "
+                    f"column '{m.column}' has type {col_type}",
+                )
+            col_expr = _nodata_wrapped_column(m.column, nodata_values, col_type)
         else:
             col_expr = quote_identifier(m.column)
         parts.append(f"{m.func.upper()}({col_expr}) AS {quote_identifier(m.output_name)}")

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -93,12 +93,63 @@ def parse_metrics(metric_str: str | None) -> list[MetricSpec]:
     return specs
 
 
-def build_metric_select(metrics: list[MetricSpec]) -> str:
-    """Build the comma-joined aggregate expressions for the SELECT (no leading comma)."""
-    return ", ".join(
-        f"{m.func.upper()}({quote_identifier(m.column)}) AS {quote_identifier(m.output_name)}"
-        for m in metrics
-    )
+def parse_metric_nodata(nodata_str: str | None) -> list[str]:
+    """Parse a --metric-nodata string into validated numeric literals.
+
+    Accepts comma-separated numbers (e.g. ``"-999"`` or ``"-999,-9999"``). Each
+    token must parse as a number; the original token is preserved verbatim in the
+    generated SQL so integer sentinels stay integer literals (no float coercion
+    of the compared column).
+    """
+    if nodata_str is None:
+        return []
+    values: list[str] = []
+    for raw in nodata_str.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        try:
+            float(token)
+        except ValueError:
+            raise InvalidParameterError(
+                "metric-nodata",
+                f"NoData sentinel '{token}' is not a number. "
+                'Pass comma-separated numeric values, e.g. "-999" or "-999,-9999".',
+            ) from None
+        values.append(token)
+    if not values:
+        raise InvalidParameterError(
+            "metric-nodata",
+            "No NoData sentinel values given. "
+            'Pass comma-separated numeric values, e.g. "-999" or "-999,-9999".',
+        )
+    return values
+
+
+def _nodata_wrapped_column(column: str, nodata_values: list[str]) -> str:
+    """SQL expression mapping sentinel values of ``column`` to NULL."""
+    qcol = quote_identifier(column)
+    if len(nodata_values) == 1:
+        return f"NULLIF({qcol}, {nodata_values[0]})"
+    in_list = ", ".join(nodata_values)
+    return f"CASE WHEN {qcol} IN ({in_list}) THEN NULL ELSE {qcol} END"
+
+
+def build_metric_select(metrics: list[MetricSpec], nodata_values: list[str] | None = None) -> str:
+    """Build the comma-joined aggregate expressions for the SELECT (no leading comma).
+
+    When ``nodata_values`` is given, each metric column is wrapped so sentinel
+    values become NULL before aggregation (#566) -- sum/avg/min/max then ignore
+    them, while the separate ``COUNT(*)`` still counts every feature.
+    """
+    parts = []
+    for m in metrics:
+        if nodata_values:
+            col_expr = _nodata_wrapped_column(m.column, nodata_values)
+        else:
+            col_expr = quote_identifier(m.column)
+        parts.append(f"{m.func.upper()}({col_expr}) AS {quote_identifier(m.output_name)}")
+    return ", ".join(parts)
 
 
 _UNSAFE_CHARS = re.compile(r"[^0-9a-zA-Z]+")

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -38,6 +38,7 @@ from geoparquet_io.core.process.aggregate.common import (
     build_breakdown_select,
     build_metric_select,
     geometry_to_geom_expr,
+    parse_metric_nodata,
     parse_metrics,
     resolve_breakdown_values,
 )
@@ -121,9 +122,15 @@ def build_grid_query(
     breakdown: str | None,
     breakdown_limit: int,
     out_geometry: str,
+    metric_nodata: str | None = None,
 ) -> str:
     """Build the full grid aggregation SQL from a source relation exposing ``__geom``."""
     metrics = parse_metrics(metric)
+    nodata_values = parse_metric_nodata(metric_nodata)
+    if nodata_values and not metrics:
+        raise InvalidParameterError(
+            "metric-nodata", "--metric-nodata requires --metric (it only affects metric columns)"
+        )
 
     key_expr = scheme.key_template.format(geom="__geom", res=resolution)
     keyed_sql = f"SELECT *, {key_expr} AS __key FROM ({source_sql})"
@@ -142,7 +149,7 @@ def build_grid_query(
         keyed_ref = keyed_sql
 
     agg_parts = [f"__key AS {quote_identifier(cell_column)}", "COUNT(*) AS count"]
-    metric_select = build_metric_select(metrics)
+    metric_select = build_metric_select(metrics, nodata_values=nodata_values)
     if metric_select:
         agg_parts.append(metric_select)
     if breakdown_select:
@@ -261,6 +268,7 @@ def aggregate_grid_file(
     verbose: bool = False,
     show_sql: bool = False,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into grid cells. Writes the output file."""
     configure_verbose(verbose)
@@ -293,6 +301,7 @@ def aggregate_grid_file(
             breakdown,
             breakdown_limit,
             out_geometry,
+            metric_nodata=metric_nodata,
         )
         if show_sql or verbose:
             debug(final_sql)
@@ -344,6 +353,7 @@ def aggregate_grid_table(
     cell_column: str | None = None,
     geometry_column: str | None = None,
     where: str | None = None,
+    metric_nodata: str | None = None,
 ):
     """Aggregate an in-memory Arrow table into grid cells. Returns a new Arrow table."""
     cell_column = cell_column or scheme.default_column
@@ -382,6 +392,7 @@ def aggregate_grid_table(
             breakdown,
             breakdown_limit,
             out_geometry,
+            metric_nodata=metric_nodata,
         )
         return con.execute(final_sql).arrow().read_all()
     finally:

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import gc
 from dataclasses import dataclass
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.common import write_geoparquet_table
@@ -38,9 +39,9 @@ from geoparquet_io.core.process.aggregate.common import (
     build_breakdown_select,
     build_metric_select,
     geometry_to_geom_expr,
-    parse_metric_nodata,
-    parse_metrics,
     resolve_breakdown_values,
+    resolve_metric_column_types,
+    validate_metric_nodata,
 )
 
 
@@ -125,12 +126,10 @@ def build_grid_query(
     metric_nodata: str | None = None,
 ) -> str:
     """Build the full grid aggregation SQL from a source relation exposing ``__geom``."""
-    metrics = parse_metrics(metric)
-    nodata_values = parse_metric_nodata(metric_nodata)
-    if nodata_values and not metrics:
-        raise InvalidParameterError(
-            "metric-nodata", "--metric-nodata requires --metric (it only affects metric columns)"
-        )
+    metrics, nodata_values = validate_metric_nodata(metric, metric_nodata)
+    # Resolve metric column types so sentinel literals match the column's actual
+    # precision (REAL vs DOUBLE, #613) and non-numeric columns fail up-front.
+    column_types = resolve_metric_column_types(con, source_sql, metrics) if nodata_values else None
 
     key_expr = scheme.key_template.format(geom="__geom", res=resolution)
     keyed_sql = f"SELECT *, {key_expr} AS __key FROM ({source_sql})"
@@ -149,7 +148,9 @@ def build_grid_query(
         keyed_ref = keyed_sql
 
     agg_parts = [f"__key AS {quote_identifier(cell_column)}", "COUNT(*) AS count"]
-    metric_select = build_metric_select(metrics, nodata_values=nodata_values)
+    metric_select = build_metric_select(
+        metrics, nodata_values=nodata_values, column_types=column_types
+    )
     if metric_select:
         agg_parts.append(metric_select)
     if breakdown_select:
@@ -276,6 +277,9 @@ def aggregate_grid_file(
     _validate_out_geometry(out_geometry)
     if where:
         validate_where_clause(where)
+    # Validate metric/nodata pairing before any expensive setup (--auto scanning,
+    # CRS reads, connection + community-extension install).
+    validate_metric_nodata(metric, metric_nodata)
     resolution = _resolve_resolution(
         scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose, where=where
     )
@@ -354,12 +358,14 @@ def aggregate_grid_table(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
-):
+) -> pa.Table:
     """Aggregate an in-memory Arrow table into grid cells. Returns a new Arrow table."""
     cell_column = cell_column or scheme.default_column
     _validate_out_geometry(out_geometry)
     if where:
         validate_where_clause(where)
+    # Validate metric/nodata pairing before connection setup and extension install.
+    validate_metric_nodata(metric, metric_nodata)
     if not scheme.min_resolution <= resolution <= scheme.max_resolution:
         raise InvalidParameterError(
             "resolution",

--- a/tests/test_process_aggregate_metric_nodata.py
+++ b/tests/test_process_aggregate_metric_nodata.py
@@ -1,0 +1,226 @@
+"""Tests for --metric-nodata sentinel handling in `gpio process aggregate` (issue #566).
+
+Sentinel values (e.g. -999) are mapped to NULL for metric computation only, so
+sum/avg/min/max ignore them while `count` still counts every feature.
+"""
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+from geoparquet_io.core.process.aggregate.common import (
+    build_metric_select,
+    parse_metric_nodata,
+    parse_metrics,
+)
+
+
+def _write_points_geoparquet(path, rows):
+    """rows: list of (lon, lat, height). Writes a tiny GeoParquet of points."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(f"({lon}, {lat}, {height})" for lon, lat, height in rows)
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry, height
+            FROM (VALUES {values}) AS t(lon, lat, height)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_metric_nodata_single():
+    assert parse_metric_nodata("-999") == ["-999"]
+
+
+def test_parse_metric_nodata_multiple_with_whitespace():
+    assert parse_metric_nodata(" -999, -9999 ,9999") == ["-999", "-9999", "9999"]
+
+
+def test_parse_metric_nodata_float():
+    assert parse_metric_nodata("-999.0") == ["-999.0"]
+
+
+def test_parse_metric_nodata_none_passthrough():
+    assert parse_metric_nodata(None) == []
+
+
+def test_parse_metric_nodata_rejects_non_numeric():
+    with pytest.raises(InvalidParameterError):
+        parse_metric_nodata("NA")
+    with pytest.raises(InvalidParameterError):
+        parse_metric_nodata("-999,oops")
+    with pytest.raises(InvalidParameterError):
+        parse_metric_nodata("")
+
+
+# ---------------------------------------------------------------------------
+# SQL generation (shared by grid + admin paths)
+# ---------------------------------------------------------------------------
+
+
+def test_build_metric_select_single_sentinel():
+    metrics = parse_metrics("avg:height,max:height")
+    sql = build_metric_select(metrics, nodata_values=["-999"])
+    assert sql == (
+        'AVG(NULLIF("height", -999)) AS "avg_height", MAX(NULLIF("height", -999)) AS "max_height"'
+    )
+
+
+def test_build_metric_select_multiple_sentinels():
+    metrics = parse_metrics("min:var")
+    sql = build_metric_select(metrics, nodata_values=["-999", "-9999"])
+    assert sql == ('MIN(CASE WHEN "var" IN (-999, -9999) THEN NULL ELSE "var" END) AS "min_var"')
+
+
+def test_build_metric_select_without_nodata_unchanged():
+    metrics = parse_metrics("sum:area_ha,avg:yield")
+    assert build_metric_select(metrics) == (
+        'SUM("area_ha") AS "sum_area_ha", AVG("yield") AS "avg_yield"'
+    )
+
+
+def test_metric_nodata_verified_against_duckdb():
+    """The generated SQL computes metrics over non-sentinel values only."""
+    con = duckdb.connect()
+    con.execute("CREATE TABLE t AS SELECT * FROM (VALUES (1.0), (-999.0), (2.0)) v(height)")
+    metrics = parse_metrics("avg:height,min:height")
+    sql = build_metric_select(metrics, nodata_values=["-999"])
+    row = con.execute(f"SELECT COUNT(*) AS count, {sql} FROM t").fetchone()
+    assert row[0] == 3  # count unaffected
+    assert row[1] == 1.5  # avg of 1.0, 2.0
+    assert row[2] == 1.0  # min ignores -999
+    con.close()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_metric_nodata_requires_metric(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, [(10.0, 50.0, 5.0)])
+    with pytest.raises(InvalidParameterError, match="metric"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, metric_nodata="-999")
+
+
+def test_cli_metric_nodata_requires_metric(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, [(10.0, 50.0, 5.0)])
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "process",
+            "aggregate",
+            "a5",
+            str(src),
+            str(tmp_path / "o.parquet"),
+            "--resolution",
+            "5",
+            "--metric-nodata",
+            "-999",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "metric" in result.output.lower()
+
+
+def test_cli_help_has_metric_nodata_option():
+    runner = CliRunner()
+    for sub in ("a5", "h3", "admin"):
+        result = runner.invoke(cli, ["process", "aggregate", sub, "--help"])
+        assert result.exit_code == 0
+        assert "--metric-nodata" in result.output, f"--metric-nodata missing from {sub} --help"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (needs grid community extensions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_a5_metric_nodata(tmp_path):
+    src = tmp_path / "f.parquet"
+    out = tmp_path / "o.parquet"
+    # One cluster: heights 4.0, 6.0, and a -999 NoData sentinel.
+    _write_points_geoparquet(
+        src, [(10.0, 50.0, 4.0), (10.001, 50.001, 6.0), (10.002, 50.002, -999.0)]
+    )
+    aggregate_by_a5(
+        str(src),
+        str(out),
+        resolution=5,
+        metric="avg:height,min:height",
+        metric_nodata="-999",
+    )
+    df = pq.read_table(out).to_pandas()
+    assert int(df["count"].sum()) == 3  # count includes the sentinel row
+    assert float(df["avg_height"].iloc[0]) == 5.0  # avg of 4.0, 6.0
+    assert float(df["min_height"].iloc[0]) == 4.0  # min ignores -999
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_cli_aggregate_a5_metric_nodata(tmp_path):
+    src = tmp_path / "f.parquet"
+    out = tmp_path / "o.parquet"
+    _write_points_geoparquet(src, [(10.0, 50.0, 4.0), (10.001, 50.001, -999.0)])
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "process",
+            "aggregate",
+            "a5",
+            str(src),
+            str(out),
+            "--resolution",
+            "5",
+            "--metric",
+            "avg:height",
+            "--metric-nodata",
+            "-999",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    df = pq.read_table(out).to_pandas()
+    assert float(df["avg_height"].iloc[0]) == 4.0
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_table_aggregate_a5_metric_nodata():
+    from geoparquet_io.api.table import Table
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    tbl = (
+        con.execute(
+            """
+            SELECT ST_AsWKB(ST_Point(lon, lat)) AS geometry, height FROM (VALUES
+                (10.0, 50.0, 2.0), (10.001, 50.001, -999.0)
+            ) AS t(lon, lat, height)
+            """
+        )
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    result = Table(tbl).aggregate_a5(resolution=5, metric="avg:height", metric_nodata="-999")
+    df = result.table.to_pandas()
+    assert int(df["count"].sum()) == 2
+    assert float(df["avg_height"].iloc[0]) == 2.0

--- a/tests/test_process_aggregate_metric_nodata.py
+++ b/tests/test_process_aggregate_metric_nodata.py
@@ -5,6 +5,7 @@ sum/avg/min/max ignore them while `count` still counts every feature.
 """
 
 import duckdb
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from click.testing import CliRunner
@@ -16,6 +17,25 @@ from geoparquet_io.core.process.aggregate.common import (
     build_metric_select,
     parse_metric_nodata,
     parse_metrics,
+    resolve_metric_column_types,
+    validate_metric_nodata,
+)
+from geoparquet_io.core.process.aggregate.grid_common import GridScheme, build_grid_query
+
+# A scheme with trivial SQL templates so the shared grid engine can be exercised
+# end-to-end on a plain DuckDB connection (no community extension, no network).
+# key_template ignores the geometry and keys every row to the resolution value.
+_DUMMY_SCHEME = GridScheme(
+    name="dummy",
+    extension="none",
+    min_resolution=0,
+    max_resolution=10,
+    default_column="cell",
+    key_template="{res}",
+    boundary_template="{cell}",
+    latlng_template="{cell}",
+    poly_wkb_template="{bnd}",
+    centroid_wkb_template="{ll}",
 )
 
 
@@ -65,6 +85,28 @@ def test_parse_metric_nodata_rejects_non_numeric():
         parse_metric_nodata("")
 
 
+def test_parse_metric_nodata_rejects_non_finite():
+    """inf/Infinity/overflowing values pass float() but must be rejected (P1)."""
+    for bad in ("inf", "-inf", "Infinity", "-Infinity", "INF", "1e999"):
+        with pytest.raises(InvalidParameterError):
+            parse_metric_nodata(bad)
+
+
+def test_parse_metric_nodata_rejects_non_ascii_and_underscore_digits():
+    """float() accepts Unicode digits and underscores; SQL would misparse them (P1)."""
+    for bad in ("٤٢", "1_000", "１２"):
+        with pytest.raises(InvalidParameterError):
+            parse_metric_nodata(bad)
+
+
+def test_parse_metric_nodata_normalizes_nan():
+    """NaN is an explicitly supported sentinel, normalized to a canonical token."""
+    assert parse_metric_nodata("nan") == ["nan"]
+    assert parse_metric_nodata("NaN") == ["nan"]
+    assert parse_metric_nodata("-nan") == ["nan"]
+    assert parse_metric_nodata("nan,-999") == ["nan", "-999"]
+
+
 # ---------------------------------------------------------------------------
 # SQL generation (shared by grid + admin paths)
 # ---------------------------------------------------------------------------
@@ -102,6 +144,159 @@ def test_metric_nodata_verified_against_duckdb():
     assert row[1] == 1.5  # avg of 1.0, 2.0
     assert row[2] == 1.0  # min ignores -999
     con.close()
+
+
+# ---------------------------------------------------------------------------
+# Column-type-aware sentinel literals (P1 NaN, P2 REAL/float32, integer columns)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_metric_column_types():
+    con = duckdb.connect()
+    metrics = parse_metrics("avg:height,min:name")
+    types = resolve_metric_column_types(
+        con, "SELECT CAST(1 AS REAL) AS height, 'x' AS name", metrics
+    )
+    con.close()
+    assert types == {"height": "FLOAT", "name": "VARCHAR"}
+
+
+def test_resolve_metric_column_types_missing_column_is_lenient():
+    """Unknown/missing columns resolve to no type info (error surfaces later)."""
+    con = duckdb.connect()
+    metrics = parse_metrics("avg:nope")
+    assert resolve_metric_column_types(con, "SELECT 1 AS height", metrics) == {}
+    con.close()
+
+
+def test_nan_sentinel_double_column():
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE t AS SELECT * FROM (VALUES "
+        "(1.0::DOUBLE), ('NaN'::DOUBLE), (3.0::DOUBLE)) v(height)"
+    )
+    sql = build_metric_select(
+        parse_metrics("avg:height,sum:height"),
+        nodata_values=parse_metric_nodata("nan"),
+        column_types={"height": "DOUBLE"},
+    )
+    row = con.execute(f"SELECT {sql} FROM t").fetchone()
+    con.close()
+    assert row[0] == 2.0  # avg of 1.0, 3.0
+    assert row[1] == 4.0
+
+
+def test_nan_sentinel_real_column():
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE t AS SELECT * FROM (VALUES (2.0::REAL), ('NaN'::REAL), (4.0::REAL)) v(height)"
+    )
+    sql = build_metric_select(
+        parse_metrics("avg:height"),
+        nodata_values=parse_metric_nodata("nan"),
+        column_types={"height": "FLOAT"},
+    )
+    row = con.execute(f"SELECT {sql} FROM t").fetchone()
+    con.close()
+    assert row[0] == 3.0
+
+
+def test_nan_sentinel_without_type_info_still_matches():
+    """With no schema info the NaN literal defaults to DOUBLE and still matches REAL."""
+    con = duckdb.connect()
+    con.execute("CREATE TABLE t AS SELECT * FROM (VALUES (2.0::REAL), ('NaN'::REAL)) v(height)")
+    sql = build_metric_select(parse_metrics("avg:height"), nodata_values=["nan"])
+    row = con.execute(f"SELECT {sql} FROM t").fetchone()
+    con.close()
+    assert row[0] == 2.0
+
+
+def test_real_column_scientific_sentinel_cast_to_real():
+    """The classic float32 nodata (-3.4028235e+38) must match a REAL column (P2)."""
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE t AS SELECT * FROM (VALUES (CAST(1.0 AS REAL)), "
+        "(CAST(-3.4028235e+38 AS REAL)), (CAST(3.0 AS REAL))) v(height)"
+    )
+    sql = build_metric_select(
+        parse_metrics("avg:height"),
+        nodata_values=["-3.4028235e+38"],
+        column_types={"height": "FLOAT"},
+    )
+    assert "CAST(-3.4028235e+38 AS REAL)" in sql
+    row = con.execute(f"SELECT {sql} FROM t").fetchone()
+    con.close()
+    assert row[0] == 2.0  # sentinel excluded; avg of 1.0, 3.0
+
+
+def test_real_column_decimal_sentinel_multiple():
+    """Decimal-form sentinels keep matching REAL columns via the CAST path."""
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE t AS SELECT * FROM (VALUES (CAST(1.5 AS REAL)), "
+        "(CAST(-999.9 AS REAL)), (CAST(-9999 AS REAL)), (CAST(2.5 AS REAL))) v(height)"
+    )
+    sql = build_metric_select(
+        parse_metrics("avg:height"),
+        nodata_values=["-999.9", "-9999"],
+        column_types={"height": "FLOAT"},
+    )
+    row = con.execute(f"SELECT {sql} FROM t").fetchone()
+    con.close()
+    assert row[0] == 2.0
+
+
+def test_integer_column_with_int_sentinel():
+    con = duckdb.connect()
+    con.execute("CREATE TABLE t AS SELECT * FROM (VALUES (1), (-999), (3)) v(height)")
+    sql = build_metric_select(
+        parse_metrics("sum:height,avg:height"),
+        nodata_values=["-999"],
+        column_types={"height": "INTEGER"},
+    )
+    row = con.execute(f"SELECT {sql} FROM t").fetchone()
+    con.close()
+    assert row[0] == 4
+    assert row[1] == 2.0
+
+
+def test_integer_column_with_float_sentinel():
+    """A float-form sentinel with an integral value matches int columns via promotion;
+    a fractional sentinel matches nothing (no int equals -999.5) and never rounds."""
+    con = duckdb.connect()
+    con.execute("CREATE TABLE t AS SELECT * FROM (VALUES (1), (-999), (-1000), (3)) v(height)")
+    metrics = parse_metrics("sum:height")
+    sql = build_metric_select(metrics, nodata_values=["-999.0"], column_types={"height": "INTEGER"})
+    assert con.execute(f"SELECT {sql} FROM t").fetchone()[0] == -996  # -999 nulled
+    sql = build_metric_select(metrics, nodata_values=["-999.5"], column_types={"height": "INTEGER"})
+    # Must NOT round to -1000 and null out a real value.
+    assert con.execute(f"SELECT {sql} FROM t").fetchone()[0] == -1995
+    con.close()
+
+
+def test_all_sentinel_group_returns_null_not_zero():
+    con = duckdb.connect()
+    con.execute("CREATE TABLE t AS SELECT * FROM (VALUES (-999.0), (-999.0)) v(height)")
+    sql = build_metric_select(
+        parse_metrics("sum:height,avg:height"),
+        nodata_values=["-999"],
+        column_types={"height": "DOUBLE"},
+    )
+    row = con.execute(f"SELECT COUNT(*), {sql} FROM t").fetchone()
+    con.close()
+    assert row[0] == 2  # count still counts sentinel rows
+    assert row[1] is None  # SUM over all-NULL is NULL, not 0
+    assert row[2] is None
+
+
+def test_varchar_metric_with_nodata_raises():
+    """Applying numeric sentinels to a VARCHAR metric column fails up-front (P3)."""
+    with pytest.raises(InvalidParameterError, match="numeric"):
+        build_metric_select(
+            parse_metrics("min:name"),
+            nodata_values=["-999"],
+            column_types={"name": "VARCHAR"},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -157,6 +352,240 @@ def test_build_grid_query_wraps_metrics_with_nodata():
     )
     con.close()
     assert 'AVG(NULLIF("height", -999)) AS "avg_height"' in sql
+
+
+def test_validate_metric_nodata_shared_and_flag_neutral():
+    """One shared validator, worded without CLI flag spellings (P3)."""
+    metrics, nodata = validate_metric_nodata("avg:height", "-999")
+    assert [m.output_name for m in metrics] == ["avg_height"]
+    assert nodata == ["-999"]
+    assert validate_metric_nodata(None, None) == ([], [])
+    with pytest.raises(InvalidParameterError, match="metric") as exc:
+        validate_metric_nodata(None, "-999")
+    assert "--" not in str(exc.value)
+
+
+def test_table_api_metric_nodata_requires_metric_flag_neutral():
+    """aggregate_a5_table validates before touching DuckDB extensions, with a
+    message that does not hard-code CLI flag spellings."""
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_a5_table
+
+    tbl = pa.table({"geometry": pa.array([b"\x00"], type=pa.binary()), "height": [1.0]})
+    with pytest.raises(InvalidParameterError, match="metric") as exc:
+        aggregate_a5_table(tbl, resolution=5, metric_nodata="-999")
+    assert "--" not in str(exc.value)
+
+
+def test_grid_validates_nodata_before_auto_resolution(tmp_path, monkeypatch):
+    """Grid path must reject bad metric/nodata combos before --auto scanning,
+    CRS reads, or extension installs (P3: early validation)."""
+    import geoparquet_io.core.partition.auto_resolution as auto_resolution
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("auto-resolution scan ran before metric-nodata validation")
+
+    monkeypatch.setattr(auto_resolution, "calculate_auto_resolution", _boom)
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, [(10.0, 50.0, 5.0)])
+    with pytest.raises(InvalidParameterError, match="metric"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), auto=True, metric_nodata="-999")
+
+
+def test_build_grid_query_varchar_metric_with_nodata_raises():
+    """The grid builder resolves column types and rejects VARCHAR metrics up-front
+    instead of failing mid-query with a conversion error (P3)."""
+    con = duckdb.connect()
+    with pytest.raises(InvalidParameterError, match="numeric"):
+        build_grid_query(
+            con,
+            _DUMMY_SCHEME,
+            "SELECT 'alpha' AS name, NULL AS __geom",
+            5,
+            "cell",
+            "min:name",
+            None,
+            20,
+            "none",
+            metric_nodata="-999",
+        )
+    con.close()
+
+
+def test_build_grid_query_real_column_sentinel_executes():
+    """Grid wiring resolves the REAL column type so the sentinel actually matches."""
+    con = duckdb.connect()
+    source = (
+        "SELECT * FROM (VALUES (CAST(2.0 AS REAL), NULL), "
+        "(CAST(-3.4028235e+38 AS REAL), NULL), (CAST(4.0 AS REAL), NULL)) t(height, __geom)"
+    )
+    sql = build_grid_query(
+        con,
+        _DUMMY_SCHEME,
+        source,
+        3,
+        "cell",
+        "avg:height",
+        None,
+        20,
+        "none",
+        metric_nodata="-3.4028235e+38",
+    )
+    tbl = con.execute(sql).arrow().read_all()
+    con.close()
+    assert tbl.num_rows == 1
+    assert tbl.column("count")[0].as_py() == 3
+    assert tbl.column("avg_height")[0].as_py() == 3.0
+
+
+def test_build_grid_query_breakdown_with_nodata():
+    """Breakdown counting and nodata-wrapped metrics coexist in one grid query."""
+    con = duckdb.connect()
+    source = (
+        "SELECT * FROM (VALUES (4.0, 'a', NULL), (6.0, 'b', NULL), "
+        "(-999.0, 'a', NULL)) t(height, cat, __geom)"
+    )
+    sql = build_grid_query(
+        con,
+        _DUMMY_SCHEME,
+        source,
+        5,
+        "cell",
+        "avg:height",
+        "cat",
+        20,
+        "none",
+        metric_nodata="-999",
+    )
+    tbl = con.execute(sql).arrow().read_all()
+    con.close()
+    assert tbl.num_rows == 1
+    assert tbl.column("count")[0].as_py() == 3  # sentinel row still counted
+    assert tbl.column("avg_height")[0].as_py() == 5.0  # avg of 4.0, 6.0
+    assert tbl.column("count_a")[0].as_py() == 2  # breakdown counts sentinel rows too
+    assert tbl.column("count_b")[0].as_py() == 1
+
+
+def test_admin_agg_sql_casts_real_sentinel():
+    """The admin builder threads resolved column types into the sentinel literals."""
+    from geoparquet_io.core.process.aggregate.by_admin import _build_agg_sql
+
+    sql = _build_agg_sql(
+        "SELECT 1", parse_metrics("avg:height"), "", ["-3.4028235e+38"], {"height": "FLOAT"}
+    )
+    assert "CAST(-3.4028235e+38 AS REAL)" in sql
+
+
+class _FakeAdminDataset:
+    """Local stand-in for an admin boundary dataset (no download, no S3)."""
+
+    def __init__(self, admin_path):
+        self._path = str(admin_path)
+
+    def supports_per_level_sources(self):
+        return True
+
+    def get_source_for_level(self, level):
+        return self._path
+
+    def get_level_column_mapping(self):
+        return {"country": "country"}
+
+    def get_geometry_column(self):
+        return "geometry"
+
+    def get_bbox_column(self):
+        return None
+
+    def configure_s3(self, con):
+        pass
+
+
+@pytest.fixture
+def fake_admin_dataset(tmp_path, monkeypatch):
+    """Patch admin setup to a tiny local boundary file covering lon 0-20, lat 40-60."""
+    admin_path = tmp_path / "admin.parquet"
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT 'AA' AS country,
+                   ST_GeomFromText('POLYGON((0 40, 20 40, 20 60, 0 60, 0 40))') AS geometry
+        ) TO '{admin_path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    monkeypatch.setattr(
+        "geoparquet_io.core.process.aggregate.by_admin._setup_admin_dataset",
+        lambda dataset, verbose, levels: (_FakeAdminDataset(admin_path), None),
+    )
+
+
+def _write_real_points(path, rows):
+    """rows: list of (lon, lat, height, cat). Writes points with a REAL height column."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(f"({lon}, {lat}, {h}, '{cat}')" for lon, lat, h, cat in rows)
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry, CAST(h AS REAL) AS height, cat
+            FROM (VALUES {values}) AS t(lon, lat, h, cat)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def test_admin_real_column_sentinel_end_to_end(tmp_path, fake_admin_dataset):
+    """Admin path resolves REAL column types so the float32 sentinel matches."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "pts.parquet"
+    out = tmp_path / "out.parquet"
+    _write_real_points(
+        src,
+        [(10.0, 50.0, 4.0, "a"), (10.1, 50.1, 6.0, "b"), (10.2, 50.2, -3.4028235e38, "a")],
+    )
+    aggregate_by_admin(
+        str(src),
+        str(out),
+        level="country",
+        metric="avg:height",
+        metric_nodata="-3.4028235e+38",
+        out_geometry="none",
+    )
+    df = pq.read_table(out).to_pandas()
+    row = df[df["admin_code"] == "AA"].iloc[0]
+    assert int(row["count"]) == 3  # sentinel row still counted
+    assert float(row["avg_height"]) == 5.0  # avg of 4.0, 6.0
+
+
+def test_admin_breakdown_with_nodata_end_to_end(tmp_path, fake_admin_dataset):
+    """Breakdown counting and nodata-wrapped metrics coexist on the admin path."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "pts.parquet"
+    out = tmp_path / "out.parquet"
+    _write_real_points(
+        src,
+        [(10.0, 50.0, 4.0, "a"), (10.1, 50.1, 6.0, "b"), (10.2, 50.2, -999.0, "a")],
+    )
+    aggregate_by_admin(
+        str(src),
+        str(out),
+        level="country",
+        metric="avg:height",
+        metric_nodata="-999",
+        breakdown="cat",
+        out_geometry="none",
+    )
+    df = pq.read_table(out).to_pandas()
+    row = df[df["admin_code"] == "AA"].iloc[0]
+    assert int(row["count"]) == 3
+    assert float(row["avg_height"]) == 5.0
+    assert int(row["count_a"]) == 2
+    assert int(row["count_b"]) == 1
 
 
 def test_cli_metric_nodata_requires_metric(tmp_path):

--- a/tests/test_process_aggregate_metric_nodata.py
+++ b/tests/test_process_aggregate_metric_nodata.py
@@ -116,6 +116,49 @@ def test_metric_nodata_requires_metric(tmp_path):
         aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, metric_nodata="-999")
 
 
+def test_admin_metric_nodata_requires_metric(tmp_path):
+    """Admin path validates before any dataset setup or download."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "f.parquet"
+    _write_points_geoparquet(src, [(10.0, 50.0, 5.0)])
+    with pytest.raises(InvalidParameterError, match="metric"):
+        aggregate_by_admin(
+            str(src), str(tmp_path / "o.parquet"), level="country", metric_nodata="-999"
+        )
+
+
+def test_admin_agg_sql_wraps_metrics_with_nodata():
+    """_build_agg_sql applies the sentinel wrap in the admin GROUP BY select."""
+    from geoparquet_io.core.process.aggregate.by_admin import _build_agg_sql
+
+    metrics = parse_metrics("avg:height")
+    sql = _build_agg_sql("SELECT 1", metrics, "", ["-999"])
+    assert 'AVG(NULLIF("height", -999)) AS "avg_height"' in sql
+
+
+def test_build_grid_query_wraps_metrics_with_nodata():
+    """The grid SQL builder threads metric_nodata into the metric select."""
+    from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME
+    from geoparquet_io.core.process.aggregate.grid_common import build_grid_query
+
+    con = duckdb.connect()
+    sql = build_grid_query(
+        con,
+        A5_SCHEME,
+        "SELECT 1 AS height, NULL AS __geom",
+        5,
+        "a5_cell",
+        "avg:height",
+        None,
+        20,
+        "none",
+        metric_nodata="-999",
+    )
+    con.close()
+    assert 'AVG(NULLIF("height", -999)) AS "avg_height"' in sql
+
+
 def test_cli_metric_nodata_requires_metric(tmp_path):
     src = tmp_path / "f.parquet"
     _write_points_geoparquet(src, [(10.0, 50.0, 5.0)])

--- a/tests/test_process_aggregate_metric_nodata.py
+++ b/tests/test_process_aggregate_metric_nodata.py
@@ -537,7 +537,8 @@ def _write_real_points(path, rows):
     con.close()
 
 
-def test_admin_real_column_sentinel_end_to_end(tmp_path, fake_admin_dataset):
+@pytest.mark.usefixtures("fake_admin_dataset")
+def test_admin_real_column_sentinel_end_to_end(tmp_path):
     """Admin path resolves REAL column types so the float32 sentinel matches."""
     from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
 
@@ -561,7 +562,8 @@ def test_admin_real_column_sentinel_end_to_end(tmp_path, fake_admin_dataset):
     assert float(row["avg_height"]) == 5.0  # avg of 4.0, 6.0
 
 
-def test_admin_breakdown_with_nodata_end_to_end(tmp_path, fake_admin_dataset):
+@pytest.mark.usefixtures("fake_admin_dataset")
+def test_admin_breakdown_with_nodata_end_to_end(tmp_path):
     """Breakdown counting and nodata-wrapped metrics coexist on the admin path."""
     from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
 


### PR DESCRIPTION
## Summary

Implements #566 (variant A from the issue): `--metric-nodata` on all three `gpio process aggregate` subcommands maps NoData sentinel values (e.g. `-999` in GlobalBuildingAtlas heights) to `NULL` for metric computation only. `sum`/`avg`/`min`/`max` then ignore the sentinels, while `count` still counts every feature — no pre-cleaning rewrite of the input needed.

```bash
gpio process aggregate a5 buildings.parquet cells.parquet --auto \
    --metric "avg:height,max:height" --metric-nodata "-999"
```

## Implementation

- `parse_metric_nodata()` in `core/process/aggregate/common.py` validates comma-separated numeric sentinels (tokens preserved verbatim in SQL, so integer sentinels stay integer literals)
- `build_metric_select()` wraps each metric column: `NULLIF("col", -999)` for a single sentinel, `CASE WHEN "col" IN (...) THEN NULL ELSE "col" END` for multiple — the admin path shares this builder, so all three subcommands behave identically
- Errors clearly if `--metric-nodata` is given without `--metric`
- Threaded through core, CLI (`grid_aggregate_options` + admin command), and Python API (`ops.aggregate_*`, `Table.aggregate_*` as `metric_nodata=`)

Per the issue, per-column sentinels (variant B) and `--metric-where` are left for later if demand appears.

## Tests

15 new tests in `tests/test_process_aggregate_metric_nodata.py`: parsing (valid/invalid/whitespace), exact SQL-string assertions matching the existing `test_process_aggregate_common.py` style, a live DuckDB verification of the generated SQL, requires-metric validation (core + CLI), CLI help presence on all three subcommands, and slow/network e2e (core, CLI, Table API). All pass locally; fast suite green (3526 passed).

## Docs

- `docs/guide/process-aggregate.md`: NoData note in "Which metric function to use" (as requested in the issue) + Common Options
- `docs/api/python-api.md` signatures + parameter row
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--metric-nodata` support to A5, H3, and administrative aggregation commands, including the Python aggregation APIs.
  * Sentinel values (including comma-separated lists and `nan`) are treated as NoData by mapping them to `NULL` for metric rollups, so `sum`/`avg`/`min`/`max` ignore them while `count` remains unchanged.
  * Added validation to ensure `--metric-nodata` is used with a corresponding `--metric`.
* **Documentation**
  * Updated guides, CLI help text, and API references (including changelogs) with option details and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->