### PR TITLE
fix(extract): validate --where on bigquery and carto extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,12 +387,41 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `o'brien/data.parquet`) was escaped twice and reported as not found by
   `check`, `inspect`, `add bbox` and `convert`; paths are now escaped exactly
   once.
-- **`--where` on `gpio extract bigquery` and `gpio extract carto` is now
-  validated (parity with #612).** Both extractors route their `--where`
-  clause through the same `validate_where_clause` check used everywhere
-  else — including the dry-run/build path — before it is interpolated into
-  a query or a network request is made, closing a statement-separator gap
-  that the primary extract/partition/aggregate paths already closed.
+- **`--where` validation is now parser-based, and reaches `gpio extract
+  bigquery` / `gpio extract carto`.** Three fixes to the shared
+  `--where` guard:
+
+    - The statement gate no longer walks the clause looking for an
+      unquoted `;`. That walker only understood `'` and `"`, so a `;`
+      hidden behind dollar quoting (`$$'$$`), a block comment, a line
+      comment, or an `E'\''` escape slipped through and executed as extra
+      statements. The clause is now composed into the exact `WHERE
+      (<clause>\n)` shape the callers emit and handed to DuckDB's parser;
+      anything that parses as more than one statement — or does not parse
+      at all — is rejected.
+    - Blocklisted keywords are matched against real SQL word tokens
+      instead of the uppercased clause text, so ordinary filters that
+      merely contain one inside a string literal are accepted again:
+      `name = 'Grant County'`, `street LIKE '%Alter Markt%'`,
+      `descr ILIKE '%drop off%'`, `status = 'DELETE'`, `name = 'Merge
+      Lane'`. `REPLACE` is no longer blocklisted at all — it is a standard
+      scalar function in DuckDB, BigQuery and Postgres/Carto, and a
+      function call cannot modify data.
+    - `gpio extract bigquery` and `gpio extract carto` now run their
+      `--where` through that check (on the dry-run/build path too, before
+      any network request), and build their SQL through the shared
+      condition helper. Previously they inlined `({where})` on one line, so
+      a clause ending in `--` commented out everything after it: a
+      `--bbox`-and-`--limit` request silently became a full-table
+      download. The bbox condition and the `LIMIT` now survive.
+
+  Scope, stated plainly: this guard is a safety net for **trusted** input,
+  not a security boundary. It stops a clause from becoming additional
+  statements; it does not stop abuse that stays inside a single expression
+  (e.g. `1=1 AND length((SELECT content FROM read_text('/etc/hosts')))>0`
+  still passes). `gpio extract arcgis --where` remains unvalidated by
+  design — it is sent as an HTTP query parameter to the Feature Service,
+  never interpolated into a local SQL statement.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,12 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `o'brien/data.parquet`) was escaped twice and reported as not found by
   `check`, `inspect`, `add bbox` and `convert`; paths are now escaped exactly
   once.
+- **`--where` on `gpio extract bigquery` and `gpio extract carto` is now
+  validated (parity with #612).** Both extractors route their `--where`
+  clause through the same `validate_where_clause` check used everywhere
+  else — including the dry-run/build path — before it is interpolated into
+  a query or a network request is made, closing a statement-separator gap
+  that the primary extract/partition/aggregate paths already closed.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -387,12 +387,41 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `o'brien/data.parquet`) was escaped twice and reported as not found by
   `check`, `inspect`, `add bbox` and `convert`; paths are now escaped exactly
   once.
-- **`--where` on `gpio extract bigquery` and `gpio extract carto` is now
-  validated (parity with #612).** Both extractors route their `--where`
-  clause through the same `validate_where_clause` check used everywhere
-  else — including the dry-run/build path — before it is interpolated into
-  a query or a network request is made, closing a statement-separator gap
-  that the primary extract/partition/aggregate paths already closed.
+- **`--where` validation is now parser-based, and reaches `gpio extract
+  bigquery` / `gpio extract carto`.** Three fixes to the shared
+  `--where` guard:
+
+    - The statement gate no longer walks the clause looking for an
+      unquoted `;`. That walker only understood `'` and `"`, so a `;`
+      hidden behind dollar quoting (`$$'$$`), a block comment, a line
+      comment, or an `E'\''` escape slipped through and executed as extra
+      statements. The clause is now composed into the exact `WHERE
+      (<clause>\n)` shape the callers emit and handed to DuckDB's parser;
+      anything that parses as more than one statement — or does not parse
+      at all — is rejected.
+    - Blocklisted keywords are matched against real SQL word tokens
+      instead of the uppercased clause text, so ordinary filters that
+      merely contain one inside a string literal are accepted again:
+      `name = 'Grant County'`, `street LIKE '%Alter Markt%'`,
+      `descr ILIKE '%drop off%'`, `status = 'DELETE'`, `name = 'Merge
+      Lane'`. `REPLACE` is no longer blocklisted at all — it is a standard
+      scalar function in DuckDB, BigQuery and Postgres/Carto, and a
+      function call cannot modify data.
+    - `gpio extract bigquery` and `gpio extract carto` now run their
+      `--where` through that check (on the dry-run/build path too, before
+      any network request), and build their SQL through the shared
+      condition helper. Previously they inlined `({where})` on one line, so
+      a clause ending in `--` commented out everything after it: a
+      `--bbox`-and-`--limit` request silently became a full-table
+      download. The bbox condition and the `LIMIT` now survive.
+
+  Scope, stated plainly: this guard is a safety net for **trusted** input,
+  not a security boundary. It stops a clause from becoming additional
+  statements; it does not stop abuse that stays inside a single expression
+  (e.g. `1=1 AND length((SELECT content FROM read_text('/etc/hosts')))>0`
+  still passes). `gpio extract arcgis --where` remains unvalidated by
+  design — it is sent as an HTTP query parameter to the Feature Service,
+  never interpolated into a local SQL statement.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -387,6 +387,12 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `o'brien/data.parquet`) was escaped twice and reported as not found by
   `check`, `inspect`, `add bbox` and `convert`; paths are now escaped exactly
   once.
+- **`--where` on `gpio extract bigquery` and `gpio extract carto` is now
+  validated (parity with #612).** Both extractors route their `--where`
+  clause through the same `validate_where_clause` check used everywhere
+  else — including the dry-run/build path — before it is interpolated into
+  a query or a network request is made, closing a statement-separator gap
+  that the primary extract/partition/aggregate paths already closed.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -22,7 +22,11 @@ from geoparquet_io.core.common import (
     write_geoparquet_table,
 )
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
-from geoparquet_io.core.duckdb_utils import quote_identifier, validate_where_clause
+from geoparquet_io.core.duckdb_utils import (
+    quote_identifier,
+    validate_where_clause,
+    where_condition_fragment,
+)
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.logging_config import (
     configure_verbose,
@@ -159,8 +163,10 @@ def _build_carto_query(
     # Build WHERE clause
     conditions = []
     if where:
-        # Already validated upstream in carto_to_table() via validate_where_clause
-        conditions.append(f"({where})")
+        # Already validated upstream in carto_to_table() via validate_where_clause.
+        # where_condition_fragment() closes the paren on its own line so a trailing
+        # '--' in the clause cannot comment out the bbox condition or the LIMIT.
+        conditions.append(where_condition_fragment(where))
     if bbox and include_geom:
         minx, miny, maxx, maxy = bbox
         # Use ST_Intersects with ST_MakeEnvelope for spatial filter
@@ -175,6 +181,40 @@ def _build_carto_query(
 
     if limit is not None:
         sql += f" LIMIT {limit}"
+
+    return sql
+
+
+def _build_carto_count_query(
+    table_name: str,
+    where: str | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+) -> str:
+    """Build the COUNT(*) query for a Carto table with the same filters as the scan.
+
+    Note:
+        The where clause is validated upstream in ``carto_to_table()`` via
+        ``validate_where_clause`` before it reaches this function, and is wrapped
+        with :func:`where_condition_fragment` so a trailing ``--`` comment cannot
+        swallow the bbox condition that follows it.
+    """
+    _validate_table_name(table_name)
+    quoted_table = quote_identifier(table_name)
+
+    sql = f"SELECT COUNT(*) as count FROM {quoted_table}"
+
+    conditions = []
+    if where:
+        conditions.append(where_condition_fragment(where))
+    if bbox:
+        minx, miny, maxx, maxy = bbox
+        conditions.append(
+            f"ST_Intersects({quote_identifier('the_geom')}, "
+            f"ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
+        )
+
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
 
     return sql
 
@@ -200,25 +240,7 @@ def _get_row_count(
     Returns:
         Number of rows matching the filter
     """
-    # Validate and quote table name
-    _validate_table_name(table_name)
-    quoted_table = quote_identifier(table_name)
-
-    # Build count query with same filters
-    sql = f"SELECT COUNT(*) as count FROM {quoted_table}"
-
-    conditions = []
-    if where:
-        conditions.append(f"({where})")
-    if bbox:
-        minx, miny, maxx, maxy = bbox
-        conditions.append(
-            f"ST_Intersects({quote_identifier('the_geom')}, "
-            f"ST_MakeEnvelope({minx}, {miny}, {maxx}, {maxy}, 4326))"
-        )
-
-    if conditions:
-        sql += " WHERE " + " AND ".join(conditions)
+    sql = _build_carto_count_query(table_name, where=where, bbox=bbox)
 
     full_url = f"{url}?q={quote(sql)}"
     if api_key:

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -138,8 +138,8 @@ def _build_carto_query(
 
     Note:
         The table_name is quoted using PostgreSQL identifier quoting.
-        The where clause is user-provided and passed through - Carto's
-        server-side validation handles SQL injection for WHERE clauses.
+        The where clause is validated upstream in ``carto_to_table()`` via
+        ``validate_where_clause`` before it reaches this function.
     """
     # Validate and quote table name to prevent SQL injection
     _validate_table_name(table_name)
@@ -159,7 +159,7 @@ def _build_carto_query(
     # Build WHERE clause
     conditions = []
     if where:
-        # WHERE clause is user-provided - Carto validates on server side
+        # Already validated upstream in carto_to_table() via validate_where_clause
         conditions.append(f"({where})")
     if bbox and include_geom:
         minx, miny, maxx, maxy = bbox

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -22,7 +22,7 @@ from geoparquet_io.core.common import (
     write_geoparquet_table,
 )
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import quote_identifier, validate_where_clause
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.logging_config import (
     configure_verbose,
@@ -563,6 +563,13 @@ def carto_to_table(
         InvalidParameterError: If URL or table name is invalid
     """
     configure_verbose(verbose)
+
+    # Validate --where before it is interpolated into any query, and before any
+    # network probe/request is made (gpio #612 parity). This is the single
+    # choke point every carto_to_table caller (geometry and plain/tabular
+    # extraction alike) funnels through.
+    if where:
+        validate_where_clause(where)
 
     # Validate URL
     url = _validate_carto_url(url)

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -135,6 +135,15 @@ def quote_identifier(name: str) -> str:
 
 # SQL keywords that could be dangerous in a user-supplied WHERE clause.
 # These could modify data or database structure.
+#
+# REPLACE is deliberately absent: ``REPLACE(str, from, to)`` is a standard
+# scalar function in DuckDB, BigQuery Standard SQL and Carto/Postgres alike, so
+# blocking it rejects ordinary filters such as ``REPLACE(zip,'-','')='19104'``.
+# A function call cannot modify data; the statement gate below is what actually
+# stops DML. TRUNCATE is kept by the opposite half of the same argument: none of
+# those three backends spells its scalar truncation ``TRUNCATE`` (they all use
+# ``trunc``/``TRUNC``), so the word only ever shows up as the DDL statement, and
+# keeping it costs no legitimate clause.
 DANGEROUS_SQL_KEYWORDS = [
     "DROP",
     "DELETE",
@@ -146,90 +155,113 @@ DANGEROUS_SQL_KEYWORDS = [
     "EXEC",
     "EXECUTE",
     "MERGE",
-    "REPLACE",
     "GRANT",
     "REVOKE",
 ]
 
 
-def _has_unquoted_semicolon(where_clause: str) -> bool:
-    """True if ``where_clause`` contains a ``;`` outside a quoted string/identifier.
-
-    Quote state is tracked so legitimate data (``name = 'a;b'``) and identifiers
-    (``"weird;col"``) are not flagged. A doubled quote inside a literal toggles
-    the state twice, which leaves the tracking correct.
-    """
-    in_single = False
-    in_double = False
-    for ch in where_clause:
-        if ch == "'" and not in_double:
-            in_single = not in_single
-        elif ch == '"' and not in_single:
-            in_double = not in_double
-        elif ch == ";" and not in_single and not in_double:
-            return True
-    return False
-
-
-def where_sql_fragment(where_clause: str | None) -> str:
-    """Return a `` WHERE (...)`` fragment for ``where_clause`` (empty if None).
+def where_condition_fragment(where_clause: str) -> str:
+    """Return ``(<clause>\\n)`` -- the clause as one AND-able boolean condition.
 
     A newline is placed before the closing paren so a trailing ``--`` comment in
     the clause cannot swallow the paren -- or whatever the caller appends next
-    (``USING SAMPLE``, a JOIN, ...). Callers are responsible for validating the
-    clause with :func:`validate_where_clause` first.
+    (another AND-ed condition, ``LIMIT``, ``USING SAMPLE``, a JOIN, ...).
+    Callers are responsible for validating the clause with
+    :func:`validate_where_clause` first.
     """
+    return f"({where_clause}\n)"
+
+
+def where_sql_fragment(where_clause: str | None) -> str:
+    """Return a `` WHERE (...)`` fragment for ``where_clause`` (empty if None)."""
     if not where_clause:
         return ""
-    return f" WHERE ({where_clause}\n)"
+    return f" WHERE {where_condition_fragment(where_clause)}"
+
+
+def _dangerous_keywords_in(where_clause: str) -> list[str]:
+    """Return the blocklisted keywords that appear as real SQL words.
+
+    Keywords inside string literals (``name = 'Grant County'``), inside quoted
+    identifiers, or inside comments are *data*, not statements, and must not be
+    flagged. DuckDB's own lexer is used to find the word tokens, which handles
+    every literal form the SQL dialect has (``'...'``, ``E'...'``, ``$$...$$``)
+    plus ``--`` and ``/* */`` comments. If the lexer is unavailable, fall back to
+    a conservative whole-word regex over the raw clause.
+    """
+    try:
+        tokens = duckdb.tokenize(where_clause)
+        word_types = {duckdb.token_type.keyword, duckdb.token_type.identifier}
+        words = set()
+        for position, token_type in tokens:
+            if token_type not in word_types:
+                continue
+            match = re.match(r"\w+", where_clause[position:])
+            if match:
+                words.add(match.group(0).upper())
+        return [kw for kw in DANGEROUS_SQL_KEYWORDS if kw in words]
+    except Exception:  # pragma: no cover - lexer is part of the duckdb API
+        upper_clause = where_clause.upper()
+        return [kw for kw in DANGEROUS_SQL_KEYWORDS if re.search(rf"\b{kw}\b", upper_clause)]
 
 
 def validate_where_clause(where_clause: str) -> None:
     """
-    Validate WHERE clause for potentially dangerous SQL keywords.
+    Validate that a user-supplied WHERE clause is a single filter expression.
 
-    This is a basic safety check to prevent accidental or intentional
-    SQL injection attacks. It checks for keywords that could modify
-    data or database structure, and for statement separators: DuckDB's
-    ``execute()`` runs multi-statement strings, so a ``;`` in an interpolated
-    clause could append an entirely new statement (gpio #612).
+    Two checks run:
 
-    Note: This feature is intended for trusted users. For untrusted input,
-    additional validation or parameterized queries would be required.
+    1. A blocklist of keywords that could modify data or database structure,
+       matched against real SQL word tokens only (see
+       :func:`_dangerous_keywords_in`).
+    2. A parser-based statement gate. The clause is composed into the same
+       ``WHERE (<clause>\\n)`` shape the callers emit and handed to DuckDB's
+       parser; anything that parses as more than one statement is rejected.
+       DuckDB's ``execute()`` runs multi-statement strings, so a clause that
+       smuggles in a second statement could ``COPY`` data out or ``ATTACH`` a
+       database (gpio #612). Counting parsed statements -- rather than scanning
+       the text for ``;`` -- is what makes the gate hold: dollar quoting
+       (``$$'$$``), block comments, line comments and ``E'\\''`` escapes all hide
+       a ``;`` from a hand-rolled quote-state walker but not from the parser.
+
+    Note: this is a safety net for *trusted* input, not a security boundary. It
+    stops a clause from becoming extra statements; it cannot stop abuse that
+    stays inside one expression (e.g. reading a local file through a scalar
+    function). Untrusted input needs parameterized queries or a real allowlist.
 
     Args:
         where_clause: The WHERE clause string to validate
 
     Raises:
-        ValidationError: If dangerous SQL keywords or a statement separator are found
+        ValidationError: If dangerous SQL keywords are found, if the clause does
+            not parse, or if it composes into more than one statement.
     """
     from geoparquet_io.core.exceptions import ValidationError
 
-    # Match dangerous keywords as whole words (case-insensitive); word boundaries
-    # avoid false positives (e.g. "UPDATED_AT" must not match).
-    upper_clause = where_clause.upper()
-    found_keywords = []
-
-    for keyword in DANGEROUS_SQL_KEYWORDS:
-        pattern = rf"\b{keyword}\b"
-        if re.search(pattern, upper_clause):
-            found_keywords.append(keyword)
-
+    found_keywords = _dangerous_keywords_in(where_clause)
     if found_keywords:
         raise ValidationError(
             f"WHERE clause contains potentially dangerous SQL keywords: {', '.join(found_keywords)}. "
             "Only SELECT-style filtering expressions are allowed in --where. "
-            "If you need to perform data modifications, use DuckDB directly."
+            "Run data-modifying statements against the source system directly."
         )
 
-    # The keyword blocklist cannot see every harmful statement (COPY, ATTACH,
-    # PRAGMA, ...), so reject the separator itself: without a ';' the clause
-    # cannot start a second statement whatever it contains (gpio #612).
-    if _has_unquoted_semicolon(where_clause):
+    probe_query = f"SELECT 1 WHERE {where_condition_fragment(where_clause)}"
+    try:
+        statements = duckdb.extract_statements(probe_query)
+    except Exception as e:
         raise ValidationError(
-            "WHERE clause contains a ';' statement separator outside a quoted string. "
-            "Only a single filtering expression is allowed in --where. "
-            "If you need to run multiple statements, use DuckDB directly."
+            f"WHERE clause is not a single filtering expression: it could not be parsed "
+            f"as SQL. {e}. Note that --where is parsed with DuckDB's SQL dialect even "
+            "when the query runs on another backend."
+        ) from e
+
+    if len(statements) > 1:
+        raise ValidationError(
+            f"WHERE clause is not a single filtering expression: it resolves to "
+            f"{len(statements)} SQL statements, separated by a ';' (possibly hidden in a "
+            "comment or a quoted string). Run additional statements against the source "
+            "system directly."
         )
 
 

--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -18,6 +18,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
     validate_where_clause,
+    where_condition_fragment,
 )
 from geoparquet_io.core.extract import parse_bbox
 from geoparquet_io.core.file_utils import handle_output_overwrite
@@ -580,12 +581,11 @@ def _handle_dry_run(
 
     query = _build_dry_run_query(validated_table_id, select_cols, bbox, bbox_mode, bbox_threshold)
 
-    # Add DuckDB-side conditions
+    # Add DuckDB-side conditions. where_condition_fragment() closes the paren on
+    # its own line so a trailing '--' in the clause cannot comment out the LIMIT.
     if where:
-        if "WHERE" in query:
-            query += f" AND ({where})"
-        else:
-            query += f" WHERE ({where})"
+        keyword = " AND " if "WHERE" in query else " WHERE "
+        query += keyword + where_condition_fragment(where)
     if limit is not None:
         query += f" LIMIT {limit}"
 
@@ -1082,7 +1082,9 @@ def _build_bigquery_query(
     # Add WHERE clause
     conditions = local_conditions.copy()
     if where:
-        conditions.append(f"({where})")
+        # Validated upstream in extract_bigquery(); wrapped so a trailing '--'
+        # cannot comment out a following condition or the LIMIT.
+        conditions.append(where_condition_fragment(where))
     if conditions:
         query += " WHERE " + " AND ".join(conditions)
 

--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -14,7 +14,11 @@ import duckdb
 import pyarrow as pa
 
 from geoparquet_io.core.common import write_geoparquet_table
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    quote_identifier,
+    validate_where_clause,
+)
 from geoparquet_io.core.extract import parse_bbox
 from geoparquet_io.core.file_utils import handle_output_overwrite
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
@@ -829,6 +833,11 @@ def extract_bigquery(
             or project ID doesn't match GCP naming rules
     """
     configure_verbose(verbose)
+
+    # Validate --where before it is interpolated into any query (dry-run or
+    # real), and before any network connection is established (gpio #612 parity).
+    if where:
+        validate_where_clause(where)
 
     # Normalize table_id early - validates format and applies project override
     # This ensures validated_table_id is always project.dataset.table format

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -263,6 +263,51 @@ class TestEmptyGeoparquetTable:
         assert geo_meta["version"] == "1.0.0"
 
 
+class TestWhereClauseValidation:
+    """--where must be routed through validate_where_clause (gpio #612 parity).
+
+    A statement-separator injection must be rejected before any network call.
+    """
+
+    INJECTION_WHERE = "1=1); COPY (SELECT 1) TO 's3://attacker/x'; --"
+
+    def test_rejects_semicolon_injection_before_network(self, monkeypatch):
+        """A ';' statement separator in --where is rejected before any request."""
+        import geoparquet_io.core.carto as carto_module
+        from geoparquet_io.core.exceptions import ValidationError
+
+        def _fail_urlopen(*_args, **_kwargs):
+            raise AssertionError("network request attempted before where-clause validation")
+
+        monkeypatch.setattr(carto_module.urllib.request, "urlopen", _fail_urlopen)
+
+        with pytest.raises(ValidationError):
+            carto_to_table(
+                url="https://phl.carto.com/api/v2/sql",
+                table_name="opa_properties_public",
+                where=self.INJECTION_WHERE,
+            )
+
+    def test_allows_legitimate_where(self, monkeypatch):
+        """A legitimate --where does not raise and reaches the fetch stage."""
+        import pyarrow as pa
+
+        import geoparquet_io.core.carto as carto_module
+
+        dummy_table = pa.table({"x": [1]})
+        monkeypatch.setattr(
+            carto_module, "_carto_plain_table", lambda *_args, **_kwargs: dummy_table
+        )
+
+        result = carto_to_table(
+            url="https://phl.carto.com/api/v2/sql",
+            table_name="opa_properties_public",
+            where="population > 1000",
+            geometry=False,
+        )
+        assert result is dummy_table
+
+
 @pytest.mark.network
 class TestCartoToTable:
     """Integration tests for Carto extraction (requires network)."""

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 from geoparquet_io.cli.main import cli
 from geoparquet_io.core.carto import (
     CartoError,
+    _build_carto_count_query,
     _build_carto_query,
     _create_empty_geoparquet_table,
     _detect_geometry_column,
@@ -130,7 +131,8 @@ class TestBuildCartoQuery:
     def test_with_where(self):
         """Query with WHERE clause."""
         sql = _build_carto_query("my_table", where="status = 'active'")
-        assert "WHERE (status = 'active')" in sql
+        # The closing paren sits on its own line so a trailing '--' cannot eat it.
+        assert "WHERE (status = 'active'\n)" in sql
 
     def test_with_bbox(self):
         """Query with bounding box filter."""
@@ -157,7 +159,7 @@ class TestBuildCartoQuery:
             bbox=(-75.2, 39.9, -75.1, 40.0),
             limit=100,
         )
-        assert "WHERE (status = 'active') AND ST_Intersects" in sql
+        assert "WHERE (status = 'active'\n) AND ST_Intersects" in sql
         assert "LIMIT 100" in sql
 
     def test_no_geom_does_not_force_the_geom(self):
@@ -185,7 +187,7 @@ class TestBuildCartoQuery:
             limit=50,
             include_geom=False,
         )
-        assert "WHERE (pop > 1000)" in sql
+        assert "WHERE (pop > 1000\n)" in sql
         assert "LIMIT 50" in sql
 
 
@@ -281,14 +283,24 @@ class TestWhereClauseValidation:
 
         monkeypatch.setattr(carto_module.urllib.request, "urlopen", _fail_urlopen)
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="not a single filtering expression"):
             carto_to_table(
                 url="https://phl.carto.com/api/v2/sql",
                 table_name="opa_properties_public",
                 where=self.INJECTION_WHERE,
             )
 
-    def test_allows_legitimate_where(self, monkeypatch):
+    # Blocklisted keywords (GRANT, DROP, DELETE) appear inside quoted literals
+    # here, so a validator that uppercases the whole clause rejects them.
+    @pytest.mark.parametrize(
+        "clause",
+        [
+            "name = 'Grant County'",
+            "descr ILIKE '%drop off%'",
+            "REPLACE(zip, '-', '') = '19104'",
+        ],
+    )
+    def test_allows_legitimate_where(self, monkeypatch, clause):
         """A legitimate --where does not raise and reaches the fetch stage."""
         import pyarrow as pa
 
@@ -302,10 +314,36 @@ class TestWhereClauseValidation:
         result = carto_to_table(
             url="https://phl.carto.com/api/v2/sql",
             table_name="opa_properties_public",
-            where="population > 1000",
+            where=clause,
             geometry=False,
         )
         assert result is dummy_table
+
+
+def _strip_line_comments(sql: str) -> str:
+    """Drop everything a ``--`` comment would swallow, line by line."""
+    return "\n".join(line.split("--")[0] for line in sql.splitlines())
+
+
+class TestWhereClauseCannotSwallowLaterClauses:
+    """A trailing ``--`` in --where must not comment out the rest of the query."""
+
+    TRAILING_COMMENT_WHERE = "1=1) --"
+
+    def test_build_carto_query_keeps_bbox_and_limit(self):
+        sql = _build_carto_query(
+            "t",
+            where=self.TRAILING_COMMENT_WHERE,
+            bbox=(0, 0, 1, 1),
+            limit=10,
+        )
+        live_sql = _strip_line_comments(sql)
+        assert "ST_Intersects" in live_sql
+        assert "LIMIT 10" in live_sql
+
+    def test_build_carto_count_query_keeps_bbox(self):
+        sql = _build_carto_count_query("t", where=self.TRAILING_COMMENT_WHERE, bbox=(0, 0, 1, 1))
+        assert "ST_Intersects" in _strip_line_comments(sql)
 
 
 @pytest.mark.network

--- a/tests/test_duckdb_utils.py
+++ b/tests/test_duckdb_utils.py
@@ -18,8 +18,11 @@ from geoparquet_io.core.duckdb_utils import (
     quote_identifier,
     s3_config_scope,
     spatial_join_strategy,
+    validate_where_clause,
+    where_condition_fragment,
+    where_sql_fragment,
 )
-from geoparquet_io.core.exceptions import ExtensionUnavailableError
+from geoparquet_io.core.exceptions import ExtensionUnavailableError, ValidationError
 
 
 class TestEscapeSqlString:
@@ -411,3 +414,97 @@ class TestAmbientS3Config:
             result = con.execute("SELECT current_setting('s3_region')").fetchone()
             assert result[0] == "eu-west-1"
             con.close()
+
+
+# Payloads that defeat a hand-rolled quote-state walker: each hides the ';'
+# statement separator behind lexical syntax the walker does not model
+# (dollar quoting, block comment, line comment, E-string escape). Every one of
+# them parses as three statements, the second of which writes a file via COPY.
+BYPASS_PAYLOADS = {
+    "dollar_quote": "1=1 OR $$'$$='a'); COPY (SELECT 42 AS p) TO '/tmp/pwn.csv'; SELECT 1 WHERE (1=1",
+    "block_comment": "1=1 /* ' */); COPY (SELECT 42 AS p) TO '/tmp/pwn.csv'; SELECT 1 WHERE (1=1",
+    "line_comment": "1=1 -- '\n); COPY (SELECT 42 AS p) TO '/tmp/pwn.csv'; SELECT 1 WHERE (1=1",
+    "e_string": "1=1 OR 'x'=E'\\''); COPY (SELECT 42 AS p) TO '/tmp/pwn.csv'; SELECT 1 WHERE (1=1",
+}
+
+# Legitimate filters that each embed a blocklisted keyword inside a quoted
+# string literal (or use REPLACE(), a standard scalar function).
+LEGITIMATE_CLAUSES = [
+    "name = 'Grant County'",
+    "street LIKE '%Alter Markt%'",
+    "descr ILIKE '%drop off%'",
+    "status = 'DELETE'",
+    "name = 'Merge Lane'",
+    "REPLACE(zip, '-', '') = '19104'",
+]
+
+
+class TestValidateWhereClauseStatementGate:
+    """The statement gate must be parser-based, not a quote-state walker."""
+
+    @pytest.mark.parametrize("payload", BYPASS_PAYLOADS.values(), ids=list(BYPASS_PAYLOADS))
+    def test_bypass_payload_rejected(self, payload):
+        """Each payload smuggles a ';' past naive quote tracking and must be rejected."""
+        with pytest.raises(ValidationError):
+            validate_where_clause(payload)
+
+    @pytest.mark.parametrize("payload", BYPASS_PAYLOADS.values(), ids=list(BYPASS_PAYLOADS))
+    def test_bypass_payload_really_is_multi_statement(self, payload):
+        """Guard the premise: these payloads genuinely compose 3 SQL statements."""
+        probe = f"SELECT 1 WHERE {where_condition_fragment(payload)}"
+        assert len(duckdb.extract_statements(probe)) == 3
+
+    def test_plain_semicolon_rejected(self):
+        with pytest.raises(ValidationError):
+            validate_where_clause("1=1;")
+
+    def test_copy_injection_rejected(self):
+        with pytest.raises(ValidationError, match=";"):
+            validate_where_clause("1=1); COPY (SELECT 42 AS x) TO '/tmp/pwned.csv'; SELECT (1=1")
+
+    def test_unparseable_clause_rejected_cleanly(self):
+        """A clause that cannot be parsed raises ValidationError, not a duckdb error."""
+        with pytest.raises(ValidationError, match="single filtering expression"):
+            validate_where_clause("1=1 AND (((")
+
+    def test_semicolon_inside_literal_still_allowed(self):
+        validate_where_clause("name = 'a;b'")
+        validate_where_clause("note = 'it''s; fine'")
+        validate_where_clause('"weird;col" = 5')
+
+
+class TestValidateWhereClauseQuotedLiterals:
+    """Blocklisted keywords inside string literals must not trigger a rejection."""
+
+    @pytest.mark.parametrize("clause", LEGITIMATE_CLAUSES)
+    def test_legitimate_clause_accepted(self, clause):
+        validate_where_clause(clause)
+
+    def test_keyword_outside_literal_still_blocked(self):
+        with pytest.raises(ValidationError, match="DELETE"):
+            validate_where_clause("DELETE FROM users WHERE 1=1")
+
+    def test_keyword_in_comment_not_flagged(self):
+        """A comment is inert; it must not trip the keyword scan."""
+        validate_where_clause("pop > 10 /* drop this later */")
+
+
+class TestWhereConditionFragment:
+    """The condition fragment must survive a trailing line comment."""
+
+    def test_trailing_comment_cannot_swallow_closing_paren(self):
+        fragment = where_condition_fragment("1=1 --")
+        # Everything after the clause's own line is still live SQL.
+        assert fragment.splitlines()[-1].strip() == ")"
+
+    def test_appended_condition_survives_trailing_comment(self):
+        sql = f"SELECT 1 WHERE {where_condition_fragment('1=1 --')} AND 2=2"
+        rows = duckdb.sql(sql).fetchall()
+        assert rows == [(1,)]
+        # And a falsifying appended condition is genuinely applied.
+        sql_false = f"SELECT 1 WHERE {where_condition_fragment('1=1 --')} AND 1=2"
+        assert duckdb.sql(sql_false).fetchall() == []
+
+    def test_where_sql_fragment_uses_condition_fragment(self):
+        assert where_sql_fragment("a = 1") == f" WHERE {where_condition_fragment('a = 1')}"
+        assert where_sql_fragment(None) == ""

--- a/tests/test_extract_bigquery.py
+++ b/tests/test_extract_bigquery.py
@@ -487,21 +487,31 @@ class TestWhereClauseValidation:
         from geoparquet_io.core.exceptions import ValidationError
         from geoparquet_io.core.extract_bigquery import extract_bigquery
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="not a single filtering expression"):
             extract_bigquery(
                 table_id="project.dataset.table",
                 dry_run=True,
                 where=self.INJECTION_WHERE,
             )
 
-    def test_dry_run_allows_legitimate_where(self):
+    # Blocklisted keywords (GRANT, DROP, DELETE) appear inside quoted literals
+    # here, so a validator that uppercases the whole clause rejects them.
+    @pytest.mark.parametrize(
+        "clause",
+        [
+            "name = 'Grant County'",
+            "descr ILIKE '%drop off%'",
+            "REPLACE(zip, '-', '') = '19104'",
+        ],
+    )
+    def test_dry_run_allows_legitimate_where(self, clause):
         """A legitimate --where does not raise on the dry-run path."""
         from geoparquet_io.core.extract_bigquery import extract_bigquery
 
         result = extract_bigquery(
             table_id="project.dataset.table",
             dry_run=True,
-            where="population > 1000",
+            where=clause,
         )
         assert result is None
 
@@ -515,7 +525,7 @@ class TestWhereClauseValidation:
             "network connection attempted before where-clause validation"
         )
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="not a single filtering expression"):
             extract_bigquery(
                 table_id="project.dataset.table",
                 dry_run=False,
@@ -523,6 +533,54 @@ class TestWhereClauseValidation:
             )
 
         mock_setup.assert_not_called()
+
+
+def _strip_line_comments(sql: str) -> str:
+    """Drop everything a ``--`` comment would swallow, line by line."""
+    return "\n".join(line.split("--")[0] for line in sql.splitlines())
+
+
+class TestWhereClauseCannotSwallowLaterClauses:
+    """A trailing ``--`` in --where must not comment out the rest of the query."""
+
+    TRAILING_COMMENT_WHERE = "1=1) --"
+
+    def test_build_bigquery_query_keeps_limit(self):
+        from geoparquet_io.core.extract_bigquery import _build_bigquery_query
+
+        sql = _build_bigquery_query(
+            con=None,
+            validated_table_id="project.dataset.table",
+            select_cols="*",
+            bbox=None,
+            bbox_mode="auto",
+            bbox_threshold=1000,
+            geom_col=None,
+            where=self.TRAILING_COMMENT_WHERE,
+            limit=10,
+        )
+        assert "LIMIT 10" in _strip_line_comments(sql)
+
+    def test_dry_run_sql_keeps_bbox_and_limit(self, monkeypatch):
+        import geoparquet_io.core.extract_bigquery as bq_module
+
+        printed: list[str] = []
+        monkeypatch.setattr(bq_module, "progress", printed.append)
+
+        bq_module._handle_dry_run(
+            validated_table_id="project.dataset.table",
+            include_list=None,
+            bbox="0,0,1,1",
+            bbox_mode="local",
+            bbox_threshold=1000,
+            where=self.TRAILING_COMMENT_WHERE,
+            limit=10,
+        )
+
+        sql = next(line for line in printed if line.startswith("SQL: "))
+        live_sql = _strip_line_comments(sql)
+        assert "ST_Intersects" in live_sql
+        assert "LIMIT 10" in live_sql
 
 
 class TestPythonAPI:

--- a/tests/test_extract_bigquery.py
+++ b/tests/test_extract_bigquery.py
@@ -473,6 +473,58 @@ class TestDryRun:
         assert result is None
 
 
+class TestWhereClauseValidation:
+    """--where must be routed through validate_where_clause (gpio #612 parity).
+
+    A statement-separator injection must be rejected before any network call,
+    on both the dry-run path and the real (non-dry-run) path.
+    """
+
+    INJECTION_WHERE = "1=1); COPY (SELECT 1) TO 's3://attacker/x'; --"
+
+    def test_dry_run_rejects_semicolon_injection(self):
+        """Dry-run must reject a ';' statement separator before printing SQL."""
+        from geoparquet_io.core.exceptions import ValidationError
+        from geoparquet_io.core.extract_bigquery import extract_bigquery
+
+        with pytest.raises(ValidationError):
+            extract_bigquery(
+                table_id="project.dataset.table",
+                dry_run=True,
+                where=self.INJECTION_WHERE,
+            )
+
+    def test_dry_run_allows_legitimate_where(self):
+        """A legitimate --where does not raise on the dry-run path."""
+        from geoparquet_io.core.extract_bigquery import extract_bigquery
+
+        result = extract_bigquery(
+            table_id="project.dataset.table",
+            dry_run=True,
+            where="population > 1000",
+        )
+        assert result is None
+
+    @patch("geoparquet_io.core.extract_bigquery._setup_bigquery_connection")
+    def test_real_path_rejects_injection_before_network(self, mock_setup):
+        """Non-dry-run path must validate before establishing a BigQuery connection."""
+        from geoparquet_io.core.exceptions import ValidationError
+        from geoparquet_io.core.extract_bigquery import extract_bigquery
+
+        mock_setup.side_effect = AssertionError(
+            "network connection attempted before where-clause validation"
+        )
+
+        with pytest.raises(ValidationError):
+            extract_bigquery(
+                table_id="project.dataset.table",
+                dry_run=False,
+                where=self.INJECTION_WHERE,
+            )
+
+        mock_setup.assert_not_called()
+
+
 class TestPythonAPI:
     """Test the Python API for BigQuery."""
 


### PR DESCRIPTION
## Summary

- Routes `--where` on `gpio extract bigquery` and `gpio extract carto` through the same `validate_where_clause` guard already used on the primary extract/partition/aggregate paths, closing the SQL-injection parity gap left open by #612 for these two service extractors.
- `extract_bigquery()` now validates `where` up front — before the dry-run/build path and before any BigQuery connection is opened — so both `--dry-run` and the real execution path are covered.
- `carto_to_table()` (the single choke point both `convert_carto_to_geoparquet` and the Python API's `ops.from_carto` funnel through, for both geometry and plain/tabular extraction) now validates `where` before `_validate_carto_url` / any network probe or request.
- Neither module forks or weakens the validator — both call the existing `validate_where_clause`, matching the `if where: validate_where_clause(where)` pattern already used in `extract.py`.
- Corrected two stale docstring/inline comments in `carto.py` that claimed Carto validates WHERE server-side; they now note validation happens upstream in `carto_to_table()`.

## Test plan

- [x] New `TestWhereClauseValidation` class in `tests/test_extract_bigquery.py`: dry-run rejects a statement-separator injection, dry-run allows a legitimate `--where`, and the real (non-dry-run) path rejects the injection before any BigQuery connection is established (verified via a mocked `_setup_bigquery_connection` that raises if called).
- [x] New `TestWhereClauseValidation` class in `tests/test_carto.py`: rejects the injection before any network request (verified via a mocked `urllib.request.urlopen` that raises if called), and confirms a legitimate `--where` reaches the fetch stage.
- [x] Full fast suite: `uv run pytest -n 4 -m "not slow and not network"` — 3544 passed, 40 skipped, 76.55% coverage.
- [x] `uv run pre-commit run --files ...` on all changed files — all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added early validation for `--where` clauses in BigQuery and Carto extraction.
  * Improved detection of unsafe SQL, including hidden multi-statement attempts and blocked keywords outside quoted values.
  * Prevented trailing SQL comments from bypassing bounding-box and row-limit filters.
  * Validation now applies consistently during dry runs and regular execution.
  * Legitimate expressions, including quoted keywords and `REPLACE`, continue to be accepted.
  * Improved handling of GeoParquet metadata and SQL identifiers.

* **New Features**
  * Added memory-limit support for BigQuery extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->