### PR TITLE
test(benchmark): assert setup ordering instead of racing a stopwatch

### DIFF
--- a/tests/test_duckdb_connection_factory_bypass.py
+++ b/tests/test_duckdb_connection_factory_bypass.py
@@ -21,7 +21,6 @@ bare `duckdb.connect(` outside `core/duckdb_utils.py`.
 """
 
 import subprocess
-import time
 from pathlib import Path
 
 import pyarrow as pa
@@ -125,25 +124,48 @@ class TestBenchmarkDuckdb:
     def test_factory_setup_is_outside_the_measured_window(self, monkeypatch, tmp_path):
         """The connection must be built before the timer starts: extension
         install/load is fixed overhead the GeoPandas/pyogrio arms never pay, so
-        including it would bias the comparison against DuckDB."""
+        including it would bias the comparison against DuckDB.
+
+        Asserts the ORDER of the two calls rather than comparing elapsed times.
+        The earlier version timed a baseline run and required a second run of the
+        same COPY to land within a fixed 0.5s of it, which run-to-run jitter on a
+        loaded CI runner exceeds -- it failed on windows-latest/3.11 while
+        measuring nothing the ordering check misses.
+        """
         import geoparquet_io.core.benchmark as benchmark
 
-        baseline, _ = benchmark.benchmark_duckdb(GEOJSON_FILE, tmp_path / "baseline.parquet")
+        events: list[str] = []
+        real_factory = benchmark.get_duckdb_connection
+        real_time = benchmark.time
 
-        slow_setup_seconds = 1.0
+        def spy_factory(**kwargs):
+            events.append("connect")
+            return real_factory(**kwargs)
 
-        def slow_factory(**kwargs):
-            con = real_get_duckdb_connection(**kwargs)
-            time.sleep(slow_setup_seconds)
-            return con
+        class _TimeSpy:
+            """Proxy benchmark's `time` module, recording perf_counter calls.
 
-        monkeypatch.setattr(benchmark, "get_duckdb_connection", slow_factory)
+            Scoped to the benchmark module so patching cannot disturb pytest's
+            own perf_counter use during the call.
+            """
 
-        elapsed, _ = benchmark.benchmark_duckdb(GEOJSON_FILE, tmp_path / "out.parquet")
+            def __getattr__(self, name):
+                return getattr(real_time, name)
 
-        # Half the injected delay: well clear of run-to-run jitter on the same
-        # COPY, but nowhere near enough to absorb the setup cost.
-        assert elapsed < baseline + slow_setup_seconds / 2
+            def perf_counter(self):
+                events.append("timer")
+                return real_time.perf_counter()
+
+        monkeypatch.setattr(benchmark, "get_duckdb_connection", spy_factory)
+        monkeypatch.setattr(benchmark, "time", _TimeSpy())
+
+        benchmark.benchmark_duckdb(GEOJSON_FILE, tmp_path / "out.parquet")
+
+        assert "connect" in events, "benchmark_duckdb never built a connection"
+        assert "timer" in events, "benchmark_duckdb never started its timer"
+        assert events.index("connect") < events.index("timer"), (
+            f"connection setup landed inside the measured window: {events}"
+        )
 
 
 class TestWkbToWktPreview:


### PR DESCRIPTION
The timing assertion added in #659 is flaky.

`test_factory_setup_is_outside_the_measured_window` times a baseline `benchmark_duckdb` run, then requires a second run of the same `COPY` to finish within a fixed **0.5s** of it. That compares two noisy measurements against an absolute tolerance, so ordinary run-to-run jitter on a loaded CI runner fails it.

It went red on `windows-latest/3.11` in #657 — a PR that does not touch `benchmark.py`:

```
FAILED tests/test_duckdb_connection_factory_bypass.py::TestBenchmarkDuckdb::test_factory_setup_is_outside_the_measured_window - assert 0.67156180...
```

Left alone it will intermittently redden `main` and every future PR.

## Change

Assert what the test is actually about — that the connection is built *before* the timer starts — by recording the order of the `get_duckdb_connection` and `perf_counter` calls. No sleep, no threshold. Runs in ~1s instead of two full benchmark runs plus a 1s sleep.

The `time` proxy is scoped to the benchmark module rather than patching `time.perf_counter` globally, so pytest's own timing is untouched.

## Verification

Non-vacuous — moving the connection inside the timed window fails it with the recorded order `['timer', 'connect', 'timer']`, and it passes once restored.

`tests/test_duckdb_connection_factory_bypass.py` → **20 passed**.
