### PR TITLE
Fix sort hilbert dropping --write-memory before it reaches the write engine

### DIFF
--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3683,6 +3683,7 @@ def hilbert_order(
             None,
             geoparquet_version,
             overwrite,
+            memory_limit=write_memory,
         )
 
 

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -213,6 +213,7 @@ def hilbert_order(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Reorder a GeoParquet file using Hilbert curve ordering.
@@ -233,6 +234,7 @@ def hilbert_order(
         row_group_rows: Exact number of rows per row group
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for streaming writes (e.g., '2GB', '512MB')
     """
     effective_version = geoparquet_version or DEFAULT_GEOPARQUET_VERSION
     if effective_version == "1.1":
@@ -267,6 +269,7 @@ def hilbert_order(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit,
         )
         return
 
@@ -284,6 +287,7 @@ def hilbert_order(
         profile,
         geoparquet_version,
         overwrite,
+        memory_limit,
     )
 
 
@@ -298,6 +302,7 @@ def _hilbert_order_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for hilbert_order."""
     # Suppress verbose when streaming to stdout
@@ -364,6 +369,7 @@ def _hilbert_order_streaming(
                 verbose=verbose,
                 profile=profile,
                 geoparquet_version=geoparquet_version,
+                memory_limit=memory_limit,
             )
             if not should_stream_output(output_path):
                 success(f"Wrote data without Hilbert ordering to: {output_path}")
@@ -409,6 +415,7 @@ def _hilbert_order_streaming(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            memory_limit=memory_limit,
         )
 
         if not should_stream_output(output_path):
@@ -428,6 +435,7 @@ def _hilbert_order_file_based(
     profile: str | None,
     geoparquet_version: str | None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle file-based hilbert_order operation."""
     # Check if output file exists and handle overwrite (fixes issue #278)
@@ -490,6 +498,7 @@ def _hilbert_order_file_based(
             profile=profile,
             geoparquet_version=geoparquet_version,
             input_file=input_parquet,
+            memory_limit=memory_limit,
         )
         con.close()
         if temp_file_created and temp_file:
@@ -534,6 +543,7 @@ def _hilbert_order_file_based(
             profile=profile,
             geoparquet_version=geoparquet_version,
             input_file=input_parquet,
+            memory_limit=memory_limit,
         )
         if verbose:
             debug("Hilbert ordering completed successfully")

--- a/geoparquet_io/core/stream_io.py
+++ b/geoparquet_io/core/stream_io.py
@@ -209,6 +209,7 @@ def write_output(
     custom_metadata: dict | None = None,
     geoparquet_version: str | None = None,
     extra_kv_metadata: dict[str, str] | None = None,
+    memory_limit: str | None = None,
 ) -> pa.Table | None:
     """
     Execute query and write result to file or stream.
@@ -232,6 +233,8 @@ def write_output(
         profile: AWS profile for S3 output
         custom_metadata: Optional dict with custom metadata
         geoparquet_version: GeoParquet version to write
+        memory_limit: DuckDB memory limit for file writes (e.g., '2GB', '512MB');
+            ignored for stream output
 
     Returns:
         Table if streaming output, None if file output
@@ -258,6 +261,7 @@ def write_output(
             custom_metadata,
             geoparquet_version,
             extra_kv_metadata,
+            memory_limit,
         )
         return None
 
@@ -331,6 +335,7 @@ def _write_file_output(
     custom_metadata: dict | None,
     geoparquet_version: str | None,
     extra_kv_metadata: dict[str, str] | None = None,
+    memory_limit: str | None = None,
 ) -> None:
     """Write output to Parquet file."""
     # Auto-detect version from input metadata if not explicitly provided
@@ -351,6 +356,7 @@ def _write_file_output(
         profile=profile,
         geoparquet_version=geoparquet_version,
         extra_kv_metadata=extra_kv_metadata,
+        memory_limit=memory_limit,
     )
 
 

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -58,6 +58,23 @@ class TestSortCommands:
         assert result.exit_code == 0
         assert os.path.exists(temp_output_file)
 
+    def test_hilbert_sort_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        """--write-memory must configure the DuckDB write connection, not be dropped."""
+        runner = CliRunner()
+        result = runner.invoke(
+            sort,
+            [
+                "hilbert",
+                places_test_file,
+                temp_output_file,
+                "--write-memory",
+                "512MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "DuckDB memory limit: 512MB" in result.output
+
     def test_hilbert_sort_with_custom_geometry_column(self, places_test_file, temp_output_file):
         """Test Hilbert sort with custom geometry column name."""
         runner = CliRunner()


### PR DESCRIPTION
## Description
`gpio sort hilbert --write-memory 3GB` silently ignored the flag: the CLI command accepted it, but `hilbert_order()` had no memory-limit parameter, so the value was never forwarded and the duckdb-kv write strategy always fell back to `get_default_memory_limit()` (50% of available RAM).

Observed on 1.3.0 with a 718M-row file inside a 4GB cgroup (`systemd-run -p MemoryMax=4G`): verbose output printed `DuckDB memory limit: 8.4GB` despite `--write-memory 3GB`, and the kernel OOM-killed the run. There was no working user-facing knob, even though docs/troubleshooting.md recommends `--write-memory` for exactly this situation.

## Technical Details
- `core/hilbert_order.py`: add `memory_limit` to `hilbert_order()`, `_hilbert_order_streaming()` and `_hilbert_order_file_based()`, forwarding to their write calls
- `core/stream_io.py`: add `memory_limit` pass-through to `write_output()` / `_write_file_output()` -> `write_parquet_with_metadata()` (which already supported it)
- `cli/main.py`: pass `memory_limit=write_memory` in the hilbert command
- Mirrors the existing idiom used by `extract` and `add quadkey` (`memory_limit=write_memory`)

## Breaking Changes
**Does this PR introduce breaking changes?** No

## Related Issue(s)
- none filed; found while converting a 20GB/718M-row AIS parquet under a memory cap

## Checklist
- [x] Tests added/updated (`test_hilbert_sort_write_memory_reaches_engine`: fails on main, passes with fix)
- [x] All tests pass (`uv run pytest -m 'not slow and not network'`: 3302 passed, coverage 74.91%)
- [x] Documentation updated (no change needed: docs already describe `--write-memory`; this fix makes them accurate)

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring memory limits when performing Hilbert sorting.
  * Applied the configured limit consistently when writing sorted output, including datasets with empty or null geometries.
  * The command-line interface accepts `--write-memory` for Hilbert sorting and reports the configured limit in verbose output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->