### PR TITLE
fix(add,sort): forward --write-memory to the write engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,11 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   read that needs it, and the unused `get_bigquery_connection()` helper — which
   set `GOOGLE_APPLICATION_CREDENTIALS` with no restore — is removed in favour of
   the `BigQueryConnection` context manager the extract path already used.
+- **`--write-memory` now honored by `add h3`/`a5`/`s2`/`kdtree`/`quadkey` and
+  `sort column`/`quadkey` (previously silently ignored).** These commands
+  accepted the flag but never forwarded it to the DuckDB write engine, so the
+  value was dropped and the auto-detected default memory limit was used
+  instead — the same bug class fixed for `sort hilbert` in #627.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,11 +273,41 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   read that needs it, and the unused `get_bigquery_connection()` helper — which
   set `GOOGLE_APPLICATION_CREDENTIALS` with no restore — is removed in favour of
   the `BigQueryConnection` context manager the extract path already used.
-- **`--write-memory` now honored by `add h3`/`a5`/`s2`/`kdtree`/`quadkey` and
-  `sort column`/`quadkey` (previously silently ignored).** These commands
-  accepted the flag but never forwarded it to the DuckDB write engine, so the
-  value was dropped and the auto-detected default memory limit was used
-  instead — the same bug class fixed for `sort hilbert` in #627.
+- **`--write-memory` now honored by every command that offers it (previously
+  silently ignored on twelve of them).** `add h3`/`a5`/`s2`/`kdtree`/`quadkey`/
+  `bbox`/`geometry-metrics`/`admin-divisions`, `sort column`/`quadkey`,
+  `convert geoparquet` and `extract bigquery` accepted the flag but never
+  forwarded it, so the value was dropped and the auto-detected default limit
+  was used instead — the same bug class fixed for `sort hilbert` in #627. The
+  flag is now forwarded by all 22 commands that expose it (`convert
+  geoparquet`/`reproject`, `extract geoparquet`/`bigquery`, `sort
+  hilbert`/`column`/`quadkey`, `add admin-divisions`/`geometry-metrics`/`bbox`/
+  `h3`/`a5`/`s2`/`kdtree`/`quadkey`, and all seven `partition` subcommands).
+  It remains absent — by design — from commands with no DuckDB write engine to
+  configure: `convert geojson`/`geopackage`/`flatgeobuf`/`csv`/`shapefile`,
+  `extract arcgis`/`wfs`/`carto`, `add bbox-metadata`, `pmtiles
+  create`/`pyramid`, `process overview`/`aggregate`, and `publish
+  stac`/`upload`. On `extract bigquery` the limit is applied to the DuckDB
+  connection that runs the BigQuery scan (the memory-heavy step); the Parquet
+  write itself is a PyArrow write.
+
+- **`--write-memory` is validated instead of reaching SQL unchecked.** The
+  value is interpolated into DuckDB's `SET memory_limit = '…'` (a SET value
+  cannot be parameterised), and DuckDB executes multi-statement strings, so an
+  unvalidated value could append arbitrary SQL — reachable from any library
+  caller passing a config-supplied `memory_limit`. Values must now match a
+  plain size literal (`512MB`, `2GB`, `4.5GB`, `1GiB`); anything else is a
+  clean Click parameter error rather than a raw DuckDB `ParserException`
+  traceback.
+
+- **`--write-memory` no longer aborts with `--geoparquet-version
+  1.1-geoarrow`.** That version reroutes WKB input to the arrow-streaming
+  write strategy, which cannot honour a memory limit; the combination raised a
+  raw `ValueError` traceback on `sort hilbert` (since #627) and on the seven
+  commands above. gpio now warns and ignores the limit when *it* rerouted the
+  strategy, and reports a clean parameter error only when the user explicitly
+  chose an incompatible `--write-strategy`. Streaming Arrow IPC to stdout also
+  warns rather than dropping the limit silently.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -273,6 +273,11 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   read that needs it, and the unused `get_bigquery_connection()` helper — which
   set `GOOGLE_APPLICATION_CREDENTIALS` with no restore — is removed in favour of
   the `BigQueryConnection` context manager the extract path already used.
+- **`--write-memory` now honored by `add h3`/`a5`/`s2`/`kdtree`/`quadkey` and
+  `sort column`/`quadkey` (previously silently ignored).** These commands
+  accepted the flag but never forwarded it to the DuckDB write engine, so the
+  value was dropped and the auto-detected default memory limit was used
+  instead — the same bug class fixed for `sort hilbert` in #627.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -273,11 +273,41 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   read that needs it, and the unused `get_bigquery_connection()` helper — which
   set `GOOGLE_APPLICATION_CREDENTIALS` with no restore — is removed in favour of
   the `BigQueryConnection` context manager the extract path already used.
-- **`--write-memory` now honored by `add h3`/`a5`/`s2`/`kdtree`/`quadkey` and
-  `sort column`/`quadkey` (previously silently ignored).** These commands
-  accepted the flag but never forwarded it to the DuckDB write engine, so the
-  value was dropped and the auto-detected default memory limit was used
-  instead — the same bug class fixed for `sort hilbert` in #627.
+- **`--write-memory` now honored by every command that offers it (previously
+  silently ignored on twelve of them).** `add h3`/`a5`/`s2`/`kdtree`/`quadkey`/
+  `bbox`/`geometry-metrics`/`admin-divisions`, `sort column`/`quadkey`,
+  `convert geoparquet` and `extract bigquery` accepted the flag but never
+  forwarded it, so the value was dropped and the auto-detected default limit
+  was used instead — the same bug class fixed for `sort hilbert` in #627. The
+  flag is now forwarded by all 22 commands that expose it (`convert
+  geoparquet`/`reproject`, `extract geoparquet`/`bigquery`, `sort
+  hilbert`/`column`/`quadkey`, `add admin-divisions`/`geometry-metrics`/`bbox`/
+  `h3`/`a5`/`s2`/`kdtree`/`quadkey`, and all seven `partition` subcommands).
+  It remains absent — by design — from commands with no DuckDB write engine to
+  configure: `convert geojson`/`geopackage`/`flatgeobuf`/`csv`/`shapefile`,
+  `extract arcgis`/`wfs`/`carto`, `add bbox-metadata`, `pmtiles
+  create`/`pyramid`, `process overview`/`aggregate`, and `publish
+  stac`/`upload`. On `extract bigquery` the limit is applied to the DuckDB
+  connection that runs the BigQuery scan (the memory-heavy step); the Parquet
+  write itself is a PyArrow write.
+
+- **`--write-memory` is validated instead of reaching SQL unchecked.** The
+  value is interpolated into DuckDB's `SET memory_limit = '…'` (a SET value
+  cannot be parameterised), and DuckDB executes multi-statement strings, so an
+  unvalidated value could append arbitrary SQL — reachable from any library
+  caller passing a config-supplied `memory_limit`. Values must now match a
+  plain size literal (`512MB`, `2GB`, `4.5GB`, `1GiB`); anything else is a
+  clean Click parameter error rather than a raw DuckDB `ParserException`
+  traceback.
+
+- **`--write-memory` no longer aborts with `--geoparquet-version
+  1.1-geoarrow`.** That version reroutes WKB input to the arrow-streaming
+  write strategy, which cannot honour a memory limit; the combination raised a
+  raw `ValueError` traceback on `sort hilbert` (since #627) and on the seven
+  commands above. gpio now warns and ignores the limit when *it* rerouted the
+  strategy, and reports a clean parameter error only when the user explicitly
+  chose an incompatible `--write-strategy`. Streaming Arrow IPC to stdout also
+  warns rather than dropping the limit silently.
 
 - **Clear errors for missing `--metric`/`--breakdown` columns in
   `gpio process aggregate`.** Requesting a column that doesn't exist now

--- a/docs/guide/write-strategies.md
+++ b/docs/guide/write-strategies.md
@@ -128,12 +128,17 @@ Override auto-detection when needed:
 
     # Smaller limit for restricted environments
     gpio extract input.parquet output.parquet --write-memory 512MB
-
-    # Combine with strategy selection
-    gpio extract input.parquet output.parquet \
-        --write-strategy streaming \
-        --write-memory 1GB
     ```
+
+    !!! warning "`--write-memory` requires the `duckdb-kv` strategy"
+        Only `duckdb-kv` (the default) has a DuckDB write engine to configure.
+        Combining `--write-memory` with an explicitly chosen `--write-strategy`
+        of `streaming`, `in-memory`, or `disk-rewrite` is rejected as a
+        parameter error. `--geoparquet-version 1.1-geoarrow` internally reroutes
+        WKB input to the arrow-streaming strategy; there gpio warns and ignores
+        `--write-memory` rather than failing. Streaming Arrow IPC to stdout
+        (`-`) also has no write engine to configure, so the limit is ignored
+        with a warning — `--write-memory` only applies to file outputs.
 
 === "Python"
 

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -217,6 +217,26 @@ def linearize_curves_options(func):
     )(func)
 
 
+def _validate_write_memory(ctx, param, value):
+    """Reject a --write-memory value that isn't a plain size.
+
+    The value is interpolated into DuckDB's ``SET memory_limit = '…'``, so
+    validating here both blocks SQL injection and turns garbage input into a
+    clean parameter error instead of a raw DuckDB ParserException traceback.
+    One shared decorator means one place to fix.
+    """
+    if value is None:
+        return None
+
+    from geoparquet_io.core.write_strategies.duckdb_kv import validate_memory_limit
+
+    try:
+        validate_memory_limit(value)
+    except ValueError as e:
+        raise click.BadParameter(str(e), ctx=ctx, param=param) from None
+    return value
+
+
 def write_memory_option(func):
     """
     Add --write-memory option to a command.
@@ -229,8 +249,11 @@ def write_memory_option(func):
         "--write-memory",
         type=str,
         default=None,
+        callback=_validate_write_memory,
+        # Click does not printf-format help text, so a literal "%%" would be
+        # rendered verbatim.
         help="Memory limit for streaming writes (e.g., '512MB', '2GB'). "
-        "Default: 50%% of available RAM (container-aware).",
+        "Default: 50% of available RAM (container-aware).",
     )(func)
 
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3771,6 +3771,7 @@ def sort_column(
             row_group_rows=row_group_size,
             geoparquet_version=geoparquet_version,
             overwrite=overwrite,
+            memory_limit=write_memory,
         )
 
 
@@ -3857,6 +3858,7 @@ def sort_quadkey(
             row_group_rows=row_group_size,
             geoparquet_version=geoparquet_version,
             overwrite=overwrite,
+            memory_limit=write_memory,
         )
 
 
@@ -4384,17 +4386,18 @@ def add_h3(
             add_h3_column_impl(
                 input_parquet,
                 output_parquet,
-                h3_name,
-                resolution,
-                dry_run,
-                verbose,
-                compression.upper(),
-                compression_level,
-                row_group_mb,
-                row_group_size,
-                None,
-                geoparquet_version,
+                h3_column_name=h3_name,
+                h3_resolution=resolution,
+                dry_run=dry_run,
+                verbose=verbose,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                row_group_size_mb=row_group_mb,
+                row_group_rows=row_group_size,
+                profile=None,
+                geoparquet_version=geoparquet_version,
                 overwrite=overwrite,
+                memory_limit=write_memory,
             )
         except StreamingError as e:
             raise click.ClickException(str(e)) from None
@@ -4466,17 +4469,18 @@ def add_a5(
             add_a5_column_impl(
                 input_parquet,
                 output_parquet,
-                a5_name,
-                resolution,
-                dry_run,
-                verbose,
-                compression.upper(),
-                compression_level,
-                row_group_mb,
-                row_group_size,
-                None,
-                geoparquet_version,
+                a5_column_name=a5_name,
+                a5_resolution=resolution,
+                dry_run=dry_run,
+                verbose=verbose,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                row_group_size_mb=row_group_mb,
+                row_group_rows=row_group_size,
+                profile=None,
+                geoparquet_version=geoparquet_version,
                 overwrite=overwrite,
+                memory_limit=write_memory,
             )
         except StreamingError as e:
             raise click.ClickException(str(e)) from None
@@ -4548,17 +4552,18 @@ def add_s2(
             add_s2_column_impl(
                 input_parquet,
                 output_parquet,
-                s2_name,
-                level,
-                dry_run,
-                verbose,
-                compression.upper(),
-                compression_level,
-                row_group_mb,
-                row_group_size,
-                None,
-                geoparquet_version,
+                s2_column_name=s2_name,
+                s2_level=level,
+                dry_run=dry_run,
+                verbose=verbose,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                row_group_size_mb=row_group_mb,
+                row_group_rows=row_group_size,
+                profile=None,
+                geoparquet_version=geoparquet_version,
                 overwrite=overwrite,
+                memory_limit=write_memory,
             )
         except StreamingError as e:
             raise click.ClickException(str(e)) from None
@@ -4693,20 +4698,21 @@ def add_kdtree(
         add_kdtree_column_impl(
             input_parquet,
             output_parquet,
-            kdtree_name,
-            iterations,
-            dry_run,
-            verbose,
-            compression.upper(),
-            compression_level,
-            row_group_mb,
-            row_group_size,
-            force,
-            sample_size,
-            auto_target,
-            None,
-            geoparquet_version,
+            kdtree_column_name=kdtree_name,
+            iterations=iterations,
+            dry_run=dry_run,
+            verbose=verbose,
+            compression=compression.upper(),
+            compression_level=compression_level,
+            row_group_size_mb=row_group_mb,
+            row_group_rows=row_group_size,
+            force=force,
+            sample_size=sample_size,
+            auto_target_rows=auto_target,
+            profile=None,
+            geoparquet_version=geoparquet_version,
             overwrite=overwrite,
+            memory_limit=write_memory,
         )
 
 
@@ -4797,6 +4803,7 @@ def add_quadkey(
                 row_group_rows=row_group_size,
                 geoparquet_version=geoparquet_version,
                 overwrite=overwrite,
+                memory_limit=write_memory,
             )
         except StreamingError as e:
             raise click.ClickException(str(e)) from None

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1367,6 +1367,7 @@ def convert_to_geoparquet_cmd(
                 repair_geometry=repair_geometry,
                 linearize_curves=linearize_curves,
                 max_angle_deg=max_angle_deg,
+                memory_limit=write_memory,
             )
         else:
             convert_to_geoparquet(
@@ -1391,6 +1392,7 @@ def convert_to_geoparquet_cmd(
                 repair_geometry=repair_geometry,
                 linearize_curves=linearize_curves,
                 max_angle_deg=max_angle_deg,
+                memory_limit=write_memory,
             )
 
 
@@ -1414,6 +1416,7 @@ def _convert_streaming(
     repair_geometry=True,
     linearize_curves=True,
     max_angle_deg=None,
+    memory_limit=None,
 ):
     """Handle streaming output for convert command."""
     import tempfile
@@ -1449,6 +1452,7 @@ def _convert_streaming(
             repair_geometry=repair_geometry,
             linearize_curves=linearize_curves,
             max_angle_deg=max_angle_deg,
+            memory_limit=memory_limit,
         )
 
         # Read and stream to stdout
@@ -3076,6 +3080,7 @@ def extract_bigquery_cmd(
         geoparquet_version=geoparquet_version,
         overwrite=overwrite,
         repair_geometry=repair_geometry,
+        memory_limit=write_memory,
     )
 
 
@@ -4107,6 +4112,7 @@ def add_country_codes(
         prefix=prefix,
         no_cache=no_cache,
         vecorel=vecorel,
+        memory_limit=write_memory,
     )
 
 
@@ -4194,6 +4200,7 @@ def add_geometry_metrics_cmd(
         geoparquet_version=geoparquet_version,
         overwrite=overwrite,
         show_sql=show_sql,
+        memory_limit=write_memory,
     )
 
 
@@ -4280,17 +4287,18 @@ def add_bbox(
             add_bbox_column_impl(
                 input_parquet,
                 output_parquet,
-                bbox_name,
-                dry_run,
-                verbose,
-                compression.upper(),
-                compression_level,
-                row_group_mb,
-                row_group_size,
-                None,
-                force,
-                geoparquet_version,
+                bbox_column_name=bbox_name,
+                dry_run=dry_run,
+                verbose=verbose,
+                compression=compression.upper(),
+                compression_level=compression_level,
+                row_group_size_mb=row_group_mb,
+                row_group_rows=row_group_size,
+                profile=None,
+                force=force,
+                geoparquet_version=geoparquet_version,
                 overwrite=overwrite,
+                memory_limit=write_memory,
             )
         except StreamingError as e:
             raise click.ClickException(str(e)) from None

--- a/geoparquet_io/core/add/a5.py
+++ b/geoparquet_io/core/add/a5.py
@@ -163,6 +163,7 @@ def add_a5_column(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Add an A5 cell ID column to a GeoParquet file.
@@ -191,6 +192,7 @@ def add_a5_column(
         row_group_rows: Exact number of rows per row group
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     # Configure logging verbosity
     configure_verbose(verbose)
@@ -215,6 +217,7 @@ def add_a5_column(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -261,6 +264,7 @@ def add_a5_column(
         custom_metadata=a5_metadata,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not dry_run:
@@ -282,6 +286,7 @@ def _add_a5_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for add_a5."""
     # Suppress verbose when streaming to stdout
@@ -326,6 +331,7 @@ def _add_a5_streaming(
         row_group_rows=row_group_rows,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not should_stream_output(output_path):

--- a/geoparquet_io/core/add/a5.py
+++ b/geoparquet_io/core/add/a5.py
@@ -286,7 +286,7 @@ def _add_a5_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
-    memory_limit: str | None = None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for add_a5."""
     # Suppress verbose when streaming to stdout

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -651,6 +651,7 @@ def _execute_per_level_joins(
     extra_kv=None,
     source_crs=None,
     has_native_geometry=False,
+    memory_limit=None,
 ):
     """Run separate spatial joins per admin level for per-level-source datasets.
 
@@ -711,6 +712,7 @@ def _execute_per_level_joins(
                 profile=profile,
                 geoparquet_version=geoparquet_version,
                 extra_kv_metadata=extra_kv,
+                memory_limit=memory_limit,
             )
         else:
             temp_table = f"_gpio_admin_step_{i}"
@@ -745,6 +747,7 @@ def add_admin_divisions_multi(
     prefix: str | None = None,
     no_cache: bool = False,
     vecorel: bool = False,
+    memory_limit: str | None = None,
 ):
     """
     Add admin division columns from a multi-level admin dataset.
@@ -765,6 +768,7 @@ def add_admin_divisions_multi(
         profile: AWS profile name (S3 only, optional)
         prefix: Optional column name prefix (default: dataset name, use "admin" for admin: format)
         no_cache: Skip local cache and use remote dataset directly
+        memory_limit: DuckDB memory limit for the write (e.g. '2GB')
     """
     # When vecorel mode is active, override prefix to use Vecorel column names
     effective_prefix = "vecorel" if vecorel else prefix
@@ -857,6 +861,7 @@ def add_admin_divisions_multi(
                     extra_kv=extra_kv,
                     source_crs=source_crs,
                     has_native_geometry=has_native_geometry,
+                    memory_limit=memory_limit,
                 )
                 if dry_run:
                     return
@@ -914,6 +919,7 @@ def add_admin_divisions_multi(
                     profile=profile,
                     geoparquet_version=geoparquet_version,
                     extra_kv_metadata=extra_kv,
+                    memory_limit=memory_limit,
                 )
 
                 total_features, features_with_admin, unique_counts = _get_result_stats(

--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -157,6 +157,7 @@ def add_bbox_column(
     force: bool = False,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Add a bbox struct column to a GeoParquet file.
@@ -184,6 +185,7 @@ def add_bbox_column(
         profile: AWS profile name (S3 only, optional)
         force: Whether to replace an existing bbox column
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
 
     Note:
         Bbox covering metadata is automatically added when the file is written.
@@ -204,6 +206,7 @@ def add_bbox_column(
             profile,
             force,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -222,6 +225,7 @@ def add_bbox_column(
         force,
         geoparquet_version,
         overwrite,
+        memory_limit=memory_limit,
     )
 
 
@@ -237,6 +241,7 @@ def _add_bbox_streaming(
     profile: str | None,
     force: bool,
     geoparquet_version: str | None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for add_bbox."""
     # Suppress verbose when streaming to stdout
@@ -284,6 +289,7 @@ def _add_bbox_streaming(
         profile=profile,
         custom_metadata=covering_metadata,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not should_stream_output(output_path):
@@ -303,7 +309,8 @@ def _add_bbox_file_based(
     profile: str | None,
     force: bool,
     geoparquet_version: str | None,
-    overwrite: bool = False,
+    overwrite: bool,
+    memory_limit: str | None,
 ) -> None:
     """Handle file-based add_bbox operation."""
     # Check if output file exists and handle overwrite (fixes issue #278)
@@ -387,6 +394,7 @@ def _add_bbox_file_based(
         replace_column=replace_column,
         geoparquet_version=geoparquet_version,
         custom_metadata=covering_metadata,
+        memory_limit=memory_limit,
     )
 
     if not dry_run:

--- a/geoparquet_io/core/add/geometry_metrics.py
+++ b/geoparquet_io/core/add/geometry_metrics.py
@@ -48,6 +48,7 @@ def add_geometry_metrics(
     geoparquet_version: str | None = None,
     overwrite: bool = False,
     show_sql: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Add geometry metrics (area and perimeter) to a GeoParquet file.
@@ -71,6 +72,7 @@ def add_geometry_metrics(
         geoparquet_version: GeoParquet version to write
         overwrite: Overwrite existing output file
         show_sql: Print SQL statements
+        memory_limit: DuckDB memory limit for the write (e.g. '2GB')
     """
     is_streaming = is_stdin(input_parquet) or should_stream_output(output_parquet)
 
@@ -86,6 +88,7 @@ def add_geometry_metrics(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit,
         )
         return
 
@@ -103,6 +106,7 @@ def add_geometry_metrics(
         geoparquet_version,
         overwrite,
         show_sql,
+        memory_limit,
     )
 
 
@@ -117,6 +121,7 @@ def _add_metrics_streaming(
     row_group_rows,
     profile,
     geoparquet_version,
+    memory_limit,
 ) -> None:
     """Handle streaming input/output for geometry metrics."""
     from geoparquet_io.core.geometry_detection import STANDARD_GEOMETRY_NAMES
@@ -157,6 +162,7 @@ def _add_metrics_streaming(
         profile=profile,
         geoparquet_version=geoparquet_version,
         extra_kv_metadata=extra_kv,
+        memory_limit=memory_limit,
     )
 
     if not should_stream_output(output_path):
@@ -177,6 +183,7 @@ def _add_metrics_file_based(
     geoparquet_version,
     overwrite,
     show_sql,
+    memory_limit,
 ) -> None:
     """Handle file-based geometry metrics addition — two passes via add_computed_column."""
     handle_output_overwrite(output_parquet, overwrite, input_parquet)
@@ -216,6 +223,7 @@ def _add_metrics_file_based(
             row_group_rows=row_group_rows,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            memory_limit=memory_limit,
         )
 
         # Pass 2: add perimeter column to final output
@@ -231,6 +239,7 @@ def _add_metrics_file_based(
             row_group_rows=row_group_rows,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            memory_limit=memory_limit,
         )
     finally:
         if os.path.exists(temp_file):
@@ -240,13 +249,15 @@ def _add_metrics_file_based(
     if vecorel:
         from geoparquet_io.core.constants import ensure_vecorel_columns
 
-        _add_vecorel_metadata_to_file(output_parquet, verbose)
+        _add_vecorel_metadata_to_file(output_parquet, verbose, memory_limit)
         ensure_vecorel_columns(output_parquet, verbose)
 
     success(f"Added {AREA_COLUMN} and {PERIMETER_COLUMN} to: {output_parquet}")
 
 
-def _add_vecorel_metadata_to_file(parquet_file: str, verbose: bool) -> None:
+def _add_vecorel_metadata_to_file(
+    parquet_file: str, verbose: bool, memory_limit: str | None
+) -> None:
     """Add Vecorel schema metadata to an existing file via rewrite."""
     from geoparquet_io.core.common import write_parquet_with_metadata
     from geoparquet_io.core.duckdb_utils import get_duckdb_connection
@@ -286,6 +297,7 @@ def _add_vecorel_metadata_to_file(parquet_file: str, verbose: bool) -> None:
                 original_metadata=metadata,
                 extra_kv_metadata=extra_kv,
                 verbose=verbose,
+                memory_limit=memory_limit,
             )
         finally:
             # Release DuckDB's read handle on the source before replacing it;

--- a/geoparquet_io/core/add/h3.py
+++ b/geoparquet_io/core/add/h3.py
@@ -163,6 +163,7 @@ def add_h3_column(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Add an H3 cell ID column to a GeoParquet file.
@@ -191,6 +192,7 @@ def add_h3_column(
         row_group_rows: Exact number of rows per row group
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     # Configure logging verbosity
     configure_verbose(verbose)
@@ -215,6 +217,7 @@ def add_h3_column(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -261,6 +264,7 @@ def add_h3_column(
         custom_metadata=h3_metadata,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not dry_run:
@@ -282,6 +286,7 @@ def _add_h3_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for add_h3."""
     # Suppress verbose when streaming to stdout
@@ -326,6 +331,7 @@ def _add_h3_streaming(
         row_group_rows=row_group_rows,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not should_stream_output(output_path):

--- a/geoparquet_io/core/add/h3.py
+++ b/geoparquet_io/core/add/h3.py
@@ -286,7 +286,7 @@ def _add_h3_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
-    memory_limit: str | None = None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for add_h3."""
     # Suppress verbose when streaming to stdout

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -288,6 +288,7 @@ def add_kdtree_column(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Add a KD-tree cell ID column to a GeoParquet file.
@@ -321,6 +322,7 @@ def add_kdtree_column(
         auto_target_rows: If set, auto-compute iterations to target this many rows per partition
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     configure_verbose(verbose)
 
@@ -341,6 +343,7 @@ def add_kdtree_column(
             sample_size,
             profile,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -532,6 +535,7 @@ def add_kdtree_column(
         verbose=verbose,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     con.close()
@@ -555,6 +559,7 @@ def _add_kdtree_streaming(
     sample_size: int,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for add_kdtree."""
     # Suppress verbose when streaming to stdout
@@ -611,6 +616,7 @@ def _add_kdtree_streaming(
                 verbose=verbose,
                 profile=profile,
                 geoparquet_version=geoparquet_version,
+                memory_limit=memory_limit,
             )
         finally:
             con.close()

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -559,7 +559,7 @@ def _add_kdtree_streaming(
     sample_size: int,
     profile: str | None,
     geoparquet_version: str | None,
-    memory_limit: str | None = None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for add_kdtree."""
     # Suppress verbose when streaming to stdout

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -405,7 +405,7 @@ def _add_quadkey_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
-    memory_limit: str | None = None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for add_quadkey."""
     # Suppress verbose when streaming to stdout
@@ -517,8 +517,8 @@ def _add_quadkey_file_based(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
-    overwrite: bool = False,
-    memory_limit: str | None = None,
+    overwrite: bool,
+    memory_limit: str | None,
 ) -> None:
     """Handle file-based add_quadkey operation."""
     configure_verbose(verbose)

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -323,6 +323,7 @@ def add_quadkey_column(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Add a quadkey column to a GeoParquet file.
@@ -348,6 +349,7 @@ def add_quadkey_column(
         row_group_rows: Exact number of rows per row group
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     # Check for streaming mode (stdin input or stdout output)
     is_streaming = is_stdin(input_parquet) or should_stream_output(output_parquet)
@@ -366,6 +368,7 @@ def add_quadkey_column(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -385,6 +388,7 @@ def add_quadkey_column(
         profile,
         geoparquet_version,
         overwrite,
+        memory_limit=memory_limit,
     )
 
 
@@ -401,6 +405,7 @@ def _add_quadkey_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for add_quadkey."""
     # Suppress verbose when streaming to stdout
@@ -488,6 +493,7 @@ def _add_quadkey_streaming(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            memory_limit=memory_limit,
         )
 
         if not should_stream_output(output_path):
@@ -512,6 +518,7 @@ def _add_quadkey_file_based(
     profile: str | None,
     geoparquet_version: str | None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle file-based add_quadkey operation."""
     configure_verbose(verbose)
@@ -650,6 +657,7 @@ def _add_quadkey_file_based(
             profile=profile,
             geoparquet_version=geoparquet_version,
             custom_metadata=quadkey_metadata,
+            memory_limit=memory_limit,
         )
 
         success(

--- a/geoparquet_io/core/add/s2.py
+++ b/geoparquet_io/core/add/s2.py
@@ -332,7 +332,7 @@ def _add_s2_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
-    memory_limit: str | None = None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for add_s2."""
     # Suppress verbose when streaming to stdout

--- a/geoparquet_io/core/add/s2.py
+++ b/geoparquet_io/core/add/s2.py
@@ -205,6 +205,7 @@ def add_s2_column(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Add an S2 cell ID column to a GeoParquet file.
@@ -232,6 +233,7 @@ def add_s2_column(
         row_group_rows: Exact number of rows per row group
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     # Configure logging verbosity
     configure_verbose(verbose)
@@ -256,6 +258,7 @@ def add_s2_column(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -307,6 +310,7 @@ def add_s2_column(
         custom_metadata=s2_metadata,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not dry_run:
@@ -328,6 +332,7 @@ def _add_s2_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for add_s2."""
     # Suppress verbose when streaming to stdout
@@ -372,6 +377,7 @@ def _add_s2_streaming(
         row_group_rows=row_group_rows,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not should_stream_output(output_path):

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -2369,6 +2369,7 @@ def write_parquet_with_metadata(
             # which requires the arrow-streaming strategy (DuckDB COPY TO cannot emit
             # nested GeoArrow types). Already-native inputs keep their preservation
             # path (duckdb-kv passes the native column through unchanged).
+            auto_routed_strategy = False
             if geoparquet_version == "1.1-geoarrow":
                 primary = (geometry_info or {}).get("primary")
                 input_encoding = (
@@ -2381,16 +2382,31 @@ def write_parquet_with_metadata(
                     if verbose:
                         debug("Routing 1.1-geoarrow WKB input through arrow-streaming")
                     write_strategy = "streaming"
+                    auto_routed_strategy = True
 
             strategy_enum = WriteStrategy(write_strategy)
             strategy = WriteStrategyFactory.get_strategy(strategy_enum)
 
-            # Validate memory_limit is only used with duckdb-kv strategy
+            # Only duckdb-kv can honour a memory limit. If *we* rerouted the
+            # strategy (1.1-geoarrow above), the user did nothing wrong: warn and
+            # drop the limit rather than aborting a command that worked before
+            # --write-memory was plumbed through (#663). A strategy the user
+            # explicitly asked for is a real error — raised as a core exception so
+            # the CLI shows a clean message instead of a traceback.
             if memory_limit is not None and strategy_enum != WriteStrategy.DUCKDB_KV:
-                raise ValueError(
-                    f"--write-memory is only supported with the 'duckdb-kv' strategy, "
-                    f"not '{write_strategy}'"
-                )
+                if auto_routed_strategy:
+                    warn(
+                        "--write-memory is ignored for GeoParquet 1.1-geoarrow output: "
+                        "GeoArrow encoding requires the arrow-streaming write strategy, "
+                        "which does not support a memory limit."
+                    )
+                    memory_limit = None
+                else:
+                    raise InvalidParameterError(
+                        "--write-memory",
+                        f"a memory limit is only supported with the 'duckdb-kv' "
+                        f"write strategy, not '{write_strategy}'",
+                    )
 
             if verbose:
                 debug(f"Writing GeoParquet version: {effective_version}")
@@ -3052,7 +3068,7 @@ def add_computed_column(
     profile=None,
     replace_column=None,
     geoparquet_version=None,
-    memory_limit=None,
+    memory_limit: str | None = None,
 ):
     """
     Add a computed column to a GeoParquet file using SQL expression.

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -3052,6 +3052,7 @@ def add_computed_column(
     profile=None,
     replace_column=None,
     geoparquet_version=None,
+    memory_limit=None,
 ):
     """
     Add a computed column to a GeoParquet file using SQL expression.
@@ -3081,6 +3082,8 @@ def add_computed_column(
         custom_metadata: Optional dict with custom metadata (e.g., H3 info)
         profile: AWS profile name (S3 only, optional)
         replace_column: Name of existing column to replace (uses EXCLUDE in query)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB');
+            None auto-detects based on available system/container memory
 
     Example:
         add_computed_column(
@@ -3215,6 +3218,7 @@ TO '{output_parquet}'
         verbose=verbose,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
 

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1867,6 +1867,7 @@ def convert_to_geoparquet(
     repair_geometry=True,
     linearize_curves=True,
     max_angle_deg=None,
+    memory_limit=None,
 ):
     """
     Convert vector format to optimized GeoParquet.
@@ -1908,6 +1909,8 @@ def convert_to_geoparquet(
             False raises the actionable unsupported-geometry error instead.
         max_angle_deg: Maximum angular step per stroked arc segment in degrees
             (default: 4.0, GDAL's OGR_ARC_STEPSIZE default).
+        memory_limit: DuckDB memory limit for the write, e.g. "2GB" (default: None,
+            meaning half of available RAM).
 
     Raises:
         GeoParquetError: If input file not found or conversion fails
@@ -2031,6 +2034,7 @@ def convert_to_geoparquet(
             # Geography inputs: DuckDB demotes GEOGRAPHY to GEOMETRY and drops
             # the edges declaration; the shared write path restores it (#588).
             input_file=input_file if is_parquet and has_geometry else None,
+            memory_limit=memory_limit,
         )
 
         _report_conversion_results(output_file, start_time, is_geo=has_geometry)

--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -25,6 +25,7 @@ from geoparquet_io.core.logging_config import (
     success,
     warn,
 )
+from geoparquet_io.core.write_strategies.duckdb_kv import validate_memory_limit
 
 # Regex patterns for GCP resource validation
 # Project IDs: 6-30 chars, lowercase letters, digits, hyphens, must start with letter
@@ -774,6 +775,7 @@ def extract_bigquery(
     geoparquet_version: str | None = None,
     overwrite: bool = False,
     repair_geometry: bool = True,
+    memory_limit: str | None = None,
 ) -> pa.Table | None:
     """
     Extract data from BigQuery table to GeoParquet or plain Parquet.
@@ -874,6 +876,7 @@ def extract_bigquery(
         geoparquet_version=geoparquet_version,
         verbose=verbose,
         repair_geometry=repair_geometry,
+        memory_limit=memory_limit,
     )
 
 
@@ -901,6 +904,7 @@ def _execute_bigquery_extraction(
     geoparquet_version: str | None,
     verbose: bool,
     repair_geometry: bool = True,
+    memory_limit: str | None = None,
 ) -> pa.Table | None:
     """Execute the BigQuery extraction with the given parameters."""
     debug("Connecting to BigQuery...")
@@ -908,6 +912,14 @@ def _execute_bigquery_extraction(
         project=project,
         credentials_file=credentials_file,
     ) as con:
+        # The BigQuery scan is what actually consumes memory here (the result is
+        # materialised as an Arrow table before the PyArrow write), so apply the
+        # user's limit to this connection. validate_memory_limit guards the
+        # interpolation — a SET value cannot be parameterised.
+        if memory_limit is not None:
+            con.execute(f"SET memory_limit = '{validate_memory_limit(memory_limit)}'")
+            debug(f"DuckDB memory limit: {memory_limit}")
+
         # Detect geometry column from schema (native GEOMETRY type only)
         geom_col = _detect_geometry_column_from_schema(con, validated_table_id, geography_column)
         is_native_geometry = geom_col is not None  # Track whether geometry is native GEOGRAPHY type

--- a/geoparquet_io/core/partition/staging.py
+++ b/geoparquet_io/core/partition/staging.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import copy
 import json
 import os
-import re
 import tempfile
 from dataclasses import dataclass
 from urllib.parse import unquote
@@ -29,33 +28,17 @@ from urllib.parse import unquote
 from geoparquet_io.core.common import write_parquet_with_metadata
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.logging_config import debug
-from geoparquet_io.core.write_strategies.duckdb_kv import get_default_memory_limit
+from geoparquet_io.core.write_strategies.duckdb_kv import (
+    get_default_memory_limit,
+)
+from geoparquet_io.core.write_strategies.duckdb_kv import (
+    validate_memory_limit as _validate_memory_limit,
+)
 
 # Internal alias used to drive the single-pass PARTITION_BY split. DuckDB drops
 # the PARTITION_BY column from the written files, so using a dedicated alias lets
 # callers keep or drop the *original* column independently.
 PARTITION_ALIAS = "__gpio_part"
-
-# A DuckDB memory-limit size: digits, optional decimal, optional unit (defaults
-# to bytes). Used to validate the user-supplied value before it is interpolated
-# into a SET statement.
-_MEMORY_LIMIT_RE = re.compile(r"^\d+(\.\d+)?\s*(B|KB|MB|GB|TB)?$", re.IGNORECASE)
-
-
-def _validate_memory_limit(value: str) -> str:
-    """Validate/normalize a DuckDB memory-limit before interpolating into SQL.
-
-    ``memory_limit`` is user-supplied (``--write-memory``) and is interpolated
-    into ``SET memory_limit = '…'``; reject anything that isn't a plain size so a
-    crafted value cannot break out of the string literal. Returns the normalized
-    value (whitespace removed, unit upper-cased).
-    """
-    text = str(value).strip()
-    if not _MEMORY_LIMIT_RE.match(text):
-        raise ValueError(
-            f"Invalid memory_limit {value!r}; expected a size like '512MB', '2GB', or '4.5GB'."
-        )
-    return text.upper().replace(" ", "")
 
 
 @dataclass(frozen=True)

--- a/geoparquet_io/core/sort_by_column.py
+++ b/geoparquet_io/core/sort_by_column.py
@@ -242,7 +242,7 @@ def _sort_by_column_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
-    memory_limit: str | None = None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for sort_by_column."""
     # Suppress verbose when streaming to stdout

--- a/geoparquet_io/core/sort_by_column.py
+++ b/geoparquet_io/core/sort_by_column.py
@@ -92,6 +92,7 @@ def sort_by_column(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Sort a GeoParquet file by specified column(s).
@@ -115,6 +116,7 @@ def sort_by_column(
         row_group_rows: Exact number of rows per row group
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     configure_verbose(verbose)
 
@@ -143,6 +145,7 @@ def sort_by_column(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -213,6 +216,7 @@ def sort_by_column(
             profile=profile,
             geoparquet_version=geoparquet_version,
             input_file=input_parquet,
+            memory_limit=memory_limit,
         )
 
         success(f"Sorted by {', '.join(column_list)} to: {output_parquet}")
@@ -238,6 +242,7 @@ def _sort_by_column_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for sort_by_column."""
     # Suppress verbose when streaming to stdout
@@ -278,6 +283,7 @@ def _sort_by_column_streaming(
         row_group_rows=row_group_rows,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        memory_limit=memory_limit,
     )
 
     if not should_stream_output(output_path):

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -96,6 +96,7 @@ def sort_by_quadkey(
     profile: str | None = None,
     geoparquet_version: str | None = None,
     overwrite: bool = False,
+    memory_limit: str | None = None,
 ) -> None:
     """
     Sort a GeoParquet file by quadkey column.
@@ -122,6 +123,7 @@ def sort_by_quadkey(
         row_group_rows: Exact number of rows per row group
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
+        memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     configure_verbose(verbose)
 
@@ -143,6 +145,7 @@ def sort_by_quadkey(
             row_group_rows,
             profile,
             geoparquet_version,
+            memory_limit=memory_limit,
         )
         return
 
@@ -260,6 +263,7 @@ def sort_by_quadkey(
             profile=profile,
             geoparquet_version=geoparquet_version,
             input_file=input_parquet,
+            memory_limit=memory_limit,
         )
 
         if remove_quadkey_column:
@@ -290,6 +294,7 @@ def _sort_by_quadkey_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
+    memory_limit: str | None = None,
 ) -> None:
     """Handle streaming input/output for sort_by_quadkey."""
     # Suppress verbose when streaming to stdout
@@ -385,6 +390,7 @@ def _sort_by_quadkey_streaming(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            memory_limit=memory_limit,
         )
 
         con.close()

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -294,7 +294,7 @@ def _sort_by_quadkey_streaming(
     row_group_rows: int | None,
     profile: str | None,
     geoparquet_version: str | None,
-    memory_limit: str | None = None,
+    memory_limit: str | None,
 ) -> None:
     """Handle streaming input/output for sort_by_quadkey."""
     # Suppress verbose when streaming to stdout

--- a/geoparquet_io/core/stream_io.py
+++ b/geoparquet_io/core/stream_io.py
@@ -415,6 +415,7 @@ def execute_transform(
     custom_metadata: dict | None = None,
     geoparquet_version: str | None = None,
     extra_kv_metadata: dict[str, str] | None = None,
+    memory_limit: str | None = None,
 ) -> pa.Table | None:
     """
     Execute a transformation with unified streaming/file I/O.
@@ -435,6 +436,8 @@ def execute_transform(
         profile: AWS profile for remote I/O
         custom_metadata: Optional dict with custom metadata
         geoparquet_version: GeoParquet version to write
+        memory_limit: DuckDB memory limit for file writes (e.g., '2GB', '512MB');
+            ignored for stream output
 
     Returns:
         Table if streaming output, None if file output or dry_run
@@ -478,4 +481,5 @@ def execute_transform(
             custom_metadata=custom_metadata,
             geoparquet_version=geoparquet_version,
             extra_kv_metadata=extra_kv_metadata,
+            memory_limit=memory_limit,
         )

--- a/geoparquet_io/core/stream_io.py
+++ b/geoparquet_io/core/stream_io.py
@@ -24,6 +24,7 @@ import pyarrow as pa
 from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.logging_config import warn
 from geoparquet_io.core.remote import needs_httpfs
 from geoparquet_io.core.streaming import (
     apply_geoarrow_extension_type,
@@ -245,6 +246,13 @@ def write_output(
     validate_output(output_path)
 
     if should_stream_output(output_path):
+        # Arrow IPC to stdout has no DuckDB write engine to configure, so a
+        # memory limit cannot be applied. Say so rather than dropping it silently.
+        if memory_limit is not None:
+            warn(
+                "--write-memory is ignored when streaming to stdout "
+                "(it only applies to file outputs)."
+            )
         return _write_stream_output(con, query, original_metadata, geometry_column)
     else:
         _write_file_output(
@@ -448,7 +456,7 @@ def execute_transform(
 
         execute_transform("input.parquet", None, make_query, verbose=True)
     """
-    from geoparquet_io.core.logging_config import progress, warn
+    from geoparquet_io.core.logging_config import progress
 
     # Suppress verbose when streaming to stdout (would corrupt the stream)
     if should_stream_output(output_path):

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -33,6 +33,38 @@ if TYPE_CHECKING:
 # Valid compression values whitelist (prevents injection via compression param)
 VALID_COMPRESSIONS = frozenset({"ZSTD", "SNAPPY", "GZIP", "LZ4", "UNCOMPRESSED", "BROTLI"})
 
+# DuckDB's memory_limit is a SET value, which cannot be parameterised, so the
+# value has to be interpolated into SQL. Only accept a plain size literal: a
+# decimal number with an optional decimal (KB/MB/GB/TB) or binary (KiB/…) unit.
+_MEMORY_LIMIT_RE = re.compile(r"^\d+(\.\d+)?\s*(K|M|G|T)?i?B$", re.IGNORECASE)
+
+
+def validate_memory_limit(value: str) -> str:
+    """Validate/normalize a DuckDB memory limit before interpolating it into SQL.
+
+    ``memory_limit`` originates from ``--write-memory`` (or from a library
+    caller's config) and ends up inside ``SET memory_limit = '…'``. DuckDB's
+    ``execute`` runs multi-statement strings, so an unvalidated value can close
+    the string literal and append arbitrary SQL. Reject anything that is not a
+    plain size.
+
+    Args:
+        value: Candidate memory limit, e.g. "512MB", "2GB", "4.5 GB", "1GiB"
+
+    Returns:
+        The normalized value (whitespace removed, unit upper-cased).
+
+    Raises:
+        ValueError: If the value is not a plain size literal.
+    """
+    text = str(value).strip()
+    if not _MEMORY_LIMIT_RE.match(text):
+        raise ValueError(
+            f"Invalid memory_limit {value!r}; expected a size like "
+            f"'512MB', '2GB', '4.5GB', or '1GiB'."
+        )
+    return text.upper().replace(" ", "")
+
 
 def _get_available_memory() -> int | None:
     """
@@ -384,7 +416,8 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         # spilling). Safe because threads=1 already makes the single pipeline emit
         # rows in order, so output ordering (e.g. sorted files) is preserved.
         con.execute("SET preserve_insertion_order = false")
-        effective_limit = memory_limit or get_default_memory_limit()
+        # Validate before interpolation: a SET value cannot be parameterised.
+        effective_limit = validate_memory_limit(memory_limit or get_default_memory_limit())
         con.execute(f"SET memory_limit = '{effective_limit}'")
         if verbose:
             debug(f"DuckDB memory limit: {effective_limit}")

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -567,6 +567,7 @@ class TestAddBboxCoveringMetadata:
             profile=None,
             force=False,
             geoparquet_version="2.0",
+            memory_limit=None,
         )
 
         assert os.path.exists(output_file)

--- a/tests/test_write_memory_forwarding.py
+++ b/tests/test_write_memory_forwarding.py
@@ -1,30 +1,47 @@
-"""Tests asserting --write-memory is forwarded (not silently dropped).
+"""Tests asserting --write-memory is forwarded, validated, and never silently dropped.
 
 Companion to the sort-hilbert fix in PR #627: the `output_format_options`
-decorator attaches `--write-memory` to every command, but several `add`/`sort`
-commands captured `write_memory` in their signature and never forwarded it to
-the core function / DuckDB write engine. This file locks down forwarding for:
+decorator attaches `--write-memory` to many commands, but several of them
+captured `write_memory` in their signature and never forwarded it to the core
+function / DuckDB write engine.
 
-    add h3, add a5, add s2, add kdtree, add quadkey, sort column, sort quadkey
-
-Three layers are tested:
+Layers tested here:
+  * Introspection: EVERY command that exposes --write-memory forwards it. This
+    is the test that cannot go stale — a new command (or a new decorator use)
+    that declares the flag and drops it fails immediately.
   * CLI -> core function: the CLI passes ``write_memory`` through as the
     keyword argument ``memory_limit`` (not positionally, not dropped).
-  * Core function (file-based path) -> DuckDB write engine: a full,
-    unmocked invocation shows "DuckDB memory limit: <value>" in --verbose
-    output, mirroring the existing sort-hilbert regression test.
-  * Core function (streaming path) -> execute_transform/write_output: the
-    private streaming helpers forward memory_limit too.
+  * Core function (file-based path) -> DuckDB write engine: a full, unmocked
+    invocation shows "DuckDB memory limit: <value>" in --verbose output.
+  * Core function (streaming path) -> execute_transform/write_output.
+  * Validation: bad values are rejected as Click parameter errors, and a value
+    crafted to break out of ``SET memory_limit = '…'`` is refused.
+  * 1.1-geoarrow: the auto-routed write strategy warns and ignores
+    --write-memory instead of aborting with a raw traceback.
 """
 
 from __future__ import annotations
 
+import inspect
+import os
 from unittest import mock
 
+import click
 import duckdb
 import pytest
 from click.testing import CliRunner
 
+# NOTE: import the *submodule object*, never a dotted mock.patch target.
+# `geoparquet_io/__init__.py` does `from geoparquet_io.cli.main import cli`,
+# which rebinds the attribute `geoparquet_io.cli` from the submodule to the
+# Click Group. Python 3.10's mock._get_target getattr-walks that path and lands
+# on `Group.main` (a bound method), so `mock.patch("geoparquet_io.cli.main.X")`
+# raises AttributeError on 3.10 while passing on 3.11+ (which uses
+# pkgutil.resolve_name). `import geoparquet_io.cli.main as cli_main` does NOT
+# help: IMPORT_FROM getattrs the parent and returns the Group on every version.
+# `from geoparquet_io.cli import main as cli_main` is the form that works
+# everywhere. Do not "simplify" this back to a dotted patch target.
+from geoparquet_io.cli import main as cli_main
 from geoparquet_io.cli.main import cli
 
 
@@ -40,43 +57,94 @@ def _find_non_geometry_column(parquet_file: str) -> str:
     raise AssertionError("No non-geometry columns found in test fixture")
 
 
+def _iter_commands(command, path=None):
+    """Yield ``(dotted name, Command)`` for every leaf command in the CLI tree."""
+    path = path or []
+    if isinstance(command, click.Group):
+        for name, sub in command.commands.items():
+            yield from _iter_commands(sub, [*path, name])
+    else:
+        yield " ".join(path), command
+
+
+def _commands_with_write_memory():
+    return [
+        (name, cmd)
+        for name, cmd in _iter_commands(cli)
+        if any(param.name == "write_memory" for param in cmd.params)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Layer 0: no command may declare --write-memory without forwarding it
+# ---------------------------------------------------------------------------
+
+
+class TestEveryCommandForwardsWriteMemory:
+    """The offender list must stay empty.
+
+    A hand-written per-command list goes stale the moment someone adds a new
+    command; walking the Click tree cannot.
+    """
+
+    def test_no_command_declares_write_memory_without_forwarding_it(self):
+        commands = _commands_with_write_memory()
+        assert commands, "Expected at least one command to expose --write-memory"
+
+        offenders = []
+        for name, cmd in commands:
+            source = inspect.getsource(inspect.unwrap(cmd.callback))
+            if "memory_limit=write_memory" not in source:
+                offenders.append(name)
+
+        assert not offenders, (
+            "These commands accept --write-memory but never forward it as "
+            f"memory_limit=write_memory: {offenders}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Layer 1: CLI forwards --write-memory as memory_limit=<value> BY KEYWORD
 # ---------------------------------------------------------------------------
 
 CLI_FORWARDING_CASES = [
     pytest.param(
-        "geoparquet_io.cli.main.add_h3_column_impl",
+        "add_h3_column_impl",
         lambda in_f, out_f, col: ["add", "h3", in_f, out_f],
         id="add-h3",
     ),
     pytest.param(
-        "geoparquet_io.cli.main.add_a5_column_impl",
+        "add_a5_column_impl",
         lambda in_f, out_f, col: ["add", "a5", in_f, out_f],
         id="add-a5",
     ),
     pytest.param(
-        "geoparquet_io.cli.main.add_s2_column_impl",
+        "add_s2_column_impl",
         lambda in_f, out_f, col: ["add", "s2", in_f, out_f],
         id="add-s2",
     ),
     pytest.param(
-        "geoparquet_io.cli.main.add_kdtree_column_impl",
+        "add_kdtree_column_impl",
         lambda in_f, out_f, col: ["add", "kdtree", in_f, out_f],
         id="add-kdtree",
     ),
     pytest.param(
-        "geoparquet_io.cli.main.add_quadkey_column_impl",
+        "add_quadkey_column_impl",
         lambda in_f, out_f, col: ["add", "quadkey", in_f, out_f],
         id="add-quadkey",
     ),
     pytest.param(
-        "geoparquet_io.cli.main.sort_by_column_impl",
+        "add_bbox_column_impl",
+        lambda in_f, out_f, col: ["add", "bbox", in_f, out_f],
+        id="add-bbox",
+    ),
+    pytest.param(
+        "sort_by_column_impl",
         lambda in_f, out_f, col: ["sort", "column", in_f, out_f, col],
         id="sort-column",
     ),
     pytest.param(
-        "geoparquet_io.cli.main.sort_by_quadkey_impl",
+        "sort_by_quadkey_impl",
         lambda in_f, out_f, col: ["sort", "quadkey", in_f, out_f],
         id="sort-quadkey",
     ),
@@ -86,20 +154,20 @@ CLI_FORWARDING_CASES = [
 class TestCliForwardsWriteMemoryByKeyword:
     """The CLI must call the core function with memory_limit=<value> as a kwarg."""
 
-    @pytest.mark.parametrize("impl_target,build_args", CLI_FORWARDING_CASES)
-    def test_write_memory_forwarded_as_keyword(self, impl_target, build_args):
+    @pytest.mark.parametrize("impl_name,build_args", CLI_FORWARDING_CASES)
+    def test_write_memory_forwarded_as_keyword(self, impl_name, build_args):
         runner = CliRunner()
         args = build_args("input.parquet", "output.parquet", "some_column")
         args = [*args, "--write-memory", "222MB"]
 
-        with mock.patch(impl_target) as mocked_impl:
+        with mock.patch.object(cli_main, impl_name) as mocked_impl:
             result = runner.invoke(cli, args)
 
         assert result.exit_code == 0, result.output
         mocked_impl.assert_called_once()
         _call_args, call_kwargs = mocked_impl.call_args
         assert "memory_limit" in call_kwargs, (
-            f"{impl_target} was not called with memory_limit as a keyword argument "
+            f"{impl_name} was not called with memory_limit as a keyword argument "
             f"(kwargs were: {sorted(call_kwargs)})"
         )
         assert call_kwargs["memory_limit"] == "222MB"
@@ -233,30 +301,236 @@ class TestFileBasedWriteMemoryReachesEngine:
         assert result.exit_code == 0, result.output
         assert "DuckDB memory limit: 519MB" in result.output
 
+    def test_add_bbox_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "bbox",
+                places_test_file,
+                temp_output_file,
+                # The fixture already has a bbox column without covering
+                # metadata; without --force the command exits early and never
+                # reaches the write engine.
+                "--force",
+                "--write-memory",
+                "520MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 520MB" in result.output
+
+    def test_add_geometry_metrics_write_memory_reaches_engine(
+        self, buildings_test_file, temp_output_file
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "geometry-metrics",
+                buildings_test_file,
+                temp_output_file,
+                "--write-memory",
+                "521MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 521MB" in result.output
+
+    def test_convert_geoparquet_write_memory_reaches_engine(self, test_data_dir, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "convert",
+                "geoparquet",
+                str(test_data_dir / "buildings_test.geojson"),
+                temp_output_file,
+                "--write-memory",
+                "522MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 522MB" in result.output
+
 
 # ---------------------------------------------------------------------------
-# Layer 3: streaming helpers forward memory_limit into execute_transform /
-# write_output.
+# Layer 3: --write-memory is validated before it reaches SQL
+# ---------------------------------------------------------------------------
+
+INJECTION_PAYLOAD = "1GB'; COPY (SELECT 42 AS x) TO '{path}'; SET memory_limit='2GB"
+
+
+class TestWriteMemoryValidation:
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["abc", "0", "", "512 megabytes", "-1GB", "1GB; DROP TABLE t"],
+        ids=["letters", "bare-zero", "empty", "words", "negative", "trailing-sql"],
+    )
+    def test_invalid_write_memory_is_a_click_parameter_error(
+        self, places_test_file, temp_output_file, bad_value
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["add", "h3", places_test_file, temp_output_file, "--write-memory", bad_value],
+        )
+        assert result.exit_code == 2, result.output
+        assert "--write-memory" in result.output
+        assert not os.path.exists(temp_output_file)
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    @pytest.mark.parametrize(
+        "good_value",
+        ["512MB", "2GB", "4.5GB", "1024kb", "1GiB", "128 MB"],
+    )
+    def test_valid_write_memory_is_accepted(self, good_value):
+        runner = CliRunner()
+        with mock.patch.object(cli_main, "add_h3_column_impl"):
+            result = runner.invoke(
+                cli,
+                ["add", "h3", "in.parquet", "out.parquet", "--write-memory", good_value],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_sql_injection_payload_is_rejected(
+        self, places_test_file, temp_output_file, temp_output_dir
+    ):
+        """A value crafted to close the SET string literal must never execute."""
+        pwned = os.path.join(temp_output_dir, "pwned.csv")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "h3",
+                places_test_file,
+                temp_output_file,
+                "--write-memory",
+                INJECTION_PAYLOAD.format(path=pwned),
+            ],
+        )
+        assert result.exit_code != 0, result.output
+        assert not os.path.exists(pwned), "Injected COPY statement executed!"
+        assert not os.path.exists(temp_output_file)
+
+    def test_core_validator_rejects_injection_payload(self):
+        """Library callers (not just the CLI) are protected at the SET site."""
+        from geoparquet_io.core.write_strategies.duckdb_kv import validate_memory_limit
+
+        with pytest.raises(ValueError, match="Invalid memory_limit"):
+            validate_memory_limit(INJECTION_PAYLOAD.format(path="/tmp/pwned.csv"))
+
+    def test_core_validator_normalizes(self):
+        from geoparquet_io.core.write_strategies.duckdb_kv import validate_memory_limit
+
+        assert validate_memory_limit("512MB") == "512MB"
+        assert validate_memory_limit("2gb") == "2GB"
+        assert validate_memory_limit("4.5 GB") == "4.5GB"
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: --write-memory + --geoparquet-version 1.1-geoarrow must not crash
 # ---------------------------------------------------------------------------
 
 
-class TestStreamingHelpersForwardMemoryLimit:
+class TestGeoarrowVersionIgnoresWriteMemory:
+    """1.1-geoarrow auto-routes to the arrow-streaming strategy, which cannot
+    honour a memory limit. Warn and continue — never abort with a traceback."""
+
+    def test_add_h3_geoarrow_with_write_memory_succeeds(self, places_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "h3",
+                places_test_file,
+                temp_output_file,
+                "--geoparquet-version",
+                "1.1-geoarrow",
+                "--write-memory",
+                "512MB",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(temp_output_file)
+        assert "--write-memory" in result.output
+
+    def test_sort_hilbert_geoarrow_with_write_memory_succeeds(
+        self, places_test_file, temp_output_file
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "sort",
+                "hilbert",
+                places_test_file,
+                temp_output_file,
+                "--geoparquet-version",
+                "1.1-geoarrow",
+                "--write-memory",
+                "512MB",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(temp_output_file)
+        assert "--write-memory" in result.output
+
+    def test_explicit_non_duckdb_kv_strategy_still_errors_cleanly(
+        self, places_test_file, temp_output_file
+    ):
+        """A user-chosen strategy that cannot honour the limit is a real error,
+        but it must surface as a clean message, not a bare ValueError."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "extract",
+                "geoparquet",
+                places_test_file,
+                temp_output_file,
+                "--write-strategy",
+                "streaming",
+                "--write-memory",
+                "512MB",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--write-memory" in result.output
+        assert not isinstance(result.exception, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Layer 5: streaming helpers forward memory_limit into execute_transform /
+# write_output. Arguments are passed BY KEYWORD so a signature reorder fails
+# loudly instead of silently rebinding every argument.
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateHelpersForwardMemoryLimit:
     def test_add_h3_streaming_forwards_memory_limit(self):
         from geoparquet_io.core.add.h3 import _add_h3_streaming
 
         with mock.patch("geoparquet_io.core.add.h3.execute_transform") as mocked:
             _add_h3_streaming(
-                "in.parquet",
-                "out.parquet",
-                "h3_cell",
-                9,
-                False,
-                "ZSTD",
-                None,
-                None,
-                None,
-                None,
-                None,
+                input_path="in.parquet",
+                output_path="out.parquet",
+                h3_column_name="h3_cell",
+                resolution=9,
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                profile=None,
+                geoparquet_version=None,
                 memory_limit="601MB",
             )
         mocked.assert_called_once()
@@ -267,17 +541,17 @@ class TestStreamingHelpersForwardMemoryLimit:
 
         with mock.patch("geoparquet_io.core.add.a5.execute_transform") as mocked:
             _add_a5_streaming(
-                "in.parquet",
-                "out.parquet",
-                "a5_cell",
-                15,
-                False,
-                "ZSTD",
-                None,
-                None,
-                None,
-                None,
-                None,
+                input_path="in.parquet",
+                output_path="out.parquet",
+                a5_column_name="a5_cell",
+                resolution=15,
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                profile=None,
+                geoparquet_version=None,
                 memory_limit="602MB",
             )
         mocked.assert_called_once()
@@ -288,17 +562,17 @@ class TestStreamingHelpersForwardMemoryLimit:
 
         with mock.patch("geoparquet_io.core.add.s2.execute_transform") as mocked:
             _add_s2_streaming(
-                "in.parquet",
-                "out.parquet",
-                "s2_cell",
-                13,
-                False,
-                "ZSTD",
-                None,
-                None,
-                None,
-                None,
-                None,
+                input_path="in.parquet",
+                output_path="out.parquet",
+                s2_column_name="s2_cell",
+                level=13,
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                profile=None,
+                geoparquet_version=None,
                 memory_limit="603MB",
             )
         mocked.assert_called_once()
@@ -309,17 +583,17 @@ class TestStreamingHelpersForwardMemoryLimit:
 
         with mock.patch("geoparquet_io.core.sort_by_column.execute_transform") as mocked:
             _sort_by_column_streaming(
-                "in.parquet",
-                "out.parquet",
-                ["name"],
-                False,
-                False,
-                "ZSTD",
-                None,
-                None,
-                None,
-                None,
-                None,
+                input_path="in.parquet",
+                output_path="out.parquet",
+                column_list=["name"],
+                descending=False,
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                profile=None,
+                geoparquet_version=None,
                 memory_limit="604MB",
             )
         mocked.assert_called_once()
@@ -330,18 +604,18 @@ class TestStreamingHelpersForwardMemoryLimit:
 
         with mock.patch("geoparquet_io.core.add.kdtree.write_output") as mocked:
             _add_kdtree_streaming(
-                buildings_test_file,
-                "unused_output.parquet",
-                "kdtree_cell",
-                1,
-                False,
-                "ZSTD",
-                None,
-                None,
-                None,
-                100,
-                None,
-                None,
+                input_path=buildings_test_file,
+                output_path="unused_output.parquet",
+                kdtree_column_name="kdtree_cell",
+                iterations=1,
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                sample_size=100,
+                profile=None,
+                geoparquet_version=None,
                 memory_limit="605MB",
             )
         mocked.assert_called_once()
@@ -352,18 +626,18 @@ class TestStreamingHelpersForwardMemoryLimit:
 
         with mock.patch("geoparquet_io.core.add.quadkey.write_output") as mocked:
             _add_quadkey_streaming(
-                places_test_file,
-                "unused_output.parquet",
-                "quadkey",
-                13,
-                False,
-                False,
-                "ZSTD",
-                None,
-                None,
-                None,
-                None,
-                None,
+                input_path=places_test_file,
+                output_path="unused_output.parquet",
+                quadkey_column_name="quadkey",
+                resolution=13,
+                use_centroid=False,
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                profile=None,
+                geoparquet_version=None,
                 memory_limit="606MB",
             )
         mocked.assert_called_once()
@@ -374,23 +648,44 @@ class TestStreamingHelpersForwardMemoryLimit:
 
         with mock.patch("geoparquet_io.core.sort_quadkey.write_output") as mocked:
             _sort_by_quadkey_streaming(
-                places_test_file,
-                "unused_output.parquet",
-                "quadkey",
-                13,
-                False,
-                False,
-                False,
-                "ZSTD",
-                None,
-                None,
-                None,
-                None,
-                None,
+                input_path=places_test_file,
+                output_path="unused_output.parquet",
+                quadkey_column_name="quadkey",
+                resolution=13,
+                use_centroid=False,
+                remove_quadkey_column=False,
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                profile=None,
+                geoparquet_version=None,
                 memory_limit="607MB",
             )
         mocked.assert_called_once()
         assert mocked.call_args.kwargs.get("memory_limit") == "607MB"
+
+    def test_add_bbox_streaming_forwards_memory_limit(self):
+        from geoparquet_io.core.add.bbox import _add_bbox_streaming
+
+        with mock.patch("geoparquet_io.core.add.bbox.execute_transform") as mocked:
+            _add_bbox_streaming(
+                input_path="in.parquet",
+                output_path="out.parquet",
+                bbox_column_name="bbox",
+                verbose=False,
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                profile=None,
+                force=False,
+                geoparquet_version=None,
+                memory_limit="609MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "609MB"
 
     def test_execute_transform_forwards_memory_limit(self, places_test_file, temp_output_file):
         """execute_transform itself (used by h3/a5/s2/sort column streaming) must
@@ -410,3 +705,28 @@ class TestStreamingHelpersForwardMemoryLimit:
             )
         mocked.assert_called_once()
         assert mocked.call_args.kwargs.get("memory_limit") == "608MB"
+
+
+class TestStdoutStreamingIgnoresMemoryLimit:
+    """Arrow IPC output to stdout has no DuckDB write engine to configure, so
+    memory_limit is dropped — but the user must be told, not silently ignored."""
+
+    def test_write_output_to_stdout_warns_that_memory_limit_is_ignored(
+        self, places_test_file, capsys
+    ):
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.stream_io import write_output
+
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+        try:
+            with mock.patch("geoparquet_io.core.stream_io._write_stream_output") as mocked:
+                write_output(
+                    con,
+                    f"SELECT * FROM '{places_test_file}'",
+                    "-",
+                    memory_limit="512MB",
+                )
+        finally:
+            con.close()
+        mocked.assert_called_once()
+        assert "memory" in capsys.readouterr().err.lower()

--- a/tests/test_write_memory_forwarding.py
+++ b/tests/test_write_memory_forwarding.py
@@ -1,0 +1,412 @@
+"""Tests asserting --write-memory is forwarded (not silently dropped).
+
+Companion to the sort-hilbert fix in PR #627: the `output_format_options`
+decorator attaches `--write-memory` to every command, but several `add`/`sort`
+commands captured `write_memory` in their signature and never forwarded it to
+the core function / DuckDB write engine. This file locks down forwarding for:
+
+    add h3, add a5, add s2, add kdtree, add quadkey, sort column, sort quadkey
+
+Three layers are tested:
+  * CLI -> core function: the CLI passes ``write_memory`` through as the
+    keyword argument ``memory_limit`` (not positionally, not dropped).
+  * Core function (file-based path) -> DuckDB write engine: a full,
+    unmocked invocation shows "DuckDB memory limit: <value>" in --verbose
+    output, mirroring the existing sort-hilbert regression test.
+  * Core function (streaming path) -> execute_transform/write_output: the
+    private streaming helpers forward memory_limit too.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import duckdb
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+
+
+def _find_non_geometry_column(parquet_file: str) -> str:
+    conn = duckdb.connect()
+    try:
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{parquet_file}"').fetchall()
+    finally:
+        conn.close()
+    for col in columns:
+        if col[0] != "geometry":
+            return col[0]
+    raise AssertionError("No non-geometry columns found in test fixture")
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: CLI forwards --write-memory as memory_limit=<value> BY KEYWORD
+# ---------------------------------------------------------------------------
+
+CLI_FORWARDING_CASES = [
+    pytest.param(
+        "geoparquet_io.cli.main.add_h3_column_impl",
+        lambda in_f, out_f, col: ["add", "h3", in_f, out_f],
+        id="add-h3",
+    ),
+    pytest.param(
+        "geoparquet_io.cli.main.add_a5_column_impl",
+        lambda in_f, out_f, col: ["add", "a5", in_f, out_f],
+        id="add-a5",
+    ),
+    pytest.param(
+        "geoparquet_io.cli.main.add_s2_column_impl",
+        lambda in_f, out_f, col: ["add", "s2", in_f, out_f],
+        id="add-s2",
+    ),
+    pytest.param(
+        "geoparquet_io.cli.main.add_kdtree_column_impl",
+        lambda in_f, out_f, col: ["add", "kdtree", in_f, out_f],
+        id="add-kdtree",
+    ),
+    pytest.param(
+        "geoparquet_io.cli.main.add_quadkey_column_impl",
+        lambda in_f, out_f, col: ["add", "quadkey", in_f, out_f],
+        id="add-quadkey",
+    ),
+    pytest.param(
+        "geoparquet_io.cli.main.sort_by_column_impl",
+        lambda in_f, out_f, col: ["sort", "column", in_f, out_f, col],
+        id="sort-column",
+    ),
+    pytest.param(
+        "geoparquet_io.cli.main.sort_by_quadkey_impl",
+        lambda in_f, out_f, col: ["sort", "quadkey", in_f, out_f],
+        id="sort-quadkey",
+    ),
+]
+
+
+class TestCliForwardsWriteMemoryByKeyword:
+    """The CLI must call the core function with memory_limit=<value> as a kwarg."""
+
+    @pytest.mark.parametrize("impl_target,build_args", CLI_FORWARDING_CASES)
+    def test_write_memory_forwarded_as_keyword(self, impl_target, build_args):
+        runner = CliRunner()
+        args = build_args("input.parquet", "output.parquet", "some_column")
+        args = [*args, "--write-memory", "222MB"]
+
+        with mock.patch(impl_target) as mocked_impl:
+            result = runner.invoke(cli, args)
+
+        assert result.exit_code == 0, result.output
+        mocked_impl.assert_called_once()
+        _call_args, call_kwargs = mocked_impl.call_args
+        assert "memory_limit" in call_kwargs, (
+            f"{impl_target} was not called with memory_limit as a keyword argument "
+            f"(kwargs were: {sorted(call_kwargs)})"
+        )
+        assert call_kwargs["memory_limit"] == "222MB"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: real (unmocked) file-based invocation reaches the DuckDB write
+# engine, mirroring tests/test_sort.py::test_hilbert_sort_write_memory_reaches_engine
+# ---------------------------------------------------------------------------
+
+
+class TestFileBasedWriteMemoryReachesEngine:
+    def test_add_h3_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "h3",
+                places_test_file,
+                temp_output_file,
+                "--write-memory",
+                "513MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 513MB" in result.output
+
+    def test_add_a5_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "a5",
+                places_test_file,
+                temp_output_file,
+                "--write-memory",
+                "514MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 514MB" in result.output
+
+    def test_add_s2_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "s2",
+                places_test_file,
+                temp_output_file,
+                "--write-memory",
+                "515MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 515MB" in result.output
+
+    def test_add_kdtree_write_memory_reaches_engine(self, buildings_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "kdtree",
+                buildings_test_file,
+                temp_output_file,
+                "--write-memory",
+                "516MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 516MB" in result.output
+
+    def test_add_quadkey_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "quadkey",
+                places_test_file,
+                temp_output_file,
+                "--write-memory",
+                "517MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 517MB" in result.output
+
+    def test_sort_column_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        test_column = _find_non_geometry_column(places_test_file)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "sort",
+                "column",
+                places_test_file,
+                temp_output_file,
+                test_column,
+                "--write-memory",
+                "518MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 518MB" in result.output
+
+    def test_sort_quadkey_write_memory_reaches_engine(self, places_test_file, temp_output_file):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "sort",
+                "quadkey",
+                places_test_file,
+                temp_output_file,
+                "--write-memory",
+                "519MB",
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "DuckDB memory limit: 519MB" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: streaming helpers forward memory_limit into execute_transform /
+# write_output.
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingHelpersForwardMemoryLimit:
+    def test_add_h3_streaming_forwards_memory_limit(self):
+        from geoparquet_io.core.add.h3 import _add_h3_streaming
+
+        with mock.patch("geoparquet_io.core.add.h3.execute_transform") as mocked:
+            _add_h3_streaming(
+                "in.parquet",
+                "out.parquet",
+                "h3_cell",
+                9,
+                False,
+                "ZSTD",
+                None,
+                None,
+                None,
+                None,
+                None,
+                memory_limit="601MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "601MB"
+
+    def test_add_a5_streaming_forwards_memory_limit(self):
+        from geoparquet_io.core.add.a5 import _add_a5_streaming
+
+        with mock.patch("geoparquet_io.core.add.a5.execute_transform") as mocked:
+            _add_a5_streaming(
+                "in.parquet",
+                "out.parquet",
+                "a5_cell",
+                15,
+                False,
+                "ZSTD",
+                None,
+                None,
+                None,
+                None,
+                None,
+                memory_limit="602MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "602MB"
+
+    def test_add_s2_streaming_forwards_memory_limit(self):
+        from geoparquet_io.core.add.s2 import _add_s2_streaming
+
+        with mock.patch("geoparquet_io.core.add.s2.execute_transform") as mocked:
+            _add_s2_streaming(
+                "in.parquet",
+                "out.parquet",
+                "s2_cell",
+                13,
+                False,
+                "ZSTD",
+                None,
+                None,
+                None,
+                None,
+                None,
+                memory_limit="603MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "603MB"
+
+    def test_sort_by_column_streaming_forwards_memory_limit(self):
+        from geoparquet_io.core.sort_by_column import _sort_by_column_streaming
+
+        with mock.patch("geoparquet_io.core.sort_by_column.execute_transform") as mocked:
+            _sort_by_column_streaming(
+                "in.parquet",
+                "out.parquet",
+                ["name"],
+                False,
+                False,
+                "ZSTD",
+                None,
+                None,
+                None,
+                None,
+                None,
+                memory_limit="604MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "604MB"
+
+    def test_add_kdtree_streaming_forwards_memory_limit(self, buildings_test_file):
+        from geoparquet_io.core.add.kdtree import _add_kdtree_streaming
+
+        with mock.patch("geoparquet_io.core.add.kdtree.write_output") as mocked:
+            _add_kdtree_streaming(
+                buildings_test_file,
+                "unused_output.parquet",
+                "kdtree_cell",
+                1,
+                False,
+                "ZSTD",
+                None,
+                None,
+                None,
+                100,
+                None,
+                None,
+                memory_limit="605MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "605MB"
+
+    def test_add_quadkey_streaming_forwards_memory_limit(self, places_test_file):
+        from geoparquet_io.core.add.quadkey import _add_quadkey_streaming
+
+        with mock.patch("geoparquet_io.core.add.quadkey.write_output") as mocked:
+            _add_quadkey_streaming(
+                places_test_file,
+                "unused_output.parquet",
+                "quadkey",
+                13,
+                False,
+                False,
+                "ZSTD",
+                None,
+                None,
+                None,
+                None,
+                None,
+                memory_limit="606MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "606MB"
+
+    def test_sort_by_quadkey_streaming_forwards_memory_limit(self, places_test_file):
+        from geoparquet_io.core.sort_quadkey import _sort_by_quadkey_streaming
+
+        with mock.patch("geoparquet_io.core.sort_quadkey.write_output") as mocked:
+            _sort_by_quadkey_streaming(
+                places_test_file,
+                "unused_output.parquet",
+                "quadkey",
+                13,
+                False,
+                False,
+                False,
+                "ZSTD",
+                None,
+                None,
+                None,
+                None,
+                None,
+                memory_limit="607MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "607MB"
+
+    def test_execute_transform_forwards_memory_limit(self, places_test_file, temp_output_file):
+        """execute_transform itself (used by h3/a5/s2/sort column streaming) must
+        forward memory_limit into write_output -> write_parquet_with_metadata."""
+        from geoparquet_io.core.stream_io import execute_transform
+
+        def make_query(source: str, con) -> str:
+            return f"SELECT * FROM {source}"
+
+        with mock.patch("geoparquet_io.core.stream_io.write_output") as mocked:
+            execute_transform(
+                places_test_file,
+                temp_output_file,
+                make_query,
+                verbose=False,
+                memory_limit="608MB",
+            )
+        mocked.assert_called_once()
+        assert mocked.call_args.kwargs.get("memory_limit") == "608MB"


### PR DESCRIPTION
## Summary

`--write-memory` was accepted by `add h3`/`a5`/`s2`/`kdtree`/`quadkey` and `sort column`/`quadkey`, but silently ignored — the value never reached the DuckDB write engine, which fell back to its auto-detected default memory limit instead. This is the same bug class fixed for `sort hilbert` in #627, and it was enabled the same way: the CLI captured `write_memory` in the command signature but called the core function positionally, so a missing/dropped argument didn't surface as an error.

## Fix

- Forward `memory_limit=write_memory` **by keyword** at each of the 7 CLI call sites in `cli/main.py` (the touched call sites were converted from positional to keyword args specifically so this class of bug can't hide behind argument position again).
- Added a `memory_limit` parameter to every core function (and private streaming/file-based helper) that didn't already have one — `add_h3_column`, `add_a5_column`, `add_s2_column`, `add_kdtree_column`, `add_quadkey_column`, `sort_by_column`, `sort_by_quadkey`, plus their streaming counterparts — and threaded it down to the DuckDB `SET memory_limit` call in the write engine, via the shared `add_computed_column` (`core/common.py`) and `execute_transform` (`core/stream_io.py`) helpers, and directly via `write_parquet_with_metadata`/`write_output` (which already accepted `memory_limit` since #627).

## Tests

22 new tests in `tests/test_write_memory_forwarding.py`, across three layers, covering all 7 commands:

1. **Mocked-forwarding** — mocks each CLI-imported core function and asserts `--write-memory` arrives as `memory_limit` in `call_args.kwargs` (fails if passed positionally or dropped).
2. **Real, unmocked end-to-end** — `CliRunner` invocations with `--write-memory X --verbose`, asserting `"DuckDB memory limit: X"` appears in output (same style as the existing `test_hilbert_sort_write_memory_reaches_engine`).
3. **Streaming-path** — direct calls to the private streaming helpers (and to `execute_transform` itself) with the downstream write call mocked, confirming `memory_limit` is forwarded on the streaming code path too, not just the file-based path.

Full fast suite: 3561 passed, 40 skipped, 76.68% coverage (floor is 67%). Pre-commit clean.

## Note on diff-cover

`diff-cover` reports "no lines with coverage information" for this diff. This is a known attribution artifact, not a coverage gap — every changed line here is a trailing kwarg (`memory_limit=memory_limit,`) or param (`memory_limit: str | None = None,`) appended to an *existing* multi-line call/def. coverage.py attributes a multi-line statement's "measured" status only to its opening line, which this diff never touches, so the added continuation lines aren't independently measurable line numbers. The same thing happens when checking #627's diff, which has the identical shape. The 22 tests above are the real evidence that the forwarding works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx