### PR TITLE
Record why the duckdb pin also holds the TRY() workaround in place

### DIFF
--- a/geoparquet_io/core/geometry_repair.py
+++ b/geoparquet_io/core/geometry_repair.py
@@ -57,8 +57,10 @@ def _layered_invalid_count_sql(source_sql: str, parsed_expr: str) -> str:
 
     Filtering ``IS NOT NULL`` and evaluating ``ST_IsValid`` over the raw rows in
     one WHERE clause segfaults DuckDB 1.5.x's spatial extension when the column
-    contains NULLs (selection-vector misalignment under conditional execution;
-    the same bug family as the OR-form repair crash noted below). Verified on
+    contains NULLs: DuckDB 1.5.1's TRY() applies the selection vector twice
+    under conditional execution, reading uninitialized vector memory (fixed in
+    DuckDB 1.5.2, see duckdb/duckdb-spatial#858 — we are pinned below it for the
+    'geography' extension). Verified on
     issue #642's reproduction: projecting the parsed geometry first, filtering
     NULLs in a middle layer, and running ``ST_IsValid`` outermost is logically
     identical and crash-free.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,18 @@ dependencies = [
     "click-plugins>=1.1.1",  # Plugin system for extending CLI
     "pyarrow>=23.0.1",  # PYSEC-2026-113 fix
     # S2 support needs the 'geography' community extension, which is built per
-    # DuckDB release. It is published up to 1.5.1 but NOT for 1.5.2/1.5.3/1.5.4
+    # DuckDB release. It is published up to 1.5.1 but NOT for 1.5.2-1.5.5
     # (INSTALL ... FROM community returns HTTP 404). Cap below 1.5.2 so S2 keeps
     # working; raise the cap once 'geography' is republished for a newer DuckDB.
     # (gpio still errors clearly via ExtensionUnavailableError if it is missing.)
+    #
+    # Staying on <=1.5.1 keeps us on a DuckDB whose TRY() applies the selection
+    # vector twice under conditional execution (dropped in 1.5.2, see
+    # duckdb/duckdb-spatial#858): TRY() over a blob can segfault, and over a
+    # fixed-width type it can silently return another row's value. That is why
+    # core/geometry_repair.py counts invalid geometry in layers (#645). When the
+    # cap moves past 1.5.1, that workaround — and the risk at the other TRY()
+    # call sites — goes away.
     "duckdb>=1.5.0,<1.5.2",
     "pandas>=1.0.0",
     "fsspec>=2023.9.0",


### PR DESCRIPTION
## Description

Comment-only follow-up to #645, recording its root cause where the next person will look.

The segfault was never a duckdb-spatial bug. DuckDB 1.5.1's `OPERATOR_TRY` (`src/execution/expression_executor/execute_operator.cpp`) applies the selection vector twice — the child result is already dense, but the copy re-maps through `sel`:

```cpp
Execute(*expr.children[0], &child_state, sel, count, try_result);
if (sel) {
    VectorOperations::Copy(try_result, result, *sel, count, 0, 0, count);  // sel applied again
}
```

It reads past `count` into uninitialized vector memory: a wild `string_t` for blobs (our crash), and **another row's value** for fixed-width types — silent, no crash. Twelve rows, no extensions:

```sql
CREATE TABLE tbl AS SELECT i AS id, i::VARCHAR AS v FROM range(12) r(i);
SELECT id, CASE WHEN id % 3 = 0 THEN TRY(CAST(v AS INTEGER)) END AS via_try,
           CASE WHEN id % 3 = 0 THEN CAST(v AS INTEGER) END AS via_plain FROM tbl ORDER BY id;
-- id 3 -> 9, id 6 -> 55369008, id 9 -> 0
```

DuckDB 1.5.2 dropped the `if (sel)` branch; verified clean on 1.5.5 (0 wrong-value rows, and #645's pre-fix query runs 6/6 at 100k rows).

**We cannot take the fix yet.** The `geography` community extension S2 needs is unpublished for 1.5.2, 1.5.3, 1.5.4 and 1.5.5 (checked each), so the `<1.5.2` cap stays. Meanwhile the #645 layered count is verified effective for our shape: 0/12 crashes at 10k and 100k rows, against 7/12 and 12/12 for the pre-#645 form.

So this PR just writes it down in the two places that matter — the pin comment and `_layered_invalid_count_sql`'s docstring — so whoever republishes `geography` and raises the cap knows the workaround can go, and knows the other 19 `TRY(...)` call sites stop being exposed at the same time.

Reported upstream: duckdb/duckdb-spatial#858 (asked for it to be closed as a core bug already fixed).

## Breaking Changes
**Does this PR introduce breaking changes?** No — comments only, no dependency range change.

## Related Issue(s)
- Follow-up to #645, #642
- duckdb/duckdb-spatial#858

## Checklist
- [x] Tests added/updated, run against real data where feasible — n/a, comment-only (`tests/test_geometry_repair.py` still green)
- [x] All tests pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)