### PR TITLE
Fix SIGSEGV in geometry repair on tables with NULL geometry rows

### DIFF
--- a/geoparquet_io/core/geometry_repair.py
+++ b/geoparquet_io/core/geometry_repair.py
@@ -52,6 +52,25 @@ def repair_geometry_sql(geom_expr: str) -> str:
     )
 
 
+def _layered_invalid_count_sql(source_sql: str, parsed_expr: str) -> str:
+    """COUNT of invalid geometries, in a shape DuckDB executes without crashing.
+
+    Filtering ``IS NOT NULL`` and evaluating ``ST_IsValid`` over the raw rows in
+    one WHERE clause segfaults DuckDB 1.5.x's spatial extension when the column
+    contains NULLs (selection-vector misalignment under conditional execution;
+    the same bug family as the OR-form repair crash noted below). Verified on
+    issue #642's reproduction: projecting the parsed geometry first, filtering
+    NULLs in a middle layer, and running ``ST_IsValid`` outermost is logically
+    identical and crash-free.
+    """
+    return (
+        f"SELECT COUNT(*) FROM ("
+        f"SELECT __g FROM (SELECT {parsed_expr} AS __g FROM {source_sql}) "
+        f"WHERE __g IS NOT NULL"
+        f") WHERE NOT ST_IsValid(__g)"
+    )
+
+
 def repair_query_geometry(con, query: str, geometry_column: str, *, repair: bool = True) -> str:
     """Count and optionally repair invalid geometry in an arbitrary query.
 
@@ -87,13 +106,11 @@ def repair_query_geometry(con, query: str, geometry_column: str, *, repair: bool
     if "GEOMETRY" in col_type:
         # Native GEOMETRY: no decode needed; it cannot be a malformed-bytes case.
         parsed = col
-        count_pred = f"{col} IS NOT NULL AND NOT ST_IsValid({parsed})"
         repaired_expr = repair_geometry_sql(parsed)
     elif "BLOB" in col_type or "BINARY" in col_type:
         # WKB-encoded: decode defensively. TRY() yields NULL on malformed bytes so
         # we never crash the pipeline; such rows are passed through unchanged.
         parsed = f"TRY(ST_GeomFromWKB({col}))"
-        count_pred = f"{col} IS NOT NULL AND {parsed} IS NOT NULL AND NOT ST_IsValid({parsed})"
         # AND-form (repair in THEN, passthrough in ELSE). The equivalent OR-form
         # with ST_MakeValid in the ELSE branch segfaults DuckDB 1.5.1's spatial
         # extension on some real WKB inputs (see repair_arrow_table_geometry).
@@ -106,7 +123,7 @@ def repair_query_geometry(con, query: str, geometry_column: str, *, repair: bool
         return query
 
     try:
-        n = con.execute(f"SELECT COUNT(*) FROM ({query}) WHERE {count_pred}").fetchone()[0]
+        n = con.execute(_layered_invalid_count_sql(f"({query})", parsed)).fetchone()[0]
     except Exception:
         # Defensive: never let geometry repair break extraction.
         return query
@@ -155,10 +172,9 @@ def repair_arrow_table_geometry(table, geometry_column: str = "geometry", *, rep
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
         con.register("_gpio_repair_src", table)
-        n = con.execute(
-            f"SELECT COUNT(*) FROM _gpio_repair_src "
-            f"WHERE {col} IS NOT NULL AND {parsed} IS NOT NULL AND NOT ST_IsValid({parsed})"
-        ).fetchone()[0]
+        # Layered count: the single-WHERE form segfaults on tables containing
+        # NULL geometry rows (issue #642) — see _layered_invalid_count_sql.
+        n = con.execute(_layered_invalid_count_sql("_gpio_repair_src", parsed)).fetchone()[0]
         _warn_invalid(n, repaired=repair)
         if not repair or n == 0:
             return table, n

--- a/tests/test_geometry_repair.py
+++ b/tests/test_geometry_repair.py
@@ -223,3 +223,41 @@ def test_repair_query_geometry_with_null_rows():
         f"FROM ({repaired_query}) WHERE geometry IS NOT NULL"
     ).fetchone()[0]
     assert valid is True
+
+
+def test_repair_arrow_table_geometry_null_rows_at_scale():
+    """The #642 segfault only reproduces at scale — keep one big case.
+
+    Review probing on #645 crashed the old single-WHERE count from ~8k rows
+    with this exact recipe (NULL every 997 rows, invalid every 13), while the
+    small fixtures above pass either form. Being memory corruption, the crash
+    is environment-dependent (it does not reproduce on every machine), so this
+    catches a regression where it manifests rather than everywhere — the best
+    a test can do for an upstream crash — and pins the counts at scale
+    regardless.
+    """
+    con = _con()
+    n = 10_000
+    table = (
+        con.execute(
+            f"""
+            SELECT i AS id, CASE
+                WHEN i % 997 = 0 THEN NULL
+                WHEN i % 13 = 0 THEN ST_AsWKB(ST_GeomFromText('{BOWTIE_WKT}'))
+                ELSE ST_AsWKB(ST_GeomFromText('{SQUARE_WKT}'))
+            END AS geometry
+            FROM range({n}) t(i)
+            """
+        )
+        .arrow()
+        .read_all()
+    )
+    expected_nulls = sum(1 for i in range(n) if i % 997 == 0)
+    expected_invalid = sum(1 for i in range(n) if i % 13 == 0 and i % 997 != 0)
+
+    repaired, count = repair_arrow_table_geometry(table, "geometry")
+
+    assert repaired.num_rows == n
+    assert count == expected_invalid
+    nulls = sum(1 for v in repaired.column("geometry").to_pylist() if v is None)
+    assert nulls == expected_nulls

--- a/tests/test_geometry_repair.py
+++ b/tests/test_geometry_repair.py
@@ -168,3 +168,58 @@ def test_repair_arrow_table_geometry_tolerates_malformed_wkb():
     # Unparsable bytes are reported as 0 invalid and passed through unchanged.
     assert n == 0
     assert result.num_rows == 3
+
+
+def _wkb_table_with_nulls(con, *wkts, geom_col="geometry"):
+    """Like _wkb_table, but WKT None entries become NULL geometry rows."""
+    rows = "\n UNION ALL ".join(
+        (
+            f'SELECT {i} AS id, NULL::BLOB AS "{geom_col}"'
+            if w is None
+            else f"SELECT {i} AS id, ST_AsWKB(ST_GeomFromText('{w}')) AS \"{geom_col}\""
+        )
+        for i, w in enumerate(wkts)
+    )
+    return con.execute(rows).arrow().read_all()
+
+
+def test_repair_arrow_table_geometry_with_null_rows(caplog):
+    """NULL geometry rows must not crash the repair pass and must survive it.
+
+    Issue #642: the previous single-WHERE invalid count segfaulted DuckDB's
+    spatial extension on real-world tables containing NULL geometry rows
+    (selection-vector misalignment under conditional execution). The layered
+    count shape is logically identical and crash-free; NULL rows pass through.
+    """
+    con = _con()
+    table = _wkb_table_with_nulls(con, SQUARE_WKT, None, BOWTIE_WKT, None, SQUARE_WKT)
+
+    with caplog.at_level(logging.WARNING):
+        repaired, n = repair_arrow_table_geometry(table, "geometry")
+
+    assert n == 1  # only the bowtie; NULLs are neither invalid nor repaired
+    assert repaired.num_rows == 5
+    null_count = sum(1 for v in repaired.column("geometry").to_pylist() if v is None)
+    assert null_count == 2
+
+
+def test_repair_query_geometry_with_null_rows():
+    """The query path's layered count also tolerates NULL geometry rows."""
+    con = _con()
+    query = (
+        f"SELECT 1 AS id, ST_AsWKB(ST_GeomFromText('{BOWTIE_WKT}')) AS geometry"
+        " UNION ALL SELECT 2, NULL::BLOB"
+        f" UNION ALL SELECT 3, ST_AsWKB(ST_GeomFromText('{SQUARE_WKT}'))"
+    )
+    repaired_query = repair_query_geometry(con, query, "geometry")
+
+    assert repaired_query != query  # the bowtie triggers a repair rewrite
+    rows = con.execute(
+        f"SELECT id, geometry IS NULL FROM ({repaired_query}) ORDER BY id"
+    ).fetchall()
+    assert [r[1] for r in rows] == [False, True, False]
+    valid = con.execute(
+        f"SELECT bool_and(ST_IsValid(TRY(ST_GeomFromWKB(geometry)))) "
+        f"FROM ({repaired_query}) WHERE geometry IS NOT NULL"
+    ).fetchone()[0]
+    assert valid is True


### PR DESCRIPTION
## Description

`gpio.convert()` crashed the whole Python process (SIGSEGV, exit 139) on a real-world GeoPackage with 4,112 features, 3 of them NULL geometry. `faulthandler` pinned it to the invalid-geometry count in `repair_arrow_table_geometry`: filtering `IS NOT NULL` and evaluating `ST_IsValid`/`ST_GeomFromWKB` over raw rows in one WHERE clause misaligns DuckDB spatial's selection vector — the same bug family as the OR-form repair crash already documented in this module.

Fix: a layered count (`_layered_invalid_count_sql`) — project the parsed geometry, filter NULLs in a middle layer, run `ST_IsValid` outermost. Logically identical, empirically crash-free (variant-tested A–D against the crashing file), applied to both the Arrow and query repair paths.

## Technical Details

The crashing file converts cleanly now: all 4,112 rows survive including the 3 NULL geometries. The trigger needs the file's real polygon blobs (synthetic points, chunked or not, don't reproduce), so the regression tests pin the NULL-row contract of both repair paths rather than the crash itself; the 53 MB reproduction file (CC-BY 4.0, Junta de Extremadura) is available on request — it's the one from #642.

## Breaking Changes
**Does this PR introduce breaking changes?** No

## Related Issue(s)
- #642

## Checklist
- [x] Tests added/updated, run against real data where feasible
- [x] Integration tests for changes that cross module/format/service boundaries
- [x] All tests pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved geometry repair reliability for datasets containing NULL or invalid geometries.
  - Preserved NULL geometry rows and overall row counts during repair.
  - Improved query-based repair to accurately detect invalid geometries and repair affected data.

- **Tests**
  - Added coverage for NULL geometry handling across table and query workflows.
  - Added large-scale regression coverage for mixed NULL and invalid geometries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->