### PR TITLE
Reproject before repairing geometry in convert geojson

### DIFF
--- a/geoparquet_io/core/geojson_stream.py
+++ b/geoparquet_io/core/geojson_stream.py
@@ -159,18 +159,30 @@ def _build_feature_query(
     """
     quoted_geom = quote_identifier(geometry_column)
 
-    # Repair invalid geometry (issue #506) before reproject/precision/GeoJSON so
-    # downstream consumers (e.g. tippecanoe in the PMTiles pipeline) never see a
+    # Reproject first, in a subquery, so everything below sees the geometry in
+    # the CRS it will be written in. Reprojection is not topology-preserving: a
+    # polygon ST_MakeValid has just made valid in the source CRS can come out of
+    # ST_Transform invalid in WGS84, and ST_ReducePrecision - a GEOS topology
+    # operation - then raises TopologyException on it. Repairing after the
+    # transform is also what the explicit --src-crs route already does, since
+    # core/pmtiles.py reprojects in a separate process before piping into this
+    # query; only the auto-detected CRS path had the two in the wrong order.
+    #
+    # The transform lives in a subquery rather than inline because
+    # repair_geometry_sql repeats its argument, and ST_Transform is far too
+    # expensive to evaluate once per repetition per row.
+    if source_crs:
+        source_ref = (
+            f"(SELECT * REPLACE ("
+            f"ST_Transform({quoted_geom}, '{source_crs}', '{WGS84_CRS}') AS {quoted_geom}"
+            f") FROM {source_ref} WHERE {quoted_geom} IS NOT NULL)"
+        )
+
+    # Repair invalid geometry (issue #506) before precision/GeoJSON so downstream
+    # consumers (e.g. tippecanoe in the PMTiles pipeline) never see a
     # self-intersection. The NULL filter in the WHERE clause stays on the raw
     # column. ST_AsGeoJSON requires native GEOMETRY, which this already is.
-    geom_base = repair_geometry_sql(quoted_geom) if repair_geometry else quoted_geom
-
-    # Apply reprojection if needed
-    if source_crs:
-        # Transform to WGS84 before converting to GeoJSON
-        geom_for_output = f"ST_Transform({geom_base}, '{source_crs}', '{WGS84_CRS}')"
-    else:
-        geom_for_output = geom_base
+    geom_for_output = repair_geometry_sql(quoted_geom) if repair_geometry else quoted_geom
 
     # Apply coordinate precision using ST_ReducePrecision before GeoJSON conversion.
     # The grid size is 10^-precision (e.g., precision=7 -> grid=0.0000001).

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -541,3 +541,80 @@ class TestWgs84Constant:
     def test_wgs84_crs_value(self):
         """Test WGS84_CRS is correctly defined."""
         assert WGS84_CRS == "EPSG:4326"
+
+
+class TestRepairAfterReprojection:
+    """Geometry must be repaired in the CRS it is written in, not the source CRS.
+
+    Reprojection is not topology-preserving, so repairing first leaves
+    ST_ReducePrecision to raise TopologyException on geometry the transform has
+    just invalidated.
+    """
+
+    # A sliver from the SITEX Extremadura "mancomunidades" layer: valid in
+    # EPSG:25830 (two of its vertices differ only in the 13th decimal), invalid
+    # once transformed to WGS84. Repairing before the transform makes
+    # ST_ReducePrecision raise "TopologyException: unable to assign free hole to
+    # a shell" on it.
+    SLIVER_25830 = (
+        "POLYGON (("
+        "217334.43251087563 4419513.990336159, "
+        "217334.2614384655 4419513.996670783, "
+        "217334.2527995768 4419513.996990671, "
+        "217334.5221580651 4419514.098189879, "
+        "217334.60769426968 4419514.09502257, "
+        "217334.60769426887 4419514.09502257, "
+        "217334.43251087563 4419513.990336159))"
+    )
+
+    def test_repair_wraps_the_reprojected_geometry(self):
+        """The repair must be applied after the transform, not before it."""
+        query = _build_feature_query("t", "geometry", ["name"], source_crs="EPSG:25830")
+        # The transform happens in the subquery that feeds the repair, so the
+        # repaired expression is a plain column reference.
+        assert "ST_MakeValid(ST_Transform(" not in query.replace(" ", "")
+        transform_pos = query.index("ST_Transform")
+        repair_pos = query.index("ST_MakeValid")
+        assert transform_pos > repair_pos, "repair must consume the reprojected column"
+
+    def test_transform_is_evaluated_once_per_row(self):
+        """repair_geometry_sql repeats its argument; ST_Transform must not be."""
+        query = _build_feature_query(
+            "t", "geometry", ["name"], source_crs="EPSG:25830", write_bbox=True
+        )
+        assert query.count("ST_Transform") == 1
+
+    def test_reprojected_sliver_survives_precision_reduction(self):
+        """The real-world regression: this raised before the reorder."""
+        import duckdb
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute(
+            f"CREATE TABLE t AS SELECT ST_GeomFromText('{self.SLIVER_25830}') "
+            "AS geometry, 'sliver' AS name"
+        )
+        query = _build_feature_query(
+            "t", "geometry", ["name"], precision=6, source_crs="EPSG:25830"
+        )
+        rows = con.execute(query).fetchall()
+        assert len(rows) == 1
+        assert json.loads(rows[0][0])["type"] == "Feature"
+
+    def test_null_geometry_still_filtered_with_reprojection(self):
+        """The NULL filter must survive the subquery rewrite."""
+        import duckdb
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute(
+            "CREATE TABLE t AS SELECT * FROM (VALUES "
+            f"(ST_GeomFromText('{self.SLIVER_25830}'), 'kept'), "
+            "(NULL::GEOMETRY, 'dropped')) AS v(geometry, name)"
+        )
+        query = _build_feature_query(
+            "t", "geometry", ["name"], precision=6, source_crs="EPSG:25830"
+        )
+        rows = con.execute(query).fetchall()
+        assert len(rows) == 1
+        assert json.loads(rows[0][0])["properties"]["name"] == "kept"


### PR DESCRIPTION
Fixes #652.

`_build_feature_query` repaired geometry in the **source** CRS and reprojected
afterwards:

```
ST_ReducePrecision( ST_Transform( ST_MakeValid(geom), src, 4326 ), 10^-precision )
```

Reprojection is not topology-preserving, so a polygon `ST_MakeValid` had just
made valid in the source CRS could come out of `ST_Transform` **invalid** in
WGS84 — and `ST_ReducePrecision`, a GEOS topology operation, then raised on it.
One such feature aborts the whole conversion, and through `create_pmtiles` it
takes the tippecanoe pipeline with it (`tippecanoe failed with exit code 110`).

gpio already got this right on its other path: with an explicit `src_crs`,
`core/pmtiles.py` runs `gpio convert reproject` in a separate process **first**
and pipes into `convert geojson`, so the repair lands on already-reprojected
data. Only the auto-detected CRS path had the two in the wrong order.

## The change

Reproject in a subquery, then repair, so the repair runs in the CRS the output
is expressed in. The transform goes in a subquery rather than inline because
`repair_geometry_sql` repeats its argument — inlining would evaluate
`ST_Transform` four times per row, twenty with `--write-bbox`. It is now
evaluated exactly once, which a test asserts.

## Tests

Four regression tests, all failing on `main` and passing here:

- the repair consumes the reprojected column, not the raw one
- `ST_Transform` appears exactly once even with `--write-bbox`
- a real-world sliver polygon survives precision reduction
- the NULL-geometry filter survives the subquery rewrite

The fixture is a 7-vertex sliver reduced from the failing feature in the SITEX
Extremadura *mancomunidades* layer (EPSG:25830): valid in the source CRS — two
of its vertices differ only in the 13th decimal — and invalid once transformed.

## Real-world verification

Found rebuilding a 28-collection catalog from Junta de Extremadura open data in
its native CRS. Three collections failed on `main`; all three convert here with
nothing dropped and no precision given up:

| collection | features |
|---|---|
| mancomunidades-integrales | 31 |
| CORINE 2012 | 14,545 |
| CORINE 2018 | 14,779 |

Every source geometry is valid (`ST_IsValid` reports 0 invalid rows); after
`ST_MakeValid` + `ST_Transform` to WGS84, 8 / 11 / 3 features respectively come
out invalid. The full catalog now builds end to end: 28/28 GeoParquet, PMTiles,
thumbnails and styles.

This only became reachable via #644 — before it the Table API wrote `crs: null`,
so pipelines that reprojected upstream produced WGS84 parquet and this query
inserted no `ST_Transform` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GeoJSON export when coordinate reference system reprojection and geometry repair are applied together.
  * Preserved valid small geometries during precision reduction.
  * Continued filtering null geometries correctly.

* **Tests**
  * Added regression coverage for reprojection, geometry repair, precision handling, and null geometry filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->