### PR TITLE
feat: process overview + pmtiles pyramid (#570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`gpio process overview` (#570)**: derive coarser aggregate levels from an
+  existing `gpio process aggregate` output. The scheme (`a5_cell`/`h3_cell`/
+  `admin_code`) and base level are detected from the file; cells roll up by
+  true hierarchy (`a5_cell_to_parent`/`h3_cell_to_parent`; admin region→country
+  via ISO code prefix with cached Overture country polygons). `count`, `sum_*`,
+  `min_*`, `max_*`, and breakdown `count_*` columns roll up exactly; `avg_*` is
+  count-weighted (exact when the metric has no NULLs). Levels are explicit
+  (`--levels 4,7`) or auto-selected against a tile-size budget
+  (`--max-tile-kb`, default 500) using a worst-tile probe of parent-cell
+  centroids in DuckDB. Outputs are siblings (`cells_r7.parquet`,
+  `by_region_country.parquet`). Python API: `ops.create_overviews`,
+  `Table.overview`.
+
 - **`--bucket-point` on `gpio process aggregate` (#567).** Grid/admin keying
   can now derive its per-feature point from a bbox covering column
   (`--bucket-point bbox`, auto-detected or via `--bbox-column`) or an existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
+  into a single zoom-banded PMTiles archive. Each level is tiled once with
+  tippecanoe, pinned to the zoom band where its worst tile fits the
+  `--max-tile-kb` budget, and the bands are merged with `tile-join` and
+  recorded under a `gpio:pyramid` key in the archive metadata. Existing
+  `_r*` overview siblings are reused; missing levels are built automatically.
+  `--include-features` appends the raw features as the final band
+  (`--features-min-zoom` defaults to base band max + 1); `--layer-mode
+  single|grouped|per-level` controls layer naming for client styling. Python
+  API: `ops.create_pmtiles_pyramid`.
+
 - **`gpio process overview` (#570)**: derive coarser aggregate levels from an
   existing `gpio process aggregate` output. The scheme (`a5_cell`/`h3_cell`/
   `admin_code`) and base level are detected from the file; cells roll up by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ geoparquet_io/
 | `gpio extract` | arcgis, bigquery, carto, geoparquet, wfs | Extract data from files and services to GeoParquet |
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or statistics |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files |
-| `gpio pmtiles` | create | PMTiles generation commands |
+| `gpio pmtiles` | create, pyramid | PMTiles generation commands |
 | `gpio process` | aggregate, overview | Transform or reduce GeoParquet data (aggregate, overview, |
 | `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata, cloud uploads) |
 | `gpio skills` |  | List and access LLM skills for gpio |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ geoparquet_io/
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or statistics |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files |
 | `gpio pmtiles` | create | PMTiles generation commands |
-| `gpio process` | aggregate | Transform or reduce GeoParquet data (aggregate, |
+| `gpio process` | aggregate, overview | Transform or reduce GeoParquet data (aggregate, overview, |
 | `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata, cloud uploads) |
 | `gpio skills` |  | List and access LLM skills for gpio |
 | `gpio sort` | column, hilbert, quadkey | Commands for sorting GeoParquet files |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`gpio process overview` (#570)**: derive coarser aggregate levels from an
+  existing `gpio process aggregate` output. The scheme (`a5_cell`/`h3_cell`/
+  `admin_code`) and base level are detected from the file; cells roll up by
+  true hierarchy (`a5_cell_to_parent`/`h3_cell_to_parent`; admin region→country
+  via ISO code prefix with cached Overture country polygons). `count`, `sum_*`,
+  `min_*`, `max_*`, and breakdown `count_*` columns roll up exactly; `avg_*` is
+  count-weighted (exact when the metric has no NULLs). Levels are explicit
+  (`--levels 4,7`) or auto-selected against a tile-size budget
+  (`--max-tile-kb`, default 500) using a worst-tile probe of parent-cell
+  centroids in DuckDB. Outputs are siblings (`cells_r7.parquet`,
+  `by_region_country.parquet`). Python API: `ops.create_overviews`,
+  `Table.overview`.
+
 - **`--bucket-point` on `gpio process aggregate` (#567).** Grid/admin keying
   can now derive its per-feature point from a bbox covering column
   (`--bucket-point bbox`, auto-detected or via `--bbox-column`) or an existing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
+  into a single zoom-banded PMTiles archive. Each level is tiled once with
+  tippecanoe, pinned to the zoom band where its worst tile fits the
+  `--max-tile-kb` budget, and the bands are merged with `tile-join` and
+  recorded under a `gpio:pyramid` key in the archive metadata. Existing
+  `_r*` overview siblings are reused; missing levels are built automatically.
+  `--include-features` appends the raw features as the final band
+  (`--features-min-zoom` defaults to base band max + 1); `--layer-mode
+  single|grouped|per-level` controls layer naming for client styling. Python
+  API: `ops.create_pmtiles_pyramid`.
+
 - **`gpio process overview` (#570)**: derive coarser aggregate levels from an
   existing `gpio process aggregate` output. The scheme (`a5_cell`/`h3_cell`/
   `admin_code`) and base level are detected from the file; cells roll up by

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -991,6 +991,36 @@ Every output row carries `admin_code` and `admin_name` bucket identifiers. Featu
 !!! note "Known limitation"
     `admin_name` currently equals the ISO code (same as `admin_code`).
 
+#### `overview(level, cell_column=None)`
+
+Roll an aggregate table up to a coarser overview level by true cell hierarchy
+(`a5_cell_to_parent` / `h3_cell_to_parent`; admin region codes collapse to
+their ISO country prefix). The table must be a `process aggregate` output.
+
+```python
+import geoparquet_io as gpio
+
+# Grid aggregate: roll res-10 cells up to res 6
+coarse = gpio.read('cells.parquet').overview(6)
+coarse.write('cells_r6.parquet')
+
+# Region-level admin aggregate: roll up to country
+by_country = gpio.read('by_region.parquet').overview('country')
+by_country.write('by_region_country.parquet')
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `level` | int or str | required | Coarser grid resolution, or `"country"` for admin |
+| `cell_column` | str | None | Cell id column when auto-detection fails |
+
+`count`, `sum_*`, `min_*`, `max_*`, and breakdown `count_*` columns roll up
+exactly; `avg_*` is count-weighted (exact when the metric had no NULLs). For
+file-based batch building of several levels (with auto level selection), use
+`ops.create_overviews`.
+
 ### Sub-Partitioning Utilities
 
 For working with directories of partitioned files, gpio provides utilities to find and sub-partition large files.
@@ -1425,6 +1455,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.convert_to_shapefile(table, output, encoding='UTF-8', overwrite=False)` | Convert to Shapefile |
 | `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=100000, auto_tile=False, ...)` | Fetch from WFS service |
 | `ops.from_wfs_layers(service_url, typenames, output_dir, parallel_layers=1, max_workers=1, page_size=100000, ...)` | Fetch multiple WFS layers to directory |
+| `ops.create_overviews(input_parquet, levels=None, max_tile_kb=500, bytes_per_cell=None, cell_column=None, output_dir=None, ...)` | Build coarser overview levels from an aggregate file |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |
 | `ops.explain_analyze(file_path, query=None)` | DuckDB EXPLAIN ANALYZE query plan |

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1015,6 +1015,7 @@ by_country.write('by_region_country.parquet')
 |-----------|------|---------|-------------|
 | `level` | int or str | required | Coarser grid resolution, or `"country"` for admin |
 | `cell_column` | str | None | Cell id column when auto-detection fails |
+| `scheme` | str | None | Bucketing scheme (`a5`/`h3`/`admin`) when inference is ambiguous, e.g. H3 ids stored as integers |
 
 `count`, `sum_*`, `min_*`, `max_*`, and breakdown `count_*` columns roll up
 exactly; `avg_*` is count-weighted (exact when the metric had no NULLs). For
@@ -1455,7 +1456,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.convert_to_shapefile(table, output, encoding='UTF-8', overwrite=False)` | Convert to Shapefile |
 | `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=100000, auto_tile=False, ...)` | Fetch from WFS service |
 | `ops.from_wfs_layers(service_url, typenames, output_dir, parallel_layers=1, max_workers=1, page_size=100000, ...)` | Fetch multiple WFS layers to directory |
-| `ops.create_overviews(input_parquet, levels=None, max_tile_kb=500, bytes_per_cell=None, cell_column=None, output_dir=None, ...)` | Build coarser overview levels from an aggregate file |
+| `ops.create_overviews(input_parquet, levels=None, max_tile_kb=500, bytes_per_cell=None, cell_column=None, scheme=None, output_dir=None, force=False, ...)` | Build coarser overview levels from an aggregate file |
 | `ops.create_pmtiles_pyramid(input_path, output_path, levels=None, max_tile_kb=500, layer_mode='grouped', include_features=False, features_source=None, max_zoom=None, ...)` | Build a zoom-banded multi-level PMTiles archive from an aggregate file (requires tippecanoe + tile-join) |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1456,6 +1456,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.from_wfs(service_url, typename, version='auto', bbox=None, limit=None, max_workers=1, page_size=100000, auto_tile=False, ...)` | Fetch from WFS service |
 | `ops.from_wfs_layers(service_url, typenames, output_dir, parallel_layers=1, max_workers=1, page_size=100000, ...)` | Fetch multiple WFS layers to directory |
 | `ops.create_overviews(input_parquet, levels=None, max_tile_kb=500, bytes_per_cell=None, cell_column=None, output_dir=None, ...)` | Build coarser overview levels from an aggregate file |
+| `ops.create_pmtiles_pyramid(input_path, output_path, levels=None, max_tile_kb=500, layer_mode='grouped', include_features=False, features_source=None, max_zoom=None, ...)` | Build a zoom-banded multi-level PMTiles archive from an aggregate file (requires tippecanoe + tile-join) |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |
 | `ops.explain_analyze(file_path, query=None)` | DuckDB EXPLAIN ANALYZE query plan |

--- a/docs/guide/geojson.md
+++ b/docs/guide/geojson.md
@@ -155,6 +155,69 @@ For national- or global-overview maps over dense data, re-enable the size limit 
     )
     ```
 
+## PMTiles Pyramids
+
+A fine-grained aggregate (say A5 resolution 10 over billions of buildings) renders beautifully zoomed in but overflows tile limits at low zooms, forcing tippecanoe to drop the densest cells — exactly the hotspots you care about. `gpio pmtiles pyramid` fixes this by building a **banded archive**: coarser aggregate levels serve low zooms, finer levels take over as you zoom in, and (optionally) the raw features appear at the highest zooms.
+
+Levels come from [`gpio process overview`](process-overview.md) — existing `_r*` siblings are reused, missing ones are built automatically — and each level is pinned to the zoom band where its worst tile fits `--max-tile-kb` (default 500 KB). One tippecanoe run per band, merged with `tile-join` (ships with tippecanoe), with the bands recorded in the archive metadata under `gpio:pyramid`.
+
+=== "CLI"
+
+    ```bash
+    # Auto bands from the tile budget (builds temp overviews if missing)
+    gpio pmtiles pyramid cells.parquet cells.pmtiles
+
+    # Explicit overview levels and a capped base band
+    gpio pmtiles pyramid cells.parquet out.pmtiles --levels 5 --max-zoom 10
+
+    # Country cells -> region cells -> raw polygons in one archive
+    gpio pmtiles pyramid by_region.parquet out.pmtiles \
+        --include-features --features-source buildings.parquet --max-zoom 8
+    ```
+
+=== "Python"
+
+    ```python
+    from geoparquet_io.api import ops
+
+    ops.create_pmtiles_pyramid('cells.parquet', 'cells.pmtiles')
+
+    ops.create_pmtiles_pyramid(
+        'cells.parquet',
+        'pyramid.pmtiles',
+        include_features=True,
+        features_source='buildings.parquet',
+        max_zoom=8,
+    )
+    ```
+
+### Layer Modes
+
+`--layer-mode` controls how bands map to vector tile layers, which drives how you style them in MapLibre:
+
+| Mode | Layers | MapLibre styling |
+|------|--------|------------------|
+| `single` | one layer named after the output file | One `source-layer` for everything. Bands never overlap zooms, so a single style layer renders seamlessly across the whole zoom range. |
+| `grouped` *(default)* | `aggregate` + `features` | Two style layers: one for `source-layer: "aggregate"` (all cell levels share the schema, so one `fill-color` ramp on `count` just works), one for `source-layer: "features"` (raw attributes differ). |
+| `per-level` | `r5`, `r10`, … (or `country`, `region`) + `features` | One style layer per `source-layer` — style each resolution independently, or toggle levels client-side for comparison. |
+
+For example, with the default `grouped` mode:
+
+```js
+map.addLayer({
+  id: 'cells',
+  type: 'fill',
+  source: 'pyramid',            // your pmtiles source
+  'source-layer': 'aggregate',  // every aggregate band lands here
+  paint: {
+    'fill-color': ['interpolate', ['linear'], ['get', 'count'],
+                   1, '#ffffcc', 10000, '#800026'],
+  },
+});
+```
+
+Because each zoom is served by exactly one band, no zoom-range filtering is needed in the style. The `gpio:pyramid` metadata key lists every band (`level`, `layer`, `minzoom`, `maxzoom`) if a client wants to introspect the archive.
+
 ## Common Workflows
 
 ### Filter Before Converting

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -529,6 +529,8 @@ Both commands support the standard output options:
 
 ## See Also
 
+- [Overview Levels](process-overview.md) — derive coarser levels from an aggregate output
+- [PMTiles Pyramids](geojson.md#pmtiles-pyramids) — bake all levels into one zoom-banded archive
 - [Adding Spatial Indices](add.md) — add A5/H3 columns before aggregating
 - [Partitioning Files](partition.md) — split large files by spatial index or admin region
 - [Python API Reference](../api/python-api.md#aggregation) — full API documentation

--- a/docs/guide/process-overview.md
+++ b/docs/guide/process-overview.md
@@ -57,10 +57,10 @@ Cells roll up by **true hierarchy** — `a5_cell_to_parent` / `h3_cell_to_parent
 | `sum_*` | sum | exact |
 | `min_*` / `max_*` | min / max | exact |
 | `count_*` breakdowns (incl. `count_other`) | sum | exact |
-| `avg_*` | count-weighted mean | exact **when the metric had no NULLs** |
+| `avg_*` | count-weighted mean over children with a value | exact **when the metric had no NULLs** |
 
 !!! note "The `avg_*` caveat"
-    A child cell's `avg_x` was computed over its non-NULL values, but the rollup weights it by the cell's full `count`. When some features had NULL `x`, the weighting is approximate. With no NULLs, the count-weighted mean is exactly the mean over all original features.
+    A child cell's `avg_x` was computed over its non-NULL values, but the rollup weights it by the cell's full `count` (children whose `avg_x` is entirely NULL are excluded). When some features had NULL `x`, the weighting is approximate. With no NULLs, the count-weighted mean is exactly the mean over all original features.
 
 Columns that don't match a rollup role are dropped with a warning. The `unassigned` bucket (features with no assignable cell/region) flows through with a NULL geometry.
 
@@ -72,7 +72,7 @@ Without `--levels`, gpio picks levels against the `--max-tile-kb` budget (defaul
 2. For each candidate level and zoom, parent-cell centroids are assigned to WebMercator tiles in DuckDB and the **worst tile's** cell count gives the estimated tile size. Because the probe uses your actual cells, regional datasets work without special casing.
 3. Walking up from z0, the finest level that fits each zoom is chosen until the base level fits; consecutive picks merge into bands. The coarsest band always extends to z0 even if a single z0 tile overflows.
 
-The selected bands drive which levels are materialized; the same selection powers `gpio pmtiles pyramid` zoom bands.
+The selected bands drive which levels are materialized; the same selection powers `gpio pmtiles pyramid` zoom bands. If the base level already fits the budget at every zoom — for grid and admin inputs alike — no overview is built. (A geometry-less admin aggregate cannot be probed and falls back to building `country`.)
 
 ## Options
 
@@ -82,7 +82,9 @@ The selected bands drive which levels are materialized; the same selection power
 | `--max-tile-kb` | 500 | Tile-size budget driving auto selection |
 | `--bytes-per-cell` | estimated | Override the compressed bytes-per-cell estimate |
 | `--cell-column` | auto | Cell id column when detection fails |
+| `--scheme` | auto | Bucketing scheme (`a5`/`h3`/`admin`) when inference is ambiguous, e.g. H3 ids stored as integers |
 | `--output-dir` | input's directory | Where to write overview files |
+| `--force` | off | Overwrite existing overview output files |
 
 Compression (`--compression`, `--compression-level`), `--geoparquet-version`, `--verbose`, and `--show-sql` behave as elsewhere in gpio.
 

--- a/docs/guide/process-overview.md
+++ b/docs/guide/process-overview.md
@@ -1,0 +1,92 @@
+# Overview Levels
+
+`gpio process overview` derives **coarser aggregate levels** from an existing `gpio process aggregate` output. Rolling up reads the small aggregate file — never the raw source — so building or re-tuning overviews takes seconds even when the original aggregation scanned billions of features.
+
+**When to use it:** a fine aggregate (say A5 resolution 10) looks great zoomed in but cannot be rendered zoomed out — at low zooms every cell lands in a handful of tiles and the tiler has to drop features. Overviews give you a resolution ladder (`cells_r4.parquet`, `cells_r7.parquet`, …) so each zoom range can be served by a level that fits the tile budget. Feed the ladder to [`gpio pmtiles pyramid`](geojson.md#pmtiles-pyramids) to bake everything into one archive.
+
+---
+
+## Basic Usage
+
+The input's scheme (`a5_cell` / `h3_cell` / `admin_code`) and base level are detected automatically:
+
+=== "CLI"
+
+    ```bash
+    # Auto-select levels against a 500 KB tile budget
+    gpio process overview cells.parquet
+
+    # Explicit grid resolutions
+    gpio process overview cells.parquet --levels 4,7
+
+    # Admin ladder: region-level input rolls up to country
+    gpio process overview by_region.parquet --levels country
+
+    # Tighter tile budget
+    gpio process overview cells.parquet --max-tile-kb 300
+    ```
+
+=== "Python"
+
+    ```python
+    from geoparquet_io.api import ops
+
+    # File-based: writes one sibling per level, returns [(level, path), ...]
+    ops.create_overviews('cells.parquet', levels=[4, 7])
+
+    # In-memory: roll a single level with the Table API
+    import geoparquet_io as gpio
+    coarse = gpio.read('cells.parquet').overview(4)
+    coarse.write('cells_r4.parquet')
+    ```
+
+Outputs are written next to the input (override with `--output-dir`):
+
+| Input | Level | Output |
+|-------|-------|--------|
+| `cells.parquet` (a5/h3) | 7 | `cells_r7.parquet` |
+| `by_region.parquet` (admin) | country | `by_region_country.parquet` |
+
+## Rollup Semantics
+
+Cells roll up by **true hierarchy** — `a5_cell_to_parent` / `h3_cell_to_parent` for grids, the ISO country prefix of `admin_code` (`US-CA` → `US`) for admin — and parent geometry is regenerated from the parent cell id (grids) or cached Overture country polygons (admin).
+
+| Column | Rollup | Exactness |
+|--------|--------|-----------|
+| `count` | sum | exact |
+| `sum_*` | sum | exact |
+| `min_*` / `max_*` | min / max | exact |
+| `count_*` breakdowns (incl. `count_other`) | sum | exact |
+| `avg_*` | count-weighted mean | exact **when the metric had no NULLs** |
+
+!!! note "The `avg_*` caveat"
+    A child cell's `avg_x` was computed over its non-NULL values, but the rollup weights it by the cell's full `count`. When some features had NULL `x`, the weighting is approximate. With no NULLs, the count-weighted mean is exactly the mean over all original features.
+
+Columns that don't match a rollup role are dropped with a warning. The `unassigned` bucket (features with no assignable cell/region) flows through with a NULL geometry.
+
+## Auto Level Selection
+
+Without `--levels`, gpio picks levels against the `--max-tile-kb` budget (default 500 KB, tippecanoe's cap):
+
+1. **Bytes per cell** are estimated from the attribute schema and output geometry (override with `--bytes-per-cell`).
+2. For each candidate level and zoom, parent-cell centroids are assigned to WebMercator tiles in DuckDB and the **worst tile's** cell count gives the estimated tile size. Because the probe uses your actual cells, regional datasets work without special casing.
+3. Walking up from z0, the finest level that fits each zoom is chosen until the base level fits; consecutive picks merge into bands. The coarsest band always extends to z0 even if a single z0 tile overflows.
+
+The selected bands drive which levels are materialized; the same selection powers `gpio pmtiles pyramid` zoom bands.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--levels` | auto | Comma-separated levels to build (grid resolutions, or `country`) |
+| `--max-tile-kb` | 500 | Tile-size budget driving auto selection |
+| `--bytes-per-cell` | estimated | Override the compressed bytes-per-cell estimate |
+| `--cell-column` | auto | Cell id column when detection fails |
+| `--output-dir` | input's directory | Where to write overview files |
+
+Compression (`--compression`, `--compression-level`), `--geoparquet-version`, `--verbose`, and `--show-sql` behave as elsewhere in gpio.
+
+## See Also
+
+- [Aggregating Data](process-aggregate.md) — create the base aggregate
+- [GeoJSON & PMTiles](geojson.md) — bake levels into a single PMTiles pyramid

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -422,6 +422,66 @@ def aggregate_admin(
     )
 
 
+def create_overviews(
+    input_parquet: str,
+    *,
+    levels: str | list | None = None,
+    max_tile_kb: int = 500,
+    bytes_per_cell: float | None = None,
+    cell_column: str | None = None,
+    output_dir: str | None = None,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    geoparquet_version: str | None = None,
+    verbose: bool = False,
+) -> list[tuple[int | str, str]]:
+    """
+    Build coarser overview levels from an aggregate GeoParquet file.
+
+    Detects the aggregate's scheme (a5/h3/admin) and base level, rolls up by
+    true cell hierarchy, and writes one GeoParquet sibling per coarser level
+    (``cells.parquet`` -> ``cells_r4.parquet``; admin ->
+    ``by_region_country.parquet``). Counts, sums, mins, maxes, and breakdown
+    counts roll up exactly; averages are count-weighted (exact when the
+    metric had no NULLs).
+
+    Args:
+        input_parquet: Path to a `gpio process aggregate` output
+        levels: Explicit levels (comma string or list; admin: "country").
+            Default: auto-select against max_tile_kb
+        max_tile_kb: Tile-size budget in KB for auto level selection (default: 500)
+        bytes_per_cell: Override the estimated compressed bytes per cell
+        cell_column: Cell id column when auto-detection fails
+        output_dir: Directory for overview files (default: beside the input)
+        compression: Parquet compression codec (default: ZSTD)
+        compression_level: Optional compression level
+        geoparquet_version: GeoParquet version to write
+        verbose: Enable verbose output
+
+    Returns:
+        List of (level, output_path) tuples, coarse to fine
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> ops.create_overviews('cells.parquet', levels=[4, 7])
+        [(4, 'cells_r4.parquet'), (7, 'cells_r7.parquet')]
+    """
+    from geoparquet_io.core.process.overview import create_overviews as _create_overviews
+
+    return _create_overviews(
+        input_parquet,
+        levels=levels,
+        max_tile_kb=max_tile_kb,
+        bytes_per_cell=bytes_per_cell,
+        cell_column=cell_column,
+        output_dir=output_dir,
+        compression=compression,
+        compression_level=compression_level,
+        geoparquet_version=geoparquet_version,
+        verbose=verbose,
+    )
+
+
 def add_kdtree(
     table: pa.Table,
     column_name: str = "kdtree_cell",

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -434,6 +434,7 @@ def create_overviews(
     compression: str = "ZSTD",
     compression_level: int | None = None,
     geoparquet_version: str | None = None,
+    force: bool = False,
     verbose: bool = False,
     show_sql: bool = False,
 ) -> list[tuple[int | str, str]]:
@@ -460,6 +461,7 @@ def create_overviews(
         compression: Parquet compression codec (default: ZSTD)
         compression_level: Optional compression level
         geoparquet_version: GeoParquet version to write
+        force: Overwrite existing overview output files
         verbose: Enable verbose output
         show_sql: Log the rollup SQL
 
@@ -484,6 +486,7 @@ def create_overviews(
         compression=compression,
         compression_level=compression_level,
         geoparquet_version=geoparquet_version,
+        force=force,
         verbose=verbose,
         show_sql=show_sql,
     )

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -425,15 +425,17 @@ def aggregate_admin(
 def create_overviews(
     input_parquet: str,
     *,
-    levels: str | list | None = None,
+    levels: str | list[int | str] | None = None,
     max_tile_kb: int = 500,
     bytes_per_cell: float | None = None,
     cell_column: str | None = None,
+    scheme: str | None = None,
     output_dir: str | None = None,
     compression: str = "ZSTD",
     compression_level: int | None = None,
     geoparquet_version: str | None = None,
     verbose: bool = False,
+    show_sql: bool = False,
 ) -> list[tuple[int | str, str]]:
     """
     Build coarser overview levels from an aggregate GeoParquet file.
@@ -452,11 +454,14 @@ def create_overviews(
         max_tile_kb: Tile-size budget in KB for auto level selection (default: 500)
         bytes_per_cell: Override the estimated compressed bytes per cell
         cell_column: Cell id column when auto-detection fails
+        scheme: Bucketing scheme (a5/h3/admin) when inference is ambiguous,
+            e.g. H3 ids stored as integers
         output_dir: Directory for overview files (default: beside the input)
         compression: Parquet compression codec (default: ZSTD)
         compression_level: Optional compression level
         geoparquet_version: GeoParquet version to write
         verbose: Enable verbose output
+        show_sql: Log the rollup SQL
 
     Returns:
         List of (level, output_path) tuples, coarse to fine
@@ -474,11 +479,13 @@ def create_overviews(
         max_tile_kb=max_tile_kb,
         bytes_per_cell=bytes_per_cell,
         cell_column=cell_column,
+        scheme=scheme,
         output_dir=output_dir,
         compression=compression,
         compression_level=compression_level,
         geoparquet_version=geoparquet_version,
         verbose=verbose,
+        show_sql=show_sql,
     )
 
 
@@ -1548,7 +1555,7 @@ def create_pmtiles_pyramid(
     input_path: str,
     output_path: str,
     *,
-    levels: str | list | None = None,
+    levels: str | list[int | str] | None = None,
     max_tile_kb: int = 500,
     bytes_per_cell: float | None = None,
     layer_mode: str = "grouped",

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1542,3 +1542,85 @@ def create_pmtiles(
         force=force,
         repair_geometry=repair_geometry,
     )
+
+
+def create_pmtiles_pyramid(
+    input_path: str,
+    output_path: str,
+    *,
+    levels: str | list | None = None,
+    max_tile_kb: int = 500,
+    bytes_per_cell: float | None = None,
+    layer_mode: str = "grouped",
+    include_features: bool = False,
+    features_source: str | None = None,
+    features_min_zoom: int | None = None,
+    max_zoom: int | None = None,
+    attribution: str | None = None,
+    force: bool = False,
+    verbose: bool = False,
+) -> None:
+    """
+    Create a banded multi-level PMTiles pyramid from an aggregate file.
+
+    Detects the aggregate's scheme (a5/h3/admin) and base level, assigns each
+    level a zoom band that fits the tile budget, runs tippecanoe once per band,
+    and merges everything into one archive with tile-join. Existing overview
+    siblings (from `gpio process overview` / `ops.create_overviews`) are
+    reused; missing levels are built automatically. Bands are recorded in the
+    PMTiles metadata under ``gpio:pyramid``.
+
+    Requires tippecanoe and tile-join (ships with tippecanoe) in PATH.
+
+    Args:
+        input_path: Path to a `gpio process aggregate` output (GeoParquet)
+        output_path: Path for the output PMTiles archive
+        levels: Explicit overview levels (comma string or list; admin:
+            "country"). Default: auto-select against max_tile_kb
+        max_tile_kb: Tile-size budget in KB for band selection (default: 500)
+        bytes_per_cell: Override the estimated compressed bytes per cell
+        layer_mode: "single", "grouped" (default), or "per-level"
+        include_features: Append the original features as the final zoom band
+        features_source: GeoParquet source for the features band
+        features_min_zoom: First zoom of the features band (default: base
+            band max zoom + 1)
+        max_zoom: Max zoom of the base aggregate band
+        attribution: Attribution HTML for the tiles
+        force: Overwrite the output archive if it exists
+        verbose: Enable verbose output
+
+    Raises:
+        TippecanoeNotFoundError: If tippecanoe is not in PATH
+        TileJoinNotFoundError: If tile-join is not in PATH
+        RuntimeError: If a tippecanoe or tile-join run fails
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> ops.create_pmtiles_pyramid('cells.parquet', 'cells.pmtiles')
+        >>> ops.create_pmtiles_pyramid(
+        ...     'cells.parquet',
+        ...     'pyramid.pmtiles',
+        ...     include_features=True,
+        ...     features_source='buildings.parquet',
+        ...     max_zoom=8,
+        ... )
+    """
+    from geoparquet_io.core.pmtiles_pyramid import (
+        create_pmtiles_pyramid as _create_pmtiles_pyramid,
+    )
+
+    _create_pmtiles_pyramid(
+        input_path,
+        output_path,
+        levels=levels,
+        max_tile_kb=max_tile_kb,
+        bytes_per_cell=bytes_per_cell,
+        layer_mode=layer_mode,
+        include_features=include_features,
+        features_source=features_source,
+        features_min_zoom=features_min_zoom,
+        max_zoom=max_zoom,
+        attribution=attribution,
+        force=force,
+        verbose=verbose,
+    )

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1513,6 +1513,33 @@ class Table:
         )
         return Table(result, "geometry" if out_geometry != "none" else None)
 
+    def overview(
+        self,
+        level: int | str,
+        cell_column: str | None = None,
+    ) -> Table:
+        """
+        Roll an aggregate table up to a coarser overview level.
+
+        The table must be a `process aggregate` output (carrying an
+        ``a5_cell``/``h3_cell``/``admin_code`` column plus ``count``). Counts,
+        sums, mins, maxes, and breakdown counts roll up exactly; averages are
+        count-weighted (exact when the metric had no NULLs).
+
+        Args:
+            level: Target level -- a coarser grid resolution, or ``"country"``
+                for a region-level admin aggregate
+            cell_column: Cell id column when auto-detection fails
+
+        Returns:
+            New Table with one row per parent cell
+        """
+        from geoparquet_io.core.process.overview import rollup_table
+
+        result = rollup_table(self._table, level, cell_column=cell_column)
+        has_geometry = "geometry" in result.column_names
+        return Table(result, "geometry" if has_geometry else None)
+
     def add_s2(
         self,
         column_name: str = "s2_cell",

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1517,6 +1517,7 @@ class Table:
         self,
         level: int | str,
         cell_column: str | None = None,
+        scheme: str | None = None,
     ) -> Table:
         """
         Roll an aggregate table up to a coarser overview level.
@@ -1530,13 +1531,15 @@ class Table:
             level: Target level -- a coarser grid resolution, or ``"country"``
                 for a region-level admin aggregate
             cell_column: Cell id column when auto-detection fails
+            scheme: Bucketing scheme (``a5``/``h3``/``admin``) when inference
+                is ambiguous, e.g. H3 ids stored as integers
 
         Returns:
             New Table with one row per parent cell
         """
         from geoparquet_io.core.process.overview import rollup_table
 
-        result = rollup_table(self._table, level, cell_column=cell_column)
+        result = rollup_table(self._table, level, cell_column=cell_column, scheme=scheme)
         has_geometry = "geometry" in result.column_names
         return Table(result, "geometry" if has_geometry else None)
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -6997,6 +6997,131 @@ def pmtiles_create(
         raise click.ClickException(str(e)) from e
 
 
+@pmtiles.command(name="pyramid")
+@click.argument("input_parquet", type=click.Path())
+@click.argument("output_pmtiles", type=click.Path())
+@click.option(
+    "--levels",
+    default=None,
+    help=(
+        "Comma-separated overview levels (grid resolutions like '5'; admin: "
+        "'country'). Default: auto-select against --max-tile-kb."
+    ),
+)
+@click.option(
+    "--max-tile-kb",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Tile-size budget in KB driving zoom-band selection.",
+)
+@click.option(
+    "--bytes-per-cell",
+    type=float,
+    default=None,
+    help="Override the estimated compressed bytes per cell used in band selection.",
+)
+@click.option(
+    "--layer-mode",
+    type=click.Choice(["single", "grouped", "per-level"]),
+    default="grouped",
+    show_default=True,
+    help=(
+        "Layer naming: 'single' puts everything in one layer, 'grouped' uses "
+        "'aggregate' + 'features', 'per-level' uses r5/r10 (or country/region)."
+    ),
+)
+@click.option(
+    "--include-features",
+    is_flag=True,
+    help="Append the original features as the final zoom band.",
+)
+@click.option(
+    "--features-source",
+    type=click.Path(),
+    default=None,
+    help="GeoParquet source for the features band (required with --include-features).",
+)
+@click.option(
+    "--features-min-zoom",
+    type=int,
+    default=None,
+    help="First zoom of the features band (default: base band max zoom + 1).",
+)
+@click.option(
+    "--max-zoom",
+    type=int,
+    default=None,
+    help="Max zoom of the base aggregate band (auto-detected if not set).",
+)
+@click.option("--attribution", help="Custom attribution HTML for tiles")
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite the output archive if it already exists",
+)
+@verbose_option
+def pmtiles_pyramid(
+    input_parquet,
+    output_pmtiles,
+    levels,
+    max_tile_kb,
+    bytes_per_cell,
+    layer_mode,
+    include_features,
+    features_source,
+    features_min_zoom,
+    max_zoom,
+    attribution,
+    force,
+    verbose,
+):
+    """Create a multi-level PMTiles pyramid from an aggregate file.
+
+    Detects the aggregate's scheme (a5/h3/admin) and base level, assigns each
+    level a zoom band that fits the tile budget, runs tippecanoe once per band,
+    and merges everything into one archive with tile-join. Existing overview
+    siblings (from `gpio process overview`) are reused; missing levels are
+    built automatically. Bands are recorded in the PMTiles metadata under
+    `gpio:pyramid`.
+
+    Requires tippecanoe and tile-join (ships with tippecanoe) in PATH.
+
+    Examples:
+
+        gpio pmtiles pyramid cells.parquet cells.pmtiles
+
+        gpio pmtiles pyramid cells.parquet out.pmtiles --levels 5 --max-zoom 10
+
+        gpio pmtiles pyramid cells.parquet out.pmtiles \\
+            --include-features --features-source buildings.parquet --max-zoom 8
+
+        gpio pmtiles pyramid by_region.parquet out.pmtiles --layer-mode per-level
+    """
+    from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+    try:
+        create_pmtiles_pyramid(
+            input_parquet,
+            output_pmtiles,
+            levels=levels,
+            max_tile_kb=max_tile_kb,
+            bytes_per_cell=bytes_per_cell,
+            layer_mode=layer_mode,
+            include_features=include_features,
+            features_source=features_source,
+            features_min_zoom=features_min_zoom,
+            max_zoom=max_zoom,
+            attribution=attribution,
+            force=force,
+            verbose=verbose,
+        )
+        click.echo(click.style(f"✓ Created {output_pmtiles}", fg="green"))
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
+
+
 # =============================================================================
 # Process Commands (aggregate, ...)
 # =============================================================================

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -7182,6 +7182,15 @@ def process(ctx):
     help="Cell id column when auto-detection fails (default: a5_cell/h3_cell/admin_code).",
 )
 @click.option(
+    "--scheme",
+    type=click.Choice(["a5", "h3", "admin"]),
+    default=None,
+    help=(
+        "Bucketing scheme of the cell column when inference is ambiguous "
+        "(e.g. H3 ids stored as integers)."
+    ),
+)
+@click.option(
     "--output-dir",
     type=click.Path(),
     default=None,
@@ -7199,6 +7208,7 @@ def process_overview(
     max_tile_kb,
     bytes_per_cell,
     cell_column,
+    scheme,
     output_dir,
     compression,
     compression_level,
@@ -7232,6 +7242,7 @@ def process_overview(
                 max_tile_kb=max_tile_kb,
                 bytes_per_cell=bytes_per_cell,
                 cell_column=cell_column,
+                scheme=scheme,
                 output_dir=output_dir,
                 compression=compression.upper(),
                 compression_level=compression_level,

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -7196,6 +7196,12 @@ def process(ctx):
     default=None,
     help="Directory for overview files (default: alongside the input).",
 )
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing overview output files.",
+)
 @compression_options
 @verbose_option
 @geoparquet_version_option
@@ -7210,6 +7216,7 @@ def process_overview(
     cell_column,
     scheme,
     output_dir,
+    force,
     compression,
     compression_level,
     verbose,
@@ -7247,6 +7254,7 @@ def process_overview(
                 compression=compression.upper(),
                 compression_level=compression_level,
                 geoparquet_version=geoparquet_version,
+                force=force,
                 verbose=verbose,
                 show_sql=show_sql,
             )

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -85,6 +85,7 @@ from geoparquet_io.core.process.aggregate.by_admin import (
     aggregate_by_admin as aggregate_by_admin_impl,
 )
 from geoparquet_io.core.process.aggregate.by_h3 import aggregate_by_h3 as aggregate_by_h3_impl
+from geoparquet_io.core.process.overview import create_overviews as create_overviews_impl
 from geoparquet_io.core.reproject import reproject as reproject_core
 from geoparquet_io.core.sort_by_column import sort_by_column as sort_by_column_impl
 from geoparquet_io.core.sort_quadkey import sort_by_quadkey as sort_by_quadkey_impl
@@ -7023,8 +7024,98 @@ def _aggregate_error(exc: Exception, where: str | None) -> click.ClickException:
 @cli.group()
 @click.pass_context
 def process(ctx):
-    """Transform or reduce GeoParquet data (aggregate, ...)."""
+    """Transform or reduce GeoParquet data (aggregate, overview, ...)."""
     pass
+
+
+@process.command(name="overview")
+@click.argument("input_parquet")
+@click.option(
+    "--levels",
+    default=None,
+    help=(
+        "Comma-separated coarser levels to build (grid resolutions like '4,7'; "
+        "admin: 'country'). Default: auto-select against --max-tile-kb."
+    ),
+)
+@click.option(
+    "--max-tile-kb",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Tile-size budget in KB driving auto level selection.",
+)
+@click.option(
+    "--bytes-per-cell",
+    type=float,
+    default=None,
+    help="Override the estimated compressed bytes per cell used in auto selection.",
+)
+@click.option(
+    "--cell-column",
+    default=None,
+    help="Cell id column when auto-detection fails (default: a5_cell/h3_cell/admin_code).",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(),
+    default=None,
+    help="Directory for overview files (default: alongside the input).",
+)
+@compression_options
+@verbose_option
+@geoparquet_version_option
+@show_sql_option
+@click.pass_context
+def process_overview(
+    ctx,
+    input_parquet,
+    levels,
+    max_tile_kb,
+    bytes_per_cell,
+    cell_column,
+    output_dir,
+    compression,
+    compression_level,
+    verbose,
+    geoparquet_version,
+    show_sql,
+):
+    """Build coarser overview levels from an aggregate output.
+
+    Reads a `gpio process aggregate` output, detects its scheme (a5/h3/admin)
+    and base level, and writes one GeoParquet sibling per coarser level
+    (`cells.parquet` -> `cells_r4.parquet`; admin -> `by_region_country.parquet`).
+    Counts, sums, mins, maxes, and breakdown counts roll up exactly; averages
+    are count-weighted.
+
+    Examples:
+
+        gpio process overview cells.parquet
+
+        gpio process overview cells.parquet --levels 4,7
+
+        gpio process overview by_region.parquet --levels country
+
+        gpio process overview cells.parquet --max-tile-kb 300
+    """
+    with _activate_s3(ctx):
+        try:
+            create_overviews_impl(
+                input_parquet,
+                levels=levels,
+                max_tile_kb=max_tile_kb,
+                bytes_per_cell=bytes_per_cell,
+                cell_column=cell_column,
+                output_dir=output_dir,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                geoparquet_version=geoparquet_version,
+                verbose=verbose,
+                show_sql=show_sql,
+            )
+        except (InvalidParameterError, ValueError, duckdb.Error) as exc:
+            raise click.ClickException(str(exc)) from exc
 
 
 @process.group(name="aggregate")

--- a/geoparquet_io/core/pmtiles_pyramid.py
+++ b/geoparquet_io/core/pmtiles_pyramid.py
@@ -137,24 +137,35 @@ def _merge_pyramid_metadata(pmtiles_path: str, pyramid: dict) -> None:
 
     Full read/write round-trip via the pmtiles package (tile data is copied
     verbatim; the writer recomputes header offsets and zoom bounds).
+
+    The archive is read fully into memory first so that no handle on either
+    file remains open when ``os.replace`` runs. In particular, pmtiles'
+    ``MmapSource`` must NOT be used here: it wraps the file in an ``mmap``
+    that lives on inside the reader's ``get_bytes`` closure with no way to
+    close it, and on Windows an open memory map keeps the file locked (even
+    after the file object itself is closed), failing the replace with
+    WinError 5/32.
     """
-    from pmtiles.reader import MmapSource, Reader, all_tiles
+    from pmtiles.reader import MemorySource, Reader, all_tiles
     from pmtiles.tile import zxy_to_tileid
     from pmtiles.writer import Writer
 
-    tmp_path = pmtiles_path + ".meta.tmp"
-    # Both handles must be closed before os.replace (Windows).
     with open(pmtiles_path, "rb") as source_file:
-        source = MmapSource(source_file)
-        reader = Reader(source)
-        header = reader.header()
-        metadata = reader.metadata()
-        metadata["gpio:pyramid"] = pyramid
-        with open(tmp_path, "wb") as out:
-            writer = Writer(out)
-            for zxy, data in all_tiles(source):
-                writer.write_tile(zxy_to_tileid(*zxy), data)
-            writer.finalize(header, metadata)
+        archive_bytes = source_file.read()
+    # No handles on the original archive remain past this point.
+
+    source = MemorySource(archive_bytes)
+    reader = Reader(source)
+    header = reader.header()
+    metadata = reader.metadata()
+    metadata["gpio:pyramid"] = pyramid
+
+    tmp_path = pmtiles_path + ".meta.tmp"
+    with open(tmp_path, "wb") as out:
+        writer = Writer(out)
+        for zxy, data in all_tiles(source):
+            writer.write_tile(zxy_to_tileid(*zxy), data)
+        writer.finalize(header, metadata)
     os.replace(tmp_path, pmtiles_path)
 
 

--- a/geoparquet_io/core/pmtiles_pyramid.py
+++ b/geoparquet_io/core/pmtiles_pyramid.py
@@ -8,16 +8,13 @@ under a ``gpio:pyramid`` key in the archive's metadata JSON.
 
 from __future__ import annotations
 
-import gc
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import configure_verbose, debug, success
 from geoparquet_io.core.pmtiles import (
     TippecanoeNotFoundError,
@@ -25,7 +22,11 @@ from geoparquet_io.core.pmtiles import (
     _validate_path,
     create_pmtiles_from_geoparquet,
 )
-from geoparquet_io.core.process.overview.detect import AggregateInfo, detect_aggregate_info
+from geoparquet_io.core.process.overview.detect import (
+    AggregateInfo,
+    aggregate_connection,
+    detect_aggregate_info,
+)
 from geoparquet_io.core.process.overview.levels import Band
 from geoparquet_io.core.process.overview.run import (
     create_overviews,
@@ -262,11 +263,7 @@ def _detect_and_plan(
     verbose: bool,
 ) -> tuple[AggregateInfo, list[Band]]:
     """Detect the aggregate's shape and select zoom bands for the pyramid."""
-    input_url = safe_file_url(input_path, verbose)
-    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
-    try:
-        con.execute("SET geometry_always_xy = true")
-        relation = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
+    with aggregate_connection(input_path, verbose) as (con, relation):
         info = detect_aggregate_info(con, relation)
         if info.out_geometry == "none":
             raise InvalidParameterError(
@@ -289,11 +286,6 @@ def _detect_and_plan(
             max_probe_zoom=max_probe,
         )
         return info, bands
-    finally:
-        con.close()
-        # Release GDAL/spatial native handles before the next spatial connection
-        # opens; leaked native state can segfault sibling xdist tests.
-        gc.collect()
 
 
 def create_pmtiles_pyramid(

--- a/geoparquet_io/core/pmtiles_pyramid.py
+++ b/geoparquet_io/core/pmtiles_pyramid.py
@@ -1,0 +1,389 @@
+"""PMTiles pyramid generation: banded multi-level archives via tile-join.
+
+Builds one tippecanoe run per aggregate level, each pinned to the zoom band
+selected by the shared overview level-selection core, then merges the per-band
+archives into a single PMTiles file with ``tile-join`` and records the bands
+under a ``gpio:pyramid`` key in the archive's metadata JSON.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.logging_config import configure_verbose, debug, success
+from geoparquet_io.core.pmtiles import (
+    TippecanoeNotFoundError,
+    _check_tippecanoe,
+    _validate_path,
+    create_pmtiles_from_geoparquet,
+)
+from geoparquet_io.core.process.overview.detect import AggregateInfo, detect_aggregate_info
+from geoparquet_io.core.process.overview.levels import Band
+from geoparquet_io.core.process.overview.run import (
+    create_overviews,
+    overview_output_path,
+    parse_levels,
+    plan_bands,
+)
+
+VALID_LAYER_MODES = ("single", "grouped", "per-level")
+
+
+class TileJoinNotFoundError(Exception):
+    """Raised when tile-join is not found in PATH."""
+
+    def __init__(self):
+        super().__init__(
+            "tile-join not found in PATH.\n\n"
+            "tile-join ships with tippecanoe; gpio pmtiles pyramid needs it to\n"
+            "merge the per-level archives. Install tippecanoe:\n"
+            "  macOS:  brew install tippecanoe\n"
+            "  Ubuntu: sudo apt install tippecanoe\n"
+            "  Source: https://github.com/felt/tippecanoe#installation"
+        )
+
+
+def _check_tile_join() -> bool:
+    """Check if tile-join is available in PATH."""
+    return shutil.which("tile-join") is not None
+
+
+def _layer_name(layer_mode: str, scheme: str, level: int | str, stem: str) -> str:
+    """Layer name for an aggregate band under the given --layer-mode."""
+    if layer_mode == "single":
+        return stem
+    if layer_mode == "grouped":
+        return "aggregate"
+    return str(level) if scheme == "admin" else f"r{level}"
+
+
+def _feature_layer_name(layer_mode: str, stem: str) -> str:
+    """Layer name for the raw-features band under the given --layer-mode."""
+    return stem if layer_mode == "single" else "features"
+
+
+def _band_zoom_args(band: Band, base_max: int | None) -> tuple[int, int | None]:
+    """(min_zoom, max_zoom) tippecanoe pinning for a band; the open-ended final
+    band inherits the archive-level max zoom (None -> tippecanoe guesses)."""
+    return band.minzoom, band.maxzoom if band.maxzoom is not None else base_max
+
+
+def _resolve_feature_zooms(
+    max_zoom: int | None, features_min_zoom: int | None, include_features: bool
+) -> tuple[int | None, int | None]:
+    """Resolve (base_band_max_zoom, features_min_zoom).
+
+    The features band starts one past the base band, so with features enabled
+    one of the two zoom anchors must be given; each derives the other.
+    """
+    if not include_features:
+        return max_zoom, None
+    if features_min_zoom is None:
+        if max_zoom is None:
+            raise InvalidParameterError(
+                "features_min_zoom",
+                "--include-features needs --features-min-zoom or --max-zoom "
+                "to know where the features band starts",
+            )
+        return max_zoom, max_zoom + 1
+    if max_zoom is None:
+        return features_min_zoom - 1, features_min_zoom
+    return max_zoom, features_min_zoom
+
+
+def _build_tile_join_command(
+    output_path: str,
+    band_files: list[str],
+    *,
+    name: str,
+    attribution: str | None = None,
+    force: bool = False,
+) -> list[str]:
+    """argv for merging per-band archives (never joined through a shell)."""
+    cmd = ["tile-join", "-o", output_path, "-pk"]
+    if force:
+        cmd.append("--force")
+    cmd.append(f"--name={name}")
+    if attribution:
+        cmd.append(f"--attribution={attribution}")
+    cmd.extend(band_files)
+    return cmd
+
+
+def _run_tile_join(cmd: list[str], verbose: bool) -> None:
+    if verbose:
+        debug(f"Running: {' '.join(cmd)}")
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        raise RuntimeError(
+            f"tile-join failed with exit code {proc.returncode}"
+            + (f"\nstderr:\n{stderr}" if stderr else "")
+        )
+    if verbose and proc.stderr.strip():
+        debug(proc.stderr.strip())
+
+
+def _merge_pyramid_metadata(pmtiles_path: str, pyramid: dict) -> None:
+    """Rewrite the archive with ``gpio:pyramid`` merged into its metadata JSON.
+
+    Full read/write round-trip via the pmtiles package (tile data is copied
+    verbatim; the writer recomputes header offsets and zoom bounds).
+    """
+    from pmtiles.reader import MmapSource, Reader, all_tiles
+    from pmtiles.tile import zxy_to_tileid
+    from pmtiles.writer import Writer
+
+    tmp_path = pmtiles_path + ".meta.tmp"
+    # Both handles must be closed before os.replace (Windows).
+    with open(pmtiles_path, "rb") as source_file:
+        source = MmapSource(source_file)
+        reader = Reader(source)
+        header = reader.header()
+        metadata = reader.metadata()
+        metadata["gpio:pyramid"] = pyramid
+        with open(tmp_path, "wb") as out:
+            writer = Writer(out)
+            for zxy, data in all_tiles(source):
+                writer.write_tile(zxy_to_tileid(*zxy), data)
+            writer.finalize(header, metadata)
+    os.replace(tmp_path, pmtiles_path)
+
+
+def _resolve_band_sources(
+    input_path: str,
+    info: AggregateInfo,
+    bands: list[Band],
+    tmpdir: str,
+    verbose: bool,
+) -> dict[int | str, str]:
+    """Map each band level to a GeoParquet source.
+
+    The base band uses the input itself. Overview levels use existing sibling
+    files from `gpio process overview` when present; missing ones are built
+    into ``tmpdir``.
+    """
+    sources: dict[int | str, str] = {info.base_level: input_path}
+    missing: list[int | str] = []
+    for band in bands:
+        if band.level == info.base_level:
+            continue
+        sibling = overview_output_path(input_path, info.scheme, band.level)
+        if Path(sibling).exists():
+            debug(f"Using existing overview for level {band.level}: {sibling}")
+            sources[band.level] = sibling
+        else:
+            missing.append(band.level)
+    if missing:
+        built = create_overviews(input_path, levels=missing, output_dir=tmpdir, verbose=verbose)
+        sources.update(dict(built))
+    return sources
+
+
+def _pyramid_metadata(
+    info: AggregateInfo,
+    bands: list[Band],
+    base_max: int | None,
+    layer_mode: str,
+    stem: str,
+    features_min_zoom: int | None,
+) -> dict:
+    entries = []
+    for band in bands:
+        minzoom, maxzoom = _band_zoom_args(band, base_max)
+        entries.append(
+            {
+                "level": band.level,
+                "layer": _layer_name(layer_mode, info.scheme, band.level, stem),
+                "minzoom": minzoom,
+                "maxzoom": maxzoom,
+            }
+        )
+    if features_min_zoom is not None:
+        entries.append(
+            {
+                "level": "features",
+                "layer": _feature_layer_name(layer_mode, stem),
+                "minzoom": features_min_zoom,
+                "maxzoom": None,
+            }
+        )
+    return {"scheme": info.scheme, "bands": entries}
+
+
+def _detect_and_plan(
+    input_path, levels, max_tile_kb, bytes_per_cell, max_zoom, verbose
+) -> tuple[AggregateInfo, list[Band]]:
+    """Detect the aggregate's shape and select zoom bands for the pyramid."""
+    input_url = safe_file_url(input_path, verbose)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
+    try:
+        con.execute("SET geometry_always_xy = true")
+        relation = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
+        info = detect_aggregate_info(con, relation)
+        if info.out_geometry == "none":
+            raise InvalidParameterError(
+                "input",
+                "aggregate has no geometry column; re-run gpio process aggregate "
+                "with --out-geometry polygon or centroid before tiling",
+            )
+        parsed_levels = parse_levels(levels, info) if levels is not None else None
+        # Cap band transitions at max_zoom-1 so the base band starts by max_zoom.
+        max_probe = max_zoom - 1 if max_zoom is not None else None
+        bands = plan_bands(
+            con,
+            f"SELECT * FROM {relation}",
+            info,
+            levels=parsed_levels,
+            max_tile_kb=max_tile_kb,
+            bytes_per_cell=bytes_per_cell,
+            verbose=verbose,
+            max_probe_zoom=max_probe,
+        )
+        return info, bands
+    finally:
+        con.close()
+        # Release GDAL/spatial native handles before the next spatial connection
+        # opens; leaked native state can segfault sibling xdist tests.
+        gc.collect()
+
+
+def create_pmtiles_pyramid(
+    input_path: str,
+    output_path: str,
+    *,
+    levels=None,
+    max_tile_kb: int = 500,
+    bytes_per_cell: float | None = None,
+    layer_mode: str = "grouped",
+    include_features: bool = False,
+    features_source: str | None = None,
+    features_min_zoom: int | None = None,
+    max_zoom: int | None = None,
+    attribution: str | None = None,
+    force: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Create a banded multi-level PMTiles archive from an aggregate file.
+
+    Detects the aggregate's scheme and base level, selects zoom bands (shared
+    core with `gpio process overview`), runs tippecanoe once per level pinned
+    to its band, merges the results with tile-join, and records the bands in
+    the archive metadata under ``gpio:pyramid``. Existing overview siblings
+    (``cells_r5.parquet``) are reused; missing levels are built into a temp
+    directory.
+
+    Args:
+        input_path: Path to a `gpio process aggregate` output (GeoParquet).
+        output_path: Path for the output PMTiles archive.
+        levels: Explicit overview levels (comma string or list); default
+            auto-selects against ``max_tile_kb``.
+        max_tile_kb: Tile-size budget in KB for band selection (default 500).
+        bytes_per_cell: Override the estimated compressed bytes per cell.
+        layer_mode: ``single`` (one layer named after the output), ``grouped``
+            (``aggregate`` + ``features``), or ``per-level`` (``r5``/``r10`` or
+            ``country``/``region`` + ``features``).
+        include_features: Append the original features as the final band.
+        features_source: GeoParquet source for the features band.
+        features_min_zoom: First zoom of the features band (default: base band
+            max zoom + 1).
+        max_zoom: Max zoom of the base aggregate band (tippecanoe guesses when
+            omitted and no features band is requested).
+        attribution: Attribution HTML for the tiles.
+        force: Overwrite the output archive if it exists.
+        verbose: Enable verbose output.
+
+    Raises:
+        TippecanoeNotFoundError: tippecanoe missing from PATH.
+        TileJoinNotFoundError: tile-join missing from PATH.
+        InvalidParameterError: invalid parameter combinations or input shape.
+        RuntimeError: a tippecanoe or tile-join run failed.
+    """
+    configure_verbose(verbose)
+    _validate_path(input_path)
+    _validate_path(output_path)
+    if layer_mode not in VALID_LAYER_MODES:
+        raise InvalidParameterError(
+            "layer_mode",
+            f"invalid value '{layer_mode}'. Valid: {', '.join(VALID_LAYER_MODES)}",
+        )
+    if include_features and not features_source:
+        raise InvalidParameterError(
+            "features_source", "--include-features requires --features-source"
+        )
+    if features_source:
+        _validate_path(features_source)
+    base_max, feat_min = _resolve_feature_zooms(max_zoom, features_min_zoom, include_features)
+    if not _check_tippecanoe():
+        raise TippecanoeNotFoundError()
+    if not _check_tile_join():
+        raise TileJoinNotFoundError()
+
+    info, bands = _detect_and_plan(
+        input_path, levels, max_tile_kb, bytes_per_cell, max_zoom, verbose
+    )
+    stem = Path(output_path).stem
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sources = _resolve_band_sources(input_path, info, bands, tmpdir, verbose)
+        band_files: list[str] = []
+        for i, band in enumerate(bands):
+            min_zoom, band_max = _band_zoom_args(band, base_max)
+            band_file = os.path.join(tmpdir, f"band_{i}.pmtiles")
+            debug(
+                f"Tiling level {band.level} for zooms {min_zoom}.."
+                f"{band_max if band_max is not None else 'auto'}"
+            )
+            create_pmtiles_from_geoparquet(
+                sources[band.level],
+                band_file,
+                layer=_layer_name(layer_mode, info.scheme, band.level, stem),
+                min_zoom=min_zoom,
+                max_zoom=band_max,
+                no_tile_size_limit=True,
+                attribution=attribution,
+                force=True,
+                verbose=verbose,
+            )
+            band_files.append(band_file)
+
+        if include_features:
+            assert features_source is not None and feat_min is not None
+            features_file = os.path.join(tmpdir, "band_features.pmtiles")
+            debug(f"Tiling raw features from zoom {feat_min}")
+            create_pmtiles_from_geoparquet(
+                features_source,
+                features_file,
+                layer=_feature_layer_name(layer_mode, stem),
+                min_zoom=feat_min,
+                max_zoom=None,
+                # Real feature data can be arbitrarily dense: keep tippecanoe's
+                # size cap so --drop-densest-as-needed has a limit to enforce.
+                no_tile_size_limit=False,
+                drop_densest_as_needed=True,
+                attribution=attribution,
+                force=True,
+                verbose=verbose,
+            )
+            band_files.append(features_file)
+
+        _run_tile_join(
+            _build_tile_join_command(
+                output_path, band_files, name=stem, attribution=attribution, force=force
+            ),
+            verbose,
+        )
+
+    _merge_pyramid_metadata(
+        output_path,
+        _pyramid_metadata(info, bands, base_max, layer_mode, stem, feat_min),
+    )
+    success(f"Created {output_path} with {len(bands)} aggregate band(s)")

--- a/geoparquet_io/core/pmtiles_pyramid.py
+++ b/geoparquet_io/core/pmtiles_pyramid.py
@@ -172,13 +172,24 @@ def _merge_pyramid_metadata(pmtiles_path: str, pyramid: dict) -> None:
     metadata = reader.metadata()
     metadata["gpio:pyramid"] = pyramid
 
-    tmp_path = pmtiles_path + ".meta.tmp"
-    with open(tmp_path, "wb") as out:
-        writer = Writer(out)
-        for zxy, data in all_tiles(source):
-            writer.write_tile(zxy_to_tileid(*zxy), data)
-        writer.finalize(header, metadata)
-    os.replace(tmp_path, pmtiles_path)
+    # Unpredictable temp name in the output dir (same filesystem for the
+    # atomic replace; not symlink-followable like a fixed "<output>.meta.tmp").
+    tmp = tempfile.NamedTemporaryFile(
+        dir=os.path.dirname(os.path.abspath(pmtiles_path)),
+        prefix=Path(pmtiles_path).name + ".",
+        suffix=".meta.tmp",
+        delete=False,
+    )
+    try:
+        with tmp:
+            writer = Writer(tmp)
+            for zxy, data in all_tiles(source):
+                writer.write_tile(zxy_to_tileid(*zxy), data)
+            writer.finalize(header, metadata)
+        os.replace(tmp.name, pmtiles_path)
+    except BaseException:
+        Path(tmp.name).unlink(missing_ok=True)
+        raise
 
 
 def _resolve_band_sources(

--- a/geoparquet_io/core/pmtiles_pyramid.py
+++ b/geoparquet_io/core/pmtiles_pyramid.py
@@ -94,8 +94,20 @@ def _resolve_feature_zooms(
                 "to know where the features band starts",
             )
         return max_zoom, max_zoom + 1
+    if features_min_zoom < 1:
+        raise InvalidParameterError(
+            "features_min_zoom",
+            f"got {features_min_zoom}; must be >= 1 so the aggregate bands keep at least zoom 0",
+        )
     if max_zoom is None:
         return features_min_zoom - 1, features_min_zoom
+    if features_min_zoom <= max_zoom:
+        raise InvalidParameterError(
+            "features_min_zoom",
+            f"got {features_min_zoom}; must be greater than --max-zoom "
+            f"({max_zoom}) so the features band does not overlap the "
+            "aggregate bands",
+        )
     return max_zoom, features_min_zoom
 
 
@@ -231,7 +243,12 @@ def _pyramid_metadata(
 
 
 def _detect_and_plan(
-    input_path, levels, max_tile_kb, bytes_per_cell, max_zoom, verbose
+    input_path: str,
+    levels: str | list[int | str] | None,
+    max_tile_kb: int,
+    bytes_per_cell: float | None,
+    base_max_zoom: int | None,
+    verbose: bool,
 ) -> tuple[AggregateInfo, list[Band]]:
     """Detect the aggregate's shape and select zoom bands for the pyramid."""
     input_url = safe_file_url(input_path, verbose)
@@ -247,8 +264,9 @@ def _detect_and_plan(
                 "with --out-geometry polygon or centroid before tiling",
             )
         parsed_levels = parse_levels(levels, info) if levels is not None else None
-        # Cap band transitions at max_zoom-1 so the base band starts by max_zoom.
-        max_probe = max_zoom - 1 if max_zoom is not None else None
+        # Cap band transitions one below the base band's max zoom so the base
+        # band starts by that zoom (and never inverts into minzoom > maxzoom).
+        max_probe = base_max_zoom - 1 if base_max_zoom is not None else None
         bands = plan_bands(
             con,
             f"SELECT * FROM {relation}",
@@ -339,7 +357,7 @@ def create_pmtiles_pyramid(
         raise TileJoinNotFoundError()
 
     info, bands = _detect_and_plan(
-        input_path, levels, max_tile_kb, bytes_per_cell, max_zoom, verbose
+        input_path, levels, max_tile_kb, bytes_per_cell, base_max, verbose
     )
     stem = Path(output_path).stem
 

--- a/geoparquet_io/core/pmtiles_pyramid.py
+++ b/geoparquet_io/core/pmtiles_pyramid.py
@@ -326,7 +326,7 @@ def create_pmtiles_pyramid(
     input_path: str,
     output_path: str,
     *,
-    levels=None,
+    levels: str | list[int | str] | None = None,
     max_tile_kb: int = 500,
     bytes_per_cell: float | None = None,
     layer_mode: str = "grouped",
@@ -429,7 +429,10 @@ def create_pmtiles_pyramid(
             band_files.append(band_file)
 
         if include_features:
-            assert features_source is not None and feat_min is not None
+            # Guarded by the parameter validation above; explicit raise (not
+            # assert) so the check survives python -O.
+            if features_source is None or feat_min is None:  # pragma: no cover
+                raise RuntimeError("features band requested without a source or min zoom")
             features_file = os.path.join(tmpdir, "band_features.pmtiles")
             debug(f"Tiling raw features from zoom {feat_min}")
             create_pmtiles_from_geoparquet(

--- a/geoparquet_io/core/pmtiles_pyramid.py
+++ b/geoparquet_io/core/pmtiles_pyramid.py
@@ -14,8 +14,10 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import pyarrow.parquet as pq
+
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.logging_config import configure_verbose, debug, success
+from geoparquet_io.core.logging_config import configure_verbose, debug, success, warn
 from geoparquet_io.core.pmtiles import (
     TippecanoeNotFoundError,
     _check_tippecanoe,
@@ -193,6 +195,36 @@ def _merge_pyramid_metadata(pmtiles_path: str, pyramid: dict) -> None:
         raise
 
 
+def _sibling_is_current(sibling: str, input_path: str, dropped_columns: tuple[str, ...]) -> bool:
+    """Whether an existing overview sibling can be reused for this input.
+
+    A sibling older than the input aggregate, or one whose columns do not
+    match the input's rollup schema (e.g. built with a different --metric),
+    would bake stale or mismatched data into the coarse zoom bands.
+    """
+    try:
+        if os.path.getmtime(sibling) < os.path.getmtime(input_path):
+            warn(
+                f"Ignoring overview sibling {sibling}: it is older than the input "
+                "aggregate. Rebuilding this level; re-run gpio process overview "
+                "--force to refresh the sibling."
+            )
+            return False
+        expected = set(pq.read_schema(input_path).names) - set(dropped_columns)
+        if set(pq.read_schema(sibling).names) != expected:
+            warn(
+                f"Ignoring overview sibling {sibling}: its columns do not match "
+                "the input aggregate. Rebuilding this level; re-run "
+                "gpio process overview --force to refresh the sibling."
+            )
+            return False
+    except OSError:
+        # Remote input or unreadable sibling: freshness cannot be verified,
+        # so rebuild rather than risk stale data.
+        return False
+    return True
+
+
 def _resolve_band_sources(
     input_path: str,
     info: AggregateInfo,
@@ -202,9 +234,9 @@ def _resolve_band_sources(
 ) -> dict[int | str, str]:
     """Map each band level to a GeoParquet source.
 
-    The base band uses the input itself. Overview levels use existing sibling
-    files from `gpio process overview` when present; missing ones are built
-    into ``tmpdir``.
+    The base band uses the input itself. Overview levels reuse existing,
+    still-current sibling files from `gpio process overview`; missing or
+    stale ones are built into ``tmpdir``.
     """
     sources: dict[int | str, str] = {info.base_level: input_path}
     missing: list[int | str] = []
@@ -212,7 +244,9 @@ def _resolve_band_sources(
         if band.level == info.base_level:
             continue
         sibling = overview_output_path(input_path, info.scheme, band.level)
-        if Path(sibling).exists():
+        if Path(sibling).exists() and _sibling_is_current(
+            sibling, input_path, info.dropped_columns
+        ):
             debug(f"Using existing overview for level {band.level}: {sibling}")
             sources[band.level] = sibling
         else:
@@ -353,6 +387,13 @@ def create_pmtiles_pyramid(
         )
     if features_source:
         _validate_path(features_source)
+    # Fail fast before any tiling work: tile-join would only reject an
+    # existing output after every per-band tippecanoe run had completed.
+    if os.path.exists(output_path) and not force:
+        raise InvalidParameterError(
+            "output_path",
+            f"output file already exists: {output_path}. Use --force to overwrite.",
+        )
     base_max, feat_min = _resolve_feature_zooms(max_zoom, features_min_zoom, include_features)
     if not _check_tippecanoe():
         raise TippecanoeNotFoundError()

--- a/geoparquet_io/core/process/overview/__init__.py
+++ b/geoparquet_io/core/process/overview/__init__.py
@@ -1,0 +1,6 @@
+"""Overview pyramids for aggregate outputs (`gpio process overview`)."""
+
+from geoparquet_io.core.process.overview.rollup import rollup_table
+from geoparquet_io.core.process.overview.run import create_overviews
+
+__all__ = ["create_overviews", "rollup_table"]

--- a/geoparquet_io/core/process/overview/detect.py
+++ b/geoparquet_io/core/process/overview/detect.py
@@ -19,7 +19,10 @@ from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import warn
 from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME
 from geoparquet_io.core.process.aggregate.by_h3 import H3_SCHEME
-from geoparquet_io.core.process.aggregate.common import geometry_to_geom_expr
+from geoparquet_io.core.process.aggregate.common import (
+    VALID_METRIC_FUNCS,
+    geometry_to_geom_expr,
+)
 
 VALID_SCHEMES = ("a5", "h3", "admin")
 # Default cell column per scheme, single-sourced from the aggregate engine's
@@ -150,7 +153,11 @@ def _classify_columns(columns: list[tuple[str, str]], cell_column: str, scheme: 
     special = {cell_column, "count", "geometry", "centroid"}
     if scheme == "admin":
         special.add("admin_name")
-    prefix_to_func = {"sum_": "sum", "count_": "sum", "min_": "min", "max_": "max", "avg_": "avg"}
+    # Single-sourced from the aggregate engine's metric functions so adding a
+    # metric func there cannot silently drop its columns here; breakdown
+    # count_* columns roll up as sums.
+    prefix_to_func = {f"{func}_": func for func in sorted(VALID_METRIC_FUNCS)}
+    prefix_to_func["count_"] = "sum"
 
     rollups: list[RollupColumn] = []
     dropped: list[str] = []

--- a/geoparquet_io/core/process/overview/detect.py
+++ b/geoparquet_io/core/process/overview/detect.py
@@ -203,14 +203,21 @@ def _detect_grid_base_level(con, relation: str, scheme: str, cell_column: str) -
 def _detect_admin_base_level(con, relation: str, cell_column: str) -> str:
     qcol = quote_identifier(cell_column)
     row = con.execute(
-        f"SELECT COUNT(*) FILTER (WHERE {qcol} LIKE '%-%') FROM {relation} "
+        f"SELECT COUNT(*), COUNT(*) FILTER (WHERE {qcol} LIKE '%-%') FROM {relation} "
         f"WHERE {qcol} IS NOT NULL AND {qcol} != 'unassigned'"
     ).fetchone()
-    if not row or row[0] == 0:
+    total, regions = row if row else (0, 0)
+    if total == 0:
+        raise InvalidParameterError(
+            "input",
+            f"no admin codes to roll up: {cell_column} has no rows besides NULL/'unassigned'.",
+        )
+    if regions == 0:
         raise InvalidParameterError(
             "input",
             "admin aggregate is already at country level (no region codes like "
-            "'US-CA' found); there is no coarser admin level to roll up to.",
+            "'US-CA' found); there is no coarser admin level to roll up to. "
+            "If this column does not hold admin codes, pass --scheme/--cell-column.",
         )
     return "region"
 

--- a/geoparquet_io/core/process/overview/detect.py
+++ b/geoparquet_io/core/process/overview/detect.py
@@ -8,13 +8,27 @@ column rolls up to a coarser level, and what output geometry to regenerate.
 
 from __future__ import annotations
 
+import gc
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass
 
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import warn
+from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME
+from geoparquet_io.core.process.aggregate.by_h3 import H3_SCHEME
 from geoparquet_io.core.process.aggregate.common import geometry_to_geom_expr
+
+VALID_SCHEMES = ("a5", "h3", "admin")
+# Default cell column per scheme, single-sourced from the aggregate engine's
+# GridScheme descriptors so the two stay in lockstep.
+DEFAULT_CELL_COLUMNS = {
+    "a5": A5_SCHEME.default_column,
+    "h3": H3_SCHEME.default_column,
+    "admin": "admin_code",
+}
 
 _INTEGER_TYPES = {
     "TINYINT",
@@ -73,8 +87,25 @@ def _describe_columns(con, relation: str) -> list[tuple[str, str]]:
     ]
 
 
-def _detect_scheme(con, relation: str, columns: dict[str, str], cell_column: str | None):
+def _detect_scheme(
+    con,
+    relation: str,
+    columns: dict[str, str],
+    cell_column: str | None,
+    scheme: str | None = None,
+):
     """Return (cell_column, scheme)."""
+    if scheme is not None:
+        if scheme not in VALID_SCHEMES:
+            raise InvalidParameterError(
+                "scheme", f"invalid scheme '{scheme}'. Valid: {', '.join(VALID_SCHEMES)}"
+            )
+        cell_col = cell_column or DEFAULT_CELL_COLUMNS[scheme]
+        if cell_col not in columns:
+            raise InvalidParameterError(
+                "cell_column", f"column '{cell_col}' not found in the input"
+            )
+        return cell_col, scheme
     if cell_column is not None:
         if cell_column not in columns:
             raise InvalidParameterError(
@@ -97,7 +128,16 @@ def _detect_scheme(con, relation: str, columns: dict[str, str], cell_column: str
 def _scheme_for_column(con, relation: str, name: str, dtype: str) -> str:
     """Infer the scheme for an explicitly named cell column."""
     if dtype in _INTEGER_TYPES:
-        return "a5"
+        if "a5" in name.lower():
+            return "a5"
+        # a5 ids and packed H3 ids are both integers; guessing a5 here would
+        # silently roll H3 data up the wrong hierarchy.
+        raise InvalidParameterError(
+            "cell_column",
+            f"cannot infer a grid scheme for integer column '{name}' "
+            "(a5 and packed H3 ids are both stored as integers). "
+            "Pass --scheme a5 or --scheme h3 to disambiguate.",
+        )
     qcol = quote_identifier(name)
     row = con.execute(f"SELECT {qcol} FROM {relation} WHERE {qcol} IS NOT NULL LIMIT 1").fetchone()
     if row and isinstance(row[0], str) and _H3_STRING_RE.match(row[0]):
@@ -175,17 +215,21 @@ def _detect_admin_base_level(con, relation: str, cell_column: str) -> str:
     return "region"
 
 
-def detect_aggregate_info(con, relation: str, cell_column: str | None = None) -> AggregateInfo:
+def detect_aggregate_info(
+    con, relation: str, cell_column: str | None = None, scheme: str | None = None
+) -> AggregateInfo:
     """Detect scheme, base level, column roles, and output geometry.
 
     ``relation`` must be usable in a FROM clause (``read_parquet('...')`` or a
     registered table name). ``con`` needs the spatial extension loaded; grid
     community extensions are installed on demand for base-level probing.
+    ``scheme`` (a5/h3/admin) skips scheme inference for ambiguous cell columns
+    (e.g. H3 ids stored as integers).
     """
     ordered = _describe_columns(con, relation)
     columns = dict(ordered)
 
-    cell_col, scheme = _detect_scheme(con, relation, columns, cell_column)
+    cell_col, scheme = _detect_scheme(con, relation, columns, cell_column, scheme)
     if "count" not in columns:
         raise InvalidParameterError(
             "input",
@@ -211,15 +255,30 @@ def detect_aggregate_info(con, relation: str, cell_column: str | None = None) ->
     )
 
 
-def detect_aggregate_file(input_parquet: str, cell_column: str | None = None) -> AggregateInfo:
+def detect_aggregate_file(
+    input_parquet: str, cell_column: str | None = None, scheme: str | None = None
+) -> AggregateInfo:
     """File-path convenience wrapper around :func:`detect_aggregate_info`."""
-    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-    from geoparquet_io.core.file_utils import safe_file_url
+    with aggregate_connection(input_parquet) as (con, relation):
+        return detect_aggregate_info(con, relation, cell_column, scheme)
 
-    url = safe_file_url(input_parquet, verbose=False)
+
+@contextmanager
+def aggregate_connection(input_parquet: str, verbose: bool = False):
+    """Yield ``(con, relation)`` for reading an aggregate file.
+
+    Shared connection boilerplate for every consumer of an aggregate file
+    (overview building, pyramid planning, file detection): spatial + httpfs
+    connection, lon/lat axis order, and a ``read_parquet`` relation string.
+    """
+    url = safe_file_url(input_parquet, verbose)
     con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
     try:
-        relation = f"read_parquet('{url}', hive_partitioning=false, union_by_name=true)"
-        return detect_aggregate_info(con, relation, cell_column)
+        con.execute("SET geometry_always_xy = true")
+        yield con, f"read_parquet('{url}', hive_partitioning=false, union_by_name=true)"
     finally:
         con.close()
+        # Release GDAL/spatial native handles before the next spatial
+        # connection opens; leaked native state can segfault sibling
+        # xdist tests.
+        gc.collect()

--- a/geoparquet_io/core/process/overview/detect.py
+++ b/geoparquet_io/core/process/overview/detect.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Detect the shape of a `gpio process aggregate` output for overview rollups.
+
+Given an aggregate file (or registered relation), works out which bucketing
+scheme produced it (a5 / h3 / admin), the base level of the cell ids, how each
+column rolls up to a coarser level, and what output geometry to regenerate.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.logging_config import warn
+from geoparquet_io.core.process.aggregate.common import geometry_to_geom_expr
+
+_INTEGER_TYPES = {
+    "TINYINT",
+    "SMALLINT",
+    "INTEGER",
+    "BIGINT",
+    "UTINYINT",
+    "USMALLINT",
+    "UINTEGER",
+    "UBIGINT",
+}
+# H3 string cell ids are 15 hex chars (e.g. "85283473fffffff").
+_H3_STRING_RE = re.compile(r"^[0-9a-fA-F]{15}$")
+
+_GRID_EXTENSIONS = {"a5": "a5", "h3": "h3"}
+_RESOLUTION_FUNCS = {"a5": "a5_get_resolution", "h3": "h3_get_resolution"}
+
+
+@dataclass(frozen=True)
+class RollupColumn:
+    """How one attribute column rolls up to a parent cell."""
+
+    name: str
+    func: str  # "sum" | "avg" | "min" | "max"
+    cast_to_bigint: bool = False  # SUM(BIGINT) widens to HUGEINT; cast back
+
+
+@dataclass(frozen=True)
+class AggregateInfo:
+    """Everything overview building needs to know about an aggregate input."""
+
+    scheme: str  # "a5" | "h3" | "admin"
+    cell_column: str
+    base_level: int | str  # grid resolution, or "region" for admin
+    rollup_columns: tuple[RollupColumn, ...]
+    out_geometry: str  # "polygon" | "centroid" | "both" | "none"
+    dropped_columns: tuple[str, ...] = ()
+
+    @property
+    def num_attributes(self) -> int:
+        """Numeric attribute columns per cell (count + rollups), for sizing."""
+        return 1 + len(self.rollup_columns)
+
+
+def ensure_grid_extension(con, scheme: str) -> None:
+    """Install/load the community extension backing a grid scheme."""
+    extension = _GRID_EXTENSIONS[scheme]
+    con.execute(f"INSTALL {extension} FROM community")
+    con.execute(f"LOAD {extension}")
+
+
+def _describe_columns(con, relation: str) -> list[tuple[str, str]]:
+    return [
+        (row[0], row[1].upper())
+        for row in con.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()
+    ]
+
+
+def _detect_scheme(con, relation: str, columns: dict[str, str], cell_column: str | None):
+    """Return (cell_column, scheme)."""
+    if cell_column is not None:
+        if cell_column not in columns:
+            raise InvalidParameterError(
+                "cell_column", f"column '{cell_column}' not found in the input"
+            )
+        return cell_column, _scheme_for_column(con, relation, cell_column, columns[cell_column])
+    if "a5_cell" in columns and columns["a5_cell"] in _INTEGER_TYPES:
+        return "a5_cell", "a5"
+    if "h3_cell" in columns and columns["h3_cell"] == "VARCHAR":
+        return "h3_cell", "h3"
+    if "admin_code" in columns:
+        return "admin_code", "admin"
+    raise InvalidParameterError(
+        "input",
+        "no aggregate cell column found (expected a5_cell, h3_cell, or admin_code). "
+        "Is this a `gpio process aggregate` output? Pass --cell-column to override.",
+    )
+
+
+def _scheme_for_column(con, relation: str, name: str, dtype: str) -> str:
+    """Infer the scheme for an explicitly named cell column."""
+    if dtype in _INTEGER_TYPES:
+        return "a5"
+    qcol = quote_identifier(name)
+    row = con.execute(f"SELECT {qcol} FROM {relation} WHERE {qcol} IS NOT NULL LIMIT 1").fetchone()
+    if row and isinstance(row[0], str) and _H3_STRING_RE.match(row[0]):
+        return "h3"
+    return "admin"
+
+
+def _classify_columns(columns: list[tuple[str, str]], cell_column: str, scheme: str):
+    """Split attribute columns into rollup roles; return (rollups, dropped)."""
+    special = {cell_column, "count", "geometry", "centroid"}
+    if scheme == "admin":
+        special.add("admin_name")
+    prefix_to_func = {"sum_": "sum", "count_": "sum", "min_": "min", "max_": "max", "avg_": "avg"}
+
+    rollups: list[RollupColumn] = []
+    dropped: list[str] = []
+    for name, dtype in columns:
+        if name in special:
+            continue
+        func = next((f for p, f in prefix_to_func.items() if name.startswith(p)), None)
+        if func is None:
+            dropped.append(name)
+            continue
+        rollups.append(
+            RollupColumn(name, func, cast_to_bigint=(func == "sum" and dtype in _INTEGER_TYPES))
+        )
+    return tuple(rollups), tuple(dropped)
+
+
+def _infer_out_geometry(con, relation: str, columns: dict[str, str]) -> str:
+    if "geometry" not in columns:
+        return "none"
+    if "centroid" in columns:
+        return "both"
+    geom_expr = geometry_to_geom_expr(con, relation, "geometry")
+    row = con.execute(
+        f"SELECT ST_GeometryType({geom_expr}) FROM {relation} WHERE geometry IS NOT NULL LIMIT 1"
+    ).fetchone()
+    if row and str(row[0]).upper() == "POINT":
+        return "centroid"
+    return "polygon"
+
+
+def _detect_grid_base_level(con, relation: str, scheme: str, cell_column: str) -> int:
+    ensure_grid_extension(con, scheme)
+    qcol = quote_identifier(cell_column)
+    res_func = _RESOLUTION_FUNCS[scheme]
+    rows = con.execute(
+        f"SELECT DISTINCT {res_func}({qcol}) FROM {relation} WHERE {qcol} IS NOT NULL"
+    ).fetchall()
+    resolutions = sorted(row[0] for row in rows)
+    if not resolutions:
+        raise InvalidParameterError("input", f"no non-NULL {cell_column} values to roll up")
+    if len(resolutions) > 1:
+        raise InvalidParameterError(
+            "input",
+            f"mixed {scheme} resolutions in {cell_column}: {resolutions}. "
+            "Overviews require a single base resolution.",
+        )
+    return int(resolutions[0])
+
+
+def _detect_admin_base_level(con, relation: str, cell_column: str) -> str:
+    qcol = quote_identifier(cell_column)
+    row = con.execute(
+        f"SELECT COUNT(*) FILTER (WHERE {qcol} LIKE '%-%') FROM {relation} "
+        f"WHERE {qcol} IS NOT NULL AND {qcol} != 'unassigned'"
+    ).fetchone()
+    if not row or row[0] == 0:
+        raise InvalidParameterError(
+            "input",
+            "admin aggregate is already at country level (no region codes like "
+            "'US-CA' found); there is no coarser admin level to roll up to.",
+        )
+    return "region"
+
+
+def detect_aggregate_info(con, relation: str, cell_column: str | None = None) -> AggregateInfo:
+    """Detect scheme, base level, column roles, and output geometry.
+
+    ``relation`` must be usable in a FROM clause (``read_parquet('...')`` or a
+    registered table name). ``con`` needs the spatial extension loaded; grid
+    community extensions are installed on demand for base-level probing.
+    """
+    ordered = _describe_columns(con, relation)
+    columns = dict(ordered)
+
+    cell_col, scheme = _detect_scheme(con, relation, columns, cell_column)
+    if "count" not in columns:
+        raise InvalidParameterError(
+            "input",
+            "aggregate input must have a count column; re-run gpio process aggregate",
+        )
+    rollups, dropped = _classify_columns(ordered, cell_col, scheme)
+    if dropped:
+        warn(f"Ignoring columns that cannot be rolled up: {', '.join(dropped)}")
+
+    if scheme == "admin":
+        base_level: int | str = _detect_admin_base_level(con, relation, cell_col)
+    else:
+        base_level = _detect_grid_base_level(con, relation, scheme, cell_col)
+
+    out_geometry = _infer_out_geometry(con, relation, columns)
+    return AggregateInfo(
+        scheme=scheme,
+        cell_column=cell_col,
+        base_level=base_level,
+        rollup_columns=rollups,
+        out_geometry=out_geometry,
+        dropped_columns=dropped,
+    )
+
+
+def detect_aggregate_file(input_parquet: str, cell_column: str | None = None) -> AggregateInfo:
+    """File-path convenience wrapper around :func:`detect_aggregate_info`."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.file_utils import safe_file_url
+
+    url = safe_file_url(input_parquet, verbose=False)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
+    try:
+        relation = f"read_parquet('{url}', hive_partitioning=false, union_by_name=true)"
+        return detect_aggregate_info(con, relation, cell_column)
+    finally:
+        con.close()

--- a/geoparquet_io/core/process/overview/levels.py
+++ b/geoparquet_io/core/process/overview/levels.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Zoom-band and overview-level selection for `gpio process overview`.
+
+Shared with `gpio pmtiles pyramid`: both need to know which aggregate level
+should serve which WebMercator zoom range so that no tile blows past the
+tile-size budget. The selection is driven by a *worst tile* probe -- for each
+candidate level, the number of cells landing in the fullest tile per zoom --
+multiplied by an estimated compressed bytes-per-cell.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from geoparquet_io.core.exceptions import InvalidParameterError
+
+# Estimated compressed bytes a single cell contributes to an MVT tile,
+# by output geometry mode. Deliberately conservative (budget heuristic,
+# not a codec model); calibrated loosely against GlobalBuildingAtlas
+# measurements (a5 res-5 z0 tile ~297 KB, res-6 z0 ~791 KB).
+GEOMETRY_BYTES: dict[str, float] = {
+    "polygon": 35.0,
+    "centroid": 12.0,
+    "both": 45.0,
+    "none": 0.0,
+}
+BYTES_PER_ATTRIBUTE = 8.0
+CELL_ID_BYTES = 8.0
+
+DEFAULT_MAX_TILE_KB = 500  # tippecanoe's default per-tile cap
+MAX_PROBE_ZOOM = 20
+
+
+@dataclass(frozen=True)
+class Band:
+    """One zoom band of the pyramid: ``level`` serves zooms minzoom..maxzoom.
+
+    ``maxzoom is None`` marks the final (open-ended) band.
+    """
+
+    level: int | str
+    minzoom: int
+    maxzoom: int | None
+
+
+def estimate_bytes_per_cell(num_attributes: int, out_geometry: str) -> float:
+    """Estimate compressed bytes one cell contributes to a tile.
+
+    ``num_attributes`` counts the numeric attribute columns carried per cell
+    (``count`` plus every rollup/breakdown column).
+    """
+    return CELL_ID_BYTES + GEOMETRY_BYTES[out_geometry] + BYTES_PER_ATTRIBUTE * num_attributes
+
+
+def probe_worst_tile_counts(con, cells_sql: str, max_zoom: int = MAX_PROBE_ZOOM) -> dict[int, int]:
+    """Worst (max) cells-per-tile for each zoom 0..max_zoom.
+
+    ``cells_sql`` must select one row per cell with ``lon``/``lat`` columns.
+    The connection must have the ``lat_lon_to_quadkey`` UDF registered (see
+    :func:`geoparquet_io.core.partition.auto_resolution._register_quadkey_udf`).
+    A quadkey prefix of length ``z`` identifies the WebMercator tile at zoom
+    ``z``, so one quadkey per cell at ``max_zoom`` covers every zoom via
+    ``substr``. Latitudes are clamped to the WebMercator domain.
+    """
+    con.execute(
+        "CREATE OR REPLACE TEMP TABLE __overview_qk AS "
+        f"SELECT lat_lon_to_quadkey(LEAST(GREATEST(lat, -85.05), 85.05), lon, {max_zoom}) AS qk "
+        f"FROM ({cells_sql}) WHERE lon IS NOT NULL AND lat IS NOT NULL"
+    )
+    counts: dict[int, int] = {}
+    for z in range(max_zoom + 1):
+        row = con.execute(
+            "SELECT COALESCE(MAX(cnt), 0) FROM "
+            f"(SELECT COUNT(*) AS cnt FROM __overview_qk GROUP BY substr(qk, 1, {z}))"
+        ).fetchone()
+        counts[z] = int(row[0]) if row else 0
+    return counts
+
+
+def select_bands(
+    worst_counts: Mapping[int | str, Mapping[int, int]],
+    candidates: Sequence[int | str],
+    bytes_per_cell: float,
+    max_tile_kb: int = DEFAULT_MAX_TILE_KB,
+) -> list[Band]:
+    """Assign candidate levels to contiguous zoom bands within the tile budget.
+
+    Walks zooms from 0 upward, at each zoom picking the finest candidate whose
+    worst tile fits ``max_tile_kb`` (never coarser than the previous pick), and
+    stops once the base level -- the last candidate -- fits. When nothing fits
+    at a zoom the coarsest candidate is used, so the first band always starts
+    at z0 (a single oversized z0 tile is acceptable). If the base never fits
+    within the probed zooms it still gets the final open-ended band.
+    """
+    if not candidates:
+        raise InvalidParameterError("levels", "no candidate levels to select from")
+    budget = max_tile_kb * 1024.0
+    base = candidates[-1]
+    max_zoom = min(max(zooms) for zooms in (worst_counts[lvl] for lvl in candidates))
+
+    picks: list[int | str] = []
+    prev_idx = 0
+    for z in range(max_zoom + 1):
+        fitting = [
+            i for i, lvl in enumerate(candidates) if worst_counts[lvl][z] * bytes_per_cell <= budget
+        ]
+        idx = max(max(fitting) if fitting else 0, prev_idx)
+        picks.append(candidates[idx])
+        prev_idx = idx
+        if candidates[idx] == base:
+            break
+    else:
+        # Probe range exhausted without the base fitting; hand the remaining
+        # zooms to the base anyway -- it is the real data.
+        picks.append(base)
+
+    bands: list[Band] = []
+    start = 0
+    for i in range(1, len(picks) + 1):
+        if i == len(picks) or picks[i] != picks[i - 1]:
+            bands.append(Band(picks[i - 1], start, i - 1))
+            start = i
+    last = bands[-1]
+    bands[-1] = Band(last.level, last.minzoom, None)
+    return bands

--- a/geoparquet_io/core/process/overview/rollup.py
+++ b/geoparquet_io/core/process/overview/rollup.py
@@ -27,7 +27,6 @@ from geoparquet_io.core.process.aggregate.grid_common import GridScheme, wrap_gr
 from geoparquet_io.core.process.overview.detect import (
     AggregateInfo,
     detect_aggregate_info,
-    ensure_grid_extension,
 )
 
 GRID_SCHEMES: dict[str, GridScheme] = {"a5": A5_SCHEME, "h3": H3_SCHEME}
@@ -188,10 +187,10 @@ def rollup_table(
     try:
         con.execute("SET geometry_always_xy = true")
         con.register("__overview_input", table)
+        # detect_aggregate_info installs/loads the grid extension while probing
+        # the base level, so no extra ensure_grid_extension call is needed.
         info = detect_aggregate_info(con, "__overview_input", cell_column, scheme)
         level = validate_level(info, level)
-        if info.scheme in GRID_SCHEMES:
-            ensure_grid_extension(con, info.scheme)
         sql = build_level_sql(con, info, "SELECT * FROM __overview_input", level)
         return con.execute(sql).arrow().read_all()
     finally:

--- a/geoparquet_io/core/process/overview/rollup.py
+++ b/geoparquet_io/core/process/overview/rollup.py
@@ -8,9 +8,10 @@ region codes to their ISO country prefix and attach cached Overture country
 polygons.
 
 Rollup exactness: ``count``, ``sum_*``, ``min_*``, ``max_*`` and breakdown
-``count_*`` columns roll up exactly. ``avg_*`` is count-weighted
-(``SUM(avg * count) / SUM(count)``), which is exact when the underlying metric
-had no NULLs -- documented caveat.
+``count_*`` columns roll up exactly. ``avg_*`` is count-weighted over the
+children that carry a value (``SUM(avg * count) / SUM(count) FILTER (avg IS
+NOT NULL)``), which is exact when the underlying metric had no NULLs --
+documented caveat.
 """
 
 from __future__ import annotations
@@ -54,8 +55,10 @@ def build_rollup_agg_parts(info: AggregateInfo) -> list[str]:
             if col.cast_to_bigint:
                 expr = f"CAST({expr} AS BIGINT)"
         elif col.func == "avg":
-            # Count-weighted mean: exact when the metric had no NULLs.
-            expr = f"SUM({qcol} * count) / NULLIF(SUM(count), 0)"
+            # Count-weighted mean. Children with a NULL avg contribute nothing
+            # to the numerator, so they must not count in the denominator
+            # either -- otherwise they dilute the parent mean.
+            expr = f"SUM({qcol} * count) / NULLIF(SUM(count) FILTER (WHERE {qcol} IS NOT NULL), 0)"
         elif col.func == "min":
             expr = f"MIN({qcol})"
         else:  # max
@@ -126,11 +129,12 @@ def build_admin_rollup_sql(
 
 def get_admin_country_context(con, verbose: bool = False) -> tuple[str, str, str]:
     """Return (country_ref, code_col, geom_expr) for the Overture country cache."""
+    from geoparquet_io.core.file_utils import safe_file_url
     from geoparquet_io.core.partition.admin_hierarchical import _setup_admin_dataset
 
     dataset, _boundary_columns = _setup_admin_dataset("overture", verbose, ["country"])
     path = dataset.get_source_for_level("country")
-    country_ref = f"read_parquet('{path}')"
+    country_ref = f"read_parquet('{safe_file_url(path, verbose)}')"
     code_col = quote_identifier(dataset.get_level_column_mapping()["country"])
     geom_expr = geometry_to_geom_expr(con, country_ref, dataset.get_geometry_column())
     return country_ref, code_col, geom_expr

--- a/geoparquet_io/core/process/overview/rollup.py
+++ b/geoparquet_io/core/process/overview/rollup.py
@@ -170,7 +170,9 @@ def build_level_sql(con, info: AggregateInfo, source_sql: str, level: int | str)
     return build_grid_rollup_sql(info, source_sql, int(level))
 
 
-def rollup_table(table, level: int | str, cell_column: str | None = None):
+def rollup_table(
+    table, level: int | str, cell_column: str | None = None, scheme: str | None = None
+):
     """Roll an in-memory aggregate Arrow table up to ``level``.
 
     In-memory counterpart of one `gpio process overview` level, backing
@@ -180,7 +182,7 @@ def rollup_table(table, level: int | str, cell_column: str | None = None):
     try:
         con.execute("SET geometry_always_xy = true")
         con.register("__overview_input", table)
-        info = detect_aggregate_info(con, "__overview_input", cell_column)
+        info = detect_aggregate_info(con, "__overview_input", cell_column, scheme)
         level = validate_level(info, level)
         if info.scheme in GRID_SCHEMES:
             ensure_grid_extension(con, info.scheme)

--- a/geoparquet_io/core/process/overview/rollup.py
+++ b/geoparquet_io/core/process/overview/rollup.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Rollup SQL builders for `gpio process overview`.
+
+Grid rollups walk the true cell hierarchy (``a5_cell_to_parent`` /
+``h3_cell_to_parent``) and regenerate parent geometry from the parent cell id
+via the same scheme templates the aggregate engine uses. Admin rollups collapse
+region codes to their ISO country prefix and attach cached Overture country
+polygons.
+
+Rollup exactness: ``count``, ``sum_*``, ``min_*``, ``max_*`` and breakdown
+``count_*`` columns roll up exactly. ``avg_*`` is count-weighted
+(``SUM(avg * count) / SUM(count)``), which is exact when the underlying metric
+had no NULLs -- documented caveat.
+"""
+
+from __future__ import annotations
+
+import gc
+
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME
+from geoparquet_io.core.process.aggregate.by_h3 import H3_SCHEME
+from geoparquet_io.core.process.aggregate.common import geometry_to_geom_expr
+from geoparquet_io.core.process.aggregate.grid_common import GridScheme, wrap_grid_geometry
+from geoparquet_io.core.process.overview.detect import (
+    AggregateInfo,
+    detect_aggregate_info,
+    ensure_grid_extension,
+)
+
+GRID_SCHEMES: dict[str, GridScheme] = {"a5": A5_SCHEME, "h3": H3_SCHEME}
+GRID_PARENT_TEMPLATES = {
+    "a5": "a5_cell_to_parent({cell}, {level})",
+    "h3": "h3_cell_to_parent({cell}, {level})",
+}
+
+# Rolled-up admin_code for a region row: 'US-CA' -> 'US'; the NULL-cell
+# 'unassigned' bucket flows through unchanged.
+ADMIN_PARENT_EXPR = (
+    "CASE WHEN admin_code = 'unassigned' THEN 'unassigned' ELSE split_part(admin_code, '-', 1) END"
+)
+
+
+def build_rollup_agg_parts(info: AggregateInfo) -> list[str]:
+    """Aggregate SELECT expressions for count + every rollup column, in order."""
+    # SUM(BIGINT) widens to HUGEINT in DuckDB; cast back so count stays BIGINT.
+    parts = ["CAST(SUM(count) AS BIGINT) AS count"]
+    for col in info.rollup_columns:
+        qcol = quote_identifier(col.name)
+        if col.func == "sum":
+            expr = f"SUM({qcol})"
+            if col.cast_to_bigint:
+                expr = f"CAST({expr} AS BIGINT)"
+        elif col.func == "avg":
+            # Count-weighted mean: exact when the metric had no NULLs.
+            expr = f"SUM({qcol} * count) / NULLIF(SUM(count), 0)"
+        elif col.func == "min":
+            expr = f"MIN({qcol})"
+        else:  # max
+            expr = f"MAX({qcol})"
+        parts.append(f"{expr} AS {qcol}")
+    return parts
+
+
+def build_grid_rollup_sql(info: AggregateInfo, source_sql: str, level: int) -> str:
+    """Roll a grid aggregate up to ``level`` and regenerate parent geometry."""
+    scheme = GRID_SCHEMES[info.scheme]
+    qcol = quote_identifier(info.cell_column)
+    parent = GRID_PARENT_TEMPLATES[info.scheme].format(cell=qcol, level=level)
+    # NULL cell ids (the 'unassigned' bucket) must not reach the parent
+    # function; they group into their own NULL parent row.
+    keyed = (
+        f"SELECT *, CASE WHEN {qcol} IS NULL THEN NULL ELSE {parent} END AS __parent "
+        f"FROM ({source_sql})"
+    )
+    agg_parts = [f"__parent AS {qcol}", *build_rollup_agg_parts(info)]
+    agg_sql = f"SELECT {', '.join(agg_parts)} FROM ({keyed}) GROUP BY __parent"
+    return wrap_grid_geometry(agg_sql, scheme, info.cell_column, info.out_geometry)
+
+
+def build_admin_rollup_sql(
+    info: AggregateInfo,
+    source_sql: str,
+    country_ref: str | None,
+    country_code_col: str | None,
+    country_geom_expr: str | None,
+) -> str:
+    """Roll a region-level admin aggregate up to country level.
+
+    ``country_ref`` (a FROM-able relation for the per-level country cache) may
+    be None only when ``info.out_geometry`` is ``none``. Countries split across
+    multiple cache rows are unioned (``ST_Union_Agg``); the 'unassigned' bucket
+    keeps a NULL geometry via the LEFT JOIN.
+    """
+    agg_parts = [
+        "__parent AS admin_code",
+        "__parent AS admin_name",
+        *build_rollup_agg_parts(info),
+    ]
+    keyed = f"SELECT *, {ADMIN_PARENT_EXPR} AS __parent FROM ({source_sql})"
+    agg_sql = f"SELECT {', '.join(agg_parts)} FROM ({keyed}) GROUP BY __parent"
+    if info.out_geometry == "none":
+        return agg_sql
+
+    countries = (
+        f"SELECT {country_code_col} AS __country_code, "
+        f"ST_Union_Agg({country_geom_expr}) AS __country_geom "
+        f"FROM {country_ref} GROUP BY {country_code_col}"
+    )
+    polygon = "ST_AsWKB(c.__country_geom)"
+    centroid = "ST_AsWKB(ST_Centroid(c.__country_geom))"
+    if info.out_geometry == "polygon":
+        geom_cols = f"{polygon} AS geometry"
+    elif info.out_geometry == "centroid":
+        geom_cols = f"{centroid} AS geometry"
+    else:  # both
+        geom_cols = f"{polygon} AS geometry, {centroid} AS centroid"
+    return (
+        f"SELECT r.*, {geom_cols} FROM ({agg_sql}) r "
+        f"LEFT JOIN ({countries}) c ON r.admin_code = c.__country_code"
+    )
+
+
+def get_admin_country_context(con, verbose: bool = False) -> tuple[str, str, str]:
+    """Return (country_ref, code_col, geom_expr) for the Overture country cache."""
+    from geoparquet_io.core.partition.admin_hierarchical import _setup_admin_dataset
+
+    dataset, _boundary_columns = _setup_admin_dataset("overture", verbose, ["country"])
+    path = dataset.get_source_for_level("country")
+    country_ref = f"read_parquet('{path}')"
+    code_col = quote_identifier(dataset.get_level_column_mapping()["country"])
+    geom_expr = geometry_to_geom_expr(con, country_ref, dataset.get_geometry_column())
+    return country_ref, code_col, geom_expr
+
+
+def validate_level(info: AggregateInfo, level: int | str) -> int | str:
+    """Validate one requested overview level against the input's base level."""
+    if info.scheme == "admin":
+        if level != "country":
+            raise InvalidParameterError(
+                "levels",
+                f"invalid admin overview level '{level}': a region-level "
+                "aggregate can only roll up to 'country'",
+            )
+        return level
+    try:
+        level_int = int(level)
+    except (TypeError, ValueError):
+        raise InvalidParameterError(
+            "levels", f"invalid {info.scheme} level '{level}': expected an integer"
+        ) from None
+    scheme = GRID_SCHEMES[info.scheme]
+    if not scheme.min_resolution <= level_int < int(info.base_level):
+        raise InvalidParameterError(
+            "levels",
+            f"level {level_int} is not coarser than the input's base resolution "
+            f"{info.base_level} (valid: {scheme.min_resolution}-{int(info.base_level) - 1})",
+        )
+    return level_int
+
+
+def build_level_sql(con, info: AggregateInfo, source_sql: str, level: int | str) -> str:
+    """Build the full rollup SQL for one validated overview level."""
+    if info.scheme == "admin":
+        if info.out_geometry == "none":
+            return build_admin_rollup_sql(info, source_sql, None, None, None)
+        country_ref, code_col, geom_expr = get_admin_country_context(con)
+        return build_admin_rollup_sql(info, source_sql, country_ref, code_col, geom_expr)
+    return build_grid_rollup_sql(info, source_sql, int(level))
+
+
+def rollup_table(table, level: int | str, cell_column: str | None = None):
+    """Roll an in-memory aggregate Arrow table up to ``level``.
+
+    In-memory counterpart of one `gpio process overview` level, backing
+    ``Table.overview``. Returns a new Arrow table.
+    """
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
+    try:
+        con.execute("SET geometry_always_xy = true")
+        con.register("__overview_input", table)
+        info = detect_aggregate_info(con, "__overview_input", cell_column)
+        level = validate_level(info, level)
+        if info.scheme in GRID_SCHEMES:
+            ensure_grid_extension(con, info.scheme)
+        sql = build_level_sql(con, info, "SELECT * FROM __overview_input", level)
+        return con.execute(sql).arrow().read_all()
+    finally:
+        con.close()
+        # Release GDAL/spatial native handles before the next spatial connection
+        # opens; leaked native state can segfault sibling xdist tests.
+        gc.collect()

--- a/geoparquet_io/core/process/overview/rollup.py
+++ b/geoparquet_io/core/process/overview/rollup.py
@@ -35,11 +35,12 @@ GRID_PARENT_TEMPLATES = {
     "h3": "h3_cell_to_parent({cell}, {level})",
 }
 
-# Rolled-up admin_code for a region row: 'US-CA' -> 'US'; the NULL-cell
-# 'unassigned' bucket flows through unchanged.
-ADMIN_PARENT_EXPR = (
-    "CASE WHEN admin_code = 'unassigned' THEN 'unassigned' ELSE split_part(admin_code, '-', 1) END"
-)
+
+def admin_parent_expr(cell_column: str) -> str:
+    """Rolled-up admin code for a region row: 'US-CA' -> 'US'; the NULL-cell
+    'unassigned' bucket flows through unchanged."""
+    qcol = quote_identifier(cell_column)
+    return f"CASE WHEN {qcol} = 'unassigned' THEN 'unassigned' ELSE split_part({qcol}, '-', 1) END"
 
 
 def build_rollup_agg_parts(info: AggregateInfo) -> list[str]:
@@ -93,12 +94,13 @@ def build_admin_rollup_sql(
     multiple cache rows are unioned (``ST_Union_Agg``); the 'unassigned' bucket
     keeps a NULL geometry via the LEFT JOIN.
     """
+    qcol = quote_identifier(info.cell_column)
     agg_parts = [
-        "__parent AS admin_code",
+        f"__parent AS {qcol}",
         "__parent AS admin_name",
         *build_rollup_agg_parts(info),
     ]
-    keyed = f"SELECT *, {ADMIN_PARENT_EXPR} AS __parent FROM ({source_sql})"
+    keyed = f"SELECT *, {admin_parent_expr(info.cell_column)} AS __parent FROM ({source_sql})"
     agg_sql = f"SELECT {', '.join(agg_parts)} FROM ({keyed}) GROUP BY __parent"
     if info.out_geometry == "none":
         return agg_sql
@@ -118,7 +120,7 @@ def build_admin_rollup_sql(
         geom_cols = f"{polygon} AS geometry, {centroid} AS centroid"
     return (
         f"SELECT r.*, {geom_cols} FROM ({agg_sql}) r "
-        f"LEFT JOIN ({countries}) c ON r.admin_code = c.__country_code"
+        f"LEFT JOIN ({countries}) c ON r.{qcol} = c.__country_code"
     )
 
 

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -114,8 +114,11 @@ def _admin_cells_probe_sql(con, info: AggregateInfo, source_sql: str, level: str
     )
     if level == "region":
         return f"SELECT lon, lat FROM ({centroids})"
+    # Circular mean of longitudes: antimeridian-spanning countries (US, RU,
+    # FJ, NZ) must probe near +/-180, not at the naive AVG(lon) near lon 0.
+    lon_expr = "degrees(atan2(AVG(sin(radians(lon))), AVG(cos(radians(lon)))))"
     return (
-        f"SELECT AVG(lon) AS lon, AVG(lat) AS lat FROM ({centroids}) "
+        f"SELECT {lon_expr} AS lon, AVG(lat) AS lat FROM ({centroids}) "
         f"GROUP BY {admin_parent_expr(info.cell_column)}"
     )
 

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Orchestration for `gpio process overview`: build coarser aggregate levels.
+
+Reads an existing `gpio process aggregate` output (small), rolls it up to one
+or more coarser levels -- explicit via ``levels`` or auto-selected against a
+tile-size budget -- and writes one GeoParquet sibling per level.
+"""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+from geoparquet_io.core.common import write_geoparquet_table
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.logging_config import configure_verbose, debug, success
+from geoparquet_io.core.logging_config import info as log_info
+from geoparquet_io.core.partition.auto_resolution import _register_quadkey_udf
+from geoparquet_io.core.process.aggregate.common import geometry_to_geom_expr
+from geoparquet_io.core.process.overview.detect import (
+    AggregateInfo,
+    detect_aggregate_info,
+)
+from geoparquet_io.core.process.overview.levels import (
+    DEFAULT_MAX_TILE_KB,
+    Band,
+    estimate_bytes_per_cell,
+    probe_worst_tile_counts,
+    select_bands,
+)
+from geoparquet_io.core.process.overview.rollup import (
+    ADMIN_PARENT_EXPR,
+    GRID_PARENT_TEMPLATES,
+    GRID_SCHEMES,
+    build_level_sql,
+    validate_level,
+)
+
+
+def overview_output_path(
+    input_parquet: str, scheme: str, level: int | str, output_dir: str | None = None
+) -> str:
+    """Sibling path for one overview level.
+
+    Grid: ``cells.parquet`` -> ``cells_r7.parquet``. Admin: ``by_region.parquet``
+    -> ``by_region_country.parquet``.
+    """
+    path = Path(input_parquet)
+    directory = Path(output_dir) if output_dir else path.parent
+    suffix = path.suffix or ".parquet"
+    if scheme == "admin":
+        return str(directory / f"{path.stem}_{level}{suffix}")
+    return str(directory / f"{path.stem}_r{level}{suffix}")
+
+
+def parse_levels(levels, info: AggregateInfo) -> list[int | str]:
+    """Normalize an explicit ``levels`` parameter (comma string or list)."""
+    if isinstance(levels, str):
+        raw: list = [part.strip() for part in levels.split(",") if part.strip()]
+    else:
+        raw = list(levels)
+    if not raw:
+        raise InvalidParameterError("levels", "no levels given")
+    parsed = [validate_level(info, level) for level in raw]
+    if len(set(parsed)) != len(parsed):
+        raise InvalidParameterError("levels", f"duplicate levels in {parsed}")
+    if info.scheme == "admin":
+        return parsed
+    return sorted(parsed)
+
+
+def _grid_cells_probe_sql(info: AggregateInfo, source_sql: str, level: int) -> str:
+    """One lon/lat row per distinct level-``level`` parent cell of a grid input."""
+    qcol = quote_identifier(info.cell_column)
+    if level == info.base_level:
+        parent = qcol
+    else:
+        parent = GRID_PARENT_TEMPLATES[info.scheme].format(cell=qcol, level=level)
+    # a5_cell_to_lonlat returns [lon, lat]; h3_cell_to_latlng returns [lat, lng].
+    if info.scheme == "a5":
+        lonlat = "a5_cell_to_lonlat(__parent)"
+        lon, lat = "__ll[1]", "__ll[2]"
+    else:
+        lonlat = "h3_cell_to_latlng(__parent)"
+        lon, lat = "__ll[2]", "__ll[1]"
+    return (
+        f"SELECT {lon} AS lon, {lat} AS lat FROM ("
+        f"SELECT {lonlat} AS __ll FROM ("
+        f"SELECT DISTINCT {parent} AS __parent FROM ({source_sql}) "
+        f"WHERE {qcol} IS NOT NULL))"
+    )
+
+
+def _admin_cells_probe_sql(con, info: AggregateInfo, source_sql: str, level: str) -> str:
+    """One lon/lat row per admin bucket at ``level`` ('region' base or 'country')."""
+    if info.out_geometry == "none":
+        raise InvalidParameterError(
+            "levels",
+            "cannot auto-select admin overview zoom bands for an aggregate "
+            "without geometry; pass explicit levels",
+        )
+    geom_expr = geometry_to_geom_expr(con, f"({source_sql})", "geometry")
+    centroids = (
+        f"SELECT admin_code, ST_X(__c) AS lon, ST_Y(__c) AS lat FROM ("
+        f"SELECT admin_code, ST_Centroid({geom_expr}) AS __c FROM ({source_sql}) "
+        "WHERE geometry IS NOT NULL AND admin_code != 'unassigned')"
+    )
+    if level == "region":
+        return f"SELECT lon, lat FROM ({centroids})"
+    return (
+        f"SELECT AVG(lon) AS lon, AVG(lat) AS lat FROM ({centroids}) GROUP BY {ADMIN_PARENT_EXPR}"
+    )
+
+
+def plan_bands(
+    con,
+    source_sql: str,
+    info: AggregateInfo,
+    levels: list[int | str] | None = None,
+    max_tile_kb: int = DEFAULT_MAX_TILE_KB,
+    bytes_per_cell: float | None = None,
+    verbose: bool = False,
+) -> list[Band]:
+    """Probe worst-tile cell counts and select zoom bands for the pyramid.
+
+    ``levels`` (already validated, coarse-to-fine, excluding the base) restricts
+    the candidate set; the base level is always the final candidate.
+    """
+    if info.scheme == "admin":
+        candidates: list[int | str] = ["country", "region"]
+    elif levels is not None:
+        candidates = [*levels, info.base_level]
+    else:
+        scheme = GRID_SCHEMES[info.scheme]
+        candidates = [*range(scheme.min_resolution, int(info.base_level)), info.base_level]
+
+    bpc = bytes_per_cell or estimate_bytes_per_cell(info.num_attributes, info.out_geometry)
+    _register_quadkey_udf(con)
+    worst: dict[int | str, dict[int, int]] = {}
+    for level in candidates:
+        if info.scheme == "admin":
+            cells_sql = _admin_cells_probe_sql(con, info, source_sql, str(level))
+        else:
+            cells_sql = _grid_cells_probe_sql(info, source_sql, int(level))
+        worst[level] = probe_worst_tile_counts(con, cells_sql)
+    bands = select_bands(worst, candidates, bpc, max_tile_kb)
+    if verbose:
+        debug(f"Estimated {bpc:.0f} bytes/cell; selected bands: {bands}")
+    return bands
+
+
+def _auto_levels(con, source_sql, info, max_tile_kb, bytes_per_cell, verbose):
+    """Auto-select the overview levels to build (excludes the base level)."""
+    if info.scheme == "admin":
+        # The admin ladder has exactly one coarser level; no probing needed.
+        return ["country"]
+    bands = plan_bands(
+        con,
+        source_sql,
+        info,
+        max_tile_kb=max_tile_kb,
+        bytes_per_cell=bytes_per_cell,
+        verbose=verbose,
+    )
+    return [band.level for band in bands if band.level != info.base_level]
+
+
+def _write_overview(table, out_path, info, compression, compression_level, gpq_version, verbose):
+    if info.out_geometry == "none":
+        kwargs = {"compression": compression}
+        if compression_level is not None:
+            kwargs["compression_level"] = compression_level
+        pq.write_table(table, out_path, **kwargs)
+        return
+    write_geoparquet_table(
+        table,
+        out_path,
+        geometry_column="geometry",
+        compression=compression,
+        compression_level=compression_level,
+        geoparquet_version=gpq_version,
+        verbose=verbose,
+    )
+
+
+def create_overviews(
+    input_parquet: str,
+    *,
+    levels=None,
+    max_tile_kb: int = DEFAULT_MAX_TILE_KB,
+    bytes_per_cell: float | None = None,
+    cell_column: str | None = None,
+    output_dir: str | None = None,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    geoparquet_version: str | None = None,
+    verbose: bool = False,
+    show_sql: bool = False,
+) -> list[tuple[int | str, str]]:
+    """Build coarser overview levels from an aggregate GeoParquet file.
+
+    Args:
+        input_parquet: Path to a `gpio process aggregate` output.
+        levels: Explicit levels to build (comma string or list). Grid schemes
+            take resolutions coarser than the input's base; admin takes
+            ``country``. Default: auto-select against ``max_tile_kb``.
+        max_tile_kb: Tile-size budget (KB) driving auto level selection.
+        bytes_per_cell: Override the estimated compressed bytes per cell.
+        cell_column: Cell id column when auto-detection fails.
+        output_dir: Directory for overview files (default: beside the input).
+        compression: Parquet compression codec (default ZSTD).
+        compression_level: Optional compression level.
+        geoparquet_version: GeoParquet spec version to write.
+        verbose: Enable verbose debug logging.
+        show_sql: Log the rollup SQL.
+
+    Returns:
+        List of ``(level, output_path)`` for every overview written,
+        coarse to fine.
+    """
+    configure_verbose(verbose)
+    input_url = safe_file_url(input_parquet, verbose)
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
+    try:
+        con.execute("SET geometry_always_xy = true")
+        relation = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
+        info = detect_aggregate_info(con, relation, cell_column)
+        source_sql = f"SELECT * FROM {relation}"
+
+        if levels is not None:
+            target_levels = parse_levels(levels, info)
+        else:
+            target_levels = _auto_levels(
+                con, source_sql, info, max_tile_kb, bytes_per_cell, verbose
+            )
+        if not target_levels:
+            log_info("Base level fits the tile budget at every zoom; no overview levels needed")
+            return []
+
+        results: list[tuple[int | str, str]] = []
+        for level in target_levels:
+            sql = build_level_sql(con, info, source_sql, level)
+            if show_sql or verbose:
+                debug(sql)
+            table = con.execute(sql).arrow().read_all()
+            out_path = overview_output_path(input_parquet, info.scheme, level, output_dir)
+            _write_overview(
+                table,
+                out_path,
+                info,
+                compression,
+                compression_level,
+                geoparquet_version,
+                verbose,
+            )
+            success(f"Wrote level {level} overview ({table.num_rows} rows) -> {out_path}")
+            results.append((level, out_path))
+        return results
+    finally:
+        con.close()
+        # Release GDAL/spatial native handles before the next spatial connection
+        # opens; leaked native state can segfault sibling xdist tests.
+        gc.collect()

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -172,9 +172,13 @@ def _auto_levels(
     bytes_per_cell: float | None,
     verbose: bool,
 ) -> list[int | str]:
-    """Auto-select the overview levels to build (excludes the base level)."""
-    if info.scheme == "admin":
-        # The admin ladder has exactly one coarser level; no probing needed.
+    """Auto-select the overview levels to build (excludes the base level).
+
+    Admin and grid schemes share the probe-based selection, so both return
+    ``[]`` when the base level already fits the budget. A geometry-less admin
+    aggregate cannot be probed; it falls back to the only coarser level.
+    """
+    if info.scheme == "admin" and info.out_geometry == "none":
         return ["country"]
     bands = plan_bands(
         con,

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -35,9 +35,9 @@ from geoparquet_io.core.process.overview.levels import (
     select_bands,
 )
 from geoparquet_io.core.process.overview.rollup import (
-    ADMIN_PARENT_EXPR,
     GRID_PARENT_TEMPLATES,
     GRID_SCHEMES,
+    admin_parent_expr,
     build_level_sql,
     validate_level,
 )
@@ -105,16 +105,18 @@ def _admin_cells_probe_sql(con, info: AggregateInfo, source_sql: str, level: str
             "cannot auto-select admin overview zoom bands for an aggregate "
             "without geometry; pass explicit levels",
         )
+    qcol = quote_identifier(info.cell_column)
     geom_expr = geometry_to_geom_expr(con, f"({source_sql})", "geometry")
     centroids = (
-        f"SELECT admin_code, ST_X(__c) AS lon, ST_Y(__c) AS lat FROM ("
-        f"SELECT admin_code, ST_Centroid({geom_expr}) AS __c FROM ({source_sql}) "
-        "WHERE geometry IS NOT NULL AND admin_code != 'unassigned')"
+        f"SELECT {qcol}, ST_X(__c) AS lon, ST_Y(__c) AS lat FROM ("
+        f"SELECT {qcol}, ST_Centroid({geom_expr}) AS __c FROM ({source_sql}) "
+        f"WHERE geometry IS NOT NULL AND {qcol} != 'unassigned')"
     )
     if level == "region":
         return f"SELECT lon, lat FROM ({centroids})"
     return (
-        f"SELECT AVG(lon) AS lon, AVG(lat) AS lat FROM ({centroids}) GROUP BY {ADMIN_PARENT_EXPR}"
+        f"SELECT AVG(lon) AS lon, AVG(lat) AS lat FROM ({centroids}) "
+        f"GROUP BY {admin_parent_expr(info.cell_column)}"
     )
 
 

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -27,6 +27,7 @@ from geoparquet_io.core.process.overview.detect import (
 )
 from geoparquet_io.core.process.overview.levels import (
     DEFAULT_MAX_TILE_KB,
+    MAX_PROBE_ZOOM,
     Band,
     estimate_bytes_per_cell,
     probe_worst_tile_counts,
@@ -124,11 +125,14 @@ def plan_bands(
     max_tile_kb: int = DEFAULT_MAX_TILE_KB,
     bytes_per_cell: float | None = None,
     verbose: bool = False,
+    max_probe_zoom: int | None = None,
 ) -> list[Band]:
     """Probe worst-tile cell counts and select zoom bands for the pyramid.
 
     ``levels`` (already validated, coarse-to-fine, excluding the base) restricts
     the candidate set; the base level is always the final candidate.
+    ``max_probe_zoom`` caps the probed zoom range (e.g. to an archive's max
+    zoom) so band transitions never land beyond it.
     """
     if info.scheme == "admin":
         candidates: list[int | str] = ["country", "region"]
@@ -139,6 +143,7 @@ def plan_bands(
         candidates = [*range(scheme.min_resolution, int(info.base_level)), info.base_level]
 
     bpc = bytes_per_cell or estimate_bytes_per_cell(info.num_attributes, info.out_geometry)
+    probe_zoom = MAX_PROBE_ZOOM if max_probe_zoom is None else max(0, max_probe_zoom)
     _register_quadkey_udf(con)
     worst: dict[int | str, dict[int, int]] = {}
     for level in candidates:
@@ -146,7 +151,7 @@ def plan_bands(
             cells_sql = _admin_cells_probe_sql(con, info, source_sql, str(level))
         else:
             cells_sql = _grid_cells_probe_sql(info, source_sql, int(level))
-        worst[level] = probe_worst_tile_counts(con, cells_sql)
+        worst[level] = probe_worst_tile_counts(con, cells_sql, max_zoom=probe_zoom)
     bands = select_bands(worst, candidates, bpc, max_tile_kb)
     if verbose:
         debug(f"Estimated {bpc:.0f} bytes/cell; selected bands: {bands}")

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -201,7 +202,7 @@ def _write_overview(
     verbose: bool,
 ) -> None:
     if info.out_geometry == "none":
-        kwargs = {"compression": compression}
+        kwargs: dict[str, Any] = {"compression": compression}
         if compression_level is not None:
             kwargs["compression_level"] = compression_level
         pq.write_table(table, out_path, **kwargs)

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -222,6 +222,7 @@ def create_overviews(
     compression: str = "ZSTD",
     compression_level: int | None = None,
     geoparquet_version: str | None = None,
+    force: bool = False,
     verbose: bool = False,
     show_sql: bool = False,
 ) -> list[tuple[int | str, str]]:
@@ -241,6 +242,7 @@ def create_overviews(
         compression: Parquet compression codec (default ZSTD).
         compression_level: Optional compression level.
         geoparquet_version: GeoParquet spec version to write.
+        force: Overwrite existing overview output files.
         verbose: Enable verbose debug logging.
         show_sql: Log the rollup SQL.
 
@@ -262,6 +264,22 @@ def create_overviews(
         if not target_levels:
             log_info("Base level fits the tile budget at every zoom; no overview levels needed")
             return []
+
+        # Refuse to silently overwrite derived sibling files the user never
+        # named (mirrors the --force gate on gpio pmtiles pyramid).
+        existing = [
+            path
+            for path in (
+                overview_output_path(input_parquet, info.scheme, level, output_dir)
+                for level in target_levels
+            )
+            if Path(path).exists()
+        ]
+        if existing and not force:
+            raise InvalidParameterError(
+                "output",
+                f"overview output already exists: {', '.join(existing)}. Use --force to overwrite.",
+            )
 
         results: list[tuple[int | str, str]] = []
         for level in target_levels:

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -8,21 +8,22 @@ tile-size budget -- and writes one GeoParquet sibling per level.
 
 from __future__ import annotations
 
-import gc
+from collections.abc import Sequence
 from pathlib import Path
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.common import write_geoparquet_table
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import configure_verbose, debug, success
 from geoparquet_io.core.logging_config import info as log_info
 from geoparquet_io.core.partition.auto_resolution import _register_quadkey_udf
 from geoparquet_io.core.process.aggregate.common import geometry_to_geom_expr
 from geoparquet_io.core.process.overview.detect import (
     AggregateInfo,
+    aggregate_connection,
     detect_aggregate_info,
 )
 from geoparquet_io.core.process.overview.levels import (
@@ -58,7 +59,7 @@ def overview_output_path(
     return str(directory / f"{path.stem}_r{level}{suffix}")
 
 
-def parse_levels(levels, info: AggregateInfo) -> list[int | str]:
+def parse_levels(levels: str | Sequence[int | str], info: AggregateInfo) -> list[int | str]:
     """Normalize an explicit ``levels`` parameter (comma string or list)."""
     if isinstance(levels, str):
         raw: list = [part.strip() for part in levels.split(",") if part.strip()]
@@ -158,7 +159,14 @@ def plan_bands(
     return bands
 
 
-def _auto_levels(con, source_sql, info, max_tile_kb, bytes_per_cell, verbose):
+def _auto_levels(
+    con,
+    source_sql: str,
+    info: AggregateInfo,
+    max_tile_kb: int,
+    bytes_per_cell: float | None,
+    verbose: bool,
+) -> list[int | str]:
     """Auto-select the overview levels to build (excludes the base level)."""
     if info.scheme == "admin":
         # The admin ladder has exactly one coarser level; no probing needed.
@@ -174,7 +182,15 @@ def _auto_levels(con, source_sql, info, max_tile_kb, bytes_per_cell, verbose):
     return [band.level for band in bands if band.level != info.base_level]
 
 
-def _write_overview(table, out_path, info, compression, compression_level, gpq_version, verbose):
+def _write_overview(
+    table: pa.Table,
+    out_path: str,
+    info: AggregateInfo,
+    compression: str,
+    compression_level: int | None,
+    gpq_version: str | None,
+    verbose: bool,
+) -> None:
     if info.out_geometry == "none":
         kwargs = {"compression": compression}
         if compression_level is not None:
@@ -195,10 +211,11 @@ def _write_overview(table, out_path, info, compression, compression_level, gpq_v
 def create_overviews(
     input_parquet: str,
     *,
-    levels=None,
+    levels: str | list[int | str] | None = None,
     max_tile_kb: int = DEFAULT_MAX_TILE_KB,
     bytes_per_cell: float | None = None,
     cell_column: str | None = None,
+    scheme: str | None = None,
     output_dir: str | None = None,
     compression: str = "ZSTD",
     compression_level: int | None = None,
@@ -216,6 +233,8 @@ def create_overviews(
         max_tile_kb: Tile-size budget (KB) driving auto level selection.
         bytes_per_cell: Override the estimated compressed bytes per cell.
         cell_column: Cell id column when auto-detection fails.
+        scheme: Bucketing scheme (a5/h3/admin) when inference is ambiguous,
+            e.g. H3 ids stored as integers.
         output_dir: Directory for overview files (default: beside the input).
         compression: Parquet compression codec (default ZSTD).
         compression_level: Optional compression level.
@@ -228,12 +247,8 @@ def create_overviews(
         coarse to fine.
     """
     configure_verbose(verbose)
-    input_url = safe_file_url(input_parquet, verbose)
-    con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
-    try:
-        con.execute("SET geometry_always_xy = true")
-        relation = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
-        info = detect_aggregate_info(con, relation, cell_column)
+    with aggregate_connection(input_parquet, verbose) as (con, relation):
+        info = detect_aggregate_info(con, relation, cell_column, scheme)
         source_sql = f"SELECT * FROM {relation}"
 
         if levels is not None:
@@ -265,8 +280,3 @@ def create_overviews(
             success(f"Wrote level {level} overview ({table.num_rows} rows) -> {out_path}")
             results.append((level, out_path))
         return results
-    finally:
-        con.close()
-        # Release GDAL/spatial native handles before the next spatial connection
-        # opens; leaked native state can segfault sibling xdist tests.
-        gc.collect()

--- a/geoparquet_io/skills/geoparquet.md
+++ b/geoparquet_io/skills/geoparquet.md
@@ -36,7 +36,7 @@ Be proactive - analyze the data and make recommendations rather than waiting to 
 | `gpio extract` | arcgis, bigquery, carto, geoparquet, wfs | Extract data from files and services to GeoParquet. By... |
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or... |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files. |
-| `gpio pmtiles` | create | PMTiles generation commands. Generate PMTiles from... |
+| `gpio pmtiles` | create, pyramid | PMTiles generation commands. Generate PMTiles from... |
 | `gpio process` | aggregate, overview | Transform or reduce GeoParquet data (aggregate, overview,... |
 | `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata,... |
 | `gpio skills` |  | List and access LLM skills for gpio. Skills are markdown... |

--- a/geoparquet_io/skills/geoparquet.md
+++ b/geoparquet_io/skills/geoparquet.md
@@ -37,7 +37,7 @@ Be proactive - analyze the data and make recommendations rather than waiting to 
 | `gpio inspect` | head, layers, meta, stats, summary, tail | Inspect GeoParquet files and show metadata, previews, or... |
 | `gpio partition` | a5, admin, h3, kdtree, quadkey, s2, string | Commands for partitioning GeoParquet files. |
 | `gpio pmtiles` | create | PMTiles generation commands. Generate PMTiles from... |
-| `gpio process` | aggregate | Transform or reduce GeoParquet data (aggregate, ...). |
+| `gpio process` | aggregate, overview | Transform or reduce GeoParquet data (aggregate, overview,... |
 | `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata,... |
 | `gpio skills` |  | List and access LLM skills for gpio. Skills are markdown... |
 | `gpio sort` | column, hilbert, quadkey | Commands for sorting GeoParquet files. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - Partitioning Files: guide/partition.md
     - Sub-Partitioning Large Files: guide/sub-partitioning.md
     - Aggregating Data: guide/process-aggregate.md
+    - Overview Levels: guide/process-overview.md
     - Remote Files & Authentication: guide/remote-files.md
     - Unix Piping: guide/piping.md
     - Uploading to Cloud Storage: guide/upload.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "geoarrow-pyarrow>=0.1.0",  # Required for CRS handling in Parquet native geo types
     "pyproj>=3.0.0",  # Required for CRS handling and PROJJSON generation
     "mercantile>=1.2.0",  # Required for quadkey generation
+    "pmtiles>=3.0.0",  # Required for reading/writing PMTiles archive metadata (pyramid bands)
     "httpx>=0.25.0",  # Required for ArcGIS REST API requests (http2 disabled due to ArcGIS compatibility)
     "owslib>=0.29.0",  # Required for OGC Web Feature Service (WFS) extraction
     # Security: explicit constraints for transitive dependencies

--- a/tests/test_overview_levels.py
+++ b/tests/test_overview_levels.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.process.overview.levels import (
     Band,
     estimate_bytes_per_cell,
@@ -100,6 +101,10 @@ class TestSelectBands:
         band = Band(4, 0, 3)
         with pytest.raises(AttributeError):
             band.level = 5
+
+    def test_empty_candidates_error(self):
+        with pytest.raises(InvalidParameterError, match="candidate"):
+            select_bands({}, [], bytes_per_cell=100.0)
 
 
 class TestEstimateBytesPerCell:

--- a/tests/test_overview_levels.py
+++ b/tests/test_overview_levels.py
@@ -1,0 +1,129 @@
+"""Unit tests for overview zoom-band selection (pure functions, no DuckDB)."""
+
+import pytest
+
+from geoparquet_io.core.process.overview.levels import (
+    Band,
+    estimate_bytes_per_cell,
+    select_bands,
+)
+
+
+def uniform_worst_counts(cells: int, max_zoom: int = 12) -> dict[int, int]:
+    """Worst tile cell-count for cells spread globally/uniformly: total / 4^z."""
+    return {z: max(1, cells // (4**z)) for z in range(max_zoom + 1)}
+
+
+def point_mass_worst_counts(cells: int, max_zoom: int = 12) -> dict[int, int]:
+    """Worst tile cell-count when every cell lands in the same tile at all zooms."""
+    return dict.fromkeys(range(max_zoom + 1), cells)
+
+
+class TestSelectBands:
+    def test_global_uniform_steps_down_with_zoom(self):
+        # A5-like global grids: 12 * 4^L cells, spread uniformly.
+        candidates = [4, 6, 8, 10]
+        worst = {lvl: uniform_worst_counts(12 * 4**lvl) for lvl in candidates}
+        bands = select_bands(worst, candidates, bytes_per_cell=100.0, max_tile_kb=500)
+        assert bands == [
+            Band(4, 0, 1),
+            Band(6, 2, 3),
+            Band(8, 4, 5),
+            Band(10, 6, None),
+        ]
+
+    def test_point_mass_coarsest_extends_to_zoom_zero(self):
+        # Nothing fits at z0 -- the coarsest band must still start at z0
+        # (a single oversized z0 tile is acceptable; the cap guards it).
+        candidates = [3, 7]
+        worst = {
+            3: point_mass_worst_counts(6000),
+            7: {z: (20000 if z < 4 else 1000) for z in range(13)},
+        }
+        bands = select_bands(worst, candidates, bytes_per_cell=100.0, max_tile_kb=500)
+        assert bands[0].level == 3
+        assert bands[0].minzoom == 0
+        assert bands == [Band(3, 0, 3), Band(7, 4, None)]
+
+    def test_base_fits_everywhere_yields_single_band(self):
+        candidates = [2, 5]
+        worst = {2: uniform_worst_counts(10), 5: uniform_worst_counts(100)}
+        bands = select_bands(worst, candidates, bytes_per_cell=50.0, max_tile_kb=500)
+        assert bands == [Band(5, 0, None)]
+
+    def test_band_invariants(self):
+        candidates = [4, 6, 8, 10]
+        worst = {lvl: uniform_worst_counts(12 * 4**lvl) for lvl in candidates}
+        bands = select_bands(worst, candidates, bytes_per_cell=100.0, max_tile_kb=500)
+
+        # First band starts at z0; final band is open-ended.
+        assert bands[0].minzoom == 0
+        assert bands[-1].maxzoom is None
+        # Contiguous zoom coverage with no gaps or overlaps.
+        for prev, nxt in zip(bands, bands[1:], strict=False):
+            assert prev.maxzoom is not None
+            assert nxt.minzoom == prev.maxzoom + 1
+        # Monotonically finer levels.
+        levels = [b.level for b in bands]
+        assert levels == sorted(levels)
+        assert len(set(levels)) == len(levels)
+        # Base level is the final band.
+        assert bands[-1].level == candidates[-1]
+
+    def test_bytes_per_cell_override_shifts_transitions(self):
+        candidates = [4, 10]
+        worst = {lvl: uniform_worst_counts(12 * 4**lvl) for lvl in candidates}
+        cheap = select_bands(worst, candidates, bytes_per_cell=100.0, max_tile_kb=500)
+        pricey = select_bands(worst, candidates, bytes_per_cell=400.0, max_tile_kb=500)
+        # More bytes per cell means the fine level only fits at a higher zoom.
+        assert pricey[-1].minzoom > cheap[-1].minzoom
+
+    def test_probe_exhaustion_forces_base_band(self):
+        # Nothing ever fits inside the probed zoom range: the coarsest level
+        # covers the probed zooms and the base still gets an open-ended band.
+        candidates = [2, 9]
+        worst = {
+            2: point_mass_worst_counts(50000, max_zoom=5),
+            9: point_mass_worst_counts(100000, max_zoom=5),
+        }
+        bands = select_bands(worst, candidates, bytes_per_cell=100.0, max_tile_kb=500)
+        assert bands == [Band(2, 0, 5), Band(9, 6, None)]
+
+    def test_explicit_candidates_restrict_selection(self):
+        # Only the passed candidates may appear, even if other levels would fit.
+        candidates = [6, 10]
+        worst = {lvl: uniform_worst_counts(12 * 4**lvl) for lvl in candidates}
+        bands = select_bands(worst, candidates, bytes_per_cell=100.0, max_tile_kb=500)
+        assert {b.level for b in bands} <= {6, 10}
+
+    def test_band_is_frozen(self):
+        band = Band(4, 0, 3)
+        with pytest.raises(AttributeError):
+            band.level = 5
+
+
+class TestEstimateBytesPerCell:
+    def test_geometry_mode_ordering(self):
+        kwargs = {"num_attributes": 3}
+        none = estimate_bytes_per_cell(out_geometry="none", **kwargs)
+        centroid = estimate_bytes_per_cell(out_geometry="centroid", **kwargs)
+        polygon = estimate_bytes_per_cell(out_geometry="polygon", **kwargs)
+        both = estimate_bytes_per_cell(out_geometry="both", **kwargs)
+        assert none < centroid < polygon < both
+
+    def test_more_attributes_cost_more(self):
+        small = estimate_bytes_per_cell(num_attributes=1, out_geometry="polygon")
+        big = estimate_bytes_per_cell(num_attributes=10, out_geometry="polygon")
+        assert big > small
+
+    def test_estimator_sanity_gba_like_schema(self):
+        # Loose regression against recorded GlobalBuildingAtlas measurements:
+        # a5 res-5 z0 tile ~= 297 KB and res-6 z0 ~= 791 KB with all cells kept
+        # in one tile. For plausible res-5/6 populated-cell counts those imply
+        # roughly 25-125 compressed bytes per cell, so a GBA-like schema
+        # (count + 4 numeric rollups, polygon geometry) must land in that
+        # ballpark. Generous tolerance on purpose: this is a conservative
+        # budgeting heuristic, not a codec model -- do not tighten it to match
+        # one dataset.
+        est = estimate_bytes_per_cell(num_attributes=5, out_geometry="polygon")
+        assert 40 <= est <= 160

--- a/tests/test_pmtiles_pyramid.py
+++ b/tests/test_pmtiles_pyramid.py
@@ -485,7 +485,71 @@ class TestMergePyramidMetadata:
         assert reader.get(1, 0, 0) == b"tile-z1"
         assert reader.header()["min_zoom"] == 0
         assert reader.header()["max_zoom"] == 1
-        assert not (tmp_path / "t.pmtiles.meta.tmp").exists()
+        # No temp file strays behind.
+        assert [p.name for p in tmp_path.iterdir()] == ["t.pmtiles"]
+
+    def _write_minimal_archive(self, path):
+        from pmtiles.tile import Compression, TileType, zxy_to_tileid
+        from pmtiles.writer import Writer
+
+        header = {
+            "tile_type": TileType.MVT,
+            "tile_compression": Compression.GZIP,
+            "min_zoom": 0,
+            "max_zoom": 0,
+        }
+        with open(path, "wb") as f:
+            writer = Writer(f)
+            writer.write_tile(zxy_to_tileid(0, 0, 0), b"tile-z0")
+            writer.finalize(header, {"name": "orig"})
+
+    def test_rewrite_never_memory_maps_the_archive(self, tmp_path, monkeypatch):
+        """A live mmap keeps an OS handle on the file, so os.replace fails on
+        Windows. Guards against MmapSource being reintroduced here."""
+        import mmap
+
+        from geoparquet_io.core.pmtiles_pyramid import _merge_pyramid_metadata
+
+        archive = tmp_path / "t.pmtiles"
+        self._write_minimal_archive(archive)
+
+        def forbidden_mmap(*args, **kwargs):
+            raise AssertionError("the metadata rewrite must not mmap the archive")
+
+        monkeypatch.setattr(mmap, "mmap", forbidden_mmap)
+        _merge_pyramid_metadata(str(archive), {"scheme": "a5", "bands": []})
+
+        assert [p.name for p in tmp_path.iterdir()] == ["t.pmtiles"]
+
+    def test_failed_rewrite_cleans_up_temp_file(self, tmp_path, monkeypatch):
+        from pmtiles.writer import Writer
+
+        from geoparquet_io.core.pmtiles_pyramid import _merge_pyramid_metadata
+
+        archive = tmp_path / "t.pmtiles"
+        self._write_minimal_archive(archive)
+        original = archive.read_bytes()
+
+        def boom(self, tileid, data):
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr(Writer, "write_tile", boom)
+        with pytest.raises(OSError, match="No space left"):
+            _merge_pyramid_metadata(str(archive), {"scheme": "a5", "bands": []})
+
+        # The original is untouched and no temp file is stranded.
+        assert [p.name for p in tmp_path.iterdir()] == ["t.pmtiles"]
+        assert archive.read_bytes() == original
+
+    def test_unreadable_archive_strands_nothing(self, tmp_path):
+        from geoparquet_io.core.pmtiles_pyramid import _merge_pyramid_metadata
+
+        archive = tmp_path / "bad.pmtiles"
+        archive.write_bytes(b"this is not a pmtiles archive at all")
+        with pytest.raises(Exception):  # noqa: B017 - any parse failure counts
+            _merge_pyramid_metadata(str(archive), {"scheme": "a5", "bands": []})
+        assert [p.name for p in tmp_path.iterdir()] == ["bad.pmtiles"]
+        assert archive.read_bytes() == b"this is not a pmtiles archive at all"
 
 
 class TestPyramidMetadataPayload:

--- a/tests/test_pmtiles_pyramid.py
+++ b/tests/test_pmtiles_pyramid.py
@@ -1,0 +1,284 @@
+"""Tests for `gpio pmtiles pyramid` (banded multi-level PMTiles archives)."""
+
+import shutil
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.pmtiles_pyramid import (
+    TileJoinNotFoundError,
+    _band_zoom_args,
+    _build_tile_join_command,
+    _feature_layer_name,
+    _layer_name,
+    _resolve_feature_zooms,
+)
+from geoparquet_io.core.process.overview.levels import Band
+
+
+def has_tippecanoe():
+    return shutil.which("tippecanoe") is not None
+
+
+def has_tile_join():
+    return shutil.which("tile-join") is not None
+
+
+def has_gpio():
+    return shutil.which("gpio") is not None
+
+
+# Skip integration tests on Windows (tippecanoe has no native Windows build)
+skip_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="tippecanoe not available on Windows",
+)
+
+
+class TestTileJoinNotFoundError:
+    def test_error_message_content(self):
+        error = TileJoinNotFoundError()
+        message = str(error)
+        assert "tile-join not found" in message
+        assert "tippecanoe" in message
+        assert "brew install tippecanoe" in message
+
+
+class TestLayerNaming:
+    def test_single_mode_uses_output_stem(self):
+        assert _layer_name("single", "a5", 6, "buildings") == "buildings"
+        assert _feature_layer_name("single", "buildings") == "buildings"
+
+    def test_grouped_mode(self):
+        assert _layer_name("grouped", "a5", 6, "buildings") == "aggregate"
+        assert _layer_name("grouped", "h3", 4, "buildings") == "aggregate"
+        assert _feature_layer_name("grouped", "buildings") == "features"
+
+    def test_per_level_mode_grid(self):
+        assert _layer_name("per-level", "a5", 6, "buildings") == "r6"
+        assert _layer_name("per-level", "h3", 10, "x") == "r10"
+
+    def test_per_level_mode_admin(self):
+        assert _layer_name("per-level", "admin", "country", "x") == "country"
+        assert _layer_name("per-level", "admin", "region", "x") == "region"
+
+    def test_per_level_features(self):
+        assert _feature_layer_name("per-level", "x") == "features"
+
+
+class TestBandZoomArgs:
+    def test_bounded_band_passes_through(self):
+        assert _band_zoom_args(Band(5, 2, 4), base_max=10) == (2, 4)
+
+    def test_final_band_uses_base_max(self):
+        assert _band_zoom_args(Band(9, 5, None), base_max=10) == (5, 10)
+
+    def test_final_band_without_base_max(self):
+        assert _band_zoom_args(Band(9, 5, None), base_max=None) == (5, None)
+
+
+class TestFeatureZoomResolution:
+    def test_features_min_defaults_to_base_max_plus_one(self):
+        base_max, feat_min = _resolve_feature_zooms(
+            max_zoom=8, features_min_zoom=None, include_features=True
+        )
+        assert (base_max, feat_min) == (8, 9)
+
+    def test_base_max_derived_from_features_min(self):
+        base_max, feat_min = _resolve_feature_zooms(
+            max_zoom=None, features_min_zoom=9, include_features=True
+        )
+        assert (base_max, feat_min) == (8, 9)
+
+    def test_no_features_passes_max_zoom_through(self):
+        assert _resolve_feature_zooms(None, None, False) == (None, None)
+        assert _resolve_feature_zooms(7, None, False) == (7, None)
+
+    def test_features_without_any_zoom_errors(self):
+        with pytest.raises(InvalidParameterError, match="features"):
+            _resolve_feature_zooms(max_zoom=None, features_min_zoom=None, include_features=True)
+
+
+class TestTileJoinCommand:
+    def test_basic_command(self):
+        cmd = _build_tile_join_command("out.pmtiles", ["a.pmtiles", "b.pmtiles"], name="out")
+        assert cmd[0] == "tile-join"
+        assert cmd[1:3] == ["-o", "out.pmtiles"]
+        assert "-pk" in cmd
+        assert "--name=out" in cmd
+        assert cmd[-2:] == ["a.pmtiles", "b.pmtiles"]
+        assert "--force" not in cmd
+
+    def test_force_and_attribution(self):
+        cmd = _build_tile_join_command(
+            "out.pmtiles",
+            ["a.pmtiles"],
+            name="out",
+            attribution="<a>me</a>",
+            force=True,
+        )
+        assert "--force" in cmd
+        assert "--attribution=<a>me</a>" in cmd
+
+
+class TestParamValidation:
+    def test_include_features_requires_source(self):
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        with pytest.raises(InvalidParameterError, match="features.source|features_source"):
+            create_pmtiles_pyramid("in.parquet", "out.pmtiles", include_features=True, max_zoom=8)
+
+    def test_invalid_layer_mode(self):
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        with pytest.raises(InvalidParameterError, match="layer_mode"):
+            create_pmtiles_pyramid("in.parquet", "out.pmtiles", layer_mode="bogus")
+
+    def test_dangerous_paths_rejected(self):
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        with pytest.raises(ValueError, match="dangerous character"):
+            create_pmtiles_pyramid("in.parquet", "out.pmtiles | cat")
+
+
+class TestCli:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["pmtiles", "pyramid", "--help"])
+        assert result.exit_code == 0
+        for opt in (
+            "--levels",
+            "--max-tile-kb",
+            "--layer-mode",
+            "--include-features",
+            "--features-source",
+            "--features-min-zoom",
+            "--max-zoom",
+        ):
+            assert opt in result.output
+
+
+# ---------------------------------------------------------------------------
+# Integration (tippecanoe + tile-join + DuckDB community extensions)
+# ---------------------------------------------------------------------------
+
+_POINTS = [
+    (2.35, 48.85, 4.0),
+    (2.36, 48.86, 2.0),
+    (13.40, 52.52, 1.5),
+    (13.41, 52.53, 3.5),
+    (-3.70, 40.42, 7.25),
+    (30.0, -10.0, 5.0),
+    (100.5, 13.75, 8.0),
+    (-71.0, -35.0, 6.0),
+]
+
+
+def _write_points(path):
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(f"({lon}, {lat}, {v})" for lon, lat, v in _POINTS)
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry, v
+            FROM (VALUES {values}) AS t(lon, lat, v)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def _read_pyramid_metadata(path):
+    from pmtiles.reader import MmapSource, Reader
+
+    with open(path, "rb") as f:
+        reader = Reader(MmapSource(f))
+        return reader.header(), reader.metadata()
+
+
+integration = pytest.mark.skipif(
+    not (has_gpio() and has_tippecanoe() and has_tile_join()),
+    reason="requires gpio, tippecanoe, and tile-join on PATH",
+)
+
+
+@skip_windows
+@integration
+@pytest.mark.slow
+@pytest.mark.network
+def test_pyramid_end_to_end_grouped(tmp_path):
+    """Aggregate -> pyramid: bands are pinned, joined, and recorded in metadata."""
+    from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+
+    src = tmp_path / "points.parquet"
+    cells = tmp_path / "cells.parquet"
+    out = tmp_path / "cells.pmtiles"
+    _write_points(src)
+    aggregate_by_a5(str(src), str(cells), resolution=7, metric="sum:v")
+
+    # Absurd bytes-per-cell => nothing fits inside the probed range, so the
+    # coarse level takes z0..max_zoom-1 and the base starts at max_zoom.
+    create_pmtiles_pyramid(
+        str(cells),
+        str(out),
+        levels=[5],
+        bytes_per_cell=1e9,
+        max_zoom=3,
+    )
+
+    assert out.exists() and out.stat().st_size > 0
+    header, metadata = _read_pyramid_metadata(out)
+    assert header["min_zoom"] == 0
+    assert header["max_zoom"] == 3
+    pyramid = metadata["gpio:pyramid"]
+    assert pyramid["scheme"] == "a5"
+    assert [band["level"] for band in pyramid["bands"]] == [5, 7]
+    assert pyramid["bands"][0]["minzoom"] == 0
+    assert pyramid["bands"][-1]["maxzoom"] == 3
+    # Grouped (default) mode: all aggregate bands share one layer.
+    layers = {layer["id"] for layer in metadata["vector_layers"]}
+    assert layers == {"aggregate"}
+    assert all(band["layer"] == "aggregate" for band in pyramid["bands"])
+
+
+@skip_windows
+@integration
+@pytest.mark.slow
+@pytest.mark.network
+def test_pyramid_per_level_with_features(tmp_path):
+    from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+
+    src = tmp_path / "points.parquet"
+    cells = tmp_path / "cells.parquet"
+    out = tmp_path / "pyramid.pmtiles"
+    _write_points(src)
+    aggregate_by_a5(str(src), str(cells), resolution=7, metric="sum:v")
+
+    create_pmtiles_pyramid(
+        str(cells),
+        str(out),
+        levels=[5],
+        bytes_per_cell=1e9,
+        max_zoom=3,
+        layer_mode="per-level",
+        include_features=True,
+        features_source=str(src),
+    )
+
+    header, metadata = _read_pyramid_metadata(out)
+    pyramid = metadata["gpio:pyramid"]
+    assert [band["layer"] for band in pyramid["bands"]] == ["r5", "r7", "features"]
+    # Features band starts right after the base band.
+    assert pyramid["bands"][-1]["minzoom"] == 4
+    layers = {layer["id"] for layer in metadata["vector_layers"]}
+    assert {"r5", "r7", "features"} <= layers
+    assert header["min_zoom"] == 0
+    assert header["max_zoom"] >= 4

--- a/tests/test_pmtiles_pyramid.py
+++ b/tests/test_pmtiles_pyramid.py
@@ -319,12 +319,50 @@ class TestOrchestration:
         out = tmp_path / "pyramid.pmtiles"
         _write_admin_region_aggregate(src)
         # Pre-build the sibling like `gpio process overview` would.
-        (sibling,) = [path for _, path in create_overviews(str(src))]
+        (sibling,) = [path for _, path in create_overviews(str(src), levels="country")]
         assert sibling == str(tmp_path / "by_region_country.parquet")
 
         create_pmtiles_pyramid(str(src), str(out), **_BAND_FORCING)
 
         assert fake_tools["tiles"][0]["input"] == sibling
+
+    def test_stale_overview_sibling_is_rebuilt(self, tmp_path, fake_tools):
+        """A sibling older than the input aggregate would bake stale data into
+        the coarse bands; it must be ignored and the level rebuilt."""
+        import os as _os
+
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+        from geoparquet_io.core.process.overview import create_overviews
+
+        src = tmp_path / "by_region.parquet"
+        out = tmp_path / "pyramid.pmtiles"
+        _write_admin_region_aggregate(src)
+        (sibling,) = [path for _, path in create_overviews(str(src), levels="country")]
+        stale = src.stat().st_mtime - 100
+        _os.utime(sibling, (stale, stale))
+
+        create_pmtiles_pyramid(str(src), str(out), **_BAND_FORCING)
+
+        rebuilt = fake_tools["tiles"][0]["input"]
+        assert rebuilt != sibling
+        assert rebuilt.endswith("by_region_country.parquet")
+
+    def test_schema_mismatched_sibling_is_rebuilt(self, tmp_path, fake_tools):
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        src = tmp_path / "by_region.parquet"
+        out = tmp_path / "pyramid.pmtiles"
+        _write_admin_region_aggregate(src)
+        # A sibling from an older aggregate run with different attributes.
+        sibling = tmp_path / "by_region_country.parquet"
+        pq.write_table(pa.table({"admin_code": ["US"], "count": [1]}), sibling)
+
+        create_pmtiles_pyramid(str(src), str(out), **_BAND_FORCING)
+
+        assert fake_tools["tiles"][0]["input"] != str(sibling)
 
     def test_band_planning_capped_by_derived_base_max(self, tmp_path, fake_tools):
         """--include-features --features-min-zoom N without --max-zoom must plan
@@ -396,6 +434,17 @@ class TestOrchestration:
 
 
 class TestPreflightAndErrors:
+    def test_existing_output_errors_without_force(self, tmp_path):
+        """Fail fast on an existing output instead of tiling every band first
+        and only then having tile-join reject it."""
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        out = tmp_path / "pyramid.pmtiles"
+        out.write_bytes(b"existing archive")
+        with pytest.raises(InvalidParameterError, match="force"):
+            create_pmtiles_pyramid("in.parquet", str(out))
+        assert out.read_bytes() == b"existing archive"
+
     def test_missing_tippecanoe(self, monkeypatch):
         import geoparquet_io.core.pmtiles_pyramid as pp
 

--- a/tests/test_pmtiles_pyramid.py
+++ b/tests/test_pmtiles_pyramid.py
@@ -579,7 +579,7 @@ class TestMergePyramidMetadata:
         self._write_minimal_archive(archive)
         original = archive.read_bytes()
 
-        def boom(self, tileid, data):
+        def boom(*args, **kwargs):
             raise OSError("No space left on device")
 
         monkeypatch.setattr(Writer, "write_tile", boom)

--- a/tests/test_pmtiles_pyramid.py
+++ b/tests/test_pmtiles_pyramid.py
@@ -46,6 +46,11 @@ class TestTileJoinNotFoundError:
         assert "tippecanoe" in message
         assert "brew install tippecanoe" in message
 
+    def test_check_tile_join_returns_bool(self):
+        from geoparquet_io.core.pmtiles_pyramid import _check_tile_join
+
+        assert isinstance(_check_tile_join(), bool)
+
 
 class TestLayerNaming:
     def test_single_mode_uses_output_stem(self):
@@ -96,6 +101,9 @@ class TestFeatureZoomResolution:
     def test_no_features_passes_max_zoom_through(self):
         assert _resolve_feature_zooms(None, None, False) == (None, None)
         assert _resolve_feature_zooms(7, None, False) == (7, None)
+
+    def test_both_anchors_given_pass_through(self):
+        assert _resolve_feature_zooms(6, 8, True) == (6, 8)
 
     def test_features_without_any_zoom_errors(self):
         with pytest.raises(InvalidParameterError, match="features"):
@@ -159,6 +167,363 @@ class TestCli:
             "--max-zoom",
         ):
             assert opt in result.output
+
+
+# ---------------------------------------------------------------------------
+# Orchestration (fast: tippecanoe/tile-join/metadata rewrite all faked)
+# ---------------------------------------------------------------------------
+
+
+def _write_admin_region_aggregate(path):
+    """Region-level admin aggregate: two US regions + one FR region."""
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT admin_code, admin_code AS admin_name, count, sum_area,
+                   ST_Buffer(ST_Point(lon, lat), 0.5) AS geometry
+            FROM (VALUES
+                ('US-CA', 2, 10.0, -120.0, 37.0),
+                ('US-NV', 3, 30.0, -116.0, 39.0),
+                ('FR-IDF', 4, 8.0, 2.3, 48.8)
+            ) AS t(admin_code, count, sum_area, lon, lat)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def _write_country_cache(path):
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT country, ST_Buffer(ST_Point(lon, lat), 2.0) AS geometry
+            FROM (VALUES ('US', -118.0, 38.0), ('FR', 2.3, 48.8)) AS t(country, lon, lat)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+@pytest.fixture
+def fake_country_cache(tmp_path, monkeypatch):
+    from geoparquet_io.core.admin_datasets import OvertureAdminDataset
+
+    cache = tmp_path / "country_cache.parquet"
+    _write_country_cache(cache)
+    monkeypatch.setattr(
+        OvertureAdminDataset,
+        "get_source_for_level",
+        lambda self, level, no_cache=False: str(cache),
+    )
+    return cache
+
+
+@pytest.fixture
+def fake_tools(monkeypatch):
+    """Fake out every external tool so orchestration runs without tippecanoe."""
+    from pathlib import Path as _Path
+
+    import geoparquet_io.core.pmtiles_pyramid as pp
+
+    calls = {"tiles": [], "tile_join": [], "metadata": []}
+    monkeypatch.setattr(pp, "_check_tippecanoe", lambda: True)
+    monkeypatch.setattr(pp, "_check_tile_join", lambda: True)
+
+    def fake_tiles(input_path, output_path, **kwargs):
+        calls["tiles"].append({"input": input_path, "output": output_path, **kwargs})
+        _Path(output_path).write_bytes(b"fake pmtiles")
+
+    monkeypatch.setattr(pp, "create_pmtiles_from_geoparquet", fake_tiles)
+    monkeypatch.setattr(pp, "_run_tile_join", lambda cmd, verbose: calls["tile_join"].append(cmd))
+    monkeypatch.setattr(
+        pp,
+        "_merge_pyramid_metadata",
+        lambda path, pyramid: calls["metadata"].append((path, pyramid)),
+    )
+    return calls
+
+
+# With bytes_per_cell=200000 and the 500 KB budget: 2 country cells fit at z0
+# (400 KB) but 3 region cells do not (600 KB); at z1 the worst region tile
+# holds the 2 US regions (400 KB) so the base fits => country [0,0], region
+# [1, None]. Deterministic for the fixture's geography.
+_BAND_FORCING = {"bytes_per_cell": 200000.0, "max_zoom": 6}
+
+
+@pytest.mark.usefixtures("fake_country_cache")
+class TestOrchestration:
+    def test_admin_pyramid_bands_layers_and_metadata(self, tmp_path, fake_tools):
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        src = tmp_path / "by_region.parquet"
+        out = tmp_path / "pyramid.pmtiles"
+        _write_admin_region_aggregate(src)
+
+        create_pmtiles_pyramid(str(src), str(out), layer_mode="per-level", **_BAND_FORCING)
+
+        tiles = fake_tools["tiles"]
+        assert [t["layer"] for t in tiles] == ["country", "region"]
+        assert (tiles[0]["min_zoom"], tiles[0]["max_zoom"]) == (0, 0)
+        assert (tiles[1]["min_zoom"], tiles[1]["max_zoom"]) == (1, 6)
+        # The country band was built on the fly (no sibling existed).
+        assert tiles[0]["input"].endswith("by_region_country.parquet")
+        assert tiles[0]["input"] != str(tmp_path / "by_region_country.parquet")
+        # The base band tiles the input itself.
+        assert tiles[1]["input"] == str(src)
+        # Aggregate bands are exempt from the size cap (bands were chosen to fit).
+        assert all(t["no_tile_size_limit"] is True for t in tiles)
+
+        (cmd,) = fake_tools["tile_join"]
+        assert cmd[0] == "tile-join"
+        assert cmd[1:3] == ["-o", str(out)]
+        assert "--name=pyramid" in cmd
+        assert len([arg for arg in cmd if arg.endswith(".pmtiles") and arg != str(out)]) == 2
+
+        ((meta_path, pyramid),) = fake_tools["metadata"]
+        assert meta_path == str(out)
+        assert pyramid["scheme"] == "admin"
+        assert [band["level"] for band in pyramid["bands"]] == ["country", "region"]
+        assert pyramid["bands"][0] == {
+            "level": "country",
+            "layer": "country",
+            "minzoom": 0,
+            "maxzoom": 0,
+        }
+        assert pyramid["bands"][1]["maxzoom"] == 6
+
+    def test_existing_overview_sibling_is_reused(self, tmp_path, fake_tools):
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+        from geoparquet_io.core.process.overview import create_overviews
+
+        src = tmp_path / "by_region.parquet"
+        out = tmp_path / "pyramid.pmtiles"
+        _write_admin_region_aggregate(src)
+        # Pre-build the sibling like `gpio process overview` would.
+        (sibling,) = [path for _, path in create_overviews(str(src))]
+        assert sibling == str(tmp_path / "by_region_country.parquet")
+
+        create_pmtiles_pyramid(str(src), str(out), **_BAND_FORCING)
+
+        assert fake_tools["tiles"][0]["input"] == sibling
+
+    def test_grouped_mode_with_features(self, tmp_path, fake_tools):
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        src = tmp_path / "by_region.parquet"
+        features = tmp_path / "features.parquet"
+        out = tmp_path / "pyramid.pmtiles"
+        _write_admin_region_aggregate(src)
+        features.write_bytes(b"")  # never read: tiling is faked
+
+        create_pmtiles_pyramid(
+            str(src),
+            str(out),
+            include_features=True,
+            features_source=str(features),
+            **_BAND_FORCING,
+        )
+
+        tiles = fake_tools["tiles"]
+        assert [t["layer"] for t in tiles] == ["aggregate", "aggregate", "features"]
+        feat = tiles[-1]
+        assert feat["input"] == str(features)
+        assert feat["min_zoom"] == 7  # base max (6) + 1
+        assert feat["max_zoom"] is None
+        # The features band keeps tippecanoe's cap so drop-densest applies.
+        assert feat["no_tile_size_limit"] is False
+        assert feat["drop_densest_as_needed"] is True
+
+        ((_, pyramid),) = fake_tools["metadata"]
+        assert pyramid["bands"][-1] == {
+            "level": "features",
+            "layer": "features",
+            "minzoom": 7,
+            "maxzoom": None,
+        }
+        assert len(fake_tools["tile_join"][0]) >= 3
+
+
+class TestPreflightAndErrors:
+    def test_missing_tippecanoe(self, monkeypatch):
+        import geoparquet_io.core.pmtiles_pyramid as pp
+
+        monkeypatch.setattr(pp, "_check_tippecanoe", lambda: False)
+        from geoparquet_io.core.pmtiles import TippecanoeNotFoundError
+
+        with pytest.raises(TippecanoeNotFoundError):
+            pp.create_pmtiles_pyramid("in.parquet", "out.pmtiles")
+
+    def test_missing_tile_join(self, monkeypatch):
+        import geoparquet_io.core.pmtiles_pyramid as pp
+
+        monkeypatch.setattr(pp, "_check_tippecanoe", lambda: True)
+        monkeypatch.setattr(pp, "_check_tile_join", lambda: False)
+        with pytest.raises(TileJoinNotFoundError):
+            pp.create_pmtiles_pyramid("in.parquet", "out.pmtiles")
+
+    def test_aggregate_without_geometry_errors(self, tmp_path, monkeypatch):
+        import duckdb
+
+        import geoparquet_io.core.pmtiles_pyramid as pp
+
+        monkeypatch.setattr(pp, "_check_tippecanoe", lambda: True)
+        monkeypatch.setattr(pp, "_check_tile_join", lambda: True)
+        src = tmp_path / "by_region.parquet"
+        con = duckdb.connect()
+        con.execute(f"COPY (SELECT 'US-CA' AS admin_code, 1 AS count) TO '{src}' (FORMAT PARQUET)")
+        con.close()
+        with pytest.raises(InvalidParameterError, match="geometry"):
+            pp.create_pmtiles_pyramid(str(src), str(tmp_path / "o.pmtiles"))
+
+
+class TestRunTileJoin:
+    class _FakeProc:
+        def __init__(self, returncode, stderr=""):
+            self.returncode = returncode
+            self.stderr = stderr
+
+    def test_failure_raises_with_stderr(self, monkeypatch):
+        import geoparquet_io.core.pmtiles_pyramid as pp
+
+        monkeypatch.setattr(pp.subprocess, "run", lambda *a, **k: self._FakeProc(1, "boom\n"))
+        with pytest.raises(RuntimeError, match="(?s)tile-join failed.*boom") as exc:
+            pp._run_tile_join(["tile-join", "-o", "x"], verbose=False)
+        assert "exit code 1" in str(exc.value)
+
+    def test_success_logs_stderr_when_verbose(self, monkeypatch):
+        import geoparquet_io.core.pmtiles_pyramid as pp
+
+        monkeypatch.setattr(
+            pp.subprocess, "run", lambda *a, **k: self._FakeProc(0, "joined 2 tilesets\n")
+        )
+        pp._run_tile_join(["tile-join", "-o", "x"], verbose=True)  # must not raise
+
+
+class TestMergePyramidMetadata:
+    def test_roundtrip_preserves_tiles_and_merges_key(self, tmp_path):
+        from pmtiles.reader import MmapSource, Reader
+        from pmtiles.tile import Compression, TileType, zxy_to_tileid
+        from pmtiles.writer import Writer
+
+        from geoparquet_io.core.pmtiles_pyramid import _merge_pyramid_metadata
+
+        archive = tmp_path / "t.pmtiles"
+        header = {
+            "tile_type": TileType.MVT,
+            "tile_compression": Compression.GZIP,
+            "min_zoom": 0,
+            "max_zoom": 1,
+        }
+        with open(archive, "wb") as f:
+            writer = Writer(f)
+            writer.write_tile(zxy_to_tileid(0, 0, 0), b"tile-z0")
+            writer.write_tile(zxy_to_tileid(1, 0, 0), b"tile-z1")
+            writer.finalize(header, {"name": "orig", "vector_layers": []})
+
+        pyramid = {"scheme": "a5", "bands": [{"level": 5, "minzoom": 0, "maxzoom": 3}]}
+        _merge_pyramid_metadata(str(archive), pyramid)
+
+        with open(archive, "rb") as f:
+            reader = Reader(MmapSource(f))
+            metadata = reader.metadata()
+            assert metadata["gpio:pyramid"] == pyramid
+            assert metadata["name"] == "orig"  # existing metadata preserved
+            assert reader.get(0, 0, 0) == b"tile-z0"
+            assert reader.get(1, 0, 0) == b"tile-z1"
+            assert reader.header()["min_zoom"] == 0
+            assert reader.header()["max_zoom"] == 1
+        assert not (tmp_path / "t.pmtiles.meta.tmp").exists()
+
+
+class TestPyramidMetadataPayload:
+    def test_bands_and_features_entries(self):
+        from geoparquet_io.core.pmtiles_pyramid import _pyramid_metadata
+        from geoparquet_io.core.process.overview.detect import AggregateInfo
+
+        info = AggregateInfo(
+            scheme="a5",
+            cell_column="a5_cell",
+            base_level=10,
+            rollup_columns=(),
+            out_geometry="polygon",
+        )
+        bands = [Band(6, 0, 4), Band(10, 5, None)]
+        payload = _pyramid_metadata(info, bands, 8, "per-level", "out", features_min_zoom=9)
+        assert payload["scheme"] == "a5"
+        assert payload["bands"] == [
+            {"level": 6, "layer": "r6", "minzoom": 0, "maxzoom": 4},
+            {"level": 10, "layer": "r10", "minzoom": 5, "maxzoom": 8},
+            {"level": "features", "layer": "features", "minzoom": 9, "maxzoom": None},
+        ]
+
+    def test_no_features_entry_without_min_zoom(self):
+        from geoparquet_io.core.pmtiles_pyramid import _pyramid_metadata
+        from geoparquet_io.core.process.overview.detect import AggregateInfo
+
+        info = AggregateInfo(
+            scheme="admin",
+            cell_column="admin_code",
+            base_level="region",
+            rollup_columns=(),
+            out_geometry="polygon",
+        )
+        payload = _pyramid_metadata(
+            info, [Band("region", 0, None)], None, "grouped", "x", features_min_zoom=None
+        )
+        assert [band["level"] for band in payload["bands"]] == ["region"]
+        assert payload["bands"][0]["maxzoom"] is None
+
+
+class TestApiAndCliWrappers:
+    def test_ops_wrapper_passes_through(self, monkeypatch):
+        import geoparquet_io.core.pmtiles_pyramid as pp
+        from geoparquet_io.api import ops
+
+        recorded = {}
+
+        def fake(input_path, output_path, **kwargs):
+            recorded["input"] = input_path
+            recorded["output"] = output_path
+            recorded.update(kwargs)
+
+        monkeypatch.setattr(pp, "create_pmtiles_pyramid", fake)
+        ops.create_pmtiles_pyramid(
+            "cells.parquet", "out.pmtiles", levels=[5], layer_mode="single", max_zoom=9
+        )
+        assert recorded["input"] == "cells.parquet"
+        assert recorded["output"] == "out.pmtiles"
+        assert recorded["levels"] == [5]
+        assert recorded["layer_mode"] == "single"
+        assert recorded["max_zoom"] == 9
+
+    def test_cli_success(self, monkeypatch):
+        import geoparquet_io.core.pmtiles_pyramid as pp
+
+        monkeypatch.setattr(pp, "create_pmtiles_pyramid", lambda *a, **k: None)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["pmtiles", "pyramid", "in.parquet", "out.pmtiles"])
+        assert result.exit_code == 0, result.output
+        assert "Created out.pmtiles" in result.output
+
+    def test_cli_error_becomes_click_exception(self, monkeypatch):
+        import geoparquet_io.core.pmtiles_pyramid as pp
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("tile-join failed with exit code 1")
+
+        monkeypatch.setattr(pp, "create_pmtiles_pyramid", boom)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["pmtiles", "pyramid", "in.parquet", "out.pmtiles"])
+        assert result.exit_code != 0
+        assert "tile-join failed" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pmtiles_pyramid.py
+++ b/tests/test_pmtiles_pyramid.py
@@ -109,6 +109,18 @@ class TestFeatureZoomResolution:
         with pytest.raises(InvalidParameterError, match="features"):
             _resolve_feature_zooms(max_zoom=None, features_min_zoom=None, include_features=True)
 
+    def test_features_min_zoom_zero_errors(self):
+        # Deriving base_max = -1 would hand tippecanoe `-z -1`.
+        with pytest.raises(InvalidParameterError, match="features_min_zoom"):
+            _resolve_feature_zooms(max_zoom=None, features_min_zoom=0, include_features=True)
+
+    def test_features_min_zoom_not_above_max_zoom_errors(self):
+        # Overlapping bands would double-render zooms into both bands.
+        with pytest.raises(InvalidParameterError, match="features_min_zoom"):
+            _resolve_feature_zooms(max_zoom=8, features_min_zoom=8, include_features=True)
+        with pytest.raises(InvalidParameterError, match="features_min_zoom"):
+            _resolve_feature_zooms(max_zoom=8, features_min_zoom=5, include_features=True)
+
 
 class TestTileJoinCommand:
     def test_basic_command(self):
@@ -313,6 +325,38 @@ class TestOrchestration:
         create_pmtiles_pyramid(str(src), str(out), **_BAND_FORCING)
 
         assert fake_tools["tiles"][0]["input"] == sibling
+
+    def test_band_planning_capped_by_derived_base_max(self, tmp_path, fake_tools):
+        """--include-features --features-min-zoom N without --max-zoom must plan
+        bands against the derived base max (N-1), not the full probe range --
+        otherwise the base band can invert (minzoom > maxzoom) and intermediate
+        bands overlap the features band."""
+        from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid
+
+        src = tmp_path / "by_region.parquet"
+        features = tmp_path / "features.parquet"
+        out = tmp_path / "pyramid.pmtiles"
+        _write_admin_region_aggregate(src)
+        features.write_bytes(b"")  # never read: tiling is faked
+
+        create_pmtiles_pyramid(
+            str(src),
+            str(out),
+            bytes_per_cell=1e9,  # nothing fits: coarse band stretches to the cap
+            include_features=True,
+            features_source=str(features),
+            features_min_zoom=3,
+        )
+
+        tiles = fake_tools["tiles"]
+        assert [t["layer"] for t in tiles] == ["aggregate", "aggregate", "features"]
+        # Derived base max is 2: the country band ends at 1, the base region
+        # band gets exactly zoom 2, and the features band starts at 3.
+        assert (tiles[0]["min_zoom"], tiles[0]["max_zoom"]) == (0, 1)
+        assert (tiles[1]["min_zoom"], tiles[1]["max_zoom"]) == (2, 2)
+        assert tiles[2]["min_zoom"] == 3
+        for tile in tiles[:2]:
+            assert tile["min_zoom"] <= tile["max_zoom"]
 
     def test_grouped_mode_with_features(self, tmp_path, fake_tools):
         from geoparquet_io.core.pmtiles_pyramid import create_pmtiles_pyramid

--- a/tests/test_pmtiles_pyramid.py
+++ b/tests/test_pmtiles_pyramid.py
@@ -409,7 +409,7 @@ class TestRunTileJoin:
 
 class TestMergePyramidMetadata:
     def test_roundtrip_preserves_tiles_and_merges_key(self, tmp_path):
-        from pmtiles.reader import MmapSource, Reader
+        from pmtiles.reader import MemorySource, Reader
         from pmtiles.tile import Compression, TileType, zxy_to_tileid
         from pmtiles.writer import Writer
 
@@ -431,15 +431,16 @@ class TestMergePyramidMetadata:
         pyramid = {"scheme": "a5", "bands": [{"level": 5, "minzoom": 0, "maxzoom": 3}]}
         _merge_pyramid_metadata(str(archive), pyramid)
 
-        with open(archive, "rb") as f:
-            reader = Reader(MmapSource(f))
-            metadata = reader.metadata()
-            assert metadata["gpio:pyramid"] == pyramid
-            assert metadata["name"] == "orig"  # existing metadata preserved
-            assert reader.get(0, 0, 0) == b"tile-z0"
-            assert reader.get(1, 0, 0) == b"tile-z1"
-            assert reader.header()["min_zoom"] == 0
-            assert reader.header()["max_zoom"] == 1
+        # MemorySource (not MmapSource): an mmap would keep the file locked
+        # on Windows until GC, breaking tmp_path cleanup.
+        reader = Reader(MemorySource(archive.read_bytes()))
+        metadata = reader.metadata()
+        assert metadata["gpio:pyramid"] == pyramid
+        assert metadata["name"] == "orig"  # existing metadata preserved
+        assert reader.get(0, 0, 0) == b"tile-z0"
+        assert reader.get(1, 0, 0) == b"tile-z1"
+        assert reader.header()["min_zoom"] == 0
+        assert reader.header()["max_zoom"] == 1
         assert not (tmp_path / "t.pmtiles.meta.tmp").exists()
 
 
@@ -560,11 +561,14 @@ def _write_points(path):
 
 
 def _read_pyramid_metadata(path):
-    from pmtiles.reader import MmapSource, Reader
+    """Read header + metadata via MemorySource: no mmap, so no lingering
+    file lock on Windows (an mmap survives its file object until GC)."""
+    from pathlib import Path as _Path
 
-    with open(path, "rb") as f:
-        reader = Reader(MmapSource(f))
-        return reader.header(), reader.metadata()
+    from pmtiles.reader import MemorySource, Reader
+
+    reader = Reader(MemorySource(_Path(path).read_bytes()))
+    return reader.header(), reader.metadata()
 
 
 integration = pytest.mark.skipif(

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -899,6 +899,21 @@ class TestAdminRollup:
         with pytest.raises(InvalidParameterError, match="country"):
             create_overviews(str(src), levels="province")
 
+    def test_existing_output_errors_without_force(self, tmp_path):
+        """Like pmtiles pyramid, refuse to silently overwrite derived sibling
+        files the user never named unless --force is given."""
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        (result,) = create_overviews(str(src), levels="country")
+        first_bytes = Path(result[1]).read_bytes()
+
+        with pytest.raises(InvalidParameterError, match="force"):
+            create_overviews(str(src), levels="country")
+        assert Path(result[1]).read_bytes() == first_bytes  # untouched
+
+        forced = create_overviews(str(src), levels="country", force=True)
+        assert forced == [result]
+
 
 # ---------------------------------------------------------------------------
 # CLI

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -634,7 +634,7 @@ class TestRollupSqlBuilders:
         sql = build_admin_rollup_sql(
             _admin_info(), "SELECT * FROM s", "read_parquet('c.parquet')", '"country"', "geometry"
         )
-        assert "split_part(admin_code, '-', 1)" in sql
+        assert "split_part(\"admin_code\", '-', 1)" in sql
         assert "'unassigned'" in sql  # unassigned passes through
         assert "ST_Union_Agg" in sql  # multi-row countries are unioned
         assert "LEFT JOIN" in sql
@@ -651,6 +651,52 @@ class TestRollupSqlBuilders:
             _admin_info("both"), "SELECT * FROM s", "read_parquet('c')", '"country"', "g"
         )
         assert "AS centroid" in both
+
+    def test_admin_rollup_sql_respects_cell_column(self):
+        from geoparquet_io.core.process.overview.detect import AggregateInfo
+        from geoparquet_io.core.process.overview.rollup import build_admin_rollup_sql
+
+        info = AggregateInfo(
+            scheme="admin",
+            cell_column="region_code",
+            base_level="region",
+            rollup_columns=(),
+            out_geometry="polygon",
+        )
+        sql = build_admin_rollup_sql(
+            info, "SELECT * FROM s", "read_parquet('c.parquet')", '"country"', "geometry"
+        )
+        assert "split_part(\"region_code\", '-', 1)" in sql
+        assert '__parent AS "region_code"' in sql
+        assert 'r."region_code" = c.__country_code' in sql
+        assert "admin_code" not in sql
+
+    def test_admin_probe_sql_respects_cell_column(self, tmp_path):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.process.overview.detect import detect_aggregate_info
+        from geoparquet_io.core.process.overview.run import _admin_cells_probe_sql
+
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        renamed = tmp_path / "renamed.parquet"
+        table = pq.read_table(src)
+        table = table.rename_columns(
+            ["region_code" if n == "admin_code" else n for n in table.column_names]
+        )
+        pq.write_table(table, renamed)
+
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            relation = f"read_parquet('{renamed}')"
+            info = detect_aggregate_info(con, relation, cell_column="region_code")
+            source_sql = f"SELECT * FROM {relation}"
+            for level in ("region", "country"):
+                sql = _admin_cells_probe_sql(con, info, source_sql, level)
+                assert "admin_code" not in sql
+                rows = con.execute(sql).fetchall()
+                assert rows  # executes cleanly against the renamed column
+        finally:
+            con.close()
 
     def test_admin_rollup_sql_none_geometry_skips_join(self):
         from geoparquet_io.core.process.overview.rollup import (
@@ -818,6 +864,28 @@ class TestAdminRollup:
         # Assigned countries got a (unioned) polygon.
         assert col("geometry", "US") is not None
         assert col("geometry", "FR") is not None
+
+    def test_custom_cell_column_rollup(self, tmp_path):
+        """--cell-column region_code must drive the whole rollup, not just
+        detection (the parent expr, output column, and country join)."""
+        src = tmp_path / "orig.parquet"
+        renamed = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        table = pq.read_table(src)
+        table = table.rename_columns(
+            ["region_code" if n == "admin_code" else n for n in table.column_names]
+        )
+        pq.write_table(table, renamed)
+
+        results = create_overviews(str(renamed), levels="country", cell_column="region_code")
+        out = pq.read_table(results[0][1])
+        assert "region_code" in out.column_names
+        assert "admin_code" not in out.column_names
+        rows = {code: i for i, code in enumerate(out.column("region_code").to_pylist())}
+        assert set(rows) == {"US", "FR", "unassigned"}
+        assert out.column("count")[rows["US"]].as_py() == 5
+        # The country join keyed on the custom column still attaches geometry.
+        assert out.column("geometry")[rows["US"]].as_py() is not None
 
     def test_explicit_levels_country(self, tmp_path):
         src = tmp_path / "by_region.parquet"

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -1,0 +1,470 @@
+"""Tests for `gpio process overview` (aggregate rollups to coarser levels)."""
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.admin_datasets import OvertureAdminDataset
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.process.overview import create_overviews
+from geoparquet_io.core.process.overview.detect import detect_aggregate_file
+from geoparquet_io.core.process.overview.run import overview_output_path
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_admin_region_aggregate(path, with_geometry=True, extra_column=False):
+    """A tiny region-level `process aggregate admin` output.
+
+    Rows: two US regions, one FR region, and an 'unassigned' bucket.
+    """
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    extra_col = ", 'x' AS notes" if extra_column else ""
+    geom_col = (
+        ", CASE WHEN admin_code = 'unassigned' THEN NULL "
+        "ELSE ST_Buffer(ST_Point(lon, lat), 0.5) END AS geometry"
+        if with_geometry
+        else ""
+    )
+    con.execute(
+        f"""
+        COPY (
+            SELECT admin_code, admin_code AS admin_name, count, sum_area,
+                   avg_height, min_year, max_year, count_barn, count_other
+                   {extra_col}{geom_col}
+            FROM (VALUES
+                ('US-CA', 2, 10.0, 4.0, 1990, 2000, 1, 1, -120.0, 37.0),
+                ('US-NV', 3, 30.0, 6.0, 1980, 1995, 2, 1, -116.0, 39.0),
+                ('FR-IDF', 4, 8.0, 2.5, 2001, 2020, 0, 4, 2.3, 48.8),
+                ('unassigned', 1, 1.0, 1.0, 1970, 1970, 0, 1, 0.0, 0.0)
+            ) AS t(admin_code, count, sum_area, avg_height, min_year,
+                   max_year, count_barn, count_other, lon, lat)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def _write_country_cache(path):
+    """A fake Overture per-level country cache (US split in two rows, FR in one)."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT country, 'country' AS subtype,
+                   ST_Buffer(ST_Point(lon, lat), 2.0) AS geometry
+            FROM (VALUES
+                ('US', -120.0, 37.0),
+                ('US', -116.0, 39.0),
+                ('FR', 2.3, 48.8)
+            ) AS t(country, lon, lat)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+@pytest.fixture
+def fake_country_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "country_cache.parquet"
+    _write_country_cache(cache)
+    monkeypatch.setattr(
+        OvertureAdminDataset,
+        "get_source_for_level",
+        lambda self, level, no_cache=False: str(cache),
+    )
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetection:
+    def test_no_cell_column_errors_with_hint(self, tmp_path):
+        path = tmp_path / "plain.parquet"
+        pq.write_table(pa.table({"id": [1, 2], "count": [3, 4]}), path)
+        with pytest.raises(InvalidParameterError, match="cell-column"):
+            detect_aggregate_file(str(path))
+
+    def test_missing_count_column_errors(self, tmp_path):
+        path = tmp_path / "no_count.parquet"
+        pq.write_table(pa.table({"admin_code": ["US-CA"], "sum_area": [1.0]}), path)
+        with pytest.raises(InvalidParameterError, match="count"):
+            detect_aggregate_file(str(path))
+
+    def test_admin_region_aggregate_detected(self, tmp_path):
+        path = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(path)
+        info = detect_aggregate_file(str(path))
+        assert info.scheme == "admin"
+        assert info.cell_column == "admin_code"
+        assert info.base_level == "region"
+        assert info.out_geometry == "polygon"
+        roles = {c.name: c.func for c in info.rollup_columns}
+        assert roles == {
+            "sum_area": "sum",
+            "avg_height": "avg",
+            "min_year": "min",
+            "max_year": "max",
+            "count_barn": "sum",
+            "count_other": "sum",
+        }
+
+    def test_admin_country_level_input_errors(self, tmp_path):
+        path = tmp_path / "by_country.parquet"
+        pq.write_table(
+            pa.table({"admin_code": ["US", "FR", "unassigned"], "count": [1, 2, 3]}),
+            path,
+        )
+        with pytest.raises(InvalidParameterError, match="country level"):
+            detect_aggregate_file(str(path))
+
+    def test_unclassifiable_columns_are_dropped(self, tmp_path):
+        path = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(path, extra_column=True)
+        info = detect_aggregate_file(str(path))
+        assert "notes" in info.dropped_columns
+        assert "notes" not in {c.name for c in info.rollup_columns}
+
+    def test_no_geometry_infers_none(self, tmp_path):
+        path = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(path, with_geometry=False)
+        info = detect_aggregate_file(str(path))
+        assert info.out_geometry == "none"
+
+
+# ---------------------------------------------------------------------------
+# Output naming
+# ---------------------------------------------------------------------------
+
+
+class TestOutputNaming:
+    def test_grid_naming(self):
+        assert overview_output_path("/x/cells.parquet", "a5", 7) == "/x/cells_r7.parquet"
+        assert overview_output_path("/x/cells.parquet", "h3", 4) == "/x/cells_r4.parquet"
+
+    def test_admin_naming(self):
+        assert (
+            overview_output_path("/x/by_region.parquet", "admin", "country")
+            == "/x/by_region_country.parquet"
+        )
+
+    def test_output_dir_override(self):
+        assert overview_output_path("/x/cells.parquet", "a5", 4, output_dir="/y") == (
+            "/y/cells_r4.parquet"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Admin rollup (fast: fake country cache, no network)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("fake_country_cache")
+class TestAdminRollup:
+    def test_region_to_country_rollup(self, tmp_path):
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+
+        results = create_overviews(str(src))
+        assert results == [("country", str(tmp_path / "by_region_country.parquet"))]
+
+        table = pq.read_table(results[0][1])
+        rows = {code: i for i, code in enumerate(table.column("admin_code").to_pylist())}
+        assert set(rows) == {"US", "FR", "unassigned"}
+
+        def col(name, code):
+            return table.column(name)[rows[code]].as_py()
+
+        # Exact rollups.
+        assert col("count", "US") == 5
+        assert col("sum_area", "US") == pytest.approx(40.0)
+        assert col("min_year", "US") == 1980
+        assert col("max_year", "US") == 2000
+        assert col("count_barn", "US") == 3
+        assert col("count_other", "US") == 2
+        # Count-weighted average: (2*4.0 + 3*6.0) / 5.
+        assert col("avg_height", "US") == pytest.approx(5.2)
+        assert col("count", "FR") == 4
+        assert col("avg_height", "FR") == pytest.approx(2.5)
+        # admin_name mirrors the country code at this level.
+        assert col("admin_name", "US") == "US"
+        # Unassigned bucket passes through with NULL geometry.
+        assert col("count", "unassigned") == 1
+        assert col("geometry", "unassigned") is None
+        # Assigned countries got a (unioned) polygon.
+        assert col("geometry", "US") is not None
+        assert col("geometry", "FR") is not None
+
+    def test_explicit_levels_country(self, tmp_path):
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        results = create_overviews(str(src), levels="country")
+        assert [lvl for lvl, _ in results] == ["country"]
+
+    def test_invalid_admin_level_errors(self, tmp_path):
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        with pytest.raises(InvalidParameterError, match="country"):
+            create_overviews(str(src), levels="province")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["process", "overview", "--help"])
+        assert result.exit_code == 0
+        for opt in ("--levels", "--max-tile-kb", "--bytes-per-cell", "--cell-column"):
+            assert opt in result.output
+
+    @pytest.mark.usefixtures("fake_country_cache")
+    def test_cli_admin_rollup(self, tmp_path):
+        src = tmp_path / "by_region.parquet"
+        outdir = tmp_path / "out"
+        outdir.mkdir()
+        _write_admin_region_aggregate(src)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["process", "overview", str(src), "--output-dir", str(outdir)])
+        assert result.exit_code == 0, result.output
+        assert (outdir / "by_region_country.parquet").exists()
+
+    def test_cli_bad_input_errors_cleanly(self, tmp_path):
+        path = tmp_path / "plain.parquet"
+        pq.write_table(pa.table({"id": [1]}), path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["process", "overview", str(path)])
+        assert result.exit_code != 0
+        assert "cell-column" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Grid gold rollups (slow: DuckDB community extensions)
+# ---------------------------------------------------------------------------
+
+_GOLD_POINTS = [
+    # Clusters around three cities plus outliers, with crop + area attributes.
+    (2.35, 48.85, "wheat", 4.0),
+    (2.36, 48.86, "corn", 2.0),
+    (2.37, 48.84, "wheat", 6.5),
+    (13.40, 52.52, "corn", 1.5),
+    (13.41, 52.53, "corn", 3.5),
+    (13.39, 52.51, "soy", 9.0),
+    (-3.70, 40.42, "wheat", 7.25),
+    (-3.71, 40.41, "soy", 0.75),
+    (30.0, -10.0, "wheat", 5.0),
+    (100.5, 13.75, "soy", 8.0),
+]
+
+_GOLD_METRIC = "sum:area,avg:area,min:area,max:area"
+
+
+def _write_points_geoparquet(path, rows):
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    values = ", ".join(f"({lon}, {lat}, '{crop}', {area})" for lon, lat, crop, area in rows)
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(lon, lat) AS geometry, crop, area
+            FROM (VALUES {values}) AS t(lon, lat, crop, area)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+def _assert_rollup_matches_direct(rolled_path, direct_path, cell_column):
+    rolled = pq.read_table(rolled_path)
+    direct = pq.read_table(direct_path)
+    assert rolled.num_rows == direct.num_rows
+
+    def by_cell(table):
+        cells = table.column(cell_column).to_pylist()
+        return {
+            c: {n: table.column(n)[i].as_py() for n in table.column_names}
+            for i, c in enumerate(cells)
+        }
+
+    rolled_rows = by_cell(rolled)
+    direct_rows = by_cell(direct)
+    assert set(rolled_rows) == set(direct_rows)
+    compare_cols = [
+        n for n in direct.column_names if n.startswith(("count", "sum_", "avg_", "min_", "max_"))
+    ]
+    assert compare_cols  # sanity: the fixture exercised every rollup kind
+    for cell, expect in direct_rows.items():
+        got = rolled_rows[cell]
+        for name in compare_cols:
+            if name.startswith("avg_"):
+                assert got[name] == pytest.approx(expect[name]), (cell, name)
+            else:
+                assert got[name] == expect[name], (cell, name)
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_gold_rollup_a5(tmp_path):
+    """Rolling res-7 cells up to res 5 must equal aggregating raw data at res 5."""
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+
+    src = tmp_path / "points.parquet"
+    base = tmp_path / "cells.parquet"
+    direct = tmp_path / "direct_r5.parquet"
+    _write_points_geoparquet(src, _GOLD_POINTS)
+    kwargs = {"metric": _GOLD_METRIC, "breakdown": "crop", "out_geometry": "both"}
+    aggregate_by_a5(str(src), str(base), resolution=7, **kwargs)
+    aggregate_by_a5(str(src), str(direct), resolution=5, **kwargs)
+
+    results = create_overviews(str(base), levels=[5])
+    assert results == [(5, str(tmp_path / "cells_r5.parquet"))]
+    _assert_rollup_matches_direct(results[0][1], str(direct), "a5_cell")
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_gold_rollup_h3(tmp_path):
+    """H3 hexagons do not nest exactly, so a point near a cell edge can have a
+    res-7 cell whose res-5 *ancestor* differs from the point's direct res-5
+    cell. The rollup follows the true hierarchy (h3_cell_to_parent), so the
+    gold expectation here is computed hierarchy-faithfully in SQL: key every
+    raw point by parent-of-its-res-7-cell, then aggregate. This also proves
+    the count-weighted avg equals the true mean when the metric has no NULLs.
+    """
+    from geoparquet_io.core.process.aggregate.by_h3 import aggregate_by_h3
+
+    src = tmp_path / "points.parquet"
+    base = tmp_path / "cells.parquet"
+    _write_points_geoparquet(src, _GOLD_POINTS)
+    kwargs = {"metric": _GOLD_METRIC, "breakdown": "crop", "out_geometry": "both"}
+    aggregate_by_h3(str(src), str(base), resolution=7, **kwargs)
+
+    results = create_overviews(str(base), levels="5")
+    assert results == [(5, str(tmp_path / "cells_r5.parquet"))]
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial")
+    con.execute("INSTALL h3 FROM community; LOAD h3")
+    expected_rows = con.execute(
+        f"""
+        SELECT h3_cell_to_parent(
+                   h3_latlng_to_cell_string(ST_Y(geometry), ST_X(geometry), 7), 5
+               ) AS h3_cell,
+               COUNT(*) AS count,
+               SUM(area) AS sum_area,
+               AVG(area) AS avg_area,
+               MIN(area) AS min_area,
+               MAX(area) AS max_area,
+               COUNT(*) FILTER (WHERE crop = 'wheat') AS count_wheat,
+               COUNT(*) FILTER (WHERE crop = 'corn') AS count_corn,
+               COUNT(*) FILTER (WHERE crop = 'soy') AS count_soy
+        FROM read_parquet('{src}')
+        GROUP BY 1
+        """
+    ).fetchall()
+    columns = [
+        "h3_cell",
+        "count",
+        "sum_area",
+        "avg_area",
+        "min_area",
+        "max_area",
+        "count_wheat",
+        "count_corn",
+        "count_soy",
+    ]
+    expected = {row[0]: dict(zip(columns, row, strict=True)) for row in expected_rows}
+    con.close()
+
+    rolled = pq.read_table(results[0][1])
+    assert rolled.num_rows == len(expected)
+    cells = rolled.column("h3_cell").to_pylist()
+    assert set(cells) == set(expected)
+    for i, cell in enumerate(cells):
+        for name in columns[1:]:
+            got = rolled.column(name)[i].as_py()
+            if name == "avg_area":
+                assert got == pytest.approx(expected[cell][name]), (cell, name)
+            else:
+                assert got == expected[cell][name], (cell, name)
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_level_not_coarser_than_base_errors(tmp_path):
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+
+    src = tmp_path / "points.parquet"
+    base = tmp_path / "cells.parquet"
+    _write_points_geoparquet(src, _GOLD_POINTS)
+    aggregate_by_a5(str(src), str(base), resolution=7)
+    with pytest.raises(InvalidParameterError, match="coarser"):
+        create_overviews(str(base), levels=[7])
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_mixed_resolution_input_errors(tmp_path):
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+
+    src = tmp_path / "points.parquet"
+    a = tmp_path / "r6.parquet"
+    b = tmp_path / "r7.parquet"
+    mixed = tmp_path / "mixed.parquet"
+    _write_points_geoparquet(src, _GOLD_POINTS)
+    aggregate_by_a5(str(src), str(a), resolution=6)
+    aggregate_by_a5(str(src), str(b), resolution=7)
+    pq.write_table(
+        pa.concat_tables([pq.read_table(a), pq.read_table(b)], promote_options="default"),
+        mixed,
+    )
+    with pytest.raises(InvalidParameterError, match="[Mm]ixed"):
+        create_overviews(str(mixed), levels=[4])
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_auto_level_selection_a5(tmp_path):
+    """With an absurd bytes-per-cell nothing fits, so the coarsest level is built."""
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+
+    src = tmp_path / "points.parquet"
+    base = tmp_path / "cells.parquet"
+    _write_points_geoparquet(src, _GOLD_POINTS)
+    aggregate_by_a5(str(src), str(base), resolution=7)
+
+    results = create_overviews(str(base), max_tile_kb=1, bytes_per_cell=1e6)
+    assert [lvl for lvl, _ in results] == [0]
+    assert (tmp_path / "cells_r0.parquet").exists()
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_table_overview_api(tmp_path):
+    from geoparquet_io.api.table import Table
+    from geoparquet_io.core.process.aggregate.by_a5 import aggregate_by_a5
+
+    src = tmp_path / "points.parquet"
+    base = tmp_path / "cells.parquet"
+    _write_points_geoparquet(src, _GOLD_POINTS)
+    aggregate_by_a5(str(src), str(base), resolution=7, metric="sum:area")
+
+    result = Table(pq.read_table(base)).overview(5)
+    assert "a5_cell" in result.column_names
+    assert "count" in result.column_names
+    assert "sum_area" in result.column_names
+    base_count = sum(pq.read_table(base).column("count").to_pylist())
+    assert sum(result.to_arrow().column("count").to_pylist()) == base_count

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -273,11 +273,65 @@ class TestGridDetectionStubbed:
             "t",
             pa.table({"h3ish": ["871fb4662ffffff"], "adminish": ["US-CA"]}),
         )
-        # Integer-typed override is a5 without probing.
-        assert _scheme_for_column(con, "t", "irrelevant", "UBIGINT") == "a5"
+        # Integer columns are a5 only when the name says so.
+        assert _scheme_for_column(con, "t", "my_a5_cells", "UBIGINT") == "a5"
         # 15-hex-char strings are h3; anything else is admin.
         assert _scheme_for_column(con, "t", "h3ish", "VARCHAR") == "h3"
         assert _scheme_for_column(con, "t", "adminish", "VARCHAR") == "admin"
+        con.close()
+
+    def test_integer_cell_column_without_a5_name_refuses_to_guess(self):
+        # H3 ids are commonly stored as UBIGINT too; routing them through the
+        # a5 hierarchy would silently produce wrong output. Require --scheme.
+        import duckdb as _duckdb
+
+        con = _duckdb.connect()
+        con.register(
+            "agg",
+            pa.table({"cells": pa.array([123, 456], type=pa.uint64()), "count": [1, 2]}),
+        )
+        with pytest.raises(InvalidParameterError, match="scheme"):
+            detect_aggregate_info(con, "agg", cell_column="cells")
+        con.close()
+
+    def test_scheme_override_h3_integer_ids(self, monkeypatch):
+        # Packed (UBIGINT) H3 ids only work via an explicit scheme override.
+        import duckdb as _duckdb
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        con.create_function("h3_get_resolution", lambda c: 7, ["UBIGINT"], "INTEGER")
+        con.register(
+            "agg",
+            pa.table({"h3_id": pa.array([1, 2], type=pa.uint64()), "count": [1, 2]}),
+        )
+        info = detect_aggregate_info(con, "agg", cell_column="h3_id", scheme="h3")
+        assert info.scheme == "h3"
+        assert info.cell_column == "h3_id"
+        assert info.base_level == 7
+        con.close()
+
+    def test_scheme_override_uses_default_column(self, monkeypatch):
+        import duckdb as _duckdb
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        _register_a5_stubs(con)
+        con.register("agg", _stub_grid_aggregate_table([7000, 7001], [1, 2], [1.0, 2.0]))
+        info = detect_aggregate_info(con, "agg", scheme="a5")
+        assert (info.scheme, info.cell_column, info.base_level) == ("a5", "a5_cell", 7)
+        # A scheme whose default column is missing fails loudly.
+        with pytest.raises(InvalidParameterError, match="not found"):
+            detect_aggregate_info(con, "agg", scheme="h3")
+        con.close()
+
+    def test_invalid_scheme_errors(self):
+        import duckdb as _duckdb
+
+        con = _duckdb.connect()
+        con.register("agg", pa.table({"a5_cell": pa.array([1], type=pa.uint64()), "count": [1]}))
+        with pytest.raises(InvalidParameterError, match="[Ii]nvalid scheme"):
+            detect_aggregate_info(con, "agg", scheme="s2")
         con.close()
 
     def test_ensure_grid_extension_statements(self):
@@ -330,7 +384,7 @@ class TestOutGeometryInference:
 class TestGridRollupStubbed:
     def test_create_overviews_explicit_level(self, tmp_path, monkeypatch):
         from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-        from geoparquet_io.core.process.overview import run as run_mod
+        from geoparquet_io.core.process.overview import detect as detect_mod
 
         _no_extension(monkeypatch)
         real_factory = get_duckdb_connection
@@ -340,7 +394,7 @@ class TestGridRollupStubbed:
             _register_a5_stubs(con)
             return con
 
-        monkeypatch.setattr(run_mod, "get_duckdb_connection", stubbed_connection)
+        monkeypatch.setattr(detect_mod, "get_duckdb_connection", stubbed_connection)
 
         src = tmp_path / "cells.parquet"
         # Parents at level 5: 7000,7001 -> 5000; 7004,7005 -> 5001.
@@ -371,7 +425,7 @@ class TestGridRollupStubbed:
 
     def test_create_overviews_auto_levels(self, tmp_path, monkeypatch):
         from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-        from geoparquet_io.core.process.overview import run as run_mod
+        from geoparquet_io.core.process.overview import detect as detect_mod
 
         _no_extension(monkeypatch)
         real_factory = get_duckdb_connection
@@ -381,7 +435,7 @@ class TestGridRollupStubbed:
             _register_a5_stubs(con)
             return con
 
-        monkeypatch.setattr(run_mod, "get_duckdb_connection", stubbed_connection)
+        monkeypatch.setattr(detect_mod, "get_duckdb_connection", stubbed_connection)
 
         src = tmp_path / "cells.parquet"
         pq.write_table(
@@ -398,7 +452,7 @@ class TestGridRollupStubbed:
 
     def test_create_overviews_base_fits_builds_nothing(self, tmp_path, monkeypatch):
         from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-        from geoparquet_io.core.process.overview import run as run_mod
+        from geoparquet_io.core.process.overview import detect as detect_mod
 
         _no_extension(monkeypatch)
         real_factory = get_duckdb_connection
@@ -408,7 +462,7 @@ class TestGridRollupStubbed:
             _register_a5_stubs(con)
             return con
 
-        monkeypatch.setattr(run_mod, "get_duckdb_connection", stubbed_connection)
+        monkeypatch.setattr(detect_mod, "get_duckdb_connection", stubbed_connection)
 
         src = tmp_path / "cells.parquet"
         pq.write_table(_stub_grid_aggregate_table([7000, 7001], [1, 2], [1.0, 2.0]), src)
@@ -671,7 +725,7 @@ class TestInMemoryAndWrappers:
 
         src = tmp_path / "by_region.parquet"
         _write_admin_region_aggregate(src)
-        result = Table(pq.read_table(src)).overview("country")
+        result = Table(pq.read_table(src)).overview("country", scheme="admin")
         assert "admin_code" in result.column_names
         assert result.geometry_column == "geometry"
 
@@ -687,11 +741,15 @@ class TestInMemoryAndWrappers:
             return [(4, "cells_r4.parquet")]
 
         monkeypatch.setattr(overview_pkg, "create_overviews", fake)
-        result = ops.create_overviews("cells.parquet", levels=[4], max_tile_kb=300)
+        result = ops.create_overviews(
+            "cells.parquet", levels=[4], max_tile_kb=300, scheme="a5", show_sql=True
+        )
         assert result == [(4, "cells_r4.parquet")]
         assert recorded["input"] == "cells.parquet"
         assert recorded["levels"] == [4]
         assert recorded["max_tile_kb"] == 300
+        assert recorded["scheme"] == "a5"
+        assert recorded["show_sql"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -784,7 +842,7 @@ class TestCli:
         runner = CliRunner()
         result = runner.invoke(cli, ["process", "overview", "--help"])
         assert result.exit_code == 0
-        for opt in ("--levels", "--max-tile-kb", "--bytes-per-cell", "--cell-column"):
+        for opt in ("--levels", "--max-tile-kb", "--bytes-per-cell", "--cell-column", "--scheme"):
             assert opt in result.output
 
     @pytest.mark.usefixtures("fake_country_cache")

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -1,5 +1,7 @@
 """Tests for `gpio process overview` (aggregate rollups to coarser levels)."""
 
+from pathlib import Path
+
 import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -10,7 +12,10 @@ from geoparquet_io.cli.main import cli
 from geoparquet_io.core.admin_datasets import OvertureAdminDataset
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.process.overview import create_overviews
-from geoparquet_io.core.process.overview.detect import detect_aggregate_file
+from geoparquet_io.core.process.overview.detect import (
+    detect_aggregate_file,
+    detect_aggregate_info,
+)
 from geoparquet_io.core.process.overview.run import overview_output_path
 
 # ---------------------------------------------------------------------------
@@ -143,25 +148,576 @@ class TestDetection:
 
 
 # ---------------------------------------------------------------------------
+# Grid detection / rollup with stub UDFs (fast: no community extensions)
+# ---------------------------------------------------------------------------
+#
+# The a5/h3 helper functions are stubbed with DuckDB Python UDFs so the SQL
+# paths execute for real without installing community extensions. Stub cell id
+# encoding: id = resolution * 1000 + n; parent(id, L) = L * 1000 + n // 4.
+
+
+def _register_a5_stubs(con):
+    con.create_function("a5_get_resolution", lambda c: c // 1000, ["UBIGINT"], "INTEGER")
+    con.create_function(
+        "a5_cell_to_parent",
+        lambda c, lvl: lvl * 1000 + (c % 1000) // 4,
+        ["UBIGINT", "INTEGER"],
+        "UBIGINT",
+    )
+    con.create_function(
+        "a5_cell_to_lonlat",
+        lambda c: [float(c % 100), float(c % 60)],
+        ["UBIGINT"],
+        "DOUBLE[]",
+    )
+
+
+def _no_extension(monkeypatch):
+    """Skip INSTALL/LOAD of grid community extensions (stubs stand in)."""
+    from geoparquet_io.core.process.overview import detect as detect_mod
+
+    monkeypatch.setattr(detect_mod, "ensure_grid_extension", lambda con, scheme: None)
+
+
+def _stub_grid_aggregate_table(cells, counts, values):
+    return pa.table(
+        {
+            "a5_cell": pa.array(cells, type=pa.uint64()),
+            "count": pa.array(counts, type=pa.int64()),
+            "sum_v": pa.array(values, type=pa.float64()),
+            "avg_v": pa.array(values, type=pa.float64()),
+            "min_v": pa.array(values, type=pa.float64()),
+            "max_v": pa.array(values, type=pa.float64()),
+        }
+    )
+
+
+class TestGridDetectionStubbed:
+    def test_detect_a5(self, monkeypatch):
+        import duckdb as _duckdb
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        _register_a5_stubs(con)
+        con.register("agg", _stub_grid_aggregate_table([7000, 7001], [1, 2], [1.0, 2.0]))
+        info = detect_aggregate_info(con, "agg")
+        assert info.scheme == "a5"
+        assert info.cell_column == "a5_cell"
+        assert info.base_level == 7
+        assert info.out_geometry == "none"
+        # count + sum/avg/min/max rollups feed the bytes-per-cell estimate.
+        assert info.num_attributes == 5
+        # An explicit --cell-column override resolves to the same scheme.
+        override = detect_aggregate_info(con, "agg", cell_column="a5_cell")
+        assert (override.scheme, override.base_level) == ("a5", 7)
+        con.close()
+
+    def test_detect_h3(self, monkeypatch):
+        import duckdb as _duckdb
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        con.create_function("h3_get_resolution", lambda c: 7, ["VARCHAR"], "INTEGER")
+        con.register(
+            "agg",
+            pa.table({"h3_cell": ["871fb4662ffffff", "871fb4663ffffff"], "count": [1, 2]}),
+        )
+        info = detect_aggregate_info(con, "agg")
+        assert info.scheme == "h3"
+        assert info.cell_column == "h3_cell"
+        assert info.base_level == 7
+        con.close()
+
+    def test_detect_mixed_resolutions_errors(self, monkeypatch):
+        import duckdb as _duckdb
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        _register_a5_stubs(con)
+        con.register("agg", _stub_grid_aggregate_table([6000, 7000], [1, 2], [1.0, 2.0]))
+        with pytest.raises(InvalidParameterError, match="[Mm]ixed"):
+            detect_aggregate_info(con, "agg")
+        con.close()
+
+    def test_detect_all_null_cells_errors(self, monkeypatch):
+        import duckdb as _duckdb
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        _register_a5_stubs(con)
+        con.register(
+            "agg",
+            pa.table({"a5_cell": pa.array([None, None], type=pa.uint64()), "count": [1, 2]}),
+        )
+        with pytest.raises(InvalidParameterError, match="non-NULL"):
+            detect_aggregate_info(con, "agg")
+        con.close()
+
+    def test_cell_column_override_missing_errors(self, monkeypatch):
+        import duckdb as _duckdb
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        con.register("agg", pa.table({"count": [1]}))
+        with pytest.raises(InvalidParameterError, match="not found"):
+            detect_aggregate_info(con, "agg", cell_column="mycell")
+        con.close()
+
+    def test_cell_column_override_scheme_inference(self, monkeypatch):
+        import duckdb as _duckdb
+
+        from geoparquet_io.core.process.overview.detect import _scheme_for_column
+
+        con = _duckdb.connect()
+        con.register(
+            "t",
+            pa.table({"h3ish": ["871fb4662ffffff"], "adminish": ["US-CA"]}),
+        )
+        # Integer-typed override is a5 without probing.
+        assert _scheme_for_column(con, "t", "irrelevant", "UBIGINT") == "a5"
+        # 15-hex-char strings are h3; anything else is admin.
+        assert _scheme_for_column(con, "t", "h3ish", "VARCHAR") == "h3"
+        assert _scheme_for_column(con, "t", "adminish", "VARCHAR") == "admin"
+        con.close()
+
+    def test_ensure_grid_extension_statements(self):
+        from geoparquet_io.core.process.overview.detect import ensure_grid_extension
+
+        class RecordingCon:
+            def __init__(self):
+                self.statements = []
+
+            def execute(self, sql):
+                self.statements.append(sql)
+
+        con = RecordingCon()
+        ensure_grid_extension(con, "a5")
+        assert con.statements == ["INSTALL a5 FROM community", "LOAD a5"]
+
+
+class TestOutGeometryInference:
+    def test_both_when_centroid_column_present(self, tmp_path):
+        src = tmp_path / "by_region.parquet"
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+        con.execute(
+            f"""
+            COPY (
+                SELECT 'US-CA' AS admin_code, 1 AS count,
+                       ST_Buffer(ST_Point(0, 0), 1.0) AS geometry,
+                       ST_Point(0, 0) AS centroid
+            ) TO '{src}' (FORMAT PARQUET)
+            """
+        )
+        con.close()
+        assert detect_aggregate_file(str(src)).out_geometry == "both"
+
+    def test_centroid_when_geometry_is_points(self, tmp_path):
+        src = tmp_path / "by_region.parquet"
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+        con.execute(
+            f"""
+            COPY (
+                SELECT 'US-CA' AS admin_code, 1 AS count, ST_Point(0, 0) AS geometry
+            ) TO '{src}' (FORMAT PARQUET)
+            """
+        )
+        con.close()
+        assert detect_aggregate_file(str(src)).out_geometry == "centroid"
+
+
+class TestGridRollupStubbed:
+    def test_create_overviews_explicit_level(self, tmp_path, monkeypatch):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.process.overview import run as run_mod
+
+        _no_extension(monkeypatch)
+        real_factory = get_duckdb_connection
+
+        def stubbed_connection(**kwargs):
+            con = real_factory(**kwargs)
+            _register_a5_stubs(con)
+            return con
+
+        monkeypatch.setattr(run_mod, "get_duckdb_connection", stubbed_connection)
+
+        src = tmp_path / "cells.parquet"
+        # Parents at level 5: 7000,7001 -> 5000; 7004,7005 -> 5001.
+        pq.write_table(
+            _stub_grid_aggregate_table(
+                [7000, 7001, 7004, 7005], [1, 2, 3, 4], [1.0, 2.0, 3.0, 4.0]
+            ),
+            src,
+        )
+        results = create_overviews(str(src), levels="5", compression_level=9, show_sql=True)
+        assert results == [(5, str(tmp_path / "cells_r5.parquet"))]
+
+        out = pq.read_table(results[0][1])
+        rows = dict(zip(out.column("a5_cell").to_pylist(), range(out.num_rows), strict=True))
+        assert set(rows) == {5000, 5001}
+
+        def col(name, cell):
+            return out.column(name)[rows[cell]].as_py()
+
+        assert col("count", 5000) == 3
+        assert col("sum_v", 5000) == pytest.approx(3.0)
+        # Count-weighted: (1*1.0 + 2*2.0) / 3.
+        assert col("avg_v", 5000) == pytest.approx(5.0 / 3.0)
+        assert col("min_v", 5000) == 1.0
+        assert col("max_v", 5000) == 2.0
+        assert col("count", 5001) == 7
+        assert col("avg_v", 5001) == pytest.approx(25.0 / 7.0)
+
+    def test_create_overviews_auto_levels(self, tmp_path, monkeypatch):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.process.overview import run as run_mod
+
+        _no_extension(monkeypatch)
+        real_factory = get_duckdb_connection
+
+        def stubbed_connection(**kwargs):
+            con = real_factory(**kwargs)
+            _register_a5_stubs(con)
+            return con
+
+        monkeypatch.setattr(run_mod, "get_duckdb_connection", stubbed_connection)
+
+        src = tmp_path / "cells.parquet"
+        pq.write_table(
+            _stub_grid_aggregate_table(
+                [7000, 7001, 7004, 7005], [1, 2, 3, 4], [1.0, 2.0, 3.0, 4.0]
+            ),
+            src,
+        )
+        # Absurd bytes-per-cell: nothing fits, so only the coarsest level (0)
+        # is selected and the base is deferred past the probe range.
+        results = create_overviews(str(src), max_tile_kb=1, bytes_per_cell=1e9)
+        assert [lvl for lvl, _ in results] == [0]
+        assert (tmp_path / "cells_r0.parquet").exists()
+
+    def test_create_overviews_base_fits_builds_nothing(self, tmp_path, monkeypatch):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.process.overview import run as run_mod
+
+        _no_extension(monkeypatch)
+        real_factory = get_duckdb_connection
+
+        def stubbed_connection(**kwargs):
+            con = real_factory(**kwargs)
+            _register_a5_stubs(con)
+            return con
+
+        monkeypatch.setattr(run_mod, "get_duckdb_connection", stubbed_connection)
+
+        src = tmp_path / "cells.parquet"
+        pq.write_table(_stub_grid_aggregate_table([7000, 7001], [1, 2], [1.0, 2.0]), src)
+        # Tiny bytes-per-cell: the base level fits at z0, so no overviews.
+        assert create_overviews(str(src), bytes_per_cell=1.0) == []
+
+    def test_plan_bands_grid_explicit_levels(self, monkeypatch):
+        import duckdb as _duckdb
+
+        from geoparquet_io.core.process.overview.run import plan_bands
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        _register_a5_stubs(con)
+        con.register("agg", _stub_grid_aggregate_table([7000, 7001], [1, 2], [1.0, 2.0]))
+        info = detect_aggregate_info(con, "agg")
+        bands = plan_bands(
+            con, "SELECT * FROM agg", info, levels=[5], bytes_per_cell=1.0, verbose=True
+        )
+        # Everything fits immediately -> single base band; candidates were
+        # restricted to the explicit level + base.
+        assert [band.level for band in bands] == [7]
+        assert bands[0].minzoom == 0 and bands[0].maxzoom is None
+        con.close()
+
+    def test_rollup_table_grid_stubbed(self, monkeypatch):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.process.overview import rollup as rollup_mod
+        from geoparquet_io.core.process.overview import rollup_table
+
+        _no_extension(monkeypatch)
+        monkeypatch.setattr(rollup_mod, "ensure_grid_extension", lambda con, scheme: None)
+        real_factory = get_duckdb_connection
+
+        def stubbed_connection(**kwargs):
+            con = real_factory(**kwargs)
+            _register_a5_stubs(con)
+            return con
+
+        monkeypatch.setattr(rollup_mod, "get_duckdb_connection", stubbed_connection)
+
+        result = rollup_table(
+            _stub_grid_aggregate_table([7000, 7001, 7004], [1, 2, 3], [1.0, 2.0, 3.0]), 5
+        )
+        rows = dict(
+            zip(
+                result.column("a5_cell").to_pylist(),
+                result.column("count").to_pylist(),
+                strict=True,
+            )
+        )
+        assert rows == {5000: 3, 5001: 3}
+
+    def test_plan_bands_admin_without_geometry_errors(self, tmp_path):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.process.overview.run import plan_bands
+
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src, with_geometry=False)
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            relation = f"read_parquet('{src}')"
+            info = detect_aggregate_info(con, relation)
+            with pytest.raises(InvalidParameterError, match="without geometry"):
+                plan_bands(con, f"SELECT * FROM {relation}", info)
+        finally:
+            con.close()
+
+
+class TestProbeWorstTileCounts:
+    def test_counts_shrink_with_zoom(self):
+        from geoparquet_io.core.partition.auto_resolution import _register_quadkey_udf
+        from geoparquet_io.core.process.overview.levels import probe_worst_tile_counts
+
+        con = duckdb.connect()
+        _register_quadkey_udf(con)
+        # Two nearby points, one far away, one beyond the WebMercator lat
+        # domain (exercises the clamp).
+        cells_sql = (
+            "SELECT * FROM (VALUES (2.0, 48.0), (2.001, 48.001), (-100.0, 40.0), (100.0, 89.0)) "
+            "t(lon, lat)"
+        )
+        counts = probe_worst_tile_counts(con, cells_sql, max_zoom=8)
+        assert set(counts) == set(range(9))
+        assert counts[0] == 4  # everything lands in the single z0 tile
+        assert counts[8] >= 1
+        assert all(counts[z + 1] <= counts[z] for z in range(8))
+        con.close()
+
+    def test_empty_input(self):
+        from geoparquet_io.core.partition.auto_resolution import _register_quadkey_udf
+        from geoparquet_io.core.process.overview.levels import probe_worst_tile_counts
+
+        con = duckdb.connect()
+        _register_quadkey_udf(con)
+        counts = probe_worst_tile_counts(
+            con, "SELECT NULL::DOUBLE AS lon, NULL::DOUBLE AS lat WHERE false", max_zoom=2
+        )
+        assert counts == {0: 0, 1: 0, 2: 0}
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Rollup SQL builders (pure string construction, nothing executed)
+# ---------------------------------------------------------------------------
+
+
+def _grid_info(scheme="a5", out_geometry="polygon"):
+    from geoparquet_io.core.process.overview.detect import AggregateInfo, RollupColumn
+
+    return AggregateInfo(
+        scheme=scheme,
+        cell_column=f"{scheme}_cell",
+        base_level=7,
+        rollup_columns=(
+            RollupColumn("sum_area", "sum"),
+            RollupColumn("avg_height", "avg"),
+            RollupColumn("min_year", "min"),
+            RollupColumn("max_year", "max"),
+            RollupColumn("count_barn", "sum", cast_to_bigint=True),
+        ),
+        out_geometry=out_geometry,
+    )
+
+
+def _admin_info(out_geometry="polygon"):
+    from geoparquet_io.core.process.overview.detect import AggregateInfo, RollupColumn
+
+    return AggregateInfo(
+        scheme="admin",
+        cell_column="admin_code",
+        base_level="region",
+        rollup_columns=(RollupColumn("sum_area", "sum"),),
+        out_geometry=out_geometry,
+    )
+
+
+class TestRollupSqlBuilders:
+    def test_grid_rollup_sql_polygon(self):
+        from geoparquet_io.core.process.overview.rollup import build_grid_rollup_sql
+
+        sql = build_grid_rollup_sql(_grid_info(), "SELECT * FROM src", 5)
+        assert 'a5_cell_to_parent("a5_cell", 5)' in sql
+        assert 'CASE WHEN "a5_cell" IS NULL THEN NULL' in sql  # unassigned guard
+        assert "GROUP BY __parent" in sql
+        assert "CAST(SUM(count) AS BIGINT) AS count" in sql
+        assert 'SUM("avg_height" * count) / NULLIF(SUM(count), 0)' in sql
+        assert 'CAST(SUM("count_barn") AS BIGINT)' in sql
+        assert "a5_cell_to_boundary" in sql  # polygon regenerated from cell id
+
+    def test_grid_rollup_sql_h3_both(self):
+        from geoparquet_io.core.process.overview.rollup import build_grid_rollup_sql
+
+        sql = build_grid_rollup_sql(_grid_info("h3", out_geometry="both"), "SELECT * FROM s", 4)
+        assert 'h3_cell_to_parent("h3_cell", 4)' in sql
+        assert "h3_cell_to_boundary_wkt" in sql
+        assert "AS centroid" in sql
+
+    def test_grid_rollup_sql_none_geometry(self):
+        from geoparquet_io.core.process.overview.rollup import build_grid_rollup_sql
+
+        sql = build_grid_rollup_sql(_grid_info(out_geometry="none"), "SELECT * FROM s", 5)
+        assert "boundary" not in sql
+        assert "geometry" not in sql
+
+    def test_admin_rollup_sql_polygon(self):
+        from geoparquet_io.core.process.overview.rollup import build_admin_rollup_sql
+
+        sql = build_admin_rollup_sql(
+            _admin_info(), "SELECT * FROM s", "read_parquet('c.parquet')", '"country"', "geometry"
+        )
+        assert "split_part(admin_code, '-', 1)" in sql
+        assert "'unassigned'" in sql  # unassigned passes through
+        assert "ST_Union_Agg" in sql  # multi-row countries are unioned
+        assert "LEFT JOIN" in sql
+        assert "AS geometry" in sql
+
+    def test_admin_rollup_sql_geometry_modes(self):
+        from geoparquet_io.core.process.overview.rollup import build_admin_rollup_sql
+
+        centroid = build_admin_rollup_sql(
+            _admin_info("centroid"), "SELECT * FROM s", "read_parquet('c')", '"country"', "g"
+        )
+        assert "ST_Centroid" in centroid
+        both = build_admin_rollup_sql(
+            _admin_info("both"), "SELECT * FROM s", "read_parquet('c')", '"country"', "g"
+        )
+        assert "AS centroid" in both
+
+    def test_admin_rollup_sql_none_geometry_skips_join(self):
+        from geoparquet_io.core.process.overview.rollup import (
+            build_admin_rollup_sql,
+            build_level_sql,
+        )
+
+        sql = build_admin_rollup_sql(_admin_info("none"), "SELECT * FROM s", None, None, None)
+        assert "LEFT JOIN" not in sql
+        # build_level_sql takes the no-country-cache shortcut (con unused).
+        assert build_level_sql(None, _admin_info("none"), "SELECT * FROM s", "country") == sql
+
+    def test_validate_level_grid_non_integer_errors(self):
+        from geoparquet_io.core.process.overview.rollup import validate_level
+
+        with pytest.raises(InvalidParameterError, match="integer"):
+            validate_level(_grid_info(), "country")
+        assert validate_level(_grid_info(), "5") == 5
+
+    def test_validate_level_not_coarser_errors(self):
+        from geoparquet_io.core.process.overview.rollup import validate_level
+
+        with pytest.raises(InvalidParameterError, match="coarser"):
+            validate_level(_grid_info(), 7)  # equal to base
+        with pytest.raises(InvalidParameterError, match="coarser"):
+            validate_level(_grid_info(), 9)  # finer than base
+
+    def test_grid_probe_sql_variants(self):
+        from geoparquet_io.core.process.overview.run import _grid_cells_probe_sql
+
+        non_base = _grid_cells_probe_sql(_grid_info(), "SELECT * FROM s", 5)
+        assert 'a5_cell_to_parent("a5_cell", 5)' in non_base
+        assert "a5_cell_to_lonlat" in non_base
+        # At the base level the cell is its own parent -- no parent call.
+        base = _grid_cells_probe_sql(_grid_info(), "SELECT * FROM s", 7)
+        assert "a5_cell_to_parent" not in base
+        # h3 returns [lat, lng]; lon must come from index 2.
+        h3 = _grid_cells_probe_sql(_grid_info("h3"), "SELECT * FROM s", 5)
+        assert "h3_cell_to_latlng" in h3
+        assert "__ll[2] AS lon" in h3
+
+    def test_parse_levels_duplicates_error(self):
+        from geoparquet_io.core.process.overview.run import parse_levels
+
+        with pytest.raises(InvalidParameterError, match="duplicate"):
+            parse_levels([5, 5], _grid_info())
+        with pytest.raises(InvalidParameterError, match="no levels"):
+            parse_levels("", _grid_info())
+        assert parse_levels("5, 3", _grid_info()) == [3, 5]
+
+
+# ---------------------------------------------------------------------------
+# In-memory rollups and API wrappers (fast)
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryAndWrappers:
+    @pytest.mark.usefixtures("fake_country_cache")
+    def test_rollup_table_admin(self, tmp_path):
+        from geoparquet_io.core.process.overview import rollup_table
+
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        result = rollup_table(pq.read_table(src), "country")
+        codes = result.column("admin_code").to_pylist()
+        assert set(codes) == {"US", "FR", "unassigned"}
+        assert sum(result.column("count").to_pylist()) == 10
+
+    @pytest.mark.usefixtures("fake_country_cache")
+    def test_table_overview_admin(self, tmp_path):
+        from geoparquet_io.api.table import Table
+
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        result = Table(pq.read_table(src)).overview("country")
+        assert "admin_code" in result.column_names
+        assert result.geometry_column == "geometry"
+
+    def test_ops_create_overviews_wrapper(self, monkeypatch):
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.process import overview as overview_pkg
+
+        recorded = {}
+
+        def fake(input_parquet, **kwargs):
+            recorded["input"] = input_parquet
+            recorded.update(kwargs)
+            return [(4, "cells_r4.parquet")]
+
+        monkeypatch.setattr(overview_pkg, "create_overviews", fake)
+        result = ops.create_overviews("cells.parquet", levels=[4], max_tile_kb=300)
+        assert result == [(4, "cells_r4.parquet")]
+        assert recorded["input"] == "cells.parquet"
+        assert recorded["levels"] == [4]
+        assert recorded["max_tile_kb"] == 300
+
+
+# ---------------------------------------------------------------------------
 # Output naming
 # ---------------------------------------------------------------------------
 
 
 class TestOutputNaming:
+    # Compare Path objects / name+parent, not raw strings: the separator is
+    # platform-specific (backslashes on Windows).
+
     def test_grid_naming(self):
-        assert overview_output_path("/x/cells.parquet", "a5", 7) == "/x/cells_r7.parquet"
-        assert overview_output_path("/x/cells.parquet", "h3", 4) == "/x/cells_r4.parquet"
+        r7 = Path(overview_output_path("/x/cells.parquet", "a5", 7))
+        assert r7.name == "cells_r7.parquet"
+        assert r7.parent == Path("/x")
+        assert Path(overview_output_path("/x/cells.parquet", "h3", 4)).name == "cells_r4.parquet"
 
     def test_admin_naming(self):
-        assert (
-            overview_output_path("/x/by_region.parquet", "admin", "country")
-            == "/x/by_region_country.parquet"
-        )
+        out = Path(overview_output_path("/x/by_region.parquet", "admin", "country"))
+        assert out.name == "by_region_country.parquet"
+        assert out.parent == Path("/x")
 
     def test_output_dir_override(self):
-        assert overview_output_path("/x/cells.parquet", "a5", 4, output_dir="/y") == (
-            "/y/cells_r4.parquet"
-        )
+        out = Path(overview_output_path("/x/cells.parquet", "a5", 4, output_dir="/y"))
+        assert out.name == "cells_r4.parquet"
+        assert out.parent == Path("/y")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -133,6 +133,16 @@ class TestDetection:
         with pytest.raises(InvalidParameterError, match="country level"):
             detect_aggregate_file(str(path))
 
+    def test_admin_empty_input_distinct_error(self, tmp_path):
+        """0 usable rows is not 'already at country level' -- say so."""
+        path = tmp_path / "empty.parquet"
+        pq.write_table(
+            pa.table({"admin_code": pa.array(["unassigned", None]), "count": [1, 2]}),
+            path,
+        )
+        with pytest.raises(InvalidParameterError, match="no admin codes"):
+            detect_aggregate_file(str(path))
+
     def test_unclassifiable_columns_are_dropped(self, tmp_path):
         path = tmp_path / "by_region.parquet"
         _write_admin_region_aggregate(path, extra_column=True)
@@ -609,7 +619,10 @@ class TestRollupSqlBuilders:
         assert 'CASE WHEN "a5_cell" IS NULL THEN NULL' in sql  # unassigned guard
         assert "GROUP BY __parent" in sql
         assert "CAST(SUM(count) AS BIGINT) AS count" in sql
-        assert 'SUM("avg_height" * count) / NULLIF(SUM(count), 0)' in sql
+        assert (
+            'SUM("avg_height" * count) / '
+            'NULLIF(SUM(count) FILTER (WHERE "avg_height" IS NOT NULL), 0)' in sql
+        )
         assert 'CAST(SUM("count_barn") AS BIGINT)' in sql
         assert "a5_cell_to_boundary" in sql  # polygon regenerated from cell id
 
@@ -723,6 +736,66 @@ class TestRollupSqlBuilders:
             validate_level(_grid_info(), 7)  # equal to base
         with pytest.raises(InvalidParameterError, match="coarser"):
             validate_level(_grid_info(), 9)  # finer than base
+
+    def test_avg_rollup_ignores_null_children(self, monkeypatch):
+        """Children avg=10/count=5 and avg=NULL/count=3 must roll up to 10.0,
+        not 6.25: NULL-avg cells cannot count in the denominator."""
+        import duckdb as _duckdb
+
+        from geoparquet_io.core.process.overview.rollup import build_grid_rollup_sql
+
+        _no_extension(monkeypatch)
+        con = _duckdb.connect()
+        _register_a5_stubs(con)
+        con.register(
+            "agg",
+            pa.table(
+                {
+                    "a5_cell": pa.array([7000, 7001], type=pa.uint64()),
+                    "count": pa.array([5, 3], type=pa.int64()),
+                    "avg_v": pa.array([10.0, None], type=pa.float64()),
+                }
+            ),
+        )
+        info = detect_aggregate_info(con, "agg")
+        sql = build_grid_rollup_sql(info, "SELECT * FROM agg", 5)
+        ((cell, count, avg),) = con.execute(sql).fetchall()
+        assert (cell, count) == (5000, 8)
+        assert avg == pytest.approx(10.0)
+        con.close()
+
+    def test_admin_country_probe_handles_antimeridian(self):
+        """Countries spanning the antimeridian must probe near +/-180, not at
+        the AVG(lon) of their region centroids (which lands near lon 0)."""
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.process.overview.detect import AggregateInfo
+        from geoparquet_io.core.process.overview.run import _admin_cells_probe_sql
+
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            con.execute("SET geometry_always_xy = true")
+            con.execute(
+                """
+                CREATE TEMP TABLE agg AS
+                SELECT * FROM (VALUES
+                    ('US-AK', 1, ST_Buffer(ST_Point(-179.5, 60.0), 0.1)),
+                    ('US-XX', 1, ST_Buffer(ST_Point(179.5, 55.0), 0.1))
+                ) t(admin_code, count, geometry)
+                """
+            )
+            info = AggregateInfo(
+                scheme="admin",
+                cell_column="admin_code",
+                base_level="region",
+                rollup_columns=(),
+                out_geometry="polygon",
+            )
+            sql = _admin_cells_probe_sql(con, info, "SELECT * FROM agg", "country")
+            ((lon, lat),) = con.execute(sql).fetchall()
+            assert abs(lon) > 170
+            assert 55.0 <= lat <= 61.0
+        finally:
+            con.close()
 
     def test_grid_probe_sql_variants(self):
         from geoparquet_io.core.process.overview.run import _grid_cells_probe_sql
@@ -898,6 +971,28 @@ class TestAdminRollup:
         _write_admin_region_aggregate(src)
         with pytest.raises(InvalidParameterError, match="country"):
             create_overviews(str(src), levels="province")
+
+    def test_country_cache_path_with_single_quote(self, tmp_path, monkeypatch):
+        """The country cache path must be SQL-escaped like every other path
+        (home dirs can contain apostrophes)."""
+        import shutil
+
+        quoted_dir = tmp_path / "o'brien"
+        quoted_dir.mkdir()
+        plain_cache = tmp_path / "country_cache.parquet"
+        quoted_cache = quoted_dir / "country_cache.parquet"
+        shutil.copy(plain_cache, quoted_cache)
+        monkeypatch.setattr(
+            OvertureAdminDataset,
+            "get_source_for_level",
+            lambda self, level, no_cache=False: str(quoted_cache),
+        )
+
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        results = create_overviews(str(src), levels="country")
+        out = pq.read_table(results[0][1])
+        assert set(out.column("admin_code").to_pylist()) == {"US", "FR", "unassigned"}
 
     def test_existing_output_errors_without_force(self, tmp_path):
         """Like pmtiles pyramid, refuse to silently overwrite derived sibling

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -504,7 +504,6 @@ class TestGridRollupStubbed:
         from geoparquet_io.core.process.overview import rollup_table
 
         _no_extension(monkeypatch)
-        monkeypatch.setattr(rollup_mod, "ensure_grid_extension", lambda con, scheme: None)
         real_factory = get_duckdb_connection
 
         def stubbed_connection(**kwargs):
@@ -908,7 +907,9 @@ class TestAdminRollup:
         src = tmp_path / "by_region.parquet"
         _write_admin_region_aggregate(src)
 
-        results = create_overviews(str(src))
+        # bytes_per_cell forces the country level into the plan (3 region
+        # cells blow the z0 budget, 2 countries fit).
+        results = create_overviews(str(src), bytes_per_cell=200000.0)
         assert results == [("country", str(tmp_path / "by_region_country.parquet"))]
 
         table = pq.read_table(results[0][1])
@@ -964,6 +965,21 @@ class TestAdminRollup:
         src = tmp_path / "by_region.parquet"
         _write_admin_region_aggregate(src)
         results = create_overviews(str(src), levels="country")
+        assert [lvl for lvl, _ in results] == ["country"]
+
+    def test_admin_auto_skips_when_base_fits(self, tmp_path):
+        """Admin auto mode probes like grid auto mode: when the region base
+        already fits the budget at every zoom, no overview is built."""
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src)
+        assert create_overviews(str(src), bytes_per_cell=1.0) == []
+
+    def test_admin_auto_without_geometry_builds_country(self, tmp_path):
+        """A geometry-less admin aggregate cannot be probed; auto mode falls
+        back to the only coarser level."""
+        src = tmp_path / "by_region.parquet"
+        _write_admin_region_aggregate(src, with_geometry=False)
+        results = create_overviews(str(src))
         assert [lvl for lvl, _ in results] == ["country"]
 
     def test_invalid_admin_level_errors(self, tmp_path):
@@ -1030,7 +1046,18 @@ class TestCli:
         outdir.mkdir()
         _write_admin_region_aggregate(src)
         runner = CliRunner()
-        result = runner.invoke(cli, ["process", "overview", str(src), "--output-dir", str(outdir)])
+        result = runner.invoke(
+            cli,
+            [
+                "process",
+                "overview",
+                str(src),
+                "--output-dir",
+                str(outdir),
+                "--bytes-per-cell",
+                "200000",
+            ],
+        )
         assert result.exit_code == 0, result.output
         assert (outdir / "by_region_country.parquet").exists()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1357,6 +1357,7 @@ dependencies = [
     { name = "owslib", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pmtiles" },
     { name = "psutil" },
     { name = "pyarrow" },
     { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1450,6 +1451,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=1.0.0" },
     { name = "pip", marker = "extra == 'dev'", specifier = ">=26.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
+    { name = "pmtiles", specifier = ">=3.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyarrow", specifier = ">=23.0.1" },
@@ -3404,6 +3406,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pmtiles"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/3e/47e371add5ba09615c95c5ef72d8c3be471819d6dce07bae26c8e15d0687/pmtiles-3.7.0.tar.gz", hash = "sha256:ed8b04d550d104c81a759c9cc07bfc5743750f62e751f840425f4b9f4bb903df", size = 14582, upload-time = "2026-02-10T16:00:22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/de/c0f177fd73818e0d671903ed986d4541674b0fad4365c7ecfd5a0af23a6d/pmtiles-3.7.0-py3-none-any.whl", hash = "sha256:d1a7a7a166ce3c5c8756cc2c8e4b0aa55e3d854fbd4517c963de16c39b631b14", size = 16848, upload-time = "2026-02-10T16:00:20.925Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements #570: first-class overview pyramids for aggregates, as two composable commands.

## Summary

**Commit 1 — `gpio process overview`** (`core/process/overview/`): derive coarser aggregate levels from an existing `gpio process aggregate` output. The scheme (`a5_cell` UBIGINT / `h3_cell` string / `admin_code`) and base level are detected from the file itself; rollup walks the true hierarchy (`a5_cell_to_parent` / `h3_cell_to_parent`; admin region→country via ISO code prefix + cached Overture country polygons with an `ST_Union_Agg` guard for multi-row countries). Outputs are re-runnable siblings: `cells_r7.parquet`, `by_region_country.parquet` (`--output-dir` to redirect). Python API: `ops.create_overviews`, `Table.overview`.

**Commit 2 — `gpio pmtiles pyramid`** (`core/pmtiles_pyramid.py`): one tippecanoe run per level pinned to its zoom band, merged with `tile-join` (`-pk`, argv only — never `shell=True`), bands recorded under a `gpio:pyramid` key in the archive metadata (rewritten via the `pmtiles` package with a full read/write round-trip; handles closed before `os.replace` for Windows). Existing `_r*` siblings are reused; missing levels are built into a temp dir. `--include-features` appends the raw features band (min zoom defaults to base band max + 1, tippecanoe size cap kept so `--drop-densest-as-needed` applies); `--layer-mode single|grouped|per-level` controls layer naming. Python API: `ops.create_pmtiles_pyramid`. New dependency: `pmtiles>=3.0.0`.

## Auto level selection (shared core)

`core/process/overview/levels.py` drives both commands from `--max-tile-kb` (default 500, tippecanoe's cap):

1. Estimate compressed bytes/cell from the attribute schema + output geometry (conservative constants, `--bytes-per-cell` override).
2. Per candidate level, compute distinct parent-cell centroids in DuckDB, quadkey them once at z20 (mercantile UDF), and take the worst tile's cell count per zoom via prefix substrings — extent-aware by construction.
3. Walk zooms from 0 picking the finest level that fits until the base fits; dedupe into contiguous `Band(level, minzoom, maxzoom)` bands. The coarsest band extends to z0 even if a single z0 tile overflows; the base always gets the final open-ended band.

## Rollup exactness semantics

- `count`, `sum_*`, `min_*`, `max_*`, and breakdown `count_*` (incl. `count_other`) roll up **exactly** (`SUM(BIGINT)` widened to HUGEINT is cast back).
- `avg_*` is **count-weighted** (`SUM(avg*count)/NULLIF(SUM(count),0)`) — exact when the metric had no NULLs; documented caveat in the guide.
- The NULL-cell / `unassigned` bucket flows through with NULL geometry; unclassifiable extra columns are warned about and dropped.
- Note: the h3 gold test intentionally compares against a hierarchy-faithful expectation (parent-of-res-7-cell) rather than a direct res-5 aggregate — H3 hexagons don't nest exactly, so a point near a cell edge can bucket differently at res 5 vs the ancestor of its res-7 cell. A5 nests cleanly and its gold test does match the direct coarse aggregate 1:1.

## Test evidence

- Fast gate: `uv run pytest -n auto -m "not slow and not network"` → **3560 passed**, coverage 75.18% (floor 67%).
- New slow/integration tests (extensions + tippecanoe v2.31 + tile-join, local run): **8 passed** — a5 gold rollup vs direct coarse aggregate (per-column exact incl. breakdowns), h3 hierarchy-faithful gold, mixed-resolution & not-coarser errors, auto-selection, `Table.overview`, and two end-to-end pyramids (grouped and per-level + features) asserting header zoom span, `gpio:pyramid` metadata, and `vector_layers` names after the metadata rewrite round-trip.
- Fast suite covers: detection (scheme/base/roles/out-geometry, all error paths), band selection unit tests on synthetic distributions (uniform global, point-mass, probe exhaustion, byte-estimate override, band invariants), admin region→country rollup end-to-end against a fake Overture country cache (monkeypatched, no network), tile-join argv construction, layer naming per mode, feature-zoom resolution, and CLI wiring.
- `tile-join` verified live to accept `.pmtiles` inputs/outputs and long options with tippecanoe v2.31.0.

## Deferred (natural follow-ups)

- One-shot `--aggregate` mode on `pmtiles pyramid` (raw data → aggregate → pyramid in one command) — kept out to keep this PR reviewable; the two commands compose today.
- Admin ladder beyond region→country (only a two-level ladder exists in the Overture per-level caches).
- `--with-overviews` sugar on `process aggregate`.

Closes #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `gpio process overview` to generate coarser grid or administrative levels from aggregate outputs, with automatic level selection and tile-size budgeting.
  * Added `gpio pmtiles pyramid` to create multi-level PMTiles archives with configurable layers, optional feature bands, and pyramid metadata.
  * Added Python API support for creating overview files and PMTiles pyramids, including `Table.overview(...)`.
* **Documentation**
  * Added CLI reference and user guides for overview levels and PMTiles pyramids.
* **Tests**
  * Added comprehensive coverage for overview processing and PMTiles pyramid generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->