### PR TITLE
Linearize curved WKB geometries on read instead of failing

### DIFF
--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -395,6 +395,52 @@ Only invalid geometry is touched: valid geometry is byte-identical, NULL is
 preserved, and bounding boxes stay correct (`ST_MakeValid` never expands an
 envelope).
 
+### Curved Geometries
+
+GeoParquet cannot represent curved geometry types (CircularString,
+CompoundCurve, CurvePolygon, MultiCurve, MultiSurface — common in GeoPackage
+and FileGDB exports from CAD or ArcGIS), so by default gpio strokes arcs into
+line segments on read, the same operation as `ogr2ogr -nlt CONVERT_TO_LINEAR`
+or PostGIS `ST_CurveToLine`. A warning reports how many features were
+linearized.
+
+Note this **alters the geometry**: arcs become chains of straight segments,
+sampled every 4° of arc by default (GDAL's default; ~0.08% area error on a
+full circle). Earlier gpio versions failed on curved input — opt out with
+`--no-linearize-curves` to keep that strict behavior.
+
+=== "CLI"
+
+    ```bash
+    # Default: linearizes and warns ("Linearized 66 curved geometries ...")
+    gpio convert curved.gpkg output.parquet
+
+    # Denser sampling: 1 degree per segment
+    gpio convert curved.gpkg output.parquet --max-angle-deg 1
+
+    # Opt out: curved input fails with an actionable error
+    gpio convert curved.gpkg output.parquet --no-linearize-curves
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    # Default: linearizes curved geometries
+    gpio.convert("curved.gpkg").write("output.parquet")
+
+    # Denser sampling: 1 degree per segment
+    gpio.convert("curved.gpkg", max_angle_deg=1.0).write("output.parquet")
+
+    # Opt out: raise on curved input instead
+    gpio.convert("curved.gpkg", linearize_curves=False)
+    ```
+
+Linear geometries pass through untouched, and NULL is preserved. The surface
+family (PolyhedralSurface, TIN, Triangle) is not linearized and still raises
+an error.
+
 ### Skip Hilbert Ordering
 
 For faster conversion when spatial ordering isn't critical:

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -437,9 +437,15 @@ full circle). Earlier gpio versions failed on curved input — opt out with
     gpio.convert("curved.gpkg", linearize_curves=False)
     ```
 
-Linear geometries pass through untouched, and NULL is preserved. The surface
-family (PolyhedralSurface, TIN, Triangle) is not linearized and still raises
-an error.
+Linear geometries pass through untouched, NULL is preserved, and empty curves
+become their empty linear counterpart. The surface family (PolyhedralSurface,
+TIN, Triangle) is not linearized and still raises an error.
+
+Curved input is spotted either by a header scan of local GeoPackages or on the
+first pass that parses geometry. `--skip-hilbert` removes that pass, so a
+curved source which is not a local `.gpkg` (FileGDB, a GeoPackage on S3) still
+errors under `--skip-hilbert` — drop the flag, or linearize with `ogr2ogr`
+first.
 
 ### Skip Hilbert Ordering
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -287,6 +287,8 @@ def convert(
     profile: str | None = None,
     layer: str | None = None,
     repair_geometry: bool = True,
+    linearize_curves: bool = True,
+    max_angle_deg: float | None = None,
 ) -> Table:
     """
     Convert a geospatial file to a Table.
@@ -306,6 +308,11 @@ def convert(
         profile: AWS profile name for S3 authentication (default: None)
         layer: Layer name for multi-layer formats (GeoPackage, FileGDB). If not specified,
                reads the first/default layer.
+        linearize_curves: Stroke curved geometries (CircularString..MultiSurface) into
+               their linear equivalents when DuckDB cannot parse them (default: True,
+               mirroring repair_geometry). False raises an actionable error instead.
+        max_angle_deg: Maximum angular step per stroked arc segment in degrees
+               (default: 4.0, GDAL's OGR_ARC_STEPSIZE default).
 
     Returns:
         Table for chaining operations
@@ -331,6 +338,8 @@ def convert(
         geometry_column=geometry_column,
         layer=layer,
         repair_geometry=repair_geometry,
+        linearize_curves=linearize_curves,
+        max_angle_deg=max_angle_deg,
     )
 
     return Table(arrow_table, geometry_column=geom_col)

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -193,6 +193,30 @@ def repair_geometry_option(func):
     )(func)
 
 
+def linearize_curves_options(func):
+    """
+    Add --linearize-curves/--no-linearize-curves and --max-angle-deg options.
+
+    Curved geometries (CircularString through MultiSurface) cannot be
+    represented in GeoParquet, so they are stroked into line segments by
+    default. Users who want curved input to fail instead can opt out.
+    """
+    func = click.option(
+        "--max-angle-deg",
+        type=click.FloatRange(min=0, min_open=True),
+        default=None,
+        help="Maximum degrees per stroked arc segment when linearizing curves (default: 4).",
+    )(func)
+    return click.option(
+        "--linearize-curves/--no-linearize-curves",
+        default=True,
+        help=(
+            "Stroke curved geometries (CircularString..MultiSurface) into line "
+            "segments (default: on). Use --no-linearize-curves to fail on curved input."
+        ),
+    )(func)
+
+
 def write_memory_option(func):
     """
     Add --write-memory option to a command.

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -21,6 +21,7 @@ from geoparquet_io.cli.decorators import (
     grid_aggregate_options,
     handle_directory_sub_partition,
     handle_geoparquet_errors,
+    linearize_curves_options,
     metric_nodata_option,
     output_format_options,
     overwrite_option,
@@ -1264,6 +1265,7 @@ def convert(ctx):
     help="Allow conversion to plain Parquet when no geometry column is detected (default: error)",
 )
 @repair_geometry_option
+@linearize_curves_options
 @geoparquet_version_option
 @verbose_option
 @output_format_options
@@ -1286,6 +1288,8 @@ def convert_to_geoparquet_cmd(
     csv_max_line_size,
     allow_no_geometry,
     repair_geometry,
+    linearize_curves,
+    max_angle_deg,
     geoparquet_version,
     verbose,
     compression,
@@ -1359,6 +1363,8 @@ def convert_to_geoparquet_cmd(
                 row_group_rows=row_group_size,
                 row_group_size_mb=row_group_mb,
                 repair_geometry=repair_geometry,
+                linearize_curves=linearize_curves,
+                max_angle_deg=max_angle_deg,
             )
         else:
             convert_to_geoparquet(
@@ -1381,6 +1387,8 @@ def convert_to_geoparquet_cmd(
                 profile=aws_profile,
                 geoparquet_version=geoparquet_version,
                 repair_geometry=repair_geometry,
+                linearize_curves=linearize_curves,
+                max_angle_deg=max_angle_deg,
             )
 
 
@@ -1402,6 +1410,8 @@ def _convert_streaming(
     row_group_rows=None,
     row_group_size_mb=None,
     repair_geometry=True,
+    linearize_curves=True,
+    max_angle_deg=None,
 ):
     """Handle streaming output for convert command."""
     import tempfile
@@ -1435,6 +1445,8 @@ def _convert_streaming(
             profile=profile,
             geoparquet_version=geoparquet_version,
             repair_geometry=repair_geometry,
+            linearize_curves=linearize_curves,
+            max_angle_deg=max_angle_deg,
         )
 
         # Read and stream to stdout

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1087,6 +1087,8 @@ def read_spatial_to_arrow(
     geometry_column="geometry",
     layer=None,
     repair_geometry=True,
+    linearize_curves=True,
+    max_angle_deg=None,
 ):
     """
     Read a geospatial file and return an Arrow table with geometry.
@@ -1188,7 +1190,13 @@ def read_spatial_to_arrow(
             )
         else:
             arrow_table = _read_spatial_to_arrow(
-                con, input_url, verbose, is_parquet=is_parquet, layer=layer
+                con,
+                input_url,
+                verbose,
+                is_parquet=is_parquet,
+                layer=layer,
+                linearize_curves=linearize_curves,
+                max_angle_deg=max_angle_deg,
             )
 
         # No geometry found — read as plain table
@@ -1305,7 +1313,15 @@ def _read_csv_to_arrow(
     return result.arrow().read_all()
 
 
-def _read_spatial_to_arrow(con, input_url, verbose, is_parquet=False, layer=None):
+def _read_spatial_to_arrow(
+    con,
+    input_url,
+    verbose,
+    is_parquet=False,
+    layer=None,
+    linearize_curves=True,
+    max_angle_deg=None,
+):
     """Read spatial file to Arrow table with geometry as WKB. Returns None if no geometry."""
     geom_column = _detect_geometry_column(
         con, input_url, verbose, is_parquet=is_parquet, layer=layer
@@ -1335,14 +1351,14 @@ def _read_spatial_to_arrow(con, input_url, verbose, is_parquet=False, layer=None
         # DuckDB's GEOMETRY type; linearize them at the WKB boundary instead
         # (issue #643). Only the spatial-file path can take this road: parquet
         # inputs have no keep_wkb escape hatch.
-        if is_parquet or "Unsupported geometry type in WKB" not in str(e):
+        if is_parquet or not linearize_curves or "Unsupported geometry type in WKB" not in str(e):
             raise
         if verbose:
             debug("Curved geometries detected; linearizing via keep_wkb read")
-        return _read_spatial_linearized(con, input_url, layer, geom_column)
+        return _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg)
 
 
-def _read_spatial_linearized(con, input_url, layer, geom_column):
+def _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg=None):
     """Read a spatial file whose WKB contains curved types, stroking them.
 
     ``ST_Read(keep_wkb := true)`` hands back the raw WKB blobs untouched (the
@@ -1352,7 +1368,14 @@ def _read_spatial_linearized(con, input_url, layer, geom_column):
     returned table is indistinguishable from the normal read path.
     """
     from geoparquet_io.core.curved_geometry import unsupported_wkb_error_message
-    from geoparquet_io.core.linearize import LinearizeError, linearize_wkb
+    from geoparquet_io.core.linearize import (
+        DEFAULT_MAX_ANGLE_DEG,
+        LinearizeError,
+        linearize_wkb,
+    )
+
+    if max_angle_deg is None:
+        max_angle_deg = DEFAULT_MAX_ANGLE_DEG
 
     opts = f", layer := '{layer}'" if layer else ""
     raw = (
@@ -1374,7 +1397,7 @@ def _read_spatial_linearized(con, input_url, layer, geom_column):
             values.append(None)
             continue
         try:
-            linear, did_change = linearize_wkb(value)
+            linear, did_change = linearize_wkb(value, max_angle_deg)
         except LinearizeError as e:
             # e.g. the surface family (POLYHEDRALSURFACE/TIN/TRIANGLE) or
             # malformed blobs: fall back to the actionable error (#643).
@@ -1386,8 +1409,8 @@ def _read_spatial_linearized(con, input_url, layer, geom_column):
     if changed:
         warn(
             f"Linearized {changed} curved geometr{'y' if changed == 1 else 'ies'} "
-            f"(arcs stroked at <= {4.0} degrees per segment); GeoParquet cannot "
-            "represent curves."
+            f"(arcs stroked at <= {max_angle_deg} degrees per segment); GeoParquet "
+            "cannot represent curves."
         )
 
     # Round-trip through DuckDB: validates the stroked WKB and yields the same
@@ -1553,6 +1576,12 @@ def convert_to_geoparquet(
             1.1-geoarrow converts geometry from any input to native GeoArrow nested-coordinate
             encoding and omits the bbox column; columns with incompatible mixed types fall back to WKB.
         repair_geometry: Repair invalid geometry with ST_MakeValid (default: True).
+        linearize_curves: Stroke curved geometries (CircularString..MultiSurface)
+            into their linear equivalents when DuckDB cannot parse them
+            (default: True, mirroring repair_geometry). False raises the
+            actionable unsupported-geometry error instead.
+        max_angle_deg: Maximum angular step per stroked arc segment in degrees
+            (default: 4.0, GDAL's OGR_ARC_STEPSIZE default).
             When False, invalid geometry is preserved and a warning reports the count.
 
     Raises:

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -3,6 +3,7 @@
 import gc
 import os
 import time
+from pathlib import Path
 
 import duckdb
 
@@ -74,12 +75,14 @@ def _validate_layer_name(layer: str) -> str:
     return _escape_sql_string(layer)
 
 
-def _build_st_read_expr(input_url: str, layer: str | None = None) -> str:
-    """Build ST_Read expression with optional layer parameter.
+def _build_st_read_expr(input_url: str, layer: str | None = None, keep_wkb: bool = False) -> str:
+    """Build ST_Read expression with optional layer/keep_wkb parameters.
 
     Args:
         input_url: Path or URL to the spatial file
         layer: Optional layer name for multi-layer formats (GeoPackage, FileGDB)
+        keep_wkb: Return raw WKB blobs instead of parsed GEOMETRY (DuckDB's
+            escape hatch for geometry subtypes it cannot represent)
 
     Returns:
         SQL expression for ST_Read
@@ -93,11 +96,37 @@ def _build_st_read_expr(input_url: str, layer: str | None = None) -> str:
         bug. Consider validating layer names against the file's available layers
         before calling this function if user input is involved.
     """
+    # DuckDB uses := for named parameters
+    params = ""
+    if keep_wkb:
+        params += ", keep_wkb := true"
     if layer:
-        safe_layer = _validate_layer_name(layer)
-        # DuckDB uses := for named parameters
-        return f"ST_Read('{input_url}', layer := '{safe_layer}')"
-    return f"ST_Read('{input_url}')"
+        params += f", layer := '{_validate_layer_name(layer)}'"
+    return f"ST_Read('{input_url}'{params})"
+
+
+def _choose_read_strategy(input_url, layer=None, linearize_curves=True):
+    """Pick how to read a spatial file: 'normal', 'linearized', or 'error'.
+
+    Local GeoPackages are pre-scanned for curved geometry types with the
+    stdlib (issue #643) so the strategy is known without provoking a DuckDB
+    error. Formats without a cheap scan return 'normal' and rely on the
+    error-triggered fallback in the caller.
+    """
+    from geoparquet_io.core.curved_geometry import find_non_linear_gpkg_types
+
+    path = Path(input_url)
+    if path.suffix.lower() != ".gpkg" or not path.exists():
+        return "normal"
+    if not find_non_linear_gpkg_types(path, layer):
+        return "normal"
+    return "linearized" if linearize_curves else "error"
+
+
+def _validate_max_angle(max_angle_deg):
+    """Reject non-positive linearization tolerances before they corrupt output."""
+    if max_angle_deg is not None and not max_angle_deg > 0:
+        raise InvalidParameterError("max_angle_deg", "must be a positive number of degrees")
 
 
 def _detect_geometry_column(con, input_file, verbose, is_parquet=False, layer=None):
@@ -203,16 +232,19 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
     return result
 
 
-def _calculate_bounds(con, input_file, geom_column, verbose, is_parquet=False, encoding="WKB"):
-    """Calculate dataset bounds from input file."""
+def _calculate_bounds(
+    con, input_file, geom_column, verbose, is_parquet=False, encoding="WKB", table_expr=None
+):
+    """Calculate dataset bounds from input file (or an explicit table_expr)."""
     if verbose:
         debug("Calculating dataset bounds...")
 
     # For parquet files, read directly; for other formats use ST_Read
-    if is_parquet:
-        table_expr = f"read_parquet('{input_file}')"
-    else:
-        table_expr = f"ST_Read('{input_file}')"
+    if table_expr is None:
+        if is_parquet:
+            table_expr = f"read_parquet('{input_file}')"
+        else:
+            table_expr = f"ST_Read('{input_file}')"
 
     # Quote column name to handle special characters, spaces, and reserved words
     quoted_geom = quote_identifier(geom_column)
@@ -793,6 +825,7 @@ def _build_conversion_query(
     existing_bbox_col=None,
     preserve_existing_bbox=False,
     encoding="WKB",
+    table_expr=None,
 ):
     """Build SQL query for conversion with optional Hilbert ordering.
 
@@ -807,12 +840,15 @@ def _build_conversion_query(
         existing_bbox_col: Name of existing bbox column to remove (for parquet input)
         preserve_existing_bbox: If True, keep existing bbox column instead of adding new one
         encoding: GeoParquet geometry encoding (e.g. "WKB", "multipolygon")
+        table_expr: Explicit source expression overriding the input_file read
+            (used for the linearized-curves view)
     """
     # For parquet files, read directly; for other formats use ST_Read
-    if is_parquet:
-        table_expr = f"read_parquet('{input_file}')"
-    else:
-        table_expr = _build_st_read_expr(input_file, layer)
+    if table_expr is None:
+        if is_parquet:
+            table_expr = f"read_parquet('{input_file}')"
+        else:
+            table_expr = _build_st_read_expr(input_file, layer)
 
     # Build exclusion list - only exclude existing bbox if needed
     # NOTE: We preserve the original geometry column name (no renaming to "geometry")
@@ -980,7 +1016,15 @@ def _convert_csv_path(
 
 
 def _convert_spatial_path(
-    con, input_file, skip_hilbert, verbose, is_parquet=False, layer=None, geoparquet_version=None
+    con,
+    input_file,
+    skip_hilbert,
+    verbose,
+    is_parquet=False,
+    layer=None,
+    geoparquet_version=None,
+    linearize_curves=True,
+    max_angle_deg=None,
 ):
     """Handle standard spatial format conversion path.
 
@@ -1010,6 +1054,25 @@ def _convert_spatial_path(
     if geom_column is None:
         return None, None
 
+    # Curved geometries cannot pass through the ST_Read-based query below;
+    # detected up front (GPKG pre-scan, issue #643) they are read once via
+    # the linearize path and exposed as a view the query can use instead.
+    table_expr = None
+    if not is_parquet:
+        strategy = _choose_read_strategy(input_file, layer, linearize_curves)
+        if strategy == "error":
+            from geoparquet_io.core.curved_geometry import unsupported_wkb_error_message
+
+            raise GeoParquetError(
+                unsupported_wkb_error_message(input_file, layer, "curved types found in pre-scan")
+            )
+        if strategy == "linearized":
+            if verbose:
+                debug("Curved geometries detected; linearizing via keep_wkb read")
+            table_expr = _register_linearized_view(
+                con, input_file, layer, geom_column, max_angle_deg
+            )
+
     # Determine if bbox should be skipped for this version
     skip_bbox = should_skip_bbox(geoparquet_version)
 
@@ -1036,7 +1099,13 @@ def _convert_spatial_path(
         None
         if skip_hilbert
         else _calculate_bounds(
-            con, input_file, geom_column, verbose, is_parquet=is_parquet, encoding=geom_encoding
+            con,
+            input_file,
+            geom_column,
+            verbose,
+            is_parquet=is_parquet,
+            encoding=geom_encoding,
+            table_expr=table_expr,
         )
     )
 
@@ -1068,6 +1137,7 @@ def _convert_spatial_path(
         existing_bbox_col=existing_bbox_col,
         preserve_existing_bbox=preserve_existing_bbox,
         encoding=geom_encoding,
+        table_expr=table_expr,
     )
 
     return query, geom_info
@@ -1109,6 +1179,13 @@ def read_spatial_to_arrow(
         geometry_column: Name for output geometry column (default: 'geometry')
         layer: Layer name for multi-layer formats (GeoPackage, FileGDB). If not specified,
                reads the first/default layer.
+        repair_geometry: Repair invalid geometry with ST_MakeValid (default: True).
+        linearize_curves: Stroke curved geometries (CircularString..MultiSurface)
+            into their linear equivalents when DuckDB cannot parse them
+            (default: True). False raises the actionable unsupported-geometry
+            error instead.
+        max_angle_deg: Maximum angular step per stroked arc segment in degrees
+            (default: 4.0, GDAL's OGR_ARC_STEPSIZE default).
 
     Returns:
         tuple: (arrow_table, detected_crs_projjson, geometry_column_name)
@@ -1116,7 +1193,7 @@ def read_spatial_to_arrow(
     Raises:
         GeoParquetError: If input file not found or reading fails
     """
-
+    _validate_max_angle(max_angle_deg)
     configure_verbose(verbose)
 
     # Validate profile is only used with S3
@@ -1232,6 +1309,11 @@ def read_spatial_to_arrow(
     except duckdb.BinderException as e:
         raise GeometryError(f"Invalid geometry data: {str(e)}") from e
 
+    except GeoParquetError:
+        # Already actionable (e.g. the curved-geometry message from the
+        # linearize path) — don't wrap it a second time.
+        raise
+
     except Exception as e:
         if "Unsupported geometry type in WKB" in str(e):
             from geoparquet_io.core.curved_geometry import unsupported_wkb_error_message
@@ -1334,6 +1416,17 @@ def _read_spatial_to_arrow(
     if is_parquet:
         table_expr = f"read_parquet('{input_url}')"
     else:
+        strategy = _choose_read_strategy(input_url, layer, linearize_curves)
+        if strategy == "error":
+            from geoparquet_io.core.curved_geometry import unsupported_wkb_error_message
+
+            raise GeoParquetError(
+                unsupported_wkb_error_message(input_url, layer, "curved types found in pre-scan")
+            )
+        if strategy == "linearized":
+            if verbose:
+                debug("Curved geometries detected; linearizing via keep_wkb read")
+            return _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg)
         table_expr = _build_st_read_expr(input_url, layer)
 
     # Convert geometry to WKB for geoarrow compatibility
@@ -1349,8 +1442,9 @@ def _read_spatial_to_arrow(
     except duckdb.Error as e:
         # Curved geometries (CIRCULARSTRING..MULTISURFACE) cannot pass through
         # DuckDB's GEOMETRY type; linearize them at the WKB boundary instead
-        # (issue #643). Only the spatial-file path can take this road: parquet
-        # inputs have no keep_wkb escape hatch.
+        # (issue #643). The pre-scan above already caught local GeoPackages —
+        # this fallback covers formats without a cheap scan (e.g. FileGDB).
+        # Parquet inputs have no keep_wkb escape hatch.
         if is_parquet or not linearize_curves or "Unsupported geometry type in WKB" not in str(e):
             raise
         if verbose:
@@ -1358,28 +1452,28 @@ def _read_spatial_to_arrow(
         return _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg)
 
 
-def _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg=None):
+def _linearize_to_arrow(con, input_url, layer, geom_column, max_angle_deg=None):
     """Read a spatial file whose WKB contains curved types, stroking them.
 
     ``ST_Read(keep_wkb := true)`` hands back the raw WKB blobs untouched (the
     escape hatch DuckDB documents for geometry subtypes it cannot represent);
-    each curved blob is stroked into its linear equivalent in Python and the
-    result is validated by round-tripping through ``ST_GeomFromWKB`` so the
-    returned table is indistinguishable from the normal read path.
+    each curved blob is stroked into its linear equivalent in Python. Returns
+    ``(raw_table, wkb_col)`` with the geometry column holding linear WKB
+    under its original name.
     """
     from geoparquet_io.core.curved_geometry import unsupported_wkb_error_message
     from geoparquet_io.core.linearize import (
         DEFAULT_MAX_ANGLE_DEG,
         LinearizeError,
+        contains_curved_wkb,
         linearize_wkb,
     )
 
     if max_angle_deg is None:
         max_angle_deg = DEFAULT_MAX_ANGLE_DEG
 
-    opts = f", layer := '{layer}'" if layer else ""
     raw = (
-        con.execute(f"SELECT * FROM ST_Read('{input_url}', keep_wkb := true{opts})")
+        con.execute(f"SELECT * FROM {_build_st_read_expr(input_url, layer, keep_wkb=True)}")
         .arrow()
         .read_all()
     )
@@ -1395,6 +1489,9 @@ def _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg=N
     for value in raw.column(wkb_col).to_pylist():
         if value is None:
             values.append(None)
+            continue
+        if not contains_curved_wkb(value):
+            values.append(value)  # linear at the top level: keep the bytes as-is
             continue
         try:
             linear, did_change = linearize_wkb(value, max_angle_deg)
@@ -1412,6 +1509,12 @@ def _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg=N
             f"(arcs stroked at <= {max_angle_deg} degrees per segment); GeoParquet "
             "cannot represent curves."
         )
+    return raw, wkb_col
+
+
+def _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg=None):
+    """Linearized read shaped like the normal read path (WKB `geometry` column)."""
+    raw, wkb_col = _linearize_to_arrow(con, input_url, layer, geom_column, max_angle_deg)
 
     # Round-trip through DuckDB: validates the stroked WKB and yields the same
     # WKB-encoded `geometry` column shape as the normal read path.
@@ -1423,6 +1526,25 @@ def _read_spatial_linearized(con, input_url, layer, geom_column, max_angle_deg=N
         f"FROM _gpio_linearized_src"
     )
     return result.arrow().read_all()
+
+
+def _register_linearized_view(con, input_url, layer, geom_column, max_angle_deg=None):
+    """Register a linearized read as a view mimicking ST_Read's shape.
+
+    The view exposes a GEOMETRY-typed column under its original name and
+    position, so the query-based conversion path (bounds, bbox, Hilbert) can
+    use it as a drop-in replacement for the ST_Read expression. Returns the
+    view name.
+    """
+    raw, wkb_col = _linearize_to_arrow(con, input_url, layer, geom_column, max_angle_deg)
+    con.register("_gpio_linearized_src", raw)
+    quoted_wkb = quote_identifier(wkb_col)
+    con.execute(
+        "CREATE OR REPLACE TEMP VIEW _gpio_linearized AS "
+        f"SELECT * REPLACE (ST_GeomFromWKB({quoted_wkb}) AS {quoted_wkb}) "
+        "FROM _gpio_linearized_src"
+    )
+    return "_gpio_linearized"
 
 
 def _determine_effective_crs(
@@ -1543,6 +1665,8 @@ def convert_to_geoparquet(
     profile=None,
     geoparquet_version=None,
     repair_geometry=True,
+    linearize_curves=True,
+    max_angle_deg=None,
 ):
     """
     Convert vector format to optimized GeoParquet.
@@ -1576,17 +1700,19 @@ def convert_to_geoparquet(
             1.1-geoarrow converts geometry from any input to native GeoArrow nested-coordinate
             encoding and omits the bbox column; columns with incompatible mixed types fall back to WKB.
         repair_geometry: Repair invalid geometry with ST_MakeValid (default: True).
+            When False, invalid geometry is preserved and a warning reports the count.
         linearize_curves: Stroke curved geometries (CircularString..MultiSurface)
             into their linear equivalents when DuckDB cannot parse them
-            (default: True, mirroring repair_geometry). False raises the
-            actionable unsupported-geometry error instead.
+            (default: True, mirroring repair_geometry). Note this alters the
+            geometry: arcs become line segments and a warning reports the count.
+            False raises the actionable unsupported-geometry error instead.
         max_angle_deg: Maximum angular step per stroked arc segment in degrees
             (default: 4.0, GDAL's OGR_ARC_STEPSIZE default).
-            When False, invalid geometry is preserved and a warning reports the count.
 
     Raises:
         GeoParquetError: If input file not found or conversion fails
     """
+    _validate_max_angle(max_angle_deg)
     configure_verbose(verbose)
     start_time = time.time()
 
@@ -1646,6 +1772,8 @@ def convert_to_geoparquet(
                 is_parquet=is_parquet,
                 layer=layer,
                 geoparquet_version=geoparquet_version,
+                linearize_curves=linearize_curves,
+                max_angle_deg=max_angle_deg,
             )
 
         # No geometry detected — error unless explicitly allowed

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1327,7 +1327,78 @@ def _read_spatial_to_arrow(con, input_url, verbose, is_parquet=False, layer=None
         FROM {table_expr}
     """
 
-    result = con.execute(query)
+    try:
+        result = con.execute(query)
+        return result.arrow().read_all()
+    except duckdb.Error as e:
+        # Curved geometries (CIRCULARSTRING..MULTISURFACE) cannot pass through
+        # DuckDB's GEOMETRY type; linearize them at the WKB boundary instead
+        # (issue #643). Only the spatial-file path can take this road: parquet
+        # inputs have no keep_wkb escape hatch.
+        if is_parquet or "Unsupported geometry type in WKB" not in str(e):
+            raise
+        if verbose:
+            debug("Curved geometries detected; linearizing via keep_wkb read")
+        return _read_spatial_linearized(con, input_url, layer, geom_column)
+
+
+def _read_spatial_linearized(con, input_url, layer, geom_column):
+    """Read a spatial file whose WKB contains curved types, stroking them.
+
+    ``ST_Read(keep_wkb := true)`` hands back the raw WKB blobs untouched (the
+    escape hatch DuckDB documents for geometry subtypes it cannot represent);
+    each curved blob is stroked into its linear equivalent in Python and the
+    result is validated by round-tripping through ``ST_GeomFromWKB`` so the
+    returned table is indistinguishable from the normal read path.
+    """
+    from geoparquet_io.core.curved_geometry import unsupported_wkb_error_message
+    from geoparquet_io.core.linearize import LinearizeError, linearize_wkb
+
+    opts = f", layer := '{layer}'" if layer else ""
+    raw = (
+        con.execute(f"SELECT * FROM ST_Read('{input_url}', keep_wkb := true{opts})")
+        .arrow()
+        .read_all()
+    )
+
+    wkb_col = geom_column if geom_column in raw.column_names else "wkb_geometry"
+    if wkb_col not in raw.column_names:
+        raise GeoParquetError(f"keep_wkb read of {input_url} exposes no '{geom_column}' column")
+
+    import pyarrow as pa
+
+    changed = 0
+    values = []
+    for value in raw.column(wkb_col).to_pylist():
+        if value is None:
+            values.append(None)
+            continue
+        try:
+            linear, did_change = linearize_wkb(value)
+        except LinearizeError as e:
+            # e.g. the surface family (POLYHEDRALSURFACE/TIN/TRIANGLE) or
+            # malformed blobs: fall back to the actionable error (#643).
+            raise GeoParquetError(unsupported_wkb_error_message(input_url, layer, str(e))) from e
+        changed += did_change
+        values.append(linear)
+    idx = raw.column_names.index(wkb_col)
+    raw = raw.set_column(idx, wkb_col, pa.array(values, type=pa.binary()))
+    if changed:
+        warn(
+            f"Linearized {changed} curved geometr{'y' if changed == 1 else 'ies'} "
+            f"(arcs stroked at <= {4.0} degrees per segment); GeoParquet cannot "
+            "represent curves."
+        )
+
+    # Round-trip through DuckDB: validates the stroked WKB and yields the same
+    # WKB-encoded `geometry` column shape as the normal read path.
+    con.register("_gpio_linearized_src", raw)
+    quoted_wkb = quote_identifier(wkb_col)
+    result = con.execute(
+        f"SELECT * EXCLUDE ({quoted_wkb}), "
+        f"ST_AsWKB(ST_GeomFromWKB({quoted_wkb})) AS geometry "
+        f"FROM _gpio_linearized_src"
+    )
     return result.arrow().read_all()
 
 

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1015,6 +1015,55 @@ def _convert_csv_path(
     return query
 
 
+def _bounds_with_curve_fallback(
+    con,
+    input_file,
+    geom_column,
+    verbose,
+    *,
+    is_parquet,
+    encoding,
+    table_expr,
+    layer,
+    linearize_curves,
+    max_angle_deg,
+):
+    """Dataset bounds, linearizing curved sources the pre-scan cannot see.
+
+    The GPKG pre-scan only covers local ``*.gpkg`` files, so other curved
+    sources (FileGDB, a GeoPackage on S3) first reveal themselves here — the
+    bounds pass is what parses every geometry. Falling back to the linearized
+    view keeps ``gpio convert`` in step with the Python API instead of
+    surfacing DuckDB's bare "Unsupported geometry type in WKB" (issue #643).
+
+    Returns:
+        tuple: (bounds, table_expr) — table_expr is the linearized view when
+        the fallback fired, otherwise the caller's value unchanged.
+    """
+    kwargs = {"is_parquet": is_parquet, "encoding": encoding}
+    try:
+        bounds = _calculate_bounds(
+            con, input_file, geom_column, verbose, table_expr=table_expr, **kwargs
+        )
+        return bounds, table_expr
+    except duckdb.Error as e:
+        already_linearized = table_expr is not None
+        if (
+            is_parquet
+            or already_linearized
+            or not linearize_curves
+            or "Unsupported geometry type in WKB" not in str(e)
+        ):
+            raise
+        if verbose:
+            debug("Curved geometries detected while measuring bounds; linearizing")
+        table_expr = _register_linearized_view(con, input_file, layer, geom_column, max_angle_deg)
+        bounds = _calculate_bounds(
+            con, input_file, geom_column, verbose, table_expr=table_expr, **kwargs
+        )
+        return bounds, table_expr
+
+
 def _convert_spatial_path(
     con,
     input_file,
@@ -1095,10 +1144,9 @@ def _convert_spatial_path(
                     debug(f"Preserving existing bbox column: {existing_bbox_col}")
 
     geom_encoding = geom_info["metadata"].get(geom_column, {}).get("encoding", "WKB")
-    bounds = (
-        None
-        if skip_hilbert
-        else _calculate_bounds(
+    bounds = None
+    if not skip_hilbert:
+        bounds, table_expr = _bounds_with_curve_fallback(
             con,
             input_file,
             geom_column,
@@ -1106,8 +1154,10 @@ def _convert_spatial_path(
             is_parquet=is_parquet,
             encoding=geom_encoding,
             table_expr=table_expr,
+            layer=layer,
+            linearize_curves=linearize_curves,
+            max_angle_deg=max_angle_deg,
         )
-    )
 
     if verbose:
         if secondary_columns:
@@ -1857,6 +1907,13 @@ def convert_to_geoparquet(
 
     except Exception as e:
         con.close()
+        if "Unsupported geometry type in WKB" in str(e):
+            # Reached when nothing parsed the geometry early enough to linearize
+            # it (e.g. --skip-hilbert skips the bounds pass): at least name the
+            # offending types and the remedy instead of DuckDB's raw error.
+            from geoparquet_io.core.curved_geometry import unsupported_wkb_error_message
+
+            raise GeoParquetError(unsupported_wkb_error_message(input_file, layer, str(e))) from e
         raise GeoParquetError(f"Conversion failed: {str(e)}") from e
 
     finally:

--- a/geoparquet_io/core/curved_geometry.py
+++ b/geoparquet_io/core/curved_geometry.py
@@ -41,6 +41,12 @@ LINEARIZE_HINT = (
 # whose size depends on bits 1-3 of the flags byte, then ISO WKB.
 _ENVELOPE_SIZES = {0: 0, 1: 32, 2: 48, 3: 48, 4: 64}
 
+#: Bytes of each geometry blob the scan needs: GPKG header, the largest
+#: possible envelope, and the leading WKB byte-order + type code. Slicing in
+#: SQL keeps the scan off the coordinate payload, which is the bulk of a
+#: geometry (a 100k-row scan reads ~8 MB instead of the whole column).
+_HEADER_BYTES = 8 + 64 + 5
+
 #: Rows scanned per feature table. Bounds the wait on multi-million-feature
 #: GeoPackages; a curve beyond the cap only means a less specific message.
 _SCAN_CAP = 100_000
@@ -50,7 +56,8 @@ def find_non_linear_gpkg_types(path: str | Path, layer: str | None = None) -> li
     """Names of non-linear geometry types present in a GeoPackage.
 
     Scans the geometry blob headers of every feature table (or just ``layer``)
-    with the standard library only, capped at ``_SCAN_CAP`` rows per table.
+    with the standard library only, reading just ``_HEADER_BYTES`` per row and
+    capped at ``_SCAN_CAP`` rows per table.
     Returns a sorted list of type names, empty when all scanned geometries are
     linear, and empty on any read problem — this is a diagnostic helper, never
     a gate.
@@ -70,7 +77,8 @@ def find_non_linear_gpkg_types(path: str | Path, layer: str | None = None) -> li
                 qtable = table.replace('"', '""')
                 qcol = col.replace('"', '""')
                 for (blob,) in con.execute(
-                    f'SELECT "{qcol}" FROM "{qtable}" WHERE "{qcol}" IS NOT NULL LIMIT {_SCAN_CAP}'
+                    f'SELECT substr("{qcol}", 1, {_HEADER_BYTES}) FROM "{qtable}" '
+                    f'WHERE "{qcol}" IS NOT NULL LIMIT {_SCAN_CAP}'
                 ):
                     if not blob or blob[:2] != b"GP" or len(blob) < 8:
                         continue

--- a/geoparquet_io/core/linearize.py
+++ b/geoparquet_io/core/linearize.py
@@ -1,0 +1,307 @@
+"""Pure-Python linearization of curved WKB geometries.
+
+DuckDB's spatial extension cannot parse the curved ISO WKB types and
+GeoParquet cannot represent them (see ``curved_geometry.py``), so the only
+correct conversion is stroking arcs into line segments at ingest — the same
+operation OGR performs for ``-nlt CONVERT_TO_LINEAR`` and PostGIS for
+``ST_CurveToLine``. This module rewrites curved WKB into its linear
+equivalent with the standard library only:
+
+- CIRCULARSTRING (8)  -> LINESTRING (2)
+- COMPOUNDCURVE (9)   -> LINESTRING (2)
+- CURVEPOLYGON (10)   -> POLYGON (3)
+- MULTICURVE (11)     -> MULTILINESTRING (5)
+- MULTISURFACE (12)   -> MULTIPOLYGON (6)
+
+Linear geometries pass through byte-identical (except inside a
+GEOMETRYCOLLECTION whose children changed, which is reserialized). Arcs are
+sampled at a maximum angular step (default 4 degrees, matching GDAL's
+``OGR_ARC_STEPSIZE`` default); arc endpoints are emitted exactly, and Z/M
+values interpolate linearly along the arc parameter. Collinear "arcs"
+degrade to straight segments.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+
+#: Default maximum angular step per emitted segment, in degrees (OGR default).
+DEFAULT_MAX_ANGLE_DEG = 4.0
+
+_LINESTRING = 2
+_POLYGON = 3
+_MULTILINESTRING = 5
+_MULTIPOLYGON = 6
+_GEOMETRYCOLLECTION = 7
+_CIRCULARSTRING = 8
+_COMPOUNDCURVE = 9
+_CURVEPOLYGON = 10
+_MULTICURVE = 11
+_MULTISURFACE = 12
+
+_CURVED = {_CIRCULARSTRING, _COMPOUNDCURVE, _CURVEPOLYGON, _MULTICURVE, _MULTISURFACE}
+
+_REMAP = {
+    _CIRCULARSTRING: _LINESTRING,
+    _COMPOUNDCURVE: _LINESTRING,
+    _CURVEPOLYGON: _POLYGON,
+    _MULTICURVE: _MULTILINESTRING,
+    _MULTISURFACE: _MULTIPOLYGON,
+}
+
+
+class LinearizeError(ValueError):
+    """Raised when a WKB blob cannot be linearized."""
+
+
+class _Reader:
+    def __init__(self, buf: bytes) -> None:
+        self.buf = buf
+        self.pos = 0
+
+    def byte(self) -> int:
+        v = self.buf[self.pos]
+        self.pos += 1
+        return v
+
+    def uint32(self, le: bool) -> int:
+        (v,) = struct.unpack_from("<I" if le else ">I", self.buf, self.pos)
+        self.pos += 4
+        return int(v)
+
+    def doubles(self, n: int, le: bool) -> tuple[float, ...]:
+        vals = struct.unpack_from(("<" if le else ">") + "d" * n, self.buf, self.pos)
+        self.pos += 8 * n
+        return vals
+
+
+def _decode_type(code: int) -> tuple[int, bool, bool]:
+    """Return (base_type, has_z, has_m) for an ISO WKB type code."""
+    if code & 0xE0000000:
+        raise LinearizeError(f"EWKB flags are not supported (type code 0x{code:08x})")
+    base = code % 1000
+    band = code // 1000
+    if band == 0:
+        return base, False, False
+    if band == 1:
+        return base, True, False
+    if band == 2:
+        return base, False, True
+    if band == 3:
+        return base, True, True
+    raise LinearizeError(f"Unrecognized WKB type code {code}")
+
+
+def _type_code(base: int, has_z: bool, has_m: bool) -> int:
+    return base + (1000 if has_z else 0) + (2000 if has_m else 0)
+
+
+def _stroke_arc(
+    p0: tuple[float, ...],
+    p1: tuple[float, ...],
+    p2: tuple[float, ...],
+    max_angle_rad: float,
+) -> list[tuple[float, ...]]:
+    """Vertices approximating the circular arc p0->p1->p2, excluding p0.
+
+    Extra ordinates (Z/M) are interpolated linearly along the sweep. A
+    degenerate (collinear or zero-radius) arc falls back to straight segments
+    through the control points.
+    """
+    (x0, y0), (x1, y1), (x2, y2) = p0[:2], p1[:2], p2[:2]
+
+    # Circumcenter via perpendicular bisectors.
+    d = 2.0 * (x0 * (y1 - y2) + x1 * (y2 - y0) + x2 * (y0 - y1))
+    if abs(d) < 1e-12:
+        return [p1, p2]  # collinear: straight lines through the control points
+    s0 = x0 * x0 + y0 * y0
+    s1 = x1 * x1 + y1 * y1
+    s2 = x2 * x2 + y2 * y2
+    cx = (s0 * (y1 - y2) + s1 * (y2 - y0) + s2 * (y0 - y1)) / d
+    cy = (s0 * (x2 - x1) + s1 * (x0 - x2) + s2 * (x1 - x0)) / d
+    radius = math.hypot(x0 - cx, y0 - cy)
+    if radius < 1e-12:
+        return [p1, p2]
+
+    a0 = math.atan2(y0 - cy, x0 - cx)
+    a1 = math.atan2(y1 - cy, x1 - cx)
+    a2 = math.atan2(y2 - cy, x2 - cx)
+
+    # Choose the sweep direction that passes through the middle control point.
+    ccw_mid = (a1 - a0) % (2.0 * math.pi)
+    ccw_end = (a2 - a0) % (2.0 * math.pi)
+    if ccw_end == 0.0:
+        ccw_end = 2.0 * math.pi  # closed circle described by three points
+    if ccw_mid <= ccw_end:
+        sweep = ccw_end
+    else:
+        sweep = ccw_end - 2.0 * math.pi  # clockwise
+
+    steps = max(2, math.ceil(abs(sweep) / max_angle_rad))
+    extras0, extras2 = p0[2:], p2[2:]
+    out: list[tuple[float, ...]] = []
+    for i in range(1, steps + 1):
+        t = i / steps
+        if i == steps:
+            out.append(p2)  # exact endpoint
+            continue
+        angle = a0 + sweep * t
+        extras = tuple(e0 + (e2 - e0) * t for e0, e2 in zip(extras0, extras2))
+        out.append((cx + radius * math.cos(angle), cy + radius * math.sin(angle), *extras))
+    return out
+
+
+class _Linearizer:
+    def __init__(self, max_angle_deg: float) -> None:
+        self.max_angle_rad = math.radians(max_angle_deg)
+        self.changed = False
+
+    # ---- parsing helpers -------------------------------------------------
+    def _points(self, r: _Reader, le: bool, dims: int) -> list[tuple[float, ...]]:
+        n = r.uint32(le)
+        return [r.doubles(dims, le) for _ in range(n)]
+
+    def _curve_to_points(self, r: _Reader, has_z: bool, has_m: bool) -> list[tuple[float, ...]]:
+        """Read one curve component (LINESTRING/CIRCULARSTRING/COMPOUNDCURVE)
+        from its own WKB header and return its linearized vertex list."""
+        le = r.byte() == 1
+        base, z, m = _decode_type(r.uint32(le))
+        if (z, m) != (has_z, has_m):
+            raise LinearizeError("Mixed Z/M dimensions inside a curve are not supported")
+        dims = 2 + z + m
+        if base == _LINESTRING:
+            return self._points(r, le, dims)
+        if base == _CIRCULARSTRING:
+            self.changed = True
+            pts = self._points(r, le, dims)
+            return self._stroke_circularstring(pts)
+        if base == _COMPOUNDCURVE:
+            self.changed = True
+            out: list[tuple[float, ...]] = []
+            for _ in range(r.uint32(le)):
+                seg = self._curve_to_points(r, has_z, has_m)
+                if out and seg and out[-1] == seg[0]:
+                    seg = seg[1:]  # segments share their joint vertex
+                out.extend(seg)
+            return out
+        raise LinearizeError(f"Unexpected curve component type {base}")
+
+    def _stroke_circularstring(self, pts: list[tuple[float, ...]]) -> list[tuple[float, ...]]:
+        if len(pts) < 3 or len(pts) % 2 == 0:
+            raise LinearizeError(f"CIRCULARSTRING needs an odd point count >= 3, got {len(pts)}")
+        out = [pts[0]]
+        for i in range(0, len(pts) - 2, 2):
+            out.extend(_stroke_arc(pts[i], pts[i + 1], pts[i + 2], self.max_angle_rad))
+        return out
+
+    # ---- serialization ---------------------------------------------------
+    def _write_geometry(self, r: _Reader, out: bytearray) -> None:
+        """Read one geometry from ``r`` and append its linear WKB to ``out``."""
+        le = r.byte() == 1
+        code = r.uint32(le)
+        base, has_z, has_m = _decode_type(code)
+        dims = 2 + has_z + has_m
+
+        def header(new_base: int) -> None:
+            out.append(1)  # emit little-endian
+            out.extend(struct.pack("<I", _type_code(new_base, has_z, has_m)))
+
+        def write_ring(ring: list[tuple[float, ...]]) -> None:
+            out.extend(struct.pack("<I", len(ring)))
+            for pt in ring:
+                out.extend(struct.pack("<" + "d" * dims, *pt))
+
+        if base in (1, _LINESTRING, _POLYGON, 4, _MULTILINESTRING, _MULTIPOLYGON):
+            # Linear: re-emit verbatim (normalized to little-endian).
+            header(base)
+            if base == 1:  # POINT
+                out.extend(struct.pack("<" + "d" * dims, *r.doubles(dims, le)))
+            elif base == _LINESTRING:
+                write_ring(self._points(r, le, dims))
+            elif base == _POLYGON:
+                n_rings = r.uint32(le)
+                out.extend(struct.pack("<I", n_rings))
+                for _ in range(n_rings):
+                    write_ring(self._points(r, le, dims))
+            else:  # MULTIPOINT / MULTILINESTRING / MULTIPOLYGON: nested WKB
+                n = r.uint32(le)
+                out.extend(struct.pack("<I", n))
+                for _ in range(n):
+                    self._write_geometry(r, out)
+        elif base == _GEOMETRYCOLLECTION:
+            header(_GEOMETRYCOLLECTION)
+            n = r.uint32(le)
+            out.extend(struct.pack("<I", n))
+            for _ in range(n):
+                self._write_geometry(r, out)
+        elif base == _CIRCULARSTRING:
+            self.changed = True
+            pts = self._stroke_circularstring(self._points(r, le, dims))
+            header(_LINESTRING)
+            write_ring(pts)
+        elif base == _COMPOUNDCURVE:
+            self.changed = True
+            segments: list[tuple[float, ...]] = []
+            for _ in range(r.uint32(le)):
+                seg = self._curve_to_points(r, has_z, has_m)
+                if segments and seg and segments[-1] == seg[0]:
+                    seg = seg[1:]
+                segments.extend(seg)
+            header(_LINESTRING)
+            write_ring(segments)
+        elif base == _CURVEPOLYGON:
+            self.changed = True
+            n_rings = r.uint32(le)
+            rings = [self._curve_to_points(r, has_z, has_m) for _ in range(n_rings)]
+            header(_POLYGON)
+            out.extend(struct.pack("<I", len(rings)))
+            for ring in rings:
+                if ring and ring[0] != ring[-1]:
+                    ring = [*ring, ring[0]]  # rings must close
+                write_ring(ring)
+        elif base in (_MULTICURVE, _MULTISURFACE):
+            self.changed = True
+            header(_REMAP[base])
+            n = r.uint32(le)
+            out.extend(struct.pack("<I", n))
+            for _ in range(n):
+                self._write_geometry(r, out)
+        else:
+            raise LinearizeError(f"WKB type {base} cannot be linearized")
+
+
+def linearize_wkb(
+    wkb: bytes | bytearray | memoryview,
+    max_angle_deg: float = DEFAULT_MAX_ANGLE_DEG,
+) -> tuple[bytes, bool]:
+    """Return ``(linear_wkb, changed)`` for one ISO WKB geometry.
+
+    ``changed`` is False when the input contained no curved types (the output
+    is then a little-endian re-emission of the same geometry). Raises
+    :class:`LinearizeError` for WKB that cannot be linearized (EWKB flags,
+    the surface family POLYHEDRALSURFACE/TIN/TRIANGLE, malformed input).
+    """
+    lin = _Linearizer(max_angle_deg)
+    out = bytearray()
+    try:
+        lin._write_geometry(_Reader(bytes(wkb)), out)
+    except (struct.error, IndexError) as e:
+        raise LinearizeError(f"Malformed WKB: {e}") from e
+    return bytes(out), lin.changed
+
+
+def contains_curved_wkb(wkb: bytes | bytearray | memoryview) -> bool:
+    """Cheap top-level check: does this WKB's outermost type belong to the
+    curved family? (Curves nested inside a GEOMETRYCOLLECTION are found by
+    :func:`linearize_wkb` itself.)"""
+    b = bytes(wkb[:5])
+    if len(b) < 5:
+        return False
+    le = b[0] == 1
+    (code,) = struct.unpack("<I" if le else ">I", b[1:5])
+    try:
+        base, _, _ = _decode_type(code)
+    except LinearizeError:
+        return False
+    return base in _CURVED or base == _GEOMETRYCOLLECTION

--- a/geoparquet_io/core/linearize.py
+++ b/geoparquet_io/core/linearize.py
@@ -13,7 +13,8 @@ equivalent with the standard library only:
 - MULTICURVE (11)     -> MULTILINESTRING (5)
 - MULTISURFACE (12)   -> MULTIPOLYGON (6)
 
-Linear geometries pass through byte-identical (except inside a
+Empty curved geometries yield their empty linear counterpart rather than an
+error. Linear geometries pass through byte-identical (except inside a
 GEOMETRYCOLLECTION whose children changed, which is reserialized). Arcs are
 sampled at a maximum angular step (default 4 degrees, matching GDAL's
 ``OGR_ARC_STEPSIZE`` default); arc endpoints are emitted exactly, and Z/M
@@ -220,6 +221,8 @@ class _Linearizer:
         raise LinearizeError(f"Unexpected curve component type {base}")
 
     def _stroke_circularstring(self, pts: list[tuple[float, ...]]) -> list[tuple[float, ...]]:
+        if not pts:
+            return []  # CIRCULARSTRING EMPTY -> LINESTRING EMPTY, as OGR does
         if len(pts) < 3 or len(pts) % 2 == 0:
             raise LinearizeError(f"CIRCULARSTRING needs an odd point count >= 3, got {len(pts)}")
         out = [pts[0]]
@@ -286,6 +289,7 @@ class _Linearizer:
             self.changed = True
             n_rings = r.uint32(le)
             rings = [self._curve_to_points(r, has_z, has_m) for _ in range(n_rings)]
+            rings = [ring for ring in rings if ring]  # an empty ring means POLYGON EMPTY
             header(_POLYGON)
             out.extend(struct.pack("<I", len(rings)))
             for ring in rings:

--- a/geoparquet_io/core/linearize.py
+++ b/geoparquet_io/core/linearize.py
@@ -97,6 +97,26 @@ def _type_code(base: int, has_z: bool, has_m: bool) -> int:
     return base + (1000 if has_z else 0) + (2000 if has_m else 0)
 
 
+def _degenerate_arc(
+    p0: tuple[float, ...],
+    p1: tuple[float, ...],
+    p2: tuple[float, ...],
+) -> list[tuple[float, ...]]:
+    """Straight-segment fallback for collinear/zero-radius "arcs".
+
+    Control points that duplicate the previously emitted vertex are skipped —
+    the caller has already emitted ``p0``, so returning it (or a repeat of
+    ``p1``) would produce consecutive duplicate vertices in the output.
+    """
+    out: list[tuple[float, ...]] = []
+    prev = p0
+    for q in (p1, p2):
+        if q != prev:
+            out.append(q)
+            prev = q
+    return out or [p2]
+
+
 def _stroke_arc(
     p0: tuple[float, ...],
     p1: tuple[float, ...],
@@ -107,36 +127,48 @@ def _stroke_arc(
 
     Extra ordinates (Z/M) are interpolated linearly along the sweep. A
     degenerate (collinear or zero-radius) arc falls back to straight segments
-    through the control points.
+    through the control points. ``p2 == p0`` is the standard compact encoding
+    of a full circle and sweeps one whole turn.
     """
     (x0, y0), (x1, y1), (x2, y2) = p0[:2], p1[:2], p2[:2]
 
-    # Circumcenter via perpendicular bisectors.
-    d = 2.0 * (x0 * (y1 - y2) + x1 * (y2 - y0) + x2 * (y0 - y1))
-    if abs(d) < 1e-12:
-        return [p1, p2]  # collinear: straight lines through the control points
-    s0 = x0 * x0 + y0 * y0
-    s1 = x1 * x1 + y1 * y1
-    s2 = x2 * x2 + y2 * y2
-    cx = (s0 * (y1 - y2) + s1 * (y2 - y0) + s2 * (y0 - y1)) / d
-    cy = (s0 * (x2 - x1) + s1 * (x0 - x2) + s2 * (x1 - x0)) / d
-    radius = math.hypot(x0 - cx, y0 - cy)
-    if radius < 1e-12:
-        return [p1, p2]
-
-    a0 = math.atan2(y0 - cy, x0 - cx)
-    a1 = math.atan2(y1 - cy, x1 - cx)
-    a2 = math.atan2(y2 - cy, x2 - cx)
-
-    # Choose the sweep direction that passes through the middle control point.
-    ccw_mid = (a1 - a0) % (2.0 * math.pi)
-    ccw_end = (a2 - a0) % (2.0 * math.pi)
-    if ccw_end == 0.0:
-        ccw_end = 2.0 * math.pi  # closed circle described by three points
-    if ccw_mid <= ccw_end:
-        sweep = ccw_end
+    if (x2, y2) == (x0, y0):
+        # Closed circle: p1 is diametrically opposite p0, so the centre is
+        # their midpoint. This must be handled before the circumcenter
+        # determinant below, which is identically zero when p2 == p0 and
+        # would collapse the circle to a zero-area line.
+        cx = (x0 + x1) / 2.0
+        cy = (y0 + y1) / 2.0
+        radius = math.hypot(x0 - cx, y0 - cy)
+        if radius < 1e-12:
+            return _degenerate_arc(p0, p1, p2)
+        a0 = math.atan2(y0 - cy, x0 - cx)
+        sweep = 2.0 * math.pi
     else:
-        sweep = ccw_end - 2.0 * math.pi  # clockwise
+        # Circumcenter via perpendicular bisectors.
+        d = 2.0 * (x0 * (y1 - y2) + x1 * (y2 - y0) + x2 * (y0 - y1))
+        if abs(d) < 1e-12:
+            return _degenerate_arc(p0, p1, p2)  # collinear
+        s0 = x0 * x0 + y0 * y0
+        s1 = x1 * x1 + y1 * y1
+        s2 = x2 * x2 + y2 * y2
+        cx = (s0 * (y1 - y2) + s1 * (y2 - y0) + s2 * (y0 - y1)) / d
+        cy = (s0 * (x2 - x1) + s1 * (x0 - x2) + s2 * (x1 - x0)) / d
+        radius = math.hypot(x0 - cx, y0 - cy)
+        if radius < 1e-12:
+            return _degenerate_arc(p0, p1, p2)
+
+        a0 = math.atan2(y0 - cy, x0 - cx)
+        a1 = math.atan2(y1 - cy, x1 - cx)
+        a2 = math.atan2(y2 - cy, x2 - cx)
+
+        # Choose the sweep direction that passes through the middle control point.
+        ccw_mid = (a1 - a0) % (2.0 * math.pi)
+        ccw_end = (a2 - a0) % (2.0 * math.pi)
+        if ccw_mid <= ccw_end:
+            sweep = ccw_end
+        else:
+            sweep = ccw_end - 2.0 * math.pi  # clockwise
 
     steps = max(2, math.ceil(abs(sweep) / max_angle_rad))
     extras0, extras2 = p0[2:], p2[2:]
@@ -280,8 +312,11 @@ def linearize_wkb(
     ``changed`` is False when the input contained no curved types (the output
     is then a little-endian re-emission of the same geometry). Raises
     :class:`LinearizeError` for WKB that cannot be linearized (EWKB flags,
-    the surface family POLYHEDRALSURFACE/TIN/TRIANGLE, malformed input).
+    the surface family POLYHEDRALSURFACE/TIN/TRIANGLE, malformed input) and
+    :class:`ValueError` for a non-positive ``max_angle_deg``.
     """
+    if max_angle_deg is None or math.isnan(max_angle_deg) or max_angle_deg <= 0:
+        raise ValueError(f"max_angle_deg must be a positive number, got {max_angle_deg!r}")
     lin = _Linearizer(max_angle_deg)
     out = bytearray()
     try:

--- a/geoparquet_io/core/linearize.py
+++ b/geoparquet_io/core/linearize.py
@@ -147,7 +147,7 @@ def _stroke_arc(
             out.append(p2)  # exact endpoint
             continue
         angle = a0 + sweep * t
-        extras = tuple(e0 + (e2 - e0) * t for e0, e2 in zip(extras0, extras2))
+        extras = tuple(e0 + (e2 - e0) * t for e0, e2 in zip(extras0, extras2, strict=True))
         out.append((cx + radius * math.cos(angle), cy + radius * math.sin(angle), *extras))
     return out
 

--- a/tests/test_curved_geometry.py
+++ b/tests/test_curved_geometry.py
@@ -95,3 +95,17 @@ class TestUnsupportedWkbError:
         assert "non-linear geometries" in message
         assert "CONVERT_TO_LINEAR" in message
         assert "Unsupported geometry type in WKB" in message
+
+    def test_envelope_and_large_payload_still_classified(self, tmp_path):
+        """The header slice must cover the largest GPKG envelope (XYZM, 64 B).
+
+        The scan reads only the leading header bytes rather than whole blobs, so
+        a geometry carrying a full envelope and a megabyte of coordinates must
+        still be classified from the slice alone.
+        """
+        flags = 4 << 1  # envelope indicator 4 -> 64-byte XYZM envelope
+        header = b"GP\x00" + bytes([flags]) + struct.pack("<i", 0) + b"\x00" * 64
+        blob = header + b"\x01" + struct.pack("<I", 10) + b"\x00" * 1_000_000
+        gpkg = tmp_path / "enveloped.gpkg"
+        _make_fake_gpkg(gpkg, "t", [blob])
+        assert find_non_linear_gpkg_types(gpkg) == ["CURVEPOLYGON"]

--- a/tests/test_curved_geometry.py
+++ b/tests/test_curved_geometry.py
@@ -69,8 +69,18 @@ class TestScanBounds:
 
 
 class TestUnsupportedWkbError:
-    def test_convert_raises_actionable_error(self):
+    def test_unlinearizable_input_raises_actionable_error(self, monkeypatch):
+        """When linearization cannot handle the WKB (e.g. the surface family),
+        the error still names the offending types and the remedy."""
         import geoparquet_io as gpio
+        from geoparquet_io.core.linearize import LinearizeError
+
+        def _fail(wkb, max_angle_deg=4.0):
+            raise LinearizeError("WKB type 16 cannot be linearized")
+
+        import geoparquet_io.core.linearize as linearize_mod
+
+        monkeypatch.setattr(linearize_mod, "linearize_wkb", _fail)
 
         with pytest.raises(GeoParquetError) as exc:
             gpio.convert(str(CURVED_GPKG))

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -141,3 +141,29 @@ class TestConvertIntegration:
         # The fixture's CURVEPOLYGON is the full unit circle centred at (1, 0).
         assert area == pytest.approx(math.pi, rel=0.005)
         assert n >= 80
+
+
+class TestConvertParameters:
+    def test_opt_out_raises_actionable_error(self):
+        """linearize_curves=False keeps the strict behavior (#646's error)."""
+        import geoparquet_io as gpio
+        from geoparquet_io.core.duckdb_metadata import GeoParquetError
+
+        with pytest.raises(GeoParquetError, match="CONVERT_TO_LINEAR"):
+            gpio.convert(str(CURVED_GPKG), linearize_curves=False)
+
+    def test_max_angle_controls_density(self, tmp_path):
+        """A coarser tolerance yields fewer stroked vertices."""
+        import duckdb
+
+        import geoparquet_io as gpio
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+
+        counts = {}
+        for deg in (2.0, 30.0):
+            out = tmp_path / f"deg{int(deg)}.parquet"
+            gpio.convert(str(CURVED_GPKG), max_angle_deg=deg).write(str(out))
+            counts[deg] = con.execute(f"SELECT ST_NPoints(geometry) FROM '{out}'").fetchone()[0]
+        assert counts[2.0] > counts[30.0] >= 13

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -1,0 +1,143 @@
+"""Tests for pure-Python curved-WKB linearization (issue #643, tier 3)."""
+
+import math
+import struct
+from pathlib import Path
+
+import pytest
+
+from geoparquet_io.core.linearize import (
+    LinearizeError,
+    contains_curved_wkb,
+    linearize_wkb,
+)
+
+TEST_DATA_DIR = Path(__file__).parent / "data"
+CURVED_GPKG = TEST_DATA_DIR / "curved_geometry_test.gpkg"
+
+
+def _wkb(type_code: int, body: bytes) -> bytes:
+    return b"\x01" + struct.pack("<I", type_code) + body
+
+
+def _points(*pts: tuple) -> bytes:
+    out = struct.pack("<I", len(pts))
+    for pt in pts:
+        out += struct.pack("<" + "d" * len(pt), *pt)
+    return out
+
+
+def _parse_linestring(wkb: bytes, dims: int = 2) -> list[tuple]:
+    assert wkb[0] == 1
+    (code,) = struct.unpack_from("<I", wkb, 1)
+    (n,) = struct.unpack_from("<I", wkb, 5)
+    vals = struct.unpack_from("<" + "d" * (n * dims), wkb, 9)
+    return code, [tuple(vals[i * dims : (i + 1) * dims]) for i in range(n)]
+
+
+class TestStroking:
+    def test_half_circle_arc(self):
+        """CIRCULARSTRING(0 0, 1 1, 2 0): unit half-circle centred at (1, 0)."""
+        src = _wkb(8, _points((0, 0), (1, 1), (2, 0)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, pts = _parse_linestring(out)
+        assert code == 2  # LINESTRING
+        assert pts[0] == (0.0, 0.0) and pts[-1] == (2.0, 0.0)  # exact endpoints
+        assert len(pts) >= 40  # ~180 degrees at 4 degrees/segment
+        for x, y in pts:
+            assert math.hypot(x - 1.0, y - 0.0) == pytest.approx(1.0, abs=1e-9)
+
+    def test_z_values_interpolate(self):
+        src = _wkb(1008, _points((0, 0, 0), (1, 1, 5), (2, 0, 10)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, pts = _parse_linestring(out, dims=3)
+        assert code == 1002  # LINESTRING Z
+        zs = [p[2] for p in pts]
+        assert zs[0] == 0.0 and zs[-1] == 10.0
+        assert zs == sorted(zs)  # monotone along the sweep
+
+    def test_collinear_arc_degrades_to_segments(self):
+        src = _wkb(8, _points((0, 0), (1, 0), (2, 0)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        _, pts = _parse_linestring(out)
+        assert pts == [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)]
+
+    def test_compoundcurve_joins_segments(self):
+        line = _wkb(2, _points((0, 0), (1, 0)))
+        arc = _wkb(8, _points((1, 0), (2, 1), (3, 0)))
+        src = _wkb(9, struct.pack("<I", 2) + line + arc)
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, pts = _parse_linestring(out)
+        assert code == 2
+        assert pts[0] == (0.0, 0.0) and pts[-1] == (3.0, 0.0)
+        assert pts.count((1.0, 0.0)) == 1  # joint vertex not duplicated
+
+    def test_multisurface_becomes_multipolygon(self):
+        ring = _wkb(8, _points((0, 0), (1, 1), (2, 0), (1, -1), (0, 0)))
+        curvepoly = _wkb(10, struct.pack("<I", 1) + ring)
+        src = _wkb(12, struct.pack("<I", 1) + curvepoly)
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        assert out[0] == 1
+        (code,) = struct.unpack_from("<I", out, 1)
+        assert code == 6  # MULTIPOLYGON
+
+
+class TestPassthrough:
+    def test_linear_geometry_unchanged(self):
+        src = _wkb(2, _points((0, 0), (5, 5)))
+        out, changed = linearize_wkb(src)
+        assert not changed
+        assert out == src  # already little-endian: byte-identical
+
+
+class TestErrors:
+    def test_surface_family_rejected(self):
+        src = _wkb(16, struct.pack("<I", 0))  # TIN
+        with pytest.raises(LinearizeError, match="cannot be linearized"):
+            linearize_wkb(src)
+
+    def test_ewkb_flags_rejected(self):
+        src = b"\x01" + struct.pack("<I", 0x20000008) + _points((0, 0), (1, 1), (2, 0))
+        with pytest.raises(LinearizeError, match="EWKB"):
+            linearize_wkb(src)
+
+    def test_even_point_count_rejected(self):
+        src = _wkb(8, _points((0, 0), (1, 1)))
+        with pytest.raises(LinearizeError, match="odd point count"):
+            linearize_wkb(src)
+
+
+class TestContainsCurved:
+    def test_detects_curved_and_linear(self):
+        assert contains_curved_wkb(_wkb(10, b""))
+        assert not contains_curved_wkb(_wkb(3, b""))
+
+
+class TestConvertIntegration:
+    def test_convert_linearizes_curved_gpkg(self, tmp_path):
+        """The curved fixture that used to be a hard error now converts (#643)."""
+        import duckdb
+
+        import geoparquet_io as gpio
+
+        out = tmp_path / "linear.parquet"
+        gpio.convert(str(CURVED_GPKG)).write(str(out))
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        area, n = con.execute(
+            f"SELECT ST_Area(geometry), ST_NPoints(geometry) FROM '{out}'"
+        ).fetchone()
+        # The fixture's CURVEPOLYGON is the full unit circle centred at (1, 0).
+        assert area == pytest.approx(math.pi, rel=0.005)
+        assert n >= 80

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -504,3 +504,117 @@ class TestProjectedCurvedGpkg:
         assert table.num_rows == 1
         assert detected_crs is not None
         assert "25830" in json.dumps(detected_crs)
+
+
+class TestEmptyCurves:
+    """Empty curved geometries must linearize, not abort the file (#647 review).
+
+    A single CIRCULARSTRING EMPTY used to raise LinearizeError, which surfaced
+    as #646's "linearize the source first" error and failed the whole
+    conversion — while `ogr2ogr -nlt CONVERT_TO_LINEAR`, the remedy that error
+    recommends, converts the same file without complaint.
+    """
+
+    def test_empty_circularstring_becomes_empty_linestring(self):
+        out, changed = linearize_wkb(_wkb(8, struct.pack("<I", 0)))
+
+        assert changed
+        code, pts = _parse_linestring(out)
+        assert code == 2 and pts == []
+
+    def test_empty_ring_dropped_from_curvepolygon(self):
+        ring = _wkb(8, struct.pack("<I", 0))
+        out, changed = linearize_wkb(_wkb(10, struct.pack("<I", 1) + ring))
+
+        assert changed
+        code, rings = _parse_polygon(out)
+        assert code == 3 and rings == []
+
+    def test_empty_curve_inside_multicurve(self):
+        empty = _wkb(8, struct.pack("<I", 0))
+        out, changed = linearize_wkb(_wkb(11, struct.pack("<I", 1) + empty))
+
+        assert changed
+        (code,) = struct.unpack_from("<I", out, 1)
+        assert code == 5  # MULTILINESTRING
+        (child_code,) = struct.unpack_from("<I", out, 10)
+        assert child_code == 2  # LINESTRING (empty)
+
+    def test_gpkg_with_empty_curve_row_converts(self, tmp_path):
+        """End-to-end: the empty row no longer takes the whole file down."""
+        import shutil
+        import sqlite3
+
+        import geoparquet_io as gpio
+
+        gpkg = tmp_path / "empty_curve.gpkg"
+        shutil.copy(CURVED_GPKG, gpkg)
+        con = sqlite3.connect(gpkg)
+        # The fixture's rtree triggers call GDAL-only SQL functions, so they
+        # must go before plain sqlite3 can insert a row.
+        for (name,) in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger'"
+        ).fetchall():
+            con.execute(f'DROP TRIGGER "{name}"')
+        header = b"GP\x00\x01" + struct.pack("<i", 0)
+        con.execute(
+            "INSERT INTO curve (geom, wkt, id) VALUES (?, ?, ?)",
+            (header + _wkb(8, struct.pack("<I", 0)), "CIRCULARSTRING EMPTY", "empty"),
+        )
+        con.commit()
+        con.close()
+
+        table = gpio.convert(str(gpkg))
+
+        assert table.num_rows == 2
+
+
+class TestCliCurveParityWithoutPrescan:
+    """`gpio convert` must not fall back to DuckDB's bare error (#647 review).
+
+    The GPKG pre-scan only fires for local files named *.gpkg, so sources it
+    cannot scan (FileGDB, remote GeoPackages) used to surface
+    "Invalid Input Error: Unsupported geometry type in WKB" from the CLI even
+    though the API path linearized them.
+    """
+
+    def _unscannable_copy(self, tmp_path):
+        import shutil
+
+        target = tmp_path / "curved.db"  # not *.gpkg: no pre-scan
+        shutil.copy(CURVED_GPKG, target)
+        return target
+
+    def test_cli_linearizes_source_the_prescan_cannot_see(self, tmp_path):
+        import duckdb
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = tmp_path / "out.parquet"
+        result = CliRunner().invoke(
+            cli, ["convert", str(self._unscannable_copy(tmp_path)), str(out)]
+        )
+
+        assert result.exit_code == 0, result.output
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        area = con.execute(f"SELECT ST_Area(geom) FROM '{out}'").fetchone()[0]
+        assert area == pytest.approx(math.pi, rel=0.005)
+
+    def test_cli_error_names_the_remedy_when_it_cannot_linearize(self, tmp_path):
+        """--skip-hilbert skips the pass that linearizes, so the conversion still
+        fails — but with the actionable message, not DuckDB's raw one."""
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = tmp_path / "out.parquet"
+        result = CliRunner().invoke(
+            cli,
+            ["convert", str(self._unscannable_copy(tmp_path)), str(out), "--skip-hilbert"],
+        )
+
+        assert result.exit_code != 0
+        assert "CONVERT_TO_LINEAR" in result.output
+        assert "Unsupported geometry type in WKB" not in result.output.split("Original error")[0]

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -14,6 +14,7 @@ from geoparquet_io.core.linearize import (
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 CURVED_GPKG = TEST_DATA_DIR / "curved_geometry_test.gpkg"
+LINEAR_GPKG = TEST_DATA_DIR / "buildings_test.gpkg"
 
 
 def _wkb(type_code: int, body: bytes) -> bytes:
@@ -33,6 +34,28 @@ def _parse_linestring(wkb: bytes, dims: int = 2) -> list[tuple]:
     (n,) = struct.unpack_from("<I", wkb, 5)
     vals = struct.unpack_from("<" + "d" * (n * dims), wkb, 9)
     return code, [tuple(vals[i * dims : (i + 1) * dims]) for i in range(n)]
+
+
+def _parse_polygon(wkb: bytes, dims: int = 2) -> tuple[int, list[list[tuple]]]:
+    assert wkb[0] == 1
+    (code,) = struct.unpack_from("<I", wkb, 1)
+    (n_rings,) = struct.unpack_from("<I", wkb, 5)
+    pos = 9
+    rings = []
+    for _ in range(n_rings):
+        (n,) = struct.unpack_from("<I", wkb, pos)
+        pos += 4
+        vals = struct.unpack_from("<" + "d" * (n * dims), wkb, pos)
+        pos += 8 * n * dims
+        rings.append([tuple(vals[i * dims : (i + 1) * dims]) for i in range(n)])
+    return code, rings
+
+
+def _shoelace(pts: list[tuple]) -> float:
+    area = 0.0
+    for (x1, y1), (x2, y2) in zip(pts, pts[1:] + pts[:1], strict=True):
+        area += x1 * y2 - x2 * y1
+    return area / 2.0
 
 
 class TestStroking:
@@ -92,6 +115,177 @@ class TestStroking:
         assert code == 6  # MULTIPOLYGON
 
 
+class TestClosedCircle:
+    def test_three_point_circle_full_sweep(self):
+        """CIRCULARSTRING(0 0, 2 0, 0 0): the compact full-circle encoding.
+
+        The circumcenter determinant is identically zero when p2 == p0, so
+        without the dedicated branch this collapsed to a zero-area line.
+        """
+        src = _wkb(8, _points((0, 0), (2, 0), (0, 0)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, pts = _parse_linestring(out)
+        assert code == 2
+        assert len(pts) >= 90  # 360 degrees at 4 degrees/segment
+        assert pts[0] == (0.0, 0.0) and pts[-1] == (0.0, 0.0)
+        for x, y in pts:
+            assert math.hypot(x - 1.0, y) == pytest.approx(1.0, abs=1e-9)
+
+    def test_curvepolygon_circle_has_area(self):
+        ring = _wkb(8, _points((0, 0), (2, 0), (0, 0)))
+        src = _wkb(10, struct.pack("<I", 1) + ring)
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, rings = _parse_polygon(out)
+        assert code == 3  # POLYGON
+        assert rings[0][0] == rings[0][-1]  # ring closed
+        assert abs(_shoelace(rings[0][:-1])) == pytest.approx(math.pi, rel=0.005)
+
+    def test_closed_subarc_mid_chain(self):
+        """pts[i] == pts[i+2] inside a longer chain must not collapse either."""
+        src = _wkb(8, _points((1, 0), (-1, 0), (1, 0), (0, -1), (-1, 0)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        _, pts = _parse_linestring(out)
+        assert len(pts) >= 130  # full circle plus a half circle
+        for x, y in pts:
+            assert math.hypot(x, y) == pytest.approx(1.0, abs=1e-9)
+
+
+class TestSweepAndDims:
+    def test_counterclockwise_arc(self):
+        """CIRCULARSTRING(2 0, 1 1, 0 0): the same half-circle swept CCW."""
+        src = _wkb(8, _points((2, 0), (1, 1), (0, 0)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        _, pts = _parse_linestring(out)
+        assert pts[0] == (2.0, 0.0) and pts[-1] == (0.0, 0.0)
+        for x, y in pts:
+            assert math.hypot(x - 1.0, y) == pytest.approx(1.0, abs=1e-9)
+        assert all(y >= 0 for _, y in pts)  # stays on the upper half
+
+    def test_m_values_interpolate(self):
+        src = _wkb(2008, _points((0, 0, 0), (1, 1, 5), (2, 0, 10)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, pts = _parse_linestring(out, dims=3)
+        assert code == 2002  # LINESTRING M
+        ms = [p[2] for p in pts]
+        assert ms[0] == 0.0 and ms[-1] == 10.0
+
+    def test_zm_values_interpolate(self):
+        src = _wkb(3008, _points((0, 0, 0, 0), (1, 1, 5, 50), (2, 0, 10, 100)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, pts = _parse_linestring(out, dims=4)
+        assert code == 3002  # LINESTRING ZM
+        assert pts[-1] == (2.0, 0.0, 10.0, 100.0)
+
+    def test_unrecognized_band_rejected(self):
+        src = _wkb(4008, _points((0, 0), (1, 1), (2, 0)))
+        with pytest.raises(LinearizeError, match="Unrecognized"):
+            linearize_wkb(src)
+
+    def test_mixed_zm_inside_curve_rejected(self):
+        ring = _wkb(1008, _points((0, 0, 0), (1, 1, 5), (2, 0, 10)))  # Z ring
+        src = _wkb(10, struct.pack("<I", 1) + ring)  # 2D CURVEPOLYGON
+        with pytest.raises(LinearizeError, match="Mixed Z/M"):
+            linearize_wkb(src)
+
+
+class TestMoreShapes:
+    def test_geometrycollection_children_linearized(self):
+        arc = _wkb(8, _points((0, 0), (1, 1), (2, 0)))
+        src = _wkb(7, struct.pack("<I", 1) + arc)
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        (code,) = struct.unpack_from("<I", out, 1)
+        assert code == 7  # still a GEOMETRYCOLLECTION
+        (child_code,) = struct.unpack_from("<I", out, 10)
+        assert child_code == 2  # child is now a LINESTRING
+
+    def test_point_and_polygon_passthrough(self):
+        point = _wkb(1, struct.pack("<dd", 3.0, 4.0))
+        ring = _points((0, 0), (1, 0), (1, 1), (0, 0))
+        polygon = _wkb(3, struct.pack("<I", 1) + ring)
+        multipolygon = _wkb(6, struct.pack("<I", 1) + polygon)
+
+        for src in (point, polygon, multipolygon):
+            out, changed = linearize_wkb(src)
+            assert not changed
+            assert out == src
+
+    def test_compoundcurve_ring_inside_curvepolygon(self):
+        """A COMPOUNDCURVE used as a CURVEPOLYGON ring is linearized too."""
+        line = _wkb(2, _points((0, 0), (2, 0)))
+        arc = _wkb(8, _points((2, 0), (1, 1), (0, 0)))
+        compound = _wkb(9, struct.pack("<I", 2) + line + arc)
+        src = _wkb(10, struct.pack("<I", 1) + compound)
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        code, rings = _parse_polygon(out)
+        assert code == 3
+        assert rings[0][0] == rings[0][-1]
+        assert abs(_shoelace(rings[0][:-1])) == pytest.approx(math.pi / 2, rel=0.005)
+
+    def test_open_arc_ring_gets_closed(self):
+        """A CURVEPOLYGON ring that ends away from its start is closed."""
+        ring = _wkb(8, _points((0, 0), (1, 1), (2, 0)))
+        src = _wkb(10, struct.pack("<I", 1) + ring)
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        _, rings = _parse_polygon(out)
+        assert rings[0][0] == rings[0][-1]
+
+    def test_big_endian_input_normalized(self):
+        src = (
+            b"\x00"
+            + struct.pack(">I", 2)
+            + struct.pack(">I", 2)
+            + struct.pack(">dddd", 0.0, 0.0, 5.0, 5.0)
+        )
+        out, changed = linearize_wkb(src)
+
+        assert not changed
+        assert out == _wkb(2, _points((0, 0), (5, 5)))  # little-endian re-emission
+
+
+class TestDegenerateArcs:
+    def test_duplicate_control_points_emit_no_duplicate_vertices(self):
+        src = _wkb(8, _points((0, 0), (0, 0), (2, 0)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        _, pts = _parse_linestring(out)
+        assert pts == [(0.0, 0.0), (2.0, 0.0)]
+
+    def test_all_coincident_points(self):
+        src = _wkb(8, _points((1, 1), (1, 1), (1, 1)))
+        out, changed = linearize_wkb(src)
+
+        assert changed
+        _, pts = _parse_linestring(out)
+        assert set(pts) == {(1.0, 1.0)}
+
+
+class TestMaxAngleValidation:
+    @pytest.mark.parametrize("bad", [0, -4.0, float("nan"), None])
+    def test_non_positive_tolerance_rejected(self, bad):
+        src = _wkb(8, _points((0, 0), (1, 1), (2, 0)))
+        with pytest.raises(ValueError, match="max_angle_deg"):
+            linearize_wkb(src, bad)
+
+
 class TestPassthrough:
     def test_linear_geometry_unchanged(self):
         src = _wkb(2, _points((0, 0), (5, 5)))
@@ -114,6 +308,12 @@ class TestErrors:
     def test_even_point_count_rejected(self):
         src = _wkb(8, _points((0, 0), (1, 1)))
         with pytest.raises(LinearizeError, match="odd point count"):
+            linearize_wkb(src)
+
+    def test_non_curve_ring_component_rejected(self):
+        point = _wkb(1, struct.pack("<dd", 0.0, 0.0))
+        src = _wkb(10, struct.pack("<I", 1) + point)  # POINT as a ring
+        with pytest.raises(LinearizeError, match="curve component"):
             linearize_wkb(src)
 
 
@@ -142,6 +342,35 @@ class TestConvertIntegration:
         assert area == pytest.approx(math.pi, rel=0.005)
         assert n >= 80
 
+    def test_error_fallback_for_formats_without_prescan(self, monkeypatch, tmp_path):
+        """Formats without a cheap curve scan (e.g. FileGDB) linearize via the
+        DuckDB-error fallback instead of the GPKG pre-scan."""
+        import duckdb
+
+        import geoparquet_io as gpio
+        import geoparquet_io.core.convert as convert_mod
+
+        monkeypatch.setattr(convert_mod, "_choose_read_strategy", lambda *a, **k: "normal")
+        out = tmp_path / "linear.parquet"
+        gpio.convert(str(CURVED_GPKG)).write(str(out))
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        area = con.execute(f"SELECT ST_Area(geometry) FROM '{out}'").fetchone()[0]
+        assert area == pytest.approx(math.pi, rel=0.005)
+
+    def test_linearized_path_passes_linear_rows_through(self, monkeypatch, tmp_path):
+        """Linear rows on the linearized path keep their bytes (prescreen)."""
+        import geoparquet_io as gpio
+        import geoparquet_io.core.convert as convert_mod
+
+        if not LINEAR_GPKG.exists():
+            pytest.skip("buildings_test.gpkg not available")
+        monkeypatch.setattr(convert_mod, "_choose_read_strategy", lambda *a, **k: "linearized")
+        out = tmp_path / "buildings.parquet"
+        gpio.convert(str(LINEAR_GPKG)).write(str(out))
+        assert out.exists()
+
 
 class TestConvertParameters:
     def test_opt_out_raises_actionable_error(self):
@@ -167,3 +396,111 @@ class TestConvertParameters:
             gpio.convert(str(CURVED_GPKG), max_angle_deg=deg).write(str(out))
             counts[deg] = con.execute(f"SELECT ST_NPoints(geometry) FROM '{out}'").fetchone()[0]
         assert counts[2.0] > counts[30.0] >= 13
+
+    def test_non_positive_max_angle_rejected_early(self):
+        import geoparquet_io as gpio
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="max_angle_deg"):
+            gpio.convert(str(CURVED_GPKG), max_angle_deg=-4.0)
+
+
+class TestStReadExpr:
+    def test_keep_wkb_layer_name_escaped(self):
+        """The keep_wkb fallback must escape layer names like the normal path."""
+        from geoparquet_io.core.convert import _build_st_read_expr
+
+        expr = _build_st_read_expr("f.gpkg", "Côte d'Ivoire", keep_wkb=True)
+        assert "keep_wkb := true" in expr
+        assert "layer := 'Côte d''Ivoire'" in expr
+
+
+class TestCliConvert:
+    def test_cli_convert_linearizes_by_default(self, tmp_path):
+        """`gpio convert` on curved input now works end to end (review on #647)."""
+        import duckdb
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = tmp_path / "out.parquet"
+        result = CliRunner().invoke(cli, ["convert", str(CURVED_GPKG), str(out), "--verbose"])
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        # The CLI path preserves the source's geometry column name (#328).
+        area = con.execute(f"SELECT ST_Area(geom) FROM '{out}'").fetchone()[0]
+        assert area == pytest.approx(math.pi, rel=0.005)
+
+    def test_cli_opt_out_raises_actionable_error(self, tmp_path):
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = tmp_path / "out.parquet"
+        result = CliRunner().invoke(
+            cli, ["convert", str(CURVED_GPKG), str(out), "--no-linearize-curves"]
+        )
+        assert result.exit_code != 0
+        assert "CONVERT_TO_LINEAR" in result.output
+
+    def test_cli_rejects_non_positive_max_angle(self, tmp_path):
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = tmp_path / "out.parquet"
+        result = CliRunner().invoke(
+            cli, ["convert", str(CURVED_GPKG), str(out), "--max-angle-deg", "-4"]
+        )
+        assert result.exit_code != 0
+
+
+class TestProjectedCurvedGpkg:
+    def test_crs_survives_linearized_read(self, tmp_path):
+        """Curved + projected: CRS detection must still work on the fallback path.
+
+        (Whether the detected CRS then reaches the written file is #625/#644's
+        territory; this pins the property that the linearized read does not
+        bypass detection.)
+        """
+        import json
+        import shutil
+        import sqlite3
+
+        from geoparquet_io.core.convert import read_spatial_to_arrow
+
+        wkt_25830 = (
+            'PROJCS["ETRS89 / UTM zone 30N",GEOGCS["ETRS89",'
+            'DATUM["European_Terrestrial_Reference_System_1989",'
+            'SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],'
+            'AUTHORITY["EPSG","6258"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],'
+            'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'
+            'AUTHORITY["EPSG","4258"]],PROJECTION["Transverse_Mercator"],'
+            'PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-3],'
+            'PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],'
+            'PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],'
+            'AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","25830"]]'
+        )
+        gpkg = tmp_path / "curved_25830.gpkg"
+        shutil.copy(CURVED_GPKG, gpkg)
+        con = sqlite3.connect(gpkg)
+        con.execute(
+            "INSERT OR REPLACE INTO gpkg_spatial_ref_sys "
+            "(srs_name, srs_id, organization, organization_coordsys_id, definition) "
+            "VALUES ('ETRS89 / UTM zone 30N', 25830, 'EPSG', 25830, ?)",
+            (wkt_25830,),
+        )
+        con.execute("UPDATE gpkg_contents SET srs_id = 25830")
+        con.execute("UPDATE gpkg_geometry_columns SET srs_id = 25830")
+        con.commit()
+        con.close()
+
+        table, detected_crs, geom_col = read_spatial_to_arrow(str(gpkg), verbose=True)
+
+        assert geom_col == "geometry"
+        assert table.num_rows == 1
+        assert detected_crs is not None
+        assert "25830" in json.dumps(detected_crs)


### PR DESCRIPTION
## Description

Builds on #646 (detection + actionable error): curved sources now **convert** instead of erroring. When the normal read hits DuckDB's `Unsupported geometry type in WKB`, the file is re-read with `ST_Read(keep_wkb := true)` — the escape hatch DuckDB documents for geometry subtypes it cannot represent — curved blobs are stroked into linear WKB in pure Python, and the result is validated through `ST_GeomFromWKB` so the output is indistinguishable from a normal read. `gpio convert` of the CURVEPOLYGON fixture now yields a Polygon whose area matches the true circle within 0.08%.

Why here and not upstream: duckdb-spatial has stated there are no plans to support circular geometry types (duckdb/duckdb-spatial#510), and GDAL's RFC 49 linearize flag cannot help because ST_Read's GPKG Arrow fast path streams raw blobs past the OGR geometry model. Linearize-at-the-WKB-boundary in the converter is the remaining correct place.

## Technical Details

New `core/linearize.py` (stdlib only, ~250 lines): ISO WKB transformer mapping CIRCULARSTRING/COMPOUNDCURVE→LINESTRING, CURVEPOLYGON→POLYGON, MULTICURVE/MULTISURFACE→MULTILINESTRING/MULTIPOLYGON, recursing through GEOMETRYCOLLECTION; arcs sampled at ≤4°/segment (GDAL's `OGR_ARC_STEPSIZE` default), exact endpoints, linear Z/M interpolation, collinear arcs degrade to segments. Fallback wiring in `_read_spatial_to_arrow`; a per-file warning reports how many geometries were stroked. EWKB flags and the surface family (POLYHEDRALSURFACE/TIN/TRIANGLE) raise `LinearizeError`, which surfaces as #646's actionable message.

## Breaking Changes
**Does this PR introduce breaking changes?** No — inputs that previously hard-errored now convert; everything else is untouched.

## Related Issue(s)
- #643

## Checklist
- [x] Tests added/updated, run against real data where feasible
- [x] Integration tests for changes that cross module/format/service boundaries
- [x] All tests pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Curved geometries are now automatically converted to linear geometries during GeoParquet conversion.
  * Added configurable angular sampling to control curve approximation accuracy.
  * Added CLI and Python API options to enable or disable curve linearization.
  * Linearization supports complex curved geometry types and preserves dimensional coordinates where applicable.
  * Added clearer errors and guidance for unsupported or malformed geometries.

* **Documentation**
  * Documented curved geometry conversion behavior, configuration options, defaults, and compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->