### PR TITLE
Order empty geometries last in convert instead of failing on ST_Hilbert

### DIFF
--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -233,20 +233,13 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
 
 
 def _calculate_bounds(
-    con,
-    input_file,
-    geom_column,
-    verbose,
-    is_parquet=False,
-    encoding="WKB",
-    table_expr=None,
-    required=True,
+    con, input_file, geom_column, verbose, is_parquet=False, encoding="WKB", table_expr=None
 ):
     """Calculate dataset bounds from input file (or an explicit table_expr).
 
-    With ``required=False`` an unmeasurable dataset — no rows, or every
-    geometry empty or NULL — returns None instead of raising, letting the
-    caller convert without spatial ordering (issue #649).
+    Returns None for a dataset with nothing to measure — no rows, or every
+    geometry empty or NULL — leaving the caller to convert without spatial
+    ordering rather than fail (issue #649).
     """
     if verbose:
         debug("Calculating dataset bounds...")
@@ -289,9 +282,7 @@ def _calculate_bounds(
     bounds_result = con.execute(bounds_query).fetchone()
 
     if not bounds_result or any(v is None for v in bounds_result):
-        if not required:
-            return None
-        raise GeoParquetError("Could not calculate dataset bounds")
+        return None
 
     if verbose:
         xmin, ymin, xmax, ymax = bounds_result
@@ -771,7 +762,12 @@ def _get_geom_expr_and_where(geom_info, skip_invalid):
 
 
 def _calculate_csv_bounds(con, geom_info, skip_invalid, verbose):
-    """Calculate dataset bounds from CSV geometry."""
+    """Calculate dataset bounds from CSV geometry.
+
+    Returns None when there is nothing to measure, mirroring
+    :func:`_calculate_bounds`: an all-empty or row-less CSV converts unordered
+    instead of failing (issue #649).
+    """
     if verbose:
         debug("Calculating dataset bounds from CSV...")
 
@@ -799,7 +795,7 @@ def _calculate_csv_bounds(con, geom_info, skip_invalid, verbose):
         raise GeoParquetError(msg) from e
 
     if not bounds_result or any(v is None for v in bounds_result):
-        raise GeoParquetError("Could not calculate dataset bounds from CSV")
+        return None  # nothing to measure: caller writes unordered (#649)
 
     if verbose:
         xmin, ymin, xmax, ymax = bounds_result
@@ -829,20 +825,13 @@ def _build_plain_select_query(input_file, is_parquet=False, is_csv=False, delimi
     return f"SELECT * FROM ST_Read('{input_file}')"
 
 
-def _bounds_with_curve_fallback_checked(con, *args, **kwargs):
-    """``_bounds_with_curve_fallback`` plus the unmeasurable-dataset case.
-
-    Every geometry empty or NULL (or no rows at all) leaves nothing to build a
-    Hilbert envelope from, so the conversion proceeds unordered with a warning
-    instead of failing on bounds (issue #649).
-    """
-    bounds, table_expr = _bounds_with_curve_fallback(con, *args, **kwargs)
-    if bounds is None:
-        warn(
-            "No measurable geometry bounds (every geometry is empty or NULL); "
-            "writing without Hilbert ordering."
-        )
-    return bounds, table_expr
+#: Warned when Hilbert ordering is skipped for want of an envelope (#649). Both
+#: causes land here — a source with no rows at all, and one where every geometry
+#: is empty or NULL — so the wording has to cover both.
+_NO_BOUNDS_WARNING = (
+    "No geometry to measure (no rows, or every geometry empty or NULL); "
+    "writing without Hilbert ordering."
+)
 
 
 def _orderable_geom(geom_expr, xmin, ymin):
@@ -856,9 +845,12 @@ def _orderable_geom(geom_expr, xmin, ymin):
     which pins those rows last exactly where NULL geometry already landed
     under DuckDB's NULLS LAST default.
 
-    Only the substitution is conditional — ``ST_Hilbert`` itself is evaluated
-    for every row, keeping spatial functions out of conditional execution
-    (the shape behind the segfaults in #642).
+    ``ST_Hilbert`` itself is evaluated for every row rather than from inside a
+    branch. The substitution does put ``ST_Point`` in a THEN branch, but with
+    constant arguments and over an already-decoded GEOMETRY, not the raw-blob
+    ``IS NULL`` shape that misaligned the selection vector in #642 (see
+    ``core/geometry_repair.py``); a 200k-row source with NULL and empty rows
+    goes through both the ST_Read and parquet paths without incident.
     """
     return (
         f"CASE WHEN {geom_expr} IS NULL OR ST_IsEmpty({geom_expr}) "
@@ -1056,6 +1048,10 @@ def _convert_csv_path(
                 msg = "Reading CSV, creating geometries, and applying Hilbert ordering..."
         debug(msg)
 
+    if not effective_skip_hilbert and bounds is None:
+        warn(_NO_BOUNDS_WARNING)
+        effective_skip_hilbert = True
+
     query = _build_csv_conversion_query(
         geom_info, effective_skip_hilbert, bounds, skip_invalid, skip_bbox=skip_bbox
     )
@@ -1097,9 +1093,7 @@ def _bounds_with_curve_fallback(
         tuple: (bounds, table_expr) — table_expr is the linearized view when
         the fallback fired, otherwise the caller's value unchanged.
     """
-    # required=False: an all-empty or empty dataset has no envelope to order
-    # by, which the caller turns into an unordered write rather than an error.
-    kwargs = {"is_parquet": is_parquet, "encoding": encoding, "required": False}
+    kwargs = {"is_parquet": is_parquet, "encoding": encoding}
     try:
         bounds = _calculate_bounds(
             con, input_file, geom_column, verbose, table_expr=table_expr, **kwargs
@@ -1205,7 +1199,7 @@ def _convert_spatial_path(
     geom_encoding = geom_info["metadata"].get(geom_column, {}).get("encoding", "WKB")
     bounds = None
     if not skip_hilbert:
-        bounds, table_expr = _bounds_with_curve_fallback_checked(
+        bounds, table_expr = _bounds_with_curve_fallback(
             con,
             input_file,
             geom_column,
@@ -1218,6 +1212,8 @@ def _convert_spatial_path(
             max_angle_deg=max_angle_deg,
         )
         skip_hilbert = bounds is None
+        if skip_hilbert:
+            warn(_NO_BOUNDS_WARNING)
 
     if verbose:
         if secondary_columns:

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -233,9 +233,21 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
 
 
 def _calculate_bounds(
-    con, input_file, geom_column, verbose, is_parquet=False, encoding="WKB", table_expr=None
+    con,
+    input_file,
+    geom_column,
+    verbose,
+    is_parquet=False,
+    encoding="WKB",
+    table_expr=None,
+    required=True,
 ):
-    """Calculate dataset bounds from input file (or an explicit table_expr)."""
+    """Calculate dataset bounds from input file (or an explicit table_expr).
+
+    With ``required=False`` an unmeasurable dataset — no rows, or every
+    geometry empty or NULL — returns None instead of raising, letting the
+    caller convert without spatial ordering (issue #649).
+    """
     if verbose:
         debug("Calculating dataset bounds...")
 
@@ -277,6 +289,8 @@ def _calculate_bounds(
     bounds_result = con.execute(bounds_query).fetchone()
 
     if not bounds_result or any(v is None for v in bounds_result):
+        if not required:
+            return None
         raise GeoParquetError("Could not calculate dataset bounds")
 
     if verbose:
@@ -721,16 +735,17 @@ def _build_csv_conversion_query(geom_info, skip_hilbert, bounds, skip_invalid, s
 
     # With Hilbert ordering - use subquery
     xmin, ymin, xmax, ymax = bounds
+    bounds_box = f"ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax}))"
+    # A WKT column can hold empty geometry, which ST_Hilbert rejects (#649).
+    unorderable = f"{geom_expr} IS NULL OR ST_IsEmpty({geom_expr})"
     return f"""
         SELECT
             * EXCLUDE ({exclude_cols}),
             {geom_expr} AS geometry{bbox_expr(geom_expr)}
         FROM {csv_read}
         {where_clause}
-        ORDER BY ST_Hilbert(
-            {geom_expr},
-            ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax}))
-        )
+        ORDER BY ({unorderable}),
+            ST_Hilbert({_orderable_geom(geom_expr, xmin, ymin)}, {bounds_box})
     """
 
 
@@ -812,6 +827,43 @@ def _build_plain_select_query(input_file, is_parquet=False, is_csv=False, delimi
         return f"SELECT * FROM {csv_read}"
     # Spatial formats (GeoJSON, Shapefile, GeoPackage, etc.) - use ST_Read
     return f"SELECT * FROM ST_Read('{input_file}')"
+
+
+def _bounds_with_curve_fallback_checked(con, *args, **kwargs):
+    """``_bounds_with_curve_fallback`` plus the unmeasurable-dataset case.
+
+    Every geometry empty or NULL (or no rows at all) leaves nothing to build a
+    Hilbert envelope from, so the conversion proceeds unordered with a warning
+    instead of failing on bounds (issue #649).
+    """
+    bounds, table_expr = _bounds_with_curve_fallback(con, *args, **kwargs)
+    if bounds is None:
+        warn(
+            "No measurable geometry bounds (every geometry is empty or NULL); "
+            "writing without Hilbert ordering."
+        )
+    return bounds, table_expr
+
+
+def _orderable_geom(geom_expr, xmin, ymin):
+    """``geom_expr`` with empty/NULL geometry swapped for a keyable point.
+
+    ``ST_Hilbert`` raises on empty geometries (issue #649), so a single
+    ``POLYGON EMPTY`` used to fail an entire conversion — while ``gpio sort
+    hilbert`` has always ordered the non-empty rows and appended the rest. The
+    substitute is a corner of the dataset envelope, so it is always in range,
+    and its key never matters: callers sort on an "unorderable" flag first,
+    which pins those rows last exactly where NULL geometry already landed
+    under DuckDB's NULLS LAST default.
+
+    Only the substitution is conditional — ``ST_Hilbert`` itself is evaluated
+    for every row, keeping spatial functions out of conditional execution
+    (the shape behind the segfaults in #642).
+    """
+    return (
+        f"CASE WHEN {geom_expr} IS NULL OR ST_IsEmpty({geom_expr}) "
+        f"THEN ST_Point({xmin}, {ymin}) ELSE {geom_expr} END"
+    )
 
 
 def _build_conversion_query(
@@ -923,11 +975,16 @@ def _build_conversion_query(
     xmin, ymin, xmax, ymax = bounds
     bounds_box = f"ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax}))"
     if geoarrow_native:
+        # Native encodings key on centroid coordinates, which are NULL for a
+        # geometry with no coordinates — ST_Hilbert returns NULL rather than
+        # failing, so those rows only need the flag to pin them last.
+        unorderable = f"{cx_e} IS NULL OR {cy_e} IS NULL"
         hilbert_expr = f"ST_Hilbert({cx_e}, {cy_e}, {bounds_box})"
     else:
-        hilbert_expr = f"ST_Hilbert({quoted_geom}, {bounds_box})"
+        unorderable = f"{quoted_geom} IS NULL OR ST_IsEmpty({quoted_geom})"
+        hilbert_expr = f"ST_Hilbert({_orderable_geom(quoted_geom, xmin, ymin)}, {bounds_box})"
     return f"""{base_select}
-        ORDER BY {hilbert_expr}
+        ORDER BY ({unorderable}), {hilbert_expr}
     """
 
 
@@ -1040,7 +1097,9 @@ def _bounds_with_curve_fallback(
         tuple: (bounds, table_expr) — table_expr is the linearized view when
         the fallback fired, otherwise the caller's value unchanged.
     """
-    kwargs = {"is_parquet": is_parquet, "encoding": encoding}
+    # required=False: an all-empty or empty dataset has no envelope to order
+    # by, which the caller turns into an unordered write rather than an error.
+    kwargs = {"is_parquet": is_parquet, "encoding": encoding, "required": False}
     try:
         bounds = _calculate_bounds(
             con, input_file, geom_column, verbose, table_expr=table_expr, **kwargs
@@ -1146,7 +1205,7 @@ def _convert_spatial_path(
     geom_encoding = geom_info["metadata"].get(geom_column, {}).get("encoding", "WKB")
     bounds = None
     if not skip_hilbert:
-        bounds, table_expr = _bounds_with_curve_fallback(
+        bounds, table_expr = _bounds_with_curve_fallback_checked(
             con,
             input_file,
             geom_column,
@@ -1158,6 +1217,7 @@ def _convert_spatial_path(
             linearize_curves=linearize_curves,
             max_angle_deg=max_angle_deg,
         )
+        skip_hilbert = bounds is None
 
     if verbose:
         if secondary_columns:

--- a/tests/test_convert_empty_geometries.py
+++ b/tests/test_convert_empty_geometries.py
@@ -1,0 +1,189 @@
+"""Conversion of sources containing empty geometries (issue #649).
+
+`ST_Hilbert` rejects empty geometries, and `gpio convert` ordered every row
+with it, so a single `POLYGON EMPTY` failed the whole conversion:
+
+    Error: Conversion failed: Invalid Input Error: ST_Hilbert(geom, bounds)
+    does not support empty geometries
+
+`gpio sort hilbert` never had the problem — it orders the non-empty rows and
+appends the rest (`core/hilbert_order.py`). Empty geometries are common in
+GeoPackage/Shapefile/FileGDB exports, and #647's linearization produces them
+too (`CIRCULARSTRING EMPTY` becomes `LINESTRING EMPTY`).
+"""
+
+from pathlib import Path
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+
+CURVED_GPKG = Path(__file__).parent / "data" / "curved_geometry_test.gpkg"
+
+
+def _spatial_con():
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    return con
+
+
+def _write_gpkg(path, rows):
+    """Write a GeoPackage from (id, WKT-or-None) pairs, empties included."""
+    con = _spatial_con()
+    values = ", ".join(
+        f"({i}, NULL)" if wkt is None else f"({i}, ST_GeomFromText('{wkt}'))" for i, wkt in rows
+    )
+    con.execute(
+        f"COPY (SELECT * FROM (VALUES {values}) v(id, geom)) "
+        f"TO '{path}' WITH (FORMAT GDAL, DRIVER 'GPKG')"
+    )
+    con.close()
+
+
+def _convert(source, output, *extra):
+    return CliRunner().invoke(cli, ["convert", str(source), str(output), *extra])
+
+
+def _count(output):
+    """Row count without touching geometry (native encodings are structs)."""
+    con = _spatial_con()
+    try:
+        return con.execute(f"SELECT count(*) FROM '{output}'").fetchall()[0][0]
+    finally:
+        con.close()
+
+
+def _rows(output, geom_col="geom"):
+    """(id, is_empty_or_null) in stored order."""
+    con = _spatial_con()
+    try:
+        return con.execute(
+            f"SELECT id, {geom_col} IS NULL OR ST_IsEmpty({geom_col}) FROM '{output}'"
+        ).fetchall()
+    finally:
+        con.close()
+
+
+class TestEmptyGeometryConversion:
+    def test_empty_geometry_no_longer_fails_the_conversion(self, tmp_path):
+        source = tmp_path / "one_empty.gpkg"
+        _write_gpkg(source, [(1, "POINT(1 1)"), (2, "POLYGON EMPTY")])
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output)
+
+        assert result.exit_code == 0, result.output
+        assert len(_rows(output)) == 2
+
+    def test_empty_and_null_geometries_sort_last(self, tmp_path):
+        """Same contract as `sort hilbert`: ordered rows first, the rest after."""
+        source = tmp_path / "mixed.gpkg"
+        _write_gpkg(
+            source,
+            [
+                (1, "POINT(9 9)"),
+                (2, "POLYGON EMPTY"),
+                (3, "POINT(1 1)"),
+                (4, None),
+                (5, "POINT(5 5)"),
+            ],
+        )
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output)
+
+        assert result.exit_code == 0, result.output
+        rows = _rows(output)
+        assert len(rows) == 5
+        unorderable = [is_empty for _, is_empty in rows]
+        assert unorderable == sorted(unorderable), f"empty rows are not last: {rows}"
+        # The non-empty rows keep Hilbert order: (1 1) before (5 5) before (9 9).
+        assert [i for i, is_empty in rows if not is_empty] == [3, 5, 1]
+
+    def test_all_geometries_empty_converts_without_ordering(self, tmp_path):
+        """With nothing to measure there is no envelope, so ordering is skipped
+        rather than failing on unmeasurable bounds."""
+        source = tmp_path / "all_empty.gpkg"
+        _write_gpkg(source, [(1, "POLYGON EMPTY"), (2, "LINESTRING EMPTY")])
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output)
+
+        assert result.exit_code == 0, result.output
+        assert len(_rows(output)) == 2
+
+    def test_geoarrow_native_encoding_handles_empty_geometry(self, tmp_path):
+        """The native-encoding branch orders by centroid expressions instead of
+        ST_Hilbert(geometry, ...) — empties must not break it either."""
+        source = tmp_path / "native.gpkg"
+        _write_gpkg(source, [(1, "POLYGON((0 0, 1 0, 1 1, 0 0))"), (2, "POLYGON EMPTY")])
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output, "--geoparquet-version", "1.1-geoarrow")
+
+        assert result.exit_code == 0, result.output
+        assert _count(output) == 2  # geometry is a nested struct here, not WKB
+
+    def test_skip_hilbert_still_works(self, tmp_path):
+        source = tmp_path / "one_empty.gpkg"
+        _write_gpkg(source, [(1, "POINT(1 1)"), (2, "POLYGON EMPTY")])
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output, "--skip-hilbert")
+
+        assert result.exit_code == 0, result.output
+        assert len(_rows(output)) == 2
+
+
+class TestEmptyGeometryFromCsv:
+    def test_empty_wkt_geometry_converts(self, tmp_path):
+        """The CSV path builds its own Hilbert ordering over a WKT expression."""
+        source = tmp_path / "points.csv"
+        source.write_text(
+            "id,geom\n1,POINT(1 1)\n2,POLYGON EMPTY\n3,POINT(5 5)\n",
+            encoding="utf-8",
+        )
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output, "--wkt-column", "geom")
+
+        assert result.exit_code == 0, result.output
+        rows = _rows(output, geom_col="geometry")
+        assert len(rows) == 3
+        unorderable = [is_empty for _, is_empty in rows]
+        assert unorderable == sorted(unorderable), f"empty rows are not last: {rows}"
+
+
+class TestLinearizedEmptyCurve:
+    def test_curved_source_with_empty_curve_converts(self, tmp_path):
+        """#647 turns CIRCULARSTRING EMPTY into LINESTRING EMPTY, which then met
+        this bug in the same command."""
+        import shutil
+        import sqlite3
+        import struct
+
+        if not CURVED_GPKG.exists():
+            pytest.skip("curved_geometry_test.gpkg not available")
+
+        source = tmp_path / "curved_with_empty.gpkg"
+        shutil.copy(CURVED_GPKG, source)
+        con = sqlite3.connect(source)
+        for (name,) in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger'"
+        ).fetchall():
+            con.execute(f'DROP TRIGGER "{name}"')
+        empty_circularstring = b"\x01" + struct.pack("<I", 8) + struct.pack("<I", 0)
+        con.execute(
+            "INSERT INTO curve (geom, wkt, id) VALUES (?, ?, ?)",
+            (b"GP\x00\x01" + struct.pack("<i", 0) + empty_circularstring, "EMPTY", "empty"),
+        )
+        con.commit()
+        con.close()
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output)
+
+        assert result.exit_code == 0, result.output
+        assert len(_rows(output)) == 2

--- a/tests/test_convert_empty_geometries.py
+++ b/tests/test_convert_empty_geometries.py
@@ -187,3 +187,24 @@ class TestLinearizedEmptyCurve:
 
         assert result.exit_code == 0, result.output
         assert len(_rows(output)) == 2
+
+    def test_all_empty_csv_converts_without_ordering(self, tmp_path):
+        """Same rescue as the spatial path: nothing to measure, so no ordering."""
+        source = tmp_path / "all_empty.csv"
+        source.write_text("id,geom\n1,POLYGON EMPTY\n2,LINESTRING EMPTY\n", encoding="utf-8")
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output, "--wkt-column", "geom")
+
+        assert result.exit_code == 0, result.output
+        assert _count(output) == 2
+
+    def test_header_only_csv_converts(self, tmp_path):
+        source = tmp_path / "empty.csv"
+        source.write_text("id,geom\n", encoding="utf-8")
+        output = tmp_path / "out.parquet"
+
+        result = _convert(source, output, "--wkt-column", "geom")
+
+        assert result.exit_code == 0, result.output
+        assert _count(output) == 0


### PR DESCRIPTION
## Description

`ST_Hilbert` rejects empty geometries, and `gpio convert` keyed every row with it, so a single `POLYGON EMPTY` anywhere in the source failed the entire conversion:

```
Error: Conversion failed: Invalid Input Error: ST_Hilbert(geom, bounds) does not support empty geometries
```

`gpio sort hilbert` never had the problem — it orders the non-empty rows and appends the rest (`core/hilbert_order.py`) — so the two commands disagreed about the same data, and `--skip-hilbert` (giving up the spatial ordering) was the only way through. Empty geometries are common in GeoPackage/Shapefile/FileGDB exports, and #647's linearization produces them too (`CIRCULARSTRING EMPTY` becomes `LINESTRING EMPTY`).

Both conversion queries — the spatial/parquet path and the CSV/WKT path — now sort on an "unorderable" flag first, which lands empty geometry exactly where NULL geometry already landed under DuckDB's `NULLS LAST` default, and the geometry handed to `ST_Hilbert` is substituted with a corner of the dataset envelope for those rows so it is never asked to key an empty one.

## Technical Details

- New `_orderable_geom()` builds the substitution; `_build_conversion_query` and `_build_csv_conversion_query` order by `(unorderable), ST_Hilbert(...)`.
- **Deliberately not the CTE + `UNION ALL` shape** the issue sketched, for two reasons: it would duplicate the generated base select and scan the source twice (expensive for remote files and for #647's linearized temp relation), and ordering inside a branch of a `UNION ALL` is not guaranteed to survive it. A single `ORDER BY` has unambiguous semantics. Verified both shapes produce identical row order on a mixed empty/NULL/valid fixture.
- Only the *substitution* is conditional; `ST_Hilbert` is still evaluated for every row, so no spatial function runs under conditional execution — the shape behind the segfaults in #642/#645.
- The native-encoding branch keys on centroid expressions, which are NULL (not an error) for a geometry with no coordinates; it gets the same flag so placement is explicit rather than relying on the NULLS LAST default.
- A source whose geometry is *entirely* empty or NULL has no envelope to order by and used to fail with the unhelpful "Could not calculate dataset bounds". `_calculate_bounds(required=False)` now returns None there and the conversion proceeds unordered with a warning. Note this also means a **zero-row source converts instead of erroring** — a deliberate behavior change, and the more useful outcome, but worth a reviewer's eye.
- No warning for the ordinary mixed case: the rows are reordered, not dropped, and NULL geometry has always been placed last silently. Emitting one would also cost an extra count pass over the source, which `sort hilbert` can afford (in-memory table) and `convert` cannot.

**Row order for sources without empty geometry is unchanged** — verified by converting `tests/data/buildings_test.gpkg` on this branch and on `main` in a separate worktree and comparing the full centroid sequence (identical).

## Tests

New `tests/test_convert_empty_geometries.py`: one empty geometry no longer fails; empty *and* NULL sort last while the non-empty rows keep Hilbert order; all-empty converts unordered; native GeoArrow encoding; `--skip-hilbert` still fine; CSV with an empty WKT value; and a curved source carrying an empty curve (the #647 interaction). All written before the fix and failing without it.

Local: 856 passed / 7 skipped on the convert/crs/hilbert/sort/csv/geopackage/curved/linearize selection; pre-commit, xenon, and import-linter clean.

## Breaking Changes
**Does this PR introduce breaking changes?** No, unless "a zero-row input now converts rather than erroring" counts.

## Related Issue(s)
- Closes #649
- Touches the same file as #650 (streaming linearized read) but different functions; they should merge in either order.

## Checklist
- [x] Tests added/updated, run against real data where feasible
- [x] Integration tests for changes that cross module/format/service boundaries
- [x] All tests pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Conversions now succeed when datasets contain empty or missing geometries.
  - Hilbert ordering safely places unorderable geometries last and skips ordering when bounds are unavailable.
  - CSV, native GeoArrow, and curved geometry conversions now handle empty geometries while preserving row counts.
  - Existing options to skip Hilbert ordering continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->