### PR TITLE
fix(tests): complete the WFS mock so six tests stop hitting the network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,8 +242,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   every exception, so the tests passed while silently making live network
   requests, contrary to the module's stated "mocked HTTP responses to avoid
   network dependencies". A shared `offline_wfs_probes` fixture now completes the
-  mock and installs a tripwire on `_make_request` that fails the test if any
-  future unmocked request escapes. No assertion changed meaning — the stubs
+  mock and installs a tripwire on `_make_request` that fails the test if a
+  future unmocked request escapes through that path. No assertion changed
+  meaning — the stubs
   return the `None` the failed requests already produced — and the file's serial
   runtime drops from 67.6s to 45.4s.
 - **Six internal DuckDB connections now route through the shared connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,20 +233,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
-- **WFS tests no longer reach the network.** Six `tests/test_wfs.py` tests that
-  exercise `wfs_to_table` mocked the version negotiation, layer lookup and
-  feature fetch, but not `_get_feature_count` — which `wfs_to_table` calls twice
-  before the mocked fetch as part of its auto-tiling probe. Against the fake
-  host those calls were real HTTP GETs that failed DNS resolution and burned the
-  full 1s+2s retry backoff twice, ~6.15s per test. `_get_feature_count` swallows
-  every exception, so the tests passed while silently making live network
-  requests, contrary to the module's stated "mocked HTTP responses to avoid
-  network dependencies". A shared `offline_wfs_probes` fixture now completes the
-  mock and installs a tripwire on `_make_request` that fails the test if a
-  future unmocked request escapes through that path. No assertion changed
-  meaning — the stubs
-  return the `None` the failed requests already produced — and the file's serial
-  runtime drops from 67.6s to 45.4s.
+- **`tests/test_wfs.py` no longer reaches the network.** Nine tests made live
+  requests against the fake host. Six exercise `wfs_to_table` and mocked the
+  version negotiation, layer lookup and feature fetch, but not
+  `_get_feature_count` — which `wfs_to_table` calls twice before the mocked
+  fetch as part of its auto-tiling probe. Three more, in
+  `TestAutoPageSingleWorker`, call `fetch_all_features_duckdb` directly, which
+  probes the server's startIndex support before paging; that probe drives httpx
+  itself, so mocking the page fetcher never covered it. Both `_get_feature_count`
+  and `_probe_startindex_limit` swallow every exception, so all nine passed
+  while silently making live requests, contrary to the module's stated "mocked
+  HTTP responses to avoid network dependencies". A shared `offline_wfs_probes`
+  fixture now completes the mock and installs a tripwire on `_make_request` that
+  fails the test if a future unmocked request escapes through that path. No
+  assertion changed meaning — the stubs return the `None` the failed requests
+  already produced. Measured over the file's fast lane: 12 outbound connection
+  attempts and 24 `time.sleep` calls totalling 36.00s of retry backoff both drop
+  to zero, and serial runtime goes from 43.4s to 6.3s.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **WFS tests no longer reach the network.** Six `tests/test_wfs.py` tests that
+  exercise `wfs_to_table` mocked the version negotiation, layer lookup and
+  feature fetch, but not `_get_feature_count` — which `wfs_to_table` calls twice
+  before the mocked fetch as part of its auto-tiling probe. Against the fake
+  host those calls were real HTTP GETs that failed DNS resolution and burned the
+  full 1s+2s retry backoff twice, ~6.15s per test. `_get_feature_count` swallows
+  every exception, so the tests passed while silently making live network
+  requests, contrary to the module's stated "mocked HTTP responses to avoid
+  network dependencies". A shared `offline_wfs_probes` fixture now completes the
+  mock and installs a tripwire on `_make_request` that fails the test if any
+  future unmocked request escapes. No assertion changed meaning — the stubs
+  return the `None` the failed requests already produced — and the file's serial
+  runtime drops from 67.6s to 45.4s.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -242,8 +242,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   every exception, so the tests passed while silently making live network
   requests, contrary to the module's stated "mocked HTTP responses to avoid
   network dependencies". A shared `offline_wfs_probes` fixture now completes the
-  mock and installs a tripwire on `_make_request` that fails the test if any
-  future unmocked request escapes. No assertion changed meaning — the stubs
+  mock and installs a tripwire on `_make_request` that fails the test if a
+  future unmocked request escapes through that path. No assertion changed
+  meaning — the stubs
   return the `None` the failed requests already produced — and the file's serial
   runtime drops from 67.6s to 45.4s.
 - **Six internal DuckDB connections now route through the shared connection

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -233,20 +233,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
-- **WFS tests no longer reach the network.** Six `tests/test_wfs.py` tests that
-  exercise `wfs_to_table` mocked the version negotiation, layer lookup and
-  feature fetch, but not `_get_feature_count` — which `wfs_to_table` calls twice
-  before the mocked fetch as part of its auto-tiling probe. Against the fake
-  host those calls were real HTTP GETs that failed DNS resolution and burned the
-  full 1s+2s retry backoff twice, ~6.15s per test. `_get_feature_count` swallows
-  every exception, so the tests passed while silently making live network
-  requests, contrary to the module's stated "mocked HTTP responses to avoid
-  network dependencies". A shared `offline_wfs_probes` fixture now completes the
-  mock and installs a tripwire on `_make_request` that fails the test if a
-  future unmocked request escapes through that path. No assertion changed
-  meaning — the stubs
-  return the `None` the failed requests already produced — and the file's serial
-  runtime drops from 67.6s to 45.4s.
+- **`tests/test_wfs.py` no longer reaches the network.** Nine tests made live
+  requests against the fake host. Six exercise `wfs_to_table` and mocked the
+  version negotiation, layer lookup and feature fetch, but not
+  `_get_feature_count` — which `wfs_to_table` calls twice before the mocked
+  fetch as part of its auto-tiling probe. Three more, in
+  `TestAutoPageSingleWorker`, call `fetch_all_features_duckdb` directly, which
+  probes the server's startIndex support before paging; that probe drives httpx
+  itself, so mocking the page fetcher never covered it. Both `_get_feature_count`
+  and `_probe_startindex_limit` swallow every exception, so all nine passed
+  while silently making live requests, contrary to the module's stated "mocked
+  HTTP responses to avoid network dependencies". A shared `offline_wfs_probes`
+  fixture now completes the mock and installs a tripwire on `_make_request` that
+  fails the test if a future unmocked request escapes through that path. No
+  assertion changed meaning — the stubs return the `None` the failed requests
+  already produced. Measured over the file's fast lane: 12 outbound connection
+  attempts and 24 `time.sleep` calls totalling 36.00s of retry backoff both drop
+  to zero, and serial runtime goes from 43.4s to 6.3s.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -233,6 +233,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **WFS tests no longer reach the network.** Six `tests/test_wfs.py` tests that
+  exercise `wfs_to_table` mocked the version negotiation, layer lookup and
+  feature fetch, but not `_get_feature_count` — which `wfs_to_table` calls twice
+  before the mocked fetch as part of its auto-tiling probe. Against the fake
+  host those calls were real HTTP GETs that failed DNS resolution and burned the
+  full 1s+2s retry backoff twice, ~6.15s per test. `_get_feature_count` swallows
+  every exception, so the tests passed while silently making live network
+  requests, contrary to the module's stated "mocked HTTP responses to avoid
+  network dependencies". A shared `offline_wfs_probes` fixture now completes the
+  mock and installs a tripwire on `_make_request` that fails the test if any
+  future unmocked request escapes. No assertion changed meaning — the stubs
+  return the `None` the failed requests already produced — and the file's serial
+  runtime drops from 67.6s to 45.4s.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # Module-level imports for WFS functions (avoids per-test imports)
+from geoparquet_io.core import wfs as wfs_module
 from geoparquet_io.core.wfs import (
     EmptyLayerError,
     LayerNotFoundError,
@@ -30,6 +31,45 @@ from geoparquet_io.core.wfs import (
     get_wfs_capabilities,
     list_available_layers,
 )
+
+
+@pytest.fixture
+def offline_wfs_probes():
+    """Complete the mock for ``wfs_to_table``: block every real HTTP request.
+
+    Mocking ``negotiate_wfs_version`` / ``get_layer_info`` /
+    ``fetch_all_features_duckdb`` is *not* enough to take ``wfs_to_table``
+    offline. Before it reaches the mocked fetch, its auto-tiling logic calls
+    ``_get_feature_count`` twice (once for WFS 2.0.0, then for the requested
+    version), and those calls are unmocked. Against a fake host they resolve to
+    real DNS lookups that fail, and ``_get_feature_count`` swallows every
+    exception -- so the tests still passed while quietly burning the 1s+2s
+    retry backoff twice, ~6s per test.
+
+    Stubbing the probes to ``None`` reproduces exactly what the failed requests
+    already returned, so no assertion changes meaning. ``_make_request`` is
+    additionally replaced with a tripwire, and the recorded calls are asserted
+    on teardown so a *future* unmocked network path fails loudly instead of
+    silently sleeping.
+    """
+    escaped_requests: list[str] = []
+
+    def _blocked_request(url, *args, **kwargs):
+        escaped_requests.append(url)
+        raise AssertionError(f"unmocked WFS HTTP request to {url}")
+
+    with (
+        patch.object(wfs_module, "_get_feature_count", return_value=None),
+        patch.object(wfs_module, "_probe_startindex_limit", return_value=None),
+        patch.object(wfs_module, "_make_request", side_effect=_blocked_request),
+    ):
+        yield
+
+    assert not escaped_requests, (
+        f"wfs_to_table made unmocked HTTP request(s): {escaped_requests}. "
+        "Extend the offline_wfs_probes fixture to cover the new call."
+    )
+
 
 # =============================================================================
 # Mock WFS Response Data
@@ -2435,7 +2475,7 @@ class TestCRSValidation:
         assert 0 < x < 10, f"Expected longitude ~4-6, got {x}"
         assert 45 < y < 55, f"Expected latitude ~50, got {y}"
 
-    def test_wfs_to_table_reprojects_on_mismatch(self):
+    def test_wfs_to_table_reprojects_on_mismatch(self, offline_wfs_probes):
         """wfs_to_table should reproject when output_crs set and server returns different CRS."""
         from unittest.mock import MagicMock, patch
 
@@ -2493,7 +2533,7 @@ class TestCRSValidation:
         assert -180 <= x <= 180, f"X {x} not in WGS84 range"
         assert -90 <= y <= 90, f"Y {y} not in WGS84 range"
 
-    def test_reproject_error_wrapped_in_wfs_error(self):
+    def test_reproject_error_wrapped_in_wfs_error(self, offline_wfs_probes):
         """Reprojection errors should be wrapped in WFSError with context."""
         from unittest.mock import MagicMock, patch
 
@@ -2780,7 +2820,7 @@ class TestResolveCRSForOutput:
         # The fallback to coordinate inference is announced (visible under --verbose).
         assert any("declared no CRS" in str(call.args[0]) for call in mock_debug.call_args_list)
 
-    def test_wfs_to_table_trusts_server_crs_end_to_end(self):
+    def test_wfs_to_table_trusts_server_crs_end_to_end(self, offline_wfs_probes):
         """End-to-end #499 regression: declared EPSG:22174 stays EPSG:22174."""
         import json
         from unittest.mock import MagicMock, patch
@@ -2818,7 +2858,7 @@ class TestResolveCRSForOutput:
         expected = parse_crs_string_to_projjson("EPSG:22174")
         assert geo["columns"]["geometry"]["crs"] == expected
 
-    def test_wfs_to_table_preserves_server_crs_through_local_bbox_filter(self):
+    def test_wfs_to_table_preserves_server_crs_through_local_bbox_filter(self, offline_wfs_probes):
         """Issue #499: local bbox filtering must not drop the server CRS.
 
         The local-filter path round-trips the table through DuckDB, which
@@ -2863,7 +2903,7 @@ class TestResolveCRSForOutput:
         geo = json.loads(result.schema.metadata[b"geo"])
         assert geo["columns"]["geometry"]["crs"] == parse_crs_string_to_projjson("EPSG:22174")
 
-    def test_local_bbox_filter_reprojects_bbox_to_server_crs(self):
+    def test_local_bbox_filter_reprojects_bbox_to_server_crs(self, offline_wfs_probes):
         """Issue #499: a bbox in the requested CRS must be aligned to the CRS the
         server actually returned, or local filtering drops valid rows.
 
@@ -2904,7 +2944,7 @@ class TestResolveCRSForOutput:
         # The point is retained because the bbox was reprojected to EPSG:22174.
         assert result.num_rows == 1
 
-    def test_wfs_to_table_strips_server_crs_marker_when_no_projjson(self):
+    def test_wfs_to_table_strips_server_crs_marker_when_no_projjson(self, offline_wfs_probes):
         """The internal server-CRS marker never leaks into the output schema.
 
         Even when no geo metadata is written (projjson unavailable for the

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -35,7 +35,7 @@ from geoparquet_io.core.wfs import (
 
 @pytest.fixture
 def offline_wfs_probes():
-    """Complete the mock for ``wfs_to_table`` so it stops reaching the network.
+    """Complete the mock for the WFS entry points so they stop reaching the network.
 
     Mocking ``negotiate_wfs_version`` / ``get_layer_info`` /
     ``fetch_all_features_duckdb`` is *not* enough to take ``wfs_to_table``
@@ -46,7 +46,13 @@ def offline_wfs_probes():
     exception -- so the tests still passed while quietly burning the 1s+2s
     retry backoff twice, ~6s per test.
 
-    Stubbing the probes to ``None`` reproduces exactly what the failed requests
+    ``_probe_startindex_limit`` is the same trap one level down, and it is
+    load-bearing for a different caller: ``fetch_all_features_duckdb`` probes
+    the server's startIndex support before paging, so tests that call it
+    directly (``TestAutoPageSingleWorker``) leak even though they mock the page
+    fetcher. It swallows ``httpx.HTTPError`` the same way.
+
+    Stubbing both probes to ``None`` reproduces exactly what the failed requests
     already returned, so no assertion changes meaning. ``_make_request`` is
     additionally replaced with a tripwire, and the recorded calls are asserted
     on teardown so a *future* unmocked network path fails loudly instead of
@@ -54,9 +60,9 @@ def offline_wfs_probes():
 
     Scope note: the tripwire covers only ``_make_request``-mediated traffic.
     ``_fetch_wfs_page`` and ``_probe_startindex_limit`` drive httpx directly and
-    bypass it -- here they are neutralised by the ``fetch_all_features_duckdb``
-    mock and the ``_probe_startindex_limit`` stub respectively, not by the
-    tripwire.
+    bypass it; they are covered by the explicit stubs above, not by the
+    tripwire. A new httpx-driven helper would therefore escape silently -- add
+    it to this fixture rather than assuming the tripwire caught it.
     """
     escaped_requests: list[str] = []
 
@@ -1759,8 +1765,17 @@ class TestEmptyProperties:
         assert result.column_names == ["geometry"]
 
 
+@pytest.mark.usefixtures("offline_wfs_probes")
 class TestAutoPageSingleWorker:
-    """Test that single-worker mode auto-paginates for large datasets."""
+    """Test that single-worker mode auto-paginates for large datasets.
+
+    These call ``fetch_all_features_duckdb`` directly, which probes the server's
+    startIndex support before paging. That probe drives httpx itself, so mocking
+    the page fetcher does not cover it -- the three tests here reached
+    ``mock.wfs:443`` on every run. Stubbing the probe to ``None`` reproduces what
+    the failed request already returned (``_probe_startindex_limit`` swallows
+    ``httpx.HTTPError``), so no assertion changes meaning.
+    """
 
     def test_single_worker_paginates_when_count_exceeds_page_size(self):
         """With max_workers=1 and total > page_size, should paginate sequentially."""
@@ -2481,7 +2496,8 @@ class TestCRSValidation:
         assert 0 < x < 10, f"Expected longitude ~4-6, got {x}"
         assert 45 < y < 55, f"Expected latitude ~50, got {y}"
 
-    def test_wfs_to_table_reprojects_on_mismatch(self, offline_wfs_probes):
+    @pytest.mark.usefixtures("offline_wfs_probes")
+    def test_wfs_to_table_reprojects_on_mismatch(self):
         """wfs_to_table should reproject when output_crs set and server returns different CRS."""
         from unittest.mock import MagicMock, patch
 
@@ -2539,7 +2555,8 @@ class TestCRSValidation:
         assert -180 <= x <= 180, f"X {x} not in WGS84 range"
         assert -90 <= y <= 90, f"Y {y} not in WGS84 range"
 
-    def test_reproject_error_wrapped_in_wfs_error(self, offline_wfs_probes):
+    @pytest.mark.usefixtures("offline_wfs_probes")
+    def test_reproject_error_wrapped_in_wfs_error(self):
         """Reprojection errors should be wrapped in WFSError with context."""
         from unittest.mock import MagicMock, patch
 
@@ -2826,7 +2843,8 @@ class TestResolveCRSForOutput:
         # The fallback to coordinate inference is announced (visible under --verbose).
         assert any("declared no CRS" in str(call.args[0]) for call in mock_debug.call_args_list)
 
-    def test_wfs_to_table_trusts_server_crs_end_to_end(self, offline_wfs_probes):
+    @pytest.mark.usefixtures("offline_wfs_probes")
+    def test_wfs_to_table_trusts_server_crs_end_to_end(self):
         """End-to-end #499 regression: declared EPSG:22174 stays EPSG:22174."""
         import json
         from unittest.mock import MagicMock, patch
@@ -2864,7 +2882,8 @@ class TestResolveCRSForOutput:
         expected = parse_crs_string_to_projjson("EPSG:22174")
         assert geo["columns"]["geometry"]["crs"] == expected
 
-    def test_wfs_to_table_preserves_server_crs_through_local_bbox_filter(self, offline_wfs_probes):
+    @pytest.mark.usefixtures("offline_wfs_probes")
+    def test_wfs_to_table_preserves_server_crs_through_local_bbox_filter(self):
         """Issue #499: local bbox filtering must not drop the server CRS.
 
         The local-filter path round-trips the table through DuckDB, which
@@ -2909,7 +2928,8 @@ class TestResolveCRSForOutput:
         geo = json.loads(result.schema.metadata[b"geo"])
         assert geo["columns"]["geometry"]["crs"] == parse_crs_string_to_projjson("EPSG:22174")
 
-    def test_local_bbox_filter_reprojects_bbox_to_server_crs(self, offline_wfs_probes):
+    @pytest.mark.usefixtures("offline_wfs_probes")
+    def test_local_bbox_filter_reprojects_bbox_to_server_crs(self):
         """Issue #499: a bbox in the requested CRS must be aligned to the CRS the
         server actually returned, or local filtering drops valid rows.
 
@@ -2950,7 +2970,8 @@ class TestResolveCRSForOutput:
         # The point is retained because the bbox was reprojected to EPSG:22174.
         assert result.num_rows == 1
 
-    def test_wfs_to_table_strips_server_crs_marker_when_no_projjson(self, offline_wfs_probes):
+    @pytest.mark.usefixtures("offline_wfs_probes")
+    def test_wfs_to_table_strips_server_crs_marker_when_no_projjson(self):
         """The internal server-CRS marker never leaks into the output schema.
 
         Even when no geo metadata is written (projjson unavailable for the

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -35,7 +35,7 @@ from geoparquet_io.core.wfs import (
 
 @pytest.fixture
 def offline_wfs_probes():
-    """Complete the mock for ``wfs_to_table``: block every real HTTP request.
+    """Complete the mock for ``wfs_to_table`` so it stops reaching the network.
 
     Mocking ``negotiate_wfs_version`` / ``get_layer_info`` /
     ``fetch_all_features_duckdb`` is *not* enough to take ``wfs_to_table``
@@ -51,6 +51,12 @@ def offline_wfs_probes():
     additionally replaced with a tripwire, and the recorded calls are asserted
     on teardown so a *future* unmocked network path fails loudly instead of
     silently sleeping.
+
+    Scope note: the tripwire covers only ``_make_request``-mediated traffic.
+    ``_fetch_wfs_page`` and ``_probe_startindex_limit`` drive httpx directly and
+    bypass it -- here they are neutralised by the ``fetch_all_features_duckdb``
+    mock and the ``_probe_startindex_limit`` stub respectively, not by the
+    tripwire.
     """
     escaped_requests: list[str] = []
 


### PR DESCRIPTION
Implements item 2 of #665: six tests in `tests/test_wfs.py` each spent ~6.15s in real retry backoff. The brief asked to zero the backoff *and* investigate why a mocked path retries at all. It turned out not to be a timing problem.

## Root cause: the tests were making real network calls

`wfs_to_table` runs an auto-tiling probe before it ever reaches the mocked fetch. With `auto_tile=True` (the default) and `version != "1.0.0"`:

```python
expected_count = _get_feature_count(service_url, layer_info.typename, "2.0.0")
if not expected_count:
    expected_count = _get_feature_count(service_url, layer_info.typename, version)
```

The six tests mocked `negotiate_wfs_version`, `get_layer_info` and `fetch_all_features_duckdb` — but **not `_get_feature_count`**. Both calls issued real HTTP GETs to the fake host `https://mock.wfs.server/wfs`, failed DNS resolution, and were retried three times with `retry_delay * (attempt + 1)` → **1s + 2s per call × 2 calls = 6.0s**.

`_get_feature_count` ends in a bare `except Exception: pass`, so the failure was silently swallowed: the tests passed while making live network requests, contradicting the module docstring's *"Tests use mocked HTTP responses to avoid network dependencies."*

Instrumented proof (patched `time.sleep` to record instead of sleep, traced `_make_request`):

```
sleep calls: [1.0, 2.0, 1.0, 2.0] total 6.0
real _make_request calls: 2
  -> https://mock.wfs.server/wfs GetFeature hits 2.0.0
  -> https://mock.wfs.server/wfs GetFeature hits 1.1.0
```

So this is an incomplete mock — a genuine test bug — not deliberate retry coverage. Injecting `retry_delay=0` or patching `time.sleep` would have hidden the defect while leaving the tests non-hermetic, so the fix completes the mock instead.

## The fix

One shared `offline_wfs_probes` fixture, wired into the six tests by parameter (no copy-pasted sleep patches):

- Stubs `_get_feature_count` → `None` and `_probe_startindex_limit` → `None`. `None` is **exactly what the failed requests already returned**, so the path through `wfs_to_table` is unchanged and **no assertion changes meaning**.
- Replaces `_make_request` with a **tripwire** that records the URL and raises, asserted on teardown — a future unmocked request through that path now fails loudly instead of silently sleeping. (Scope is documented in the docstring: `_fetch_wfs_page` and `_probe_startindex_limit` drive httpx directly and bypass the tripwire; here they are covered by the fetch mock and the probe stub.)
- Uses `patch.object(...)`, not dotted-string targets, per the known Python 3.10 patch-target trap.

## Verification

**Non-vacuity.** Run with the tripwire only (probe stubs disabled), the guard fires on all six, each reporting exactly two escaped requests:

```
E   AssertionError: wfs_to_table made unmocked HTTP request(s):
    ['https://mock.wfs.server/wfs', 'https://mock.wfs.server/wfs'].
6 passed, 209 deselected, 6 errors in 1.26s
```

Note the tests themselves still "passed" — that is the silent-swallow bug in one line.

**Timings** (`-k "CRSValidation or ResolveCRSForOutput" --durations`):

| Test | Before | After |
|---|---|---|
| `test_wfs_to_table_reprojects_on_mismatch` | 6.37s | 1.93s* |
| `test_local_bbox_filter_reprojects_bbox_to_server_crs` | 6.16s | 0.60s |
| `test_wfs_to_table_preserves_server_crs_through_local_bbox_filter` | 6.15s | 0.35s |
| `test_wfs_to_table_trusts_server_crs_end_to_end` | 6.13s | 0.28s |
| `test_wfs_to_table_strips_server_crs_marker_when_no_projjson` | 6.11s | 0.16s |
| `test_reproject_error_wrapped_in_wfs_error` | 6.11s | 0.30s |
| **selection wall time** | **47.05s** | **10.46s** |

\* Not sleep — the one-time ~1.5s DuckDB spatial-extension load, paid by whichever test opens the first connection. Before the fix `test_validate_crs_coordinates_passes_for_valid_wgs84` was the first-runner at 7.21s and is now 1.49s; the cost simply moved.

**No behavioural regression.** Full `tests/test_wfs.py`, identical outcomes before and after — `204 passed, 1 xfailed, 10 xpassed` — with serial runtime **67.6s → 45.4s**. Same xfail/xpass counts, so nothing was masked or re-classified.

**Full fast suite:** `3959 passed, 40 skipped` (`-n 4 -m "not slow and not network"`). All pre-commit hooks pass.

## Follow-up

The bare `except Exception: pass` in `_get_feature_count` is a **production** smell, not just a test one — a server hiccup silently degrades auto-tiling to no-tiling, the same silent-truncation class the `auto_tile` CHANGELOG entry warns about. Filed separately as #678 rather than bolted onto this branch.

No production code changed here. References #665; closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WFS test isolation by preventing unexpected network requests during test runs.
  * Reduced delays caused by retries in reprojection and coordinate reference system tests.
  * Preserved existing test assertions while improving reliability.

* **Documentation**
  * Added changelog entries describing the WFS test isolation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->