### PR TITLE
Fix Table API dropping the source CRS between convert() and write()

### DIFF
--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -486,14 +486,24 @@ class Table:
         self._auto_version_hint: str | None = None
         self._crs_hint: dict | str | None = crs
 
-    def _wrap(self, table: pa.Table, geometry_column: str | None) -> Table:
+    _KEEP_CRS_HINT = object()
+
+    def _wrap(
+        self,
+        table: pa.Table,
+        geometry_column: str | None,
+        crs: dict | str | None | object = _KEEP_CRS_HINT,
+    ) -> Table:
         """Build a derived Table, carrying the read-time hints forward.
 
         Chained operations (add_bbox, sort_hilbert, ...) produce new Arrow
         tables that still contain no embedded CRS, so the CRS hint (and the
-        auto-version hint) must survive the chain to reach write().
+        auto-version hint) must survive the chain to reach write(). An
+        operation that changes the CRS (reproject) passes ``crs=`` explicitly
+        so the hint never mislabels transformed coordinates.
         """
-        derived = Table(table, geometry_column=geometry_column, crs=self._crs_hint)
+        hint = self._crs_hint if crs is Table._KEEP_CRS_HINT else crs
+        derived = Table(table, geometry_column=geometry_column, crs=hint)
         derived._auto_version_hint = self._auto_version_hint
         return derived
 
@@ -1737,7 +1747,9 @@ class Table:
             geometry_column=self._geometry_column,
             assume_crs84=assume_crs84,
         )
-        return self._wrap(result, self._geometry_column)
+        # The source-CRS hint would mislabel transformed coordinates; the
+        # reprojected table's CRS is target_crs by construction.
+        return self._wrap(result, self._geometry_column, crs=target_crs)
 
     def partition_by_quadkey(
         self,
@@ -2029,7 +2041,7 @@ class Table:
         if n < 0:
             raise ValueError(f"n must be non-negative, got {n}")
         n = min(n, self.num_rows)
-        return Table(self._table.slice(0, n), self._geometry_column)
+        return self._wrap(self._table.slice(0, n), self._geometry_column)
 
     def tail(self, n: int = 10) -> Table:
         """
@@ -2053,7 +2065,7 @@ class Table:
             raise ValueError(f"n must be non-negative, got {n}")
         n = min(n, self.num_rows)
         offset = max(0, self.num_rows - n)
-        return Table(self._table.slice(offset, n), self._geometry_column)
+        return self._wrap(self._table.slice(offset, n), self._geometry_column)
 
     def stats(self) -> dict:
         """
@@ -2771,7 +2783,7 @@ class Table:
         schema_metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
         new_table = self._table.replace_schema_metadata(schema_metadata)
 
-        return Table(new_table, self._geometry_column)
+        return self._wrap(new_table, self._geometry_column)
 
     def partition_by_string(
         self,

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -333,7 +333,7 @@ def convert(
         repair_geometry=repair_geometry,
     )
 
-    return Table(arrow_table, geometry_column=geom_col)
+    return Table(arrow_table, geometry_column=geom_col, crs=detected_crs)
 
 
 def extract_arcgis(
@@ -459,13 +459,23 @@ class Table:
         >>> result.write('output.parquet')
     """
 
-    def __init__(self, table: pa.Table, geometry_column: str | None = None):
+    def __init__(
+        self,
+        table: pa.Table,
+        geometry_column: str | None = None,
+        crs: dict | str | None = None,
+    ):
         """
         Create a Table wrapper.
 
         Args:
             table: PyArrow Table containing GeoParquet data
             geometry_column: Name of geometry column (auto-detected if None)
+            crs: CRS detected at read time (PROJJSON dict or string), used as a
+                fallback when the Arrow table itself carries no CRS. Spatial
+                sources read through DuckDB arrive as bare WKB with no embedded
+                CRS, so without this hint the written GeoParquet silently
+                claimed OGC:CRS84 for projected data (issue #625).
         """
         self._table = table
         self._geometry_column = geometry_column or self._detect_geometry_column()
@@ -474,6 +484,18 @@ class Table:
         # registered, so the table alone can't always tell a native-geo-only
         # source from generic WKB. None when the table wasn't read from a file.
         self._auto_version_hint: str | None = None
+        self._crs_hint: dict | str | None = crs
+
+    def _wrap(self, table: pa.Table, geometry_column: str | None) -> Table:
+        """Build a derived Table, carrying the read-time hints forward.
+
+        Chained operations (add_bbox, sort_hilbert, ...) produce new Arrow
+        tables that still contain no embedded CRS, so the CRS hint (and the
+        auto-version hint) must survive the chain to reach write().
+        """
+        derived = Table(table, geometry_column=geometry_column, crs=self._crs_hint)
+        derived._auto_version_hint = self._auto_version_hint
+        return derived
 
     def _detect_geometry_column(self) -> str | None:
         """Detect geometry column from metadata or common names."""
@@ -710,7 +732,10 @@ class Table:
         """
         from geoparquet_io.core.streaming import extract_crs_from_table
 
-        return extract_crs_from_table(self._table, self._geometry_column)
+        embedded = extract_crs_from_table(self._table, self._geometry_column)
+        if embedded is not None:
+            return embedded
+        return self._crs_hint
 
     @property
     def bounds(self) -> tuple[float, float, float, float] | None:
@@ -1243,7 +1268,7 @@ class Table:
             bbox_column_name=column_name,
             geometry_column=self._geometry_column,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def add_quadkey(
         self,
@@ -1271,7 +1296,7 @@ class Table:
             use_centroid=use_centroid,
             geometry_column=self._geometry_column,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def sort_hilbert(self) -> Table:
         """
@@ -1286,7 +1311,7 @@ class Table:
             self._table,
             geometry_column=self._geometry_column,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def extract(
         self,
@@ -1323,7 +1348,7 @@ class Table:
             geometry_column=self._geometry_column,
             repair_geometry=repair_geometry,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def add_h3(
         self,
@@ -1347,7 +1372,7 @@ class Table:
             h3_column_name=column_name,
             resolution=resolution,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def add_a5(
         self,
@@ -1371,7 +1396,7 @@ class Table:
             a5_column_name=column_name,
             resolution=resolution,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def aggregate_a5(
         self,
@@ -1418,7 +1443,7 @@ class Table:
             bucket_point=bucket_point,
             bbox_column=bbox_column,
         )
-        return Table(result, "geometry" if out_geometry != "none" else None)
+        return self._wrap(result, "geometry" if out_geometry != "none" else None)
 
     def aggregate_h3(
         self,
@@ -1465,7 +1490,7 @@ class Table:
             bucket_point=bucket_point,
             bbox_column=bbox_column,
         )
-        return Table(result, "geometry" if out_geometry != "none" else None)
+        return self._wrap(result, "geometry" if out_geometry != "none" else None)
 
     def aggregate_admin(
         self,
@@ -1511,7 +1536,7 @@ class Table:
             bucket_point=bucket_point,
             bbox_column=bbox_column,
         )
-        return Table(result, "geometry" if out_geometry != "none" else None)
+        return self._wrap(result, "geometry" if out_geometry != "none" else None)
 
     def overview(
         self,
@@ -1541,7 +1566,7 @@ class Table:
 
         result = rollup_table(self._table, level, cell_column=cell_column, scheme=scheme)
         has_geometry = "geometry" in result.column_names
-        return Table(result, "geometry" if has_geometry else None)
+        return self._wrap(result, "geometry" if has_geometry else None)
 
     def add_s2(
         self,
@@ -1572,7 +1597,7 @@ class Table:
             s2_column_name=column_name,
             level=level,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def add_geometry_metrics(
         self,
@@ -1600,7 +1625,7 @@ class Table:
             add_geometry_metrics,
             vecorel=vecorel,
         )
-        return Table(result_table, self._geometry_column)
+        return self._wrap(result_table, self._geometry_column)
 
     def add_kdtree(
         self,
@@ -1627,7 +1652,7 @@ class Table:
             iterations=iterations,
             sample_size=sample_size,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def sort_column(
         self,
@@ -1651,7 +1676,7 @@ class Table:
             columns=column_name,
             descending=descending,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def sort_quadkey(
         self,
@@ -1683,7 +1708,7 @@ class Table:
             use_centroid=use_centroid,
             remove_quadkey_column=remove_column,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def reproject(
         self,
@@ -1712,7 +1737,7 @@ class Table:
             geometry_column=self._geometry_column,
             assume_crs84=assume_crs84,
         )
-        return Table(result, self._geometry_column)
+        return self._wrap(result, self._geometry_column)
 
     def partition_by_quadkey(
         self,
@@ -2670,7 +2695,7 @@ class Table:
             vecorel=vecorel,
             verbose=False,
         )
-        return Table(result_table, self._geometry_column)
+        return self._wrap(result_table, self._geometry_column)
 
     def add_bbox_metadata(self, bbox_column: str = "bbox") -> Table:
         """

--- a/tests/test_crs_write_paths.py
+++ b/tests/test_crs_write_paths.py
@@ -504,3 +504,38 @@ class TestTableAPICRSPreservation:
         metadata_crs = get_metadata_crs(temp_output_file)
         if metadata_crs is not None:
             assert extract_epsg_code(metadata_crs) == 4326
+
+    def test_every_chained_op_carries_the_crs_hint(self, buildings_gpkg_6933, monkeypatch):
+        """All derived-Table constructors must propagate the CRS hint (review
+        follow-up on #625): heavy delegates are stubbed so each Table method's
+        return path runs without optional deps or network."""
+        if not os.path.exists(buildings_gpkg_6933):
+            pytest.skip("buildings_test_6933.gpkg not available")
+        import geoparquet_io as gpio
+        from geoparquet_io.api.table import Table
+
+        source = gpio.convert(buildings_gpkg_6933)
+        assert source._crs_hint is not None
+        passthrough = lambda *args, **kwargs: source._table  # noqa: E731
+
+        import geoparquet_io.api.ops as ops_mod
+        import geoparquet_io.core.add.a5 as a5_mod
+        import geoparquet_io.core.process.aggregate.by_a5 as agg_a5_mod
+        import geoparquet_io.core.process.aggregate.by_h3 as agg_h3_mod
+
+        monkeypatch.setattr(a5_mod, "add_a5_table", passthrough)
+        monkeypatch.setattr(agg_a5_mod, "aggregate_a5_table", passthrough)
+        monkeypatch.setattr(agg_h3_mod, "aggregate_h3_table", passthrough)
+        monkeypatch.setattr(ops_mod, "aggregate_admin", passthrough)
+        monkeypatch.setattr(Table, "_with_temp_io_files", lambda self, fn, **kw: source._table)
+
+        derived = {
+            "add_a5": source.add_a5(),
+            "aggregate_a5": source.aggregate_a5(10),
+            "aggregate_h3": source.aggregate_h3(7),
+            "aggregate_admin": source.aggregate_admin(),
+            "add_geometry_metrics": source.add_geometry_metrics(),
+            "add_admin_divisions": source.add_admin_divisions(),
+        }
+        for name, table in derived.items():
+            assert table._crs_hint == source._crs_hint, f"{name} dropped the CRS hint"

--- a/tests/test_crs_write_paths.py
+++ b/tests/test_crs_write_paths.py
@@ -527,7 +527,7 @@ class TestTableAPICRSPreservation:
         monkeypatch.setattr(agg_a5_mod, "aggregate_a5_table", passthrough)
         monkeypatch.setattr(agg_h3_mod, "aggregate_h3_table", passthrough)
         monkeypatch.setattr(ops_mod, "aggregate_admin", passthrough)
-        monkeypatch.setattr(Table, "_with_temp_io_files", lambda self, fn, **kw: source._table)
+        monkeypatch.setattr(Table, "_with_temp_io_files", lambda self, fn, **_kw: source._table)
 
         derived = {
             "add_a5": source.add_a5(),

--- a/tests/test_crs_write_paths.py
+++ b/tests/test_crs_write_paths.py
@@ -424,3 +424,55 @@ class TestCRSPROJJSONFormat:
         # Should be dict (PROJJSON format)
         assert isinstance(schema_crs, dict), "schema CRS should be PROJJSON dict"
         assert "id" in schema_crs, "schema CRS missing 'id' key"
+
+
+class TestTableAPICRSPreservation:
+    """The fluent Table API must not drop the source CRS (issue #625).
+
+    gpio.convert() detected the CRS but discarded it, so written GeoParquet
+    silently claimed OGC:CRS84 for projected data — while the function API
+    (convert_to_geoparquet) preserved it.
+    """
+
+    def test_convert_write_preserves_crs(self, buildings_gpkg_6933, temp_output_file):
+        if not os.path.exists(buildings_gpkg_6933):
+            pytest.skip("buildings_test_6933.gpkg not available")
+        import geoparquet_io as gpio
+
+        gpio.convert(buildings_gpkg_6933).write(temp_output_file)
+
+        metadata_crs = get_metadata_crs(temp_output_file)
+        assert metadata_crs is not None
+        assert extract_epsg_code(metadata_crs) == 6933
+
+    def test_chained_ops_preserve_crs(self, buildings_gpkg_6933, temp_output_file):
+        """The hint must survive derived Tables (the portolan-cli path)."""
+        if not os.path.exists(buildings_gpkg_6933):
+            pytest.skip("buildings_test_6933.gpkg not available")
+        import geoparquet_io as gpio
+
+        gpio.convert(buildings_gpkg_6933).add_bbox().sort_hilbert().write(temp_output_file)
+
+        metadata_crs = get_metadata_crs(temp_output_file)
+        assert metadata_crs is not None
+        assert extract_epsg_code(metadata_crs) == 6933
+
+    def test_crs_property_reports_detected_crs(self, buildings_gpkg_6933):
+        if not os.path.exists(buildings_gpkg_6933):
+            pytest.skip("buildings_test_6933.gpkg not available")
+        import geoparquet_io as gpio
+
+        table = gpio.convert(buildings_gpkg_6933)
+        assert table.crs is not None
+        assert table.add_bbox().crs is not None
+
+    def test_embedded_crs_wins_over_hint(self, buildings_gpkg_6933, temp_output_file):
+        """A Table read back from parquet uses the embedded CRS, not a hint."""
+        if not os.path.exists(buildings_gpkg_6933):
+            pytest.skip("buildings_test_6933.gpkg not available")
+        import geoparquet_io as gpio
+
+        gpio.convert(buildings_gpkg_6933).write(temp_output_file)
+        table = gpio.read(temp_output_file)
+        assert table.crs is not None
+        assert extract_epsg_code(table.crs) == 6933

--- a/tests/test_crs_write_paths.py
+++ b/tests/test_crs_write_paths.py
@@ -476,3 +476,31 @@ class TestTableAPICRSPreservation:
         table = gpio.read(temp_output_file)
         assert table.crs is not None
         assert extract_epsg_code(table.crs) == 6933
+
+    def test_head_tail_and_metadata_ops_keep_crs(self, buildings_gpkg_6933, temp_output_file):
+        """Derived Tables from head/tail must not drop the CRS hint (review follow-up)."""
+        if not os.path.exists(buildings_gpkg_6933):
+            pytest.skip("buildings_test_6933.gpkg not available")
+        import geoparquet_io as gpio
+
+        gpio.convert(buildings_gpkg_6933).head(5).write(temp_output_file)
+
+        metadata_crs = get_metadata_crs(temp_output_file)
+        assert metadata_crs is not None
+        assert extract_epsg_code(metadata_crs) == 6933
+
+    def test_reproject_does_not_keep_stale_source_hint(self, buildings_gpkg_6933, temp_output_file):
+        """After reproject(), the CRS hint must be the target CRS, never the source."""
+        if not os.path.exists(buildings_gpkg_6933):
+            pytest.skip("buildings_test_6933.gpkg not available")
+        import geoparquet_io as gpio
+
+        table = gpio.convert(buildings_gpkg_6933).reproject("EPSG:4326")
+        crs = table.crs
+        if crs is not None:
+            assert extract_epsg_code(crs) != 6933
+
+        table.write(temp_output_file)
+        metadata_crs = get_metadata_crs(temp_output_file)
+        if metadata_crs is not None:
+            assert extract_epsg_code(metadata_crs) == 4326


### PR DESCRIPTION
## Description

`gpio.convert('data.gpkg').write('out.parquet')` wrote `"crs": null` (= OGC:CRS84) for projected sources: `convert()` received the detected CRS from `read_spatial_to_arrow` and discarded it. The CLI/function path preserved CRS, which is the inconsistency reported in #625. Downstream this shipped wrong bboxes and broken PMTiles in portolan-cli, which converts through this API.

The Table now carries the detected CRS as a fallback for `.crs` (CRS embedded in the Arrow table still wins), `_write_geoparquet` picks it up through the existing `input_crs` plumbing, and chained operations (`add_bbox`, `sort_hilbert`, …) propagate it via a `_wrap` helper — they previously also dropped the auto-version hint, which now survives too.

## Technical Details

- `Table.__init__` gains an optional `crs` hint; `convert()` passes `detected_crs`.
- `Table.crs`: embedded CRS first, hint as fallback.
- 17 `return Table(...)` sites in chained methods now go through `self._wrap(...)`.
- No writer changes: all write strategies already accepted `input_crs`.

Verified on the real data from the report follow-up (Junta de Extremadura, EPSG:25829 shapefile and EPSG:25830 GeoPackage): plain, chained, and parquet-passthrough writes all keep their EPSG now.

## Breaking Changes
**Does this PR introduce breaking changes?** No

## Related Issue(s)
- #625

## Checklist
- [x] Tests added/updated, run against real data where feasible
- [x] Integration tests for changes that cross module/format/service boundaries
- [x] All tests pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved coordinate reference system (CRS) information when converting and writing GeoParquet files.
  * Maintained CRS metadata across chained table operations, slicing, transformations, and metadata updates.
  * Ensured detected CRS information remains available when source metadata lacks embedded CRS details.
  * Embedded CRS metadata continues to take precedence when available.
  * Updated CRS information correctly when reprojecting data to a new coordinate system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->