### PR TITLE
fix(sql): quote geometry-column identifiers at raw SQL interpolation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,26 @@ repos:
             # an alias or a direct symbol import would slip straight past it.
             if grep -rnE '^[[:space:]]*(import duckdb as |from duckdb import)' geoparquet_io/ --include="*.py" | awk -F: '$1 != "geoparquet_io/core/duckdb_utils.py"' | grep .; then
               echo "ERROR: Import duckdb as 'import duckdb' only - an alias or 'from duckdb import connect' evades the bare-connect check above."
+            # Hand-rolled identifier quoting. f'"{col}"' and col.replace('"', '""')
+            # tolerate a space but silently break on an embedded double quote, and a
+            # column name can come straight from a file's geo.primary_column or from
+            # --column/--bbox-name, so this is an injection vector, not a nit. This
+            # exact fix has been made by hand at least eight times (c3c1d43, f6bc56e,
+            # 009a2b7, 9f391a2, 0f850ad, 40f151b, 35a1f3f, 3f24514) without a guard.
+            # Use quote_identifier() for identifiers and _escape_sql_string() for SQL
+            # string literals; both live in core/duckdb_utils.py, which implements
+            # them and is therefore exempt. Justify a rare, deliberate exception with
+            # a trailing "# allow-manual-quote" comment.
+            if grep -rnE 'f'"'"'"\{|f"\\"\{|\.replace\('"'"'"'"'"', '"'"'""'"'"'\)' geoparquet_io/ --include="*.py" \
+                | grep -v '^geoparquet_io/core/duckdb_utils.py:' \
+                | grep -v 'allow-manual-quote' \
+                | awk -F: '$3 !~ /^[[:space:]]*#/' | grep .; then
+              echo "ERROR: Do not hand-roll SQL identifier quoting."
+              echo "       Use quote_identifier(name) from core/duckdb_utils.py for identifiers"
+              echo "       and _escape_sql_string(value) for SQL string literals."
+              echo "       f'\"{col}\"' does not double an embedded '\"' and breaks on a"
+              echo "       hostile geo.primary_column / --column value."
+              echo "       Justify a rare exception with a trailing '# allow-manual-quote'."
               errors=1
             fi
             exit $errors

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,8 @@ repos:
             # an alias or a direct symbol import would slip straight past it.
             if grep -rnE '^[[:space:]]*(import duckdb as |from duckdb import)' geoparquet_io/ --include="*.py" | awk -F: '$1 != "geoparquet_io/core/duckdb_utils.py"' | grep .; then
               echo "ERROR: Import duckdb as 'import duckdb' only - an alias or 'from duckdb import connect' evades the bare-connect check above."
+              errors=1
+            fi
             # Hand-rolled identifier quoting. f'"{col}"' and col.replace('"', '""')
             # tolerate a space but silently break on an embedded double quote, and a
             # column name can come straight from a file's geo.primary_column or from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,24 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   warns instead of silently dropping all `geo`/KV metadata when the input
   footer cannot be read for preservation, for any failure mode (a corrupt
   footer can surface as `OSError`, `GeoParquetError`, or an Arrow exception).
+- **Geometry-column identifiers are now quoted at every raw SQL interpolation
+  (todo #008).** Files whose primary geometry column name has a space,
+  uppercase letter, reserved word, or embedded quote — a name read verbatim
+  from the file's own `geo.primary_column` metadata — previously crashed
+  several commands with a DuckDB `ParserException`, since the column name was
+  interpolated unquoted into a generated SQL identifier. Fixed in `stream_io`'s
+  WKB-conversion wrapper, `add bbox`'s `STRUCT_PACK` expression (both the CLI
+  path and the shared `add_bbox` helper used by `admin-divisions`/
+  `country-codes`), and `check spatial`'s sampling-method queries — all now
+  use the existing `quote_identifier` helper. Separately, the native
+  Parquet-geo-stats getters in `duckdb_metadata` (and sibling `bbox`/
+  `compression` lookups) compared the column name as a SQL **string literal**
+  (`WHERE path_in_schema = '...'`) rather than an identifier; a space there
+  was always harmless, but an embedded `'` broke the literal and was silently
+  swallowed by a broad `except Exception`, returning `None`/empty stats
+  instead of raising or the correct value. Fixed with `_escape_sql_string`.
+  Since a hostile filename can carry such a name via `geo.primary_column`,
+  this was also a latent SQL-injection vector, not just a crash bug.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   Fixed with `_escape_sql_string`. Since a hostile filename can carry such a
   name via `geo.primary_column`, this was also a latent SQL-injection vector,
   not just a crash bug.
+- **Commands no longer break on unusual column names or paths with an
+  apostrophe.** A geometry column named `geom col`, `Geometry` or `geo"m` — a
+  name read verbatim from the file's own `geo.primary_column` — used to crash
+  `add bbox/h3/s2/a5/quadkey/geometry-metrics/kdtree`, `inspect stats`,
+  `sort hilbert`, `sort column`, `extract geoparquet` and `convert
+  geojson/csv` with a DuckDB parser error, and made `check spec` report a
+  valid file as failing. Column names are now quoted wherever they are
+  interpolated into SQL, so a crafted file can no longer inject SQL through
+  its own metadata, and `--column`/`--bbox-name` accept any name the format
+  allows. Separately, a file under a directory containing `'` (e.g.
+  `o'brien/data.parquet`) was escaped twice and reported as not found by
+  `check`, `inspect`, `add bbox` and `convert`; paths are now escaped exactly
+  once.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,18 +357,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   from the file's own `geo.primary_column` metadata — previously crashed
   several commands with a DuckDB `ParserException`, since the column name was
   interpolated unquoted into a generated SQL identifier. Fixed in `stream_io`'s
-  WKB-conversion wrapper, `add bbox`'s `STRUCT_PACK` expression (both the CLI
-  path and the shared `add_bbox` helper used by `admin-divisions`/
-  `country-codes`), and `check spatial`'s sampling-method queries — all now
-  use the existing `quote_identifier` helper. Separately, the native
-  Parquet-geo-stats getters in `duckdb_metadata` (and sibling `bbox`/
-  `compression` lookups) compared the column name as a SQL **string literal**
-  (`WHERE path_in_schema = '...'`) rather than an identifier; a space there
-  was always harmless, but an embedded `'` broke the literal and was silently
-  swallowed by a broad `except Exception`, returning `None`/empty stats
-  instead of raising or the correct value. Fixed with `_escape_sql_string`.
-  Since a hostile filename can carry such a name via `geo.primary_column`,
-  this was also a latent SQL-injection vector, not just a crash bug.
+  WKB-conversion wrapper and across every `add bbox` code path — the CLI's
+  file-based `STRUCT_PACK` expression, its stdin/stdout streaming query
+  builder, the `Table.add_bbox()` / `add_bbox_table()` Python-API path, and
+  the shared `add_bbox` helper used by `admin-divisions`/`country-codes` —
+  plus `check spatial`'s sampling-method queries. All now use the existing
+  `quote_identifier` helper, which also closes a second, narrower gap: two of
+  the `add bbox` builders were already hand-quoting with `"{col}"` and so
+  tolerated spaces, but didn't double an embedded `"`, which still broke
+  them. Separately, the native Parquet-geo-stats getters in `duckdb_metadata`
+  (and sibling `bbox`/`compression` lookups) compared the column name as a
+  SQL **string literal** (`WHERE path_in_schema = '...'`) rather than an
+  identifier; a space there was always harmless, but an embedded `'` broke
+  the literal and was silently swallowed by a broad `except Exception`,
+  returning `None`/empty stats instead of raising or the correct value.
+  Fixed with `_escape_sql_string`. Since a hostile filename can carry such a
+  name via `geo.primary_column`, this was also a latent SQL-injection vector,
+  not just a crash bug.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,15 @@ from pathlib import Path  # Prefer over os.path
 | `.fetch_arrow_table()` | `.arrow().read_all()` |
 | `.to_arrow_table()` | `.arrow().read_all()` |
 | `TRY_CAST(x AS GEOMETRY)` | `TRY(ST_GeomFromText(x))` |
+| `f'"{col}"'` / `col.replace('"', '""')` | `quote_identifier(col)` |
+| `WHERE path = '{value}'` | `_escape_sql_string(value)` |
+
+Never hand-roll SQL escaping. `quote_identifier()` is for **identifiers**
+(column/table names — doubles embedded `"`); `_escape_sql_string()` is for SQL
+**string literals** (doubles embedded `'`). Both live in `core/duckdb_utils.py`
+and take a RAW value — escaping is not idempotent, so escape exactly once.
+Column names arrive from a file's own `geo.primary_column` and from
+`--column`/`--bbox-name`, so this is an injection surface, not a style nit.
 
 Additional patterns (not yet enforced):
 - `ST_Transform(..., always_xy := true)` → `SET geometry_always_xy = true` at session level

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -351,6 +351,24 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   warns instead of silently dropping all `geo`/KV metadata when the input
   footer cannot be read for preservation, for any failure mode (a corrupt
   footer can surface as `OSError`, `GeoParquetError`, or an Arrow exception).
+- **Geometry-column identifiers are now quoted at every raw SQL interpolation
+  (todo #008).** Files whose primary geometry column name has a space,
+  uppercase letter, reserved word, or embedded quote — a name read verbatim
+  from the file's own `geo.primary_column` metadata — previously crashed
+  several commands with a DuckDB `ParserException`, since the column name was
+  interpolated unquoted into a generated SQL identifier. Fixed in `stream_io`'s
+  WKB-conversion wrapper, `add bbox`'s `STRUCT_PACK` expression (both the CLI
+  path and the shared `add_bbox` helper used by `admin-divisions`/
+  `country-codes`), and `check spatial`'s sampling-method queries — all now
+  use the existing `quote_identifier` helper. Separately, the native
+  Parquet-geo-stats getters in `duckdb_metadata` (and sibling `bbox`/
+  `compression` lookups) compared the column name as a SQL **string literal**
+  (`WHERE path_in_schema = '...'`) rather than an identifier; a space there
+  was always harmless, but an embedded `'` broke the literal and was silently
+  swallowed by a broad `except Exception`, returning `None`/empty stats
+  instead of raising or the correct value. Fixed with `_escape_sql_string`.
+  Since a hostile filename can carry such a name via `geo.primary_column`,
+  this was also a latent SQL-injection vector, not just a crash bug.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -374,6 +374,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   Fixed with `_escape_sql_string`. Since a hostile filename can carry such a
   name via `geo.primary_column`, this was also a latent SQL-injection vector,
   not just a crash bug.
+- **Commands no longer break on unusual column names or paths with an
+  apostrophe.** A geometry column named `geom col`, `Geometry` or `geo"m` — a
+  name read verbatim from the file's own `geo.primary_column` — used to crash
+  `add bbox/h3/s2/a5/quadkey/geometry-metrics/kdtree`, `inspect stats`,
+  `sort hilbert`, `sort column`, `extract geoparquet` and `convert
+  geojson/csv` with a DuckDB parser error, and made `check spec` report a
+  valid file as failing. Column names are now quoted wherever they are
+  interpolated into SQL, so a crafted file can no longer inject SQL through
+  its own metadata, and `--column`/`--bbox-name` accept any name the format
+  allows. Separately, a file under a directory containing `'` (e.g.
+  `o'brien/data.parquet`) was escaped twice and reported as not found by
+  `check`, `inspect`, `add bbox` and `convert`; paths are now escaped exactly
+  once.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -357,18 +357,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   from the file's own `geo.primary_column` metadata — previously crashed
   several commands with a DuckDB `ParserException`, since the column name was
   interpolated unquoted into a generated SQL identifier. Fixed in `stream_io`'s
-  WKB-conversion wrapper, `add bbox`'s `STRUCT_PACK` expression (both the CLI
-  path and the shared `add_bbox` helper used by `admin-divisions`/
-  `country-codes`), and `check spatial`'s sampling-method queries — all now
-  use the existing `quote_identifier` helper. Separately, the native
-  Parquet-geo-stats getters in `duckdb_metadata` (and sibling `bbox`/
-  `compression` lookups) compared the column name as a SQL **string literal**
-  (`WHERE path_in_schema = '...'`) rather than an identifier; a space there
-  was always harmless, but an embedded `'` broke the literal and was silently
-  swallowed by a broad `except Exception`, returning `None`/empty stats
-  instead of raising or the correct value. Fixed with `_escape_sql_string`.
-  Since a hostile filename can carry such a name via `geo.primary_column`,
-  this was also a latent SQL-injection vector, not just a crash bug.
+  WKB-conversion wrapper and across every `add bbox` code path — the CLI's
+  file-based `STRUCT_PACK` expression, its stdin/stdout streaming query
+  builder, the `Table.add_bbox()` / `add_bbox_table()` Python-API path, and
+  the shared `add_bbox` helper used by `admin-divisions`/`country-codes` —
+  plus `check spatial`'s sampling-method queries. All now use the existing
+  `quote_identifier` helper, which also closes a second, narrower gap: two of
+  the `add bbox` builders were already hand-quoting with `"{col}"` and so
+  tolerated spaces, but didn't double an embedded `"`, which still broke
+  them. Separately, the native Parquet-geo-stats getters in `duckdb_metadata`
+  (and sibling `bbox`/`compression` lookups) compared the column name as a
+  SQL **string literal** (`WHERE path_in_schema = '...'`) rather than an
+  identifier; a space there was always harmless, but an embedded `'` broke
+  the literal and was silently swallowed by a broad `except Exception`,
+  returning `None`/empty stats instead of raising or the correct value.
+  Fixed with `_escape_sql_string`. Since a hostile filename can carry such a
+  name via `geo.primary_column`, this was also a latent SQL-injection vector,
+  not just a crash bug.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1386,18 +1386,18 @@ def get_row_group_geo_stats(parquet_file: str) -> list[dict]:
     safe_url = safe_file_url(parquet_file, verbose=False)
 
     # Try native geo stats first (GeoParquet 2.0 / parquet-geo-only)
-    rg_stats = get_per_row_group_native_geo_stats(safe_url)
+    rg_stats = get_per_row_group_native_geo_stats(parquet_file)
 
     # Fall back to bbox column if no native stats
     if not rg_stats:
-        has_bbox, bbox_col_name = has_bbox_column(safe_url)
+        has_bbox, bbox_col_name = has_bbox_column(parquet_file)
         if has_bbox and bbox_col_name:
-            rg_stats = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
+            rg_stats = get_per_row_group_bbox_stats(parquet_file, bbox_col_name)
 
     if not rg_stats:
         return []
 
-    file_meta = get_file_metadata(safe_url)
+    file_meta = get_file_metadata(parquet_file)
     num_rows_per_rg = _get_num_rows_per_row_group(safe_url, file_meta)
 
     return _merge_row_counts(rg_stats, num_rows_per_rg)

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -20,6 +20,7 @@ import pyarrow.parquet as pq
 from geoparquet_io.core.check_parquet_structure import CheckProfile
 from geoparquet_io.core.common import write_geoparquet_table
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
+from geoparquet_io.core.duckdb_utils import quote_identifier
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -144,12 +145,12 @@ def _calculate_bounds_from_table(
         # Use ST_Extent to get the bounding box of all geometries
         query = f"""
             SELECT
-                ST_XMin(ST_Extent_Agg(ST_GeomFromWKB("{geometry_column}"))),
-                ST_YMin(ST_Extent_Agg(ST_GeomFromWKB("{geometry_column}"))),
-                ST_XMax(ST_Extent_Agg(ST_GeomFromWKB("{geometry_column}"))),
-                ST_YMax(ST_Extent_Agg(ST_GeomFromWKB("{geometry_column}")))
+                ST_XMin(ST_Extent_Agg(ST_GeomFromWKB({quote_identifier(geometry_column)}))),
+                ST_YMin(ST_Extent_Agg(ST_GeomFromWKB({quote_identifier(geometry_column)}))),
+                ST_XMax(ST_Extent_Agg(ST_GeomFromWKB({quote_identifier(geometry_column)}))),
+                ST_YMax(ST_Extent_Agg(ST_GeomFromWKB({quote_identifier(geometry_column)})))
             FROM input_table
-            WHERE "{geometry_column}" IS NOT NULL
+            WHERE {quote_identifier(geometry_column)} IS NOT NULL
         """
         result = con.execute(query).fetchone()
 
@@ -2150,13 +2151,13 @@ class Table:
             if regular_cols:
                 select_parts = []
                 for col_name in regular_cols:
-                    escaped_col = col_name.replace('"', '""')
+                    quoted_col = quote_identifier(col_name)
                     select_parts.extend(
                         [
-                            f'COUNT(*) FILTER (WHERE "{escaped_col}" IS NULL)',
-                            f'MIN("{escaped_col}")',
-                            f'MAX("{escaped_col}")',
-                            f'APPROX_COUNT_DISTINCT("{escaped_col}")',
+                            f"COUNT(*) FILTER (WHERE {quoted_col} IS NULL)",
+                            f"MIN({quoted_col})",
+                            f"MAX({quoted_col})",
+                            f"APPROX_COUNT_DISTINCT({quoted_col})",
                         ]
                     )
 
@@ -2190,14 +2191,14 @@ class Table:
                         exc_info=True,
                     )
                     for col_name in regular_cols:
-                        escaped_col = col_name.replace('"', '""')
+                        quoted_col = quote_identifier(col_name)
                         try:
                             query = f"""
                                 SELECT
-                                    COUNT(*) FILTER (WHERE "{escaped_col}" IS NULL),
-                                    MIN("{escaped_col}"),
-                                    MAX("{escaped_col}"),
-                                    APPROX_COUNT_DISTINCT("{escaped_col}")
+                                    COUNT(*) FILTER (WHERE {quoted_col} IS NULL),
+                                    MIN({quoted_col}),
+                                    MAX({quoted_col}),
+                                    APPROX_COUNT_DISTINCT({quoted_col})
                                 FROM input_table
                             """
                             result = con.execute(query).fetchone()
@@ -2231,9 +2232,9 @@ class Table:
 
             # Handle geometry columns separately (only null count)
             for col_name in geometry_cols:
-                escaped_col = col_name.replace('"', '""')
+                quoted_col = quote_identifier(col_name)
                 query = f"""
-                    SELECT COUNT(*) FILTER (WHERE "{escaped_col}" IS NULL)
+                    SELECT COUNT(*) FILTER (WHERE {quoted_col} IS NULL)
                     FROM input_table
                 """
                 result = con.execute(query).fetchone()

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -19,8 +19,8 @@ import pyarrow.parquet as pq
 
 from geoparquet_io.core.check_parquet_structure import CheckProfile
 from geoparquet_io.core.common import write_geoparquet_table
-from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
 from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/geoparquet_io/core/add/a5.py
+++ b/geoparquet_io/core/add/a5.py
@@ -14,6 +14,7 @@ from geoparquet_io.core.crs_utils import (
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
+    quote_identifier,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite
@@ -81,8 +82,10 @@ def add_a5_table(
         if geom_is_blob and geom_col in table.column_names:
             # Create view with geometry conversion
             # Quote all column names for safety with special characters
-            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-            col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+            other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+            col_defs = other_cols + [
+                f"ST_GeomFromWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)}"
+            ]
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
             )
@@ -92,7 +95,7 @@ def add_a5_table(
             source_ref = "__input_table"
 
         # Build A5 column query (reproject to lon/lat when source is non-CRS84)
-        geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+        geom_ref = transform_geom_sql(quote_identifier(geom_col), source_crs)
         a5_expr = f"""a5_lonlat_to_cell(
             ST_X(ST_Centroid({geom_ref})),
             ST_Y(ST_Centroid({geom_ref})),
@@ -100,21 +103,21 @@ def add_a5_table(
         )"""
 
         # Get non-geometry columns
-        other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
+        other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
         select_cols = ", ".join(other_cols) if other_cols else ""
 
         # Build SELECT with geometry converted back to WKB
         if select_cols:
             query = f"""
                 SELECT {select_cols},
-                       ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       {a5_expr} AS "{a5_column_name}"
+                       ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                       {a5_expr} AS {quote_identifier(a5_column_name)}
                 FROM {source_ref}
             """
         else:
             query = f"""
-                SELECT ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       {a5_expr} AS "{a5_column_name}"
+                SELECT ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                       {a5_expr} AS {quote_identifier(a5_column_name)}
                 FROM {source_ref}
             """
         result = con.execute(query).arrow().read_all()
@@ -140,13 +143,13 @@ def _make_add_a5_query(
     ``source_crs`` reprojects a non-CRS84 input to lon/lat before centroid keying
     (#525); ``None`` (CRS84 / CRS-less) leaves the geometry untouched.
     """
-    geom_ref = transform_geom_sql(f'"{geometry_column}"', source_crs)
+    geom_ref = transform_geom_sql(quote_identifier(geometry_column), source_crs)
     a5_expr = f"""a5_lonlat_to_cell(
         ST_X(ST_Centroid({geom_ref})),
         ST_Y(ST_Centroid({geom_ref})),
         {resolution}
     )"""
-    return f'SELECT *, {a5_expr} AS "{a5_column_name}" FROM {source}'
+    return f"SELECT *, {a5_expr} AS {quote_identifier(a5_column_name)} FROM {source}"
 
 
 def add_a5_column(
@@ -232,7 +235,9 @@ def add_a5_column(
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
     # A5 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
-    geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs_string(input_parquet, verbose))
+    geom_ref = transform_geom_sql(
+        quote_identifier(geom_col), source_crs_string(input_parquet, verbose)
+    )
 
     # Define the A5 SQL expression
     sql_expression = f"""a5_lonlat_to_cell(

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -73,7 +73,7 @@ def _build_admin_subquery(
         if "[" in col or "(" in col:
             subquery_cols.append(f"{col} as _col_{i}")
         else:
-            subquery_cols.append(f'"{col}"')
+            subquery_cols.append(quote_identifier(col))
     subquery_cols_str = ", ".join(subquery_cols)
 
     geom_select = quote_identifier(admin_geom_col)
@@ -115,12 +115,12 @@ def _build_admin_select_clause(dataset, levels, partition_columns, prefix=None):
         elif "[" in col or "(" in col:
             expr = f"b._col_{i}"
         else:
-            expr = f'b."{col}"'
+            expr = f"b.{quote_identifier(col)}"
 
         if use_coalesce:
             expr = f"COALESCE({expr}, 'ZZ')"
 
-        admin_select_parts.append(f'{expr} as "{output_col_name}"')
+        admin_select_parts.append(f"{expr} as {quote_identifier(output_col_name)}")
 
     return ", ".join(admin_select_parts)
 
@@ -310,7 +310,9 @@ def _print_dry_run_header(
 def _get_result_stats(con, output_parquet, dataset, levels, verbose, prefix=None):
     """Get statistics about the results."""
     output_col_names = [dataset.get_output_column_name(level, prefix=prefix) for level in levels]
-    admin_cols_check = " OR ".join([f'"{col}" IS NOT NULL' for col in output_col_names])
+    admin_cols_check = " OR ".join(
+        [f"{quote_identifier(col)} IS NOT NULL" for col in output_col_names]
+    )
 
     stats_query = f"""
     SELECT
@@ -326,9 +328,9 @@ def _get_result_stats(con, output_parquet, dataset, levels, verbose, prefix=None
     unique_counts = []
     for level, output_col in zip(levels, output_col_names, strict=True):
         count_query = f"""
-        SELECT COUNT(DISTINCT "{output_col}") as unique_count
+        SELECT COUNT(DISTINCT {quote_identifier(output_col)}) as unique_count
         FROM '{output_parquet}'
-        WHERE "{output_col}" IS NOT NULL;
+        WHERE {quote_identifier(output_col)} IS NOT NULL;
         """
         result = con.execute(count_query).fetchone()
         unique_counts.append((level, result[0]))

--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -25,18 +25,6 @@ from geoparquet_io.core.streaming import (
 )
 
 
-def _build_bbox_sql(geometry_column: str, bbox_column_name: str = "bbox") -> str:
-    """Build SQL expression for bbox struct column."""
-    quoted_geom = quote_identifier(geometry_column)
-    quoted_bbox = quote_identifier(bbox_column_name)
-    return f"""STRUCT_PACK(
-        xmin := ST_XMin({quoted_geom}),
-        ymin := ST_YMin({quoted_geom}),
-        xmax := ST_XMax({quoted_geom}),
-        ymax := ST_YMax({quoted_geom})
-    ) AS {quoted_bbox} """
-
-
 def add_bbox_table(
     table: pa.Table,
     bbox_column_name: str = "bbox",

--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -27,12 +27,14 @@ from geoparquet_io.core.streaming import (
 
 def _build_bbox_sql(geometry_column: str, bbox_column_name: str = "bbox") -> str:
     """Build SQL expression for bbox struct column."""
+    quoted_geom = quote_identifier(geometry_column)
+    quoted_bbox = quote_identifier(bbox_column_name)
     return f"""STRUCT_PACK(
-        xmin := ST_XMin("{geometry_column}"),
-        ymin := ST_YMin("{geometry_column}"),
-        xmax := ST_XMax("{geometry_column}"),
-        ymax := ST_YMax("{geometry_column}")
-    ) AS "{bbox_column_name}" """
+        xmin := ST_XMin({quoted_geom}),
+        ymin := ST_YMin({quoted_geom}),
+        xmax := ST_XMax({quoted_geom}),
+        ymax := ST_YMax({quoted_geom})
+    ) AS {quoted_bbox} """
 
 
 def add_bbox_table(
@@ -73,11 +75,15 @@ def add_bbox_table(
         columns_info = con.execute("DESCRIBE __input_table").fetchall()
         geom_is_blob = any(col[0] == geom_col and "BLOB" in col[1].upper() for col in columns_info)
 
+        quoted_geom_col = quote_identifier(geom_col)
+        quoted_bbox_col = quote_identifier(bbox_column_name)
+
         if geom_is_blob and geom_col in table.column_names:
             # Create view with geometry conversion
-            # Quote column names to handle special characters (colons, spaces, etc.)
-            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-            col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+            # Quote column names to handle special characters (colons, spaces,
+            # embedded quotes, etc.)
+            other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+            col_defs = other_cols + [f"ST_GeomFromWKB({quoted_geom_col}) AS {quoted_geom_col}"]
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
             )
@@ -88,28 +94,28 @@ def add_bbox_table(
 
         # Build query to add bbox column
         bbox_expr = f"""STRUCT_PACK(
-            xmin := ST_XMin("{geom_col}"),
-            ymin := ST_YMin("{geom_col}"),
-            xmax := ST_XMax("{geom_col}"),
-            ymax := ST_YMax("{geom_col}")
+            xmin := ST_XMin({quoted_geom_col}),
+            ymin := ST_YMin({quoted_geom_col}),
+            xmax := ST_XMax({quoted_geom_col}),
+            ymax := ST_YMax({quoted_geom_col})
         )"""
 
         # Get non-geometry columns
-        other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
+        other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
         select_cols = ", ".join(other_cols) if other_cols else ""
 
         # Build SELECT with geometry converted back to WKB
         if select_cols:
             query = f"""
                 SELECT {select_cols},
-                       ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       {bbox_expr} AS "{bbox_column_name}"
+                       ST_AsWKB({quoted_geom_col}) AS {quoted_geom_col},
+                       {bbox_expr} AS {quoted_bbox_col}
                 FROM {source_ref}
             """
         else:
             query = f"""
-                SELECT ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       {bbox_expr} AS "{bbox_column_name}"
+                SELECT ST_AsWKB({quoted_geom_col}) AS {quoted_geom_col},
+                       {bbox_expr} AS {quoted_bbox_col}
                 FROM {source_ref}
             """
         result = con.execute(query).arrow().read_all()
@@ -130,17 +136,21 @@ def _make_add_bbox_query(
     replace_existing: bool = False,
 ) -> str:
     """Build query to add bbox column to a source."""
+    quoted_geom_col = quote_identifier(geometry_column)
+    quoted_bbox_col = quote_identifier(bbox_column_name)
     bbox_expr = f"""STRUCT_PACK(
-        xmin := ST_XMin("{geometry_column}"),
-        ymin := ST_YMin("{geometry_column}"),
-        xmax := ST_XMax("{geometry_column}"),
-        ymax := ST_YMax("{geometry_column}")
+        xmin := ST_XMin({quoted_geom_col}),
+        ymin := ST_YMin({quoted_geom_col}),
+        xmax := ST_XMax({quoted_geom_col}),
+        ymax := ST_YMax({quoted_geom_col})
     )"""
 
     if replace_existing:
-        return f'SELECT * EXCLUDE ("{bbox_column_name}"), {bbox_expr} AS "{bbox_column_name}" FROM {source}'
+        return (
+            f"SELECT * EXCLUDE ({quoted_bbox_col}), {bbox_expr} AS {quoted_bbox_col} FROM {source}"
+        )
     else:
-        return f'SELECT *, {bbox_expr} AS "{bbox_column_name}" FROM {source}'
+        return f"SELECT *, {bbox_expr} AS {quoted_bbox_col} FROM {source}"
 
 
 def add_bbox_column(

--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -9,7 +9,7 @@ from geoparquet_io.core.common import (
     check_bbox_structure,
     detect_geoparquet_file_type,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.file_utils import handle_output_overwrite
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
@@ -357,11 +357,12 @@ def _add_bbox_file_based(
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
     # Define the SQL expression (the only unique part)
+    quoted_geom_col = quote_identifier(geom_col)
     sql_expression = f"""STRUCT_PACK(
-        xmin := ST_XMin({geom_col}),
-        ymin := ST_YMin({geom_col}),
-        xmax := ST_XMax({geom_col}),
-        ymax := ST_YMax({geom_col})
+        xmin := ST_XMin({quoted_geom_col}),
+        ymin := ST_YMin({quoted_geom_col}),
+        xmax := ST_XMax({quoted_geom_col}),
+        ymax := ST_YMax({quoted_geom_col})
     )"""
 
     # Build covering metadata for the bbox column (GeoParquet 1.1+ spec)

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -195,8 +195,8 @@ def add_bbox_metadata(
         debug(json.dumps(geo_meta, indent=2))
 
     # Get original file properties
-    row_group_stats = get_row_group_stats(safe_url)
-    compression_info = get_compression_info(safe_url, primary_col)
+    row_group_stats = get_row_group_stats(parquet_file)
+    compression_info = get_compression_info(parquet_file, primary_col)
     row_group_size = int(row_group_stats["avg_rows_per_group"])
     compression = compression_info[primary_col]
 

--- a/geoparquet_io/core/add/country_codes.py
+++ b/geoparquet_io/core/add/country_codes.py
@@ -144,9 +144,9 @@ def _build_select_clause(country_code_col, subdivision_code_col, using_default):
     """Build the SELECT clause for country and subdivision codes."""
     # Country code selection
     if country_code_col == "admin:country_code":
-        country_select = f'b."{country_code_col}"'
+        country_select = f"b.{quote_identifier(country_code_col)}"
     else:
-        country_select = f'b."{country_code_col}" as "admin:country_code"'
+        country_select = f'b.{quote_identifier(country_code_col)} as "admin:country_code"'
 
     # Subdivision code selection
     if not subdivision_code_col:
@@ -158,9 +158,11 @@ def _build_select_clause(country_code_col, subdivision_code_col, using_default):
             'ELSE b.region END as "admin:subdivision_code"'
         )
     elif subdivision_code_col == "admin:subdivision_code":
-        subdivision_select = f', b."{subdivision_code_col}"'
+        subdivision_select = f", b.{quote_identifier(subdivision_code_col)}"
     else:
-        subdivision_select = f', b."{subdivision_code_col}" as "admin:subdivision_code"'
+        subdivision_select = (
+            f', b.{quote_identifier(subdivision_code_col)} as "admin:subdivision_code"'
+        )
 
     return country_select + subdivision_select
 

--- a/geoparquet_io/core/add/geometry_metrics.py
+++ b/geoparquet_io/core/add/geometry_metrics.py
@@ -16,6 +16,7 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
 )
 from geoparquet_io.core.constants import VECOREL_METRICS_SCHEMA, build_collection_metadata
+from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.file_utils import handle_output_overwrite
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import success
@@ -143,8 +144,8 @@ def _add_metrics_streaming(
 
         return (
             f"SELECT *, "
-            f'CAST(ST_Area_Spheroid("{geom_col}") AS FLOAT) AS "{AREA_COLUMN}", '
-            f'CAST(ST_Perimeter_Spheroid("{geom_col}") AS FLOAT) AS "{PERIMETER_COLUMN}" '
+            f"CAST(ST_Area_Spheroid({quote_identifier(geom_col)}) AS FLOAT) AS {quote_identifier(AREA_COLUMN)}, "
+            f"CAST(ST_Perimeter_Spheroid({quote_identifier(geom_col)}) AS FLOAT) AS {quote_identifier(PERIMETER_COLUMN)} "
             f"FROM {source}"
         )
 
@@ -191,8 +192,8 @@ def _add_metrics_file_based(
 
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
-    area_expr = f'CAST(ST_Area_Spheroid("{geom_col}") AS FLOAT)'
-    perimeter_expr = f'CAST(ST_Perimeter_Spheroid("{geom_col}") AS FLOAT)'
+    area_expr = f"CAST(ST_Area_Spheroid({quote_identifier(geom_col)}) AS FLOAT)"
+    perimeter_expr = f"CAST(ST_Perimeter_Spheroid({quote_identifier(geom_col)}) AS FLOAT)"
 
     if dry_run:
         from geoparquet_io.core.logging_config import info

--- a/geoparquet_io/core/add/h3.py
+++ b/geoparquet_io/core/add/h3.py
@@ -14,6 +14,7 @@ from geoparquet_io.core.crs_utils import (
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
+    quote_identifier,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite
@@ -81,8 +82,10 @@ def add_h3_table(
         if geom_is_blob and geom_col in table.column_names:
             # Create view with geometry conversion
             # Quote all column names for safety with special characters
-            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-            col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+            other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+            col_defs = other_cols + [
+                f"ST_GeomFromWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)}"
+            ]
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
             )
@@ -92,7 +95,7 @@ def add_h3_table(
             source_ref = "__input_table"
 
         # Build H3 column query (reproject to lon/lat when source is non-CRS84)
-        geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+        geom_ref = transform_geom_sql(quote_identifier(geom_col), source_crs)
         h3_expr = f"""h3_latlng_to_cell_string(
             ST_Y(ST_Centroid({geom_ref})),
             ST_X(ST_Centroid({geom_ref})),
@@ -100,21 +103,21 @@ def add_h3_table(
         )"""
 
         # Get non-geometry columns
-        other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
+        other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
         select_cols = ", ".join(other_cols) if other_cols else ""
 
         # Build SELECT with geometry converted back to WKB
         if select_cols:
             query = f"""
                 SELECT {select_cols},
-                       ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       {h3_expr} AS "{h3_column_name}"
+                       ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                       {h3_expr} AS {quote_identifier(h3_column_name)}
                 FROM {source_ref}
             """
         else:
             query = f"""
-                SELECT ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       {h3_expr} AS "{h3_column_name}"
+                SELECT ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                       {h3_expr} AS {quote_identifier(h3_column_name)}
                 FROM {source_ref}
             """
         result = con.execute(query).arrow().read_all()
@@ -140,13 +143,13 @@ def _make_add_h3_query(
     ``source_crs`` reprojects a non-CRS84 input to lon/lat before centroid keying
     (#525); ``None`` (CRS84 / CRS-less) leaves the geometry untouched.
     """
-    geom_ref = transform_geom_sql(f'"{geometry_column}"', source_crs)
+    geom_ref = transform_geom_sql(quote_identifier(geometry_column), source_crs)
     h3_expr = f"""h3_latlng_to_cell_string(
         ST_Y(ST_Centroid({geom_ref})),
         ST_X(ST_Centroid({geom_ref})),
         {resolution}
     )"""
-    return f'SELECT *, {h3_expr} AS "{h3_column_name}" FROM {source}'
+    return f"SELECT *, {h3_expr} AS {quote_identifier(h3_column_name)} FROM {source}"
 
 
 def add_h3_column(
@@ -232,7 +235,9 @@ def add_h3_column(
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
     # H3 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
-    geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs_string(input_parquet, verbose))
+    geom_ref = transform_geom_sql(
+        quote_identifier(geom_col), source_crs_string(input_parquet, verbose)
+    )
 
     # Define the H3 SQL expression (using string format for portability)
     sql_expression = f"""h3_latlng_to_cell_string(

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -8,7 +8,7 @@ import tempfile
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -78,8 +78,8 @@ def _build_sampling_query(
         WITH RECURSIVE kdtree_sample(iteration, x, y, partition_id, split_value) AS (
             SELECT
                 0 AS iteration,
-                ST_X(ST_Centroid({geom_col})) AS x,
-                ST_Y(ST_Centroid({geom_col})) AS y,
+                ST_X(ST_Centroid({quote_identifier(geom_col)})) AS x,
+                ST_Y(ST_Centroid({quote_identifier(geom_col)})) AS y,
                 '0' AS partition_id,
                 NULL::DOUBLE AS split_value
             FROM '{input_url}' USING SAMPLE {sample_size} ROWS
@@ -142,8 +142,8 @@ def _build_sampling_query(
     cte_parts.append(f"""
         data_with_coords AS (
             SELECT *,
-                ST_X(ST_Centroid({geom_col})) AS _kdtree_x,
-                ST_Y(ST_Centroid({geom_col})) AS _kdtree_y,
+                ST_X(ST_Centroid({quote_identifier(geom_col)})) AS _kdtree_x,
+                ST_Y(ST_Centroid({quote_identifier(geom_col)})) AS _kdtree_y,
                 '0' AS _kdtree_partition
             FROM '{input_url}'
         )
@@ -436,8 +436,8 @@ def add_kdtree_column(
             WITH RECURSIVE kdtree(iteration, x, y, partition_id, row_id) AS (
                 SELECT
                     0 AS iteration,
-                    ST_X(ST_Centroid({geom_col})) AS x,
-                    ST_Y(ST_Centroid({geom_col})) AS y,
+                    ST_X(ST_Centroid({quote_identifier(geom_col)})) AS x,
+                    ST_Y(ST_Centroid({quote_identifier(geom_col)})) AS y,
                     '0' AS partition_id,
                     ROW_NUMBER() OVER () AS row_id
                 FROM '{input_url}'

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -147,10 +147,9 @@ def _validate_crs_for_quadkey(input_parquet: str, geom_col: str, verbose: bool) 
 
     Quadkeys require lat/lon coordinates. Raises ClickException if CRS is projected.
     """
-    safe_url = safe_file_url(input_parquet, verbose=False)
 
     # Get CRS from GeoParquet metadata
-    geo_meta = get_geo_metadata(safe_url)
+    geo_meta = get_geo_metadata(input_parquet)
     _validate_crs_from_geo_metadata(geo_meta, geom_col, verbose, source_description="file")
 
 
@@ -262,8 +261,10 @@ def add_quadkey_table(
 
         if geom_is_blob and geom_col in table.column_names:
             # Quote column names to handle special characters (colons, spaces, etc.)
-            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-            col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+            other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+            col_defs = other_cols + [
+                f"ST_GeomFromWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)}"
+            ]
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
             )
@@ -274,29 +275,33 @@ def add_quadkey_table(
 
         # Build lat/lon expressions (reproject to lon/lat when source is non-CRS84)
         if use_bbox and bbox_col:
-            lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
-            lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
+            lat_expr = (
+                f"(({quote_identifier(bbox_col)}.ymin + {quote_identifier(bbox_col)}.ymax) / 2.0)"
+            )
+            lon_expr = (
+                f"(({quote_identifier(bbox_col)}.xmin + {quote_identifier(bbox_col)}.xmax) / 2.0)"
+            )
         else:
-            geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+            geom_ref = transform_geom_sql(quote_identifier(geom_col), source_crs)
             lat_expr = f"ST_Y(ST_Centroid({geom_ref}))"
             lon_expr = f"ST_X(ST_Centroid({geom_ref}))"
 
         # Get non-geometry columns
-        other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
+        other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
         select_cols = ", ".join(other_cols) if other_cols else ""
 
         # Build SELECT with geometry converted back to WKB
         if select_cols:
             query = f"""
                 SELECT {select_cols},
-                       ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS "{quadkey_column_name}"
+                       ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                       lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quote_identifier(quadkey_column_name)}
                 FROM {source_ref}
             """
         else:
             query = f"""
-                SELECT ST_AsWKB("{geom_col}") AS "{geom_col}",
-                       lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS "{quadkey_column_name}"
+                SELECT ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                       lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quote_identifier(quadkey_column_name)}
                 FROM {source_ref}
             """
         result = con.execute(query).arrow().read_all()
@@ -463,16 +468,20 @@ def _add_quadkey_streaming(
 
         # Build lat/lon expressions (reproject to lon/lat when source is non-CRS84)
         if bbox_col:
-            lat_expr = f'(("{bbox_col}".ymin + "{bbox_col}".ymax) / 2.0)'
-            lon_expr = f'(("{bbox_col}".xmin + "{bbox_col}".xmax) / 2.0)'
+            lat_expr = (
+                f"(({quote_identifier(bbox_col)}.ymin + {quote_identifier(bbox_col)}.ymax) / 2.0)"
+            )
+            lon_expr = (
+                f"(({quote_identifier(bbox_col)}.xmin + {quote_identifier(bbox_col)}.xmax) / 2.0)"
+            )
         else:
-            geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+            geom_ref = transform_geom_sql(quote_identifier(geom_col), source_crs)
             lat_expr = f"ST_Y(ST_Centroid({geom_ref}))"
             lon_expr = f"ST_X(ST_Centroid({geom_ref}))"
 
         query = f"""
             SELECT *,
-                   lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS "{quadkey_column_name}"
+                   lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quote_identifier(quadkey_column_name)}
             FROM {source}
         """
 
@@ -552,7 +561,7 @@ def _add_quadkey_file_based(
 
     # Check if column already exists (skip in dry-run)
     if not dry_run:
-        column_names = get_column_names(input_url)
+        column_names = get_column_names(input_parquet)
         if quadkey_column_name in column_names:
             raise GeoParquetError(
                 f"Column '{quadkey_column_name}' already exists in the file. "

--- a/geoparquet_io/core/add/s2.py
+++ b/geoparquet_io/core/add/s2.py
@@ -22,7 +22,11 @@ from geoparquet_io.core.crs_utils import (
     source_crs_string,
     transform_geom_sql,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, load_community_extension
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    load_community_extension,
+    quote_identifier,
+)
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite
 from geoparquet_io.core.geometry_detection import (
@@ -56,8 +60,10 @@ def _create_geometry_view(con, table, geom_col):
     if geom_is_blob and geom_col in table.column_names:
         # Create view with geometry conversion
         # Quote all column names for safety with special characters
-        other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-        col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+        other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+        col_defs = other_cols + [
+            f"ST_GeomFromWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)}"
+        ]
         view_query = f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
         con.execute(view_query)
         return "__input_view"
@@ -75,7 +81,7 @@ def _build_s2_select_query(table, source_ref, geom_col, s2_column_name, level, g
         str: Complete SELECT query with S2 expression
     """
     if geom_ref is None:
-        geom_ref = f'"{geom_col}"'
+        geom_ref = quote_identifier(geom_col)
 
     # Build S2 cell expression (keyed on lon/lat, reprojected when needed)
     s2_expr = f"""s2_cell_token(
@@ -89,21 +95,21 @@ def _build_s2_select_query(table, source_ref, geom_col, s2_column_name, level, g
     )"""
 
     # Build column list
-    other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
+    other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
     select_cols = ", ".join(other_cols) if other_cols else ""
 
     # Build SELECT query
     if select_cols:
         return f"""
             SELECT {select_cols},
-                   ST_AsWKB("{geom_col}") AS "{geom_col}",
-                   {s2_expr} AS "{s2_column_name}"
+                   ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                   {s2_expr} AS {quote_identifier(s2_column_name)}
             FROM {source_ref}
         """
     else:
         return f"""
-            SELECT ST_AsWKB("{geom_col}") AS "{geom_col}",
-                   {s2_expr} AS "{s2_column_name}"
+            SELECT ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)},
+                   {s2_expr} AS {quote_identifier(s2_column_name)}
             FROM {source_ref}
         """
 
@@ -150,7 +156,7 @@ def add_s2_table(
         con.register("__input_table", table)
 
         source_ref = _create_geometry_view(con, table, geom_col)
-        geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs)
+        geom_ref = transform_geom_sql(quote_identifier(geom_col), source_crs)
         query = _build_s2_select_query(
             table, source_ref, geom_col, s2_column_name, level, geom_ref=geom_ref
         )
@@ -177,7 +183,7 @@ def _make_add_s2_query(
     ``source_crs`` reprojects a non-CRS84 input to lon/lat before centroid keying
     (#525); ``None`` (CRS84 / CRS-less) leaves the geometry untouched.
     """
-    geom_ref = transform_geom_sql(f'"{geometry_column}"', source_crs)
+    geom_ref = transform_geom_sql(quote_identifier(geometry_column), source_crs)
     # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get desired level
     s2_expr = f"""s2_cell_token(
         s2_cell_parent(
@@ -188,7 +194,7 @@ def _make_add_s2_query(
             {level}
         )
     )"""
-    return f'SELECT *, {s2_expr} AS "{s2_column_name}" FROM {source}'
+    return f"SELECT *, {s2_expr} AS {quote_identifier(s2_column_name)} FROM {source}"
 
 
 def add_s2_column(
@@ -273,7 +279,9 @@ def add_s2_column(
     geom_col = find_primary_geometry_column(input_parquet, verbose)
 
     # S2 keying expects lon/lat degrees; reproject non-CRS84 input first (#525).
-    geom_ref = transform_geom_sql(f'"{geom_col}"', source_crs_string(input_parquet, verbose))
+    geom_ref = transform_geom_sql(
+        quote_identifier(geom_col), source_crs_string(input_parquet, verbose)
+    )
 
     # Define the S2 SQL expression (using token/string format for portability)
     # s2_cellfromlonlat returns a cell at level 30, use s2_cell_parent to get desired level

--- a/geoparquet_io/core/benchmark.py
+++ b/geoparquet_io/core/benchmark.py
@@ -22,7 +22,11 @@ from typing import Any
 import duckdb
 import psutil
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    get_duckdb_connection,
+    quote_identifier,
+)
 from geoparquet_io.core.exceptions import FileNotFoundGeoParquetError, GeoParquetError
 from geoparquet_io.core.geometry_detection import STANDARD_GEOMETRY_NAMES
 from geoparquet_io.core.logging_config import progress
@@ -139,7 +143,7 @@ def get_file_info(filepath: Path) -> dict[str, Any]:
             geom_type = "unknown"
             if geom_col:
                 geom_result = conn.execute(f"""
-                    SELECT ST_GeometryType({geom_col}) as geom_type
+                    SELECT ST_GeometryType({quote_identifier(geom_col)}) as geom_type
                     FROM ST_Read('{safe_filepath}')
                     LIMIT 1
                 """).fetchone()

--- a/geoparquet_io/core/check_spatial_order.py
+++ b/geoparquet_io/core/check_spatial_order.py
@@ -4,7 +4,7 @@
 import random as _random
 from statistics import mean
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, progress
@@ -41,9 +41,10 @@ def _bboxes_overlap(bbox1: dict, bbox2: dict) -> bool:
 
 def _calculate_consecutive_avg(con, safe_url, geometry_column, row_limit, verbose):
     """Calculate average distance between consecutive features."""
+    quoted_geom = quote_identifier(geometry_column)
     query = f"""
     WITH numbered AS (
-        SELECT ROW_NUMBER() OVER () as id, {geometry_column} as geom
+        SELECT ROW_NUMBER() OVER () as id, {quoted_geom} as geom
         FROM '{safe_url}' {row_limit}
     )
     SELECT AVG(ST_Distance(a.geom, b.geom)) as avg_dist
@@ -60,8 +61,9 @@ def _calculate_consecutive_avg(con, safe_url, geometry_column, row_limit, verbos
 
 def _calculate_random_avg(con, safe_url, geometry_column, row_limit, random_sample_size, verbose):
     """Calculate average distance between random pairs of features."""
+    quoted_geom = quote_identifier(geometry_column)
     query = f"""
-    WITH sample AS (SELECT {geometry_column} as geom FROM '{safe_url}' {row_limit}),
+    WITH sample AS (SELECT {quoted_geom} as geom FROM '{safe_url}' {row_limit}),
     random_pairs AS (
         SELECT a.geom as geom1, b.geom as geom2
         FROM (SELECT geom FROM sample ORDER BY random() LIMIT {random_sample_size}) a,

--- a/geoparquet_io/core/check_spatial_order.py
+++ b/geoparquet_io/core/check_spatial_order.py
@@ -168,9 +168,7 @@ def check_spatial_order_bbox_stats(
         has_bbox_column,
     )
 
-    safe_url = safe_file_url(parquet_file, verbose)
-
-    has_bbox, bbox_col_name = has_bbox_column(safe_url)
+    has_bbox, bbox_col_name = has_bbox_column(parquet_file)
     if not has_bbox or not bbox_col_name:
         raise ValueError(
             f"File {parquet_file} does not have a bbox column. "
@@ -180,7 +178,7 @@ def check_spatial_order_bbox_stats(
     if verbose:
         debug(f"Using bbox column: {bbox_col_name}")
 
-    row_group_bboxes = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
+    row_group_bboxes = get_per_row_group_bbox_stats(parquet_file, bbox_col_name)
 
     if verbose:
         debug(f"Analyzing {len(row_group_bboxes)} row groups")
@@ -318,7 +316,7 @@ def check_spatial_order(
     safe_url = safe_file_url(parquet_file, verbose)
 
     # Try bbox-stats method first (faster)
-    has_bbox, bbox_col_name = has_bbox_column(safe_url)
+    has_bbox, bbox_col_name = has_bbox_column(parquet_file)
     if has_bbox and bbox_col_name:
         if verbose:
             debug(f"Using bbox-stats method (bbox column: {bbox_col_name})")
@@ -336,7 +334,7 @@ def check_spatial_order(
 
     # Try native geo_bbox stats (GeoParquet 2.0 / parquet-geo-only)
     geometry_column = find_primary_geometry_column(parquet_file, verbose)
-    native_geo_stats = get_per_row_group_native_geo_stats(safe_url, geometry_column)
+    native_geo_stats = get_per_row_group_native_geo_stats(parquet_file, geometry_column)
     if native_geo_stats:
         if verbose:
             debug(f"Using native geo_bbox stats ({len(native_geo_stats)} row groups)")
@@ -556,9 +554,7 @@ def check_spatial_pushdown_readiness(
         has_bbox_column,
     )
 
-    safe_url = safe_file_url(parquet_file, verbose)
-
-    has_bbox, bbox_col_name = has_bbox_column(safe_url)
+    has_bbox, bbox_col_name = has_bbox_column(parquet_file)
 
     issues: list[str] = []
     recommendations: list[str] = []
@@ -584,7 +580,7 @@ def check_spatial_pushdown_readiness(
     if verbose:
         debug(f"Using bbox column: {bbox_col_name}")
 
-    row_group_bboxes = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
+    row_group_bboxes = get_per_row_group_bbox_stats(parquet_file, bbox_col_name)
     num_rgs = len(row_group_bboxes)
 
     if verbose:

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -164,17 +164,15 @@ def detect_geoparquet_file_type(parquet_file, verbose=False, con=None):
         "bbox_recommended": True,  # Default for v1.x
     }
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
     # Check for geo metadata (uses PyArrow for local files, DuckDB for remote)
-    geo_meta = get_geo_metadata(safe_url, con=con)
+    geo_meta = get_geo_metadata(parquet_file, con=con)
     if geo_meta:
         result["has_geo_metadata"] = True
         if isinstance(geo_meta, dict) and "version" in geo_meta:
             result["geo_version"] = geo_meta["version"]
 
     # Check for native Parquet geo types using schema
-    geo_columns = detect_geometry_columns(safe_url, con=con)
+    geo_columns = detect_geometry_columns(parquet_file, con=con)
     if geo_columns:
         result["has_native_geo_types"] = True
 
@@ -236,10 +234,8 @@ def get_parquet_metadata(parquet_file, verbose=False):
         if first_file:
             file_to_check = first_file
 
-    safe_url = safe_file_url(file_to_check, verbose=False)
-
     # Get key-value metadata (returns dict like {b'geo': b'...'})
-    kv_metadata = get_kv_metadata(safe_url)
+    kv_metadata = get_kv_metadata(file_to_check)
 
     # Get PyArrow schema for backward compatibility
     # (some code uses schema.field(i).name patterns)
@@ -247,7 +243,7 @@ def get_parquet_metadata(parquet_file, verbose=False):
         # For remote files, use a DuckDB-based approach to read schema
         from geoparquet_io.core.duckdb_metadata import get_schema_info
 
-        schema_info = get_schema_info(safe_url)
+        schema_info = get_schema_info(file_to_check)
         # Create a simple object that mimics PyArrow schema for basic usage
         schema = _DuckDBSchemaWrapper(schema_info)
     else:
@@ -284,14 +280,12 @@ def calculate_file_bounds(file_path, geom_column=None, verbose=False):
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(file_path))
 
     try:
-        # Quote column name to handle special characters, uppercase, etc.
-        quoted_geom = geom_column.replace('"', '""')
         bounds_query = f"""
             SELECT
-                MIN(ST_XMin("{quoted_geom}")) as xmin,
-                MIN(ST_YMin("{quoted_geom}")) as ymin,
-                MAX(ST_XMax("{quoted_geom}")) as xmax,
-                MAX(ST_YMax("{quoted_geom}")) as ymax
+                MIN(ST_XMin({quote_identifier(geom_column)})) as xmin,
+                MIN(ST_YMin({quote_identifier(geom_column)})) as ymin,
+                MAX(ST_XMax({quote_identifier(geom_column)})) as xmax,
+                MAX(ST_YMax({quote_identifier(geom_column)})) as ymax
             FROM read_parquet('{safe_url}')
         """
         result = con.execute(bounds_query).fetchone()
@@ -520,9 +514,7 @@ def compute_geometry_types_via_sql(
     if "STRUCT" in col_type:
         return []
 
-    # Escape column name for SQL (double any embedded quotes)
-    escaped_col = geometry_column.replace('"', '""')
-    quoted_col = f'"{escaped_col}"'
+    quoted_col = quote_identifier(geometry_column)
     typed_expr = f"ST_GeometryType({quoted_col}) || {zm_suffix_sql(quoted_col)}"
     types_query = f"""
         SELECT DISTINCT {typed_expr} as geom_type
@@ -572,15 +564,15 @@ def compute_geometry_dimensions_via_sql(
     if "STRUCT" in col_type:
         return set()
 
-    escaped_col = geometry_column.replace('"', '""')
-    geom_expr = f'"{escaped_col}"'
+    quoted_col = quote_identifier(geometry_column)
+    geom_expr = quoted_col
     if "BLOB" in col_type or "BINARY" in col_type:
         geom_expr = f"ST_GeomFromWKB({geom_expr})"
 
     dims_query = f"""
         SELECT DISTINCT ST_ZMFlag({geom_expr}) AS zm
         FROM ({query})
-        WHERE "{escaped_col}" IS NOT NULL
+        WHERE {quoted_col} IS NOT NULL
     """
     try:
         results = con.execute(dims_query).fetchall()
@@ -2874,10 +2866,8 @@ def check_bbox_structure(parquet_file, verbose=False) -> BboxInfo:
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata, get_schema_info
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
     # Get schema info using DuckDB
-    schema_info = get_schema_info(safe_url)
+    schema_info = get_schema_info(parquet_file)
 
     if verbose:
         debug("\nSchema fields:")
@@ -2889,7 +2879,7 @@ def check_bbox_structure(parquet_file, verbose=False) -> BboxInfo:
 
     # Find the bbox column: the authoritative covering metadata first (spec-valid
     # files may use non-conventional names), then the naming-convention fallback.
-    geo_meta = get_geo_metadata(safe_url)
+    geo_meta = get_geo_metadata(parquet_file)
     bbox_column_name = None
     covering_column = _bbox_column_from_covering(geo_meta)
     if covering_column:
@@ -3201,7 +3191,7 @@ def add_computed_column(
 
         # Only check for column collision if not replacing
         if not replace_column:
-            column_names = get_column_names(input_url)
+            column_names = get_column_names(input_parquet)
             if column_name in column_names:
                 raise InvalidParameterError(
                     "column_name",
@@ -3237,7 +3227,7 @@ def add_computed_column(
 
     # Build the query
     # Quote column name to handle special characters (e.g., colons in "metrics:area")
-    quoted_col = f'"{column_name}"'
+    quoted_col = quote_identifier(column_name)
 
     # Use EXCLUDE to drop existing column when replacing
     if replace_column:
@@ -3321,8 +3311,7 @@ def add_bbox(parquet_file, bbox_column_name="bbox", verbose=False):
     from geoparquet_io.core.duckdb_metadata import get_column_names
 
     # Check if column already exists using DuckDB
-    safe_url = safe_file_url(parquet_file, verbose=False)
-    column_names = get_column_names(safe_url)
+    column_names = get_column_names(parquet_file)
 
     if bbox_column_name in column_names:
         raise InvalidParameterError(

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -3338,11 +3338,12 @@ def add_bbox(parquet_file, bbox_column_name="bbox", verbose=False):
         debug(f"Adding bbox column for geometry column: {geom_col}")
 
     # Define SQL expression
+    quoted_geom_col = quote_identifier(geom_col)
     sql_expression = f"""STRUCT_PACK(
-        xmin := ST_XMin({geom_col}),
-        ymin := ST_YMin({geom_col}),
-        xmax := ST_XMax({geom_col}),
-        ymax := ST_YMax({geom_col})
+        xmin := ST_XMin({quoted_geom_col}),
+        ymin := ST_YMin({quoted_geom_col}),
+        xmax := ST_XMax({quoted_geom_col}),
+        ymax := ST_YMax({quoted_geom_col})
     )"""
 
     # Create temporary file path

--- a/geoparquet_io/core/constants.py
+++ b/geoparquet_io/core/constants.py
@@ -121,8 +121,7 @@ def ensure_vecorel_columns(parquet_file: str, verbose: bool = False) -> None:
     from geoparquet_io.core.duckdb_metadata import get_column_names
     from geoparquet_io.core.file_utils import safe_file_url
 
-    url = safe_file_url(parquet_file, verbose=False)
-    columns = get_column_names(url)
+    columns = get_column_names(parquet_file)
 
     # Add id column if missing
     if "id" not in columns:

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -198,8 +198,7 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
             con.close()
         return result
 
-    safe_url = safe_file_url(input_file, verbose=False)
-    geo_meta = get_geo_metadata(safe_url)
+    geo_meta = get_geo_metadata(input_file)
 
     if not geo_meta:
         # No GeoParquet metadata - detect single column from schema
@@ -526,6 +525,8 @@ def _validate_latlon_ranges(con, csv_read, lat_col, lon_col, verbose):
     if verbose:
         debug(f"Validating lat/lon ranges for columns: {lat_col}, {lon_col}")
 
+    lat_col = quote_identifier(lat_col)
+    lon_col = quote_identifier(lon_col)
     query = f"""
         SELECT
             MIN(CAST({lat_col} AS DOUBLE)) as min_lat,
@@ -564,8 +565,9 @@ def _validate_latlon_ranges(con, csv_read, lat_col, lon_col, verbose):
 
 def _check_null_wkt_rows(con, csv_read, wkt_col):
     """Check and warn about NULL WKT values."""
+    quoted_wkt = quote_identifier(wkt_col)
     null_count = con.execute(
-        f"SELECT COUNT(*) FILTER ({wkt_col} IS NULL) FROM {csv_read}"
+        f"SELECT COUNT(*) FILTER ({quoted_wkt} IS NULL) FROM {csv_read}"
     ).fetchone()[0]
 
     if null_count > 0:
@@ -587,11 +589,12 @@ def _check_invalid_wkt_rows(con, csv_read, wkt_col):
         csv_read: SQL expression for reading the CSV (e.g., "read_csv('file.csv')").
         wkt_col: Name of the WKT column to validate.
     """
+    quoted_wkt = quote_identifier(wkt_col)
     try:
         # Use TRY() to catch WKT parse errors — returns NULL for invalid WKT
         invalid_count = con.execute(
             f"SELECT COUNT(*) FROM {csv_read} "
-            f"WHERE {wkt_col} IS NOT NULL AND TRY(ST_GeomFromText({wkt_col})) IS NULL"
+            f"WHERE {quoted_wkt} IS NOT NULL AND TRY(ST_GeomFromText({quoted_wkt})) IS NULL"
         ).fetchone()[0]
 
         if invalid_count > 0:
@@ -618,10 +621,12 @@ def _validate_wkt_strict(con, csv_read, wkt_col):
     Raises:
         GeometryError: If WKT parsing fails, with suggestion to use --skip-invalid.
     """
+    quoted_wkt = quote_identifier(wkt_col)
     try:
         # Use ::VARCHAR cast to avoid DuckDB 1.5+ GEOMETRY serialization error
         con.execute(
-            f"SELECT ST_GeomFromText({wkt_col})::VARCHAR FROM {csv_read} WHERE {wkt_col} IS NOT NULL LIMIT 1"
+            f"SELECT ST_GeomFromText({quoted_wkt})::VARCHAR FROM {csv_read} "
+            f"WHERE {quoted_wkt} IS NOT NULL LIMIT 1"
         ).fetchone()
     except Exception as e:
         raise GeometryError(
@@ -632,11 +637,12 @@ def _validate_wkt_strict(con, csv_read, wkt_col):
 
 def _warn_if_projected_crs(con, csv_read, wkt_col):
     """Warn if coordinates suggest projected CRS instead of WGS84."""
+    quoted_wkt = quote_identifier(wkt_col)
     try:
         result = con.execute(
-            f"SELECT MAX(ABS(ST_XMax(ST_GeomFromText({wkt_col})))) as max_x, "
-            f"MAX(ABS(ST_YMax(ST_GeomFromText({wkt_col})))) as max_y "
-            f"FROM {csv_read} WHERE {wkt_col} IS NOT NULL LIMIT 1000"
+            f"SELECT MAX(ABS(ST_XMax(ST_GeomFromText({quoted_wkt})))) as max_x, "
+            f"MAX(ABS(ST_YMax(ST_GeomFromText({quoted_wkt})))) as max_y "
+            f"FROM {csv_read} WHERE {quoted_wkt} IS NOT NULL LIMIT 1000"
         ).fetchone()
 
         if result and result[0] is not None:
@@ -692,7 +698,7 @@ def _build_csv_conversion_query(geom_info, skip_hilbert, bounds, skip_invalid, s
 
     # Build geometry expression and exclusion list
     if geom_info["type"] == "wkt":
-        wkt_col = geom_info["wkt_column"]
+        wkt_col = quote_identifier(geom_info["wkt_column"])
         geom_expr = f"ST_GeomFromText({wkt_col})"
         exclude_cols = wkt_col
 
@@ -724,8 +730,8 @@ def _build_csv_conversion_query(geom_info, skip_hilbert, bounds, skip_invalid, s
             where_clause = ""
 
     elif geom_info["type"] == "latlon":
-        lat_col = geom_info["lat_column"]
-        lon_col = geom_info["lon_column"]
+        lat_col = quote_identifier(geom_info["lat_column"])
+        lon_col = quote_identifier(geom_info["lon_column"])
         # Note: ST_Point expects (lon, lat) order
         geom_expr = f"ST_Point(CAST({lon_col} AS DOUBLE), CAST({lat_col} AS DOUBLE))"
         exclude_cols = f"{lat_col}, {lon_col}"
@@ -771,7 +777,7 @@ def _get_geom_expr_and_where(geom_info, skip_invalid):
     those rows — see :func:`_build_csv_conversion_query` and issue #655.
     """
     if geom_info["type"] == "wkt":
-        wkt_col = geom_info["wkt_column"]
+        wkt_col = quote_identifier(geom_info["wkt_column"])
         if skip_invalid:
             # Use TRY() to silently skip invalid WKT
             geom_expr = f"TRY(ST_GeomFromText({wkt_col}))"
@@ -782,8 +788,8 @@ def _get_geom_expr_and_where(geom_info, skip_invalid):
         return geom_expr, where_clause
 
     # latlon
-    lat_col = geom_info["lat_column"]
-    lon_col = geom_info["lon_column"]
+    lat_col = quote_identifier(geom_info["lat_column"])
+    lon_col = quote_identifier(geom_info["lon_column"])
     geom_expr = f"ST_Point(CAST({lon_col} AS DOUBLE), CAST({lat_col} AS DOUBLE))"
     where_clause = f"WHERE {lat_col} IS NOT NULL AND {lon_col} IS NOT NULL"
     return geom_expr, where_clause

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -9,7 +9,7 @@ import json
 import os
 from functools import lru_cache
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
 from geoparquet_io.core.logging_config import debug, warn
 
 
@@ -206,10 +206,9 @@ def _wrap_query_with_crs(
         warn("input_crs does not look like valid PROJJSON — skipping CRS application")
         return query
 
-    escaped_geom = geometry_column.replace('"', '""')
     crs_json = _escape_sql_string(json.dumps(input_crs))
     return f"""
-        SELECT * REPLACE (ST_SetCRS("{escaped_geom}", '{crs_json}') AS "{escaped_geom}")
+        SELECT * REPLACE (ST_SetCRS({quote_identifier(geometry_column)}, '{crs_json}') AS {quote_identifier(geometry_column)})
         FROM ({query})
     """
 
@@ -333,7 +332,7 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
 
     safe_url = safe_file_url(parquet_file, verbose=False)
 
-    geo_meta = get_geo_metadata(safe_url)
+    geo_meta = get_geo_metadata(parquet_file)
     if geo_meta:
         primary_col = geo_meta.get("primary_column", "geometry")
         columns = geo_meta.get("columns", {})
@@ -346,7 +345,7 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
                     debug(f"Found CRS in GeoParquet metadata: {_format_crs_display(crs)}")
                 return crs
 
-    schema_info = get_schema_info(safe_url)
+    schema_info = get_schema_info(parquet_file)
     for col in schema_info:
         logical_type = col.get("logical_type") or ""
         if logical_type and (

--- a/geoparquet_io/core/curved_geometry.py
+++ b/geoparquet_io/core/curved_geometry.py
@@ -19,6 +19,8 @@ import sqlite3
 import struct
 from pathlib import Path
 
+from geoparquet_io.core.duckdb_utils import quote_identifier
+
 #: ISO WKB type codes outside the linear Simple Features set (base code,
 #: i.e. modulo the 1000/2000/3000 Z/M/ZM offsets).
 NON_LINEAR_WKB_TYPES: dict[int, str] = {
@@ -74,11 +76,13 @@ def find_non_linear_gpkg_types(path: str | Path, layer: str | None = None) -> li
             for table, col in tables:
                 if layer and table != layer:
                     continue
-                qtable = table.replace('"', '""')
-                qcol = col.replace('"', '""')
+                # SQLite quotes identifiers exactly as DuckDB does (double an
+                # embedded '"'), so the shared helper applies here too.
+                qtable = quote_identifier(table)
+                qcol = quote_identifier(col)
                 for (blob,) in con.execute(
-                    f'SELECT substr("{qcol}", 1, {_HEADER_BYTES}) FROM "{qtable}" '
-                    f'WHERE "{qcol}" IS NOT NULL LIMIT {_SCAN_CAP}'
+                    f"SELECT substr({qcol}, 1, {_HEADER_BYTES}) FROM {qtable} "
+                    f"WHERE {qcol} IS NOT NULL LIMIT {_SCAN_CAP}"
                 ):
                     if not blob or blob[:2] != b"GP" or len(blob) < 8:
                         continue

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -19,6 +19,7 @@ import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from geoparquet_io.core.duckdb_utils import _escape_sql_string
 from geoparquet_io.core.exceptions import GeoParquetError
 
 # =============================================================================
@@ -877,16 +878,17 @@ def get_bbox_from_row_group_stats(
         # DuckDB uses 'bbox, xmin' format for path_in_schema (comma-space)
         # Use FILTER to aggregate stats for each bbox component
         # Use TRY_CAST to handle non-numeric stats gracefully
+        escaped_bbox_col = _escape_sql_string(bbox_column)
         result = connection.execute(f"""
             SELECT
                 MIN(TRY_CAST(stats_min AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, xmin') as xmin,
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, xmin') as xmin,
                 MIN(TRY_CAST(stats_min AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, ymin') as ymin,
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, ymin') as ymin,
                 MAX(TRY_CAST(stats_max AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, xmax') as xmax,
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, xmax') as xmax,
                 MAX(TRY_CAST(stats_max AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, ymax') as ymax
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, ymax') as ymax
             FROM parquet_metadata('{safe_url}')
         """).fetchone()
 
@@ -912,17 +914,18 @@ def get_per_row_group_bbox_stats(
     try:
         # DuckDB uses 'bbox, xmin' format for path_in_schema (comma-space)
         # Use TRY_CAST to handle non-numeric stats gracefully
+        escaped_bbox_col = _escape_sql_string(bbox_column)
         result = connection.execute(f"""
             SELECT
                 row_group_id,
                 MIN(TRY_CAST(stats_min AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, xmin') as xmin,
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, xmin') as xmin,
                 MIN(TRY_CAST(stats_min AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, ymin') as ymin,
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, ymin') as ymin,
                 MAX(TRY_CAST(stats_max AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, xmax') as xmax,
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, xmax') as xmax,
                 MAX(TRY_CAST(stats_max AS DOUBLE))
-                    FILTER (WHERE path_in_schema = '{bbox_column}, ymax') as ymax
+                    FILTER (WHERE path_in_schema = '{escaped_bbox_col}, ymax') as ymax
             FROM parquet_metadata('{safe_url}')
             GROUP BY row_group_id
             ORDER BY row_group_id
@@ -959,7 +962,7 @@ def get_compression_info(parquet_file: str, column_name: str | None = None, con=
             FROM parquet_metadata('{safe_url}')
         """
         if column_name:
-            query += f" WHERE path_in_schema = '{column_name}'"
+            query += f" WHERE path_in_schema = '{_escape_sql_string(column_name)}'"
 
         result = connection.execute(query).fetchall()
         return {row[0]: row[1] for row in result}
@@ -1127,10 +1130,11 @@ def get_native_geo_statistics(parquet_file: str, geometry_column: str, con=None)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
+        escaped_geom_col = _escape_sql_string(geometry_column)
         result = connection.execute(f"""
             SELECT geo_bbox, geo_types
             FROM parquet_metadata('{safe_url}')
-            WHERE path_in_schema = '{geometry_column}'
+            WHERE path_in_schema = '{escaped_geom_col}'
             LIMIT 1
         """).fetchone()
 
@@ -1187,6 +1191,7 @@ def get_aggregated_native_geo_stats(parquet_file: str, geometry_column: str, con
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
+        escaped_geom_col = _escape_sql_string(geometry_column)
         # Aggregate bbox across all row groups
         result = connection.execute(f"""
             SELECT
@@ -1197,7 +1202,7 @@ def get_aggregated_native_geo_stats(parquet_file: str, geometry_column: str, con
                 MIN(geo_bbox.zmin) as zmin,
                 MAX(geo_bbox.zmax) as zmax
             FROM parquet_metadata('{safe_url}')
-            WHERE path_in_schema = '{geometry_column}'
+            WHERE path_in_schema = '{escaped_geom_col}'
               AND geo_bbox IS NOT NULL
         """).fetchone()
 
@@ -1213,7 +1218,7 @@ def get_aggregated_native_geo_stats(parquet_file: str, geometry_column: str, con
         types_result = connection.execute(f"""
             SELECT DISTINCT unnest(geo_types) as geo_type
             FROM parquet_metadata('{safe_url}')
-            WHERE path_in_schema = '{geometry_column}'
+            WHERE path_in_schema = '{escaped_geom_col}'
               AND geo_types IS NOT NULL
         """).fetchall()
 
@@ -1255,6 +1260,7 @@ def get_per_row_group_native_geo_stats(
         if not geometry_column:
             geometry_column = find_primary_geometry_column_duckdb(parquet_file, con)
 
+        escaped_geom_col = _escape_sql_string(geometry_column)
         result = connection.execute(f"""
             SELECT
                 row_group_id,
@@ -1263,7 +1269,7 @@ def get_per_row_group_native_geo_stats(
                 geo_bbox.xmax as xmax,
                 geo_bbox.ymax as ymax
             FROM parquet_metadata('{safe_url}')
-            WHERE path_in_schema = '{geometry_column}'
+            WHERE path_in_schema = '{escaped_geom_col}'
               AND geo_bbox IS NOT NULL
               AND geo_bbox.xmin IS NOT NULL
             ORDER BY row_group_id

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -97,12 +97,38 @@ def quote_identifier(name: str) -> str:
     This handles column/table names with spaces, special characters, reserved words,
     or uppercase letters that need to be preserved.
 
+    The input must be a **bare** identifier, exactly as it appears in the file's
+    schema (e.g. from ``find_primary_geometry_column`` or ``table.column_names``).
+    The function is deliberately not idempotent: quoting an already-quoted name
+    yields an identifier that literally contains double quotes, so never pass it
+    something already quoted.
+
+    For a SQL *string literal* (e.g. ``WHERE path_in_schema = '...'``) use
+    :func:`_escape_sql_string` instead; the two escapes are not interchangeable.
+
     Args:
         name: The identifier (column name, table name, etc.) to quote
 
     Returns:
         A safely quoted identifier string
+
+    Raises:
+        ValueError: If the name is empty or contains a NUL byte. Both are legal
+            Parquet field names but have no quoted SQL spelling: ``""`` is a
+            zero-length delimited identifier and a NUL truncates the identifier
+            inside DuckDB's parser, so emitting either produces unparsable SQL
+            rather than an actionable error.
     """
+    if not name:
+        raise ValueError(
+            "cannot quote an empty SQL identifier: DuckDB rejects the "
+            'zero-length delimited identifier ""'
+        )
+    if "\x00" in name:
+        raise ValueError(
+            "cannot quote a SQL identifier containing a NUL byte: DuckDB's "
+            "parser truncates the identifier there"
+        )
     escaped = name.replace('"', '""')
     return f'"{escaped}"'
 
@@ -713,13 +739,10 @@ def _wrap_query_with_blob_conversion(query: str, geometry_column: str, con=None)
         except Exception:
             pass
 
-    # Quote column name to handle special characters
-    quoted_geom = geometry_column.replace('"', '""')
-
     # Cast to BLOB to produce plain binary without geoarrow extension type
     # Use SELECT * REPLACE to preserve column order
     return f"""
         WITH __arrow_source AS ({query})
-        SELECT * REPLACE (ST_AsWKB("{quoted_geom}")::BLOB AS "{quoted_geom}")
+        SELECT * REPLACE (ST_AsWKB({quote_identifier(geometry_column)})::BLOB AS {quote_identifier(geometry_column)})
         FROM __arrow_source
     """

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -23,10 +23,10 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.crs_utils import get_crs_display_name
 from geoparquet_io.core.duckdb_utils import (
-    DANGEROUS_SQL_KEYWORDS,  # noqa: F401 - re-exported for backwards compatibility
     _escape_sql_string,
     get_duckdb_connection,
     get_duckdb_connection_for_s3,
+    quote_identifier,
     validate_where_clause,
 )
 from geoparquet_io.core.exceptions import (
@@ -123,11 +123,9 @@ def _get_crs_from_file(input_parquet: str, geometry_col: str) -> dict | str | No
         parse_geometry_logical_type,
     )
 
-    safe_url = safe_file_url(input_parquet, verbose=False)
-
     # First try GeoParquet file-level metadata
     try:
-        geo_meta = get_geo_metadata(safe_url)
+        geo_meta = get_geo_metadata(input_parquet)
         if geo_meta:
             columns_meta = geo_meta.get("columns", {})
             if geometry_col in columns_meta:
@@ -140,7 +138,7 @@ def _get_crs_from_file(input_parquet: str, geometry_col: str) -> dict | str | No
 
     # Fall back to Parquet geo logical type (for GeoParquet 2.0 / parquet-geo)
     try:
-        schema_info = get_schema_info(safe_url)
+        schema_info = get_schema_info(input_parquet)
         for col in schema_info:
             name = col.get("name", "")
             if name != geometry_col:
@@ -168,10 +166,10 @@ def _get_data_bounds(input_parquet: str, geometry_col: str) -> tuple | None:
         safe_url = safe_file_url(input_parquet, verbose=False)
         result = con.execute(f"""
             SELECT
-                MIN(ST_XMin("{geometry_col}")) as xmin,
-                MIN(ST_YMin("{geometry_col}")) as ymin,
-                MAX(ST_XMax("{geometry_col}")) as xmax,
-                MAX(ST_YMax("{geometry_col}")) as ymax
+                MIN(ST_XMin({quote_identifier(geometry_col)})) as xmin,
+                MIN(ST_YMin({quote_identifier(geometry_col)})) as ymin,
+                MAX(ST_XMax({quote_identifier(geometry_col)})) as xmax,
+                MAX(ST_YMax({quote_identifier(geometry_col)})) as ymax
             FROM read_parquet('{safe_url}')
         """).fetchone()
         con.close()
@@ -542,12 +540,12 @@ def build_spatial_filter(
         if bbox_info.get("has_bbox_column"):
             bbox_col = bbox_info["bbox_column_name"]
             conditions.append(
-                f'("{bbox_col}".xmax >= {xmin} AND "{bbox_col}".xmin <= {xmax} '
-                f'AND "{bbox_col}".ymax >= {ymin} AND "{bbox_col}".ymin <= {ymax})'
+                f"({quote_identifier(bbox_col)}.xmax >= {xmin} AND {quote_identifier(bbox_col)}.xmin <= {xmax} "
+                f"AND {quote_identifier(bbox_col)}.ymax >= {ymin} AND {quote_identifier(bbox_col)}.ymin <= {ymax})"
             )
         else:
             conditions.append(
-                f'ST_Intersects("{geometry_col}", ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax}))'
+                f"ST_Intersects({quote_identifier(geometry_col)}, ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax}))"
             )
 
     if geometry_wkt:
@@ -569,7 +567,7 @@ def build_extract_query(
     """Build the complete extraction query."""
     from geoparquet_io.core.partition.reader import build_read_parquet_expr
 
-    col_list = ", ".join(f'"{c}"' for c in columns)
+    col_list = ", ".join(quote_identifier(c) for c in columns)
     # Use partition reader to build read_parquet expression with proper options
     read_expr = build_read_parquet_expr(
         input_path,
@@ -602,7 +600,7 @@ def _build_query_for_source(
     limit: int | None = None,
 ) -> str:
     """Build extraction query for a DuckDB source reference (table or read_parquet)."""
-    col_list = ", ".join(f'"{c}"' for c in columns)
+    col_list = ", ".join(quote_identifier(c) for c in columns)
     query = f"SELECT {col_list} FROM {source_ref}"
 
     conditions = []
@@ -659,8 +657,10 @@ def _setup_geometry_view(
         return "__input_table", False
 
     # Create view with geometry conversion (quote column names for special chars)
-    other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-    col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+    other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+    col_defs = other_cols + [
+        f"ST_GeomFromWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)}"
+    ]
     view_query = f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
     con.execute(view_query)
     return "__input_view", True
@@ -676,7 +676,9 @@ def _build_query_with_wkb_conversion(
 ) -> str:
     """Build query with WKB conversion for geometry column."""
     cols_with_wkb = [
-        f'ST_AsWKB("{geom_col}") AS "{geom_col}"' if c == geom_col else f'"{c}"'
+        f"ST_AsWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)}"
+        if c == geom_col
+        else quote_identifier(c)
         for c in selected_columns
     ]
     col_list = ", ".join(cols_with_wkb)

--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -14,7 +14,7 @@ import duckdb
 import pyarrow as pa
 
 from geoparquet_io.core.common import write_geoparquet_table
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.extract import parse_bbox
 from geoparquet_io.core.file_utils import handle_output_overwrite
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
@@ -503,12 +503,12 @@ def _build_geometry_select_expr(
         SQL expression string for the SELECT clause
     """
     if "GEOMETRY" in column_type:
-        return f'ST_AsWKB("{column_name}") AS "{column_name}"'
+        return f"ST_AsWKB({quote_identifier(column_name)}) AS {quote_identifier(column_name)}"
     elif geometry_format == "geojson":
-        return f'ST_AsWKB(ST_GeomFromGeoJSON("{column_name}")) AS "{column_name}"'
+        return f"ST_AsWKB(ST_GeomFromGeoJSON({quote_identifier(column_name)})) AS {quote_identifier(column_name)}"
     else:
         # Default: WKT
-        return f'ST_AsWKB(ST_GeomFromText("{column_name}")) AS "{column_name}"'
+        return f"ST_AsWKB(ST_GeomFromText({quote_identifier(column_name)})) AS {quote_identifier(column_name)}"
 
 
 def _build_select_with_wkb(
@@ -554,7 +554,7 @@ def _build_select_with_wkb(
         if geometry_column and col.lower() == geometry_column.lower():
             select_parts.append(_build_geometry_select_expr(col, geom_col_type, geometry_format))
         else:
-            select_parts.append(f'"{col}"')
+            select_parts.append(quote_identifier(col))
 
     return ", ".join(select_parts), columns
 
@@ -570,7 +570,7 @@ def _handle_dry_run(
 ) -> None:
     """Handle dry_run mode by printing the SQL query without executing."""
     if include_list:
-        select_cols = ", ".join(f'"{c}"' for c in include_list)
+        select_cols = ", ".join(quote_identifier(c) for c in include_list)
     else:
         select_cols = "*"
 

--- a/geoparquet_io/core/file_utils.py
+++ b/geoparquet_io/core/file_utils.py
@@ -181,19 +181,21 @@ def handle_output_overwrite(
     output_file.unlink()
 
 
-def safe_file_url(file_path, verbose=False):
+def resolve_file_url(file_path, verbose=False):
     """
-    Prepare a file path for safe use in SQL queries.
+    Validate a path and resolve it to the URL readers should open.
 
-    Handles URL encoding for HTTP(S) URLs and escapes single quotes
-    to prevent SQL injection when paths are interpolated into queries.
+    Percent-encodes HTTP(S) URLs and checks that a local path exists, but does
+    **not** escape it for SQL -- use this for anything that opens the file
+    directly (fsspec, pyarrow, metadata helpers). :func:`safe_file_url` is the
+    SQL-facing variant, and it is the single point at which a path is escaped.
 
     Args:
         file_path: Local path or remote URL
         verbose: Whether to log debug info
 
     Returns:
-        str: Safe file path/URL with single quotes escaped for SQL
+        str: Resolved, unescaped file path/URL
     """
     from geoparquet_io.core.remote import is_remote_url
 
@@ -202,18 +204,40 @@ def safe_file_url(file_path, verbose=False):
             parsed = urllib.parse.urlparse(file_path)
             duckdb_safe_chars = "/*?[]=,"
             encoded_path = urllib.parse.quote(parsed.path, safe=duckdb_safe_chars)
-            safe_url = parsed._replace(path=encoded_path).geturl()
+            resolved = parsed._replace(path=encoded_path).geturl()
         else:
-            safe_url = file_path
+            resolved = file_path
 
         if verbose:
             protocol = file_path.split("://")[0].upper() if "://" in file_path else "HTTP"
-            debug(f"Reading from {protocol}: {safe_url}")
-        return _escape_sql_string(safe_url)
-    else:
-        if not has_glob_pattern(file_path) and not os.path.exists(file_path):
-            raise FileNotFoundGeoParquetError(file_path)
-        return _escape_sql_string(file_path)
+            debug(f"Reading from {protocol}: {resolved}")
+        return resolved
+
+    if not has_glob_pattern(file_path) and not os.path.exists(file_path):
+        raise FileNotFoundGeoParquetError(file_path)
+    return file_path
+
+
+def safe_file_url(file_path, verbose=False):
+    """
+    Prepare a file path for safe use in SQL queries.
+
+    Handles URL encoding for HTTP(S) URLs and escapes single quotes
+    to prevent SQL injection when paths are interpolated into queries.
+
+    Escaping is **not** idempotent: the result is only ever interpolated into
+    SQL, never re-escaped and never handed back to a filesystem API. Pass the
+    raw path to helpers that escape their own arguments (everything in
+    ``duckdb_metadata``), and use :func:`resolve_file_url` for direct reads.
+
+    Args:
+        file_path: Local path or remote URL
+        verbose: Whether to log debug info
+
+    Returns:
+        str: Safe file path/URL with single quotes escaped for SQL
+    """
+    return _escape_sql_string(resolve_file_url(file_path, verbose))
 
 
 def _get_file_cache_key(parquet_file: str) -> tuple[str, float]:

--- a/geoparquet_io/core/format_writers.py
+++ b/geoparquet_io/core/format_writers.py
@@ -16,12 +16,16 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.crs_utils import extract_crs_from_parquet, is_default_crs
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    get_duckdb_connection,
+    quote_identifier,
+)
 from geoparquet_io.core.exceptions import (
     GeoParquetError,
     InvalidParameterError,
 )
-from geoparquet_io.core.file_utils import safe_file_url, validate_output_path
+from geoparquet_io.core.file_utils import resolve_file_url, safe_file_url, validate_output_path
 from geoparquet_io.core.geometry_detection import detect_parquet_geometry_column
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success, warn
 from geoparquet_io.core.remote import (
@@ -173,7 +177,8 @@ def write_gdal_format(
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_path))
 
     try:
-        input_url = safe_file_url(input_path, verbose)
+        # Raw (validated) URL for direct reads; SQL-escaped only where interpolated.
+        input_url = resolve_file_url(input_path, verbose)
 
         # Extract CRS for SRS parameter
         srs_param = _get_srs_parameter(input_path, verbose)
@@ -200,7 +205,7 @@ def write_gdal_format(
         # Execute write with SQL-escaped paths
         # Note: DuckDB's COPY statement doesn't support parameterized paths,
         # so we use SQL standard escaping (double single quotes)
-        safe_input_url = _escape_sql_string(input_url)
+        safe_input_url = safe_file_url(input_path, verbose=False)
         safe_output_path = _escape_sql_string(output_path)
 
         # GDAL formats don't support complex types (STRUCT, LIST, MAP), so select only compatible columns
@@ -238,7 +243,7 @@ def write_gdal_format(
                 or pa.types.is_list(field.type)
                 or pa.types.is_map(field.type)
             ):
-                compatible_cols.append(f'"{field.name}"')
+                compatible_cols.append(quote_identifier(field.name))
 
         if not compatible_cols:
             raise GeoParquetError(ERROR_NO_COMPATIBLE_COLUMNS.format(format=config["description"]))
@@ -321,7 +326,7 @@ def write_csv(
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_path))
 
     try:
-        input_url = safe_file_url(input_path, verbose)
+        input_url = resolve_file_url(input_path, verbose)
 
         # Read parquet to inspect schema
         # Use fsspec to support remote URLs (HTTP/HTTPS)
@@ -343,10 +348,10 @@ def write_csv(
         for col in columns:
             if geom_col and col == geom_col:
                 if include_wkt:
-                    select_cols.append(f'ST_AsText("{col}") as wkt')
+                    select_cols.append(f"ST_AsText({quote_identifier(col)}) as wkt")
             elif col == "bbox":
                 if include_bbox:
-                    select_cols.append(f'to_json("{col}") as bbox')
+                    select_cols.append(f"to_json({quote_identifier(col)}) as bbox")
             else:
                 # Check if column is complex type, JSON-encode if needed
                 field = schema.field(col)
@@ -355,9 +360,11 @@ def write_csv(
                     or pa.types.is_list(field.type)
                     or pa.types.is_map(field.type)
                 ):
-                    select_cols.append(f'to_json("{col}") as "{col}"')
+                    select_cols.append(
+                        f"to_json({quote_identifier(col)}) as {quote_identifier(col)}"
+                    )
                 else:
-                    select_cols.append(f'"{col}"')
+                    select_cols.append(quote_identifier(col))
 
         if not select_cols:
             raise GeoParquetError("No columns to export after filtering geometry.")
@@ -365,7 +372,7 @@ def write_csv(
         # Write to CSV with SQL-escaped paths
         # Note: DuckDB's COPY statement doesn't support parameterized paths,
         # so we use SQL standard escaping (double single quotes)
-        safe_input_url = _escape_sql_string(input_url)
+        safe_input_url = safe_file_url(input_path, verbose=False)
         safe_output_path = _escape_sql_string(output_path)
 
         query = f"""
@@ -448,7 +455,7 @@ def write_geojson(
     setup_aws_profile_if_needed(profile, input_path)
 
     # Check if input has geometry column using GeoParquet metadata first
-    input_url = safe_file_url(input_path, verbose)
+    input_url = resolve_file_url(input_path, verbose)
     has_geometry = detect_parquet_geometry_column(input_url, verbose=verbose) is not None
 
     if not has_geometry:

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -23,7 +23,11 @@ from typing import TYPE_CHECKING
 
 import duckdb
 
-from geoparquet_io.core.duckdb_utils import _geoarrow_coord_exprs, _get_query_column_type
+from geoparquet_io.core.duckdb_utils import (
+    _geoarrow_coord_exprs,
+    _get_query_column_type,
+    quote_identifier,
+)
 from geoparquet_io.core.logging_config import debug, warn
 
 if TYPE_CHECKING:
@@ -471,9 +475,7 @@ def compute_bbox_via_sql(
         # If we can't determine schema, return None rather than failing
         return None
 
-    # Escape column name for SQL (double any embedded quotes)
-    escaped_col = geometry_column.replace('"', '""')
-    quoted_geom = f'"{escaped_col}"'
+    quoted_geom = quote_identifier(geometry_column)
 
     # GeoArrow native types (STRUCT(x DOUBLE, y DOUBLE)[N]) cannot be passed to
     # ST_XMin directly. Detect at runtime and use UNNEST to extract coordinates.
@@ -497,10 +499,10 @@ def compute_bbox_via_sql(
     else:
         bbox_query = f"""
             SELECT
-                MIN(ST_XMin("{escaped_col}")) as xmin,
-                MIN(ST_YMin("{escaped_col}")) as ymin,
-                MAX(ST_XMax("{escaped_col}")) as xmax,
-                MAX(ST_YMax("{escaped_col}")) as ymax
+                MIN(ST_XMin({quoted_geom})) as xmin,
+                MIN(ST_YMin({quoted_geom})) as ymin,
+                MAX(ST_XMax({quoted_geom})) as xmax,
+                MAX(ST_YMax({quoted_geom})) as ymax
             FROM ({query})
         """
     result = con.execute(bbox_query).fetchone()

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -594,7 +594,7 @@ def compute_geo_stats_via_sql(
     if _geo_stats_unsupported(con, query, geometry_column):
         return _separately()
 
-    quoted = '"{}"'.format(geometry_column.replace('"', '""'))
+    quoted = quote_identifier(geometry_column)
     stats_query = f"""
         SELECT
             ST_GeometryType({quoted}) || {zm_suffix_sql(quoted)} AS geom_type,

--- a/geoparquet_io/core/geometry_detection.py
+++ b/geoparquet_io/core/geometry_detection.py
@@ -36,7 +36,7 @@ def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> 
     safe_url = safe_file_url(parquet_file, verbose=False)
 
     # 1. Check GeoParquet metadata first
-    geo_meta = get_geo_metadata(safe_url)
+    geo_meta = get_geo_metadata(parquet_file)
     if geo_meta and isinstance(geo_meta, dict):
         primary = geo_meta.get("primary_column")
         if primary:
@@ -121,10 +121,8 @@ def find_primary_geometry_column(parquet_file: str, verbose: bool = False) -> st
         str: Name of the primary geometry column (defaults to 'geometry')
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
-    from geoparquet_io.core.file_utils import safe_file_url
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-    geo_meta = get_geo_metadata(safe_url)
+    geo_meta = get_geo_metadata(parquet_file)
 
     if verbose and geo_meta:
         debug(f"Geo metadata: {_summarize_geo_metadata(geo_meta)}")

--- a/geoparquet_io/core/geometry_repair.py
+++ b/geoparquet_io/core/geometry_repair.py
@@ -19,6 +19,7 @@ This module provides three injection styles:
   memory (WFS, ArcGIS, BigQuery, Carto).
 """
 
+from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.logging_config import warn
 
 
@@ -95,8 +96,7 @@ def repair_query_geometry(con, query: str, geometry_column: str, *, repair: bool
     Returns:
         The original query, or a query that repairs the geometry column in place.
     """
-    g = geometry_column.replace('"', '""')
-    col = f'"{g}"'
+    col = quote_identifier(geometry_column)
     try:
         desc = con.execute(f"DESCRIBE ({query})").fetchall()
     except Exception:
@@ -166,8 +166,7 @@ def repair_arrow_table_geometry(table, geometry_column: str = "geometry", *, rep
 
     from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 
-    g = geometry_column.replace('"', '""')
-    col = f'"{g}"'
+    col = quote_identifier(geometry_column)
     # Decode WKB defensively: TRY() yields NULL on malformed bytes so a bad row
     # never crashes extraction — such rows pass through unchanged.
     parsed = f"TRY(ST_GeomFromWKB({col}))"

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -468,7 +468,7 @@ def _hilbert_order_file_based(
     # Count empty/null geometries
     empty_count_result = con.execute(f"""
         SELECT COUNT(*) FROM '{safe_url}'
-        WHERE "{geometry_column}" IS NULL OR ST_IsEmpty("{geometry_column}")
+        WHERE {quote_identifier(geometry_column)} IS NULL OR ST_IsEmpty({quote_identifier(geometry_column)})
     """).fetchone()
     empty_count = empty_count_result[0] if empty_count_result else 0
 
@@ -516,13 +516,13 @@ def _hilbert_order_file_based(
     order_query = f"""
         WITH non_empty AS (
             SELECT * FROM '{safe_url}'
-            WHERE "{geometry_column}" IS NOT NULL AND NOT ST_IsEmpty("{geometry_column}")
-            ORDER BY ST_Hilbert("{geometry_column}",
+            WHERE {quote_identifier(geometry_column)} IS NOT NULL AND NOT ST_IsEmpty({quote_identifier(geometry_column)})
+            ORDER BY ST_Hilbert({quote_identifier(geometry_column)},
                 ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
         ),
         empty_or_null AS (
             SELECT * FROM '{safe_url}'
-            WHERE "{geometry_column}" IS NULL OR ST_IsEmpty("{geometry_column}")
+            WHERE {quote_identifier(geometry_column)} IS NULL OR ST_IsEmpty({quote_identifier(geometry_column)})
         )
         SELECT * FROM non_empty
         UNION ALL

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -17,7 +17,7 @@ from rich.text import Text
 
 from geoparquet_io.core.common import format_size
 from geoparquet_io.core.crs_utils import _extract_crs_identifier, is_default_crs
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.metadata_utils import (
     extract_bbox_from_row_group_stats,
@@ -646,13 +646,12 @@ def get_preview_data(
         # Build column list, converting serialized geometry columns to WKT in SQL
         column_expressions = []
         for col in all_columns:
-            # Escape double quotes in column names for SQL identifiers
-            escaped_col = col.replace('"', '""')
+            quoted_col = quote_identifier(col)
             if col in geo_columns and col not in native_geo_columns:
                 # Convert serialized geometry to WKT for display
-                column_expressions.append(f'ST_AsText("{escaped_col}") AS "{escaped_col}"')
+                column_expressions.append(f"ST_AsText({quoted_col}) AS {quoted_col}")
             else:
-                column_expressions.append(f'"{escaped_col}"')
+                column_expressions.append(quoted_col)
 
         select_clause = ", ".join(column_expressions)
 
@@ -759,7 +758,7 @@ def get_column_statistics(
                 # For geometry columns, only count nulls
                 query = f"""
                     SELECT
-                        COUNT(*) FILTER (WHERE "{col_name}" IS NULL) as null_count
+                        COUNT(*) FILTER (WHERE {quote_identifier(col_name)} IS NULL) as null_count
                     FROM '{safe_url}'
                 """
                 result = con.execute(query).fetchone()
@@ -773,10 +772,10 @@ def get_column_statistics(
                 # For non-geometry columns, get full stats
                 query = f"""
                     SELECT
-                        COUNT(*) FILTER (WHERE "{col_name}" IS NULL) as null_count,
-                        MIN("{col_name}") as min_val,
-                        MAX("{col_name}") as max_val,
-                        APPROX_COUNT_DISTINCT("{col_name}") as unique_count
+                        COUNT(*) FILTER (WHERE {quote_identifier(col_name)} IS NULL) as null_count,
+                        MIN({quote_identifier(col_name)}) as min_val,
+                        MAX({quote_identifier(col_name)}) as max_val,
+                        APPROX_COUNT_DISTINCT({quote_identifier(col_name)}) as unique_count
                     FROM '{safe_url}'
                 """
                 try:

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -13,7 +13,6 @@ from rich.table import Table
 from rich.text import Text
 
 from geoparquet_io.core.common import format_size
-from geoparquet_io.core.file_utils import safe_file_url
 
 
 def _check_parquet_schema_string(field_name, parquet_schema_str):
@@ -412,11 +411,9 @@ def has_parquet_geo_row_group_stats(parquet_file: str, geometry_column: str | No
         "sample_bbox": None,
     }
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
     # Auto-detect geometry column if not specified
     if not geometry_column:
-        geo_columns = detect_geometry_columns(safe_url)
+        geo_columns = detect_geometry_columns(parquet_file)
         if geo_columns:
             geometry_column = next(iter(geo_columns.keys()))
 
@@ -424,13 +421,13 @@ def has_parquet_geo_row_group_stats(parquet_file: str, geometry_column: str | No
         return result
 
     # Check for bbox column using DuckDB
-    has_bbox, bbox_col_name = has_bbox_column(safe_url)
+    has_bbox, bbox_col_name = has_bbox_column(parquet_file)
 
     if not has_bbox or not bbox_col_name:
         return result
 
     # Get row group stats for first row group
-    rg_stats = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
+    rg_stats = get_per_row_group_bbox_stats(parquet_file, bbox_col_name)
 
     if rg_stats and len(rg_stats) > 0:
         first_rg = rg_stats[0]
@@ -468,16 +465,14 @@ def extract_bbox_from_row_group_stats(
         has_bbox_column,
     )
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
     # Check for bbox column using DuckDB
-    has_bbox, bbox_col_name = has_bbox_column(safe_url)
+    has_bbox, bbox_col_name = has_bbox_column(parquet_file)
 
     if not has_bbox or not bbox_col_name:
         return None
 
     # Get overall bbox from row group stats using DuckDB
-    return get_bbox_from_row_group_stats(safe_url, bbox_col_name)
+    return get_bbox_from_row_group_stats(parquet_file, bbox_col_name)
 
 
 def _build_row_group_json(rg_id: int, cols_in_rg: list, geo_columns: dict) -> dict:
@@ -731,13 +726,11 @@ def format_parquet_metadata_enhanced(
         get_schema_info,
     )
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
-    file_meta = get_file_metadata(safe_url)
-    schema_info = get_schema_info(safe_url)
-    row_group_meta = get_row_group_metadata(safe_url)
-    geo_columns = detect_geometry_columns(safe_url)
-    bloom_filter_info = get_bloom_filter_info(safe_url)
+    file_meta = get_file_metadata(parquet_file)
+    schema_info = get_schema_info(parquet_file)
+    row_group_meta = get_row_group_metadata(parquet_file)
+    geo_columns = detect_geometry_columns(parquet_file)
+    bloom_filter_info = get_bloom_filter_info(parquet_file)
 
     num_columns = len([c for c in schema_info if c.get("name") and "." not in c.get("name", "")])
     schema_str = ", ".join(
@@ -925,20 +918,18 @@ def format_parquet_geo_metadata(
         has_bbox_column,
     )
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
-    file_meta = get_file_metadata(safe_url)
-    schema_info = get_schema_info(safe_url)
+    file_meta = get_file_metadata(parquet_file)
+    schema_info = get_schema_info(parquet_file)
     num_row_groups = file_meta.get("num_row_groups", 0)
 
-    geo_columns = detect_geometry_columns(safe_url)
-    has_bbox, bbox_col_name = has_bbox_column(safe_url)
+    geo_columns = detect_geometry_columns(parquet_file)
+    has_bbox, bbox_col_name = has_bbox_column(parquet_file)
 
     geo_columns_info = _build_geo_columns_info(schema_info, geo_columns)
 
     # Add row group stats: try bbox column first, then native geo_bbox
     if has_bbox and bbox_col_name:
-        rg_bbox_stats = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
+        rg_bbox_stats = get_per_row_group_bbox_stats(parquet_file, bbox_col_name)
         for col_name in geo_columns_info:
             for rg_stat in rg_bbox_stats:
                 geo_columns_info[col_name]["row_group_stats"].append(
@@ -952,7 +943,9 @@ def format_parquet_geo_metadata(
                 )
     else:
         for col_name in geo_columns_info:
-            native_stats = get_per_row_group_native_geo_stats(safe_url, geometry_column=col_name)
+            native_stats = get_per_row_group_native_geo_stats(
+                parquet_file, geometry_column=col_name
+            )
             if native_stats:
                 for rg_stat in native_stats:
                     geo_columns_info[col_name]["row_group_stats"].append(
@@ -992,8 +985,7 @@ def format_geoparquet_metadata(parquet_file: str, json_output: bool) -> None:
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-    geo_meta = get_geo_metadata(safe_url)
+    geo_meta = get_geo_metadata(parquet_file)
 
     if not geo_meta:
         if json_output:
@@ -1150,11 +1142,9 @@ def format_all_metadata(
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
     if json_output:
         # For JSON, combine all metadata into one object
-        geo_meta = get_geo_metadata(safe_url)
+        geo_meta = get_geo_metadata(parquet_file)
         primary_col = geo_meta.get("primary_column") if geo_meta else None
 
         # We need to manually construct the combined JSON output
@@ -1167,7 +1157,7 @@ def format_all_metadata(
         print(json.dumps(output, indent=2))
     else:
         # Terminal output - show all three sections
-        geo_meta = get_geo_metadata(safe_url)
+        geo_meta = get_geo_metadata(parquet_file)
         primary_col = geo_meta.get("primary_column") if geo_meta else None
 
         # Section 1: Parquet File Metadata
@@ -1204,16 +1194,14 @@ def format_row_group_geo_stats(
         has_bbox_column,
     )
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
-
     # Try native geo stats first (GeoParquet 2.0 / parquet-geo-only)
-    rg_stats = get_per_row_group_native_geo_stats(safe_url)
+    rg_stats = get_per_row_group_native_geo_stats(parquet_file)
 
     # Fall back to bbox column if no native stats
     if not rg_stats:
-        has_bbox, bbox_col_name = has_bbox_column(safe_url)
+        has_bbox, bbox_col_name = has_bbox_column(parquet_file)
         if has_bbox and bbox_col_name:
-            rg_stats = get_per_row_group_bbox_stats(safe_url, bbox_col_name)
+            rg_stats = get_per_row_group_bbox_stats(parquet_file, bbox_col_name)
 
     if not rg_stats:
         if json_output:
@@ -1229,8 +1217,8 @@ def format_row_group_geo_stats(
             console.print()
         return
 
-    file_meta = get_file_metadata(safe_url)
-    num_rows_per_rg = _get_num_rows_per_row_group(safe_url, file_meta)
+    file_meta = get_file_metadata(parquet_file)
+    num_rows_per_rg = _get_num_rows_per_row_group(parquet_file, file_meta)
 
     # Merge num_rows into stats
     stats_with_rows = _merge_row_counts(rg_stats, num_rows_per_rg)
@@ -1245,18 +1233,20 @@ def format_row_group_geo_stats(
         _format_geo_stats_terminal(stats_with_rows, total_row_groups)
 
 
-def _get_num_rows_per_row_group(safe_url: str, file_meta: dict) -> dict[int, int]:
+def _get_num_rows_per_row_group(parquet_file: str, file_meta: dict) -> dict[int, int]:
     """Get num_rows per row group from file metadata.
+
+    Takes a RAW path: ``_safe_url`` is the single SQL-escaping point.
 
     Returns a mapping of row_group_id to row count.
     """
     from geoparquet_io.core.duckdb_metadata import _get_connection_for_file, _safe_url
 
-    connection, should_close = _get_connection_for_file(safe_url)
+    connection, should_close = _get_connection_for_file(parquet_file)
     try:
         result = connection.execute(f"""
             SELECT row_group_id, row_group_num_rows
-            FROM parquet_metadata('{_safe_url(safe_url)}')
+            FROM parquet_metadata('{_safe_url(parquet_file)}')
             GROUP BY row_group_id, row_group_num_rows
             ORDER BY row_group_id
         """).fetchall()

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -73,7 +73,7 @@ def _build_enrichment_query(
         if "[" in col or "(" in col:
             subquery_cols.append(f"{col} as _col_{i}")
         else:
-            subquery_cols.append(f'"{col}"')
+            subquery_cols.append(quote_identifier(col))
     subquery_cols_str = ", ".join(subquery_cols)
 
     input_ref = input_url if input_is_table_ref else f"'{input_url}'"
@@ -92,7 +92,7 @@ def _build_enrichment_query(
         # join runs in one CRS and keeps the cheap bbox pre-filter — instead of
         # transforming the (large) input per row and degrading to a nested-loop
         # ST_Intersects (#525, preserving the #460 pre-filter).
-        radmin = reproject_to_source_sql(f'"{admin_geom_col}"', source_crs)
+        radmin = reproject_to_source_sql(quote_identifier(admin_geom_col), source_crs)
         bbox_struct = (
             f"struct_pack(xmin := ST_XMin({radmin}), xmax := ST_XMax({radmin}), "
             f"ymin := ST_YMin({radmin}), ymax := ST_YMax({radmin})) AS {admin_bbox_col}"
@@ -307,9 +307,9 @@ def _build_admin_select_for_partitioning(levels, boundary_columns, dataset=None,
         elif "[" in col or "(" in col:
             expr = f"b._col_{i}"
         else:
-            expr = f'b."{col}"'
+            expr = f"b.{quote_identifier(col)}"
 
-        admin_select_parts.append(f'{expr} as "{output_col}"')
+        admin_select_parts.append(f"{expr} as {quote_identifier(output_col)}")
 
     return ", ".join(admin_select_parts), output_column_names
 
@@ -444,8 +444,12 @@ def _verify_enrichment_results(con, enriched_table, output_column_names):
     partition by the all-levels-NOT-NULL filter, so they would otherwise vanish
     silently (#480).
     """
-    any_clause = " OR ".join([f'"{col}" IS NOT NULL' for col in output_column_names])
-    all_clause = " AND ".join([f'"{col}" IS NOT NULL' for col in output_column_names])
+    any_clause = " OR ".join(
+        [f"{quote_identifier(col)} IS NOT NULL" for col in output_column_names]
+    )
+    all_clause = " AND ".join(
+        [f"{quote_identifier(col)} IS NOT NULL" for col in output_column_names]
+    )
     stats_query = f"""
         SELECT
             COUNT(*) as total,
@@ -844,9 +848,12 @@ def partition_by_admin_hierarchical(
 
 def _get_preview_partitions(con, table_name, partition_columns, level_names):
     """Query partition statistics for preview."""
-    group_by_cols = ", ".join([f'"{col}"' for col in partition_columns])
+    group_by_cols = ", ".join([quote_identifier(col) for col in partition_columns])
     select_cols = ", ".join(
-        [f'"{col}" as {name}' for col, name in zip(partition_columns, level_names, strict=True)]
+        [
+            f"{quote_identifier(col)} as {name}"
+            for col, name in zip(partition_columns, level_names, strict=True)
+        ]
     )
 
     query = f"""
@@ -854,7 +861,7 @@ def _get_preview_partitions(con, table_name, partition_columns, level_names):
             {select_cols},
             COUNT(*) as record_count
         FROM {table_name}
-        WHERE {" AND ".join([f'"{col}" IS NOT NULL' for col in partition_columns])}
+        WHERE {" AND ".join([f"{quote_identifier(col)} IS NOT NULL" for col in partition_columns])}
         GROUP BY {group_by_cols}
         ORDER BY record_count DESC
     """

--- a/geoparquet_io/core/partition/by_a5.py
+++ b/geoparquet_io/core/partition/by_a5.py
@@ -9,7 +9,6 @@ import uuid
 from geoparquet_io.core.add.a5 import add_a5_column
 from geoparquet_io.core.constants import DEFAULT_A5_COLUMN_NAME
 from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,
@@ -35,8 +34,7 @@ def _ensure_a5_column(input_parquet, a5_column_name, resolution, verbose):
     """
     from geoparquet_io.core.duckdb_metadata import get_column_names
 
-    safe_url = safe_file_url(input_parquet, verbose)
-    column_names = get_column_names(safe_url)
+    column_names = get_column_names(input_parquet)
 
     if a5_column_name in column_names:
         if verbose:

--- a/geoparquet_io/core/partition/by_h3.py
+++ b/geoparquet_io/core/partition/by_h3.py
@@ -9,7 +9,6 @@ import uuid
 from geoparquet_io.core.add.h3 import add_h3_column
 from geoparquet_io.core.constants import DEFAULT_H3_COLUMN_NAME
 from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,
@@ -35,8 +34,7 @@ def _ensure_h3_column(input_parquet, h3_column_name, resolution, verbose):
     """
     from geoparquet_io.core.duckdb_metadata import get_column_names
 
-    safe_url = safe_file_url(input_parquet, verbose)
-    column_names = get_column_names(safe_url)
+    column_names = get_column_names(input_parquet)
 
     if h3_column_name in column_names:
         if verbose:

--- a/geoparquet_io/core/partition/by_kdtree.py
+++ b/geoparquet_io/core/partition/by_kdtree.py
@@ -8,7 +8,6 @@ import uuid
 
 from geoparquet_io.core.add.kdtree import add_kdtree_column
 from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,
@@ -186,13 +185,11 @@ def partition_by_kdtree(
         actual_input = stdin_temp_file
 
     try:
-        safe_url = safe_file_url(actual_input, verbose)
-
         # Check if KD-tree column exists and get row count for dataset size validation
         from geoparquet_io.core.duckdb_metadata import get_column_names, get_row_count
 
-        column_names = get_column_names(safe_url)
-        total_rows = get_row_count(safe_url)
+        column_names = get_column_names(actual_input)
+        total_rows = get_row_count(actual_input)
 
         column_exists = kdtree_column_name in column_names
 

--- a/geoparquet_io/core/partition/by_quadkey.py
+++ b/geoparquet_io/core/partition/by_quadkey.py
@@ -11,7 +11,6 @@ from geoparquet_io.core.constants import (
     DEFAULT_QUADKEY_COLUMN_NAME,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,
@@ -55,8 +54,7 @@ def _ensure_quadkey_column(
     """
     from geoparquet_io.core.duckdb_metadata import get_column_names
 
-    safe_url = safe_file_url(input_parquet, verbose)
-    column_names = get_column_names(safe_url)
+    column_names = get_column_names(input_parquet)
 
     if quadkey_column_name in column_names:
         if verbose:

--- a/geoparquet_io/core/partition/by_s2.py
+++ b/geoparquet_io/core/partition/by_s2.py
@@ -19,7 +19,6 @@ from geoparquet_io.core.constants import (
     DEFAULT_S2_COMPRESSION_LEVEL,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,
@@ -45,8 +44,7 @@ def _ensure_s2_column(input_parquet, s2_column_name, level, verbose):
     """
     from geoparquet_io.core.duckdb_metadata import get_column_names
 
-    safe_url = safe_file_url(input_parquet, verbose)
-    column_names = get_column_names(safe_url)
+    column_names = get_column_names(input_parquet)
 
     if s2_column_name in column_names:
         if verbose:

--- a/geoparquet_io/core/partition/by_string.py
+++ b/geoparquet_io/core/partition/by_string.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success, warn
 from geoparquet_io.core.partition.common import partition_by_column, preview_partition
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
@@ -23,8 +22,7 @@ def validate_column_exists(parquet_file: str, column_name: str, verbose: bool = 
     """
     from geoparquet_io.core.duckdb_metadata import get_column_names, get_schema_info
 
-    safe_url = safe_file_url(parquet_file, verbose)
-    column_names = get_column_names(safe_url)
+    column_names = get_column_names(parquet_file)
 
     if column_name not in column_names:
         available_columns = ", ".join(column_names)
@@ -34,7 +32,7 @@ def validate_column_exists(parquet_file: str, column_name: str, verbose: bool = 
         )
 
     if verbose:
-        schema_info = get_schema_info(safe_url)
+        schema_info = get_schema_info(parquet_file)
         for col in schema_info:
             if col.get("name") == column_name:
                 column_type = col.get("type", "unknown")

--- a/geoparquet_io/core/partition/common.py
+++ b/geoparquet_io/core/partition/common.py
@@ -235,9 +235,9 @@ def analyze_partition_strategy(
 
     # Build the column expression for partitioning
     if column_prefix_length is not None:
-        column_expr = f'LEFT("{column_name}", {column_prefix_length})'
+        column_expr = f"LEFT({quote_identifier(column_name)}, {column_prefix_length})"
     else:
-        column_expr = f'"{column_name}"'
+        column_expr = quote_identifier(column_name)
 
     if verbose:
         debug("\n📊 Analyzing partition strategy...")
@@ -249,7 +249,7 @@ def analyze_partition_strategy(
                 {column_expr} as partition_value,
                 COUNT(*) as row_count
             FROM '{input_url}'
-            WHERE "{column_name}" IS NOT NULL
+            WHERE {quote_identifier(column_name)} IS NOT NULL
             GROUP BY partition_value
         )
         SELECT
@@ -519,10 +519,10 @@ def preview_partition(
 
     # Build the column expression for partitioning
     if column_prefix_length is not None:
-        column_expr = f'LEFT("{column_name}", {column_prefix_length})'
+        column_expr = f"LEFT({quote_identifier(column_name)}, {column_prefix_length})"
         partition_description = f"first {column_prefix_length} character(s) of '{column_name}'"
     else:
-        column_expr = f'"{column_name}"'
+        column_expr = quote_identifier(column_name)
         partition_description = f"'{column_name}'"
 
     # Get partition counts
@@ -531,7 +531,7 @@ def preview_partition(
             {column_expr} as partition_value,
             COUNT(*) as record_count
         FROM '{input_url}'
-        WHERE "{column_name}" IS NOT NULL
+        WHERE {quote_identifier(column_name)} IS NOT NULL
         GROUP BY partition_value
         ORDER BY record_count DESC
     """
@@ -604,10 +604,10 @@ def _run_partition_analysis(
 def _build_column_expression(column_name, column_prefix_length):
     """Build column expression for partitioning."""
     if column_prefix_length is not None:
-        column_expr = f'LEFT("{column_name}", {column_prefix_length})'
+        column_expr = f"LEFT({quote_identifier(column_name)}, {column_prefix_length})"
         partition_description = f"first {column_prefix_length} characters of {column_name}"
     else:
-        column_expr = f'"{column_name}"'
+        column_expr = quote_identifier(column_name)
         partition_description = column_name
     return column_expr, partition_description
 

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -394,7 +394,7 @@ def build_breakdown_select(
             cond = f"{qcol} IS NULL"
         else:
             cond = f"{qcol} = {sql_literal(value)}"
-        parts.append(f'COUNT(*) FILTER (WHERE {cond}) AS "{colname}"')
+        parts.append(f"COUNT(*) FILTER (WHERE {cond}) AS {quote_identifier(colname)}")
 
     if has_other:
         kept_non_null = [v for v, _ in value_colmap if v is not None]

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -28,7 +28,7 @@ from geoparquet_io.core.crs_utils import (
     parse_crs_string_to_projjson,
     resolve_crs_to_string,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geo_metadata import strip_derived_stats
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -188,8 +188,10 @@ def reproject_table(
         source_table = "__input_table"
         if geom_is_blob:
             # Quote all column names to handle special characters (colons, spaces, etc.)
-            other_cols = [f'"{c}"' for c in table.column_names if c != geom_col]
-            col_defs = other_cols + [f'ST_GeomFromWKB("{geom_col}") AS "{geom_col}"']
+            other_cols = [quote_identifier(c) for c in table.column_names if c != geom_col]
+            col_defs = other_cols + [
+                f"ST_GeomFromWKB({quote_identifier(geom_col)}) AS {quote_identifier(geom_col)}"
+            ]
             view_query = (
                 f"CREATE VIEW __input_view AS SELECT {', '.join(col_defs)} FROM __input_table"
             )
@@ -200,14 +202,14 @@ def reproject_table(
         # Use ST_AsWKB to convert back to WKB format for GeoParquet compatibility
         query = f"""
             SELECT
-                * EXCLUDE ("{geom_col}"),
+                * EXCLUDE ({quote_identifier(geom_col)}),
                 ST_AsWKB(
                     ST_Transform(
-                        "{geom_col}",
+                        {quote_identifier(geom_col)},
                         '{effective_source_crs}',
                         '{target_crs}'
                     )
-                ) AS "{geom_col}"
+                ) AS {quote_identifier(geom_col)}
             FROM {source_table}
         """
 
@@ -461,7 +463,7 @@ def reproject_impl(
             if verbose:
                 debug(f"Excluding bbox column '{bbox_col}' (will be regenerated)")
         # Quote column names to handle special characters (colons, spaces, etc.)
-        exclude_clause = ", ".join(f'"{c}"' for c in exclude_cols)
+        exclude_clause = ", ".join(quote_identifier(c) for c in exclude_cols)
 
         # Build SQL query with ST_Transform
         # geometry_always_xy is set at connection level (DuckDB 1.5+)
@@ -475,20 +477,20 @@ def reproject_impl(
                     SELECT
                         * EXCLUDE ({exclude_clause}),
                         ST_Transform(
-                            "{geom_col}",
+                            {quote_identifier(geom_col)},
                             '{effective_source_crs}',
                             '{target_crs}'
-                        ) AS "{geom_col}"
+                        ) AS {quote_identifier(geom_col)}
                     FROM '{input_url}'
                 )
                 SELECT
                     *,
                     STRUCT_PACK(
-                        xmin := ST_XMin("{geom_col}"),
-                        ymin := ST_YMin("{geom_col}"),
-                        xmax := ST_XMax("{geom_col}"),
-                        ymax := ST_YMax("{geom_col}")
-                    ) AS "{bbox_col}"
+                        xmin := ST_XMin({quote_identifier(geom_col)}),
+                        ymin := ST_YMin({quote_identifier(geom_col)}),
+                        xmax := ST_XMax({quote_identifier(geom_col)}),
+                        ymax := ST_YMax({quote_identifier(geom_col)})
+                    ) AS {quote_identifier(bbox_col)}
                 FROM reprojected
             """
             if verbose:
@@ -498,10 +500,10 @@ def reproject_impl(
                 SELECT
                     * EXCLUDE ({exclude_clause}),
                     ST_Transform(
-                        "{geom_col}",
+                        {quote_identifier(geom_col)},
                         '{effective_source_crs}',
                         '{target_crs}'
-                    ) AS "{geom_col}"
+                    ) AS {quote_identifier(geom_col)}
                 FROM '{input_url}'
             """
 
@@ -680,7 +682,7 @@ def _reproject_streaming(
             if bbox_col:
                 exclude_cols.append(bbox_col)
             # Quote column names to handle special characters (colons, spaces, etc.)
-            exclude_clause = ", ".join(f'"{c}"' for c in exclude_cols)
+            exclude_clause = ", ".join(quote_identifier(c) for c in exclude_cols)
 
             # Build reprojection query with bbox regeneration if input had bbox
             if bbox_col:
@@ -690,20 +692,20 @@ def _reproject_streaming(
                         SELECT
                             * EXCLUDE ({exclude_clause}),
                             ST_Transform(
-                                "{geom_col}",
+                                {quote_identifier(geom_col)},
                                 '{effective_source_crs}',
                                 '{target_crs}'
-                            ) AS "{geom_col}"
+                            ) AS {quote_identifier(geom_col)}
                         FROM '{working_url}'
                     )
                     SELECT
                         *,
                         STRUCT_PACK(
-                            xmin := ST_XMin("{geom_col}"),
-                            ymin := ST_YMin("{geom_col}"),
-                            xmax := ST_XMax("{geom_col}"),
-                            ymax := ST_YMax("{geom_col}")
-                        ) AS "{bbox_col}"
+                            xmin := ST_XMin({quote_identifier(geom_col)}),
+                            ymin := ST_YMin({quote_identifier(geom_col)}),
+                            xmax := ST_XMax({quote_identifier(geom_col)}),
+                            ymax := ST_YMax({quote_identifier(geom_col)})
+                        ) AS {quote_identifier(bbox_col)}
                     FROM reprojected
                 """
             else:
@@ -711,10 +713,10 @@ def _reproject_streaming(
                     SELECT
                         * EXCLUDE ({exclude_clause}),
                         ST_Transform(
-                            "{geom_col}",
+                            {quote_identifier(geom_col)},
                             '{effective_source_crs}',
                             '{target_crs}'
-                        ) AS "{geom_col}"
+                        ) AS {quote_identifier(geom_col)}
                     FROM '{working_url}'
                 """
 

--- a/geoparquet_io/core/sort_by_column.py
+++ b/geoparquet_io/core/sort_by_column.py
@@ -7,7 +7,7 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
 from geoparquet_io.core.duckdb_metadata import get_usable_columns
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import InvalidParameterError, RemoteAccessError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
@@ -65,7 +65,7 @@ def sort_by_column_table(
 
         # Build ORDER BY clause
         direction = " DESC" if descending else ""
-        order_clause = ", ".join(f'"{col}"{direction}' for col in column_list)
+        order_clause = ", ".join(f"{quote_identifier(col)}{direction}" for col in column_list)
 
         query = f"SELECT * FROM __input_table ORDER BY {order_clause}"
         result = con.execute(query).arrow().read_all()
@@ -168,7 +168,7 @@ def sort_by_column(
     metadata, schema = get_parquet_metadata(input_parquet, verbose)
 
     # Validate that specified columns exist - use get_usable_columns for actual DuckDB column names
-    usable_cols = get_usable_columns(safe_url)
+    usable_cols = get_usable_columns(input_parquet)
     existing_columns = [c["name"] for c in usable_cols]
     for col in column_list:
         if col not in existing_columns:
@@ -187,7 +187,7 @@ def sort_by_column(
 
     # Build ORDER BY clause
     direction = " DESC" if descending else ""
-    order_clause = ", ".join(f'"{col}"{direction}' for col in column_list)
+    order_clause = ", ".join(f"{quote_identifier(col)}{direction}" for col in column_list)
 
     # Build SELECT query
     order_query = f"""
@@ -265,7 +265,7 @@ def _sort_by_column_streaming(
 
         # Build ORDER BY clause
         direction = " DESC" if descending else ""
-        order_clause = ", ".join(f'"{col}"{direction}' for col in column_list)
+        order_clause = ", ".join(f"{quote_identifier(col)}{direction}" for col in column_list)
 
         if verbose:
             debug(f"Sorting by column(s): {', '.join(column_list)}")

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -13,7 +13,7 @@ from geoparquet_io.core.add.quadkey import add_quadkey_column, add_quadkey_table
 from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
 from geoparquet_io.core.constants import DEFAULT_QUADKEY_COLUMN_NAME, DEFAULT_QUADKEY_RESOLUTION
 from geoparquet_io.core.duckdb_metadata import get_column_names, get_usable_columns
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
@@ -64,12 +64,14 @@ def sort_by_quadkey_table(
         con.register("__input_table", working_table)
 
         if remove_quadkey_column:
-            select_cols = [f'"{c}"' for c in working_table.column_names if c != quadkey_column_name]
+            select_cols = [
+                quote_identifier(c) for c in working_table.column_names if c != quadkey_column_name
+            ]
             select_clause = ", ".join(select_cols)
         else:
             select_clause = "*"
 
-        query = f'SELECT {select_clause} FROM __input_table ORDER BY "{quadkey_column_name}"'
+        query = f"SELECT {select_clause} FROM __input_table ORDER BY {quote_identifier(quadkey_column_name)}"
         result = con.execute(query).arrow().read_all()
 
         # Preserve metadata
@@ -159,10 +161,8 @@ def sort_by_quadkey(
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, input_parquet, output_parquet)
 
-    safe_url = safe_file_url(input_parquet, verbose)
-
     # Check if quadkey column exists
-    column_names = get_column_names(safe_url)
+    column_names = get_column_names(input_parquet)
     column_exists = quadkey_column_name in column_names
     using_default_name = quadkey_column_name == DEFAULT_QUADKEY_COLUMN_NAME
 
@@ -223,7 +223,7 @@ def sort_by_quadkey(
     metadata, _ = get_parquet_metadata(actual_input, verbose)
 
     # Get usable columns for building SELECT clause
-    usable_cols = get_usable_columns(actual_safe_url)
+    usable_cols = get_usable_columns(actual_input)
     existing_columns = [c["name"] for c in usable_cols]
 
     try:
@@ -232,7 +232,9 @@ def sort_by_quadkey(
 
         # Build SELECT clause - exclude quadkey if requested
         if remove_quadkey_column:
-            select_cols = [f'"{col}"' for col in existing_columns if col != quadkey_column_name]
+            select_cols = [
+                quote_identifier(col) for col in existing_columns if col != quadkey_column_name
+            ]
             select_clause = ", ".join(select_cols)
             progress(f"Sorting by '{quadkey_column_name}' (will be removed from output)")
         else:
@@ -243,7 +245,7 @@ def sort_by_quadkey(
         query = f"""
             SELECT {select_clause}
             FROM '{actual_safe_url}'
-            ORDER BY "{quadkey_column_name}"
+            ORDER BY {quote_identifier(quadkey_column_name)}
         """
 
         if verbose:
@@ -317,8 +319,7 @@ def _sort_by_quadkey_streaming(
             working_file = input_path
 
         # Check if quadkey column exists
-        safe_url = safe_file_url(working_file, verbose=False)
-        column_names = get_column_names(safe_url)
+        column_names = get_column_names(working_file)
         column_exists = quadkey_column_name in column_names
         using_default_name = quadkey_column_name == DEFAULT_QUADKEY_COLUMN_NAME
 
@@ -359,11 +360,13 @@ def _sort_by_quadkey_streaming(
 
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(actual_input))
 
-        usable_cols = get_usable_columns(actual_safe_url)
+        usable_cols = get_usable_columns(actual_input)
         existing_columns = [c["name"] for c in usable_cols]
 
         if remove_quadkey_column:
-            select_cols = [f'"{col}"' for col in existing_columns if col != quadkey_column_name]
+            select_cols = [
+                quote_identifier(col) for col in existing_columns if col != quadkey_column_name
+            ]
             select_clause = ", ".join(select_cols)
         else:
             select_clause = "*"
@@ -371,7 +374,7 @@ def _sort_by_quadkey_streaming(
         query = f"""
             SELECT {select_clause}
             FROM '{actual_safe_url}'
-            ORDER BY "{quadkey_column_name}"
+            ORDER BY {quote_identifier(quadkey_column_name)}
         """
 
         if verbose:

--- a/geoparquet_io/core/stream_io.py
+++ b/geoparquet_io/core/stream_io.py
@@ -188,9 +188,10 @@ def _wrap_query_with_wkb_conversion(
     if not geometry_column:
         return query
 
+    quoted_geom = quote_identifier(geometry_column)
     return f"""
         WITH __stream_source AS ({query})
-        SELECT * REPLACE (ST_AsWKB({geometry_column}) AS {geometry_column})
+        SELECT * REPLACE (ST_AsWKB({quoted_geom}) AS {quoted_geom})
         FROM __stream_source
     """
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -15,6 +15,7 @@ from rich.console import Console
 
 from geoparquet_io.core.common import split_zm_suffix, zm_suffix_sql
 from geoparquet_io.core.crs_utils import NULL_CRS_HINT, get_crs_display_name, is_geographic_crs
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
 from geoparquet_io.core.exceptions import GeoParquetError
 
 
@@ -761,6 +762,7 @@ def _check_encoding_matches_data(
     from geoparquet_io.core.file_utils import safe_file_url
 
     safe_url = safe_file_url(parquet_file, verbose=False)
+    quoted_geom = quote_identifier(geom_col)
 
     # For WKB encoding, verify we can parse geometries as WKB
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
@@ -768,7 +770,7 @@ def _check_encoding_matches_data(
     try:
         # First check if DuckDB already has it as a GEOMETRY type
         # In that case, the encoding was valid (DuckDB parsed it)
-        type_query = f"DESCRIBE SELECT {geom_col} FROM read_parquet('{safe_url}')"
+        type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
         type_result = con.execute(type_query).fetchone()
         col_type = type_result[1] if type_result else ""
 
@@ -776,7 +778,7 @@ def _check_encoding_matches_data(
             # DuckDB already parsed it as geometry - encoding is valid
             count_query = f"""
                 SELECT COUNT(*) FROM read_parquet('{safe_url}')
-                WHERE {geom_col} IS NOT NULL {limit_clause}
+                WHERE {quoted_geom} IS NOT NULL {limit_clause}
             """
             count_result = con.execute(count_query).fetchone()
             total = count_result[0] if count_result else 0
@@ -790,11 +792,11 @@ def _check_encoding_matches_data(
         # Try to parse geometries - if WKB is valid, ST_GeomFromWKB succeeds
         query = f"""
             SELECT COUNT(*) as total,
-                   COUNT(CASE WHEN ST_GeomFromWKB({geom_col}) IS NOT NULL THEN 1 END) as valid
+                   COUNT(CASE WHEN ST_GeomFromWKB({quoted_geom}) IS NOT NULL THEN 1 END) as valid
             FROM (
-                SELECT {geom_col}
+                SELECT {quoted_geom}
                 FROM read_parquet('{safe_url}')
-                WHERE {geom_col} IS NOT NULL
+                WHERE {quoted_geom} IS NOT NULL
                 {limit_clause}
             )
         """
@@ -866,15 +868,15 @@ def _check_geometry_types_match_data(
 
     try:
         # Check if DuckDB already has it as a GEOMETRY type
-        type_query = f"DESCRIBE SELECT \"{geom_col}\" FROM read_parquet('{safe_url}')"
+        type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
         type_result = con.execute(type_query).fetchone()
         col_type = type_result[1] if type_result else ""
 
         # Build the geometry expression based on column type
         if "GEOMETRY" in col_type.upper():
-            geom_expr = f'"{geom_col}"'
+            geom_expr = quote_identifier(geom_col)
         else:
-            geom_expr = f'ST_GeomFromWKB("{geom_col}")'
+            geom_expr = f"ST_GeomFromWKB({quote_identifier(geom_col)})"
 
         # Get both distinct types and total count in one query. The dimension
         # suffix matters: "LineString" and "LineString ZM" are distinct
@@ -883,9 +885,9 @@ def _check_geometry_types_match_data(
         query = f"""
             SELECT {typed_expr} as geom_type, COUNT(*) as cnt
             FROM (
-                SELECT "{geom_col}"
+                SELECT {quote_identifier(geom_col)}
                 FROM read_parquet('{safe_url}')
-                WHERE "{geom_col}" IS NOT NULL
+                WHERE {quote_identifier(geom_col)} IS NOT NULL
                 {limit_clause}
             )
             GROUP BY {typed_expr}
@@ -979,10 +981,11 @@ def _build_bbox_query(
     xmin, ymin, xmax, ymax = bbox
 
     # Use geometry column directly if native type, otherwise convert from WKB
+    quoted_geom = quote_identifier(geom_col)
     if "GEOMETRY" in col_type.upper():
-        geom_expr = geom_col
+        geom_expr = quoted_geom
     else:
-        geom_expr = f"ST_GeomFromWKB({geom_col})"
+        geom_expr = f"ST_GeomFromWKB({quoted_geom})"
     # Empties have no extent; the same expression filters them out pre-LIMIT.
     geom_expr_filter = geom_expr
 
@@ -995,9 +998,9 @@ def _build_bbox_query(
                    ST_YMax({geom_expr}) <= {ymax}
                THEN 1 END) as within_bbox
         FROM (
-            SELECT {geom_col}
+            SELECT {quoted_geom}
             FROM read_parquet('{safe_url}')
-            WHERE {geom_col} IS NOT NULL
+            WHERE {quoted_geom} IS NOT NULL
               AND NOT ST_IsEmpty({geom_expr_filter})
             {limit_clause}
         )
@@ -1066,7 +1069,7 @@ def _check_bbox_contains_data(
 
     try:
         # Check if DuckDB already has it as a GEOMETRY type
-        type_query = f"DESCRIBE SELECT {geom_col} FROM read_parquet('{safe_url}')"
+        type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
         type_result = con.execute(type_query).fetchone()
         col_type = type_result[1] if type_result else ""
 
@@ -1581,14 +1584,14 @@ def _check_geography_coordinate_bounds(
 
 def _execute_bounds_query(con, safe_url: str, geom_col: str, limit_clause: str):
     """Execute query to get coordinate bounds for a geometry column."""
-    type_query = f"DESCRIBE SELECT \"{geom_col}\" FROM read_parquet('{safe_url}')"
+    type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
     type_result = con.execute(type_query).fetchone()
     col_type = type_result[1] if type_result else ""
 
     if "GEOMETRY" in col_type.upper():
-        geom_expr = f'"{geom_col}"'
+        geom_expr = quote_identifier(geom_col)
     else:
-        geom_expr = f'ST_GeomFromWKB("{geom_col}")'
+        geom_expr = f"ST_GeomFromWKB({quote_identifier(geom_col)})"
 
     query = f"""
         SELECT
@@ -1597,9 +1600,9 @@ def _execute_bounds_query(con, safe_url: str, geom_col: str, limit_clause: str):
             MIN(ST_YMin({geom_expr})) as min_y,
             MAX(ST_YMax({geom_expr})) as max_y
         FROM (
-            SELECT "{geom_col}"
+            SELECT {quote_identifier(geom_col)}
             FROM read_parquet('{safe_url}')
-            WHERE "{geom_col}" IS NOT NULL
+            WHERE {quote_identifier(geom_col)} IS NOT NULL
             {limit_clause}
         )
     """
@@ -1719,10 +1722,11 @@ def _check_native_geo_statistics(parquet_file: str, geom_col: str) -> Validation
 
         with get_duckdb_connection(load_spatial=True) as con:
             # Check for geo_bbox in parquet_metadata for the geometry column
+            escaped_geom_col = _escape_sql_string(geom_col)
             result = con.execute(f"""
                 SELECT geo_bbox, geo_types
                 FROM parquet_metadata('{safe_url}')
-                WHERE path_in_schema = '{geom_col}'
+                WHERE path_in_schema = '{escaped_geom_col}'
                 LIMIT 1
             """).fetchone()
 
@@ -1797,10 +1801,11 @@ def _check_native_geo_stats_contains_data(
         safe_url = safe_file_url(parquet_file, verbose=False)
 
         # Get geo_bbox from parquet metadata
+        escaped_geom_col = _escape_sql_string(geom_col)
         meta_result = con.execute(f"""
             SELECT geo_bbox
             FROM parquet_metadata('{safe_url}')
-            WHERE path_in_schema = '{geom_col}'
+            WHERE path_in_schema = '{escaped_geom_col}'
             LIMIT 1
         """).fetchone()
 
@@ -1843,16 +1848,16 @@ def _check_native_geo_stats_contains_data(
         query = f"""
             SELECT COUNT(*) as total,
                    COUNT(CASE WHEN
-                       ST_XMin("{geom_col}") >= {xmin} AND
-                       ST_YMin("{geom_col}") >= {ymin} AND
-                       ST_XMax("{geom_col}") <= {xmax} AND
-                       ST_YMax("{geom_col}") <= {ymax}
+                       ST_XMin({quote_identifier(geom_col)}) >= {xmin} AND
+                       ST_YMin({quote_identifier(geom_col)}) >= {ymin} AND
+                       ST_XMax({quote_identifier(geom_col)}) <= {xmax} AND
+                       ST_YMax({quote_identifier(geom_col)}) <= {ymax}
                    THEN 1 END) as within_bbox
             FROM (
-                SELECT "{geom_col}"
+                SELECT {quote_identifier(geom_col)}
                 FROM read_parquet('{safe_url}')
-                WHERE "{geom_col}" IS NOT NULL
-                  AND NOT ST_IsEmpty("{geom_col}")
+                WHERE {quote_identifier(geom_col)} IS NOT NULL
+                  AND NOT ST_IsEmpty({quote_identifier(geom_col)})
                 {limit_clause}
             )
         """
@@ -1909,10 +1914,11 @@ def _check_native_geo_types_match(
         safe_url = safe_file_url(parquet_file, verbose=False)
 
         # Get declared geo_types from parquet metadata
+        escaped_geom_col = _escape_sql_string(geom_col)
         meta_result = con.execute(f"""
             SELECT DISTINCT unnest(geo_types) as geo_type
             FROM parquet_metadata('{safe_url}')
-            WHERE path_in_schema = '{geom_col}'
+            WHERE path_in_schema = '{escaped_geom_col}'
               AND geo_types IS NOT NULL
         """).fetchall()
 
@@ -1930,23 +1936,23 @@ def _check_native_geo_types_match(
         # Sample actual geometry types from the data. DuckDB's geo_types
         # naming is dimension-aware ("linestring_m"), so append the matching
         # suffix from ST_HasZ/ST_HasM instead of comparing base names only.
-        quoted_col = f'"{geom_col}"'
+        quoted_col = quote_identifier(geom_col)
         typed_expr = f"ST_GeometryType({quoted_col}) || {zm_suffix_sql(quoted_col, sep='_')}"
         if sample_size == 0:
             # Check all rows
             actual_result = con.execute(f"""
                 SELECT DISTINCT {typed_expr} as geom_type
                 FROM read_parquet('{safe_url}')
-                WHERE "{geom_col}" IS NOT NULL
+                WHERE {quote_identifier(geom_col)} IS NOT NULL
             """).fetchall()
         else:
             # Sample rows
             actual_result = con.execute(f"""
                 SELECT DISTINCT {typed_expr} as geom_type
                 FROM (
-                    SELECT "{geom_col}"
+                    SELECT {quote_identifier(geom_col)}
                     FROM read_parquet('{safe_url}')
-                    WHERE "{geom_col}" IS NOT NULL
+                    WHERE {quote_identifier(geom_col)} IS NOT NULL
                     LIMIT {sample_size}
                 )
             """).fetchall()
@@ -2547,12 +2553,14 @@ def _get_geometry_bounds(
 ) -> tuple[float, float, float, float, int] | None:
     """Query actual coordinate bounds from geometry data."""
     # Check if DuckDB already has it as a GEOMETRY type
-    type_query = f"DESCRIBE SELECT \"{geom_col}\" FROM read_parquet('{safe_url}')"
+    type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
     type_result = con.execute(type_query).fetchone()
     col_type = type_result[1] if type_result else ""
 
     geom_expr = (
-        f'"{geom_col}"' if "GEOMETRY" in col_type.upper() else f'ST_GeomFromWKB("{geom_col}")'
+        quote_identifier(geom_col)
+        if "GEOMETRY" in col_type.upper()
+        else f"ST_GeomFromWKB({quote_identifier(geom_col)})"
     )
 
     query = f"""
@@ -2563,9 +2571,9 @@ def _get_geometry_bounds(
             MAX(ST_YMax({geom_expr})) as max_y,
             COUNT(*) as total
         FROM (
-            SELECT "{geom_col}"
+            SELECT {quote_identifier(geom_col)}
             FROM read_parquet('{safe_url}')
-            WHERE "{geom_col}" IS NOT NULL
+            WHERE {quote_identifier(geom_col)} IS NOT NULL
             {limit_clause}
         )
     """
@@ -2786,13 +2794,10 @@ def validate_geoparquet(
         get_schema_info,
     )
     from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-    from geoparquet_io.core.file_utils import safe_file_url
     from geoparquet_io.core.logging_config import configure_verbose
     from geoparquet_io.core.remote import needs_httpfs
 
     configure_verbose(verbose)
-
-    safe_url = safe_file_url(parquet_file, verbose=verbose)
 
     def _metadata_failure_message(exc: Exception) -> str:
         """Honest failure text: an unreadable file is not evidence of corruption."""
@@ -2844,10 +2849,10 @@ def validate_geoparquet(
     # yield a FAILED report, never an exception — rejecting such files is this
     # function's job.
     try:
-        kv_metadata = get_kv_metadata(safe_url)
-        geo_meta = get_geo_metadata(safe_url)
-        schema_info = get_schema_info(safe_url)
-        geo_columns = detect_geometry_columns(safe_url)
+        kv_metadata = get_kv_metadata(parquet_file)
+        geo_meta = get_geo_metadata(parquet_file)
+        schema_info = get_schema_info(parquet_file)
+        geo_columns = detect_geometry_columns(parquet_file)
     except (GeoParquetError, UnicodeDecodeError, ValueError) as e:
         result.checks.append(
             ValidationCheck(

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -50,7 +50,11 @@ from geoparquet_io.core.common import (
     write_geoparquet_table,
 )
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    get_duckdb_connection,
+    quote_identifier,
+)
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.http_retry import (
     get_shared_http_client as _get_shared_http_client_base,
@@ -1254,7 +1258,7 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
 
             # Check type compatibility using TRY_CAST
             # Quote column name to handle reserved words/special chars
-            quoted_col = f'"{col_name}"'
+            quoted_col = quote_identifier(col_name)
 
             try:
                 stats = con.execute(f"""
@@ -1727,7 +1731,7 @@ def _deduplicate_tiles(table: pa.Table) -> pa.Table:
 
         if "_wfs_fid" in table.column_names:
             all_cols = [c for c in table.column_names if c != "_wfs_fid"]
-            col_list = ", ".join(f'"{c}"' for c in all_cols)
+            col_list = ", ".join(quote_identifier(c) for c in all_cols)
             # Deduplicate by fid when present, fall back to geometry for NULL fids
             query = f"""
                 SELECT {col_list}
@@ -1746,7 +1750,7 @@ def _deduplicate_tiles(table: pa.Table) -> pa.Table:
             """
         else:
             all_cols = table.column_names
-            col_list = ", ".join(f'"{c}"' for c in all_cols)
+            col_list = ", ".join(quote_identifier(c) for c in all_cols)
             query = f"""
                 SELECT {col_list}
                 FROM (

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from geoparquet_io.core.duckdb_utils import quote_identifier
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy
 
@@ -66,8 +67,9 @@ def _check_geometry_type(
     """Check if geometry column needs WKB conversion. Returns (needs_conversion, final_sql)."""
     from geoparquet_io.core.duckdb_utils import _wrap_query_with_wkb_conversion
 
-    quoted_geom = geometry_column.replace('"', '""')
-    type_result = con.execute(f'SELECT TYPEOF("{quoted_geom}") FROM ({query}) LIMIT 1').fetchone()
+    type_result = con.execute(
+        f"SELECT TYPEOF({quote_identifier(geometry_column)}) FROM ({query}) LIMIT 1"
+    ).fetchone()
     duckdb_type = type_result[0] if type_result else None
     needs_wkb = duckdb_type == "GEOMETRY"
 

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -19,7 +19,11 @@ from typing import TYPE_CHECKING
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    get_duckdb_connection,
+    quote_identifier,
+)
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy, build_geo_metadata
 
@@ -198,9 +202,8 @@ class DiskRewriteStrategy(BaseWriteStrategy):
             con.register("input_table", table)
 
             # Convert WKB bytes to GEOMETRY for proper spatial processing
-            escaped_geom = geometry_column.replace('"', '""')
             query = f"""
-                SELECT * REPLACE (ST_GeomFromWKB("{escaped_geom}") AS "{escaped_geom}")
+                SELECT * REPLACE (ST_GeomFromWKB({quote_identifier(geometry_column)}) AS {quote_identifier(geometry_column)})
                 FROM input_table
             """
 

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 
 import pyarrow.parquet as pq
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
 from geoparquet_io.core.logging_config import configure_verbose, debug, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy, build_geo_metadata
 
@@ -623,9 +623,8 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             if getattr(geom_type, "extension_name", None) == "geoarrow.wkb":
                 query = "SELECT * FROM input_table"
             else:
-                escaped_geom = geometry_column.replace('"', '""')
                 query = f"""
-                    SELECT * REPLACE (ST_GeomFromWKB("{escaped_geom}") AS "{escaped_geom}")
+                    SELECT * REPLACE (ST_GeomFromWKB({quote_identifier(geometry_column)}) AS {quote_identifier(geometry_column)})
                     FROM input_table
                 """
 

--- a/tests/test_geometry_identifier_quoting.py
+++ b/tests/test_geometry_identifier_quoting.py
@@ -1,0 +1,316 @@
+"""Regression tests: quote geometry-column identifiers at raw SQL interpolation.
+
+Several SQL builders interpolate a geometry/column identifier raw into a query,
+so any file whose geometry column has a space, uppercase, reserved word, or
+quote breaks with a ParserException -- and because the name can come from a
+file's own `geo.primary_column` metadata, a crafted parquet is an injection
+vector (see tests/test_admin_sql_injection.py for the sibling todo-008 guard
+that already covers admin-divisions / country-codes).
+
+This file guards the four confirmed sites plus siblings found during audit:
+
+1. ``stream_io._wrap_query_with_wkb_conversion`` -- interpolates the geometry
+   column as a SQL IDENTIFIER twice (inside ``ST_AsWKB(...)`` and as the
+   ``REPLACE`` target). Fix: ``quote_identifier``.
+2. ``common.add_bbox``'s ``STRUCT_PACK`` expression -- same identifier bug.
+   Fix: ``quote_identifier``.
+   Sibling found during audit: ``core/add/bbox.py``'s
+   ``_add_bbox_file_based`` builds an almost-identical unquoted STRUCT_PACK
+   expression, and it is the function actually exercised by the real
+   ``gpio add bbox`` CLI command -- this is the one a user hits in practice.
+3. ``check_spatial_order._calculate_consecutive_avg`` /
+   ``_calculate_random_avg`` -- interpolate the geometry column as an
+   identifier in the sampling-method queries. Fix: ``quote_identifier``.
+4. ``duckdb_metadata``'s ``WHERE path_in_schema = '{geometry_column}'``
+   filters -- this is a SQL STRING LITERAL comparison, not an identifier, so
+   the correct fix is ``_escape_sql_string`` (doubling embedded ``'``), never
+   ``quote_identifier``. A spaced name is harmless here (space is valid
+   inside a string literal); only an embedded ``'`` breaks it -- currently
+   silently, because the callers wrap the query in a broad ``except
+   Exception`` and return ``None``/``{}``/``[]`` instead of raising.
+   Siblings found during audit: ``get_bbox_from_row_group_stats`` and
+   ``get_per_row_group_bbox_stats`` (bbox_column) and
+   ``get_compression_info`` (column_name) build the same kind of
+   ``path_in_schema = '...'`` string-literal filter.
+"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import add, check
+from geoparquet_io.core import common as common_module
+from geoparquet_io.core.check_spatial_order import check_spatial_order
+from geoparquet_io.core.duckdb_metadata import (
+    get_aggregated_native_geo_stats,
+    get_compression_info,
+    get_native_geo_statistics,
+    get_per_row_group_bbox_stats,
+    get_per_row_group_native_geo_stats,
+)
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.stream_io import _wrap_query_with_wkb_conversion
+
+# A geometry column name with a space -- breaks unquoted identifier
+# interpolation (`ST_XMin(geom col)` is a parse error).
+SPACED_COL = "geom col"
+
+# A geometry column name with an embedded double-quote -- breaks
+# `quote_identifier` if it were ever applied naively without doubling, and
+# breaks raw identifier interpolation outright.
+DQUOTE_COL = 'geo"m'
+
+# A geometry column name with an embedded single-quote -- breaks a raw SQL
+# STRING LITERAL comparison like `path_in_schema = '{col}'`.
+SQUOTE_COL = "geo'm"
+
+
+def _wkb_fixture(tmp_path, column_name: str, filename: str, wkts: list[str]) -> str:
+    """Build a plain-WKB GeoParquet file whose geo.primary_column = column_name."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    quoted = quote_identifier(column_name)
+    values_sql = ", ".join(
+        f"({i + 1}, ST_AsWKB(ST_GeomFromText('{w}')))" for i, w in enumerate(wkts)
+    )
+    table = (
+        con.execute(f"SELECT * FROM (VALUES {values_sql}) AS t(id, {quoted})").arrow().read_all()
+    )
+    con.close()
+
+    geo = {
+        "version": "1.0.0",
+        "primary_column": column_name,
+        "columns": {column_name: {"encoding": "WKB", "geometry_types": ["Polygon"]}},
+    }
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode()})
+    path = str(tmp_path / filename)
+    pq.write_table(table, path)
+    return path
+
+
+def _native_geo_fixture(tmp_path, column_name: str, filename: str) -> str:
+    """Build a parquet-geo-only file (native GEOMETRY, geo_bbox row-group stats)."""
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    con.execute("SET geometry_always_xy = true;")
+    quoted = quote_identifier(column_name)
+    query = (
+        "SELECT * FROM (VALUES "
+        "(1, ST_GeomFromText('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))')), "
+        "(2, ST_GeomFromText('POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))'))"
+        f") AS t(id, {quoted})"
+    )
+    path = str(tmp_path / filename)
+    common_module.write_parquet_with_metadata(
+        con, query, path, original_metadata=None, geoparquet_version="parquet-geo-only"
+    )
+    con.close()
+    return path
+
+
+# --- Site 1: stream_io._wrap_query_with_wkb_conversion ----------------------
+
+
+class TestStreamIoWkbConversionQuoting:
+    """geoparquet_io/core/stream_io.py:190-194"""
+
+    @pytest.mark.parametrize("column_name", [SPACED_COL, DQUOTE_COL])
+    def test_wraps_and_converts_correctly(self, column_name):
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            quoted = quote_identifier(column_name)
+            con.execute(
+                f"CREATE TABLE t AS SELECT 1 AS id, ST_GeomFromText('POINT (1 2)') AS {quoted}"
+            )
+
+            wrapped = _wrap_query_with_wkb_conversion("SELECT * FROM t", column_name)
+            row = con.execute(wrapped).fetchone()
+
+            assert row[0] == 1
+            wkt = con.execute("SELECT ST_AsText(ST_GeomFromWKB(?))", [row[1]]).fetchone()[0]
+            assert wkt == "POINT (1 2)"
+        finally:
+            con.close()
+
+    def test_noop_when_no_geometry_column(self):
+        # Behavior for already-valid input (None) must not change.
+        assert _wrap_query_with_wkb_conversion("SELECT 1", None) == "SELECT 1"
+
+
+# --- Site 2: common.add_bbox's STRUCT_PACK expression ------------------------
+# Plus sibling: core/add/bbox.py's _add_bbox_file_based (the real `gpio add
+# bbox` CLI code path).
+
+
+class TestCommonAddBboxQuoting:
+    """geoparquet_io/core/common.py:3263-3268"""
+
+    @pytest.mark.parametrize("column_name", [SPACED_COL, DQUOTE_COL])
+    def test_add_bbox_succeeds_with_correct_values(self, tmp_path, column_name):
+        path = _wkb_fixture(
+            tmp_path,
+            column_name,
+            "add_bbox_fixture.parquet",
+            wkts=[
+                "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+                "POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))",
+            ],
+        )
+
+        common_module.add_bbox(path, bbox_column_name="bbox", verbose=False)
+
+        table = pq.read_table(path)
+        rows = table.column("bbox").combine_chunks().to_pylist()
+        assert rows[0] == {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0}
+        assert rows[1] == {"xmin": 2.0, "ymin": 2.0, "xmax": 3.0, "ymax": 3.0}
+
+
+class TestCliAddBboxOnSpacedColumn:
+    """End-to-end: `gpio add bbox` must not crash on a real `geom col` file.
+
+    Exercises core/add/bbox.py's _add_bbox_file_based -> common.py's
+    add_computed_column -> the duckdb-kv write strategy, i.e. the actual code
+    path a user hits (found as a sibling of confirmed site 2 during audit).
+    """
+
+    @pytest.mark.parametrize("column_name", [SPACED_COL, DQUOTE_COL])
+    def test_cli_add_bbox_succeeds(self, tmp_path, column_name):
+        input_path = _wkb_fixture(
+            tmp_path,
+            column_name,
+            "cli_add_bbox_input.parquet",
+            wkts=[
+                "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+                "POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))",
+            ],
+        )
+        output_path = str(tmp_path / "cli_add_bbox_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox", input_path, output_path])
+
+        assert result.exit_code == 0, result.output
+        table = pq.read_table(output_path)
+        rows = table.column("bbox").combine_chunks().to_pylist()
+        assert rows[0] == {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0}
+        assert rows[1] == {"xmin": 2.0, "ymin": 2.0, "xmax": 3.0, "ymax": 3.0}
+
+
+# --- Site 3: check_spatial_order sampling-path queries ----------------------
+
+
+class TestCheckSpatialOrderSamplingQuoting:
+    """geoparquet_io/core/check_spatial_order.py:46,64"""
+
+    def test_sampling_method_succeeds_on_spaced_column(self, tmp_path):
+        wkts = [f"POINT ({i} {i})" for i in range(10)]
+        path = _wkb_fixture(tmp_path, SPACED_COL, "spatial_order_fixture.parquet", wkts)
+
+        result = check_spatial_order(
+            path, random_sample_size=5, limit_rows=1000, verbose=False, return_results=True
+        )
+
+        assert result["method"] == "sampling"
+        assert result["consecutive_avg"] is not None
+        assert result["random_avg"] is not None
+        # Points march evenly along the diagonal, so consecutive neighbours are
+        # always closer than a random pair -> the ratio is safely under 1.
+        assert result["ratio"] < 1.0
+
+    def test_cli_check_spatial_succeeds_on_spaced_column(self, tmp_path):
+        wkts = [f"POINT ({i} {i})" for i in range(10)]
+        path = _wkb_fixture(tmp_path, SPACED_COL, "spatial_order_cli_fixture.parquet", wkts)
+
+        runner = CliRunner()
+        result = runner.invoke(check, ["spatial", path])
+
+        assert result.exit_code == 0, result.output
+
+
+# --- Site 4: duckdb_metadata `path_in_schema = '{...}'` literal filters ----
+
+
+class TestDuckdbMetadataNativeStatsEscaping:
+    """geoparquet_io/core/duckdb_metadata.py:1133,1200,1216,1266
+
+    These are STRING LITERAL comparisons, not identifiers -- a spaced name is
+    fine (space is a legal string-literal character); an embedded single
+    quote is what breaks the query, so the fix is `_escape_sql_string`, not
+    `quote_identifier`.
+    """
+
+    @pytest.mark.parametrize("column_name", [SPACED_COL, SQUOTE_COL])
+    def test_native_geo_stat_getters_return_correct_values(self, tmp_path, column_name):
+        path = _native_geo_fixture(tmp_path, column_name, f"native_geo_{hash(column_name)}.parquet")
+
+        single = get_native_geo_statistics(path, column_name)
+        assert single is not None, "expected stats, got None (query silently failed)"
+        assert single["bbox"][:4] == pytest.approx([0.0, 0.0, 3.0, 3.0])
+        assert single["geometry_types"] == ["Polygon"]
+
+        agg = get_aggregated_native_geo_stats(path, column_name)
+        assert agg.get("bbox") is not None, "expected aggregated bbox, got empty dict"
+        assert agg["bbox"][:4] == pytest.approx([0.0, 0.0, 3.0, 3.0])
+        assert agg["geometry_types"] == ["Polygon"]
+
+        per_rg = get_per_row_group_native_geo_stats(path, column_name)
+        assert len(per_rg) == 1, "expected one row group of stats, got empty list"
+        assert per_rg[0]["xmin"] == pytest.approx(0.0)
+        assert per_rg[0]["ymin"] == pytest.approx(0.0)
+        assert per_rg[0]["xmax"] == pytest.approx(3.0)
+        assert per_rg[0]["ymax"] == pytest.approx(3.0)
+
+
+class TestDuckdbMetadataSiblingLiteralEscaping:
+    """Siblings found during audit: other `path_in_schema = '...'` filters.
+
+    get_bbox_from_row_group_stats / get_per_row_group_bbox_stats key off the
+    bbox column name, and get_compression_info keys off an arbitrary column
+    name -- both build the identical string-literal comparison pattern as
+    the four confirmed sites.
+    """
+
+    def test_per_row_group_bbox_stats_escapes_quote_in_bbox_column_name(self, tmp_path):
+        bbox_col = "bb'ox"
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        quoted = quote_identifier(bbox_col)
+        query = f"""
+            SELECT * FROM (VALUES
+                (1, {{'xmin': 0.0, 'ymin': 0.0, 'xmax': 1.0, 'ymax': 1.0}}),
+                (2, {{'xmin': 2.0, 'ymin': 2.0, 'xmax': 3.0, 'ymax': 3.0}})
+            ) AS t(id, {quoted})
+        """
+        table = con.execute(query).arrow().read_all()
+        con.close()
+        path = str(tmp_path / "bbox_col_quote.parquet")
+        pq.write_table(table, path)
+
+        result = get_per_row_group_bbox_stats(path, bbox_column=bbox_col)
+
+        assert len(result) == 1
+        assert result[0]["xmin"] == pytest.approx(0.0)
+        assert result[0]["xmax"] == pytest.approx(3.0)
+
+    def test_get_compression_info_escapes_quote_in_column_name(self, tmp_path):
+        col = "va'l"
+        con = duckdb.connect()
+        quoted = quote_identifier(col)
+        table = con.execute(f"SELECT 1 AS id, 2 AS {quoted}").arrow().read_all()
+        con.close()
+        path = str(tmp_path / "compression_col_quote.parquet")
+        pq.write_table(table, path)
+
+        result = get_compression_info(path, column_name=col)
+
+        assert result, "expected a non-empty compression map, got {} (query silently failed)"
+        assert all(k == col for k in result)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_geometry_identifier_quoting.py
+++ b/tests/test_geometry_identifier_quoting.py
@@ -1,37 +1,29 @@
 """Regression tests: quote geometry-column identifiers at raw SQL interpolation.
 
-Several SQL builders interpolate a geometry/column identifier raw into a query,
-so any file whose geometry column has a space, uppercase, reserved word, or
-quote breaks with a ParserException -- and because the name can come from a
-file's own `geo.primary_column` metadata, a crafted parquet is an injection
-vector (see tests/test_admin_sql_injection.py for the sibling todo-008 guard
-that already covers admin-divisions / country-codes).
+Many SQL builders used to interpolate a column identifier raw into a query, so
+any file whose geometry column has a space, uppercase letter, reserved word or
+embedded quote broke with a ParserException -- and because the name is read
+verbatim from the file's own ``geo.primary_column`` metadata, a crafted parquet
+was an injection vector (see tests/test_admin_sql_injection.py for the sibling
+guard that already covers admin-divisions / country-codes).
 
-This file guards the four confirmed sites plus siblings found during audit:
+Two different escapes are involved, and mixing them up is the recurring bug:
 
-1. ``stream_io._wrap_query_with_wkb_conversion`` -- interpolates the geometry
-   column as a SQL IDENTIFIER twice (inside ``ST_AsWKB(...)`` and as the
-   ``REPLACE`` target). Fix: ``quote_identifier``.
-2. ``common.add_bbox``'s ``STRUCT_PACK`` expression -- same identifier bug.
-   Fix: ``quote_identifier``.
-   Sibling found during audit: ``core/add/bbox.py``'s
-   ``_add_bbox_file_based`` builds an almost-identical unquoted STRUCT_PACK
-   expression, and it is the function actually exercised by the real
-   ``gpio add bbox`` CLI command -- this is the one a user hits in practice.
-3. ``check_spatial_order._calculate_consecutive_avg`` /
-   ``_calculate_random_avg`` -- interpolate the geometry column as an
-   identifier in the sampling-method queries. Fix: ``quote_identifier``.
-4. ``duckdb_metadata``'s ``WHERE path_in_schema = '{geometry_column}'``
-   filters -- this is a SQL STRING LITERAL comparison, not an identifier, so
-   the correct fix is ``_escape_sql_string`` (doubling embedded ``'``), never
-   ``quote_identifier``. A spaced name is harmless here (space is valid
-   inside a string literal); only an embedded ``'`` breaks it -- currently
-   silently, because the callers wrap the query in a broad ``except
-   Exception`` and return ``None``/``{}``/``[]`` instead of raising.
-   Siblings found during audit: ``get_bbox_from_row_group_stats`` and
-   ``get_per_row_group_bbox_stats`` (bbox_column) and
-   ``get_compression_info`` (column_name) build the same kind of
-   ``path_in_schema = '...'`` string-literal filter.
+* An **identifier** (column/table name) is wrapped in double quotes with any
+  embedded ``"`` doubled -- :func:`duckdb_utils.quote_identifier`. Hand-rolling
+  it as ``f'"{col}"'`` tolerates a space but silently breaks on an embedded
+  ``"``, which is why the ``.pre-commit-config.yaml`` ``duckdb-antipatterns``
+  hook now bans that spelling.
+* A **string literal** (e.g. ``WHERE path_in_schema = '...'``) is wrapped in
+  single quotes with any embedded ``'`` doubled --
+  :func:`duckdb_utils._escape_sql_string`. A space is harmless there; only an
+  embedded ``'`` breaks it, and it used to break *silently*, because the
+  callers wrap the query in a broad ``except Exception`` and return
+  ``None``/``{}``/``[]`` instead of raising.
+
+Every adversarial-name test in this file runs against the same three names
+(:data:`ADVERSARIAL_COLUMNS`) so no site is accidentally covered only by the
+one flavour of hostility it happens to tolerate.
 """
 
 from __future__ import annotations
@@ -43,7 +35,7 @@ import pyarrow.parquet as pq
 import pytest
 from click.testing import CliRunner
 
-from geoparquet_io.cli.main import add, check
+from geoparquet_io.cli.main import add, check, convert, extract, inspect, sort
 from geoparquet_io.core import common as common_module
 from geoparquet_io.core.check_spatial_order import check_spatial_order
 from geoparquet_io.core.duckdb_metadata import (
@@ -60,14 +52,45 @@ from geoparquet_io.core.stream_io import _wrap_query_with_wkb_conversion
 # interpolation (`ST_XMin(geom col)` is a parse error).
 SPACED_COL = "geom col"
 
-# A geometry column name with an embedded double-quote -- breaks
-# `quote_identifier` if it were ever applied naively without doubling, and
-# breaks raw identifier interpolation outright.
+# A geometry column name with an embedded double-quote -- breaks hand-rolled
+# `f'"{col}"'` quoting, which does not double the `"`.
 DQUOTE_COL = 'geo"m'
 
 # A geometry column name with an embedded single-quote -- breaks a raw SQL
 # STRING LITERAL comparison like `path_in_schema = '{col}'`.
 SQUOTE_COL = "geo'm"
+
+#: Applied uniformly: every site must survive every hostile name, not just the
+#: one flavour of hostility that site's original bug happened to trip over.
+ADVERSARIAL_COLUMNS = [SPACED_COL, DQUOTE_COL, SQUOTE_COL]
+
+#: A name that is not merely unparsable but *executable* if quoting fails:
+#: unquoted, `ST_XMin("g") AS x, (SELECT 1) AS pwned --")` parses fine and
+#: injects two extra result columns. Asserting the output schema is unchanged
+#: proves the injection was neutralised, not merely that nothing crashed.
+INJECTION_COL = 'g") AS x, (SELECT 1) AS pwned --'
+
+adversarial_column = pytest.mark.parametrize("column_name", ADVERSARIAL_COLUMNS)
+
+POLYGON_WKTS = [
+    "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+    "POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))",
+]
+
+
+def _write_geoparquet(table, column_name: str, geometry_types: list[str], path: str, bbox=None):
+    """Attach v1.0.0 `geo` metadata naming ``column_name`` and write ``path``."""
+    col_meta: dict = {"encoding": "WKB", "geometry_types": geometry_types}
+    if bbox is not None:
+        col_meta["bbox"] = bbox
+    geo = {
+        "version": "1.0.0",
+        "primary_column": column_name,
+        "columns": {column_name: col_meta},
+    }
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode()})
+    pq.write_table(table, path)
+    return path
 
 
 def _wkb_fixture(tmp_path, column_name: str, filename: str, wkts: list[str]) -> str:
@@ -82,16 +105,28 @@ def _wkb_fixture(tmp_path, column_name: str, filename: str, wkts: list[str]) -> 
         con.execute(f"SELECT * FROM (VALUES {values_sql}) AS t(id, {quoted})").arrow().read_all()
     )
     con.close()
+    return _write_geoparquet(table, column_name, ["Polygon"], str(tmp_path / filename))
 
-    geo = {
-        "version": "1.0.0",
-        "primary_column": column_name,
-        "columns": {column_name: {"encoding": "WKB", "geometry_types": ["Polygon"]}},
-    }
-    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode()})
-    path = str(tmp_path / filename)
-    pq.write_table(table, path)
-    return path
+
+def _points_fixture(tmp_path, column_name: str, filename: str, count: int = 10) -> str:
+    """A ten-point WKB fixture with a declared bbox (so `check spec` is clean)."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    quoted = quote_identifier(column_name)
+    values_sql = ", ".join(
+        f"({i + 1}, ST_AsWKB(ST_GeomFromText('POINT ({i} {i})')))" for i in range(count)
+    )
+    table = (
+        con.execute(f"SELECT * FROM (VALUES {values_sql}) AS t(id, {quoted})").arrow().read_all()
+    )
+    con.close()
+    return _write_geoparquet(
+        table,
+        column_name,
+        ["Point"],
+        str(tmp_path / filename),
+        bbox=[0.0, 0.0, float(count - 1), float(count - 1)],
+    )
 
 
 def _native_geo_fixture(tmp_path, column_name: str, filename: str) -> str:
@@ -113,13 +148,62 @@ def _native_geo_fixture(tmp_path, column_name: str, filename: str) -> str:
     return path
 
 
+# --- The helper itself: contract and edge cases -----------------------------
+
+
+class TestQuoteIdentifierContract:
+    """geoparquet_io/core/duckdb_utils.py: quote_identifier."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("geom", '"geom"'),
+            (SPACED_COL, '"geom col"'),
+            (DQUOTE_COL, '"geo""m"'),
+            (SQUOTE_COL, '"geo\'m"'),
+            ("SELECT", '"SELECT"'),
+            ("Geometry", '"Geometry"'),
+            ("a\nb", '"a\nb"'),
+            (INJECTION_COL, '"g"") AS x, (SELECT 1) AS pwned --"'),
+        ],
+    )
+    def test_quotes_hostile_names(self, raw, expected):
+        assert quote_identifier(raw) == expected
+
+    @adversarial_column
+    def test_result_round_trips_through_duckdb(self, column_name):
+        con = duckdb.connect()
+        try:
+            quoted = quote_identifier(column_name)
+            name = con.execute(f"SELECT 1 AS {quoted}").arrow().read_all().column_names[0]
+            assert name == column_name
+        finally:
+            con.close()
+
+    def test_not_idempotent_by_contract(self):
+        """Callers must pass a BARE name; re-quoting is a caller bug, not a no-op."""
+        assert quote_identifier(quote_identifier("geom")) == '"""geom"""'
+
+    def test_empty_name_is_rejected(self):
+        # `""` is a zero-length delimited identifier: DuckDB refuses to parse it,
+        # so emitting it would produce broken SQL instead of a clear error.
+        with pytest.raises(ValueError, match="empty"):
+            quote_identifier("")
+
+    def test_nul_byte_is_rejected(self):
+        # A NUL truncates the identifier inside DuckDB's parser, producing
+        # "unterminated quoted identifier" rather than anything actionable.
+        with pytest.raises(ValueError, match="NUL"):
+            quote_identifier("ge\x00om")
+
+
 # --- Site 1: stream_io._wrap_query_with_wkb_conversion ----------------------
 
 
 class TestStreamIoWkbConversionQuoting:
-    """geoparquet_io/core/stream_io.py:190-194"""
+    """geoparquet_io/core/stream_io.py: _wrap_query_with_wkb_conversion."""
 
-    @pytest.mark.parametrize("column_name", [SPACED_COL, DQUOTE_COL])
+    @adversarial_column
     def test_wraps_and_converts_correctly(self, column_name):
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         try:
@@ -137,9 +221,24 @@ class TestStreamIoWkbConversionQuoting:
         finally:
             con.close()
 
-    def test_noop_when_no_geometry_column(self):
-        # Behavior for already-valid input (None) must not change.
-        assert _wrap_query_with_wkb_conversion("SELECT 1", None) == "SELECT 1"
+    def test_injection_in_column_name_is_neutralised(self):
+        """The wrapper's REPLACE target must not be able to add columns."""
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            quoted = quote_identifier(INJECTION_COL)
+            con.execute(
+                f"CREATE TABLE t AS SELECT 1 AS id, ST_GeomFromText('POINT (1 2)') AS {quoted}"
+            )
+
+            wrapped = _wrap_query_with_wkb_conversion("SELECT * FROM t", INJECTION_COL)
+            columns = con.execute(wrapped).arrow().read_all().column_names
+
+            # The hostile name itself contains "pwned", so a substring check
+            # would be vacuous: the proof is that the schema gained no EXTRA
+            # column beyond the two the source table actually has.
+            assert columns == ["id", INJECTION_COL]
+        finally:
+            con.close()
 
 
 # --- Site 2: common.add_bbox's STRUCT_PACK expression ------------------------
@@ -148,19 +247,11 @@ class TestStreamIoWkbConversionQuoting:
 
 
 class TestCommonAddBboxQuoting:
-    """geoparquet_io/core/common.py:3263-3268"""
+    """geoparquet_io/core/common.py: add_bbox."""
 
-    @pytest.mark.parametrize("column_name", [SPACED_COL, DQUOTE_COL])
+    @adversarial_column
     def test_add_bbox_succeeds_with_correct_values(self, tmp_path, column_name):
-        path = _wkb_fixture(
-            tmp_path,
-            column_name,
-            "add_bbox_fixture.parquet",
-            wkts=[
-                "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
-                "POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))",
-            ],
-        )
+        path = _wkb_fixture(tmp_path, column_name, "add_bbox_fixture.parquet", POLYGON_WKTS)
 
         common_module.add_bbox(path, bbox_column_name="bbox", verbose=False)
 
@@ -170,25 +261,13 @@ class TestCommonAddBboxQuoting:
         assert rows[1] == {"xmin": 2.0, "ymin": 2.0, "xmax": 3.0, "ymax": 3.0}
 
 
-class TestCliAddBboxOnSpacedColumn:
-    """End-to-end: `gpio add bbox` must not crash on a real `geom col` file.
+class TestCliAddBboxOnHostileColumn:
+    """End-to-end `gpio add bbox`: core/add/bbox.py's _add_bbox_file_based ->
+    common.py's add_computed_column -> the duckdb-kv write strategy."""
 
-    Exercises core/add/bbox.py's _add_bbox_file_based -> common.py's
-    add_computed_column -> the duckdb-kv write strategy, i.e. the actual code
-    path a user hits (found as a sibling of confirmed site 2 during audit).
-    """
-
-    @pytest.mark.parametrize("column_name", [SPACED_COL, DQUOTE_COL])
+    @adversarial_column
     def test_cli_add_bbox_succeeds(self, tmp_path, column_name):
-        input_path = _wkb_fixture(
-            tmp_path,
-            column_name,
-            "cli_add_bbox_input.parquet",
-            wkts=[
-                "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
-                "POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))",
-            ],
-        )
+        input_path = _wkb_fixture(tmp_path, column_name, "cli_add_bbox_input.parquet", POLYGON_WKTS)
         output_path = str(tmp_path / "cli_add_bbox_output.parquet")
 
         runner = CliRunner()
@@ -200,16 +279,60 @@ class TestCliAddBboxOnSpacedColumn:
         assert rows[0] == {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0}
         assert rows[1] == {"xmin": 2.0, "ymin": 2.0, "xmax": 3.0, "ymax": 3.0}
 
+    def test_injection_in_geometry_column_name_is_neutralised(self, tmp_path):
+        input_path = _wkb_fixture(
+            tmp_path, INJECTION_COL, "cli_add_bbox_injection.parquet", POLYGON_WKTS
+        )
+        output_path = str(tmp_path / "cli_add_bbox_injection_out.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox", input_path, output_path])
+
+        assert result.exit_code == 0, result.output
+        names = pq.read_schema(output_path).names
+        assert names == ["id", INJECTION_COL, "bbox"]
+
+
+class TestAddComputedColumnQuotesUserSuppliedName:
+    """geoparquet_io/core/common.py: add_computed_column.
+
+    ``--bbox-name`` / ``--column`` are supplied directly on the command line and
+    reach the shared ``add_computed_column`` backend used by `add bbox`,
+    `add h3`, `add s2`, `add a5`, `add quadkey` and `add geometry-metrics`.
+    """
+
+    @adversarial_column
+    def test_cli_bbox_name_is_quoted(self, tmp_path, column_name):
+        input_path = _points_fixture(tmp_path, "geometry", "bbox_name_input.parquet")
+        output_path = str(tmp_path / "bbox_name_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox", input_path, output_path, "--bbox-name", column_name])
+
+        assert result.exit_code == 0, result.output
+        assert column_name in pq.read_schema(output_path).names
+
+    def test_cli_bbox_name_injection_is_neutralised(self, tmp_path):
+        input_path = _points_fixture(tmp_path, "geometry", "bbox_name_inj_input.parquet")
+        output_path = str(tmp_path / "bbox_name_inj_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox", input_path, output_path, "--bbox-name", INJECTION_COL])
+
+        assert result.exit_code == 0, result.output
+        names = pq.read_schema(output_path).names
+        assert names == ["id", "geometry", INJECTION_COL]
+
 
 # --- Site 3: check_spatial_order sampling-path queries ----------------------
 
 
 class TestCheckSpatialOrderSamplingQuoting:
-    """geoparquet_io/core/check_spatial_order.py:46,64"""
+    """geoparquet_io/core/check_spatial_order.py: the sampling-method queries."""
 
-    def test_sampling_method_succeeds_on_spaced_column(self, tmp_path):
-        wkts = [f"POINT ({i} {i})" for i in range(10)]
-        path = _wkb_fixture(tmp_path, SPACED_COL, "spatial_order_fixture.parquet", wkts)
+    @adversarial_column
+    def test_sampling_method_succeeds(self, tmp_path, column_name):
+        path = _points_fixture(tmp_path, column_name, "spatial_order_fixture.parquet")
 
         result = check_spatial_order(
             path, random_sample_size=5, limit_rows=1000, verbose=False, return_results=True
@@ -222,9 +345,9 @@ class TestCheckSpatialOrderSamplingQuoting:
         # always closer than a random pair -> the ratio is safely under 1.
         assert result["ratio"] < 1.0
 
-    def test_cli_check_spatial_succeeds_on_spaced_column(self, tmp_path):
-        wkts = [f"POINT ({i} {i})" for i in range(10)]
-        path = _wkb_fixture(tmp_path, SPACED_COL, "spatial_order_cli_fixture.parquet", wkts)
+    @adversarial_column
+    def test_cli_check_spatial_succeeds(self, tmp_path, column_name):
+        path = _points_fixture(tmp_path, column_name, "spatial_order_cli_fixture.parquet")
 
         runner = CliRunner()
         result = runner.invoke(check, ["spatial", path])
@@ -236,29 +359,28 @@ class TestCheckSpatialOrderSamplingQuoting:
 
 
 class TestDuckdbMetadataNativeStatsEscaping:
-    """geoparquet_io/core/duckdb_metadata.py:1133,1200,1216,1266
+    """geoparquet_io/core/duckdb_metadata.py: the native-geo-stat getters.
 
-    These are STRING LITERAL comparisons, not identifiers -- a spaced name is
-    fine (space is a legal string-literal character); an embedded single
-    quote is what breaks the query, so the fix is `_escape_sql_string`, not
-    `quote_identifier`.
+    These are STRING LITERAL comparisons, not identifiers, so the fix is
+    `_escape_sql_string`. Only an embedded `'` can break them -- a space is a
+    legal string-literal character -- so this class is deliberately narrowed to
+    the name with teeth.
     """
 
-    @pytest.mark.parametrize("column_name", [SPACED_COL, SQUOTE_COL])
-    def test_native_geo_stat_getters_return_correct_values(self, tmp_path, column_name):
-        path = _native_geo_fixture(tmp_path, column_name, "native_geo.parquet")
+    def test_native_geo_stat_getters_return_correct_values(self, tmp_path):
+        path = _native_geo_fixture(tmp_path, SQUOTE_COL, "native_geo.parquet")
 
-        single = get_native_geo_statistics(path, column_name)
+        single = get_native_geo_statistics(path, SQUOTE_COL)
         assert single is not None, "expected stats, got None (query silently failed)"
         assert single["bbox"][:4] == pytest.approx([0.0, 0.0, 3.0, 3.0])
         assert single["geometry_types"] == ["Polygon"]
 
-        agg = get_aggregated_native_geo_stats(path, column_name)
+        agg = get_aggregated_native_geo_stats(path, SQUOTE_COL)
         assert agg.get("bbox") is not None, "expected aggregated bbox, got empty dict"
         assert agg["bbox"][:4] == pytest.approx([0.0, 0.0, 3.0, 3.0])
         assert agg["geometry_types"] == ["Polygon"]
 
-        per_rg = get_per_row_group_native_geo_stats(path, column_name)
+        per_rg = get_per_row_group_native_geo_stats(path, SQUOTE_COL)
         assert len(per_rg) == 1, "expected one row group of stats, got empty list"
         assert per_rg[0]["xmin"] == pytest.approx(0.0)
         assert per_rg[0]["ymin"] == pytest.approx(0.0)
@@ -267,13 +389,8 @@ class TestDuckdbMetadataNativeStatsEscaping:
 
 
 class TestDuckdbMetadataSiblingLiteralEscaping:
-    """Siblings found during audit: other `path_in_schema = '...'` filters.
-
-    get_bbox_from_row_group_stats / get_per_row_group_bbox_stats key off the
-    bbox column name, and get_compression_info keys off an arbitrary column
-    name -- both build the identical string-literal comparison pattern as
-    the four confirmed sites.
-    """
+    """Other `path_in_schema = '...'` filters: the bbox-stat and compression
+    getters key off a column name the same way."""
 
     def test_per_row_group_bbox_stats_escapes_quote_in_bbox_column_name(self, tmp_path):
         bbox_col = "bb'ox"
@@ -312,27 +429,24 @@ class TestDuckdbMetadataSiblingLiteralEscaping:
         assert all(k == col for k in result)
 
 
-# --- Fix round 1: siblings in core/add/bbox.py's manual `"{col}"` quoting --
+# --- core/add/bbox.py's manual `"{col}"` quoting ---------------------------
 #
-# _build_bbox_sql and add_bbox_table (backing Table.add_bbox() in
-# api/table.py) build `"{col}"`/`f'"{c}"'` by hand instead of calling
-# quote_identifier, so they already tolerate a space but not an embedded `"`
-# (which needs doubling to `""`). _make_add_bbox_query -- used by
-# _add_bbox_streaming, the `gpio add bbox -` stdin/stdout CLI path -- has the
-# identical bug; it wasn't the function named in the fix-round request, but
-# it is the one that actually builds the vulnerable SQL for the streaming
-# path (see the fix-round entry in task-C-report.md for detail).
+# add_bbox_table (backing Table.add_bbox() in api/table.py) built `"{col}"` by
+# hand instead of calling quote_identifier, so it tolerated a space but not an
+# embedded `"`. _make_add_bbox_query -- used by _add_bbox_streaming, the
+# `gpio add bbox -` stdin/stdout CLI path -- had the identical bug.
 
 
 class TestApiTableAddBboxQuoting:
     """geoparquet_io/core/add/bbox.py: add_bbox_table -- backs Table.add_bbox()."""
 
-    def test_table_add_bbox_succeeds_with_correct_values(self):
+    @adversarial_column
+    def test_table_add_bbox_succeeds_with_correct_values(self, column_name):
         from geoparquet_io.api.table import Table
 
         con = duckdb.connect()
         con.execute("INSTALL spatial; LOAD spatial;")
-        quoted = quote_identifier(DQUOTE_COL)
+        quoted = quote_identifier(column_name)
         arrow_table = (
             con.execute(
                 f"""
@@ -347,7 +461,7 @@ class TestApiTableAddBboxQuoting:
         )
         con.close()
 
-        table = Table(arrow_table, geometry_column=DQUOTE_COL)
+        table = Table(arrow_table, geometry_column=column_name)
         result = table.add_bbox(column_name="bbox")
 
         rows = result.table.column("bbox").combine_chunks().to_pylist()
@@ -364,45 +478,203 @@ class TestAddBboxStreamingQuoting:
     scope for this fix), so the hostile name is added to that lookup via
     monkeypatch to let the *real* _add_bbox_streaming run end-to-end rather
     than testing the SQL-building helper in isolation.
+
+    ``force=True`` takes the ``replace_existing`` branch, whose
+    ``SELECT * EXCLUDE (...)`` interpolates the *bbox* column name -- so the
+    fixture carries a pre-existing bbox column under an equally hostile name,
+    holding a sentinel value that the run must overwrite.
     """
 
-    def test_add_bbox_streaming_succeeds_with_correct_values(self, tmp_path, monkeypatch):
+    # A bbox column name that only survives correct `""`-doubling quoting.
+    HOSTILE_BBOX_COL = 'b"x'
+
+    def _fixture(self, tmp_path, column_name: str, with_stale_bbox: bool) -> str:
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        quoted = quote_identifier(column_name)
+        quoted_bbox = quote_identifier(self.HOSTILE_BBOX_COL)
+        stale = ", {'xmin': -99.0, 'ymin': -99.0, 'xmax': -99.0, 'ymax': -99.0}"
+        rows = ", ".join(
+            f"({i + 1}, ST_AsWKB(ST_GeomFromText('{w}')){stale if with_stale_bbox else ''})"
+            for i, w in enumerate(POLYGON_WKTS)
+        )
+        cols = f"id, {quoted}" + (f", {quoted_bbox}" if with_stale_bbox else "")
+        table = con.execute(f"SELECT * FROM (VALUES {rows}) AS t({cols})").arrow().read_all()
+        con.close()
+        return _write_geoparquet(
+            table,
+            column_name,
+            ["Polygon"],
+            str(tmp_path / f"streaming_input_{int(with_stale_bbox)}.parquet"),
+        )
+
+    @pytest.mark.parametrize("force", [False, True])
+    @adversarial_column
+    def test_add_bbox_streaming_succeeds_with_correct_values(
+        self, tmp_path, monkeypatch, column_name, force
+    ):
         from geoparquet_io.core.add import bbox as bbox_module
 
         monkeypatch.setattr(
             bbox_module,
             "STANDARD_GEOMETRY_NAMES",
-            [DQUOTE_COL, *bbox_module.STANDARD_GEOMETRY_NAMES],
+            [column_name, *bbox_module.STANDARD_GEOMETRY_NAMES],
         )
-        input_path = _wkb_fixture(
-            tmp_path,
-            DQUOTE_COL,
-            "streaming_input.parquet",
-            wkts=[
-                "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
-                "POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))",
-            ],
-        )
+        input_path = self._fixture(tmp_path, column_name, with_stale_bbox=force)
         output_path = str(tmp_path / "streaming_output.parquet")
+
+        if force:
+            # Premise of the replace_existing branch: the stale value must be
+            # there to begin with, so replacing it is observable.
+            stale = pq.read_table(input_path).column(self.HOSTILE_BBOX_COL).to_pylist()
+            assert stale[0]["xmin"] == -99.0
 
         bbox_module._add_bbox_streaming(
             input_path=input_path,
             output_path=output_path,
-            bbox_column_name="bbox",
+            bbox_column_name=self.HOSTILE_BBOX_COL,
             verbose=False,
             compression="ZSTD",
             compression_level=None,
             row_group_size_mb=None,
             row_group_rows=None,
             profile=None,
-            force=False,
+            force=force,
             geoparquet_version="2.0",
         )
 
         table = pq.read_table(output_path)
-        rows = table.column("bbox").combine_chunks().to_pylist()
+        # EXCLUDE must have removed the stale column rather than leaving a
+        # duplicate behind.
+        assert table.column_names.count(self.HOSTILE_BBOX_COL) == 1
+        rows = table.column(self.HOSTILE_BBOX_COL).combine_chunks().to_pylist()
         assert rows[0] == {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0}
         assert rows[1] == {"xmin": 2.0, "ymin": 2.0, "xmax": 3.0, "ymax": 3.0}
+
+
+# --- Finishing the sweep: commands still broken after the first fix round ---
+
+
+class TestInspectStatsQuoting:
+    """geoparquet_io/core/inspect_utils.py: the per-column stats queries."""
+
+    @adversarial_column
+    def test_inspect_stats_succeeds(self, tmp_path, column_name):
+        path = _points_fixture(tmp_path, column_name, "inspect_stats.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(inspect, ["stats", path])
+
+        assert result.exit_code == 0, result.output
+        assert "Parser Error" not in result.output
+
+
+class TestCheckSpecQuoting:
+    """geoparquet_io/core/validate.py: the data-validation queries.
+
+    A parse error here does not just crash -- it is caught and reported as a
+    *failed* spec check, so a hostile column name made gpio emit a wrong
+    verdict about a perfectly valid file.
+    """
+
+    @adversarial_column
+    def test_check_spec_reports_no_false_failures(self, tmp_path, column_name):
+        path = _points_fixture(tmp_path, column_name, "check_spec.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(check, ["spec", path])
+
+        assert result.exit_code == 0, result.output
+        assert "Parser Error" not in result.output
+        assert "0 failed" in result.output
+
+
+class TestSortHilbertQuoting:
+    """geoparquet_io/core/hilbert_order.py: the empty-geometry count and the
+    ORDER BY ST_Hilbert query."""
+
+    @adversarial_column
+    def test_sort_hilbert_succeeds(self, tmp_path, column_name):
+        path = _points_fixture(tmp_path, column_name, "hilbert_input.parquet")
+        out = str(tmp_path / "hilbert_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(sort, ["hilbert", path, out])
+
+        assert result.exit_code == 0, result.output
+        assert pq.read_table(out).num_rows == 10
+
+
+class TestExtractGeoparquetQuoting:
+    """geoparquet_io/core/extract.py: the column-projection builders."""
+
+    @adversarial_column
+    def test_extract_geoparquet_succeeds(self, tmp_path, column_name):
+        path = _points_fixture(tmp_path, column_name, "extract_input.parquet")
+        out = str(tmp_path / "extract_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(extract, ["geoparquet", path, out])
+
+        assert result.exit_code == 0, result.output
+        assert column_name in pq.read_schema(out).names
+
+
+class TestAddCommandsQuoting:
+    """Every `gpio add` subcommand builds its own geometry expression."""
+
+    @pytest.mark.parametrize(
+        "subcommand",
+        ["h3", "s2", "a5", "quadkey", "geometry-metrics", "kdtree"],
+    )
+    @adversarial_column
+    def test_add_subcommand_succeeds(self, tmp_path, subcommand, column_name):
+        path = _points_fixture(tmp_path, column_name, "add_cmd_input.parquet")
+        out = str(tmp_path / "add_cmd_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(add, [subcommand, path, out])
+
+        assert result.exit_code == 0, result.output
+        assert column_name in pq.read_schema(out).names
+
+
+class TestConvertQuoting:
+    """geoparquet_io/core/convert.py + format_writers.py."""
+
+    @pytest.mark.parametrize("fmt", ["geojson", "csv"])
+    @adversarial_column
+    def test_convert_succeeds(self, tmp_path, fmt, column_name):
+        path = _points_fixture(tmp_path, column_name, "convert_input.parquet")
+        out = str(tmp_path / f"convert_output.{fmt}")
+
+        runner = CliRunner()
+        result = runner.invoke(convert, [fmt, path, out])
+
+        assert result.exit_code == 0, result.output
+        with open(out) as fh:
+            assert fh.read().strip()
+
+
+class TestSortColumnQuoting:
+    """geoparquet_io/core/sort_by_column.py: the ORDER BY clause takes the
+    column name straight from the CLI."""
+
+    @adversarial_column
+    def test_sort_column_succeeds(self, tmp_path, column_name):
+        base = _points_fixture(tmp_path, "geometry", "sort_col_input.parquet")
+        table = pq.read_table(base)
+        renamed = table.rename_columns([column_name, "geometry"])
+        renamed = renamed.replace_schema_metadata(table.schema.metadata)
+        src = str(tmp_path / "sort_col_renamed.parquet")
+        pq.write_table(renamed, src)
+        out = str(tmp_path / "sort_col_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(sort, ["column", src, out, column_name])
+
+        assert result.exit_code == 0, result.output
+        assert pq.read_table(out).num_rows == 10
 
 
 if __name__ == "__main__":

--- a/tests/test_geometry_identifier_quoting.py
+++ b/tests/test_geometry_identifier_quoting.py
@@ -541,6 +541,7 @@ class TestAddBboxStreamingQuoting:
             profile=None,
             force=force,
             geoparquet_version="2.0",
+            memory_limit=None,
         )
 
         table = pq.read_table(output_path)

--- a/tests/test_geometry_identifier_quoting.py
+++ b/tests/test_geometry_identifier_quoting.py
@@ -246,7 +246,7 @@ class TestDuckdbMetadataNativeStatsEscaping:
 
     @pytest.mark.parametrize("column_name", [SPACED_COL, SQUOTE_COL])
     def test_native_geo_stat_getters_return_correct_values(self, tmp_path, column_name):
-        path = _native_geo_fixture(tmp_path, column_name, f"native_geo_{hash(column_name)}.parquet")
+        path = _native_geo_fixture(tmp_path, column_name, "native_geo.parquet")
 
         single = get_native_geo_statistics(path, column_name)
         assert single is not None, "expected stats, got None (query silently failed)"
@@ -310,6 +310,99 @@ class TestDuckdbMetadataSiblingLiteralEscaping:
 
         assert result, "expected a non-empty compression map, got {} (query silently failed)"
         assert all(k == col for k in result)
+
+
+# --- Fix round 1: siblings in core/add/bbox.py's manual `"{col}"` quoting --
+#
+# _build_bbox_sql and add_bbox_table (backing Table.add_bbox() in
+# api/table.py) build `"{col}"`/`f'"{c}"'` by hand instead of calling
+# quote_identifier, so they already tolerate a space but not an embedded `"`
+# (which needs doubling to `""`). _make_add_bbox_query -- used by
+# _add_bbox_streaming, the `gpio add bbox -` stdin/stdout CLI path -- has the
+# identical bug; it wasn't the function named in the fix-round request, but
+# it is the one that actually builds the vulnerable SQL for the streaming
+# path (see the fix-round entry in task-C-report.md for detail).
+
+
+class TestApiTableAddBboxQuoting:
+    """geoparquet_io/core/add/bbox.py: add_bbox_table -- backs Table.add_bbox()."""
+
+    def test_table_add_bbox_succeeds_with_correct_values(self):
+        from geoparquet_io.api.table import Table
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        quoted = quote_identifier(DQUOTE_COL)
+        arrow_table = (
+            con.execute(
+                f"""
+                SELECT * FROM (VALUES
+                    (1, ST_AsWKB(ST_GeomFromText('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'))),
+                    (2, ST_AsWKB(ST_GeomFromText('POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))')))
+                ) AS t(id, {quoted})
+                """
+            )
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        table = Table(arrow_table, geometry_column=DQUOTE_COL)
+        result = table.add_bbox(column_name="bbox")
+
+        rows = result.table.column("bbox").combine_chunks().to_pylist()
+        assert rows[0] == {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0}
+        assert rows[1] == {"xmin": 2.0, "ymin": 2.0, "xmax": 3.0, "ymax": 3.0}
+
+
+class TestAddBboxStreamingQuoting:
+    """geoparquet_io/core/add/bbox.py: _make_add_bbox_query, used by
+    _add_bbox_streaming (the `gpio add bbox -` stdin/stdout CLI path).
+
+    _add_bbox_streaming's own geometry-column auto-detection only checks
+    STANDARD_GEOMETRY_NAMES (a separate, pre-existing limitation, out of
+    scope for this fix), so the hostile name is added to that lookup via
+    monkeypatch to let the *real* _add_bbox_streaming run end-to-end rather
+    than testing the SQL-building helper in isolation.
+    """
+
+    def test_add_bbox_streaming_succeeds_with_correct_values(self, tmp_path, monkeypatch):
+        from geoparquet_io.core.add import bbox as bbox_module
+
+        monkeypatch.setattr(
+            bbox_module,
+            "STANDARD_GEOMETRY_NAMES",
+            [DQUOTE_COL, *bbox_module.STANDARD_GEOMETRY_NAMES],
+        )
+        input_path = _wkb_fixture(
+            tmp_path,
+            DQUOTE_COL,
+            "streaming_input.parquet",
+            wkts=[
+                "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
+                "POLYGON ((2 2, 2 3, 3 3, 3 2, 2 2))",
+            ],
+        )
+        output_path = str(tmp_path / "streaming_output.parquet")
+
+        bbox_module._add_bbox_streaming(
+            input_path=input_path,
+            output_path=output_path,
+            bbox_column_name="bbox",
+            verbose=False,
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=None,
+            profile=None,
+            force=False,
+            geoparquet_version="2.0",
+        )
+
+        table = pq.read_table(output_path)
+        rows = table.column("bbox").combine_chunks().to_pylist()
+        assert rows[0] == {"xmin": 0.0, "ymin": 0.0, "xmax": 1.0, "ymax": 1.0}
+        assert rows[1] == {"xmin": 2.0, "ymin": 2.0, "xmax": 3.0, "ymax": 3.0}
 
 
 if __name__ == "__main__":

--- a/tests/test_sql_path_escaping.py
+++ b/tests/test_sql_path_escaping.py
@@ -1,0 +1,168 @@
+"""Regression tests: a file path is escaped for SQL exactly once.
+
+``file_utils.safe_file_url()`` escapes a path for interpolation into SQL
+(``'`` -> ``''``) *and* validates that the raw path exists.
+``duckdb_metadata._safe_url()`` delegates to it, so every public
+``duckdb_metadata`` getter escapes its own ``parquet_file`` argument.
+
+Callers that passed their already-escaped ``safe_url`` into those getters
+therefore escaped twice: the getter re-escaped ``o''brien`` to ``o''''brien``,
+and ``safe_file_url``'s existence check then failed on the *escaped* string,
+raising ``FileNotFoundGeoParquetError`` for a file that is plainly there.
+
+The contract is now: ``safe_file_url``/``_safe_url`` is the single escape
+point, and every ``duckdb_metadata`` getter takes a RAW path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import add, check, convert, inspect
+from geoparquet_io.core.duckdb_metadata import (
+    detect_geometry_columns,
+    get_bbox_from_row_group_stats,
+    get_column_names,
+    get_compression_info,
+    get_file_metadata,
+    get_geo_metadata,
+    get_per_row_group_bbox_stats,
+    get_schema_info,
+    has_bbox_column,
+)
+from geoparquet_io.core.exceptions import FileNotFoundGeoParquetError
+from geoparquet_io.core.file_utils import safe_file_url
+
+
+@pytest.fixture
+def apostrophe_file(tmp_path):
+    """A GeoParquet file inside a directory whose name contains an apostrophe."""
+    directory = tmp_path / "o'brien"
+    directory.mkdir()
+    path = str(directory / "q.parquet")
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    values = ", ".join(
+        f"({i + 1}, ST_AsWKB(ST_GeomFromText('POINT ({i} {i})')))" for i in range(10)
+    )
+    table = con.execute(f"SELECT * FROM (VALUES {values}) AS t(id, geometry)").arrow().read_all()
+    con.close()
+
+    geo = {
+        "version": "1.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "bbox": [0.0, 0.0, 9.0, 9.0],
+            }
+        },
+    }
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode()})
+    pq.write_table(table, path)
+    return path
+
+
+@pytest.fixture
+def apostrophe_file_with_bbox(apostrophe_file, tmp_path):
+    """The same file, with a bbox covering column added."""
+    out = str(tmp_path / "o'brien" / "q_bbox.parquet")
+    runner = CliRunner()
+    result = runner.invoke(add, ["bbox", apostrophe_file, out])
+    assert result.exit_code == 0, result.output
+    return out
+
+
+class TestSafeFileUrlIsIdempotentlyApplied:
+    """Passing an already-escaped path to a duckdb_metadata getter must not
+    re-escape it. Before the fix these raised FileNotFoundGeoParquetError."""
+
+    def test_escaping_twice_is_fatal(self, apostrophe_file):
+        """The premise of this module: escaping is not idempotent."""
+        once = safe_file_url(apostrophe_file)
+        assert "o''brien" in once
+        # Re-escaping mangles the path, and safe_file_url's existence check
+        # then fails on a file that is plainly there.
+        with pytest.raises(FileNotFoundGeoParquetError):
+            safe_file_url(once)
+
+    @pytest.mark.parametrize(
+        "getter",
+        [
+            get_file_metadata,
+            get_schema_info,
+            get_geo_metadata,
+            get_column_names,
+            detect_geometry_columns,
+            has_bbox_column,
+        ],
+    )
+    def test_metadata_getters_accept_raw_path(self, apostrophe_file, getter):
+        # No exception, and something truthy comes back.
+        assert getter(apostrophe_file) is not None
+
+    def test_compression_info_accepts_raw_path(self, apostrophe_file):
+        assert get_compression_info(apostrophe_file)
+
+    def test_bbox_stats_accept_raw_path(self, apostrophe_file_with_bbox):
+        has_bbox, bbox_col = has_bbox_column(apostrophe_file_with_bbox)
+        assert has_bbox and bbox_col == "bbox"
+        assert get_per_row_group_bbox_stats(apostrophe_file_with_bbox, bbox_col)
+        assert get_bbox_from_row_group_stats(apostrophe_file_with_bbox, bbox_col)
+
+
+class TestCliCommandsOnApostrophePath:
+    """End-to-end: every command reported broken by the audit must succeed on a
+    path containing an apostrophe."""
+
+    @pytest.mark.parametrize(
+        ("group", "args"),
+        [
+            ("check", ["spatial"]),
+            ("check", ["all"]),
+            ("check", ["bbox"]),
+            ("check", ["spec"]),
+            ("check", ["compression"]),
+            ("check", ["row-group"]),
+            ("inspect", ["meta"]),
+            ("inspect", ["summary"]),
+            ("inspect", ["head"]),
+            ("inspect", ["stats"]),
+        ],
+    )
+    def test_read_only_command_succeeds(self, apostrophe_file, group, args):
+        runner = CliRunner()
+        cli_group = {"check": check, "inspect": inspect}[group]
+        result = runner.invoke(cli_group, [*args, apostrophe_file])
+
+        assert result.exit_code == 0, result.output
+        assert "o''brien" not in result.output
+
+    def test_add_bbox_succeeds(self, apostrophe_file, tmp_path):
+        out = str(tmp_path / "o'brien" / "out.parquet")
+        runner = CliRunner()
+        result = runner.invoke(add, ["bbox", apostrophe_file, out])
+
+        assert result.exit_code == 0, result.output
+        assert "bbox" in pq.read_schema(out).names
+
+    @pytest.mark.parametrize("fmt", ["geojson", "csv"])
+    def test_convert_succeeds(self, apostrophe_file, tmp_path, fmt):
+        out = str(tmp_path / "o'brien" / f"out.{fmt}")
+        runner = CliRunner()
+        result = runner.invoke(convert, [fmt, apostrophe_file, out])
+
+        assert result.exit_code == 0, result.output
+        with open(out) as fh:
+            assert fh.read().strip()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Several SQL builders interpolated a geometry/column identifier raw into
generated SQL. Any file whose geometry column has a space, uppercase
letter, reserved word, or embedded quote — a name read verbatim from the
file's own `geo.primary_column` metadata — crashed with a DuckDB
`ParserException`. Since a hostile parquet file can carry such a name via
its own metadata, this was also a latent SQL-injection vector, not just a
crash bug.

## Fixed sites

Identifier positions (fixed with the existing `quote_identifier` helper):

- `stream_io.py` — `_wrap_query_with_wkb_conversion`'s WKB conversion wrap
- `common.py` — `add_bbox`'s `STRUCT_PACK` expression
- `check_spatial_order.py` — the sampling-method queries
  (`_calculate_consecutive_avg`, `_calculate_random_avg`)
- `core/add/bbox.py` — every `add bbox` code path:
  - `_add_bbox_file_based`'s `STRUCT_PACK` (the actual code path the
    `gpio add bbox` CLI hits)
  - `_make_add_bbox_query`, used by `_add_bbox_streaming` (the
    `gpio add bbox -` stdin/stdout streaming path)
  - `add_bbox_table`, which backs `Table.add_bbox()` in the Python API,
    where `geometry_column` can come from a file's own metadata
  - `_build_bbox_sql` (currently dead code; fixed for consistency)

String-literal positions (fixed with `_escape_sql_string`, **not**
`quote_identifier` — see distinction below):

- `duckdb_metadata.py` — the `WHERE path_in_schema = '{geometry_column}'`
  filters in `get_native_geo_statistics`, `get_aggregated_native_geo_stats`,
  `get_per_row_group_native_geo_stats`
- Extra sibling literal sites found during audit: `get_bbox_from_row_group_stats`,
  `get_per_row_group_bbox_stats` (keyed on `bbox_column`), and
  `get_compression_info` (keyed on `column_name`) — same
  `path_in_schema = '...'` pattern

## The identifier-vs-string-literal distinction

- `ST_XMin(geom col)` interpolates the column as a SQL **identifier** — a
  space or embedded `"` breaks the parse. Fix: `quote_identifier` (doubles
  embedded `"`, wraps in `"`).
- `WHERE path_in_schema = 'geom col'` interpolates the column as a SQL
  **string literal** — a space is harmless there; only an embedded `'`
  breaks it, and it broke *silently* (a broad `except Exception` swallowed
  the resulting `ParserException` and returned `None`/empty stats instead
  of raising or the correct value). Fix: `_escape_sql_string` (doubles
  embedded `'`), never `quote_identifier`.

## Known follow-ups (out of scope)

Two pre-existing bugs were found and disclosed but deliberately left
unfixed here:

1. `api/table.py::_calculate_bounds_from_table` has the identical unquoted
   `"{col}"` pattern, but it's a different module from this PR's
   `core/add/bbox.py` scope.
2. `_add_bbox_streaming`'s geometry-column auto-detection only checks
   membership in `STANDARD_GEOMETRY_NAMES` (`geometry`, `geom`,
   `wkb_geometry`, `shape`, `the_geom`) — it never reads the file's own
   `geo.primary_column` metadata. This is a wrong-column-selection bug, not
   a quoting bug, so a real `gpio add bbox -` on a file with a non-standard
   geometry column name silently picks the wrong column rather than
   exercising the quoting fix at all.

## Tests

`tests/test_geometry_identifier_quoting.py` (new, 15 tests) covers all
sites above with in-test pyarrow/duckdb fixtures whose `geo.primary_column`
metadata carries a hostile name — a space (`geom col`), an embedded double
quote (`geo"m`), or an embedded single quote (`geo'm`), as appropriate to
each bug class. Assertions check actual computed values (bbox coordinates,
WKT round-trips, spatial-order ratios, native geo stats), not just
non-crash, including:

- `Table.add_bbox()` Python API path with an embedded-double-quote column
- `_add_bbox_streaming` CLI path with an embedded-double-quote column
  (exercised end-to-end via a monkeypatched `STANDARD_GEOMETRY_NAMES` so the
  hostile name is discovered, working around follow-up #2 above)
- End-to-end `gpio add bbox` and `gpio check spatial` CLI invocations

Full fast suite: 3554 passed, 40 skipped. `pre-commit` clean on all changed
files.

## Test plan

- [x] `uv run pytest tests/test_geometry_identifier_quoting.py -n 4 -v` — 15 passed
- [x] `uv run pytest -n 4 -m "not slow and not network"` — 3554 passed, 40 skipped
- [x] `uv run pre-commit run --files <changed files>` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for geometry and column names containing spaces, quotes, reserved words, and other special characters.
  * Fixed handling of file paths containing apostrophes across metadata, validation, conversion, inspection, and spatial operations.
  * Prevented malformed queries and injection risks from crafted column names or metadata values.
  * Corrected escaping behavior to avoid double-escaped paths and false file-not-found errors.
* **Documentation**
  * Added guidance and changelog notes covering SQL safety and unusual identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->