### PR TITLE
feat(process): add --bucket-point bbox keying to process aggregate (#567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`--bucket-point` on `gpio process aggregate` (#567).** Grid/admin keying
+  can now derive its per-feature point from a bbox covering column
+  (`--bucket-point bbox`, auto-detected or via `--bbox-column`) or an existing
+  point column, instead of the geometry centroid. Since the default output
+  synthesizes cell polygons from the cell id, the (usually huge) geometry
+  column is excluded from the scan entirely — Parquet projection pushdown
+  skips its column chunks, making low-zoom aggregation of large polygon
+  datasets (e.g. 225 GB of building footprints with a `bbox` column)
+  dramatically cheaper, with no DuckDB pre-step. Also on the Python API as
+  `aggregate_a5/h3/admin(..., bucket_point=..., bbox_column=...)`.
+
 - **`--where` row filter on `gpio process aggregate` (#568).** All three
   subcommands (`a5`, `h3`, `admin`) accept a DuckDB WHERE clause that filters
   input rows before aggregation — slice a dataset by year, category, or

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`--bucket-point` on `gpio process aggregate` (#567).** Grid/admin keying
+  can now derive its per-feature point from a bbox covering column
+  (`--bucket-point bbox`, auto-detected or via `--bbox-column`) or an existing
+  point column, instead of the geometry centroid. Since the default output
+  synthesizes cell polygons from the cell id, the (usually huge) geometry
+  column is excluded from the scan entirely — Parquet projection pushdown
+  skips its column chunks, making low-zoom aggregation of large polygon
+  datasets (e.g. 225 GB of building footprints with a `bbox` column)
+  dramatically cheaper, with no DuckDB pre-step. Also on the Python API as
+  `aggregate_a5/h3/admin(..., bucket_point=..., bbox_column=...)`.
+
 - **`--where` row filter on `gpio process aggregate` (#568).** All three
   subcommands (`a5`, `h3`, `admin`) accept a DuckDB WHERE clause that filters
   input rows before aggregation — slice a dataset by year, category, or

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -884,7 +884,7 @@ stats = table.partition_by_admin('output/', vecorel=True)
 
 ### Aggregation Methods {#aggregation}
 
-#### `aggregate_a5(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None)`
+#### `aggregate_a5(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None, bucket_point='geometry', bbox_column=None)`
 
 Aggregate features into A5 grid cells with per-cell statistics for low-zoom visualization.
 
@@ -931,10 +931,12 @@ result.write('cells_stats.parquet')
 | `out_geometry` | str | `"polygon"` | Geometry per cell: `"polygon"`, `"centroid"`, `"both"`, or `"none"` |
 | `where` | str | None | DuckDB WHERE clause filtering input rows before aggregation |
 | `metric_nodata` | str | None | NoData sentinel value(s) mapped to NULL in metric columns, e.g. `"-999"` or `"-999,-9999"` (`"nan"` matches NaN) |
+| `bucket_point` | str | `"geometry"` | Keying point source: `"geometry"` (centroid), `"bbox"` (bbox covering column center, skips reading geometry), or a point column name |
+| `bbox_column` | str | None | Bbox covering column for `bucket_point="bbox"` (auto-detected when omitted) |
 
 Every output row carries `a5_cell` (UBIGINT) as the bucket identifier.
 
-#### `aggregate_h3(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None)`
+#### `aggregate_h3(resolution, metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None, bucket_point='geometry', bbox_column=None)`
 
 Aggregate features into H3 hexagonal grid cells. Same options as `aggregate_a5`,
 but the resolution range is **0–15** and the bucket id column is `h3_cell` (a
@@ -953,7 +955,7 @@ result.write('cells.parquet')
 
 Every output row carries `h3_cell` (string) as the bucket identifier.
 
-#### `aggregate_admin(level='country', metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None)`
+#### `aggregate_admin(level='country', metric=None, breakdown=None, breakdown_limit=20, out_geometry='polygon', where=None, metric_nodata=None, bucket_point='geometry', bbox_column=None)`
 
 Aggregate features into administrative regions (Overture Maps) with per-region statistics.
 

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -214,6 +214,61 @@ Use `--where` to aggregate only a subset of rows — a year, a category, a confi
 On a hive-partitioned input (`year=2025/...`), the partition columns are part of the scan, so `--where "year = 2025"` filters on them and DuckDB prunes the partitions it does not need. Partition columns never appear in the aggregated output.
 
 The clause must be a single filtering expression: a `;` statement separator outside a quoted string is rejected, as are keywords that modify data (`DROP`, `DELETE`, `INSERT`, ...).
+### Bucketing Point
+
+Grid keying reduces every feature to a single point (by default the geometry
+centroid) just to pick a cell — and with the default cell-polygon output, the
+input geometry is read *only* to compute that point. For large polygon datasets
+where geometry dominates file size, `--bucket-point bbox` derives the point from
+a [bbox covering column](add.md) instead and **skips reading the geometry column
+entirely**, cutting the scan to a small fraction:
+
+| Value | Keying point | Reads geometry column? |
+|-------|--------------|------------------------|
+| `geometry` *(default)* | `ST_Centroid(geometry)` | yes |
+| `bbox` | Center of the bbox covering column | **no** |
+| `<column>` | An existing point column | **no** |
+
+The bbox column is auto-detected from naming conventions (`bbox`, `*_bbox`,
+`bounds`, `extent` structs with `xmin`/`ymin`/`xmax`/`ymax`); pass
+`--bbox-column NAME` for nonstandard names. Bbox center differs from the true
+centroid only for L-shaped/very elongated features — negligible at aggregation
+resolutions, where keying by centroid is already an approximation.
+
+=== "CLI"
+
+    ```bash
+    # 225 GB of building polygons, but only the bbox + height columns are read
+    gpio process aggregate a5 buildings.parquet cells.parquet --auto \
+        --bucket-point bbox --metric "avg:height"
+
+    # Nonstandard bbox column name
+    gpio process aggregate a5 buildings.parquet cells.parquet --resolution 8 \
+        --bucket-point bbox --bbox-column geometry_bbox
+
+    # Key from an existing point column
+    gpio process aggregate h3 parcels.parquet cells.parquet --resolution 8 \
+        --bucket-point anchor_point
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    result = gpio.read('buildings.parquet').aggregate_a5(
+        resolution=10,
+        metric="avg:height",
+        bucket_point="bbox",
+    )
+    result.write('cells.parquet')
+    ```
+
+!!! note "`--auto` still probes the geometry column"
+    Auto-resolution sizing samples geometry centroids over a bounded sample
+    (≤500k rows), so `--auto` reads a small slice of the geometry column even
+    with `--bucket-point bbox`. Pass `--resolution` explicitly to avoid touching
+    geometry altogether.
 
 ### Output Geometry
 

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -229,9 +229,10 @@ entirely**, cutting the scan to a small fraction:
 | `bbox` | Center of the bbox covering column | **no** |
 | `<column>` | An existing point column | **no** |
 
-The bbox column is auto-detected from naming conventions (`bbox`, `*_bbox`,
+The bbox column is auto-detected from the file's GeoParquet `covering.bbox`
+metadata when present, falling back to naming conventions (`bbox`, `*_bbox`,
 `bounds`, `extent` structs with `xmin`/`ymin`/`xmax`/`ymax`); pass
-`--bbox-column NAME` for nonstandard names. Bbox center differs from the true
+`--bbox-column NAME` for uncovered, nonconventional names. Bbox center differs from the true
 centroid only for L-shaped/very elongated features — negligible at aggregation
 resolutions, where keying by centroid is already an approximation.
 
@@ -242,9 +243,10 @@ resolutions, where keying by centroid is already an approximation.
     gpio process aggregate a5 buildings.parquet cells.parquet --auto \
         --bucket-point bbox --metric "avg:height"
 
-    # Nonstandard bbox column name
+    # Nonstandard bbox column name (not referenced by covering metadata and
+    # not matching the naming conventions, so it can't be auto-detected)
     gpio process aggregate a5 buildings.parquet cells.parquet --resolution 8 \
-        --bucket-point bbox --bbox-column geometry_bbox
+        --bucket-point bbox --bbox-column my_box
 
     # Key from an existing point column
     gpio process aggregate h3 parcels.parquet cells.parquet --resolution 8 \

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -273,6 +273,8 @@ def aggregate_a5(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into A5 grid cells with per-cell statistics.
@@ -288,6 +290,10 @@ def aggregate_a5(
         where: DuckDB WHERE clause filtering input rows before aggregation
         metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns,
             e.g. "-999" or "-999,-9999"
+        bucket_point: Keying point source: "geometry" (centroid, default),
+            "bbox" (center of a bbox covering column), or a point column name
+        bbox_column: Bbox covering column for bucket_point="bbox" (auto-detected
+            when omitted)
 
     Returns:
         New PyArrow Table with one row per A5 cell
@@ -304,6 +310,8 @@ def aggregate_a5(
         geometry_column=geometry_column,
         where=where,
         metric_nodata=metric_nodata,
+        bucket_point=bucket_point,
+        bbox_column=bbox_column,
     )
 
 
@@ -317,6 +325,8 @@ def aggregate_h3(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into H3 grid cells with per-cell statistics.
@@ -332,6 +342,10 @@ def aggregate_h3(
         where: DuckDB WHERE clause filtering input rows before aggregation
         metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns,
             e.g. "-999" or "-999,-9999"
+        bucket_point: Keying point source: "geometry" (centroid, default),
+            "bbox" (center of a bbox covering column), or a point column name
+        bbox_column: Bbox covering column for bucket_point="bbox" (auto-detected
+            when omitted)
 
     Returns:
         New PyArrow Table with one row per H3 cell
@@ -348,6 +362,8 @@ def aggregate_h3(
         geometry_column=geometry_column,
         where=where,
         metric_nodata=metric_nodata,
+        bucket_point=bucket_point,
+        bbox_column=bbox_column,
     )
 
 
@@ -360,6 +376,8 @@ def aggregate_admin(
     out_geometry: str = "polygon",
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> pa.Table:
     """
     Aggregate an Arrow table into administrative regions with per-region statistics.
@@ -374,6 +392,10 @@ def aggregate_admin(
         where: DuckDB WHERE clause filtering input rows before aggregation
         metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns,
             e.g. "-999" or "-999,-9999"
+        bucket_point: Join-point source: "geometry" (centroid, default),
+            "bbox" (center of a bbox covering column), or a point column name
+        bbox_column: Bbox covering column for bucket_point="bbox" (auto-detected
+            when omitted)
 
     Returns:
         New PyArrow Table with one row per admin region
@@ -395,6 +417,8 @@ def aggregate_admin(
         out_geometry=out_geometry,
         where=where,
         metric_nodata=metric_nodata,
+        bucket_point=bucket_point,
+        bbox_column=bbox_column,
     )
 
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1382,6 +1382,8 @@ class Table:
         out_geometry: str = "polygon",
         where: str | None = None,
         metric_nodata: str | None = None,
+        bucket_point: str = "geometry",
+        bbox_column: str | None = None,
     ) -> Table:
         """
         Aggregate features into A5 grid cells with per-cell statistics.
@@ -1394,6 +1396,9 @@ class Table:
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
             where: DuckDB WHERE clause filtering input rows before aggregation
             metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns
+            bucket_point: Keying point source: "geometry" (centroid, default),
+                "bbox" (center of a bbox covering column), or a point column name
+            bbox_column: Bbox covering column for bucket_point="bbox"
 
         Returns:
             New Table with one row per A5 cell
@@ -1410,6 +1415,8 @@ class Table:
             geometry_column=self._geometry_column,
             where=where,
             metric_nodata=metric_nodata,
+            bucket_point=bucket_point,
+            bbox_column=bbox_column,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 
@@ -1422,6 +1429,8 @@ class Table:
         out_geometry: str = "polygon",
         where: str | None = None,
         metric_nodata: str | None = None,
+        bucket_point: str = "geometry",
+        bbox_column: str | None = None,
     ) -> Table:
         """
         Aggregate features into H3 grid cells with per-cell statistics.
@@ -1434,6 +1443,9 @@ class Table:
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
             where: DuckDB WHERE clause filtering input rows before aggregation
             metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns
+            bucket_point: Keying point source: "geometry" (centroid, default),
+                "bbox" (center of a bbox covering column), or a point column name
+            bbox_column: Bbox covering column for bucket_point="bbox"
 
         Returns:
             New Table with one row per H3 cell
@@ -1450,6 +1462,8 @@ class Table:
             geometry_column=self._geometry_column,
             where=where,
             metric_nodata=metric_nodata,
+            bucket_point=bucket_point,
+            bbox_column=bbox_column,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 
@@ -1462,6 +1476,8 @@ class Table:
         out_geometry: str = "polygon",
         where: str | None = None,
         metric_nodata: str | None = None,
+        bucket_point: str = "geometry",
+        bbox_column: str | None = None,
     ) -> Table:
         """
         Aggregate features into administrative regions with per-region statistics.
@@ -1474,6 +1490,9 @@ class Table:
             out_geometry: Output geometry type: "polygon", "centroid", "both", or "none"
             where: DuckDB WHERE clause filtering input rows before aggregation
             metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns
+            bucket_point: Join-point source: "geometry" (centroid, default),
+                "bbox" (center of a bbox covering column), or a point column name
+            bbox_column: Bbox covering column for bucket_point="bbox"
 
         Returns:
             New Table with one row per admin region
@@ -1489,6 +1508,8 @@ class Table:
             out_geometry=out_geometry,
             where=where,
             metric_nodata=metric_nodata,
+            bucket_point=bucket_point,
+            bbox_column=bbox_column,
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -372,6 +372,23 @@ def metric_nodata_option(func):
     )(func)
 
 
+def bucket_point_options(func):
+    """Add the ``--bucket-point`` / ``--bbox-column`` keying options (#567)."""
+    func = click.option(
+        "--bbox-column",
+        default=None,
+        help="Bbox covering column for --bucket-point bbox (auto-detected if omitted).",
+    )(func)
+    func = click.option(
+        "--bucket-point",
+        default="geometry",
+        help="Where the bucketing point comes from: 'geometry' (centroid, default), "
+        "'bbox' (center of a bbox covering column -- skips reading the geometry "
+        "column), or the name of an existing point column.",
+    )(func)
+    return func
+
+
 def grid_aggregate_options(func):
     """Add the options shared by `gpio process aggregate <grid>` commands.
 
@@ -379,8 +396,9 @@ def grid_aggregate_options(func):
     valid range differs between grids):
     - --auto, --target-per-cell, --max-cells
     - --metric, --metric-nodata, --breakdown, --breakdown-limit
-    - --out-geometry, --where
+    - --out-geometry, --where, --bucket-point, --bbox-column
     """
+    func = bucket_point_options(func)
     func = where_option(func)
     func = click.option(
         "--out-geometry",

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -13,6 +13,7 @@ from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     any_extension_option,
     aws_profile_option,
+    bucket_point_options,
     check_partition_options,
     compression_options,
     dry_run_option,
@@ -7067,6 +7068,8 @@ def process_aggregate_a5(
     breakdown_limit,
     out_geometry,
     where,
+    bucket_point,
+    bbox_column,
     compression,
     compression_level,
     verbose,
@@ -7084,6 +7087,8 @@ def process_aggregate_a5(
             --where "\\"crop:name\\" = 'wheat'"
         gpio process aggregate a5 buildings.parquet cells.parquet --auto \\
             --metric "avg:height,max:height" --metric-nodata "-999"
+        gpio process aggregate a5 buildings.parquet cells.parquet --auto \\
+            --bucket-point bbox --metric "avg:height"
         gpio process aggregate a5 fields.parquet cells.csv-like.parquet \\
             --resolution 8 --out-geometry none
     """
@@ -7107,6 +7112,8 @@ def process_aggregate_a5(
                 show_sql=show_sql,
                 where=where,
                 metric_nodata=metric_nodata,
+                bucket_point=bucket_point,
+                bbox_column=bbox_column,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise _aggregate_error(exc, where) from exc
@@ -7141,6 +7148,8 @@ def process_aggregate_h3(
     breakdown_limit,
     out_geometry,
     where,
+    bucket_point,
+    bbox_column,
     compression,
     compression_level,
     verbose,
@@ -7158,6 +7167,8 @@ def process_aggregate_h3(
             --where "confidence >= 50"
         gpio process aggregate h3 buildings.parquet cells.parquet --auto \\
             --metric "avg:height" --metric-nodata "-999"
+        gpio process aggregate h3 buildings.parquet cells.parquet --auto \\
+            --bucket-point bbox
         gpio process aggregate h3 fields.parquet cells.parquet \\
             --resolution 8 --out-geometry none
     """
@@ -7181,6 +7192,8 @@ def process_aggregate_h3(
                 show_sql=show_sql,
                 where=where,
                 metric_nodata=metric_nodata,
+                bucket_point=bucket_point,
+                bbox_column=bbox_column,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise _aggregate_error(exc, where) from exc
@@ -7219,6 +7232,7 @@ def process_aggregate_h3(
     help="Output geometry per region (default: polygon).",
 )
 @where_option
+@bucket_point_options
 @compression_options
 @verbose_option
 @geoparquet_version_option
@@ -7235,6 +7249,8 @@ def process_aggregate_admin(
     breakdown_limit,
     out_geometry,
     where,
+    bucket_point,
+    bbox_column,
     compression,
     compression_level,
     verbose,
@@ -7252,6 +7268,8 @@ def process_aggregate_admin(
             --level country --where "confidence >= 50"
         gpio process aggregate admin buildings.parquet by_country.parquet \\
             --level country --metric "avg:height" --metric-nodata "-999"
+        gpio process aggregate admin buildings.parquet by_country.parquet \\
+            --level country --bucket-point bbox
     """
     with _activate_s3(ctx):
         try:
@@ -7270,6 +7288,8 @@ def process_aggregate_admin(
                 show_sql=show_sql,
                 where=where,
                 metric_nodata=metric_nodata,
+                bucket_point=bucket_point,
+                bbox_column=bbox_column,
             )
         except (InvalidParameterError, ValidationError, ValueError, duckdb.Error) as exc:
             raise _aggregate_error(exc, where) from exc

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -992,12 +992,27 @@ def _detect_version_from_table(table, verbose: bool = False) -> str | None:
         return None
 
 
+def _table_bbox_struct_ok(table, column_name: str) -> bool:
+    """True when ``column_name`` is a struct column with the bbox fields."""
+    import pyarrow as pa
+
+    try:
+        field = table.schema.field(column_name)
+    except KeyError:
+        return False
+    return pa.types.is_struct(field.type) and {"xmin", "ymin", "xmax", "ymax"}.issubset(
+        {f.name for f in field.type}
+    )
+
+
 def _detect_bbox_column_from_table(table, verbose: bool = False) -> str | None:
     """
     Detect bbox struct column from Arrow table schema.
 
-    Looks for columns with conventional names (bbox, bounds, extent) that have
-    the required struct fields (xmin, ymin, xmax, ymax).
+    Consults the GeoParquet ``covering.bbox`` metadata first (the authoritative
+    pointer, which may use a non-conventional name), then falls back to columns
+    with conventional names (bbox, bounds, extent) that have the required
+    struct fields (xmin, ymin, xmax, ymax).
 
     Args:
         table: PyArrow Table to check
@@ -1007,6 +1022,15 @@ def _detect_bbox_column_from_table(table, verbose: bool = False) -> str | None:
         str: Name of bbox column if found, None otherwise
     """
     import pyarrow as pa
+
+    from geoparquet_io.core.crs_utils import parse_geo_metadata_from_schema
+
+    geo_meta = parse_geo_metadata_from_schema(table.schema.metadata)
+    covering_column = _bbox_column_from_covering(geo_meta)
+    if covering_column and _table_bbox_struct_ok(table, covering_column):
+        if verbose:
+            debug(f"Found bbox column from covering metadata: {covering_column}")
+        return covering_column
 
     conventional_suffixes = ["bbox", "bounds", "extent"]
     required_fields = {"xmin", "ymin", "xmax", "ymax"}
@@ -2613,6 +2637,53 @@ def format_size(size_bytes):
     return f"{size_bytes:.2f} TB"
 
 
+#: Struct fields a bbox covering column must expose.
+_BBOX_REQUIRED_FIELDS = frozenset({"xmin", "ymin", "xmax", "ymax"})
+
+
+def _bbox_column_from_covering(geo_meta) -> str | None:
+    """Return the bbox column name referenced by GeoParquet ``covering.bbox``.
+
+    The covering metadata is the authoritative pointer to a file's bbox column
+    (its name need not follow any convention). Returns ``None`` when absent or
+    malformed.
+    """
+    if not isinstance(geo_meta, dict):
+        return None
+    columns = geo_meta.get("columns", {})
+    if not isinstance(columns, dict):
+        return None
+    for col_info in columns.values():
+        if not isinstance(col_info, dict):
+            continue
+        covering = col_info.get("covering")
+        bbox_refs = covering.get("bbox") if isinstance(covering, dict) else None
+        if (
+            isinstance(bbox_refs, dict)
+            and _BBOX_REQUIRED_FIELDS.issubset(bbox_refs)
+            and all(isinstance(ref, list) and len(ref) == 2 for ref in bbox_refs.values())
+        ):
+            return bbox_refs["xmin"][0]
+    return None
+
+
+def _schema_struct_child_names(schema_info, column_name) -> set | None:
+    """Child field names of struct column ``column_name`` from a flat
+    ``parquet_schema()`` listing; ``None`` if the column is absent or not a struct."""
+    for i, col in enumerate(schema_info):
+        if col.get("name") != column_name:
+            continue
+        num_children = col.get("num_children") or 0
+        if num_children < 1:
+            return None
+        return {
+            schema_info[i + j].get("name", "")
+            for j in range(1, num_children + 1)
+            if i + j < len(schema_info)
+        }
+    return None
+
+
 def _find_bbox_column_in_schema(schema_info, verbose):
     """Find bbox column in schema by conventional names or structure.
 
@@ -2742,12 +2813,22 @@ def check_bbox_structure(parquet_file, verbose=False) -> BboxInfo:
             if name:  # Skip empty names
                 debug(f"  {name}: {col_type}")
 
-    # Find the bbox column in the schema
-    bbox_column_name = _find_bbox_column_in_schema(schema_info, verbose)
+    # Find the bbox column: the authoritative covering metadata first (spec-valid
+    # files may use non-conventional names), then the naming-convention fallback.
+    geo_meta = get_geo_metadata(safe_url)
+    bbox_column_name = None
+    covering_column = _bbox_column_from_covering(geo_meta)
+    if covering_column:
+        children = _schema_struct_child_names(schema_info, covering_column)
+        if children and _BBOX_REQUIRED_FIELDS.issubset(children):
+            bbox_column_name = covering_column
+            if verbose:
+                debug(f"Found bbox column from covering metadata: {covering_column}")
+    if bbox_column_name is None:
+        bbox_column_name = _find_bbox_column_in_schema(schema_info, verbose)
     has_bbox_column = bbox_column_name is not None
 
-    # Get geo metadata and check for bbox covering
-    geo_meta = get_geo_metadata(safe_url)
+    # Check for bbox covering in the geo metadata
     has_bbox_metadata = _check_bbox_metadata_covering(geo_meta, has_bbox_column, verbose)
 
     # Determine status and message

--- a/geoparquet_io/core/process/aggregate/by_a5.py
+++ b/geoparquet_io/core/process/aggregate/by_a5.py
@@ -21,7 +21,7 @@ A5_SCHEME = GridScheme(
     min_resolution=0,
     max_resolution=30,
     default_column=DEFAULT_A5_COLUMN_NAME,
-    key_template="a5_lonlat_to_cell(ST_X(ST_Centroid({geom})), ST_Y(ST_Centroid({geom})), {res})",
+    key_template="a5_lonlat_to_cell(ST_X({pt}), ST_Y({pt}), {res})",
     boundary_template="a5_cell_to_boundary({cell})",
     latlng_template="a5_cell_to_lonlat({cell})",
     # a5_cell_to_boundary returns DOUBLE[2][]; close the ring and build a polygon.
@@ -53,6 +53,8 @@ def aggregate_by_a5(
     show_sql: bool = False,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into A5 cells. Writes the output file."""
     aggregate_grid_file(
@@ -75,6 +77,8 @@ def aggregate_by_a5(
         show_sql=show_sql,
         where=where,
         metric_nodata=metric_nodata,
+        bucket_point=bucket_point,
+        bbox_column=bbox_column,
     )
 
 
@@ -89,6 +93,8 @@ def aggregate_a5_table(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> pa.Table:
     """Aggregate an in-memory Arrow table by a5 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
@@ -103,4 +109,6 @@ def aggregate_a5_table(
         geometry_column=geometry_column,
         where=where,
         metric_nodata=metric_nodata,
+        bucket_point=bucket_point,
+        bbox_column=bbox_column,
     )

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -37,7 +37,9 @@ from geoparquet_io.core.process.aggregate.common import (
 from geoparquet_io.core.process.aggregate.grid_common import (
     _resolve_bbox_column_for_file,
     _validate_bucket_point_args,
+    _validate_keying_columns_for_file,
     bucket_point_expr,
+    build_exclude_clause,
 )
 
 
@@ -65,7 +67,7 @@ def _build_joined_sql(
     admin_geom_col: str,
     admin_bbox_col: str | None = None,
     where: str | None = None,
-    exclude_input_columns: tuple[str, ...] = (),
+    exclude_sql: str = "",
 ) -> str:
     """Build the spatial-join SQL tagging each input feature with its admin region.
 
@@ -83,9 +85,12 @@ def _build_joined_sql(
     ``where`` is applied to the inner input scan, so the spatial join, metrics,
     and breakdowns all see only the filtered rows (#568). The caller validates
     the clause. Hive partition columns are visible to it (#612); see
-    :func:`aggregate_source_relation`. ``exclude_input_columns`` drops columns
+    :func:`aggregate_source_relation`. ``exclude_sql`` is a prebuilt
+    `` EXCLUDE (...)`` clause (see ``build_exclude_clause``) dropping columns
     (typically the geometry) from the passthrough SELECT so their Parquet pages
-    are never read.
+    are never read; building it with ``build_exclude_clause`` keeps it
+    existence-checked, so a geometry-less bbox-only input never trips a binder
+    error on a nonexistent column.
     """
     if admin_bbox_col:
         bbox_filter = (
@@ -96,11 +101,6 @@ def _build_joined_sql(
         )
     else:
         bbox_filter = ""
-    if exclude_input_columns:
-        cols = ", ".join(quote_identifier(c) for c in exclude_input_columns)
-        exclude_sql = f" EXCLUDE ({cols})"
-    else:
-        exclude_sql = ""
     return f"""
         SELECT s.*,
                b.{quote_identifier(code_col)} AS __admin_code,
@@ -220,6 +220,8 @@ def aggregate_by_admin(
     _validate_bucket_point_args(bucket_point, bbox_column)
     if bucket_point == "bbox":
         bbox_column = _resolve_bbox_column_for_file(input_parquet, bbox_column, verbose)
+    # Fail on a bad keying column before the (possibly network-bound) dataset setup.
+    _validate_keying_columns_for_file(input_parquet, bucket_point, bbox_column, verbose)
 
     admin_dataset, _boundary_columns = _setup_admin_dataset(dataset, verbose, [level])
     mapping = admin_dataset.get_level_column_mapping()
@@ -266,7 +268,7 @@ def aggregate_by_admin(
             admin_geom_col,
             admin_bbox_col,
             where=where,
-            exclude_input_columns=exclude_cols,
+            exclude_sql=build_exclude_clause(con, read_rel, exclude_cols),
         )
 
         # When a breakdown is requested, materialize the spatial join once so that

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -8,7 +8,7 @@ import gc
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.common import write_geoparquet_table
-from geoparquet_io.core.crs_utils import crs_transform_sql_expr, extract_crs_from_parquet
+from geoparquet_io.core.crs_utils import extract_crs_from_parquet
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
@@ -30,10 +30,14 @@ from geoparquet_io.core.process.aggregate.common import (
     build_breakdown_column_names,
     build_breakdown_select,
     build_metric_select,
-    geometry_to_geom_expr,
     resolve_breakdown_values,
     resolve_metric_column_types,
     validate_metric_nodata,
+)
+from geoparquet_io.core.process.aggregate.grid_common import (
+    _resolve_bbox_column_for_file,
+    _validate_bucket_point_args,
+    bucket_point_expr,
 )
 
 
@@ -54,31 +58,34 @@ def _get_admin_ref(dataset, con, level: str) -> str:
 
 def _build_joined_sql(
     input_url: str,
-    input_geom_expr: str,
+    input_pt_expr: str,
     admin_ref: str,
     code_col: str,
     name_col: str,
     admin_geom_col: str,
     admin_bbox_col: str | None = None,
     where: str | None = None,
+    exclude_input_columns: tuple[str, ...] = (),
 ) -> str:
     """Build the spatial-join SQL tagging each input feature with its admin region.
 
     The admin geometry column is GEOMETRY type in all supported datasets, so it
-    is used directly in ST_Intersects.  ``input_geom_expr`` is a SQL expression
-    that yields a GEOMETRY for the input geometry column (the caller detects
-    whether the column is GEOMETRY or WKB BLOB).  The admin geometry is stored as
-    WKB (ST_AsWKB) so that _wrap_admin_geometry can treat __admin_geom uniformly
-    as WKB binary.
+    is used directly in ST_Intersects.  ``input_pt_expr`` is a SQL expression
+    yielding the per-feature POINT used for the join (geometry centroid by
+    default; bbox center or an existing point column for --bucket-point, #567).
+    The admin geometry is stored as WKB (ST_AsWKB) so that _wrap_admin_geometry
+    can treat __admin_geom uniformly as WKB binary.
 
     When admin_bbox_col is provided, a cheap bbox prefilter is added to the ON
     clause so ST_Intersects is only evaluated for admin polygons whose bounding
-    box contains the feature centroid point.
+    box contains the feature point.
 
     ``where`` is applied to the inner input scan, so the spatial join, metrics,
     and breakdowns all see only the filtered rows (#568). The caller validates
     the clause. Hive partition columns are visible to it (#612); see
-    :func:`aggregate_source_relation`.
+    :func:`aggregate_source_relation`. ``exclude_input_columns`` drops columns
+    (typically the geometry) from the passthrough SELECT so their Parquet pages
+    are never read.
     """
     if admin_bbox_col:
         bbox_filter = (
@@ -89,13 +96,18 @@ def _build_joined_sql(
         )
     else:
         bbox_filter = ""
+    if exclude_input_columns:
+        cols = ", ".join(quote_identifier(c) for c in exclude_input_columns)
+        exclude_sql = f" EXCLUDE ({cols})"
+    else:
+        exclude_sql = ""
     return f"""
         SELECT s.*,
                b.{quote_identifier(code_col)} AS __admin_code,
                b.{quote_identifier(name_col)} AS __admin_name,
                ST_AsWKB(b.{quote_identifier(admin_geom_col)}) AS __admin_geom
         FROM (
-            SELECT *, ST_Centroid({input_geom_expr}) AS __cen
+            SELECT *{exclude_sql}, {input_pt_expr} AS __cen
             FROM {aggregate_source_relation(input_url)}
             {where_sql_fragment(where)}
         ) s
@@ -163,6 +175,8 @@ def aggregate_by_admin(
     show_sql: bool = False,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> None:
     """Aggregate input features by administrative region.
 
@@ -187,6 +201,12 @@ def aggregate_by_admin(
         show_sql: Log the final SQL query.
         where: DuckDB WHERE clause filtering input rows before aggregation.
         metric_nodata: NoData sentinel value(s) mapped to NULL in metric columns.
+        bucket_point: Where the per-feature join point comes from: ``geometry``
+            (centroid, default), ``bbox`` (center of a bbox covering column,
+            skips reading the geometry column), or the name of an existing
+            point column.
+        bbox_column: Bbox covering column for ``bucket_point='bbox'``
+            (auto-detected when omitted).
     """
     configure_verbose(verbose)
     if out_geometry not in VALID_OUT_GEOMETRY:
@@ -197,6 +217,9 @@ def aggregate_by_admin(
     if where:
         validate_where_clause(where)
     metrics, nodata_values = validate_metric_nodata(metric, metric_nodata)
+    _validate_bucket_point_args(bucket_point, bbox_column)
+    if bucket_point == "bbox":
+        bbox_column = _resolve_bbox_column_for_file(input_parquet, bbox_column, verbose)
 
     admin_dataset, _boundary_columns = _setup_admin_dataset(dataset, verbose, [level])
     mapping = admin_dataset.get_level_column_mapping()
@@ -229,20 +252,21 @@ def aggregate_by_admin(
             else None
         )
         # Admin boundaries are OGC:CRS84; reproject a non-CRS84 input so ST_Intersects
-        # does not fail on a CRS mismatch and the centroid lands correctly (#525).
+        # does not fail on a CRS mismatch and the join point lands correctly (#525).
         source_crs = extract_crs_from_parquet(input_parquet, verbose)
-        input_geom_expr = crs_transform_sql_expr(
-            geometry_to_geom_expr(con, read_rel, geom_col), source_crs
+        input_pt_expr, exclude_cols = bucket_point_expr(
+            con, read_rel, geom_col, source_crs, bucket_point, bbox_column
         )
         joined_sql = _build_joined_sql(
             input_url,
-            input_geom_expr,
+            input_pt_expr,
             admin_ref,
             code_col,
             name_col,
             admin_geom_col,
             admin_bbox_col,
             where=where,
+            exclude_input_columns=exclude_cols,
         )
 
         # When a breakdown is requested, materialize the spatial join once so that

--- a/geoparquet_io/core/process/aggregate/by_h3.py
+++ b/geoparquet_io/core/process/aggregate/by_h3.py
@@ -22,9 +22,7 @@ H3_SCHEME = GridScheme(
     max_resolution=15,
     default_column=DEFAULT_H3_COLUMN_NAME,
     # h3_latlng_to_cell_string takes (lat, lng) -> note Y before X.
-    key_template=(
-        "h3_latlng_to_cell_string(ST_Y(ST_Centroid({geom})), ST_X(ST_Centroid({geom})), {res})"
-    ),
+    key_template="h3_latlng_to_cell_string(ST_Y({pt}), ST_X({pt}), {res})",
     # h3_cell_to_boundary_wkt returns a WKT polygon directly.
     boundary_template="h3_cell_to_boundary_wkt({cell})",
     latlng_template="h3_cell_to_latlng({cell})",
@@ -53,6 +51,8 @@ def aggregate_by_h3(
     show_sql: bool = False,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into H3 cells. Writes the output file."""
     aggregate_grid_file(
@@ -75,6 +75,8 @@ def aggregate_by_h3(
         show_sql=show_sql,
         where=where,
         metric_nodata=metric_nodata,
+        bucket_point=bucket_point,
+        bbox_column=bbox_column,
     )
 
 
@@ -89,6 +91,8 @@ def aggregate_h3_table(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = "geometry",
+    bbox_column: str | None = None,
 ) -> pa.Table:
     """Aggregate an in-memory Arrow table by h3 cell. Returns a new Arrow table."""
     return aggregate_grid_table(
@@ -103,4 +107,6 @@ def aggregate_h3_table(
         geometry_column=geometry_column,
         where=where,
         metric_nodata=metric_nodata,
+        bucket_point=bucket_point,
+        bbox_column=bbox_column,
     )

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -51,7 +51,7 @@ class GridScheme:
 
     Templates use ``str.format`` placeholders:
 
-    - ``key_template``: ``{geom}`` (a GEOMETRY expression), ``{res}`` -> cell id
+    - ``key_template``: ``{pt}`` (a POINT GEOMETRY expression), ``{res}`` -> cell id
     - ``boundary_template``: ``{cell}`` -> per-row boundary intermediate
     - ``latlng_template``: ``{cell}`` -> per-row centroid intermediate
     - ``poly_wkb_template``: ``{bnd}`` (boundary intermediate alias) -> WKB polygon
@@ -75,8 +75,13 @@ class GridScheme:
 
 # Internal column aliases used while building the aggregation. Any input column
 # with one of these names is dropped from the SELECT * passthrough so a generated
-# column can never be shadowed by a same-named user column.
-_RESERVED_INTERNAL = ("__geom", "__key", "__bnd", "__ll")
+# column can never be shadowed by a same-named user column. ("__geom" is kept
+# reserved for inputs that carry a stale column from earlier gpio versions.)
+_RESERVED_INTERNAL = ("__geom", "__pt", "__key", "__bnd", "__ll")
+
+# --bucket-point mode keywords; any other value names an existing point column.
+BUCKET_POINT_GEOMETRY = "geometry"
+BUCKET_POINT_BBOX = "bbox"
 
 
 def _exclude_reserved(con, relation: str, extra: tuple[str, ...] = ()) -> str:
@@ -90,10 +95,50 @@ def _exclude_reserved(con, relation: str, extra: tuple[str, ...] = ()) -> str:
     return f" EXCLUDE ({', '.join(quote_identifier(c) for c in drop)})" if drop else ""
 
 
+def _validate_bucket_point_args(bucket_point: str, bbox_column: str | None) -> None:
+    """Reject option combinations that would silently do the wrong thing."""
+    if bbox_column and bucket_point != BUCKET_POINT_BBOX:
+        raise InvalidParameterError("bucket-point", "--bbox-column requires --bucket-point bbox")
+
+
+def bucket_point_expr(
+    con, relation: str, geom_col: str, source_crs, bucket_point: str, bbox_column: str | None
+) -> tuple[str, tuple[str, ...]]:
+    """Build the keying-point expression for a source relation.
+
+    Returns ``(pt_expr, exclude_columns)``. ``pt_expr`` yields a lon/lat POINT
+    (reprojected from a non-CRS84 ``source_crs``, #525). In ``bbox`` and
+    point-column modes the main geometry column is excluded from the passthrough
+    SELECT so Parquet projection pushdown never reads its column chunks (#567).
+    """
+    if bucket_point == BUCKET_POINT_GEOMETRY:
+        geom_expr = crs_transform_sql_expr(
+            geometry_to_geom_expr(con, relation, geom_col), source_crs
+        )
+        return f"ST_Centroid({geom_expr})", ()
+    if bucket_point == BUCKET_POINT_BBOX:
+        qbox = quote_identifier(bbox_column)
+        pt = f"ST_Point(({qbox}.xmin + {qbox}.xmax) / 2.0, ({qbox}.ymin + {qbox}.ymax) / 2.0)"
+        # The bbox covering column is stored in the file's CRS, same as geometry.
+        return crs_transform_sql_expr(pt, source_crs), (geom_col,)
+    # Any other value names an existing (point) geometry column. ST_Centroid is a
+    # no-op for points and keeps non-point columns keyable rather than erroring.
+    point_expr = crs_transform_sql_expr(
+        geometry_to_geom_expr(con, relation, bucket_point), source_crs
+    )
+    return f"ST_Centroid({point_expr})", (geom_col,)
+
+
 def read_grid_source_sql(
-    con, input_url: str, geom_col: str, source_crs=None, where: str | None = None
+    con,
+    input_url: str,
+    geom_col: str,
+    source_crs=None,
+    where: str | None = None,
+    bucket_point: str = BUCKET_POINT_GEOMETRY,
+    bbox_column: str | None = None,
 ) -> str:
-    """Source relation exposing the original columns plus a GEOMETRY ``__geom``.
+    """Source relation exposing the original columns plus a keying POINT ``__pt``.
 
     Detects whether the input geometry column is read as GEOMETRY (real GeoParquet)
     or BLOB (plain WKB) so it works on both. Grid keying expects lon/lat, so a
@@ -104,11 +149,17 @@ def read_grid_source_sql(
     all see only the filtered rows (#568). The caller validates the clause. Hive
     partition columns are visible to it (#612); see
     :func:`aggregate_source_relation`.
+
+    ``bucket_point`` selects where ``__pt`` comes from: the geometry centroid
+    (default), the center of a bbox covering column, or an existing point column
+    (#567) -- the latter two skip reading the geometry column entirely.
     """
     read_rel = aggregate_source_relation(input_url)
-    geom_expr = crs_transform_sql_expr(geometry_to_geom_expr(con, read_rel, geom_col), source_crs)
+    pt_expr, exclude = bucket_point_expr(
+        con, read_rel, geom_col, source_crs, bucket_point, bbox_column
+    )
     return (
-        f"SELECT *{_exclude_reserved(con, read_rel)}, {geom_expr} AS __geom "
+        f"SELECT *{_exclude_reserved(con, read_rel, exclude)}, {pt_expr} AS __pt "
         f"FROM {read_rel}{where_sql_fragment(where)}"
     )
 
@@ -125,13 +176,13 @@ def build_grid_query(
     out_geometry: str,
     metric_nodata: str | None = None,
 ) -> str:
-    """Build the full grid aggregation SQL from a source relation exposing ``__geom``."""
+    """Build the full grid aggregation SQL from a source relation exposing ``__pt``."""
     metrics, nodata_values = validate_metric_nodata(metric, metric_nodata)
     # Resolve metric column types so sentinel literals match the column's actual
     # precision (REAL vs DOUBLE, #613) and non-numeric columns fail up-front.
     column_types = resolve_metric_column_types(con, source_sql, metrics) if nodata_values else None
 
-    key_expr = scheme.key_template.format(geom="__geom", res=resolution)
+    key_expr = scheme.key_template.format(pt="__pt", res=resolution)
     keyed_sql = f"SELECT *, {key_expr} AS __key FROM ({source_sql})"
 
     # Materialize the keyed relation once when a breakdown is requested so that
@@ -241,6 +292,40 @@ def _resolve_resolution(
     return resolution
 
 
+def _resolve_bbox_column_for_file(
+    input_parquet: str, bbox_column: str | None, verbose: bool
+) -> str:
+    """Return the bbox covering column to key from, auto-detecting when not given."""
+    from geoparquet_io.core.common import check_bbox_structure
+
+    if bbox_column:
+        return bbox_column
+    detected = check_bbox_structure(input_parquet, verbose).get("bbox_column_name")
+    if not detected:
+        raise InvalidParameterError(
+            "bucket-point",
+            "--bucket-point bbox requires a bbox covering column, but none was "
+            "detected. Pass --bbox-column NAME or use --bucket-point geometry.",
+        )
+    return detected
+
+
+def _resolve_bbox_column_for_table(table, bbox_column: str | None) -> str:
+    """Table-path variant of bbox column resolution (Arrow schema detection)."""
+    from geoparquet_io.core.common import _detect_bbox_column_from_table
+
+    if bbox_column:
+        return bbox_column
+    detected = _detect_bbox_column_from_table(table)
+    if not detected:
+        raise InvalidParameterError(
+            "bucket-point",
+            "bucket_point='bbox' requires a bbox covering column, but none was "
+            "detected. Pass bbox_column or use bucket_point='geometry'.",
+        )
+    return detected
+
+
 def _validate_out_geometry(out_geometry: str) -> None:
     if out_geometry not in VALID_OUT_GEOMETRY:
         raise InvalidParameterError(
@@ -270,6 +355,8 @@ def aggregate_grid_file(
     show_sql: bool = False,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = BUCKET_POINT_GEOMETRY,
+    bbox_column: str | None = None,
 ) -> None:
     """Aggregate a GeoParquet file into grid cells. Writes the output file."""
     configure_verbose(verbose)
@@ -280,6 +367,9 @@ def aggregate_grid_file(
     # Validate metric/nodata pairing before any expensive setup (--auto scanning,
     # CRS reads, connection + community-extension install).
     validate_metric_nodata(metric, metric_nodata)
+    _validate_bucket_point_args(bucket_point, bbox_column)
+    if bucket_point == BUCKET_POINT_BBOX:
+        bbox_column = _resolve_bbox_column_for_file(input_parquet, bbox_column, verbose)
     resolution = _resolve_resolution(
         scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose, where=where
     )
@@ -294,7 +384,15 @@ def aggregate_grid_file(
         con.execute(f"LOAD {scheme.extension}")
         con.execute("SET geometry_always_xy = true")
 
-        source_sql = read_grid_source_sql(con, input_url, geom_col, source_crs, where=where)
+        source_sql = read_grid_source_sql(
+            con,
+            input_url,
+            geom_col,
+            source_crs,
+            where=where,
+            bucket_point=bucket_point,
+            bbox_column=bbox_column,
+        )
         final_sql = build_grid_query(
             con,
             scheme,
@@ -358,6 +456,8 @@ def aggregate_grid_table(
     geometry_column: str | None = None,
     where: str | None = None,
     metric_nodata: str | None = None,
+    bucket_point: str = BUCKET_POINT_GEOMETRY,
+    bbox_column: str | None = None,
 ) -> pa.Table:
     """Aggregate an in-memory Arrow table into grid cells. Returns a new Arrow table."""
     cell_column = cell_column or scheme.default_column
@@ -366,6 +466,9 @@ def aggregate_grid_table(
         validate_where_clause(where)
     # Validate metric/nodata pairing before connection setup and extension install.
     validate_metric_nodata(metric, metric_nodata)
+    _validate_bucket_point_args(bucket_point, bbox_column)
+    if bucket_point == BUCKET_POINT_BBOX:
+        bbox_column = _resolve_bbox_column_for_table(table, bbox_column)
     if not scheme.min_resolution <= resolution <= scheme.max_resolution:
         raise InvalidParameterError(
             "resolution",
@@ -381,12 +484,12 @@ def aggregate_grid_table(
         con.execute("SET geometry_always_xy = true")
         con.register("__agg_input", table)
         source_crs = extract_crs_from_table(table, geom_col)
-        geom_expr = crs_transform_sql_expr(
-            geometry_to_geom_expr(con, "__agg_input", geom_col), source_crs
+        pt_expr, exclude = bucket_point_expr(
+            con, "__agg_input", geom_col, source_crs, bucket_point, bbox_column
         )
         source_sql = (
-            f"SELECT *{_exclude_reserved(con, '__agg_input', (geom_col,))}, "
-            f"{geom_expr} AS __geom FROM __agg_input{where_sql_fragment(where)}"
+            f"SELECT *{_exclude_reserved(con, '__agg_input', (geom_col, *exclude))}, "
+            f"{pt_expr} AS __pt FROM __agg_input{where_sql_fragment(where)}"
         )
         final_sql = build_grid_query(
             con,

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import gc
 from dataclasses import dataclass
 
+import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 
@@ -21,8 +22,10 @@ from geoparquet_io.core.crs_utils import (
     crs_transform_sql_expr,
     extract_crs_from_parquet,
     extract_crs_from_table,
+    is_geographic_crs,
 )
 from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
     get_duckdb_connection,
     quote_identifier,
     validate_where_clause,
@@ -31,7 +34,7 @@ from geoparquet_io.core.duckdb_utils import (
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
-from geoparquet_io.core.logging_config import configure_verbose, debug, info, success
+from geoparquet_io.core.logging_config import configure_verbose, debug, info, success, warn
 from geoparquet_io.core.process.aggregate.common import (
     VALID_OUT_GEOMETRY,
     aggregate_source_relation,
@@ -43,6 +46,7 @@ from geoparquet_io.core.process.aggregate.common import (
     resolve_metric_column_types,
     validate_metric_nodata,
 )
+from geoparquet_io.core.remote import needs_httpfs
 
 
 @dataclass(frozen=True)
@@ -83,26 +87,114 @@ _RESERVED_INTERNAL = ("__geom", "__pt", "__key", "__bnd", "__ll")
 BUCKET_POINT_GEOMETRY = "geometry"
 BUCKET_POINT_BBOX = "bbox"
 
+# Struct fields a bbox covering column must expose.
+_BBOX_STRUCT_FIELDS = frozenset({"xmin", "ymin", "xmax", "ymax"})
 
-def _exclude_reserved(con, relation: str, extra: tuple[str, ...] = ()) -> str:
-    """Return an `` EXCLUDE (...)`` clause dropping input columns that would collide
-    with the internal aliases (or names in ``extra``); empty string if none clash."""
-    cols = {row[0] for row in con.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()}
+
+def _relation_columns(con, relation: str) -> set[str]:
+    """Column names exposed by ``relation``."""
+    return {row[0] for row in con.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()}
+
+
+def build_exclude_clause(
+    con: duckdb.DuckDBPyConnection, relation: str, columns: tuple[str, ...]
+) -> str:
+    """Return an `` EXCLUDE (...)`` clause dropping the ``columns`` that actually
+    exist in ``relation``; empty string when none do.
+
+    Checking existence keeps the clause safe for inputs that lack a column —
+    e.g. attribute+bbox-only files with no geometry column at all (#567).
+    """
+    cols = _relation_columns(con, relation)
     drop: list[str] = []
-    for name in (*extra, *_RESERVED_INTERNAL):
+    for name in columns:
         if name in cols and name not in drop:
             drop.append(name)
     return f" EXCLUDE ({', '.join(quote_identifier(c) for c in drop)})" if drop else ""
 
 
+def _exclude_reserved(con, relation: str, extra: tuple[str, ...] = ()) -> str:
+    """Return an `` EXCLUDE (...)`` clause dropping input columns that would collide
+    with the internal aliases (or names in ``extra``); empty string if none clash."""
+    return build_exclude_clause(con, relation, (*extra, *_RESERVED_INTERNAL))
+
+
 def _validate_bucket_point_args(bucket_point: str, bbox_column: str | None) -> None:
     """Reject option combinations that would silently do the wrong thing."""
+    if not bucket_point:
+        raise InvalidParameterError(
+            "bucket-point",
+            "bucket point must be 'geometry', 'bbox', or the name of an existing "
+            "point column; got an empty string",
+        )
     if bbox_column and bucket_point != BUCKET_POINT_BBOX:
-        raise InvalidParameterError("bucket-point", "--bbox-column requires --bucket-point bbox")
+        raise InvalidParameterError(
+            "bucket-point", "a bbox column only applies when the bucket point is 'bbox'"
+        )
+
+
+def _validate_bbox_struct_column(con, relation: str, bbox_column: str) -> None:
+    """Ensure ``bbox_column`` exists in ``relation`` and is a bbox covering struct."""
+    if bbox_column not in _relation_columns(con, relation):
+        raise InvalidParameterError(
+            "bbox-column", f"bbox column '{bbox_column}' not found in the input"
+        )
+    qbox = quote_identifier(bbox_column)
+    try:
+        fields = {
+            row[0] for row in con.execute(f"DESCRIBE SELECT {qbox}.* FROM {relation}").fetchall()
+        }
+    except duckdb.Error:  # not a struct -- .* expansion does not bind
+        fields = set()
+    missing = _BBOX_STRUCT_FIELDS - fields
+    if missing:
+        raise InvalidParameterError(
+            "bbox-column",
+            f"column '{bbox_column}' is not a bbox covering struct: expected "
+            f"xmin/ymin/xmax/ymax fields, missing {'/'.join(sorted(missing))}",
+        )
+
+
+def _validate_point_column(con, relation: str, bucket_point: str) -> None:
+    """Ensure a point-column ``bucket_point`` names an existing column."""
+    if bucket_point in _relation_columns(con, relation):
+        return
+    hint = ""
+    lowered = bucket_point.lower()
+    if lowered in (BUCKET_POINT_BBOX, BUCKET_POINT_GEOMETRY):
+        hint = f" (mode keywords are lowercase — did you mean '{lowered}'?)"
+    raise InvalidParameterError(
+        "bucket-point",
+        f"point column '{bucket_point}' not found in the input{hint}; the bucket "
+        "point must be 'geometry', 'bbox', or the name of an existing point column",
+    )
+
+
+def _bbox_center_lon_sql(qbox: str, source_crs) -> str:
+    """Longitude of the bbox center, wraparound-aware for the antimeridian.
+
+    GeoJSON/GeoParquet coverings encode an antimeridian crossing as
+    ``xmin > xmax`` (Fiji: xmin=179.9, xmax=-179.9); the naive midpoint would
+    land near lon 0. For those rows take the +360-shifted midpoint and wrap
+    values > 180 back into (-180, 180]. Only geographic CRSs get this
+    treatment: in a projected CRS ``xmin > xmax`` cannot encode a dateline
+    crossing, so the plain midpoint is always correct there.
+    """
+    plain = f"({qbox}.xmin + {qbox}.xmax) / 2.0"
+    if not is_geographic_crs(source_crs):
+        return plain
+    shifted = f"(({qbox}.xmin + {qbox}.xmax + 360.0) / 2.0)"
+    wrapped = f"CASE WHEN {shifted} > 180.0 THEN {shifted} - 360.0 ELSE {shifted} END"
+    return f"CASE WHEN {qbox}.xmin > {qbox}.xmax THEN {wrapped} ELSE {plain} END"
 
 
 def bucket_point_expr(
-    con, relation: str, geom_col: str, source_crs, bucket_point: str, bbox_column: str | None
+    con: duckdb.DuckDBPyConnection,
+    relation: str,
+    geom_col: str,
+    source_crs: dict | str | None,
+    bucket_point: str,
+    bbox_column: str | None,
 ) -> tuple[str, tuple[str, ...]]:
     """Build the keying-point expression for a source relation.
 
@@ -110,19 +202,30 @@ def bucket_point_expr(
     (reprojected from a non-CRS84 ``source_crs``, #525). In ``bbox`` and
     point-column modes the main geometry column is excluded from the passthrough
     SELECT so Parquet projection pushdown never reads its column chunks (#567).
+    The bbox/point column is validated against ``relation`` so a typo fails with
+    a clear error instead of a late binder error.
     """
+    _validate_bucket_point_args(bucket_point, bbox_column)
     if bucket_point == BUCKET_POINT_GEOMETRY:
         geom_expr = crs_transform_sql_expr(
             geometry_to_geom_expr(con, relation, geom_col), source_crs
         )
         return f"ST_Centroid({geom_expr})", ()
     if bucket_point == BUCKET_POINT_BBOX:
+        if not bbox_column:
+            raise InvalidParameterError(
+                "bbox-column",
+                "bucket point 'bbox' requires a bbox column name (none given or detected)",
+            )
+        _validate_bbox_struct_column(con, relation, bbox_column)
         qbox = quote_identifier(bbox_column)
-        pt = f"ST_Point(({qbox}.xmin + {qbox}.xmax) / 2.0, ({qbox}.ymin + {qbox}.ymax) / 2.0)"
+        lon = _bbox_center_lon_sql(qbox, source_crs)
+        pt = f"ST_Point({lon}, ({qbox}.ymin + {qbox}.ymax) / 2.0)"
         # The bbox covering column is stored in the file's CRS, same as geometry.
         return crs_transform_sql_expr(pt, source_crs), (geom_col,)
     # Any other value names an existing (point) geometry column. ST_Centroid is a
     # no-op for points and keeps non-point columns keyable rather than erroring.
+    _validate_point_column(con, relation, bucket_point)
     point_expr = crs_transform_sql_expr(
         geometry_to_geom_expr(con, relation, bucket_point), source_crs
     )
@@ -295,7 +398,11 @@ def _resolve_resolution(
 def _resolve_bbox_column_for_file(
     input_parquet: str, bbox_column: str | None, verbose: bool
 ) -> str:
-    """Return the bbox covering column to key from, auto-detecting when not given."""
+    """Return the bbox covering column to key from, auto-detecting when not given.
+
+    Detection consults the file's GeoParquet ``covering.bbox`` metadata first,
+    falling back to naming conventions (see ``check_bbox_structure``).
+    """
     from geoparquet_io.core.common import check_bbox_structure
 
     if bbox_column:
@@ -304,10 +411,29 @@ def _resolve_bbox_column_for_file(
     if not detected:
         raise InvalidParameterError(
             "bucket-point",
-            "--bucket-point bbox requires a bbox covering column, but none was "
-            "detected. Pass --bbox-column NAME or use --bucket-point geometry.",
+            "bucket_point='bbox' requires a bbox covering column, but none was "
+            "detected. Pass bbox_column or use bucket_point='geometry'.",
         )
     return detected
+
+
+def _validate_bbox_column_in_table(table, bbox_column: str) -> None:
+    """Ensure an explicit table-path ``bbox_column`` exists and is a bbox struct."""
+    import pyarrow as pa
+
+    try:
+        field = table.schema.field(bbox_column)
+    except KeyError:
+        raise InvalidParameterError(
+            "bbox-column", f"bbox column '{bbox_column}' not found in the table"
+        ) from None
+    if not pa.types.is_struct(field.type) or not _BBOX_STRUCT_FIELDS.issubset(
+        {f.name for f in field.type}
+    ):
+        raise InvalidParameterError(
+            "bbox-column",
+            f"column '{bbox_column}' is not a bbox covering struct with xmin/ymin/xmax/ymax fields",
+        )
 
 
 def _resolve_bbox_column_for_table(table, bbox_column: str | None) -> str:
@@ -315,6 +441,7 @@ def _resolve_bbox_column_for_table(table, bbox_column: str | None) -> str:
     from geoparquet_io.core.common import _detect_bbox_column_from_table
 
     if bbox_column:
+        _validate_bbox_column_in_table(table, bbox_column)
         return bbox_column
     detected = _detect_bbox_column_from_table(table)
     if not detected:
@@ -324,6 +451,71 @@ def _resolve_bbox_column_for_table(table, bbox_column: str | None) -> str:
             "detected. Pass bbox_column or use bucket_point='geometry'.",
         )
     return detected
+
+
+def _warn_files_missing_column(con, input_url: str, column: str) -> None:
+    """Warn when a glob input has files that lack the keying ``column``.
+
+    With ``union_by_name=true`` those files' rows get NULL for the column, so
+    all of their features silently land in the unassigned bucket. Detection
+    (and up-front validation) only sees the merged schema, hence this check.
+    """
+    if not any(ch in input_url for ch in "*?["):
+        return
+    url_lit = _escape_sql_string(input_url)
+    col_lit = _escape_sql_string(column)
+    try:
+        total, with_col = con.execute(
+            f"SELECT count(DISTINCT file_name), "
+            f"count(DISTINCT file_name) FILTER (WHERE name = '{col_lit}') "
+            f"FROM parquet_schema('{url_lit}')"
+        ).fetchone()
+    except duckdb.Error:  # pragma: no cover - best-effort diagnostics only
+        return
+    if total and with_col < total:
+        warn(
+            f"{total - with_col} of {total} input files lack column '{column}'; "
+            f"their rows have no keying value and will be counted as unassigned"
+        )
+
+
+def _validate_keying_columns_for_file(
+    input_parquet: str, bucket_point: str, bbox_column: str | None, verbose: bool
+) -> None:
+    """Validate the bbox/point keying column against the file schema up front.
+
+    Runs before any expensive work (the --auto probe, grid extension install,
+    admin dataset setup) so a typo'd or wrongly-shaped column fails immediately
+    with a clear error rather than a late binder error. Also warns when a glob
+    input is heterogeneous (some files lack the keying column).
+    """
+    if bucket_point == BUCKET_POINT_GEOMETRY:
+        return
+    input_url = safe_file_url(input_parquet, verbose=False)
+    relation = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
+    con = get_duckdb_connection(load_spatial=False, load_httpfs=needs_httpfs(input_parquet))
+    try:
+        if bucket_point == BUCKET_POINT_BBOX and bbox_column:
+            _validate_bbox_struct_column(con, relation, bbox_column)
+            _warn_files_missing_column(con, input_url, bbox_column)
+        elif bucket_point != BUCKET_POINT_BBOX:
+            _validate_point_column(con, relation, bucket_point)
+            _warn_files_missing_column(con, input_url, bucket_point)
+    finally:
+        con.close()
+
+
+def _unassigned_reason(bucket_point: str, bbox_column: str | None) -> str:
+    """Describe why rows had no keying point, per bucket-point mode.
+
+    When keying came from a bbox or point column, the geometry itself may be
+    perfectly intact -- do not blame it.
+    """
+    if bucket_point == BUCKET_POINT_BBOX:
+        return f"NULL '{bbox_column}' bbox value"
+    if bucket_point != BUCKET_POINT_GEOMETRY:
+        return f"NULL/empty '{bucket_point}' point"
+    return "NULL/empty geometry"
 
 
 def _validate_out_geometry(out_geometry: str) -> None:
@@ -370,6 +562,7 @@ def aggregate_grid_file(
     _validate_bucket_point_args(bucket_point, bbox_column)
     if bucket_point == BUCKET_POINT_BBOX:
         bbox_column = _resolve_bbox_column_for_file(input_parquet, bbox_column, verbose)
+    _validate_keying_columns_for_file(input_parquet, bucket_point, bbox_column, verbose)
     resolution = _resolve_resolution(
         scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose, where=where
     )
@@ -414,11 +607,14 @@ def aggregate_grid_file(
         # opens; leaked native state can segfault sibling xdist tests.
         gc.collect()
 
-    # Report features that had no assignable cell (NULL/empty geometry).
+    # Report features that had no assignable cell (no keying point).
     ids = result.column(cell_column).to_pylist()
     if None in ids:
         unassigned = result.column("count")[ids.index(None)].as_py()
-        info(f"{unassigned} features had no assignable {scheme.name} cell (NULL/empty geometry)")
+        info(
+            f"{unassigned} features had no assignable {scheme.name} cell "
+            f"({_unassigned_reason(bucket_point, bbox_column)})"
+        )
 
     if out_geometry == "none":
         if compression_level is not None:

--- a/tests/test_process_aggregate_bucket_point.py
+++ b/tests/test_process_aggregate_bucket_point.py
@@ -222,7 +222,9 @@ def test_table_bbox_mode_autodetects_from_schema():
     )
     con.close()
     assert _resolve_bbox_column_for_table(tbl, None) == "bbox"
-    assert _resolve_bbox_column_for_table(tbl, "custom") == "custom"
+    # An explicit column that does not exist fails up front, not at bind time.
+    with pytest.raises(InvalidParameterError, match="custom"):
+        _resolve_bbox_column_for_table(tbl, "custom")
 
 
 def test_cli_help_has_bucket_point_options():
@@ -244,11 +246,655 @@ def test_admin_joined_sql_uses_point_expr_and_exclude():
         "country",
         "country",
         "geometry",
-        exclude_input_columns=("geometry",),
+        exclude_sql=' EXCLUDE ("geometry")',
     )
     inner = sql.split(") s")[0]
     assert "ST_Point((bbox.xmin" in inner
     assert 'EXCLUDE ("geometry")' in inner
+
+
+# ---------------------------------------------------------------------------
+# Antimeridian-crossing bboxes (xmin > xmax encodes a dateline crossing)
+# ---------------------------------------------------------------------------
+
+
+def _write_bbox_rows(path, rows, bbox_col="bbox", with_geometry=False):
+    """rows: list of (id, xmin, ymin, xmax, ymax). Optional point geometry at bbox 'center'."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(
+        f"({i}, {xmin}, {ymin}, {xmax}, {ymax})" for i, xmin, ymin, xmax, ymax in rows
+    )
+    geom_sql = "ST_Point(xmin, ymin) AS geometry, " if with_geometry else ""
+    con.execute(
+        f"""
+        COPY (
+            SELECT id, {geom_sql}
+                   {{'xmin': xmin, 'ymin': ymin, 'xmax': xmax, 'ymax': ymax}} AS "{bbox_col}"
+            FROM (VALUES {values}) AS t(id, xmin, ymin, xmax, ymax)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def test_bbox_center_wraps_antimeridian(tmp_path):
+    """A covering with xmin > xmax crosses the dateline; its center must not be lon 0."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_bbox_rows(
+        src,
+        [
+            (1, 179.9, -17.0, -179.9, -16.0),  # Fiji-style crossing -> lon 180
+            (2, 170.0, 0.0, -160.0, 2.0),  # wide crossing -> (170-160+360)/2=185 -> -175
+            (3, 9.9, 49.9, 10.1, 50.1),  # ordinary box -> lon 10
+        ],
+    )
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(
+            con, str(src), "geometry", bucket_point="bbox", bbox_column="bbox"
+        )
+        rows = con.execute(f"SELECT id, ST_X(__pt), ST_Y(__pt) FROM ({sql}) ORDER BY id").fetchall()
+        lons = {r[0]: r[1] for r in rows}
+        assert lons[1] == pytest.approx(180.0)
+        assert lons[2] == pytest.approx(-175.0)
+        assert lons[3] == pytest.approx(10.0)
+        assert rows[0][2] == pytest.approx(-16.5)
+    finally:
+        con.close()
+
+
+def test_bbox_center_no_wraparound_for_projected_crs(tmp_path):
+    """xmin > xmax has no dateline meaning in a projected CRS -> plain midpoint."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import bucket_point_expr
+
+    src = tmp_path / "f.parquet"
+    _write_bbox_rows(src, [(1, 1500000.0, 2000000.0, 1600000.0, 2100000.0)])
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        projected = {"type": "ProjectedCRS", "id": {"authority": "EPSG", "code": 5070}}
+        expr, _ = bucket_point_expr(
+            con, f"read_parquet('{src}')", "geometry", projected, "bbox", "bbox"
+        )
+        assert "360.0" not in expr  # no antimeridian arithmetic for projected coords
+        geographic_expr, _ = bucket_point_expr(
+            con, f"read_parquet('{src}')", "geometry", None, "bbox", "bbox"
+        )
+        assert "360.0" in geographic_expr
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Up-front validation of keying columns and --bucket-point values
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_point_expr_bbox_mode_requires_column(tmp_path):
+    """bbox mode with no column raises InvalidParameterError, not AttributeError."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import bucket_point_expr
+
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        with pytest.raises(InvalidParameterError, match="bbox"):
+            bucket_point_expr(con, f"read_parquet('{src}')", "geometry", None, "bbox", None)
+    finally:
+        con.close()
+
+
+def test_bucket_point_empty_string_rejected(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_plain_points(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="empty"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, bucket_point="")
+
+
+def test_explicit_bbox_column_missing_fails_fast(tmp_path):
+    """A typo'd --bbox-column errors up front (before the --auto probe or grid install)."""
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="nope"):
+        aggregate_by_a5(
+            str(src),
+            str(tmp_path / "o.parquet"),
+            auto=True,  # would be expensive; validation must precede it
+            bucket_point="bbox",
+            bbox_column="nope",
+        )
+
+
+def test_explicit_bbox_column_not_a_struct_fails_fast(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="height"):
+        aggregate_by_a5(
+            str(src),
+            str(tmp_path / "o.parquet"),
+            resolution=5,
+            bucket_point="bbox",
+            bbox_column="height",
+        )
+
+
+def test_explicit_bbox_column_wrong_struct_fields_fails_fast(tmp_path):
+    """A struct with minx/maxx-style fields is rejected with a clear error."""
+    src = tmp_path / "f.parquet"
+    con = duckdb.connect()
+    con.execute(
+        f"""
+        COPY (
+            SELECT 1 AS id,
+                   {{'minx': 9.9, 'miny': 49.9, 'maxx': 10.1, 'maxy': 50.1}} AS my_box
+        ) TO '{src}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    with pytest.raises(InvalidParameterError, match="xmin"):
+        aggregate_by_a5(
+            str(src),
+            str(tmp_path / "o.parquet"),
+            resolution=5,
+            bucket_point="bbox",
+            bbox_column="my_box",
+        )
+
+
+def test_nonexistent_point_column_fails_fast(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_plain_points(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="anchor"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, bucket_point="anchor")
+
+
+def test_wrong_case_bbox_keyword_gets_hint(tmp_path):
+    """'BBOX' falls into point-column mode by design; the error must say why."""
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="did you mean 'bbox'"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, bucket_point="BBOX")
+
+
+def test_core_error_messages_are_flag_neutral(tmp_path):
+    """Core errors surface through the Python API too — no CLI flag wording."""
+    src = tmp_path / "f.parquet"
+    _write_plain_points(src, POINTS)
+    with pytest.raises(InvalidParameterError) as exc1:
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, bucket_point="bbox")
+    assert "--" not in str(exc1.value)
+    src2 = tmp_path / "g.parquet"
+    _write_points_with_bbox(src2, POINTS)
+    with pytest.raises(InvalidParameterError) as exc2:
+        aggregate_by_a5(str(src2), str(tmp_path / "o.parquet"), resolution=5, bbox_column="bbox")
+    assert "--" not in str(exc2.value)
+
+
+# ---------------------------------------------------------------------------
+# bbox mode combined with --where
+# ---------------------------------------------------------------------------
+
+
+def test_read_grid_source_sql_bbox_mode_with_where(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)  # heights 4.0, 6.0, 1.0
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(
+            con, str(src), "geometry", where="height > 2", bucket_point="bbox", bbox_column="bbox"
+        )
+        assert con.execute(f"SELECT count(*) FROM ({sql})").fetchone()[0] == 2
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# NULL bboxes and heterogeneous globs
+# ---------------------------------------------------------------------------
+
+
+def test_null_bbox_yields_null_keying_point(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    con0 = duckdb.connect()
+    con0.execute(
+        f"""
+        COPY (
+            SELECT 1 AS id, {{'xmin': 9.9, 'ymin': 49.9, 'xmax': 10.1, 'ymax': 50.1}} AS bbox
+            UNION ALL
+            SELECT 2 AS id, NULL AS bbox
+        ) TO '{src}' (FORMAT PARQUET)
+        """
+    )
+    con0.close()
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(
+            con, str(src), "geometry", bucket_point="bbox", bbox_column="bbox"
+        )
+        rows = con.execute(f"SELECT id, __pt IS NULL FROM ({sql}) ORDER BY id").fetchall()
+        assert rows == [(1, False), (2, True)]
+    finally:
+        con.close()
+
+
+def test_unassigned_reason_is_mode_aware():
+    from geoparquet_io.core.process.aggregate.grid_common import _unassigned_reason
+
+    assert "geometry" in _unassigned_reason("geometry", None)
+    bbox_reason = _unassigned_reason("bbox", "my_box")
+    assert "my_box" in bbox_reason and "geometry" not in bbox_reason
+    pt_reason = _unassigned_reason("anchor", None)
+    assert "anchor" in pt_reason and "geometry" not in pt_reason
+
+
+def test_heterogeneous_glob_warns_about_missing_column(tmp_path, caplog):
+    """union_by_name NULL-fills the keying column for files that lack it — warn."""
+    import logging
+
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import _warn_files_missing_column
+
+    _write_points_with_bbox(tmp_path / "a.parquet", POINTS)
+    _write_plain_points(tmp_path / "b.parquet", POINTS)  # no bbox column
+    con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+    try:
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            _warn_files_missing_column(con, f"{tmp_path}/*.parquet", "bbox")
+        assert any("bbox" in r.message and "unassigned" in r.message for r in caplog.records)
+        caplog.clear()
+        # Homogeneous glob: no warning.
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            _warn_files_missing_column(con, f"{tmp_path}/a*.parquet", "bbox")
+        assert not caplog.records
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Covering-metadata-first bbox auto-detection
+# ---------------------------------------------------------------------------
+
+
+def _write_parquet_with_covering(path, bbox_col, extra_bbox_col=None):
+    """Write a GeoParquet file whose covering metadata references ``bbox_col``."""
+    import json
+
+    import pyarrow as pa
+
+    box = {"xmin": 9.9, "ymin": 49.9, "xmax": 10.1, "ymax": 50.1}
+    struct_type = pa.struct([(k, pa.float64()) for k in ("xmin", "ymin", "xmax", "ymax")])
+    cols = {
+        # WKB for POINT(10 50), little-endian.
+        "geometry": pa.array(
+            [bytes.fromhex("010100000000000000000024400000000000004940")],
+            type=pa.binary(),
+        ),
+        bbox_col: pa.array([box], type=struct_type),
+    }
+    if extra_bbox_col:
+        cols[extra_bbox_col] = pa.array([box], type=struct_type)
+    geo_meta = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "covering": {
+                    "bbox": {
+                        "xmin": [bbox_col, "xmin"],
+                        "ymin": [bbox_col, "ymin"],
+                        "xmax": [bbox_col, "xmax"],
+                        "ymax": [bbox_col, "ymax"],
+                    }
+                },
+            }
+        },
+    }
+    table = pa.table(cols)
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo_meta).encode()})
+    pq.write_table(table, path)
+    return table
+
+
+def test_check_bbox_structure_uses_covering_metadata_first(tmp_path):
+    """Spec-valid files with non-conventional covering names are detected."""
+    from geoparquet_io.core.common import check_bbox_structure
+
+    src = tmp_path / "f.parquet"
+    _write_parquet_with_covering(src, "my_box")
+    result = check_bbox_structure(str(src))
+    assert result["bbox_column_name"] == "my_box"
+    assert result["has_bbox_column"] is True
+
+
+def test_check_bbox_structure_covering_beats_name_convention(tmp_path):
+    """When covering points at one struct and a decoy conventional name exists,
+    the authoritative covering wins."""
+    from geoparquet_io.core.common import check_bbox_structure
+
+    src = tmp_path / "f.parquet"
+    _write_parquet_with_covering(src, "my_box", extra_bbox_col="bbox")
+    assert check_bbox_structure(str(src))["bbox_column_name"] == "my_box"
+
+
+def test_detect_bbox_column_from_table_uses_covering_first(tmp_path):
+    from geoparquet_io.core.common import _detect_bbox_column_from_table
+
+    table = _write_parquet_with_covering(tmp_path / "f.parquet", "my_box", extra_bbox_col="bbox")
+    assert _detect_bbox_column_from_table(table, verbose=True) == "my_box"
+
+
+def test_resolve_bbox_column_autodetects_covering_name(tmp_path):
+    from geoparquet_io.core.process.aggregate.grid_common import _resolve_bbox_column_for_file
+
+    src = tmp_path / "f.parquet"
+    _write_parquet_with_covering(src, "my_box")
+    assert _resolve_bbox_column_for_file(str(src), None, False) == "my_box"
+
+
+# ---------------------------------------------------------------------------
+# Geometry-less (attribute + bbox only) inputs — the input this feature enables
+# ---------------------------------------------------------------------------
+
+
+def _write_geometry_less_bbox_file(path, rows, bbox_col="bbox"):
+    """Attribute + bbox covering columns only — no geometry column at all."""
+    con = duckdb.connect()
+    values = ", ".join(f"({lon}, {lat}, {height})" for lon, lat, height in rows)
+    con.execute(
+        f"""
+        COPY (
+            SELECT {{'xmin': lon - 0.0004, 'ymin': lat - 0.0004,
+                     'xmax': lon + 0.0004, 'ymax': lat + 0.0004}} AS "{bbox_col}",
+                   height
+            FROM (VALUES {values}) AS t(lon, lat, height)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def test_grid_source_sql_geometry_less_bbox_input(tmp_path):
+    """The a5/h3 source relation binds cleanly with no geometry column present."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_geometry_less_bbox_file(src, POINTS)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(
+            con, str(src), "geometry", bucket_point="bbox", bbox_column="bbox"
+        )
+        assert con.execute(f"SELECT count(*) FROM ({sql})").fetchone()[0] == len(POINTS)
+    finally:
+        con.close()
+
+
+class _FakeAdminDataset:
+    """Local stand-in for the Overture dataset so the admin path runs offline."""
+
+    def __init__(self, admin_path):
+        self._path = str(admin_path)
+
+    def get_level_column_mapping(self):
+        return {"country": "country"}
+
+    def get_geometry_column(self):
+        return "geometry"
+
+    def get_bbox_column(self):
+        return None
+
+    def configure_s3(self, con):
+        pass
+
+    def supports_per_level_sources(self):
+        return True
+
+    def get_source_for_level(self, level):
+        return self._path
+
+
+def _write_admin_polygons(path):
+    """One country polygon around (10, 50) with code 'XX'."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT 'XX' AS country,
+                   ST_GeomFromText('POLYGON((9 49, 11 49, 11 51, 9 51, 9 49))') AS geometry
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def _run_admin_offline(monkeypatch, admin_path):
+    from geoparquet_io.core.process.aggregate import by_admin
+
+    monkeypatch.setattr(
+        by_admin,
+        "_setup_admin_dataset",
+        lambda dataset, verbose, levels: (_FakeAdminDataset(admin_path), None),
+    )
+
+
+def test_admin_geometry_less_bbox_input(tmp_path, monkeypatch):
+    """Admin path must not EXCLUDE a geometry column the input does not have (P2)."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    admin_path = tmp_path / "admin.parquet"
+    _write_admin_polygons(admin_path)
+    _run_admin_offline(monkeypatch, admin_path)
+
+    src = tmp_path / "pts.parquet"
+    out = tmp_path / "out.parquet"
+    _write_geometry_less_bbox_file(src, POINTS)  # two near (10, 50), one at (-120, 40)
+    aggregate_by_admin(str(src), str(out), level="country", bucket_point="bbox", where="height > 0")
+    df = pq.read_table(out).to_pandas()
+    assert int(df.loc[df["admin_code"] == "XX", "count"].iloc[0]) == 2
+    assert int(df.loc[df["admin_code"] == "unassigned", "count"].iloc[0]) == 1
+
+
+def test_admin_bbox_mode_still_excludes_real_geometry(tmp_path, monkeypatch):
+    """With a geometry column present, bbox mode still works (column excluded from scan)."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    admin_path = tmp_path / "admin.parquet"
+    _write_admin_polygons(admin_path)
+    _run_admin_offline(monkeypatch, admin_path)
+
+    src = tmp_path / "pts.parquet"
+    out = tmp_path / "out.parquet"
+    _write_points_with_bbox(src, POINTS)
+    aggregate_by_admin(str(src), str(out), level="country", bucket_point="bbox")
+    df = pq.read_table(out).to_pandas()
+    assert int(df.loc[df["admin_code"] == "XX", "count"].iloc[0]) == 2
+
+
+def test_table_explicit_bbox_column_wrong_shape_errors():
+    from geoparquet_io.core.process.aggregate.grid_common import _resolve_bbox_column_for_table
+
+    con = duckdb.connect()
+    tbl = con.execute("SELECT 1.5 AS height").arrow().read_all()
+    con.close()
+    with pytest.raises(InvalidParameterError, match="xmin"):
+        _resolve_bbox_column_for_table(tbl, "height")
+
+
+def test_cli_bad_bbox_column_is_clean_error(tmp_path):
+    """Core InvalidParameterError surfaces as a clean CLI error, not a traceback."""
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    runner = CliRunner()
+    for sub in ("a5", "h3", "admin"):
+        args = ["process", "aggregate", sub, str(src), str(tmp_path / "o.parquet")]
+        if sub != "admin":
+            args += ["--resolution", "5"]
+        args += ["--bucket-point", "bbox", "--bbox-column", "nope"]
+        result = runner.invoke(cli, args)
+        assert result.exit_code != 0
+        assert "nope" in result.output
+
+
+def test_validate_keying_columns_accepts_existing_point_column(tmp_path):
+    from geoparquet_io.core.process.aggregate.grid_common import (
+        _validate_keying_columns_for_file,
+    )
+
+    src = tmp_path / "f.parquet"
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"COPY (SELECT ST_Point(10.0, 50.0) AS geometry, ST_Point(10.0, 50.0) AS anchor) "
+        f"TO '{src}' (FORMAT PARQUET)"
+    )
+    con.close()
+    _validate_keying_columns_for_file(str(src), "anchor", None, False)  # no raise
+
+
+def test_bbox_column_from_covering_edge_cases():
+    from geoparquet_io.core.common import _bbox_column_from_covering
+
+    refs = {k: ["my_box", k] for k in ("xmin", "ymin", "xmax", "ymax")}
+    good = {"columns": {"geometry": {"covering": {"bbox": refs}}}}
+    assert _bbox_column_from_covering(good) == "my_box"
+    assert _bbox_column_from_covering(None) is None
+    assert _bbox_column_from_covering({"columns": ["not-a-dict"]}) is None
+    assert _bbox_column_from_covering({"columns": {"geometry": "not-a-dict"}}) is None
+    assert _bbox_column_from_covering({"columns": {"geometry": {"covering": {}}}}) is None
+    # Malformed refs (not [column, field] pairs) are ignored.
+    bad_refs = dict.fromkeys(("xmin", "ymin", "xmax", "ymax"), "my_box.xmin")
+    assert _bbox_column_from_covering({"columns": {"g": {"covering": {"bbox": bad_refs}}}}) is None
+
+
+def test_covering_reference_to_bad_column_falls_back(tmp_path):
+    """Covering pointing at a non-struct or missing column falls back to conventions."""
+    import json
+
+    import pyarrow as pa
+
+    from geoparquet_io.core.common import check_bbox_structure
+
+    box = {"xmin": 9.9, "ymin": 49.9, "xmax": 10.1, "ymax": 50.1}
+    struct_type = pa.struct([(k, pa.float64()) for k in ("xmin", "ymin", "xmax", "ymax")])
+    for target, name in (("height", "nonstruct"), ("ghost", "missing")):
+        table = pa.table(
+            {
+                "geometry": pa.array(
+                    [bytes.fromhex("010100000000000000000024400000000000004940")],
+                    type=pa.binary(),
+                ),
+                "height": pa.array([1.5]),
+                "bbox": pa.array([box], type=struct_type),
+            }
+        )
+        geo_meta = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": ["Point"],
+                    "covering": {"bbox": {k: [target, k] for k in box}},
+                }
+            },
+        }
+        table = table.replace_schema_metadata({b"geo": json.dumps(geo_meta).encode()})
+        path = tmp_path / f"{name}.parquet"
+        pq.write_table(table, path)
+        assert check_bbox_structure(str(path))["bbox_column_name"] == "bbox"
+
+
+def test_detect_bbox_column_from_table_bad_covering_falls_back():
+    """Table-path detection ignores a covering that references a missing column."""
+    import json
+
+    import pyarrow as pa
+
+    from geoparquet_io.core.common import _detect_bbox_column_from_table
+
+    box = {"xmin": 9.9, "ymin": 49.9, "xmax": 10.1, "ymax": 50.1}
+    struct_type = pa.struct([(k, pa.float64()) for k in ("xmin", "ymin", "xmax", "ymax")])
+    table = pa.table({"bbox": pa.array([box], type=struct_type)})
+    geo_meta = {"columns": {"geometry": {"covering": {"bbox": {k: ["ghost", k] for k in box}}}}}
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo_meta).encode()})
+    assert _detect_bbox_column_from_table(table, verbose=True) == "bbox"
+
+
+def test_build_grid_query_with_metric_and_breakdown(tmp_path):
+    """The shared grid query builder runs end-to-end with a plain-SQL scheme."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import (
+        GridScheme,
+        build_grid_query,
+        read_grid_source_sql,
+    )
+
+    scheme = GridScheme(
+        name="dummy",
+        extension="",
+        min_resolution=0,
+        max_resolution=5,
+        default_column="cell",
+        key_template="CAST(floor(ST_X({pt})) AS INTEGER)",
+        boundary_template="{cell}",
+        latlng_template="{cell}",
+        poly_wkb_template="ST_AsWKB(ST_Point(CAST({bnd} AS DOUBLE), 0.0))",
+        centroid_wkb_template="ST_AsWKB(ST_Point(CAST({ll} AS DOUBLE), 0.0))",
+    )
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        source_sql = read_grid_source_sql(
+            con, str(src), "geometry", bucket_point="bbox", bbox_column="bbox"
+        )
+        sql = build_grid_query(con, scheme, source_sql, 1, "cell", "avg:height", None, 20, "none")
+        rows = con.execute(sql).fetchall()
+        assert sum(r[1] for r in rows) == len(POINTS)
+    finally:
+        con.close()
+
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        source_sql = read_grid_source_sql(con, str(src), "geometry")
+        sql = build_grid_query(con, scheme, source_sql, 1, "cell", None, "height", 20, "polygon")
+        result = con.execute(sql).arrow().read_all()
+        assert "geometry" in result.column_names
+        assert sum(result.column("count").to_pylist()) == len(POINTS)
+    finally:
+        con.close()
+
+
+def test_build_exclude_clause_drops_only_existing_columns(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import build_exclude_clause
+
+    src = tmp_path / "f.parquet"
+    _write_geometry_less_bbox_file(src, POINTS)
+    con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+    try:
+        rel = f"read_parquet('{src}')"
+        assert build_exclude_clause(con, rel, ("geometry",)) == ""
+        assert build_exclude_clause(con, rel, ("geometry", "height")) == ' EXCLUDE ("height")'
+    finally:
+        con.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_process_aggregate_bucket_point.py
+++ b/tests/test_process_aggregate_bucket_point.py
@@ -1,0 +1,313 @@
+"""Tests for --bucket-point on `gpio process aggregate` (issue #567).
+
+Keying can derive its point from a bbox covering column (or an existing point
+column) instead of the full geometry, so the (usually huge) geometry column is
+never scanned for the common cell-polygon output.
+"""
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+from geoparquet_io.core.process.aggregate.by_h3 import aggregate_by_h3
+
+
+def _write_points_with_bbox(path, rows, bbox_col="bbox"):
+    """rows: list of (lon, lat, height). Writes points plus a bbox struct column."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(f"({lon}, {lat}, {height})" for lon, lat, height in rows)
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry,
+                   {{'xmin': lon - 0.0004, 'ymin': lat - 0.0004,
+                     'xmax': lon + 0.0004, 'ymax': lat + 0.0004}} AS "{bbox_col}",
+                   height
+            FROM (VALUES {values}) AS t(lon, lat, height)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def _write_plain_points(path, rows):
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(f"({lon}, {lat}, {height})" for lon, lat, height in rows)
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry, height
+            FROM (VALUES {values}) AS t(lon, lat, height)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+POINTS = [
+    (10.00, 50.00, 4.0),
+    (10.001, 50.001, 6.0),
+    (-120.0, 40.0, 1.0),
+]
+
+
+# ---------------------------------------------------------------------------
+# Source-SQL construction (fast, no grid extension)
+# ---------------------------------------------------------------------------
+
+
+def test_read_grid_source_sql_bbox_mode(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(
+            con, str(src), "geometry", bucket_point="bbox", bbox_column="bbox"
+        )
+        # Keying point from the bbox center, geometry column excluded from the scan.
+        assert "AS __pt" in sql
+        assert "ST_Point" in sql
+        assert 'EXCLUDE ("geometry")' in sql
+        cols = {r[0] for r in con.execute(f"DESCRIBE SELECT * FROM ({sql})").fetchall()}
+        assert "geometry" not in cols
+        assert "__pt" in cols
+        # bbox center == the original point (symmetric box)
+        row = con.execute(f"SELECT ST_X(__pt), ST_Y(__pt) FROM ({sql}) LIMIT 1").fetchone()
+        assert row[0] == pytest.approx(10.0)
+        assert row[1] == pytest.approx(50.0)
+    finally:
+        con.close()
+
+
+def test_read_grid_source_sql_geometry_mode_default(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_plain_points(src, POINTS)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(con, str(src), "geometry")
+        assert "ST_Centroid" in sql
+        assert "AS __pt" in sql
+        cols = {r[0] for r in con.execute(f"DESCRIBE SELECT * FROM ({sql})").fetchall()}
+        assert "geometry" in cols  # geometry passthrough kept in default mode
+    finally:
+        con.close()
+
+
+def test_read_grid_source_sql_point_column_mode(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    con0 = duckdb.connect()
+    con0.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con0.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(0.0, 0.0) AS geometry, ST_Point(10.0, 50.0) AS anchor, 1.0 AS height
+        ) TO '{src}' (FORMAT PARQUET)
+        """
+    )
+    con0.close()
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(con, str(src), "geometry", bucket_point="anchor")
+        assert 'EXCLUDE ("geometry")' in sql
+        row = con.execute(f"SELECT ST_X(__pt), ST_Y(__pt) FROM ({sql})").fetchone()
+        assert row == (10.0, 50.0)
+    finally:
+        con.close()
+
+
+def test_read_grid_source_sql_bbox_mode_transforms_non_crs84(tmp_path):
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.process.aggregate.grid_common import read_grid_source_sql
+
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        sql = read_grid_source_sql(
+            con,
+            str(src),
+            "geometry",
+            source_crs="EPSG:5070",
+            bucket_point="bbox",
+            bbox_column="bbox",
+        )
+        assert "ST_Transform" in sql  # bbox coords are in the file's CRS
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Validation / detection
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_mode_errors_when_no_bbox_column(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_plain_points(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="bbox"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, bucket_point="bbox")
+
+
+def test_bbox_column_requires_bbox_mode(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="bucket-point"):
+        aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, bbox_column="bbox")
+
+
+def test_cli_help_has_bucket_point_options():
+    runner = CliRunner()
+    for sub in ("a5", "h3", "admin"):
+        result = runner.invoke(cli, ["process", "aggregate", sub, "--help"])
+        assert result.exit_code == 0
+        assert "--bucket-point" in result.output, f"--bucket-point missing from {sub} --help"
+        assert "--bbox-column" in result.output, f"--bbox-column missing from {sub} --help"
+
+
+def test_admin_joined_sql_uses_point_expr_and_exclude():
+    from geoparquet_io.core.process.aggregate.by_admin import _build_joined_sql
+
+    sql = _build_joined_sql(
+        "in.parquet",
+        "ST_Point((bbox.xmin + bbox.xmax) / 2.0, (bbox.ymin + bbox.ymax) / 2.0)",
+        "read_parquet('admin.parquet')",
+        "country",
+        "country",
+        "geometry",
+        exclude_input_columns=("geometry",),
+    )
+    inner = sql.split(") s")[0]
+    assert "ST_Point((bbox.xmin" in inner
+    assert 'EXCLUDE ("geometry")' in inner
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (grid community extensions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_a5_bbox_matches_geometry_keying(tmp_path):
+    """For symmetric boxes around points, bbox keying == centroid keying."""
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    out_geom = tmp_path / "geom.parquet"
+    out_bbox = tmp_path / "bbox.parquet"
+    aggregate_by_a5(str(src), str(out_geom), resolution=5, metric="avg:height")
+    aggregate_by_a5(str(src), str(out_bbox), resolution=5, metric="avg:height", bucket_point="bbox")
+    df_g = pq.read_table(out_geom).to_pandas().sort_values("a5_cell").reset_index(drop=True)
+    df_b = pq.read_table(out_bbox).to_pandas().sort_values("a5_cell").reset_index(drop=True)
+    assert list(df_g["a5_cell"]) == list(df_b["a5_cell"])
+    assert list(df_g["count"]) == list(df_b["count"])
+    assert list(df_g["avg_height"]) == list(df_b["avg_height"])
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_a5_bbox_autodetects_column(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)  # conventional name "bbox" -> auto-detected
+    out = tmp_path / "o.parquet"
+    aggregate_by_a5(str(src), str(out), resolution=5, bucket_point="bbox")
+    assert sum(pq.read_table(out).column("count").to_pylist()) == 3
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_a5_bbox_explicit_nonstandard_column(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS, bbox_col="my_box")  # convention can't find this
+    out = tmp_path / "o.parquet"
+    aggregate_by_a5(str(src), str(out), resolution=5, bucket_point="bbox", bbox_column="my_box")
+    assert sum(pq.read_table(out).column("count").to_pylist()) == 3
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_h3_bbox_mode(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    out = tmp_path / "o.parquet"
+    aggregate_by_h3(str(src), str(out), resolution=5, bucket_point="bbox")
+    assert sum(pq.read_table(out).column("count").to_pylist()) == 3
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_cli_aggregate_a5_bucket_point_bbox(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_points_with_bbox(src, POINTS)
+    out = tmp_path / "o.parquet"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "process",
+            "aggregate",
+            "a5",
+            str(src),
+            str(out),
+            "--resolution",
+            "5",
+            "--bucket-point",
+            "bbox",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_table_aggregate_a5_bucket_point_bbox():
+    from geoparquet_io.api.table import Table
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    tbl = (
+        con.execute(
+            """
+            SELECT ST_AsWKB(ST_Point(lon, lat)) AS geometry,
+                   {'xmin': lon - 0.001, 'ymin': lat - 0.001,
+                    'xmax': lon + 0.001, 'ymax': lat + 0.001} AS bbox,
+                   height
+            FROM (VALUES (10.0, 50.0, 2.0), (-120.0, 40.0, 4.0)) AS t(lon, lat, height)
+            """
+        )
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    result = Table(tbl).aggregate_a5(resolution=5, bucket_point="bbox")
+    assert sum(result.table.column("count").to_pylist()) == 2
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_admin_bucket_point_bbox(tmp_path):
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "pts.parquet"
+    out = tmp_path / "by_country.parquet"
+    # Paris + Lyon (France) and one ocean point.
+    _write_points_with_bbox(src, [(2.35, 48.85, 1.0), (4.85, 45.75, 2.0), (-30.0, 0.0, 3.0)])
+    aggregate_by_admin(str(src), str(out), level="country", bucket_point="bbox")
+    df = pq.read_table(out).to_pandas()
+    assert int(df.loc[df["admin_code"] == "FR", "count"].iloc[0]) == 2
+    assert int(df.loc[df["admin_code"] == "unassigned", "count"].iloc[0]) == 1

--- a/tests/test_process_aggregate_bucket_point.py
+++ b/tests/test_process_aggregate_bucket_point.py
@@ -170,6 +170,61 @@ def test_bbox_column_requires_bbox_mode(tmp_path):
         aggregate_by_a5(str(src), str(tmp_path / "o.parquet"), resolution=5, bbox_column="bbox")
 
 
+def test_h3_bbox_mode_errors_when_no_bbox_column(tmp_path):
+    src = tmp_path / "f.parquet"
+    _write_plain_points(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="bbox"):
+        aggregate_by_h3(str(src), str(tmp_path / "o.parquet"), resolution=5, bucket_point="bbox")
+
+
+def test_admin_bbox_mode_errors_when_no_bbox_column(tmp_path):
+    """Admin path resolves the bbox column before any dataset setup or download."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "f.parquet"
+    _write_plain_points(src, POINTS)
+    with pytest.raises(InvalidParameterError, match="bbox"):
+        aggregate_by_admin(
+            str(src), str(tmp_path / "o.parquet"), level="country", bucket_point="bbox"
+        )
+
+
+def test_table_bbox_mode_errors_when_no_bbox_column():
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_a5_table
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    tbl = (
+        con.execute("SELECT ST_AsWKB(ST_Point(10.0, 50.0)) AS geometry, 1.0 AS height")
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    with pytest.raises(InvalidParameterError, match="bbox"):
+        aggregate_a5_table(tbl, resolution=5, bucket_point="bbox")
+
+
+def test_table_bbox_mode_autodetects_from_schema():
+    """Table-path detection finds a conventional bbox struct in the Arrow schema."""
+    from geoparquet_io.core.process.aggregate.grid_common import (
+        _resolve_bbox_column_for_table,
+    )
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    tbl = (
+        con.execute(
+            "SELECT ST_AsWKB(ST_Point(10.0, 50.0)) AS geometry, "
+            "{'xmin': 9.9, 'ymin': 49.9, 'xmax': 10.1, 'ymax': 50.1} AS bbox"
+        )
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    assert _resolve_bbox_column_for_table(tbl, None) == "bbox"
+    assert _resolve_bbox_column_for_table(tbl, "custom") == "custom"
+
+
 def test_cli_help_has_bucket_point_options():
     runner = CliRunner()
     for sub in ("a5", "h3", "admin"):

--- a/tests/test_process_aggregate_where.py
+++ b/tests/test_process_aggregate_where.py
@@ -380,7 +380,7 @@ def test_grid_aggregation_output_has_no_hive_partition_column(tmp_path):
         min_resolution=0,
         max_resolution=10,
         default_column="test_cell",
-        key_template="CAST(floor(ST_X({geom}) * {res}) AS VARCHAR)",
+        key_template="CAST(floor(ST_X({pt}) * {res}) AS VARCHAR)",
         boundary_template="{cell}",
         latlng_template="{cell}",
         poly_wkb_template="ST_AsWKB(ST_Point(0, 0))",


### PR DESCRIPTION
## Summary

Implements #567: `gpio process aggregate {a5,h3,admin}` can now derive its bucketing point from a **bbox covering column** (`--bucket-point bbox`) or an existing point column, instead of the full geometry. Since the default output synthesizes cell polygons from the cell id, the geometry column is **excluded from the source SELECT** — Parquet projection pushdown skips its column chunks entirely, making low-zoom aggregation of huge polygon datasets (GlobalBuildingAtlas: 225 GB, 2.75B polygons with a `bbox` column) a pure-gpio, fraction-of-the-IO operation.

```bash
gpio process aggregate a5 buildings/*.parquet cells.parquet --auto \
    --bucket-point bbox --metric "avg:height,max:height"
```

> **Stacked on #612** (`--where`, #568) since both rewrite the same source-SQL builders — the diff here shows only the #567 changes. GitHub will retarget to `main` when #612 merges. Together with #612 and #613 (`--metric-nodata`, independent), this completes the pure-gpio GBA pipeline from the issue.

## Implementation

- **Scheme templates refactored**: `key_template` now takes a `{pt}` point placeholder (`a5_lonlat_to_cell(ST_X({pt}), ...)`) instead of baking `ST_Centroid({geom})` in twice; the engine emits a single `__pt` keying point. Default mode is byte-for-byte the same semantics (centroid of the CRS84-transformed geometry).
- **bbox mode**: `__pt = ST_Point((b.xmin+b.xmax)/2, (b.ymin+b.ymax)/2)`, geometry column EXCLUDEd. Column auto-detected via the existing `check_bbox_structure` name-convention detection (`bbox`/`*_bbox`/`bounds`/`extent` structs), `--bbox-column NAME` for nonstandard names, clear error when none found. CRS-aware: the point is wrapped in the same `crs_transform_sql_expr` treatment as geometry (#525).
- **Point-column mode**: any other `--bucket-point` value names an existing point column (wrapped in `ST_Centroid`, a no-op for points).
- **Admin path**: `_build_joined_sql` takes the pluggable point expression for `__cen` plus the geometry EXCLUDE.
- **Validation**: `--bbox-column` without `--bucket-point bbox` errors; bbox mode without a detectable column errors with the fix spelled out.
- API parity: `bucket_point=`/`bbox_column=` on `ops.aggregate_*` and `Table.aggregate_*`.

Per the issue, the row-group-statistics metadata-only tier is deferred, and `--auto`'s resolution probe still samples geometry centroids (bounded ≤500k-row sample; documented in the guide with the `--resolution` workaround).

## Tests

15 new tests in `tests/test_process_aggregate_bucket_point.py`: source-SQL construction for all three modes (incl. verifying the geometry column is truly absent from the scan schema and that non-CRS84 input gets `ST_Transform`), validation errors, CLI help, admin SQL construction, and slow/network e2e — including **bbox keying ≡ centroid keying** on symmetric-box fixtures for a5, plus h3, CLI, Table API, and admin-with-bbox France/ocean assignment. All 72 aggregate tests (including pre-existing CRS and e2e suites) pass against the refactored keying; fast suite green (3530 passed).

## Docs

- `docs/guide/process-aggregate.md`: new "Bucketing Point" section with the mode table, IO rationale, and the `--auto` probe note
- `docs/api/python-api.md` signatures + parameter rows
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)