### PR TITLE
fix(process): clear errors for missing --metric/--breakdown columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,14 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Clear errors for missing `--metric`/`--breakdown` columns in
+  `gpio process aggregate`.** Requesting a column that doesn't exist now
+  reports the column name and the available columns instead of a raw DuckDB
+  binder error — and `--metric count` specifically explains that `count` is
+  emitted automatically for every bucket (use `--breakdown` for per-category
+  counts). A literal `count` column in the input (e.g. re-aggregating an
+  aggregate) still works.
+
 - **Non-planar edges metadata survives rewrites (#588).** `"edges":
   "spherical"` (e.g. from BigQuery GEOGRAPHY extracts) is now preserved across
   `convert`, `extract`, `sort`, `convert reproject`, and `partition`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -180,6 +180,14 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Clear errors for missing `--metric`/`--breakdown` columns in
+  `gpio process aggregate`.** Requesting a column that doesn't exist now
+  reports the column name and the available columns instead of a raw DuckDB
+  binder error — and `--metric count` specifically explains that `count` is
+  emitted automatically for every bucket (use `--breakdown` for per-category
+  counts). A literal `count` column in the input (e.g. re-aggregating an
+  aggregate) still works.
+
 - **Non-planar edges metadata survives rewrites (#588).** `"edges":
   "spherical"` (e.g. from BigQuery GEOGRAPHY extracts) is now preserved across
   `convert`, `extract`, `sort`, `convert reproject`, and `partition`

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -42,8 +42,8 @@ Rules of thumb:
 - **`avg` does *not* scale with count** — it isolates size/intensity, so a cell with 5 large fields is comparable to one with 5 000 small fields. Best for "typical value" maps.
 - **`min`/`max`** surface outliers; pair `min:year` with `max:year` to show the span of values in a cell.
 - **Don't request `count` via `--metric`** — every output row already includes a
-  `count` column automatically (`COUNT(*)` per bucket). Use `--breakdown <column>`
-  for per-category counts.
+  `count` column automatically (`COUNT(*)` per bucket). For per-category counts see
+  [Which breakdown to use](#which-breakdown-to-use).
 - The column must already exist and be numeric. To aggregate a **geometry-derived** value like area, compute it first with `gpio add geometry-metrics` (writes `metrics:area` in m²), then `--metric "sum:metrics:area"`.
 - **NoData sentinels skew every metric.** Real-world numeric columns frequently
   encode "no value" as a sentinel like `-999` or `-9999` rather than SQL `NULL`

--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -41,6 +41,9 @@ Rules of thumb:
 - **`sum` scales with `count`** — dense cells naturally get large sums. Use it for "total stuff here," and keep `count` alongside to interpret it.
 - **`avg` does *not* scale with count** — it isolates size/intensity, so a cell with 5 large fields is comparable to one with 5 000 small fields. Best for "typical value" maps.
 - **`min`/`max`** surface outliers; pair `min:year` with `max:year` to show the span of values in a cell.
+- **Don't request `count` via `--metric`** — every output row already includes a
+  `count` column automatically (`COUNT(*)` per bucket). Use `--breakdown <column>`
+  for per-category counts.
 - The column must already exist and be numeric. To aggregate a **geometry-derived** value like area, compute it first with `gpio add geometry-metrics` (writes `metrics:area` in m²), then `--metric "sum:metrics:area"`.
 - **NoData sentinels skew every metric.** Real-world numeric columns frequently
   encode "no value" as a sentinel like `-999` or `-9999` rather than SQL `NULL`

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -32,6 +32,7 @@ from geoparquet_io.core.process.aggregate.common import (
     build_metric_select,
     resolve_breakdown_values,
     resolve_metric_column_types,
+    validate_agg_columns,
     validate_metric_nodata,
 )
 from geoparquet_io.core.process.aggregate.grid_common import (
@@ -242,9 +243,18 @@ def aggregate_by_admin(
         con.execute("SET geometry_always_xy = true")
         admin_dataset.configure_s3(con)
 
+        read_rel = aggregate_source_relation(input_url)
+        if metrics or breakdown:
+            # Clear error (not a DuckDB binder error) for missing metric/breakdown
+            # columns -- especially `--metric count`, a no-op request since count
+            # is always emitted. Checked before _get_admin_ref so a typo fails now
+            # rather than after downloading the admin boundary cache, and before
+            # the type resolution below so a missing column reports as missing.
+            cols = {r[0] for r in con.execute(f"DESCRIBE SELECT * FROM {read_rel}").fetchall()}
+            validate_agg_columns(cols, metrics, breakdown)
+
         admin_ref = _get_admin_ref(admin_dataset, con, level)
 
-        read_rel = aggregate_source_relation(input_url)
         # Resolve metric column types from the input so sentinel literals match the
         # column's actual precision (REAL vs DOUBLE, #613) and non-numeric metric
         # columns fail up-front instead of mid-query.

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import re
+import string
 from dataclasses import dataclass
 
 from geoparquet_io.core.duckdb_utils import quote_identifier
@@ -259,6 +260,33 @@ def build_metric_select(
     return ", ".join(parts)
 
 
+# DuckDB folds identifiers case-insensitively, but only over ASCII: "HEIGHT"
+# binds to a `Height` column while "STRASSE" does not bind to `straße`. Column
+# lookups here follow the same rule so validation accepts exactly what the
+# generated SQL would bind -- no more, no less.
+_ASCII_LOWER = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+
+
+def _fold(name: str) -> str:
+    return name.translate(_ASCII_LOWER)
+
+
+def _has_column(available: set[str], name: str) -> bool:
+    """Whether ``name`` resolves to a column of the input, as DuckDB would resolve it."""
+    return name in available or any(_fold(c) == _fold(name) for c in available)
+
+
+def _format_available(available: set[str]) -> str:
+    """Render the column list for an error message.
+
+    The internal ``__``-prefixed aliases the aggregation adds to its source
+    relation (``__geom`` and friends) are not columns a user can request, so
+    they are left out.
+    """
+    names = sorted(c for c in available if not c.startswith("__"))
+    return ", ".join(names) if names else "(none)"
+
+
 def validate_agg_columns(
     available: set[str], metrics: list[MetricSpec], breakdown: str | None
 ) -> None:
@@ -269,11 +297,14 @@ def validate_agg_columns(
     ``count`` is emitted automatically for every bucket, so a missing literal
     ``count`` column gets a dedicated explanation. A file that really has a
     ``count`` column (e.g. re-aggregating an aggregate) is still accepted.
+
+    Names are matched the way DuckDB matches them, so ``sum:HEIGHT`` is a valid
+    request against a ``Height`` column.
     """
     for m in metrics:
-        if m.column in available:
+        if _has_column(available, m.column):
             continue
-        if m.column.lower() == "count":
+        if _fold(m.column) == "count":
             raise InvalidParameterError(
                 "metric",
                 "'count' does not need to be requested: every output row "
@@ -284,13 +315,13 @@ def validate_agg_columns(
         raise InvalidParameterError(
             "metric",
             f"Metric column '{m.column}' not found in input. "
-            f"Available columns: {', '.join(sorted(available))}",
+            f"Available columns: {_format_available(available)}",
         )
-    if breakdown and breakdown not in available:
+    if breakdown and not _has_column(available, breakdown):
         raise InvalidParameterError(
             "breakdown",
             f"Breakdown column '{breakdown}' not found in input. "
-            f"Available columns: {', '.join(sorted(available))}",
+            f"Available columns: {_format_available(available)}",
         )
 
 

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -259,6 +259,41 @@ def build_metric_select(
     return ", ".join(parts)
 
 
+def validate_agg_columns(
+    available: set[str], metrics: list[MetricSpec], breakdown: str | None
+) -> None:
+    """Check that requested metric/breakdown columns exist in the input.
+
+    Raises a clear InvalidParameterError instead of letting the generated SQL
+    fail with a DuckDB binder error. The common trap is ``--metric count``:
+    ``count`` is emitted automatically for every bucket, so a missing literal
+    ``count`` column gets a dedicated explanation. A file that really has a
+    ``count`` column (e.g. re-aggregating an aggregate) is still accepted.
+    """
+    for m in metrics:
+        if m.column in available:
+            continue
+        if m.column.lower() == "count":
+            raise InvalidParameterError(
+                "metric",
+                "'count' does not need to be requested: every output row "
+                "automatically includes a count column (COUNT(*) of features per "
+                "bucket). Use --metric for numeric rollups of existing columns "
+                '(e.g. "sum:area"), or --breakdown <column> for per-category counts.',
+            )
+        raise InvalidParameterError(
+            "metric",
+            f"Metric column '{m.column}' not found in input. "
+            f"Available columns: {', '.join(sorted(available))}",
+        )
+    if breakdown and breakdown not in available:
+        raise InvalidParameterError(
+            "breakdown",
+            f"Breakdown column '{breakdown}' not found in input. "
+            f"Available columns: {', '.join(sorted(available))}",
+        )
+
+
 _UNSAFE_CHARS = re.compile(r"[^0-9a-zA-Z]+")
 
 

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -44,6 +44,7 @@ from geoparquet_io.core.process.aggregate.common import (
     geometry_to_geom_expr,
     resolve_breakdown_values,
     resolve_metric_column_types,
+    validate_agg_columns,
     validate_metric_nodata,
 )
 from geoparquet_io.core.remote import needs_httpfs
@@ -281,6 +282,14 @@ def build_grid_query(
 ) -> str:
     """Build the full grid aggregation SQL from a source relation exposing ``__pt``."""
     metrics, nodata_values = validate_metric_nodata(metric, metric_nodata)
+    if metrics or breakdown:
+        # Fail with a clear message (not a DuckDB binder error) when a requested
+        # metric/breakdown column doesn't exist -- especially `--metric count`,
+        # which is a no-op request since count is always emitted. Runs before the
+        # type resolution below so a missing column reports as missing, not as a
+        # non-numeric metric.
+        cols = {r[0] for r in con.execute(f"DESCRIBE SELECT * FROM ({source_sql})").fetchall()}
+        validate_agg_columns(cols, metrics, breakdown)
     # Resolve metric column types so sentinel literals match the column's actual
     # precision (REAL vs DOUBLE, #613) and non-numeric columns fail up-front.
     column_types = resolve_metric_column_types(con, source_sql, metrics) if nodata_values else None

--- a/tests/test_process_aggregate_column_validation.py
+++ b/tests/test_process_aggregate_column_validation.py
@@ -1,0 +1,199 @@
+"""Friendly errors for --metric/--breakdown columns that don't exist in the input.
+
+Previously a missing metric column surfaced as a raw DuckDB binder error. The
+common trap is `--metric count`: `count` is produced automatically for every
+bucket, so requesting it (on input without a literal `count` column) now gets a
+message explaining that, instead of failing on the generated `SUM("count")`.
+"""
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.process.aggregate.common import (
+    parse_metrics,
+    validate_agg_columns,
+)
+
+# ---------------------------------------------------------------------------
+# Unit: validate_agg_columns
+# ---------------------------------------------------------------------------
+
+
+def test_count_metric_gets_automatic_count_hint():
+    with pytest.raises(InvalidParameterError, match="automatically"):
+        validate_agg_columns({"geometry", "height"}, parse_metrics("count"), None)
+
+
+def test_func_count_metric_gets_hint_too():
+    with pytest.raises(InvalidParameterError, match="automatically"):
+        validate_agg_columns({"geometry"}, parse_metrics("avg:count"), None)
+
+
+def test_count_metric_allowed_when_column_exists():
+    # A literal `count` column (e.g. re-aggregating an aggregate) is legitimate.
+    validate_agg_columns({"geometry", "count"}, parse_metrics("sum:count"), None)
+
+
+def test_missing_metric_column_lists_available():
+    with pytest.raises(InvalidParameterError, match="'altitude' not found") as exc:
+        validate_agg_columns({"geometry", "height"}, parse_metrics("avg:altitude"), None)
+    assert "height" in str(exc.value)
+
+
+def test_missing_breakdown_column_errors():
+    with pytest.raises(InvalidParameterError, match="Breakdown column 'crop'"):
+        validate_agg_columns({"geometry", "height"}, [], "crop")
+
+
+def test_valid_columns_pass():
+    validate_agg_columns({"geometry", "height", "crop"}, parse_metrics("avg:height"), "crop")
+
+
+# ---------------------------------------------------------------------------
+# Grid query builder applies the validation (no grid extension execution)
+# ---------------------------------------------------------------------------
+
+
+def _build(metric=None, breakdown=None):
+    from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME
+    from geoparquet_io.core.process.aggregate.grid_common import build_grid_query
+
+    con = duckdb.connect()
+    try:
+        return build_grid_query(
+            con,
+            A5_SCHEME,
+            "SELECT 1 AS height, 'x' AS crop, NULL AS __geom",
+            5,
+            "a5_cell",
+            metric,
+            breakdown,
+            20,
+            "none",
+        )
+    finally:
+        con.close()
+
+
+def test_grid_query_count_metric_hint():
+    with pytest.raises(InvalidParameterError, match="automatically"):
+        _build(metric="count")
+
+
+def test_grid_query_missing_metric_column():
+    with pytest.raises(InvalidParameterError, match="'area' not found"):
+        _build(metric="sum:area")
+
+
+def test_grid_query_missing_breakdown_column():
+    with pytest.raises(InvalidParameterError, match="Breakdown column"):
+        _build(breakdown="croptype")
+
+
+def test_grid_query_valid_columns_build():
+    sql = _build(metric="avg:height")
+    assert 'AVG("height") AS "avg_height"' in sql
+
+
+# ---------------------------------------------------------------------------
+# Admin path applies the validation (fake dataset, no network)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdminDataset:
+    def __init__(self, path):
+        self._path = path
+
+    def supports_per_level_sources(self):
+        return True
+
+    def get_source_for_level(self, level):
+        return str(self._path)
+
+    def get_level_column_mapping(self):
+        return {"country": "country"}
+
+    def get_geometry_column(self):
+        return "geometry"
+
+    def get_bbox_column(self):
+        return None
+
+    def configure_s3(self, con):
+        pass
+
+
+@pytest.fixture
+def fake_admin_dataset(tmp_path, monkeypatch):
+    admin_path = tmp_path / "admin.parquet"
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT 'AA' AS country,
+                   ST_GeomFromText('POLYGON((0 40, 20 40, 20 60, 0 60, 0 40))') AS geometry
+        ) TO '{admin_path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    monkeypatch.setattr(
+        "geoparquet_io.core.process.aggregate.by_admin._setup_admin_dataset",
+        lambda dataset, verbose, levels: (_FakeAdminDataset(admin_path), None),
+    )
+
+
+def _write_points(path):
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    con.execute(
+        f"""
+        COPY (
+            SELECT ST_Point(10.0, 50.0) AS geometry, 4.0 AS height
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+
+
+@pytest.mark.usefixtures("fake_admin_dataset")
+def test_admin_count_metric_hint(tmp_path):
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    src = tmp_path / "pts.parquet"
+    _write_points(src)
+    with pytest.raises(InvalidParameterError, match="automatically"):
+        aggregate_by_admin(str(src), str(tmp_path / "o.parquet"), level="country", metric="count")
+
+
+# ---------------------------------------------------------------------------
+# CLI surfaces the message cleanly (needs grid extension)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_cli_count_metric_clean_error(tmp_path):
+    src = tmp_path / "pts.parquet"
+    _write_points(src)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "process",
+            "aggregate",
+            "a5",
+            str(src),
+            str(tmp_path / "o.parquet"),
+            "--resolution",
+            "5",
+            "--metric",
+            "count",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "automatically" in result.output
+    assert "Binder" not in result.output

--- a/tests/test_process_aggregate_column_validation.py
+++ b/tests/test_process_aggregate_column_validation.py
@@ -53,11 +53,43 @@ def test_valid_columns_pass():
 
 
 # ---------------------------------------------------------------------------
+# Name matching follows DuckDB: ASCII case-insensitive, nothing more
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_case_metric_column_resolves():
+    # DuckDB binds SUM("HEIGHT") against a `Height` column, so validation must too.
+    validate_agg_columns({"geometry", "Height"}, parse_metrics("sum:HEIGHT"), None)
+
+
+def test_mixed_case_breakdown_column_resolves():
+    validate_agg_columns({"geometry", "CropType"}, [], "croptype")
+
+
+def test_count_metric_allowed_when_column_exists_in_other_case():
+    # A real `COUNT` column must not be mistaken for the reserved automatic count.
+    validate_agg_columns({"geometry", "COUNT"}, parse_metrics("sum:count"), None)
+
+
+def test_non_ascii_case_is_not_folded():
+    # DuckDB does not fold non-ASCII: "héight" does not bind to `HÉIGHT`.
+    with pytest.raises(InvalidParameterError, match="not found"):
+        validate_agg_columns({"geometry", "HÉIGHT"}, parse_metrics("sum:héight"), None)
+
+
+def test_internal_aliases_are_not_listed_as_available():
+    with pytest.raises(InvalidParameterError, match="not found") as exc:
+        validate_agg_columns({"__pt", "__key", "height"}, parse_metrics("sum:area"), None)
+    assert "__pt" not in str(exc.value)
+    assert "height" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
 # Grid query builder applies the validation (no grid extension execution)
 # ---------------------------------------------------------------------------
 
 
-def _build(metric=None, breakdown=None):
+def _build(metric=None, breakdown=None, source="SELECT 1 AS height, 'x' AS crop, NULL AS __pt"):
     from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME
     from geoparquet_io.core.process.aggregate.grid_common import build_grid_query
 
@@ -66,7 +98,7 @@ def _build(metric=None, breakdown=None):
         return build_grid_query(
             con,
             A5_SCHEME,
-            "SELECT 1 AS height, 'x' AS crop, NULL AS __geom",
+            source,
             5,
             "a5_cell",
             metric,
@@ -98,19 +130,34 @@ def test_grid_query_valid_columns_build():
     assert 'AVG("height") AS "avg_height"' in sql
 
 
+def test_grid_query_mixed_case_metric_builds():
+    sql = _build(metric="avg:HEIGHT", source="SELECT 1 AS Height, NULL AS __pt")
+    assert 'AVG("HEIGHT")' in sql
+
+
+def test_grid_query_missing_metric_omits_internal_alias():
+    with pytest.raises(InvalidParameterError, match="'area' not found") as exc:
+        _build(metric="sum:area")
+    assert "__pt" not in str(exc.value)
+
+
 # ---------------------------------------------------------------------------
 # Admin path applies the validation (fake dataset, no network)
 # ---------------------------------------------------------------------------
 
 
 class _FakeAdminDataset:
-    def __init__(self, path):
+    def __init__(self, path, fail_on_source=False):
         self._path = path
+        self._fail_on_source = fail_on_source
 
     def supports_per_level_sources(self):
         return True
 
     def get_source_for_level(self, level):
+        if self._fail_on_source:
+            # Stands in for the multi-GB boundary-cache download.
+            raise AssertionError("admin boundaries resolved before validating columns")
         return str(self._path)
 
     def get_level_column_mapping(self):
@@ -167,6 +214,22 @@ def test_admin_count_metric_hint(tmp_path):
     _write_points(src)
     with pytest.raises(InvalidParameterError, match="automatically"):
         aggregate_by_admin(str(src), str(tmp_path / "o.parquet"), level="country", metric="count")
+
+
+def test_admin_validates_before_resolving_boundaries(tmp_path, monkeypatch):
+    """A typo'd column must fail before the admin boundary cache is fetched."""
+    from geoparquet_io.core.process.aggregate.by_admin import aggregate_by_admin
+
+    monkeypatch.setattr(
+        "geoparquet_io.core.process.aggregate.by_admin._setup_admin_dataset",
+        lambda dataset, verbose, levels: (_FakeAdminDataset(None, fail_on_source=True), None),
+    )
+    src = tmp_path / "pts.parquet"
+    _write_points(src)
+    with pytest.raises(InvalidParameterError, match="'altitude' not found"):
+        aggregate_by_admin(
+            str(src), str(tmp_path / "o.parquet"), level="country", metric="sum:altitude"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`gpio process aggregate ... --metric count` on input without a literal `count` column previously died with a raw DuckDB binder error on the generated `SUM("count")`. It's an easy trap because `count` is produced automatically for every bucket — the error now says exactly that:

> 'count' does not need to be requested: every output row automatically includes a count column (COUNT(*) of features per bucket). Use --metric for numeric rollups of existing columns (e.g. "sum:area"), or --breakdown <column> for per-category counts.

More generally, all `--metric` and `--breakdown` columns are now validated against the input schema (one `DESCRIBE`, footer-only) before any SQL runs, so a typo'd column reports the name plus the available columns instead of a binder error. A file that genuinely has a `count` column (e.g. re-aggregating an aggregate output) still works — validation only fires when the column is absent.

Applies to all three subcommands (`a5`, `h3`, `admin`) via a shared `validate_agg_columns` helper in `core/process/aggregate/common.py`, hooked into `build_grid_query` (grid file + in-memory paths) and the admin flow.

## Tests

12 new tests in `tests/test_process_aggregate_column_validation.py`: helper units (count hint, func:count hint, legitimate count column accepted, missing column lists available, breakdown missing, valid passes), `build_grid_query` integration as pure SQL construction (fast, no grid extension), admin path with a faked local dataset (fast, no network), and a slow/network CLI test asserting the clean message with no binder error. Docs note added to the metric guidance; CHANGELOG entry under Fixed.

## Merge note

Touches the same `build_grid_query`/`by_admin` regions as #612/#613/#614 — trivial conflicts (adjacent added lines); happy to rebase whichever lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aggregation errors for missing metric or breakdown columns, including available column names.
  * Clarified that `count` is automatically included for each bucket; use `--breakdown` for per-category counts.
  * Continued support for input files containing a literal `count` column.
* **Documentation**
  * Updated aggregation guidance and changelogs to explain metric and count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->