### PR TITLE
test(cli): pin the CLI surface with a structural snapshot (#664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,12 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   fails naming the exact field that drifted. Help prose is deliberately not
   pinned. Plugin-contributed commands are excluded, so an installed plugin
   cannot break the test. Intentional changes are accepted by re-recording with
-  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py`. A companion
-  parametrized test renders `--help` for every built-in leaf command.
+  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py` (refused
+  when `CI` is set, so a stray env var cannot rewrite the baseline green). The
+  snapshot also pins which subcommand each default-dispatch group falls back to
+  (`check` → `all`, `inspect` → `summary`), which lived only in a closure and
+  was previously unobservable. Companion parametrized tests render `--help` for
+  every built-in leaf command and every group.
 
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,16 +66,25 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
   whole Click command tree into a structural snapshot at
   `tests/data/cli_surface.json` — every group, command, option and argument
-  with its opts, type, default, `required`, `is_flag` and `multiple` — and
-  fails naming the exact field that drifted. Help prose is deliberately not
+  with its opts, its *secondary* opts, type, default, `required`, `is_flag` and
+  `multiple` — and fails naming the exact field that drifted. Recording
+  `--warmup` and `--no-warmup` in separate fields matters: concatenated, a
+  boolean flag pair is indistinguishable from two aliases for the same switch,
+  which is a user-visible behavior change. Help prose is deliberately not
   pinned. Plugin-contributed commands are excluded, so an installed plugin
   cannot break the test. Intentional changes are accepted by re-recording with
-  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py` (refused
-  when `CI` is set, so a stray env var cannot rewrite the baseline green). The
-  snapshot also pins which subcommand each default-dispatch group falls back to
-  (`check` → `all`, `inspect` → `summary`), which lived only in a closure and
-  was previously unobservable. Companion parametrized tests render `--help` for
-  every built-in leaf command and every group.
+  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py` — honored
+  only for an affirmative value, so `GPIO_UPDATE_SNAPSHOT=0` means no, and
+  refused outright when `CI` is set so a stray env var cannot rewrite the
+  baseline green. The snapshot also pins each group's argv rewriting: the
+  subcommand a default-dispatch group falls back to (`check` → `all`, `inspect`
+  → `summary`) and the output-extension map `gpio convert` dispatches on
+  (`.gpkg` → `geopackage`, `.fgb` → `flatgeobuf`, ...). Both lived only in a
+  closure and were previously unobservable. Companion parametrized tests render
+  `--help` for every built-in leaf command and every group. The snapshot
+  comparison needs click >= 8.2's `UNSET` sentinel to distinguish an undeclared
+  default from an explicit `None`, and skips below that; the help-render cases
+  still run.
 
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,16 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
+  whole Click command tree into a structural snapshot at
+  `tests/data/cli_surface.json` — every group, command, option and argument
+  with its opts, type, default, `required`, `is_flag` and `multiple` — and
+  fails naming the exact field that drifted. Help prose is deliberately not
+  pinned. Plugin-contributed commands are excluded, so an installed plugin
+  cannot break the test. Intentional changes are accepted by re-recording with
+  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py`. A companion
+  parametrized test renders `--help` for every built-in leaf command.
+
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with
   tippecanoe, pinned to the zoom band where its worst tile fits the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,8 +70,12 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   fails naming the exact field that drifted. Help prose is deliberately not
   pinned. Plugin-contributed commands are excluded, so an installed plugin
   cannot break the test. Intentional changes are accepted by re-recording with
-  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py`. A companion
-  parametrized test renders `--help` for every built-in leaf command.
+  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py` (refused
+  when `CI` is set, so a stray env var cannot rewrite the baseline green). The
+  snapshot also pins which subcommand each default-dispatch group falls back to
+  (`check` → `all`, `inspect` → `summary`), which lived only in a closure and
+  was previously unobservable. Companion parametrized tests render `--help` for
+  every built-in leaf command and every group.
 
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,16 +66,25 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 - **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
   whole Click command tree into a structural snapshot at
   `tests/data/cli_surface.json` — every group, command, option and argument
-  with its opts, type, default, `required`, `is_flag` and `multiple` — and
-  fails naming the exact field that drifted. Help prose is deliberately not
+  with its opts, its *secondary* opts, type, default, `required`, `is_flag` and
+  `multiple` — and fails naming the exact field that drifted. Recording
+  `--warmup` and `--no-warmup` in separate fields matters: concatenated, a
+  boolean flag pair is indistinguishable from two aliases for the same switch,
+  which is a user-visible behavior change. Help prose is deliberately not
   pinned. Plugin-contributed commands are excluded, so an installed plugin
   cannot break the test. Intentional changes are accepted by re-recording with
-  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py` (refused
-  when `CI` is set, so a stray env var cannot rewrite the baseline green). The
-  snapshot also pins which subcommand each default-dispatch group falls back to
-  (`check` → `all`, `inspect` → `summary`), which lived only in a closure and
-  was previously unobservable. Companion parametrized tests render `--help` for
-  every built-in leaf command and every group.
+  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py` — honored
+  only for an affirmative value, so `GPIO_UPDATE_SNAPSHOT=0` means no, and
+  refused outright when `CI` is set so a stray env var cannot rewrite the
+  baseline green. The snapshot also pins each group's argv rewriting: the
+  subcommand a default-dispatch group falls back to (`check` → `all`, `inspect`
+  → `summary`) and the output-extension map `gpio convert` dispatches on
+  (`.gpkg` → `geopackage`, `.fgb` → `flatgeobuf`, ...). Both lived only in a
+  closure and were previously unobservable. Companion parametrized tests render
+  `--help` for every built-in leaf command and every group. The snapshot
+  comparison needs click >= 8.2's `UNSET` sentinel to distinguish an undeclared
+  default from an explicit `None`, and skips below that; the help-render cases
+  still run.
 
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,16 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
+  whole Click command tree into a structural snapshot at
+  `tests/data/cli_surface.json` — every group, command, option and argument
+  with its opts, type, default, `required`, `is_flag` and `multiple` — and
+  fails naming the exact field that drifted. Help prose is deliberately not
+  pinned. Plugin-contributed commands are excluded, so an installed plugin
+  cannot break the test. Intentional changes are accepted by re-recording with
+  `GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py`. A companion
+  parametrized test renders `--help` for every built-in leaf command.
+
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with
   tippecanoe, pinned to the zoom band where its worst tile fits the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,21 @@ from pathlib import Path  # noqa: E402
 import pyarrow.parquet as pq  # noqa: E402
 import pytest  # noqa: E402
 
+# ---------------------------------------------------------------------------
+# Click "no default declared" sentinel
+# ---------------------------------------------------------------------------
+# Click 8.2 added ``click.core.UNSET`` to distinguish "no default was declared"
+# from an explicitly declared ``None``. On click 8.1 the two are
+# indistinguishable and ``param.default`` is plain ``None``. Tests that
+# introspect Click defaults share this shim instead of each carrying a copy.
+try:
+    from click.core import UNSET  # noqa: E402
+
+    CLICK_HAS_UNSET = True
+except ImportError:  # pragma: no cover - click < 8.2
+    UNSET = object()
+    CLICK_HAS_UNSET = False
+
 # Test data directory
 TEST_DATA_DIR = Path(__file__).parent / "data"
 PLACES_TEST_FILE = TEST_DATA_DIR / "places_test.parquet"

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -11,6 +11,7 @@
      "params": [
       {
        "default": "'a5_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "a5_name",
@@ -24,6 +25,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -37,6 +39,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -46,10 +49,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -63,6 +67,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -76,6 +81,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -85,10 +91,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -102,6 +109,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -115,6 +123,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -128,6 +137,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "resolution",
@@ -141,6 +151,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -153,7 +164,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -167,6 +179,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -180,6 +193,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -194,6 +208,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -214,6 +229,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "add_bbox",
@@ -227,6 +243,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -240,6 +257,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "clear_cache",
@@ -253,6 +271,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -262,10 +281,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -279,6 +299,7 @@
       },
       {
        "default": "'gaul'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "dataset",
@@ -288,10 +309,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[gaul|overture]"
+       "type": "choice[gaul|overture,case_sensitive=False]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -305,6 +327,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -314,10 +337,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -330,7 +354,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "levels",
@@ -344,6 +369,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_cache",
@@ -357,6 +383,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -370,6 +397,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -383,6 +411,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -396,6 +425,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -408,7 +438,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -422,6 +453,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -435,6 +467,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "vecorel",
@@ -448,6 +481,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -462,6 +496,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -482,6 +517,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -495,6 +531,7 @@
       },
       {
        "default": "'bbox'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox_name",
@@ -508,6 +545,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -517,10 +555,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -534,6 +573,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -547,6 +587,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -560,6 +601,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -569,10 +611,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -586,6 +629,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -599,6 +643,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -612,6 +657,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -624,7 +670,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -638,6 +685,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -651,6 +699,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -665,6 +714,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -684,7 +734,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -698,6 +749,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -719,6 +771,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -732,6 +785,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -741,10 +795,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -758,6 +813,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -771,6 +827,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -780,10 +837,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -797,6 +855,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_vecorel",
@@ -810,6 +869,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -823,6 +883,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -836,6 +897,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -848,7 +910,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -862,6 +925,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -875,6 +939,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -889,6 +954,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -909,6 +975,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -922,6 +989,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -931,10 +999,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -948,6 +1017,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -961,6 +1031,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -970,10 +1041,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "'h3_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "h3_name",
@@ -986,7 +1058,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -1000,6 +1073,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -1013,6 +1087,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -1026,6 +1101,7 @@
       },
       {
        "default": "9",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "resolution",
@@ -1039,6 +1115,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -1051,7 +1128,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -1065,6 +1143,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -1078,6 +1157,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -1092,6 +1172,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -1112,6 +1193,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -1125,6 +1207,7 @@
       },
       {
        "default": "100000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "approx",
@@ -1138,6 +1221,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "auto",
@@ -1151,6 +1235,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -1160,10 +1245,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -1177,6 +1263,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -1190,6 +1277,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "exact",
@@ -1203,6 +1291,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -1216,6 +1305,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -1225,10 +1315,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -1242,6 +1333,7 @@
       },
       {
        "default": "'kdtree_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "kdtree_name",
@@ -1254,7 +1346,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -1268,6 +1361,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -1281,6 +1375,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "partitions",
@@ -1294,6 +1389,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -1306,7 +1402,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -1320,6 +1417,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -1333,6 +1431,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -1347,6 +1446,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -1367,6 +1467,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -1380,6 +1481,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -1389,10 +1491,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -1406,6 +1509,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -1419,6 +1523,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -1428,10 +1533,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -1445,6 +1551,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -1458,6 +1565,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -1471,6 +1579,7 @@
       },
       {
        "default": "'quadkey'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "quadkey_name",
@@ -1484,6 +1593,7 @@
       },
       {
        "default": "13",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "resolution",
@@ -1497,6 +1607,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -1509,7 +1620,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -1523,6 +1635,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -1536,6 +1649,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "use_centroid",
@@ -1549,6 +1663,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -1563,6 +1678,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -1583,6 +1699,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -1596,6 +1713,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -1605,10 +1723,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -1622,6 +1741,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -1635,6 +1755,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -1644,10 +1765,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -1661,6 +1783,7 @@
       },
       {
        "default": "13",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "level",
@@ -1674,6 +1797,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -1687,6 +1811,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -1700,6 +1825,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -1712,7 +1838,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -1726,6 +1853,7 @@
       },
       {
        "default": "'s2_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "s2_name",
@@ -1739,6 +1867,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -1752,6 +1881,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -1766,6 +1896,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -1780,6 +1911,7 @@
      ]
     }
    },
+   "default_subcommand": null,
    "hidden": false,
    "kind": "group",
    "params": []
@@ -1793,7 +1925,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "converters",
@@ -1807,7 +1940,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -1821,6 +1955,7 @@
       },
       {
        "default": "3",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "iterations",
@@ -1834,7 +1969,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "keep_output",
@@ -1848,6 +1984,7 @@
       },
       {
        "default": "'table'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_format",
@@ -1857,10 +1994,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[table|json]"
+       "type": "choice[table|json,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_json",
@@ -1875,6 +2013,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "quiet",
@@ -1889,6 +2028,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -1903,6 +2043,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "warmup",
@@ -1923,7 +2064,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -1937,6 +2079,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output",
@@ -1951,6 +2094,7 @@
       },
       {
        "default": "'table'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_format",
@@ -1960,10 +2104,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[table|json]"
+       "type": "choice[table|json,case_sensitive=True]"
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "query",
@@ -1978,6 +2123,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -1999,6 +2145,7 @@
      "params": [
       {
        "default": "'table'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_format",
@@ -2008,10 +2155,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[table|json]"
+       "type": "choice[table|json,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "result_files",
@@ -2025,6 +2173,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2045,7 +2194,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": true,
        "name": "files",
@@ -2059,6 +2209,7 @@
       },
       {
        "default": "3",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "iterations",
@@ -2073,6 +2224,7 @@
       },
       {
        "default": "'core'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "operations",
@@ -2082,10 +2234,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[core|full]"
+       "type": "choice[core|full,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output",
@@ -2100,6 +2253,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "profile",
@@ -2113,6 +2267,7 @@
       },
       {
        "default": "'./profiles'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "profile_dir",
@@ -2126,6 +2281,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2141,6 +2297,7 @@
      ]
     }
    },
+   "default_subcommand": null,
    "hidden": false,
    "kind": "group",
    "params": []
@@ -2155,6 +2312,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "check_all_files",
@@ -2168,6 +2326,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "check_sample",
@@ -2181,6 +2340,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "fix",
@@ -2193,7 +2353,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "fix_output",
@@ -2207,6 +2368,7 @@
       },
       {
        "default": "500000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "limit_rows",
@@ -2220,6 +2382,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_backup",
@@ -2233,6 +2396,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -2245,7 +2409,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -2259,6 +2424,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "pmtiles",
@@ -2272,6 +2438,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "profile",
@@ -2281,10 +2448,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[web]"
+       "type": "choice[web,case_sensitive=False]"
       },
       {
        "default": "100",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "random_sample_size",
@@ -2298,6 +2466,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "spec_details",
@@ -2311,6 +2480,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2331,6 +2501,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "check_all_files",
@@ -2344,6 +2515,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "check_sample",
@@ -2357,6 +2529,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "fix",
@@ -2369,7 +2542,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "fix_output",
@@ -2383,6 +2557,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_backup",
@@ -2396,6 +2571,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -2408,7 +2584,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -2422,6 +2599,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2442,6 +2620,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "check_all_files",
@@ -2455,6 +2634,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "check_sample",
@@ -2468,6 +2648,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "fix",
@@ -2480,7 +2661,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "fix_output",
@@ -2494,6 +2676,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_backup",
@@ -2507,6 +2690,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -2519,7 +2703,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -2533,6 +2718,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2553,6 +2739,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "check_all_files",
@@ -2566,6 +2753,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "check_sample",
@@ -2578,7 +2766,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -2592,6 +2781,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2612,6 +2802,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "check_all_files",
@@ -2625,6 +2816,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "check_sample",
@@ -2638,6 +2830,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "fix",
@@ -2650,7 +2843,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "fix_output",
@@ -2664,6 +2858,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_backup",
@@ -2677,6 +2872,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -2689,7 +2885,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -2703,6 +2900,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "profile",
@@ -2712,10 +2910,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[web]"
+       "type": "choice[web,case_sensitive=False]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2736,6 +2935,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "check_all_files",
@@ -2749,6 +2949,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "check_sample",
@@ -2762,6 +2963,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "fix",
@@ -2774,7 +2976,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "fix_output",
@@ -2788,6 +2991,7 @@
       },
       {
        "default": "500000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "limit_rows",
@@ -2801,6 +3005,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_backup",
@@ -2813,7 +3018,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -2827,6 +3033,7 @@
       },
       {
        "default": "100",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "random_sample_size",
@@ -2840,6 +3047,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2860,6 +3068,7 @@
      "params": [
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -2869,10 +3078,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "json_output",
@@ -2885,7 +3095,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -2899,6 +3110,7 @@
       },
       {
        "default": "1000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "sample_size",
@@ -2912,6 +3124,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_data_validation",
@@ -2925,6 +3138,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2945,7 +3159,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "stac_file",
@@ -2959,6 +3174,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -2974,6 +3190,7 @@
      ]
     }
    },
+   "default_subcommand": "all",
    "hidden": false,
    "kind": "group",
    "params": []
@@ -2987,7 +3204,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -3000,7 +3218,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -3014,6 +3233,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_bbox",
@@ -3027,6 +3247,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_wkt",
@@ -3040,6 +3261,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -3053,6 +3275,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -3066,6 +3289,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -3079,6 +3303,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -3099,7 +3324,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -3112,7 +3338,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -3126,6 +3353,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -3139,6 +3367,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -3152,6 +3381,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -3165,6 +3395,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -3185,7 +3416,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -3199,6 +3431,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "description",
@@ -3212,6 +3445,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "id_field",
@@ -3224,7 +3458,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -3238,6 +3473,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "keep_crs",
@@ -3251,6 +3487,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_rs",
@@ -3264,6 +3501,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_seq",
@@ -3277,6 +3515,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -3290,6 +3529,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -3303,6 +3543,7 @@
       },
       {
        "default": "7",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "precision",
@@ -3316,6 +3557,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "pretty",
@@ -3329,6 +3571,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -3343,6 +3586,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -3356,6 +3600,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -3370,6 +3615,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "write_bbox",
@@ -3389,7 +3635,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -3402,7 +3649,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -3416,6 +3664,7 @@
       },
       {
        "default": "'features'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "layer_name",
@@ -3429,6 +3678,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -3442,6 +3692,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -3455,6 +3706,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -3468,6 +3720,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -3489,6 +3742,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "allow_no_geometry",
@@ -3502,6 +3756,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -3514,7 +3769,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -3528,6 +3784,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -3537,10 +3794,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -3554,6 +3812,7 @@
       },
       {
        "default": "'EPSG:4326'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "crs",
@@ -3567,6 +3826,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "csv_max_line_size",
@@ -3579,7 +3839,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "delimiter",
@@ -3593,6 +3854,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -3602,10 +3864,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -3618,7 +3881,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "lat_column",
@@ -3631,7 +3895,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "layer",
@@ -3645,6 +3910,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "linearize_curves",
@@ -3658,7 +3924,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "lon_column",
@@ -3672,6 +3939,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_angle_deg",
@@ -3685,6 +3953,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -3698,6 +3967,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -3712,6 +3982,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -3724,7 +3995,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -3738,6 +4010,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -3751,6 +4024,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_hilbert",
@@ -3764,6 +4038,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_invalid",
@@ -3777,6 +4052,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -3790,7 +4066,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "wkt_column",
@@ -3804,6 +4081,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -3824,6 +4102,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -3837,6 +4116,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "assume_crs84",
@@ -3849,7 +4129,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -3863,6 +4144,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -3872,10 +4154,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -3889,6 +4172,7 @@
       },
       {
        "default": "'EPSG:4326'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "dst_crs",
@@ -3903,6 +4187,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -3912,10 +4197,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -3929,6 +4215,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -3942,6 +4229,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -3955,6 +4243,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -3967,7 +4256,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -3981,6 +4271,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -3994,6 +4285,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "src_crs",
@@ -4008,6 +4300,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -4022,6 +4315,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -4041,7 +4335,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -4055,6 +4350,7 @@
       },
       {
        "default": "'UTF-8'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "encoding",
@@ -4067,7 +4363,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -4081,6 +4378,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -4094,6 +4392,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -4107,6 +4406,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -4120,6 +4420,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -4135,6 +4436,7 @@
      ]
     }
    },
+   "default_subcommand": "geoparquet",
    "hidden": false,
    "kind": "group",
    "params": []
@@ -4149,6 +4451,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -4161,7 +4464,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -4175,6 +4479,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "batch_size",
@@ -4187,7 +4492,8 @@
        "type": "integer range[min=1,max=5000,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox",
@@ -4201,6 +4507,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -4210,10 +4517,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -4226,7 +4534,8 @@
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "exclude_cols",
@@ -4240,6 +4549,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -4249,10 +4559,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "include_cols",
@@ -4265,7 +4576,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "limit",
@@ -4279,6 +4591,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_allowable_offset",
@@ -4291,7 +4604,8 @@
        "type": "float"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_crs",
@@ -4304,7 +4618,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -4318,6 +4633,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -4330,7 +4646,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "password",
@@ -4343,7 +4660,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "portal_url",
@@ -4357,6 +4675,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -4371,6 +4690,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -4383,7 +4703,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -4396,7 +4717,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "service_url",
@@ -4410,6 +4732,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -4423,6 +4746,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_bbox",
@@ -4436,6 +4760,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_hilbert",
@@ -4449,6 +4774,7 @@
       },
       {
        "default": "60.0",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "timeout",
@@ -4461,7 +4787,8 @@
        "type": "float range[min=0,max=None,min_open=True,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "token",
@@ -4474,7 +4801,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "token_file",
@@ -4487,7 +4815,8 @@
        "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "username",
@@ -4501,6 +4830,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -4515,6 +4845,7 @@
       },
       {
        "default": "'1=1'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "where",
@@ -4528,6 +4859,7 @@
       },
       {
        "default": "1",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "workers",
@@ -4548,6 +4880,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -4560,7 +4893,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox",
@@ -4574,6 +4908,7 @@
       },
       {
        "default": "'auto'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox_mode",
@@ -4583,10 +4918,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[auto|server|local]"
+       "type": "choice[auto|server|local,case_sensitive=True]"
       },
       {
        "default": "500000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox_threshold",
@@ -4600,6 +4936,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -4609,10 +4946,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -4625,7 +4963,8 @@
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "credentials_file",
@@ -4639,6 +4978,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -4652,6 +4992,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "edges",
@@ -4661,10 +5002,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[spherical|planar]"
+       "type": "choice[spherical|planar,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "exclude_cols",
@@ -4677,7 +5019,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geography_column",
@@ -4691,6 +5034,7 @@
       },
       {
        "default": "'wkt'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geometry_format",
@@ -4700,10 +5044,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[wkt|geojson]"
+       "type": "choice[wkt|geojson,case_sensitive=False]"
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -4713,10 +5058,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "include_cols",
@@ -4729,7 +5075,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "limit",
@@ -4743,6 +5090,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -4756,6 +5104,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -4768,7 +5117,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "project",
@@ -4782,6 +5132,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -4796,6 +5147,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -4808,7 +5160,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -4822,6 +5175,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -4834,7 +5188,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "table_id",
@@ -4848,6 +5203,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -4861,7 +5217,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "where",
@@ -4875,6 +5232,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -4895,6 +5253,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -4907,7 +5266,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -4920,7 +5280,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox",
@@ -4934,6 +5295,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -4943,10 +5305,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -4959,7 +5322,8 @@
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "exclude_cols",
@@ -4973,6 +5337,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "geometry",
@@ -4987,6 +5352,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -4996,10 +5362,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "include_cols",
@@ -5012,7 +5379,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "limit",
@@ -5025,7 +5393,8 @@
        "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -5039,6 +5408,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -5052,6 +5422,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -5066,6 +5437,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -5078,7 +5450,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -5092,6 +5465,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_bbox",
@@ -5105,6 +5479,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_hilbert",
@@ -5117,7 +5492,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "table_name",
@@ -5131,6 +5507,7 @@
       },
       {
        "default": "120",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "timeout",
@@ -5143,7 +5520,8 @@
        "type": "integer range[min=1,max=3600,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "url",
@@ -5157,6 +5535,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -5170,7 +5549,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "where",
@@ -5191,6 +5571,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "allow_schema_diff",
@@ -5204,6 +5585,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -5216,7 +5598,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -5229,7 +5612,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox",
@@ -5243,6 +5627,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -5252,10 +5637,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -5269,6 +5655,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -5281,7 +5668,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "exclude_cols",
@@ -5294,7 +5682,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geometry",
@@ -5308,6 +5697,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -5317,10 +5707,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive_input",
@@ -5333,7 +5724,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "include_cols",
@@ -5346,7 +5738,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -5359,7 +5752,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "limit",
@@ -5373,6 +5767,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -5386,6 +5781,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -5399,6 +5795,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -5413,6 +5810,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -5425,7 +5823,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -5439,6 +5838,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -5452,6 +5852,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_count",
@@ -5465,6 +5866,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "use_first_geometry",
@@ -5478,6 +5880,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -5491,7 +5894,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "where",
@@ -5505,6 +5909,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -5518,6 +5923,7 @@
       },
       {
        "default": "'duckdb-kv'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_strategy",
@@ -5527,7 +5933,7 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[duckdb-kv|in-memory|streaming|disk-rewrite]"
+       "type": "choice[duckdb-kv|in-memory|streaming|disk-rewrite,case_sensitive=True]"
       }
      ]
     },
@@ -5538,6 +5944,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -5551,6 +5958,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "auto_tile",
@@ -5565,6 +5973,7 @@
       },
       {
        "default": "'auto'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "axis_order",
@@ -5574,10 +5983,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[auto|xy|latlon]"
+       "type": "choice[auto|xy|latlon,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox",
@@ -5591,6 +6001,7 @@
       },
       {
        "default": "'auto'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox_mode",
@@ -5600,10 +6011,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[auto|server|local]"
+       "type": "choice[auto|server|local,case_sensitive=True]"
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -5613,10 +6025,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -5629,7 +6042,8 @@
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "deprecated_version",
@@ -5639,10 +6053,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[auto|2.0.0|1.1.0|1.0.0]"
+       "type": "choice[auto|2.0.0|1.1.0|1.0.0,case_sensitive=True]"
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -5652,10 +6067,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "limit",
@@ -5668,7 +6084,8 @@
        "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_crs",
@@ -5681,7 +6098,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -5695,6 +6113,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -5708,6 +6127,7 @@
       },
       {
        "default": "100000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "page_size",
@@ -5721,6 +6141,7 @@
       },
       {
        "default": "1",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parallel_layers",
@@ -5734,6 +6155,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -5748,6 +6170,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -5760,7 +6183,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -5773,7 +6197,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "service_url",
@@ -5787,6 +6212,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_bbox",
@@ -5800,6 +6226,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_hilbert",
@@ -5812,7 +6239,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "sort_by",
@@ -5826,6 +6254,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "strict_crs",
@@ -5838,7 +6267,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "typename",
@@ -5852,6 +6282,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -5866,6 +6297,7 @@
       },
       {
        "default": "'1.1.0'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "wfs_version",
@@ -5875,10 +6307,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[auto|2.0.0|1.1.0|1.0.0]"
+       "type": "choice[auto|2.0.0|1.1.0|1.0.0,case_sensitive=True]"
       },
       {
        "default": "1",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "workers",
@@ -5893,6 +6326,7 @@
      ]
     }
    },
+   "default_subcommand": "geoparquet",
    "hidden": false,
    "kind": "group",
    "params": []
@@ -5907,6 +6341,7 @@
      "params": [
       {
        "default": "10",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "count",
@@ -5920,6 +6355,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "json_output",
@@ -5933,6 +6369,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "markdown_output",
@@ -5946,6 +6383,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_columns",
@@ -5959,6 +6397,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_truncate",
@@ -5971,7 +6410,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -5985,6 +6425,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6005,7 +6446,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -6019,6 +6461,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "json_output",
@@ -6032,6 +6475,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6053,6 +6497,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "json_output",
@@ -6066,6 +6511,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "meta_geo_stats",
@@ -6079,6 +6525,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "meta_geoparquet",
@@ -6092,6 +6539,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "meta_parquet",
@@ -6105,6 +6553,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "meta_parquet_geo",
@@ -6118,6 +6567,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "meta_row_groups",
@@ -6130,7 +6580,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -6144,6 +6595,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6165,6 +6617,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "json_output",
@@ -6178,6 +6631,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "markdown_output",
@@ -6190,7 +6644,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -6204,6 +6659,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6225,6 +6681,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "check_all_files",
@@ -6238,6 +6695,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "json_output",
@@ -6251,6 +6709,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "markdown_output",
@@ -6263,7 +6722,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -6277,6 +6737,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6298,6 +6759,7 @@
      "params": [
       {
        "default": "10",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "count",
@@ -6311,6 +6773,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "json_output",
@@ -6324,6 +6787,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "markdown_output",
@@ -6337,6 +6801,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_columns",
@@ -6350,6 +6815,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_truncate",
@@ -6362,7 +6828,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "parquet_file",
@@ -6376,6 +6843,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6391,6 +6859,7 @@
      ]
     }
    },
+   "default_subcommand": "summary",
    "hidden": false,
    "kind": "group",
    "params": []
@@ -6405,6 +6874,7 @@
      "params": [
       {
        "default": "'a5_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "a5_name",
@@ -6418,6 +6888,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "auto",
@@ -6431,6 +6902,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -6440,10 +6912,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -6457,6 +6930,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -6470,6 +6944,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -6479,10 +6954,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive",
@@ -6495,7 +6971,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -6509,6 +6986,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "keep_a5_column",
@@ -6522,6 +7000,7 @@
       },
       {
        "default": "10000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_partitions",
@@ -6534,7 +7013,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_folder",
@@ -6548,6 +7028,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -6560,7 +7041,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -6574,6 +7056,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "preview",
@@ -6587,6 +7070,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "preview_limit",
@@ -6600,6 +7084,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "resolution",
@@ -6613,6 +7098,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -6625,7 +7111,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -6639,6 +7126,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -6652,6 +7140,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_analysis",
@@ -6665,6 +7154,7 @@
       },
       {
        "default": "100000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "target_rows",
@@ -6678,6 +7168,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6692,6 +7183,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -6712,6 +7204,7 @@
      "params": [
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -6721,10 +7214,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -6738,6 +7232,7 @@
       },
       {
        "default": "'gaul'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "dataset",
@@ -6747,10 +7242,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[gaul|overture]"
+       "type": "choice[gaul|overture,case_sensitive=False]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -6764,6 +7260,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -6773,10 +7270,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive",
@@ -6789,7 +7287,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -6803,6 +7302,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "levels",
@@ -6815,7 +7315,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_folder",
@@ -6829,6 +7330,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -6841,7 +7343,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -6855,6 +7358,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "preview",
@@ -6868,6 +7372,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "preview_limit",
@@ -6881,6 +7386,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -6893,7 +7399,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -6907,6 +7414,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -6920,6 +7428,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_analysis",
@@ -6933,6 +7442,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "vecorel",
@@ -6946,6 +7456,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -6960,6 +7471,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -6980,6 +7492,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "auto",
@@ -6993,6 +7506,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -7002,10 +7516,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -7019,6 +7534,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -7032,6 +7548,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -7041,10 +7558,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "'h3_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "h3_name",
@@ -7058,6 +7576,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive",
@@ -7071,6 +7590,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "in_place",
@@ -7083,7 +7603,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -7097,6 +7618,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "keep_h3_column",
@@ -7110,6 +7632,7 @@
       },
       {
        "default": "10000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_partitions",
@@ -7123,6 +7646,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "min_size",
@@ -7135,7 +7659,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_folder",
@@ -7149,6 +7674,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -7161,7 +7687,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -7175,6 +7702,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "preview",
@@ -7188,6 +7716,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "preview_limit",
@@ -7201,6 +7730,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "resolution",
@@ -7214,6 +7744,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -7226,7 +7757,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -7240,6 +7772,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -7253,6 +7786,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_analysis",
@@ -7266,6 +7800,7 @@
       },
       {
        "default": "100000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "target_rows",
@@ -7279,6 +7814,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -7293,6 +7829,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -7313,6 +7850,7 @@
      "params": [
       {
        "default": "100000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "approx",
@@ -7326,6 +7864,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "auto",
@@ -7339,6 +7878,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -7348,10 +7888,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -7365,6 +7906,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "exact",
@@ -7378,6 +7920,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -7391,6 +7934,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -7400,10 +7944,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive",
@@ -7416,7 +7961,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -7430,6 +7976,7 @@
       },
       {
        "default": "'kdtree_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "kdtree_name",
@@ -7443,6 +7990,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "keep_kdtree_column",
@@ -7455,7 +8003,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_folder",
@@ -7469,6 +8018,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -7482,6 +8032,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "partitions",
@@ -7494,7 +8045,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -7508,6 +8060,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "preview",
@@ -7521,6 +8074,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "preview_limit",
@@ -7534,6 +8088,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -7546,7 +8101,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -7560,6 +8116,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -7573,6 +8130,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_analysis",
@@ -7586,6 +8144,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -7600,6 +8159,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -7620,6 +8180,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "auto",
@@ -7633,6 +8194,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -7642,10 +8204,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -7659,6 +8222,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -7672,6 +8236,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -7681,10 +8246,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive",
@@ -7698,6 +8264,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "in_place",
@@ -7710,7 +8277,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -7724,6 +8292,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "keep_quadkey_column",
@@ -7737,6 +8306,7 @@
       },
       {
        "default": "10000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_partitions",
@@ -7750,6 +8320,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "min_size",
@@ -7762,7 +8333,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_folder",
@@ -7776,6 +8348,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -7789,6 +8362,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "partition_resolution",
@@ -7801,7 +8375,8 @@
        "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -7815,6 +8390,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "preview",
@@ -7828,6 +8404,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "preview_limit",
@@ -7841,6 +8418,7 @@
       },
       {
        "default": "'quadkey'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "quadkey_column",
@@ -7854,6 +8432,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "resolution",
@@ -7867,6 +8446,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -7879,7 +8459,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -7893,6 +8474,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -7906,6 +8488,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_analysis",
@@ -7919,6 +8502,7 @@
       },
       {
        "default": "100000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "target_rows",
@@ -7932,6 +8516,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "use_centroid",
@@ -7945,6 +8530,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -7959,6 +8545,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -7979,6 +8566,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "auto",
@@ -7992,6 +8580,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -8001,10 +8590,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -8018,6 +8608,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -8031,6 +8622,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -8040,10 +8632,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive",
@@ -8057,6 +8650,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "in_place",
@@ -8069,7 +8663,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -8083,6 +8678,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "keep_s2_column",
@@ -8096,6 +8692,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "level",
@@ -8109,6 +8706,7 @@
       },
       {
        "default": "10000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_partitions",
@@ -8122,6 +8720,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "min_size",
@@ -8134,7 +8733,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_folder",
@@ -8148,6 +8748,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -8160,7 +8761,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -8174,6 +8776,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "preview",
@@ -8187,6 +8790,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "preview_limit",
@@ -8200,6 +8804,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -8212,7 +8817,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -8226,6 +8832,7 @@
       },
       {
        "default": "'s2_cell'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "s2_name",
@@ -8239,6 +8846,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -8252,6 +8860,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_analysis",
@@ -8265,6 +8874,7 @@
       },
       {
        "default": "100000",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "target_rows",
@@ -8278,6 +8888,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -8292,6 +8903,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -8311,7 +8923,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "chars",
@@ -8324,7 +8937,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "column",
@@ -8338,6 +8952,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -8347,10 +8962,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -8364,6 +8980,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -8377,6 +8994,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -8386,10 +9004,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "hive",
@@ -8402,7 +9021,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -8415,7 +9035,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_folder",
@@ -8429,6 +9050,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -8441,7 +9063,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "prefix",
@@ -8455,6 +9078,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "preview",
@@ -8468,6 +9092,7 @@
       },
       {
        "default": "15",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "preview_limit",
@@ -8481,6 +9106,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -8493,7 +9119,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -8507,6 +9134,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -8520,6 +9148,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "skip_analysis",
@@ -8533,6 +9162,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -8547,6 +9177,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -8561,6 +9192,7 @@
      ]
     }
    },
+   "default_subcommand": null,
    "hidden": false,
    "kind": "group",
    "params": []
@@ -8574,7 +9206,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "attribution",
@@ -8587,7 +9220,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -8600,7 +9234,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bbox",
@@ -8614,6 +9249,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "drop_densest_as_needed",
@@ -8628,6 +9264,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -8641,7 +9278,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "include_cols",
@@ -8654,7 +9292,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_file",
@@ -8667,7 +9306,8 @@
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "layer",
@@ -8682,6 +9322,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "layer_by_column",
@@ -8694,7 +9335,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_zoom",
@@ -8708,6 +9350,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "maximum_tile_bytes",
@@ -8720,7 +9363,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "min_zoom",
@@ -8734,6 +9378,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_simplification_of_shared_nodes",
@@ -8748,6 +9393,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "no_tile_size_limit",
@@ -8761,7 +9407,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_file",
@@ -8775,6 +9422,7 @@
       },
       {
        "default": "6",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "precision",
@@ -8788,6 +9436,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "repair_geometry",
@@ -8802,6 +9451,7 @@
       },
       {
        "default": "True",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "simplify_only_low_zooms",
@@ -8815,7 +9465,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "src_crs",
@@ -8829,6 +9480,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -8842,7 +9494,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "where",
@@ -8862,7 +9515,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "attribution",
@@ -8876,6 +9530,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bytes_per_cell",
@@ -8889,6 +9544,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "features_min_zoom",
@@ -8902,6 +9558,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "features_source",
@@ -8915,6 +9572,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -8929,6 +9587,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "include_features",
@@ -8941,7 +9600,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -8955,6 +9615,7 @@
       },
       {
        "default": "'grouped'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "layer_mode",
@@ -8964,10 +9625,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[single|grouped|per-level]"
+       "type": "choice[single|grouped|per-level,case_sensitive=True]"
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "levels",
@@ -8981,6 +9643,7 @@
       },
       {
        "default": "500",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_tile_kb",
@@ -8994,6 +9657,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_zoom",
@@ -9006,7 +9670,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_pmtiles",
@@ -9020,6 +9685,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -9035,6 +9701,7 @@
      ]
     }
    },
+   "default_subcommand": null,
    "hidden": false,
    "kind": "group",
    "params": []
@@ -9052,6 +9719,7 @@
        "params": [
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "auto",
@@ -9065,6 +9733,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "bbox_column",
@@ -9078,6 +9747,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "breakdown",
@@ -9091,6 +9761,7 @@
         },
         {
          "default": "20",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "breakdown_limit",
@@ -9104,6 +9775,7 @@
         },
         {
          "default": "'geometry'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "bucket_point",
@@ -9117,6 +9789,7 @@
         },
         {
          "default": "'ZSTD'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "compression",
@@ -9126,10 +9799,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "compression_level",
@@ -9143,6 +9817,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "geoparquet_version",
@@ -9152,10 +9827,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "input_parquet",
@@ -9169,6 +9845,7 @@
         },
         {
          "default": "500000",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "max_cells",
@@ -9182,6 +9859,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "metric",
@@ -9195,6 +9873,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "metric_nodata",
@@ -9208,6 +9887,7 @@
         },
         {
          "default": "'polygon'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "out_geometry",
@@ -9217,10 +9897,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[polygon|centroid|both|none]"
+         "type": "choice[polygon|centroid|both|none,case_sensitive=True]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "output_parquet",
@@ -9234,6 +9915,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "resolution",
@@ -9247,6 +9929,7 @@
         },
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "show_sql",
@@ -9260,6 +9943,7 @@
         },
         {
          "default": "10000",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "target_per_cell",
@@ -9273,6 +9957,7 @@
         },
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "verbose",
@@ -9286,7 +9971,8 @@
          "type": "boolean"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "where",
@@ -9307,6 +9993,7 @@
        "params": [
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "bbox_column",
@@ -9320,6 +10007,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "breakdown",
@@ -9333,6 +10021,7 @@
         },
         {
          "default": "20",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "breakdown_limit",
@@ -9346,6 +10035,7 @@
         },
         {
          "default": "'geometry'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "bucket_point",
@@ -9359,6 +10049,7 @@
         },
         {
          "default": "'ZSTD'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "compression",
@@ -9368,10 +10059,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "compression_level",
@@ -9385,6 +10077,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "geoparquet_version",
@@ -9394,10 +10087,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "input_parquet",
@@ -9411,6 +10105,7 @@
         },
         {
          "default": "'country'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "level",
@@ -9420,10 +10115,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[country|region]"
+         "type": "choice[country|region,case_sensitive=True]"
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "metric",
@@ -9437,6 +10133,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "metric_nodata",
@@ -9450,6 +10147,7 @@
         },
         {
          "default": "'polygon'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "out_geometry",
@@ -9459,10 +10157,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[polygon|centroid|both|none]"
+         "type": "choice[polygon|centroid|both|none,case_sensitive=True]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "output_parquet",
@@ -9476,6 +10175,7 @@
         },
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "show_sql",
@@ -9489,6 +10189,7 @@
         },
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "verbose",
@@ -9502,7 +10203,8 @@
          "type": "boolean"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "where",
@@ -9523,6 +10225,7 @@
        "params": [
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "auto",
@@ -9536,6 +10239,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "bbox_column",
@@ -9549,6 +10253,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "breakdown",
@@ -9562,6 +10267,7 @@
         },
         {
          "default": "20",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "breakdown_limit",
@@ -9575,6 +10281,7 @@
         },
         {
          "default": "'geometry'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "bucket_point",
@@ -9588,6 +10295,7 @@
         },
         {
          "default": "'ZSTD'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "compression",
@@ -9597,10 +10305,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "compression_level",
@@ -9614,6 +10323,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "geoparquet_version",
@@ -9623,10 +10333,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "input_parquet",
@@ -9640,6 +10351,7 @@
         },
         {
          "default": "500000",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "max_cells",
@@ -9653,6 +10365,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "metric",
@@ -9666,6 +10379,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "metric_nodata",
@@ -9679,6 +10393,7 @@
         },
         {
          "default": "'polygon'",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "out_geometry",
@@ -9688,10 +10403,11 @@
          ],
          "param_type": "Option",
          "required": false,
-         "type": "choice[polygon|centroid|both|none]"
+         "type": "choice[polygon|centroid|both|none,case_sensitive=True]"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "output_parquet",
@@ -9705,6 +10421,7 @@
         },
         {
          "default": "None",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "resolution",
@@ -9718,6 +10435,7 @@
         },
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "show_sql",
@@ -9731,6 +10449,7 @@
         },
         {
          "default": "10000",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "target_per_cell",
@@ -9744,6 +10463,7 @@
         },
         {
          "default": "False",
+         "hidden": false,
          "is_flag": true,
          "multiple": false,
          "name": "verbose",
@@ -9757,7 +10477,8 @@
          "type": "boolean"
         },
         {
-         "default": "Sentinel.UNSET",
+         "default": "<unset>",
+         "hidden": false,
          "is_flag": false,
          "multiple": false,
          "name": "where",
@@ -9772,6 +10493,7 @@
        ]
       }
      },
+     "default_subcommand": null,
      "hidden": false,
      "kind": "group",
      "params": []
@@ -9783,6 +10505,7 @@
      "params": [
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bytes_per_cell",
@@ -9796,6 +10519,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "cell_column",
@@ -9809,6 +10533,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -9818,10 +10543,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -9835,6 +10561,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "force",
@@ -9849,6 +10576,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -9858,10 +10586,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -9875,6 +10604,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "levels",
@@ -9888,6 +10618,7 @@
       },
       {
        "default": "500",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_tile_kb",
@@ -9901,6 +10632,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_dir",
@@ -9914,6 +10646,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "scheme",
@@ -9923,10 +10656,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[a5|h3|admin]"
+       "type": "choice[a5|h3|admin,case_sensitive=True]"
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -9940,6 +10674,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -9955,6 +10690,7 @@
      ]
     }
    },
+   "default_subcommand": null,
    "hidden": false,
    "kind": "group",
    "params": []
@@ -9968,7 +10704,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "bucket",
@@ -9981,7 +10718,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "collection_id",
@@ -9994,7 +10732,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input",
@@ -10007,7 +10746,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "item_id",
@@ -10020,7 +10760,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output",
@@ -10034,6 +10775,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -10046,7 +10788,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "public_url",
@@ -10060,6 +10803,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -10080,7 +10824,8 @@
      "kind": "command",
      "params": [
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "aws_profile",
@@ -10094,6 +10839,7 @@
       },
       {
        "default": "12",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "chunk_concurrency",
@@ -10106,7 +10852,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "chunk_size",
@@ -10119,7 +10866,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "destination",
@@ -10133,6 +10881,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "dry_run",
@@ -10146,6 +10895,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "fail_fast",
@@ -10159,6 +10909,7 @@
       },
       {
        "default": "4",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "max_files",
@@ -10171,7 +10922,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "pattern",
@@ -10184,7 +10936,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "s3_endpoint",
@@ -10198,6 +10951,7 @@
       },
       {
        "default": "False",
+       "hidden": true,
        "is_flag": true,
        "multiple": false,
        "name": "s3_no_ssl",
@@ -10210,7 +10964,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": true,
        "is_flag": false,
        "multiple": false,
        "name": "s3_region",
@@ -10223,7 +10978,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "source",
@@ -10237,6 +10993,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -10252,6 +11009,7 @@
      ]
     }
    },
+   "default_subcommand": null,
    "hidden": false,
    "kind": "group",
    "params": []
@@ -10262,7 +11020,8 @@
    "kind": "command",
    "params": [
     {
-     "default": "Sentinel.UNSET",
+     "default": "<unset>",
+     "hidden": false,
      "is_flag": false,
      "multiple": false,
      "name": "copy_to",
@@ -10276,6 +11035,7 @@
     },
     {
      "default": "'geoparquet'",
+     "hidden": false,
      "is_flag": false,
      "multiple": false,
      "name": "name",
@@ -10289,6 +11049,7 @@
     },
     {
      "default": "False",
+     "hidden": false,
      "is_flag": true,
      "multiple": false,
      "name": "show",
@@ -10312,6 +11073,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -10324,7 +11086,8 @@
        "type": "boolean"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "columns",
@@ -10338,6 +11101,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -10347,10 +11111,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -10364,6 +11129,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "descending",
@@ -10377,6 +11143,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -10386,10 +11153,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -10402,7 +11170,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -10416,6 +11185,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -10429,6 +11199,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -10441,7 +11212,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -10455,6 +11227,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -10468,6 +11241,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -10482,6 +11256,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -10502,6 +11277,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "add_bbox",
@@ -10515,6 +11291,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -10528,6 +11305,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -10537,10 +11315,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -10554,6 +11333,7 @@
       },
       {
        "default": "'geometry'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geometry_column",
@@ -10568,6 +11348,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -10577,10 +11358,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -10594,6 +11376,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -10607,6 +11390,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -10620,6 +11404,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -10632,7 +11417,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -10646,6 +11432,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -10659,6 +11446,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -10673,6 +11461,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -10693,6 +11482,7 @@
      "params": [
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "any_extension",
@@ -10706,6 +11496,7 @@
       },
       {
        "default": "'ZSTD'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression",
@@ -10715,10 +11506,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "compression_level",
@@ -10732,6 +11524,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "geoparquet_version",
@@ -10741,10 +11534,11 @@
        ],
        "param_type": "Option",
        "required": false,
-       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "input_parquet",
@@ -10757,7 +11551,8 @@
        "type": "text"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "output_parquet",
@@ -10771,6 +11566,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "overwrite",
@@ -10784,6 +11580,7 @@
       },
       {
        "default": "'quadkey'",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "quadkey_name",
@@ -10797,6 +11594,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "remove_quadkey_column",
@@ -10810,6 +11608,7 @@
       },
       {
        "default": "13",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "resolution",
@@ -10823,6 +11622,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size",
@@ -10835,7 +11635,8 @@
        "type": "integer"
       },
       {
-       "default": "Sentinel.UNSET",
+       "default": "<unset>",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "row_group_size_mb",
@@ -10849,6 +11650,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "show_sql",
@@ -10862,6 +11664,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "use_centroid",
@@ -10875,6 +11678,7 @@
       },
       {
        "default": "False",
+       "hidden": false,
        "is_flag": true,
        "multiple": false,
        "name": "verbose",
@@ -10889,6 +11693,7 @@
       },
       {
        "default": "None",
+       "hidden": false,
        "is_flag": false,
        "multiple": false,
        "name": "write_memory",
@@ -10903,16 +11708,19 @@
      ]
     }
    },
+   "default_subcommand": null,
    "hidden": false,
    "kind": "group",
    "params": []
   }
  },
+ "default_subcommand": null,
  "hidden": false,
  "kind": "group",
  "params": [
   {
    "default": "None",
+   "hidden": false,
    "is_flag": false,
    "multiple": false,
    "name": "aws_profile",
@@ -10926,6 +11734,7 @@
   },
   {
    "default": "None",
+   "hidden": false,
    "is_flag": false,
    "multiple": false,
    "name": "s3_endpoint",
@@ -10939,6 +11748,7 @@
   },
   {
    "default": "False",
+   "hidden": false,
    "is_flag": true,
    "multiple": false,
    "name": "s3_no_ssl",
@@ -10952,6 +11762,7 @@
   },
   {
    "default": "None",
+   "hidden": false,
    "is_flag": false,
    "multiple": false,
    "name": "s3_region",
@@ -10965,6 +11776,7 @@
   },
   {
    "default": "False",
+   "hidden": false,
    "is_flag": true,
    "multiple": false,
    "name": "timestamps",
@@ -10978,6 +11790,7 @@
   },
   {
    "default": "False",
+   "hidden": false,
    "is_flag": true,
    "multiple": false,
    "name": "version",

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -1,0 +1,10993 @@
+{
+ "class": "Group",
+ "commands": {
+  "add": {
+   "class": "Group",
+   "commands": {
+    "a5": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "'a5_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "a5_name",
+       "nargs": 1,
+       "opts": [
+        "--a5-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "resolution",
+       "nargs": 1,
+       "opts": [
+        "--resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "admin-divisions": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "add_bbox",
+       "nargs": 1,
+       "opts": [
+        "--add-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "clear_cache",
+       "nargs": 1,
+       "opts": [
+        "--clear-cache"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "'gaul'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "dataset",
+       "nargs": 1,
+       "opts": [
+        "--dataset"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[gaul|overture]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "levels",
+       "nargs": 1,
+       "opts": [
+        "--levels"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_cache",
+       "nargs": 1,
+       "opts": [
+        "--no-cache"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "vecorel",
+       "nargs": 1,
+       "opts": [
+        "--vecorel"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "bbox": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'bbox'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox_name",
+       "nargs": 1,
+       "opts": [
+        "--bbox-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "bbox-metadata": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "geometry-metrics": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_vecorel",
+       "nargs": 1,
+       "opts": [
+        "--no-vecorel"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "h3": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "'h3_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "h3_name",
+       "nargs": 1,
+       "opts": [
+        "--h3-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "9",
+       "is_flag": false,
+       "multiple": false,
+       "name": "resolution",
+       "nargs": 1,
+       "opts": [
+        "--resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=15,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "kdtree": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "100000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "approx",
+       "nargs": 1,
+       "opts": [
+        "--approx"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "auto",
+       "nargs": 1,
+       "opts": [
+        "--auto"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "exact",
+       "nargs": 1,
+       "opts": [
+        "--exact"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "'kdtree_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "kdtree_name",
+       "nargs": 1,
+       "opts": [
+        "--kdtree-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "partitions",
+       "nargs": 1,
+       "opts": [
+        "--partitions"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "quadkey": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'quadkey'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "quadkey_name",
+       "nargs": 1,
+       "opts": [
+        "--quadkey-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "13",
+       "is_flag": false,
+       "multiple": false,
+       "name": "resolution",
+       "nargs": 1,
+       "opts": [
+        "--resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "use_centroid",
+       "nargs": 1,
+       "opts": [
+        "--use-centroid"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "s2": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "13",
+       "is_flag": false,
+       "multiple": false,
+       "name": "level",
+       "nargs": 1,
+       "opts": [
+        "--level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'s2_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "s2_name",
+       "nargs": 1,
+       "opts": [
+        "--s2-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "benchmark": {
+   "class": "Group",
+   "commands": {
+    "compare": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "converters",
+       "nargs": 1,
+       "opts": [
+        "--converters",
+        "-c"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "3",
+       "is_flag": false,
+       "multiple": false,
+       "name": "iterations",
+       "nargs": 1,
+       "opts": [
+        "--iterations",
+        "-n"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "keep_output",
+       "nargs": 1,
+       "opts": [
+        "--keep-output"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "'table'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_format",
+       "nargs": 1,
+       "opts": [
+        "--format"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[table|json]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_json",
+       "nargs": 1,
+       "opts": [
+        "--output-json",
+        "-o"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "quiet",
+       "nargs": 1,
+       "opts": [
+        "--quiet",
+        "-q"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "warmup",
+       "nargs": 1,
+       "opts": [
+        "--warmup",
+        "--no-warmup"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "explain": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output",
+       "nargs": 1,
+       "opts": [
+        "--output",
+        "-o"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "'table'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_format",
+       "nargs": 1,
+       "opts": [
+        "--format"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[table|json]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "query",
+       "nargs": 1,
+       "opts": [
+        "--query",
+        "-q"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "report": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "'table'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_format",
+       "nargs": 1,
+       "opts": [
+        "--format"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[table|json]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "result_files",
+       "nargs": -1,
+       "opts": [
+        "result_files"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "suite": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": true,
+       "name": "files",
+       "nargs": 1,
+       "opts": [
+        "--files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "3",
+       "is_flag": false,
+       "multiple": false,
+       "name": "iterations",
+       "nargs": 1,
+       "opts": [
+        "--iterations",
+        "-n"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "'core'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "operations",
+       "nargs": 1,
+       "opts": [
+        "--operations"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[core|full]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output",
+       "nargs": 1,
+       "opts": [
+        "--output",
+        "-o"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "profile",
+       "nargs": 1,
+       "opts": [
+        "--profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'./profiles'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "profile_dir",
+       "nargs": 1,
+       "opts": [
+        "--profile-dir"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "check": {
+   "class": "_DefaultGroup",
+   "commands": {
+    "all": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "check_all_files",
+       "nargs": 1,
+       "opts": [
+        "--all-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "check_sample",
+       "nargs": 1,
+       "opts": [
+        "--sample-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "fix",
+       "nargs": 1,
+       "opts": [
+        "--fix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "fix_output",
+       "nargs": 1,
+       "opts": [
+        "--fix-output"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "500000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "limit_rows",
+       "nargs": 1,
+       "opts": [
+        "--limit-rows"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_backup",
+       "nargs": 1,
+       "opts": [
+        "--no-backup"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "pmtiles",
+       "nargs": 1,
+       "opts": [
+        "--pmtiles"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "profile",
+       "nargs": 1,
+       "opts": [
+        "--profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[web]"
+      },
+      {
+       "default": "100",
+       "is_flag": false,
+       "multiple": false,
+       "name": "random_sample_size",
+       "nargs": 1,
+       "opts": [
+        "--random-sample-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "spec_details",
+       "nargs": 1,
+       "opts": [
+        "--spec-details"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "bbox": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "check_all_files",
+       "nargs": 1,
+       "opts": [
+        "--all-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "check_sample",
+       "nargs": 1,
+       "opts": [
+        "--sample-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "fix",
+       "nargs": 1,
+       "opts": [
+        "--fix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "fix_output",
+       "nargs": 1,
+       "opts": [
+        "--fix-output"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_backup",
+       "nargs": 1,
+       "opts": [
+        "--no-backup"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "compression": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "check_all_files",
+       "nargs": 1,
+       "opts": [
+        "--all-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "check_sample",
+       "nargs": 1,
+       "opts": [
+        "--sample-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "fix",
+       "nargs": 1,
+       "opts": [
+        "--fix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "fix_output",
+       "nargs": 1,
+       "opts": [
+        "--fix-output"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_backup",
+       "nargs": 1,
+       "opts": [
+        "--no-backup"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "optimization": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "check_all_files",
+       "nargs": 1,
+       "opts": [
+        "--all-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "check_sample",
+       "nargs": 1,
+       "opts": [
+        "--sample-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "row-group": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "check_all_files",
+       "nargs": 1,
+       "opts": [
+        "--all-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "check_sample",
+       "nargs": 1,
+       "opts": [
+        "--sample-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "fix",
+       "nargs": 1,
+       "opts": [
+        "--fix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "fix_output",
+       "nargs": 1,
+       "opts": [
+        "--fix-output"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_backup",
+       "nargs": 1,
+       "opts": [
+        "--no-backup"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "profile",
+       "nargs": 1,
+       "opts": [
+        "--profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[web]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "spatial": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "check_all_files",
+       "nargs": 1,
+       "opts": [
+        "--all-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "check_sample",
+       "nargs": 1,
+       "opts": [
+        "--sample-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "fix",
+       "nargs": 1,
+       "opts": [
+        "--fix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "fix_output",
+       "nargs": 1,
+       "opts": [
+        "--fix-output"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "500000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "limit_rows",
+       "nargs": 1,
+       "opts": [
+        "--limit-rows"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_backup",
+       "nargs": 1,
+       "opts": [
+        "--no-backup"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "100",
+       "is_flag": false,
+       "multiple": false,
+       "name": "random_sample_size",
+       "nargs": 1,
+       "opts": [
+        "--random-sample-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "spec": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "json_output",
+       "nargs": 1,
+       "opts": [
+        "--json"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "1000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "sample_size",
+       "nargs": 1,
+       "opts": [
+        "--sample-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_data_validation",
+       "nargs": 1,
+       "opts": [
+        "--skip-data-validation"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "stac": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "stac_file",
+       "nargs": 1,
+       "opts": [
+        "stac_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "convert": {
+   "class": "ConvertDefaultGroup",
+   "commands": {
+    "csv": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_bbox",
+       "nargs": 1,
+       "opts": [
+        "--no-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_wkt",
+       "nargs": 1,
+       "opts": [
+        "--no-wkt"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "flatgeobuf": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "geojson": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "description",
+       "nargs": 1,
+       "opts": [
+        "--description"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "id_field",
+       "nargs": 1,
+       "opts": [
+        "--id-field"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "keep_crs",
+       "nargs": 1,
+       "opts": [
+        "--keep-crs"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_rs",
+       "nargs": 1,
+       "opts": [
+        "--no-rs"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_seq",
+       "nargs": 1,
+       "opts": [
+        "--feature-collection"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "7",
+       "is_flag": false,
+       "multiple": false,
+       "name": "precision",
+       "nargs": 1,
+       "opts": [
+        "--precision"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "pretty",
+       "nargs": 1,
+       "opts": [
+        "--pretty"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "write_bbox",
+       "nargs": 1,
+       "opts": [
+        "--write-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "geopackage": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "'features'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "layer_name",
+       "nargs": 1,
+       "opts": [
+        "--layer-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "geoparquet": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "allow_no_geometry",
+       "nargs": 1,
+       "opts": [
+        "--allow-no-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "'EPSG:4326'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "crs",
+       "nargs": 1,
+       "opts": [
+        "--crs"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "csv_max_line_size",
+       "nargs": 1,
+       "opts": [
+        "--csv-max-line-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "delimiter",
+       "nargs": 1,
+       "opts": [
+        "--delimiter"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "lat_column",
+       "nargs": 1,
+       "opts": [
+        "--lat-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "layer",
+       "nargs": 1,
+       "opts": [
+        "--layer"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "linearize_curves",
+       "nargs": 1,
+       "opts": [
+        "--linearize-curves",
+        "--no-linearize-curves"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "lon_column",
+       "nargs": 1,
+       "opts": [
+        "--lon-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_angle_deg",
+       "nargs": 1,
+       "opts": [
+        "--max-angle-deg"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "float range[min=0,max=None,min_open=True,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_hilbert",
+       "nargs": 1,
+       "opts": [
+        "--skip-hilbert"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_invalid",
+       "nargs": 1,
+       "opts": [
+        "--skip-invalid"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "wkt_column",
+       "nargs": 1,
+       "opts": [
+        "--wkt-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "reproject": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "assume_crs84",
+       "nargs": 1,
+       "opts": [
+        "--assume-crs84"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "'EPSG:4326'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "dst_crs",
+       "nargs": 1,
+       "opts": [
+        "--dst-crs",
+        "-d"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "src_crs",
+       "nargs": 1,
+       "opts": [
+        "--src-crs",
+        "-s"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "shapefile": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'UTF-8'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "encoding",
+       "nargs": 1,
+       "opts": [
+        "--encoding"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "extract": {
+   "class": "_DefaultGroup",
+   "commands": {
+    "arcgis": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "batch_size",
+       "nargs": 1,
+       "opts": [
+        "--batch-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=5000,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox",
+       "nargs": 1,
+       "opts": [
+        "--bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "exclude_cols",
+       "nargs": 1,
+       "opts": [
+        "--exclude-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "include_cols",
+       "nargs": 1,
+       "opts": [
+        "--include-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "limit",
+       "nargs": 1,
+       "opts": [
+        "--limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_allowable_offset",
+       "nargs": 1,
+       "opts": [
+        "--max-allowable-offset"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "float"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_crs",
+       "nargs": 1,
+       "opts": [
+        "--output-crs"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "password",
+       "nargs": 1,
+       "opts": [
+        "--password"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "portal_url",
+       "nargs": 1,
+       "opts": [
+        "--portal-url"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "service_url",
+       "nargs": 1,
+       "opts": [
+        "service_url"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_bbox",
+       "nargs": 1,
+       "opts": [
+        "--skip-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_hilbert",
+       "nargs": 1,
+       "opts": [
+        "--skip-hilbert"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "60.0",
+       "is_flag": false,
+       "multiple": false,
+       "name": "timeout",
+       "nargs": 1,
+       "opts": [
+        "--timeout"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "float range[min=0,max=None,min_open=True,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "token",
+       "nargs": 1,
+       "opts": [
+        "--token"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "token_file",
+       "nargs": 1,
+       "opts": [
+        "--token-file"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "username",
+       "nargs": 1,
+       "opts": [
+        "--username"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'1=1'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "where",
+       "nargs": 1,
+       "opts": [
+        "--where"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "1",
+       "is_flag": false,
+       "multiple": false,
+       "name": "workers",
+       "nargs": 1,
+       "opts": [
+        "--workers"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=10,min_open=False,max_open=False,clamp=False]"
+      }
+     ]
+    },
+    "bigquery": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox",
+       "nargs": 1,
+       "opts": [
+        "--bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'auto'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox_mode",
+       "nargs": 1,
+       "opts": [
+        "--bbox-mode"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[auto|server|local]"
+      },
+      {
+       "default": "500000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox_threshold",
+       "nargs": 1,
+       "opts": [
+        "--bbox-threshold"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "credentials_file",
+       "nargs": 1,
+       "opts": [
+        "--credentials-file"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "edges",
+       "nargs": 1,
+       "opts": [
+        "--edges"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[spherical|planar]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "exclude_cols",
+       "nargs": 1,
+       "opts": [
+        "--exclude-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geography_column",
+       "nargs": 1,
+       "opts": [
+        "--geography-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'wkt'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geometry_format",
+       "nargs": 1,
+       "opts": [
+        "--geometry-format"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[wkt|geojson]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "include_cols",
+       "nargs": 1,
+       "opts": [
+        "--include-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "limit",
+       "nargs": 1,
+       "opts": [
+        "--limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "project",
+       "nargs": 1,
+       "opts": [
+        "--project"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "table_id",
+       "nargs": 1,
+       "opts": [
+        "table_id"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "where",
+       "nargs": 1,
+       "opts": [
+        "--where"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "carto": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox",
+       "nargs": 1,
+       "opts": [
+        "--bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "exclude_cols",
+       "nargs": 1,
+       "opts": [
+        "--exclude-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": true,
+       "multiple": false,
+       "name": "geometry",
+       "nargs": 1,
+       "opts": [
+        "--geometry",
+        "--no-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "include_cols",
+       "nargs": 1,
+       "opts": [
+        "--include-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "limit",
+       "nargs": 1,
+       "opts": [
+        "--limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_bbox",
+       "nargs": 1,
+       "opts": [
+        "--skip-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_hilbert",
+       "nargs": 1,
+       "opts": [
+        "--skip-hilbert"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "table_name",
+       "nargs": 1,
+       "opts": [
+        "table_name"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "120",
+       "is_flag": false,
+       "multiple": false,
+       "name": "timeout",
+       "nargs": 1,
+       "opts": [
+        "--timeout"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=3600,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "url",
+       "nargs": 1,
+       "opts": [
+        "url"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "where",
+       "nargs": 1,
+       "opts": [
+        "--where"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "geoparquet": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "allow_schema_diff",
+       "nargs": 1,
+       "opts": [
+        "--allow-schema-diff"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox",
+       "nargs": 1,
+       "opts": [
+        "--bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "exclude_cols",
+       "nargs": 1,
+       "opts": [
+        "--exclude-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geometry",
+       "nargs": 1,
+       "opts": [
+        "--geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive_input",
+       "nargs": 1,
+       "opts": [
+        "--hive-input"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "include_cols",
+       "nargs": 1,
+       "opts": [
+        "--include-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "limit",
+       "nargs": 1,
+       "opts": [
+        "--limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_count",
+       "nargs": 1,
+       "opts": [
+        "--skip-count"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "use_first_geometry",
+       "nargs": 1,
+       "opts": [
+        "--use-first-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "where",
+       "nargs": 1,
+       "opts": [
+        "--where"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'duckdb-kv'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_strategy",
+       "nargs": 1,
+       "opts": [
+        "--write-strategy"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[duckdb-kv|in-memory|streaming|disk-rewrite]"
+      }
+     ]
+    },
+    "wfs": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "auto_tile",
+       "nargs": 1,
+       "opts": [
+        "--auto-tile",
+        "--no-auto-tile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'auto'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "axis_order",
+       "nargs": 1,
+       "opts": [
+        "--axis-order"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[auto|xy|latlon]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox",
+       "nargs": 1,
+       "opts": [
+        "--bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'auto'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox_mode",
+       "nargs": 1,
+       "opts": [
+        "--bbox-mode"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[auto|server|local]"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "deprecated_version",
+       "nargs": 1,
+       "opts": [
+        "--version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[auto|2.0.0|1.1.0|1.0.0]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "limit",
+       "nargs": 1,
+       "opts": [
+        "--limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_crs",
+       "nargs": 1,
+       "opts": [
+        "--output-crs"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "100000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "page_size",
+       "nargs": 1,
+       "opts": [
+        "--page-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1000,max=500000,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "1",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parallel_layers",
+       "nargs": 1,
+       "opts": [
+        "--parallel-layers"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=10,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "service_url",
+       "nargs": 1,
+       "opts": [
+        "service_url"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_bbox",
+       "nargs": 1,
+       "opts": [
+        "--skip-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_hilbert",
+       "nargs": 1,
+       "opts": [
+        "--skip-hilbert"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "sort_by",
+       "nargs": 1,
+       "opts": [
+        "--sort-by"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "strict_crs",
+       "nargs": 1,
+       "opts": [
+        "--strict-crs"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "typename",
+       "nargs": 1,
+       "opts": [
+        "typename"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'1.1.0'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "wfs_version",
+       "nargs": 1,
+       "opts": [
+        "--wfs-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[auto|2.0.0|1.1.0|1.0.0]"
+      },
+      {
+       "default": "1",
+       "is_flag": false,
+       "multiple": false,
+       "name": "workers",
+       "nargs": 1,
+       "opts": [
+        "--workers"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=10,min_open=False,max_open=False,clamp=False]"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "inspect": {
+   "class": "_DefaultGroup",
+   "commands": {
+    "head": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "10",
+       "is_flag": false,
+       "multiple": false,
+       "name": "count",
+       "nargs": 1,
+       "opts": [
+        "count"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "json_output",
+       "nargs": 1,
+       "opts": [
+        "--json"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "markdown_output",
+       "nargs": 1,
+       "opts": [
+        "--markdown"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_columns",
+       "nargs": 1,
+       "opts": [
+        "--max-columns"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=None,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_truncate",
+       "nargs": 1,
+       "opts": [
+        "--no-truncate"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "layers": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "json_output",
+       "nargs": 1,
+       "opts": [
+        "--json"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "meta": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "json_output",
+       "nargs": 1,
+       "opts": [
+        "--json"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "meta_geo_stats",
+       "nargs": 1,
+       "opts": [
+        "--geo-stats"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "meta_geoparquet",
+       "nargs": 1,
+       "opts": [
+        "--geo"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "meta_parquet",
+       "nargs": 1,
+       "opts": [
+        "--parquet"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "meta_parquet_geo",
+       "nargs": 1,
+       "opts": [
+        "--parquet-geo"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "meta_row_groups",
+       "nargs": 1,
+       "opts": [
+        "--row-groups"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "stats": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "json_output",
+       "nargs": 1,
+       "opts": [
+        "--json"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "markdown_output",
+       "nargs": 1,
+       "opts": [
+        "--markdown"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "summary": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "check_all_files",
+       "nargs": 1,
+       "opts": [
+        "--check-all"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "json_output",
+       "nargs": 1,
+       "opts": [
+        "--json"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "markdown_output",
+       "nargs": 1,
+       "opts": [
+        "--markdown"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "tail": {
+     "class": "GlobAwareCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "10",
+       "is_flag": false,
+       "multiple": false,
+       "name": "count",
+       "nargs": 1,
+       "opts": [
+        "count"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "json_output",
+       "nargs": 1,
+       "opts": [
+        "--json"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "markdown_output",
+       "nargs": 1,
+       "opts": [
+        "--markdown"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_columns",
+       "nargs": 1,
+       "opts": [
+        "--max-columns"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=None,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_truncate",
+       "nargs": 1,
+       "opts": [
+        "--no-truncate"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "parquet_file",
+       "nargs": 1,
+       "opts": [
+        "parquet_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "partition": {
+   "class": "Group",
+   "commands": {
+    "a5": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "'a5_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "a5_name",
+       "nargs": 1,
+       "opts": [
+        "--a5-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "auto",
+       "nargs": 1,
+       "opts": [
+        "--auto"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive",
+       "nargs": 1,
+       "opts": [
+        "--hive"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "keep_a5_column",
+       "nargs": 1,
+       "opts": [
+        "--keep-a5-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "10000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_partitions",
+       "nargs": 1,
+       "opts": [
+        "--max-partitions"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_folder",
+       "nargs": 1,
+       "opts": [
+        "output_folder"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "preview",
+       "nargs": 1,
+       "opts": [
+        "--preview"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "preview_limit",
+       "nargs": 1,
+       "opts": [
+        "--preview-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "resolution",
+       "nargs": 1,
+       "opts": [
+        "--resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_analysis",
+       "nargs": 1,
+       "opts": [
+        "--skip-analysis"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "100000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "target_rows",
+       "nargs": 1,
+       "opts": [
+        "--target-rows"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "admin": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "'gaul'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "dataset",
+       "nargs": 1,
+       "opts": [
+        "--dataset"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[gaul|overture]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive",
+       "nargs": 1,
+       "opts": [
+        "--hive"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "levels",
+       "nargs": 1,
+       "opts": [
+        "--levels"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_folder",
+       "nargs": 1,
+       "opts": [
+        "output_folder"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "preview",
+       "nargs": 1,
+       "opts": [
+        "--preview"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "preview_limit",
+       "nargs": 1,
+       "opts": [
+        "--preview-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_analysis",
+       "nargs": 1,
+       "opts": [
+        "--skip-analysis"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "vecorel",
+       "nargs": 1,
+       "opts": [
+        "--vecorel"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "h3": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "auto",
+       "nargs": 1,
+       "opts": [
+        "--auto"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "'h3_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "h3_name",
+       "nargs": 1,
+       "opts": [
+        "--h3-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive",
+       "nargs": 1,
+       "opts": [
+        "--hive"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "in_place",
+       "nargs": 1,
+       "opts": [
+        "--in-place"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "keep_h3_column",
+       "nargs": 1,
+       "opts": [
+        "--keep-h3-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "10000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_partitions",
+       "nargs": 1,
+       "opts": [
+        "--max-partitions"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "min_size",
+       "nargs": 1,
+       "opts": [
+        "--min-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_folder",
+       "nargs": 1,
+       "opts": [
+        "output_folder"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "preview",
+       "nargs": 1,
+       "opts": [
+        "--preview"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "preview_limit",
+       "nargs": 1,
+       "opts": [
+        "--preview-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "resolution",
+       "nargs": 1,
+       "opts": [
+        "--resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=15,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_analysis",
+       "nargs": 1,
+       "opts": [
+        "--skip-analysis"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "100000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "target_rows",
+       "nargs": 1,
+       "opts": [
+        "--target-rows"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "kdtree": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "100000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "approx",
+       "nargs": 1,
+       "opts": [
+        "--approx"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "auto",
+       "nargs": 1,
+       "opts": [
+        "--auto"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "exact",
+       "nargs": 1,
+       "opts": [
+        "--exact"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive",
+       "nargs": 1,
+       "opts": [
+        "--hive"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "'kdtree_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "kdtree_name",
+       "nargs": 1,
+       "opts": [
+        "--kdtree-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "keep_kdtree_column",
+       "nargs": 1,
+       "opts": [
+        "--keep-kdtree-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_folder",
+       "nargs": 1,
+       "opts": [
+        "output_folder"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "partitions",
+       "nargs": 1,
+       "opts": [
+        "--partitions"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "preview",
+       "nargs": 1,
+       "opts": [
+        "--preview"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "preview_limit",
+       "nargs": 1,
+       "opts": [
+        "--preview-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_analysis",
+       "nargs": 1,
+       "opts": [
+        "--skip-analysis"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "quadkey": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "auto",
+       "nargs": 1,
+       "opts": [
+        "--auto"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive",
+       "nargs": 1,
+       "opts": [
+        "--hive"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "in_place",
+       "nargs": 1,
+       "opts": [
+        "--in-place"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "keep_quadkey_column",
+       "nargs": 1,
+       "opts": [
+        "--keep-quadkey-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "10000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_partitions",
+       "nargs": 1,
+       "opts": [
+        "--max-partitions"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "min_size",
+       "nargs": 1,
+       "opts": [
+        "--min-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_folder",
+       "nargs": 1,
+       "opts": [
+        "output_folder"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "partition_resolution",
+       "nargs": 1,
+       "opts": [
+        "--partition-resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "preview",
+       "nargs": 1,
+       "opts": [
+        "--preview"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "preview_limit",
+       "nargs": 1,
+       "opts": [
+        "--preview-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "'quadkey'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "quadkey_column",
+       "nargs": 1,
+       "opts": [
+        "--quadkey-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "resolution",
+       "nargs": 1,
+       "opts": [
+        "--resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_analysis",
+       "nargs": 1,
+       "opts": [
+        "--skip-analysis"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "100000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "target_rows",
+       "nargs": 1,
+       "opts": [
+        "--target-rows"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "use_centroid",
+       "nargs": 1,
+       "opts": [
+        "--use-centroid"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "s2": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "auto",
+       "nargs": 1,
+       "opts": [
+        "--auto"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive",
+       "nargs": 1,
+       "opts": [
+        "--hive"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "in_place",
+       "nargs": 1,
+       "opts": [
+        "--in-place"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "keep_s2_column",
+       "nargs": 1,
+       "opts": [
+        "--keep-s2-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "level",
+       "nargs": 1,
+       "opts": [
+        "--level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "10000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_partitions",
+       "nargs": 1,
+       "opts": [
+        "--max-partitions"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "min_size",
+       "nargs": 1,
+       "opts": [
+        "--min-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_folder",
+       "nargs": 1,
+       "opts": [
+        "output_folder"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "preview",
+       "nargs": 1,
+       "opts": [
+        "--preview"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "preview_limit",
+       "nargs": 1,
+       "opts": [
+        "--preview-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'s2_cell'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "s2_name",
+       "nargs": 1,
+       "opts": [
+        "--s2-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_analysis",
+       "nargs": 1,
+       "opts": [
+        "--skip-analysis"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "100000",
+       "is_flag": false,
+       "multiple": false,
+       "name": "target_rows",
+       "nargs": 1,
+       "opts": [
+        "--target-rows"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "string": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "chars",
+       "nargs": 1,
+       "opts": [
+        "--chars"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "column",
+       "nargs": 1,
+       "opts": [
+        "--column"
+       ],
+       "param_type": "Option",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "hive",
+       "nargs": 1,
+       "opts": [
+        "--hive"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_folder",
+       "nargs": 1,
+       "opts": [
+        "output_folder"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "prefix",
+       "nargs": 1,
+       "opts": [
+        "--prefix"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "preview",
+       "nargs": 1,
+       "opts": [
+        "--preview"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "15",
+       "is_flag": false,
+       "multiple": false,
+       "name": "preview_limit",
+       "nargs": 1,
+       "opts": [
+        "--preview-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "skip_analysis",
+       "nargs": 1,
+       "opts": [
+        "--skip-analysis"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "pmtiles": {
+   "class": "Group",
+   "commands": {
+    "create": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "attribution",
+       "nargs": 1,
+       "opts": [
+        "--attribution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bbox",
+       "nargs": 1,
+       "opts": [
+        "--bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "drop_densest_as_needed",
+       "nargs": 1,
+       "opts": [
+        "--drop-densest-as-needed",
+        "--no-drop-densest-as-needed"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force",
+        "-f"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "include_cols",
+       "nargs": 1,
+       "opts": [
+        "--include-cols"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_file",
+       "nargs": 1,
+       "opts": [
+        "input_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "layer",
+       "nargs": 1,
+       "opts": [
+        "--layer",
+        "-l"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "layer_by_column",
+       "nargs": 1,
+       "opts": [
+        "--layer-by-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_zoom",
+       "nargs": 1,
+       "opts": [
+        "--max-zoom"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "maximum_tile_bytes",
+       "nargs": 1,
+       "opts": [
+        "--maximum-tile-bytes"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "min_zoom",
+       "nargs": 1,
+       "opts": [
+        "--min-zoom"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_simplification_of_shared_nodes",
+       "nargs": 1,
+       "opts": [
+        "--no-simplification-of-shared-nodes",
+        "--simplification-of-shared-nodes"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "no_tile_size_limit",
+       "nargs": 1,
+       "opts": [
+        "--no-tile-size-limit",
+        "--tile-size-limit"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_file",
+       "nargs": 1,
+       "opts": [
+        "output_file"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "6",
+       "is_flag": false,
+       "multiple": false,
+       "name": "precision",
+       "nargs": 1,
+       "opts": [
+        "--precision"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "repair_geometry",
+       "nargs": 1,
+       "opts": [
+        "--repair-geometry",
+        "--no-repair-geometry"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "True",
+       "is_flag": true,
+       "multiple": false,
+       "name": "simplify_only_low_zooms",
+       "nargs": 1,
+       "opts": [
+        "--simplify-only-low-zooms",
+        "--no-simplify-only-low-zooms"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "src_crs",
+       "nargs": 1,
+       "opts": [
+        "--src-crs"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "where",
+       "nargs": 1,
+       "opts": [
+        "--where"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "pyramid": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "attribution",
+       "nargs": 1,
+       "opts": [
+        "--attribution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bytes_per_cell",
+       "nargs": 1,
+       "opts": [
+        "--bytes-per-cell"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "float"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "features_min_zoom",
+       "nargs": 1,
+       "opts": [
+        "--features-min-zoom"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "features_source",
+       "nargs": 1,
+       "opts": [
+        "--features-source"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force",
+        "-f"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "include_features",
+       "nargs": 1,
+       "opts": [
+        "--include-features"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "'grouped'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "layer_mode",
+       "nargs": 1,
+       "opts": [
+        "--layer-mode"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[single|grouped|per-level]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "levels",
+       "nargs": 1,
+       "opts": [
+        "--levels"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "500",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_tile_kb",
+       "nargs": 1,
+       "opts": [
+        "--max-tile-kb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_zoom",
+       "nargs": 1,
+       "opts": [
+        "--max-zoom"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_pmtiles",
+       "nargs": 1,
+       "opts": [
+        "output_pmtiles"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "process": {
+   "class": "Group",
+   "commands": {
+    "aggregate": {
+     "class": "Group",
+     "commands": {
+      "a5": {
+       "class": "Command",
+       "hidden": false,
+       "kind": "command",
+       "params": [
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "auto",
+         "nargs": 1,
+         "opts": [
+          "--auto"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "bbox_column",
+         "nargs": 1,
+         "opts": [
+          "--bbox-column"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "breakdown",
+         "nargs": 1,
+         "opts": [
+          "--breakdown"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "20",
+         "is_flag": false,
+         "multiple": false,
+         "name": "breakdown_limit",
+         "nargs": 1,
+         "opts": [
+          "--breakdown-limit"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer"
+        },
+        {
+         "default": "'geometry'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "bucket_point",
+         "nargs": 1,
+         "opts": [
+          "--bucket-point"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "'ZSTD'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "compression",
+         "nargs": 1,
+         "opts": [
+          "--compression"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "compression_level",
+         "nargs": 1,
+         "opts": [
+          "--compression-level"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "geoparquet_version",
+         "nargs": 1,
+         "opts": [
+          "--geoparquet-version"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "input_parquet",
+         "nargs": 1,
+         "opts": [
+          "input_parquet"
+         ],
+         "param_type": "Argument",
+         "required": true,
+         "type": "text"
+        },
+        {
+         "default": "500000",
+         "is_flag": false,
+         "multiple": false,
+         "name": "max_cells",
+         "nargs": 1,
+         "opts": [
+          "--max-cells"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "metric",
+         "nargs": 1,
+         "opts": [
+          "--metric"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "metric_nodata",
+         "nargs": 1,
+         "opts": [
+          "--metric-nodata"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "'polygon'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "out_geometry",
+         "nargs": 1,
+         "opts": [
+          "--out-geometry"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[polygon|centroid|both|none]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "output_parquet",
+         "nargs": 1,
+         "opts": [
+          "output_parquet"
+         ],
+         "param_type": "Argument",
+         "required": true,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "resolution",
+         "nargs": 1,
+         "opts": [
+          "--resolution"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
+        },
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "show_sql",
+         "nargs": 1,
+         "opts": [
+          "--show-sql"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "10000",
+         "is_flag": false,
+         "multiple": false,
+         "name": "target_per_cell",
+         "nargs": 1,
+         "opts": [
+          "--target-per-cell"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer"
+        },
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "verbose",
+         "nargs": 1,
+         "opts": [
+          "--verbose",
+          "-v"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "where",
+         "nargs": 1,
+         "opts": [
+          "--where"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        }
+       ]
+      },
+      "admin": {
+       "class": "Command",
+       "hidden": false,
+       "kind": "command",
+       "params": [
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "bbox_column",
+         "nargs": 1,
+         "opts": [
+          "--bbox-column"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "breakdown",
+         "nargs": 1,
+         "opts": [
+          "--breakdown"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "20",
+         "is_flag": false,
+         "multiple": false,
+         "name": "breakdown_limit",
+         "nargs": 1,
+         "opts": [
+          "--breakdown-limit"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer"
+        },
+        {
+         "default": "'geometry'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "bucket_point",
+         "nargs": 1,
+         "opts": [
+          "--bucket-point"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "'ZSTD'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "compression",
+         "nargs": 1,
+         "opts": [
+          "--compression"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "compression_level",
+         "nargs": 1,
+         "opts": [
+          "--compression-level"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "geoparquet_version",
+         "nargs": 1,
+         "opts": [
+          "--geoparquet-version"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "input_parquet",
+         "nargs": 1,
+         "opts": [
+          "input_parquet"
+         ],
+         "param_type": "Argument",
+         "required": true,
+         "type": "text"
+        },
+        {
+         "default": "'country'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "level",
+         "nargs": 1,
+         "opts": [
+          "--level"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[country|region]"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "metric",
+         "nargs": 1,
+         "opts": [
+          "--metric"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "metric_nodata",
+         "nargs": 1,
+         "opts": [
+          "--metric-nodata"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "'polygon'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "out_geometry",
+         "nargs": 1,
+         "opts": [
+          "--out-geometry"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[polygon|centroid|both|none]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "output_parquet",
+         "nargs": 1,
+         "opts": [
+          "output_parquet"
+         ],
+         "param_type": "Argument",
+         "required": true,
+         "type": "text"
+        },
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "show_sql",
+         "nargs": 1,
+         "opts": [
+          "--show-sql"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "verbose",
+         "nargs": 1,
+         "opts": [
+          "--verbose",
+          "-v"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "where",
+         "nargs": 1,
+         "opts": [
+          "--where"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        }
+       ]
+      },
+      "h3": {
+       "class": "Command",
+       "hidden": false,
+       "kind": "command",
+       "params": [
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "auto",
+         "nargs": 1,
+         "opts": [
+          "--auto"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "bbox_column",
+         "nargs": 1,
+         "opts": [
+          "--bbox-column"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "breakdown",
+         "nargs": 1,
+         "opts": [
+          "--breakdown"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "20",
+         "is_flag": false,
+         "multiple": false,
+         "name": "breakdown_limit",
+         "nargs": 1,
+         "opts": [
+          "--breakdown-limit"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer"
+        },
+        {
+         "default": "'geometry'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "bucket_point",
+         "nargs": 1,
+         "opts": [
+          "--bucket-point"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "'ZSTD'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "compression",
+         "nargs": 1,
+         "opts": [
+          "--compression"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "compression_level",
+         "nargs": 1,
+         "opts": [
+          "--compression-level"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "geoparquet_version",
+         "nargs": 1,
+         "opts": [
+          "--geoparquet-version"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "input_parquet",
+         "nargs": 1,
+         "opts": [
+          "input_parquet"
+         ],
+         "param_type": "Argument",
+         "required": true,
+         "type": "text"
+        },
+        {
+         "default": "500000",
+         "is_flag": false,
+         "multiple": false,
+         "name": "max_cells",
+         "nargs": 1,
+         "opts": [
+          "--max-cells"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "metric",
+         "nargs": 1,
+         "opts": [
+          "--metric"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "metric_nodata",
+         "nargs": 1,
+         "opts": [
+          "--metric-nodata"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        },
+        {
+         "default": "'polygon'",
+         "is_flag": false,
+         "multiple": false,
+         "name": "out_geometry",
+         "nargs": 1,
+         "opts": [
+          "--out-geometry"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "choice[polygon|centroid|both|none]"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "output_parquet",
+         "nargs": 1,
+         "opts": [
+          "output_parquet"
+         ],
+         "param_type": "Argument",
+         "required": true,
+         "type": "text"
+        },
+        {
+         "default": "None",
+         "is_flag": false,
+         "multiple": false,
+         "name": "resolution",
+         "nargs": 1,
+         "opts": [
+          "--resolution"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer range[min=0,max=15,min_open=False,max_open=False,clamp=False]"
+        },
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "show_sql",
+         "nargs": 1,
+         "opts": [
+          "--show-sql"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "10000",
+         "is_flag": false,
+         "multiple": false,
+         "name": "target_per_cell",
+         "nargs": 1,
+         "opts": [
+          "--target-per-cell"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "integer"
+        },
+        {
+         "default": "False",
+         "is_flag": true,
+         "multiple": false,
+         "name": "verbose",
+         "nargs": 1,
+         "opts": [
+          "--verbose",
+          "-v"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "boolean"
+        },
+        {
+         "default": "Sentinel.UNSET",
+         "is_flag": false,
+         "multiple": false,
+         "name": "where",
+         "nargs": 1,
+         "opts": [
+          "--where"
+         ],
+         "param_type": "Option",
+         "required": false,
+         "type": "text"
+        }
+       ]
+      }
+     },
+     "hidden": false,
+     "kind": "group",
+     "params": []
+    },
+    "overview": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bytes_per_cell",
+       "nargs": 1,
+       "opts": [
+        "--bytes-per-cell"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "float"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "cell_column",
+       "nargs": 1,
+       "opts": [
+        "--cell-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "force",
+       "nargs": 1,
+       "opts": [
+        "--force",
+        "-f"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "levels",
+       "nargs": 1,
+       "opts": [
+        "--levels"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "500",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_tile_kb",
+       "nargs": 1,
+       "opts": [
+        "--max-tile-kb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_dir",
+       "nargs": 1,
+       "opts": [
+        "--output-dir"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "scheme",
+       "nargs": 1,
+       "opts": [
+        "--scheme"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[a5|h3|admin]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "publish": {
+   "class": "Group",
+   "commands": {
+    "stac": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "bucket",
+       "nargs": 1,
+       "opts": [
+        "--bucket"
+       ],
+       "param_type": "Option",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "collection_id",
+       "nargs": 1,
+       "opts": [
+        "--collection-id"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input",
+       "nargs": 1,
+       "opts": [
+        "input"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "item_id",
+       "nargs": 1,
+       "opts": [
+        "--item-id"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output",
+       "nargs": 1,
+       "opts": [
+        "output"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "public_url",
+       "nargs": 1,
+       "opts": [
+        "--public-url"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    },
+    "upload": {
+     "class": "Command",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "aws_profile",
+       "nargs": 1,
+       "opts": [
+        "--aws-profile"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "12",
+       "is_flag": false,
+       "multiple": false,
+       "name": "chunk_concurrency",
+       "nargs": 1,
+       "opts": [
+        "--chunk-concurrency"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "chunk_size",
+       "nargs": 1,
+       "opts": [
+        "--chunk-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "destination",
+       "nargs": 1,
+       "opts": [
+        "destination"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "dry_run",
+       "nargs": 1,
+       "opts": [
+        "--dry-run"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "fail_fast",
+       "nargs": 1,
+       "opts": [
+        "--fail-fast"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "4",
+       "is_flag": false,
+       "multiple": false,
+       "name": "max_files",
+       "nargs": 1,
+       "opts": [
+        "--max-files"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "pattern",
+       "nargs": 1,
+       "opts": [
+        "--pattern"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "s3_endpoint",
+       "nargs": 1,
+       "opts": [
+        "--s3-endpoint"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "s3_no_ssl",
+       "nargs": 1,
+       "opts": [
+        "--s3-no-ssl"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "s3_region",
+       "nargs": 1,
+       "opts": [
+        "--s3-region"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "source",
+       "nargs": 1,
+       "opts": [
+        "source"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  },
+  "skills": {
+   "class": "Command",
+   "hidden": false,
+   "kind": "command",
+   "params": [
+    {
+     "default": "Sentinel.UNSET",
+     "is_flag": false,
+     "multiple": false,
+     "name": "copy_to",
+     "nargs": 1,
+     "opts": [
+      "--copy"
+     ],
+     "param_type": "Option",
+     "required": false,
+     "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+    },
+    {
+     "default": "'geoparquet'",
+     "is_flag": false,
+     "multiple": false,
+     "name": "name",
+     "nargs": 1,
+     "opts": [
+      "--name"
+     ],
+     "param_type": "Option",
+     "required": false,
+     "type": "text"
+    },
+    {
+     "default": "False",
+     "is_flag": true,
+     "multiple": false,
+     "name": "show",
+     "nargs": 1,
+     "opts": [
+      "--show"
+     ],
+     "param_type": "Option",
+     "required": false,
+     "type": "boolean"
+    }
+   ]
+  },
+  "sort": {
+   "class": "Group",
+   "commands": {
+    "column": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "columns",
+       "nargs": 1,
+       "opts": [
+        "columns"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "descending",
+       "nargs": 1,
+       "opts": [
+        "--descending"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "hilbert": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "add_bbox",
+       "nargs": 1,
+       "opts": [
+        "--add-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "'geometry'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geometry_column",
+       "nargs": 1,
+       "opts": [
+        "--geometry-column",
+        "-g"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    },
+    "quadkey": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only]"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "text"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "'quadkey'",
+       "is_flag": false,
+       "multiple": false,
+       "name": "quadkey_name",
+       "nargs": 1,
+       "opts": [
+        "--quadkey-name"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "remove_quadkey_column",
+       "nargs": 1,
+       "opts": [
+        "--remove-quadkey-column"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "13",
+       "is_flag": false,
+       "multiple": false,
+       "name": "resolution",
+       "nargs": 1,
+       "opts": [
+        "--resolution"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "integer"
+      },
+      {
+       "default": "Sentinel.UNSET",
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "use_centroid",
+       "nargs": 1,
+       "opts": [
+        "--use-centroid"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "type": "text"
+      }
+     ]
+    }
+   },
+   "hidden": false,
+   "kind": "group",
+   "params": []
+  }
+ },
+ "hidden": false,
+ "kind": "group",
+ "params": [
+  {
+   "default": "None",
+   "is_flag": false,
+   "multiple": false,
+   "name": "aws_profile",
+   "nargs": 1,
+   "opts": [
+    "--aws-profile"
+   ],
+   "param_type": "Option",
+   "required": false,
+   "type": "text"
+  },
+  {
+   "default": "None",
+   "is_flag": false,
+   "multiple": false,
+   "name": "s3_endpoint",
+   "nargs": 1,
+   "opts": [
+    "--s3-endpoint"
+   ],
+   "param_type": "Option",
+   "required": false,
+   "type": "text"
+  },
+  {
+   "default": "False",
+   "is_flag": true,
+   "multiple": false,
+   "name": "s3_no_ssl",
+   "nargs": 1,
+   "opts": [
+    "--s3-no-ssl"
+   ],
+   "param_type": "Option",
+   "required": false,
+   "type": "boolean"
+  },
+  {
+   "default": "None",
+   "is_flag": false,
+   "multiple": false,
+   "name": "s3_region",
+   "nargs": 1,
+   "opts": [
+    "--s3-region"
+   ],
+   "param_type": "Option",
+   "required": false,
+   "type": "text"
+  },
+  {
+   "default": "False",
+   "is_flag": true,
+   "multiple": false,
+   "name": "timestamps",
+   "nargs": 1,
+   "opts": [
+    "--timestamps"
+   ],
+   "param_type": "Option",
+   "required": false,
+   "type": "boolean"
+  },
+  {
+   "default": "False",
+   "is_flag": true,
+   "multiple": false,
+   "name": "version",
+   "nargs": 1,
+   "opts": [
+    "--version"
+   ],
+   "param_type": "Option",
+   "required": false,
+   "type": "boolean"
+  }
+ ]
+}

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -21,6 +21,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -35,6 +36,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -49,6 +51,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -63,6 +66,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -77,6 +81,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -91,6 +96,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -105,6 +111,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -119,6 +126,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -133,6 +141,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -147,6 +156,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -161,6 +171,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -175,6 +186,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -189,6 +201,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -204,6 +217,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -218,6 +232,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -239,6 +254,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -253,6 +269,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -267,6 +284,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -281,6 +299,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -295,6 +314,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -309,6 +329,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[gaul|overture,case_sensitive=False]"
       },
       {
@@ -323,6 +344,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -337,6 +359,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -351,6 +374,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -365,6 +389,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -379,6 +404,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -393,6 +419,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -407,6 +434,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -421,6 +449,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -435,6 +464,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -449,6 +479,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -463,6 +494,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -477,6 +509,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -492,6 +525,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -506,6 +540,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -527,6 +562,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -541,6 +577,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -555,6 +592,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -569,6 +607,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -583,6 +622,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -597,6 +637,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -611,6 +652,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -625,6 +667,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -639,6 +682,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -653,6 +697,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -667,6 +712,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -681,6 +727,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -695,6 +742,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -710,6 +758,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -724,6 +773,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -745,6 +795,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -760,6 +811,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -781,6 +833,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -795,6 +848,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -809,6 +863,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -823,6 +878,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -837,6 +893,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -851,6 +908,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -865,6 +923,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -879,6 +938,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -893,6 +953,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -907,6 +968,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -921,6 +983,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -935,6 +998,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -950,6 +1014,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -964,6 +1029,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -985,6 +1051,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -999,6 +1066,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -1013,6 +1081,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -1027,6 +1096,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1041,6 +1111,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -1055,6 +1126,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1069,6 +1141,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1083,6 +1156,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1097,6 +1171,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1111,6 +1186,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=15,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -1125,6 +1201,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1139,6 +1216,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1153,6 +1231,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1168,6 +1247,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1182,6 +1262,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -1203,6 +1284,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1217,6 +1299,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1231,6 +1314,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1245,6 +1329,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -1259,6 +1344,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -1273,6 +1359,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1287,6 +1374,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1301,6 +1389,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1315,6 +1404,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -1329,6 +1419,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1343,6 +1434,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1357,6 +1449,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1371,6 +1464,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1385,6 +1479,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1399,6 +1494,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1413,6 +1509,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1427,6 +1524,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1442,6 +1540,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1456,6 +1555,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -1477,6 +1577,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1491,6 +1592,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -1505,6 +1607,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -1519,6 +1622,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1533,6 +1637,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -1547,6 +1652,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1561,6 +1667,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1575,6 +1682,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1589,6 +1697,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1603,6 +1712,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -1617,6 +1727,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1631,6 +1742,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1645,6 +1757,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1659,6 +1772,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1674,6 +1788,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1688,6 +1803,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -1709,6 +1825,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1723,6 +1840,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -1737,6 +1855,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -1751,6 +1870,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1765,6 +1885,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -1779,6 +1900,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1793,6 +1915,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -1807,6 +1930,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1821,6 +1945,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1835,6 +1960,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1849,6 +1975,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1863,6 +1990,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1877,6 +2005,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1892,6 +2021,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -1906,12 +2036,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
     }
    },
    "default_subcommand": null,
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -1937,6 +2069,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -1951,6 +2084,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -1966,6 +2100,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -1980,6 +2115,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -1994,6 +2130,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[table|json,case_sensitive=True]"
       },
       {
@@ -2009,6 +2146,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2024,6 +2162,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2039,6 +2178,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2049,11 +2189,13 @@
        "name": "warmup",
        "nargs": 1,
        "opts": [
-        "--warmup",
-        "--no-warmup"
+        "--warmup"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-warmup"
+       ],
        "type": "boolean"
       }
      ]
@@ -2075,6 +2217,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2090,6 +2233,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2104,6 +2248,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[table|json,case_sensitive=True]"
       },
       {
@@ -2119,6 +2264,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -2134,6 +2280,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -2155,6 +2302,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[table|json,case_sensitive=True]"
       },
       {
@@ -2169,6 +2317,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2184,6 +2333,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -2205,6 +2355,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -2220,6 +2371,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2234,6 +2386,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[core|full,case_sensitive=True]"
       },
       {
@@ -2249,6 +2402,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2263,6 +2417,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2277,6 +2432,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2292,12 +2448,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
     }
    },
    "default_subcommand": null,
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -2322,6 +2480,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2336,6 +2495,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2350,6 +2510,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2364,6 +2525,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2378,6 +2540,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2392,6 +2555,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2406,6 +2570,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2420,6 +2585,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -2434,6 +2600,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2448,6 +2615,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[web,case_sensitive=False]"
       },
       {
@@ -2462,6 +2630,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2476,6 +2645,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2490,6 +2660,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -2511,6 +2682,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2525,6 +2697,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2539,6 +2712,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2553,6 +2727,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2567,6 +2742,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2581,6 +2757,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2595,6 +2772,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -2609,6 +2787,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -2630,6 +2809,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2644,6 +2824,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2658,6 +2839,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2672,6 +2854,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2686,6 +2869,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2700,6 +2884,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2714,6 +2899,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -2728,6 +2914,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -2749,6 +2936,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2763,6 +2951,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2777,6 +2966,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -2791,6 +2981,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -2812,6 +3003,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2826,6 +3018,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2840,6 +3033,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2854,6 +3048,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -2868,6 +3063,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2882,6 +3078,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2896,6 +3093,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -2910,6 +3108,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[web,case_sensitive=False]"
       },
       {
@@ -2924,6 +3123,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -2945,6 +3145,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2959,6 +3160,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -2973,6 +3175,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -2987,6 +3190,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -3001,6 +3205,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -3015,6 +3220,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3029,6 +3235,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3043,6 +3250,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -3057,6 +3265,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -3078,6 +3287,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -3092,6 +3302,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3106,6 +3317,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3120,6 +3332,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -3134,6 +3347,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3149,6 +3363,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -3170,6 +3385,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3185,12 +3401,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
     }
    },
    "default_subcommand": "all",
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -3215,6 +3433,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3229,6 +3448,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3243,6 +3463,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3257,6 +3478,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3271,6 +3493,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -3285,6 +3508,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3299,6 +3523,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3314,6 +3539,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -3335,6 +3561,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3349,6 +3576,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3363,6 +3591,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -3377,6 +3606,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3391,6 +3621,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3406,6 +3637,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -3427,6 +3659,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3441,6 +3674,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3455,6 +3689,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3469,6 +3704,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3483,6 +3719,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3497,6 +3734,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3511,6 +3749,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3525,6 +3764,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -3539,6 +3779,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3553,6 +3794,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -3567,6 +3809,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3577,11 +3820,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -3596,6 +3841,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3611,6 +3857,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3625,6 +3872,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -3646,6 +3894,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3660,6 +3909,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3674,6 +3924,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3688,6 +3939,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -3702,6 +3954,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3716,6 +3969,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3731,6 +3985,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -3752,6 +4007,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3766,6 +4022,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -3780,6 +4037,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3794,6 +4052,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -3808,6 +4067,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -3822,6 +4082,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3836,6 +4097,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -3850,6 +4112,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3864,6 +4127,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -3878,6 +4142,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3892,6 +4157,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3906,6 +4172,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3916,11 +4183,13 @@
        "name": "linearize_curves",
        "nargs": 1,
        "opts": [
-        "--linearize-curves",
-        "--no-linearize-curves"
+        "--linearize-curves"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-linearize-curves"
+       ],
        "type": "boolean"
       },
       {
@@ -3935,6 +4204,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -3949,6 +4219,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "float range[min=0,max=None,min_open=True,max_open=False,clamp=False]"
       },
       {
@@ -3963,6 +4234,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -3973,11 +4245,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -3992,6 +4266,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -4006,6 +4281,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4020,6 +4296,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4034,6 +4311,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4048,6 +4326,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4063,6 +4342,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4077,6 +4357,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4091,6 +4372,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -4112,6 +4394,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4126,6 +4409,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4140,6 +4424,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4154,6 +4439,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -4168,6 +4454,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -4183,6 +4470,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4197,6 +4485,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -4211,6 +4500,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4225,6 +4515,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -4239,6 +4530,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4253,6 +4545,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -4267,6 +4560,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4281,6 +4575,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4296,6 +4591,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4311,6 +4607,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4325,6 +4622,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -4346,6 +4644,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4360,6 +4659,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4374,6 +4674,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4388,6 +4689,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -4402,6 +4704,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4416,6 +4719,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4431,12 +4735,21 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
     }
    },
    "default_subcommand": "geoparquet",
+   "extension_dispatch": {
+    ".csv": "csv",
+    ".fgb": "flatgeobuf",
+    ".geojson": "geojson",
+    ".gpkg": "geopackage",
+    ".json": "geojson",
+    ".shp": "shapefile"
+   },
    "hidden": false,
    "kind": "group",
    "params": []
@@ -4461,6 +4774,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4475,6 +4789,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4489,6 +4804,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=5000,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -4503,6 +4819,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4517,6 +4834,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -4531,6 +4849,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -4545,6 +4864,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4559,6 +4879,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -4573,6 +4894,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4587,6 +4909,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -4601,6 +4924,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "float"
       },
       {
@@ -4615,6 +4939,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4629,6 +4954,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -4643,6 +4969,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4657,6 +4984,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4671,6 +4999,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4681,11 +5010,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -4700,6 +5031,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -4714,6 +5046,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4728,6 +5061,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4742,6 +5076,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4756,6 +5091,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4770,6 +5106,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4784,6 +5121,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "float range[min=0,max=None,min_open=True,max_open=False,clamp=False]"
       },
       {
@@ -4798,6 +5136,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4812,6 +5151,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -4826,6 +5166,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4841,6 +5182,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4855,6 +5197,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4869,6 +5212,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=10,min_open=False,max_open=False,clamp=False]"
       }
      ]
@@ -4890,6 +5234,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -4904,6 +5249,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -4918,6 +5264,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[auto|server|local,case_sensitive=True]"
       },
       {
@@ -4932,6 +5279,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -4946,6 +5294,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -4960,6 +5309,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -4974,6 +5324,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -4988,6 +5339,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5002,6 +5354,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[spherical|planar,case_sensitive=False]"
       },
       {
@@ -5016,6 +5369,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5030,6 +5384,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5044,6 +5399,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[wkt|geojson,case_sensitive=False]"
       },
       {
@@ -5058,6 +5414,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -5072,6 +5429,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5086,6 +5444,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -5100,6 +5459,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -5114,6 +5474,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5128,6 +5489,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5138,11 +5500,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -5157,6 +5521,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -5171,6 +5536,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5185,6 +5551,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5199,6 +5566,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5214,6 +5582,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5228,6 +5597,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5242,6 +5612,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -5263,6 +5634,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5277,6 +5649,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5291,6 +5664,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5305,6 +5679,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -5319,6 +5694,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -5333,6 +5709,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5343,11 +5720,13 @@
        "name": "geometry",
        "nargs": 1,
        "opts": [
-        "--geometry",
-        "--no-geometry"
+        "--geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -5362,6 +5741,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -5376,6 +5756,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5390,6 +5771,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -5404,6 +5786,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -5418,6 +5801,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5428,11 +5812,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -5447,6 +5833,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -5461,6 +5848,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5475,6 +5863,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5489,6 +5878,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5503,6 +5893,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5517,6 +5908,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=3600,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -5531,6 +5923,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5546,6 +5939,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5560,6 +5954,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -5581,6 +5976,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5595,6 +5991,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5609,6 +6006,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5623,6 +6021,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5637,6 +6036,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -5651,6 +6051,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -5665,6 +6066,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5679,6 +6081,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5693,6 +6096,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5707,6 +6111,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -5721,6 +6126,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5735,6 +6141,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5749,6 +6156,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5763,6 +6171,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -5777,6 +6186,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -5791,6 +6201,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5801,11 +6212,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -5820,6 +6233,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -5834,6 +6248,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5848,6 +6263,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5862,6 +6278,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5876,6 +6293,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5891,6 +6309,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5905,6 +6324,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5919,6 +6339,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -5933,6 +6354,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[duckdb-kv|in-memory|streaming|disk-rewrite,case_sensitive=True]"
       }
      ]
@@ -5954,6 +6376,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -5964,11 +6387,13 @@
        "name": "auto_tile",
        "nargs": 1,
        "opts": [
-        "--auto-tile",
-        "--no-auto-tile"
+        "--auto-tile"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-auto-tile"
+       ],
        "type": "boolean"
       },
       {
@@ -5983,6 +6408,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[auto|xy|latlon,case_sensitive=True]"
       },
       {
@@ -5997,6 +6423,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6011,6 +6438,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[auto|server|local,case_sensitive=True]"
       },
       {
@@ -6025,6 +6453,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -6039,6 +6468,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -6053,6 +6483,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[auto|2.0.0|1.1.0|1.0.0,case_sensitive=True]"
       },
       {
@@ -6067,6 +6498,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -6081,6 +6513,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -6095,6 +6528,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6109,6 +6543,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -6123,6 +6558,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6137,6 +6573,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1000,max=500000,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -6151,6 +6588,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=10,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -6161,11 +6599,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -6180,6 +6620,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -6194,6 +6635,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6208,6 +6650,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6222,6 +6665,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6236,6 +6680,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6250,6 +6695,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6264,6 +6710,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6278,6 +6725,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6293,6 +6741,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6307,6 +6756,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[auto|2.0.0|1.1.0|1.0.0,case_sensitive=True]"
       },
       {
@@ -6321,12 +6771,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=10,min_open=False,max_open=False,clamp=False]"
       }
      ]
     }
    },
    "default_subcommand": "geoparquet",
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -6351,6 +6803,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -6365,6 +6818,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6379,6 +6833,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6393,6 +6848,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -6407,6 +6863,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6421,6 +6878,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6436,6 +6894,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -6457,6 +6916,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6471,6 +6931,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6486,6 +6947,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -6507,6 +6969,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6521,6 +6984,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6535,6 +6999,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6549,6 +7014,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6563,6 +7029,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6577,6 +7044,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -6591,6 +7059,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6606,6 +7075,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -6627,6 +7097,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6641,6 +7112,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6655,6 +7127,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6670,6 +7143,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -6691,6 +7165,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6705,6 +7180,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6719,6 +7195,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6733,6 +7210,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6748,6 +7226,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -6769,6 +7248,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -6783,6 +7263,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6797,6 +7278,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6811,6 +7293,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=None,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -6825,6 +7308,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6839,6 +7323,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6854,12 +7339,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
     }
    },
    "default_subcommand": "summary",
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -6884,6 +7371,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6898,6 +7386,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6912,6 +7401,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -6926,6 +7416,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -6940,6 +7431,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6954,6 +7446,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -6968,6 +7461,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -6982,6 +7476,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -6996,6 +7491,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7010,6 +7506,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7024,6 +7521,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7038,6 +7536,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7052,6 +7551,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7066,6 +7566,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7080,6 +7581,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7094,6 +7596,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -7108,6 +7611,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7122,6 +7626,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7136,6 +7641,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7150,6 +7656,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7164,6 +7671,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7179,6 +7687,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7193,6 +7702,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -7214,6 +7724,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -7228,6 +7739,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -7242,6 +7754,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[gaul|overture,case_sensitive=False]"
       },
       {
@@ -7256,6 +7769,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7270,6 +7784,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -7284,6 +7799,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7298,6 +7814,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7312,6 +7829,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7326,6 +7844,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7340,6 +7859,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7354,6 +7874,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7368,6 +7889,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7382,6 +7904,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7396,6 +7919,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7410,6 +7934,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7424,6 +7949,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7438,6 +7964,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7452,6 +7979,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7467,6 +7995,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7481,6 +8010,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -7502,6 +8032,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7516,6 +8047,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -7530,6 +8062,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -7544,6 +8077,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7558,6 +8092,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -7572,6 +8107,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7586,6 +8122,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7600,6 +8137,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7614,6 +8152,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7628,6 +8167,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7642,6 +8182,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7656,6 +8197,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7670,6 +8212,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7684,6 +8227,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7698,6 +8242,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7712,6 +8257,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7726,6 +8272,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7740,6 +8287,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=15,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -7754,6 +8302,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7768,6 +8317,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7782,6 +8332,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7796,6 +8347,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7810,6 +8362,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7825,6 +8378,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7839,6 +8393,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -7860,6 +8415,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7874,6 +8430,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -7888,6 +8445,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -7902,6 +8460,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -7916,6 +8475,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7930,6 +8490,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7944,6 +8505,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -7958,6 +8520,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -7972,6 +8535,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -7986,6 +8550,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8000,6 +8565,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8014,6 +8580,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8028,6 +8595,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8042,6 +8610,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8056,6 +8625,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8070,6 +8640,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8084,6 +8655,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8098,6 +8670,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8112,6 +8685,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8126,6 +8700,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8140,6 +8715,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8155,6 +8731,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8169,6 +8746,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -8190,6 +8768,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8204,6 +8783,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -8218,6 +8798,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -8232,6 +8813,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8246,6 +8828,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -8260,6 +8843,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8274,6 +8858,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8288,6 +8873,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8302,6 +8888,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8316,6 +8903,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8330,6 +8918,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8344,6 +8933,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8358,6 +8948,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8372,6 +8963,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -8386,6 +8978,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8400,6 +8993,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8414,6 +9008,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8428,6 +9023,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8442,6 +9038,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -8456,6 +9053,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8470,6 +9068,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8484,6 +9083,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8498,6 +9098,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8512,6 +9113,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8526,6 +9128,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8541,6 +9144,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8555,6 +9159,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -8576,6 +9181,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8590,6 +9196,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -8604,6 +9211,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -8618,6 +9226,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8632,6 +9241,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -8646,6 +9256,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8660,6 +9271,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8674,6 +9286,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8688,6 +9301,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8702,6 +9316,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -8716,6 +9331,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8730,6 +9346,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8744,6 +9361,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8758,6 +9376,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8772,6 +9391,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8786,6 +9406,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8800,6 +9421,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8814,6 +9436,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8828,6 +9451,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8842,6 +9466,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8856,6 +9481,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8870,6 +9496,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8884,6 +9511,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8899,6 +9527,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -8913,6 +9542,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -8934,6 +9564,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -8948,6 +9579,7 @@
        ],
        "param_type": "Option",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -8962,6 +9594,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -8976,6 +9609,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -8990,6 +9624,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9004,6 +9639,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -9018,6 +9654,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9032,6 +9669,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9046,6 +9684,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9060,6 +9699,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9074,6 +9714,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9088,6 +9729,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9102,6 +9744,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9116,6 +9759,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9130,6 +9774,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9144,6 +9789,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9158,6 +9804,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9173,6 +9820,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9187,12 +9835,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
     }
    },
    "default_subcommand": null,
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -9217,6 +9867,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9231,6 +9882,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9245,6 +9897,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9255,11 +9908,13 @@
        "name": "drop_densest_as_needed",
        "nargs": 1,
        "opts": [
-        "--drop-densest-as-needed",
-        "--no-drop-densest-as-needed"
+        "--drop-densest-as-needed"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-drop-densest-as-needed"
+       ],
        "type": "boolean"
       },
       {
@@ -9275,6 +9930,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9289,6 +9945,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9303,6 +9960,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -9318,6 +9976,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9332,6 +9991,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9346,6 +10006,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9360,6 +10021,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9374,6 +10036,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9384,11 +10047,13 @@
        "name": "no_simplification_of_shared_nodes",
        "nargs": 1,
        "opts": [
-        "--no-simplification-of-shared-nodes",
-        "--simplification-of-shared-nodes"
+        "--no-simplification-of-shared-nodes"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--simplification-of-shared-nodes"
+       ],
        "type": "boolean"
       },
       {
@@ -9399,11 +10064,13 @@
        "name": "no_tile_size_limit",
        "nargs": 1,
        "opts": [
-        "--no-tile-size-limit",
-        "--tile-size-limit"
+        "--no-tile-size-limit"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--tile-size-limit"
+       ],
        "type": "boolean"
       },
       {
@@ -9418,6 +10085,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -9432,6 +10100,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9442,11 +10111,13 @@
        "name": "repair_geometry",
        "nargs": 1,
        "opts": [
-        "--repair-geometry",
-        "--no-repair-geometry"
+        "--repair-geometry"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-repair-geometry"
+       ],
        "type": "boolean"
       },
       {
@@ -9457,11 +10128,13 @@
        "name": "simplify_only_low_zooms",
        "nargs": 1,
        "opts": [
-        "--simplify-only-low-zooms",
-        "--no-simplify-only-low-zooms"
+        "--simplify-only-low-zooms"
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [
+        "--no-simplify-only-low-zooms"
+       ],
        "type": "boolean"
       },
       {
@@ -9476,6 +10149,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9491,6 +10165,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9505,6 +10180,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -9526,6 +10202,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9540,6 +10217,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "float"
       },
       {
@@ -9554,6 +10232,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9568,6 +10247,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -9583,6 +10263,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9597,6 +10278,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -9611,6 +10293,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -9625,6 +10308,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[single|grouped|per-level,case_sensitive=True]"
       },
       {
@@ -9639,6 +10323,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -9653,6 +10338,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9667,6 +10353,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -9681,6 +10368,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -9696,12 +10384,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
     }
    },
    "default_subcommand": null,
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -9729,6 +10419,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -9743,6 +10434,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -9757,6 +10449,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -9771,6 +10464,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer"
         },
         {
@@ -9785,6 +10479,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -9799,6 +10494,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
         },
         {
@@ -9813,6 +10509,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
         },
         {
@@ -9827,6 +10524,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
         },
         {
@@ -9841,6 +10539,7 @@
          ],
          "param_type": "Argument",
          "required": true,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -9855,6 +10554,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer"
         },
         {
@@ -9869,6 +10569,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -9883,6 +10584,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -9897,6 +10599,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[polygon|centroid|both|none,case_sensitive=True]"
         },
         {
@@ -9911,6 +10614,7 @@
          ],
          "param_type": "Argument",
          "required": true,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -9925,6 +10629,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer range[min=0,max=30,min_open=False,max_open=False,clamp=False]"
         },
         {
@@ -9939,6 +10644,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -9953,6 +10659,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer"
         },
         {
@@ -9968,6 +10675,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -9982,6 +10690,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         }
        ]
@@ -10003,6 +10712,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10017,6 +10727,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10031,6 +10742,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer"
         },
         {
@@ -10045,6 +10757,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10059,6 +10772,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
         },
         {
@@ -10073,6 +10787,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
         },
         {
@@ -10087,6 +10802,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
         },
         {
@@ -10101,6 +10817,7 @@
          ],
          "param_type": "Argument",
          "required": true,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10115,6 +10832,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[country|region,case_sensitive=True]"
         },
         {
@@ -10129,6 +10847,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10143,6 +10862,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10157,6 +10877,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[polygon|centroid|both|none,case_sensitive=True]"
         },
         {
@@ -10171,6 +10892,7 @@
          ],
          "param_type": "Argument",
          "required": true,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10185,6 +10907,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -10200,6 +10923,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -10214,6 +10938,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         }
        ]
@@ -10235,6 +10960,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -10249,6 +10975,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10263,6 +10990,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10277,6 +11005,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer"
         },
         {
@@ -10291,6 +11020,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10305,6 +11035,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
         },
         {
@@ -10319,6 +11050,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
         },
         {
@@ -10333,6 +11065,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
         },
         {
@@ -10347,6 +11080,7 @@
          ],
          "param_type": "Argument",
          "required": true,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10361,6 +11095,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer"
         },
         {
@@ -10375,6 +11110,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10389,6 +11125,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10403,6 +11140,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "choice[polygon|centroid|both|none,case_sensitive=True]"
         },
         {
@@ -10417,6 +11155,7 @@
          ],
          "param_type": "Argument",
          "required": true,
+         "secondary_opts": [],
          "type": "text"
         },
         {
@@ -10431,6 +11170,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer range[min=0,max=15,min_open=False,max_open=False,clamp=False]"
         },
         {
@@ -10445,6 +11185,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -10459,6 +11200,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "integer"
         },
         {
@@ -10474,6 +11216,7 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "boolean"
         },
         {
@@ -10488,12 +11231,14 @@
          ],
          "param_type": "Option",
          "required": false,
+         "secondary_opts": [],
          "type": "text"
         }
        ]
       }
      },
      "default_subcommand": null,
+     "extension_dispatch": {},
      "hidden": false,
      "kind": "group",
      "params": []
@@ -10515,6 +11260,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "float"
       },
       {
@@ -10529,6 +11275,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10543,6 +11290,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -10557,6 +11305,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -10572,6 +11321,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -10586,6 +11336,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -10600,6 +11351,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10614,6 +11366,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10628,6 +11381,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -10642,6 +11396,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -10656,6 +11411,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[a5|h3|admin,case_sensitive=True]"
       },
       {
@@ -10670,6 +11426,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -10685,12 +11442,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
     }
    },
    "default_subcommand": null,
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -10715,6 +11474,7 @@
        ],
        "param_type": "Option",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10729,6 +11489,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10743,6 +11504,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10757,6 +11519,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10771,6 +11534,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -10785,6 +11549,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -10799,6 +11564,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10814,6 +11580,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
@@ -10835,6 +11602,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10849,6 +11617,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -10863,6 +11632,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -10877,6 +11647,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10891,6 +11662,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -10905,6 +11677,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -10919,6 +11692,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -10933,6 +11707,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10947,6 +11722,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10961,6 +11737,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -10975,6 +11752,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -10989,6 +11767,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=True,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -11004,12 +11783,14 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       }
      ]
     }
    },
    "default_subcommand": null,
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
@@ -11031,6 +11812,7 @@
      ],
      "param_type": "Option",
      "required": false,
+     "secondary_opts": [],
      "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
     },
     {
@@ -11045,6 +11827,7 @@
      ],
      "param_type": "Option",
      "required": false,
+     "secondary_opts": [],
      "type": "text"
     },
     {
@@ -11059,6 +11842,7 @@
      ],
      "param_type": "Option",
      "required": false,
+     "secondary_opts": [],
      "type": "boolean"
     }
    ]
@@ -11083,6 +11867,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11097,6 +11882,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11111,6 +11897,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -11125,6 +11912,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -11139,6 +11927,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11153,6 +11942,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -11167,6 +11957,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11181,6 +11972,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -11195,6 +11987,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11209,6 +12002,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -11223,6 +12017,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11237,6 +12032,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11252,6 +12048,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11266,6 +12063,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -11287,6 +12085,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11301,6 +12100,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11315,6 +12115,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -11329,6 +12130,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -11344,6 +12146,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11358,6 +12161,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -11372,6 +12176,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11386,6 +12191,7 @@
        ],
        "param_type": "Argument",
        "required": false,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -11400,6 +12206,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11414,6 +12221,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -11428,6 +12236,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11442,6 +12251,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11457,6 +12267,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11471,6 +12282,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
@@ -11492,6 +12304,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11506,6 +12319,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
       },
       {
@@ -11520,6 +12334,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -11534,6 +12349,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
       },
       {
@@ -11548,6 +12364,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11562,6 +12379,7 @@
        ],
        "param_type": "Argument",
        "required": true,
+       "secondary_opts": [],
        "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
       },
       {
@@ -11576,6 +12394,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11590,6 +12409,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11604,6 +12424,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11618,6 +12439,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer range[min=0,max=23,min_open=False,max_open=False,clamp=False]"
       },
       {
@@ -11632,6 +12454,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "integer"
       },
       {
@@ -11646,6 +12469,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       },
       {
@@ -11660,6 +12484,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11674,6 +12499,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11689,6 +12515,7 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "boolean"
       },
       {
@@ -11703,18 +12530,21 @@
        ],
        "param_type": "Option",
        "required": false,
+       "secondary_opts": [],
        "type": "text"
       }
      ]
     }
    },
    "default_subcommand": null,
+   "extension_dispatch": {},
    "hidden": false,
    "kind": "group",
    "params": []
   }
  },
  "default_subcommand": null,
+ "extension_dispatch": {},
  "hidden": false,
  "kind": "group",
  "params": [
@@ -11730,6 +12560,7 @@
    ],
    "param_type": "Option",
    "required": false,
+   "secondary_opts": [],
    "type": "text"
   },
   {
@@ -11744,6 +12575,7 @@
    ],
    "param_type": "Option",
    "required": false,
+   "secondary_opts": [],
    "type": "text"
   },
   {
@@ -11758,6 +12590,7 @@
    ],
    "param_type": "Option",
    "required": false,
+   "secondary_opts": [],
    "type": "boolean"
   },
   {
@@ -11772,6 +12605,7 @@
    ],
    "param_type": "Option",
    "required": false,
+   "secondary_opts": [],
    "type": "text"
   },
   {
@@ -11786,6 +12620,7 @@
    ],
    "param_type": "Option",
    "required": false,
+   "secondary_opts": [],
    "type": "boolean"
   },
   {
@@ -11800,6 +12635,7 @@
    ],
    "param_type": "Option",
    "required": false,
+   "secondary_opts": [],
    "type": "boolean"
   }
  ]

--- a/tests/test_cli_api_default_parity.py
+++ b/tests/test_cli_api_default_parity.py
@@ -29,11 +29,10 @@ from geoparquet_io.api.table import Table
 from geoparquet_io.cli.main import cli
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
 
-try:  # click >= 8.4 marks "no default given" with a sentinel object
-    from click.core import UNSET
-except ImportError:  # pragma: no cover - older click
-    UNSET = object()
-
+# click >= 8.2 marks "no default given" with a sentinel object; the shim that
+# keeps this working on click 8.1 lives in conftest so both introspection
+# suites share one copy.
+from tests.conftest import UNSET
 
 # --------------------------------------------------------------------------
 # CLI command -> API twin resolution

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -9,7 +9,9 @@ To accept an intentional change::
 
     GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py
 
-then review the diff of ``tests/data/cli_surface.json`` before committing.
+then review the diff of ``tests/data/cli_surface.json`` before committing. The
+variable is honored only for an affirmative value (``1``/``true``/``yes``/``on``)
+and is refused outright when ``CI`` is set.
 """
 
 from __future__ import annotations
@@ -23,6 +25,8 @@ import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.cli.main import cli
+from tests.conftest import CLICK_HAS_UNSET
+from tests.conftest import UNSET as _UNSET
 
 SNAPSHOT_PATH = Path(__file__).parent / "data" / "cli_surface.json"
 UPDATE_ENV_VAR = "GPIO_UPDATE_SNAPSHOT"
@@ -31,8 +35,18 @@ UPDATE_ENV_VAR = "GPIO_UPDATE_SNAPSHOT"
 # explicitly declared ``None``. Its ``repr`` is a click implementation detail,
 # so it is recorded as a stable token instead; ``None`` still records as
 # ``'None'``, keeping the unset-vs-explicit-None distinction visible.
-_UNSET = getattr(click.core, "UNSET", object())
+#
+# On click 8.1 that distinction does not exist -- every unset default reads back
+# as plain ``None`` -- so the committed snapshot is simply not representable
+# there and the comparison is skipped. The help-render cases below still run.
 UNSET_TOKEN = "<unset>"
+requires_click_unset = pytest.mark.skipif(
+    not CLICK_HAS_UNSET,
+    reason=(
+        "click < 8.2 has no click.core.UNSET sentinel, so every unset default "
+        "reads back as None and cannot match the recorded '<unset>' token"
+    ),
+)
 
 # Commands contributed by third-party plugins (loaded through the
 # ``gpio.plugins`` entry point group) are excluded from the snapshot so an
@@ -103,11 +117,18 @@ def _default_repr(param: click.Parameter) -> str:
 
 
 def describe_param(param: click.Parameter) -> dict:
-    """Describe one Click parameter as a JSON-serializable dict."""
+    """Describe one Click parameter as a JSON-serializable dict.
+
+    ``opts`` and ``secondary_opts`` are recorded separately: concatenating them
+    makes ``--warmup/--no-warmup`` (a boolean flag whose off-switch clears the
+    value) indistinguishable from ``--warmup``/``--no-warmup`` declared as two
+    aliases for the *same* switch, which is a user-visible behavior change.
+    """
     return {
         "name": param.name,
         "param_type": type(param).__name__,
-        "opts": sorted(param.opts) + sorted(param.secondary_opts),
+        "opts": sorted(param.opts),
+        "secondary_opts": sorted(param.secondary_opts),
         "type": _type_repr(param.type),
         "required": bool(param.required),
         "default": _default_repr(param),
@@ -118,33 +139,107 @@ def describe_param(param: click.Parameter) -> dict:
     }
 
 
-def _probe_default_subcommand(group: click.Group) -> str | None:
-    """Return the subcommand a group dispatches to when given no arguments.
+def _dispatch_target(ctx: click.Context, group: click.Group) -> str | None:
+    """Return the subcommand name ``parse_args`` left on a context, if any.
+
+    Click 8.2 renamed ``Context.protected_args`` to ``_protected_args`` and left
+    the old name as a deprecated property, so the private name is preferred when
+    present to avoid emitting ``DeprecationWarning`` during collection.
+
+    The result is only reported when it names a real subcommand: a plain
+    ``click.Group`` handed ``["in.parquet", "out.gpkg"]`` leaves the *filename*
+    in this slot, which is a parse failure waiting to happen at invoke time, not
+    a dispatch decision.
+    """
+    attrs = (
+        ("_protected_args", "args")
+        if hasattr(ctx, "_protected_args")
+        else ("protected_args", "args")
+    )
+    for attr in attrs:
+        found = getattr(ctx, attr, None)
+        if found and str(found[0]) in group.commands:
+            return str(found[0])
+    return None
+
+
+def _probe_dispatch(group: click.Group, argv: list[str]) -> str | None:
+    """Return the subcommand a group rewrites ``argv`` to, or ``None``.
 
     ``create_default_group`` in ``cli/main.py`` builds its groups from a
     factory, so every generated class is named ``_DefaultGroup`` and the
     configured subcommand lives only in a closure. Rather than reaching into
     ``__closure__`` cells, this asks the group what it actually does with an
-    empty argv through the public ``parse_args`` API: a default-dispatch group
-    rewrites argv to its default subcommand, while a plain ``click.Group``
-    raises ``NoArgsIsHelpError`` and records ``None``.
+    argv through the public ``parse_args`` API.
+
+    ``resilient_parsing=True`` is load-bearing twice over. Without it, click 8.1
+    answers an empty argv by echoing the group's help to stdout and raising
+    ``click.exceptions.Exit`` -- not a ``UsageError``, so it would escape the
+    handler below and fail collection of this whole module.
+
+    It also stops click from *enforcing* the group's own parameters: a group
+    that later grows a required option would otherwise raise
+    ``MissingParameter`` (a ``UsageError``) here and be recorded as a bogus
+    ``None`` default rather than its real dispatch target.
+
+    Note it does not stop eager callbacks from running -- click's convention is
+    that a callback checks ``ctx.resilient_parsing`` and returns early, which
+    the only eager option in the tree (``--version`` on the root group) does.
+    """
+    ctx = click.Context(group, resilient_parsing=True)
+    try:
+        group.parse_args(ctx, list(argv))
+    except click.UsageError:
+        # Defensive: resilient parsing suppresses click's own usage errors, but
+        # a future click answering "no subcommand" this way must not turn into a
+        # collection-time error for the entire module.
+        return None
+    return _dispatch_target(ctx, group)
+
+
+def _probe_default_subcommand(group: click.Group) -> str | None:
+    """Return the subcommand a group dispatches to when given no arguments.
 
     Note this pins the *dispatch target* only. Full behavioral coverage of bare
     default dispatch (``gpio check <file>`` running ``check all``) is deferred
     to the test-consolidation issue, #666.
     """
-    ctx = click.Context(group)
-    try:
-        group.parse_args(ctx, [])
-    except click.UsageError:
-        # NoArgsIsHelpError (a UsageError) is how a plain click.Group answers an
-        # empty argv. Anything else is a genuine failure and is left to surface.
-        return None
-    for attr in ("_protected_args", "protected_args", "args"):
-        found = getattr(ctx, attr, None)
-        if found:
-            return str(found[0])
-    return None
+    return _probe_dispatch(group, [])
+
+
+# Output extensions probed against each group's argv rewriting. ``gpio convert``
+# picks its subcommand from the output file's extension, and that map -- not the
+# empty-argv fallback -- is the user-visible behavior of the group. The probe set
+# is the union of a fixed baseline (so *dropping* a mapping is caught) and
+# whatever a group declares for itself (so *adding* one is discovered rather
+# than silently missed).
+BASELINE_PROBE_EXTENSIONS = (
+    ".csv",
+    ".fgb",
+    ".geojson",
+    ".gpkg",
+    ".json",
+    ".parquet",
+    ".shp",
+    ".unrecognized",
+)
+
+
+def _probe_extension_dispatch(group: click.Group, default_subcommand: str | None) -> dict:
+    """Map output-file extension -> subcommand, for extensions that change it.
+
+    Extensions that dispatch to the same place as a bare argv are omitted: they
+    are behaviorally indistinguishable from the fallback, so recording them
+    would bulk up every group in the tree with a copy of the same answer.
+    """
+    declared = getattr(type(group), "EXTENSION_TO_SUBCOMMAND", None) or {}
+    extensions = sorted({*BASELINE_PROBE_EXTENSIONS, *declared})
+    dispatch = {}
+    for ext in extensions:
+        target = _probe_dispatch(group, ["in.parquet", f"out{ext}"])
+        if target != default_subcommand:
+            dispatch[ext] = target
+    return dispatch
 
 
 def describe_command(command: click.Command) -> dict:
@@ -159,7 +254,9 @@ def describe_command(command: click.Command) -> dict:
         ),
     }
     if isinstance(command, click.Group):
-        described["default_subcommand"] = _probe_default_subcommand(command)
+        default_subcommand = _probe_default_subcommand(command)
+        described["default_subcommand"] = default_subcommand
+        described["extension_dispatch"] = _probe_extension_dispatch(command, default_subcommand)
         described["commands"] = {
             name: describe_command(sub)
             for name, sub in sorted(command.commands.items())
@@ -197,6 +294,39 @@ def _serialize(surface: dict) -> str:
     return json.dumps(surface, indent=1, sort_keys=True) + "\n"
 
 
+def _is_name_keyed_list(value) -> bool:
+    """True for a list of dicts that each carry a ``name`` (i.e. a params list)."""
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, dict) and "name" in item for item in value)
+    )
+
+
+def _describe_subtree(value, prefix: str, verb: str) -> list[str]:
+    """Render a wholly added/removed value as readable, path-addressed lines.
+
+    A single ``repr`` of an added or removed *group* is one 18k-character line
+    that no line cap can help with, so containers are walked and each branch
+    reported at its own path. Recursion stops at the first level with nothing
+    nested below it -- a params list is summarized by name, and one parameter's
+    field bag is reported whole -- which keeps a deleted group to a few dozen
+    lines instead of several hundred.
+    """
+    if _is_name_keyed_list(value):
+        names = ", ".join(sorted(str(item["name"]) for item in value))
+        return [f"{prefix}: {verb} ({len(value)} entries: {names})"]
+    if isinstance(value, dict) and any(
+        isinstance(v, dict) or _is_name_keyed_list(v) for v in value.values()
+    ):
+        lines = []
+        for key in sorted(value):
+            lines.extend(_describe_subtree(value[key], f"{prefix}/{key}", verb))
+        if lines:
+            return lines
+    return [f"{prefix}: {verb} ({value!r})"]
+
+
 def _diff_paths(expected, actual, prefix: str = "") -> list[str]:
     """Return human-readable descriptions of every difference between two trees."""
     where = prefix or "<root>"
@@ -205,9 +335,9 @@ def _diff_paths(expected, actual, prefix: str = "") -> list[str]:
     if isinstance(expected, dict):
         diffs = []
         for key in sorted(set(expected) - set(actual)):
-            diffs.append(f"{prefix}/{key}: removed (was {expected[key]!r})")
+            diffs.extend(_describe_subtree(expected[key], f"{prefix}/{key}", "removed, was"))
         for key in sorted(set(actual) - set(expected)):
-            diffs.append(f"{prefix}/{key}: added ({actual[key]!r})")
+            diffs.extend(_describe_subtree(actual[key], f"{prefix}/{key}", "added"))
         for key in sorted(set(expected) & set(actual)):
             diffs.extend(_diff_paths(expected[key], actual[key], f"{prefix}/{key}"))
         return diffs
@@ -225,18 +355,34 @@ def _diff_paths(expected, actual, prefix: str = "") -> list[str]:
     return []
 
 
+TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _env_flag(name: str) -> bool:
+    """True only for an explicitly affirmative value.
+
+    Plain truthiness would treat ``GPIO_UPDATE_SNAPSHOT=0`` -- the obvious way
+    to say "no" -- as a request to rewrite the baseline.
+    """
+    return os.environ.get(name, "").strip().lower() in TRUTHY_ENV_VALUES
+
+
+@requires_click_unset
 def test_cli_surface_matches_snapshot():
     """The Click command tree matches the committed structural snapshot."""
     surface = build_surface()
 
-    if os.environ.get(UPDATE_ENV_VAR):
+    if _env_flag(UPDATE_ENV_VAR):
         # Never let a stray env var turn CI green by rewriting the baseline.
         assert not os.environ.get("CI"), (
             f"{UPDATE_ENV_VAR} must not be set in CI: it would rewrite the "
             "baseline instead of checking against it. Re-record the snapshot "
             "locally and commit the diff."
         )
-        SNAPSHOT_PATH.write_text(_serialize(surface), encoding="utf-8")
+        # newline="\n" keeps a re-record on Windows from rewriting all 11k lines
+        # with CRLF. The read side deliberately keeps universal newlines, so a
+        # snapshot that arrives with CRLF still compares clean.
+        SNAPSHOT_PATH.write_text(_serialize(surface), encoding="utf-8", newline="\n")
         pytest.skip(f"{UPDATE_ENV_VAR} set: refreshed {SNAPSHOT_PATH.name}")
 
     assert SNAPSHOT_PATH.exists(), (

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -1,0 +1,217 @@
+"""Characterization snapshot of the ``gpio`` CLI surface.
+
+This suite freezes the *structure* of the Click command tree - groups,
+commands, parameter names, types, defaults and flags - not the help prose.
+Help wording may be reflowed freely; adding, removing or re-typing an option
+is a user-visible change and must be acknowledged explicitly.
+
+To accept an intentional change::
+
+    GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py
+
+then review the diff of ``tests/data/cli_surface.json`` before committing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+
+SNAPSHOT_PATH = Path(__file__).parent / "data" / "cli_surface.json"
+UPDATE_ENV_VAR = "GPIO_UPDATE_SNAPSHOT"
+
+# Commands contributed by third-party plugins (loaded through the
+# ``gpio.plugins`` entry point group) are excluded from the snapshot so an
+# installed plugin cannot break this test.
+BUILTIN_PACKAGE = "geoparquet_io"
+
+
+def _origin_module(command: click.Command) -> str:
+    """Return the module a command was defined in (for plugin filtering)."""
+    callback = getattr(command, "callback", None)
+    if callback is not None:
+        return getattr(callback, "__module__", "") or ""
+    return type(command).__module__ or ""
+
+
+def _is_builtin(command: click.Command) -> bool:
+    module = _origin_module(command)
+    return module == BUILTIN_PACKAGE or module.startswith(f"{BUILTIN_PACKAGE}.")
+
+
+def _type_repr(param_type: click.ParamType) -> str:
+    """Render a param type as a stable, machine-independent string.
+
+    ``str(click.Path(...))`` embeds the object's memory address, so types are
+    described structurally instead of by their default repr.
+    """
+    if isinstance(param_type, click.Choice):
+        return "choice[" + "|".join(str(choice) for choice in param_type.choices) + "]"
+    if isinstance(param_type, click.Path):
+        return (
+            "path["
+            f"exists={param_type.exists},"
+            f"file_okay={param_type.file_okay},"
+            f"dir_okay={param_type.dir_okay},"
+            f"writable={param_type.writable},"
+            f"readable={param_type.readable},"
+            f"resolve_path={param_type.resolve_path}"
+            "]"
+        )
+    if isinstance(param_type, (click.IntRange, click.FloatRange)):
+        return (
+            f"{param_type.name}["
+            f"min={param_type.min},"
+            f"max={param_type.max},"
+            f"min_open={param_type.min_open},"
+            f"max_open={param_type.max_open},"
+            f"clamp={param_type.clamp}"
+            "]"
+        )
+    if isinstance(param_type, click.Tuple):
+        return "tuple[" + ",".join(_type_repr(inner) for inner in param_type.types) + "]"
+    return param_type.name
+
+
+def _default_repr(param: click.Parameter) -> str:
+    """Return ``repr`` of a parameter default, invoking callable defaults."""
+    default = param.default
+    if callable(default):
+        default = default()
+    return repr(default)
+
+
+def describe_param(param: click.Parameter) -> dict:
+    """Describe one Click parameter as a JSON-serializable dict."""
+    return {
+        "name": param.name,
+        "param_type": type(param).__name__,
+        "opts": sorted(param.opts) + sorted(param.secondary_opts),
+        "type": _type_repr(param.type),
+        "required": bool(param.required),
+        "default": _default_repr(param),
+        "is_flag": bool(getattr(param, "is_flag", False)),
+        "multiple": bool(getattr(param, "multiple", False)),
+        "nargs": param.nargs,
+    }
+
+
+def describe_command(command: click.Command) -> dict:
+    """Describe a command (or group, recursively) as a JSON-serializable dict."""
+    described: dict = {
+        "kind": "group" if isinstance(command, click.Group) else "command",
+        "class": type(command).__name__,
+        "hidden": bool(getattr(command, "hidden", False)),
+        "params": sorted(
+            (describe_param(param) for param in command.params),
+            key=lambda entry: entry["name"] or "",
+        ),
+    }
+    if isinstance(command, click.Group):
+        described["commands"] = {
+            name: describe_command(sub)
+            for name, sub in sorted(command.commands.items())
+            if _is_builtin(sub)
+        }
+    return described
+
+
+def build_surface() -> dict:
+    """Walk the built-in ``gpio`` command tree into a JSON-serializable dict."""
+    return describe_command(cli)
+
+
+def iter_leaf_paths(described: dict, prefix: tuple[str, ...] = ()) -> list[tuple[str, ...]]:
+    """Yield the argv path of every non-group command in a described tree."""
+    if described["kind"] != "group":
+        return [prefix]
+    leaves: list[tuple[str, ...]] = []
+    for name, sub in described["commands"].items():
+        leaves.extend(iter_leaf_paths(sub, prefix + (name,)))
+    return leaves
+
+
+def _serialize(surface: dict) -> str:
+    return json.dumps(surface, indent=1, sort_keys=True) + "\n"
+
+
+def _diff_paths(expected, actual, prefix: str = "") -> list[str]:
+    """Return human-readable descriptions of every difference between two trees."""
+    where = prefix or "<root>"
+    if type(expected) is not type(actual):
+        return [f"{where}: type changed {type(expected).__name__} -> {type(actual).__name__}"]
+    if isinstance(expected, dict):
+        diffs = []
+        for key in sorted(set(expected) - set(actual)):
+            diffs.append(f"{prefix}/{key}: removed (was {expected[key]!r})")
+        for key in sorted(set(actual) - set(expected)):
+            diffs.append(f"{prefix}/{key}: added ({actual[key]!r})")
+        for key in sorted(set(expected) & set(actual)):
+            diffs.extend(_diff_paths(expected[key], actual[key], f"{prefix}/{key}"))
+        return diffs
+    if isinstance(expected, list):
+        # Params are keyed by name so a reorder is not reported as a change.
+        if all(isinstance(item, dict) and "name" in item for item in expected + actual):
+            keyed_expected = {item["name"]: item for item in expected}
+            keyed_actual = {item["name"]: item for item in actual}
+            return _diff_paths(keyed_expected, keyed_actual, prefix)
+        if expected != actual:
+            return [f"{where}: {expected!r} != {actual!r}"]
+        return []
+    if expected != actual:
+        return [f"{where}: expected {expected!r}, got {actual!r}"]
+    return []
+
+
+def test_cli_surface_matches_snapshot():
+    """The Click command tree matches the committed structural snapshot."""
+    surface = build_surface()
+
+    if os.environ.get(UPDATE_ENV_VAR):
+        SNAPSHOT_PATH.write_text(_serialize(surface), encoding="utf-8")
+        pytest.skip(f"{UPDATE_ENV_VAR} set: refreshed {SNAPSHOT_PATH.name}")
+
+    assert SNAPSHOT_PATH.exists(), (
+        f"Missing CLI surface snapshot {SNAPSHOT_PATH}. "
+        f"Create it with {UPDATE_ENV_VAR}=1 uv run pytest {Path(__file__).name}"
+    )
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+    diffs = _diff_paths(expected, surface)
+    assert not diffs, (
+        "CLI surface drifted from tests/data/cli_surface.json:\n"
+        + "\n".join(f"  - {line}" for line in diffs[:40])
+        + (f"\n  ... and {len(diffs) - 40} more" if len(diffs) > 40 else "")
+        + f"\n\nIf the change is intentional, re-record the snapshot with:\n"
+        f"  {UPDATE_ENV_VAR}=1 uv run pytest tests/{Path(__file__).name}\n"
+        "and review the resulting diff before committing."
+    )
+
+
+LEAF_PATHS = iter_leaf_paths(build_surface())
+
+
+@pytest.mark.parametrize(
+    "argv",
+    LEAF_PATHS,
+    ids=["/".join(path) for path in LEAF_PATHS],
+)
+def test_leaf_command_help_renders(argv):
+    """``--help`` renders successfully for every built-in leaf command."""
+    result = CliRunner().invoke(cli, [*argv, "--help"])
+    assert result.exit_code == 0, (
+        f"gpio {' '.join(argv)} --help exited {result.exit_code}\n{result.output}"
+    )
+    assert "Usage:" in result.output
+
+
+def test_leaf_command_inventory_is_non_trivial():
+    """Guard against the walker silently collecting nothing."""
+    assert len(LEAF_PATHS) > 40

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -136,7 +136,9 @@ def _probe_default_subcommand(group: click.Group) -> str | None:
     ctx = click.Context(group)
     try:
         group.parse_args(ctx, [])
-    except Exception:
+    except click.UsageError:
+        # NoArgsIsHelpError (a UsageError) is how a plain click.Group answers an
+        # empty argv. Anything else is a genuine failure and is left to surface.
         return None
     for attr in ("_protected_args", "protected_args", "args"):
         found = getattr(ctx, attr, None)

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -27,6 +27,13 @@ from geoparquet_io.cli.main import cli
 SNAPSHOT_PATH = Path(__file__).parent / "data" / "cli_surface.json"
 UPDATE_ENV_VAR = "GPIO_UPDATE_SNAPSHOT"
 
+# Click 8.2 introduced a sentinel distinguishing "no default declared" from an
+# explicitly declared ``None``. Its ``repr`` is a click implementation detail,
+# so it is recorded as a stable token instead; ``None`` still records as
+# ``'None'``, keeping the unset-vs-explicit-None distinction visible.
+_UNSET = getattr(click.core, "UNSET", object())
+UNSET_TOKEN = "<unset>"
+
 # Commands contributed by third-party plugins (loaded through the
 # ``gpio.plugins`` entry point group) are excluded from the snapshot so an
 # installed plugin cannot break this test.
@@ -53,7 +60,8 @@ def _type_repr(param_type: click.ParamType) -> str:
     described structurally instead of by their default repr.
     """
     if isinstance(param_type, click.Choice):
-        return "choice[" + "|".join(str(choice) for choice in param_type.choices) + "]"
+        choices = "|".join(str(choice) for choice in param_type.choices)
+        return f"choice[{choices},case_sensitive={param_type.case_sensitive}]"
     if isinstance(param_type, click.Path):
         return (
             "path["
@@ -81,8 +89,14 @@ def _type_repr(param_type: click.ParamType) -> str:
 
 
 def _default_repr(param: click.Parameter) -> str:
-    """Return ``repr`` of a parameter default, invoking callable defaults."""
+    """Return ``repr`` of a parameter default, invoking callable defaults.
+
+    Click's "no default declared" sentinel is normalized to ``<unset>`` so the
+    snapshot does not churn wholesale when click changes the sentinel's repr.
+    """
     default = param.default
+    if default is _UNSET:
+        return UNSET_TOKEN
     if callable(default):
         default = default()
     return repr(default)
@@ -99,8 +113,36 @@ def describe_param(param: click.Parameter) -> dict:
         "default": _default_repr(param),
         "is_flag": bool(getattr(param, "is_flag", False)),
         "multiple": bool(getattr(param, "multiple", False)),
+        "hidden": bool(getattr(param, "hidden", False)),
         "nargs": param.nargs,
     }
+
+
+def _probe_default_subcommand(group: click.Group) -> str | None:
+    """Return the subcommand a group dispatches to when given no arguments.
+
+    ``create_default_group`` in ``cli/main.py`` builds its groups from a
+    factory, so every generated class is named ``_DefaultGroup`` and the
+    configured subcommand lives only in a closure. Rather than reaching into
+    ``__closure__`` cells, this asks the group what it actually does with an
+    empty argv through the public ``parse_args`` API: a default-dispatch group
+    rewrites argv to its default subcommand, while a plain ``click.Group``
+    raises ``NoArgsIsHelpError`` and records ``None``.
+
+    Note this pins the *dispatch target* only. Full behavioral coverage of bare
+    default dispatch (``gpio check <file>`` running ``check all``) is deferred
+    to the test-consolidation issue, #666.
+    """
+    ctx = click.Context(group)
+    try:
+        group.parse_args(ctx, [])
+    except Exception:
+        return None
+    for attr in ("_protected_args", "protected_args", "args"):
+        found = getattr(ctx, attr, None)
+        if found:
+            return str(found[0])
+    return None
 
 
 def describe_command(command: click.Command) -> dict:
@@ -115,6 +157,7 @@ def describe_command(command: click.Command) -> dict:
         ),
     }
     if isinstance(command, click.Group):
+        described["default_subcommand"] = _probe_default_subcommand(command)
         described["commands"] = {
             name: describe_command(sub)
             for name, sub in sorted(command.commands.items())
@@ -136,6 +179,16 @@ def iter_leaf_paths(described: dict, prefix: tuple[str, ...] = ()) -> list[tuple
     for name, sub in described["commands"].items():
         leaves.extend(iter_leaf_paths(sub, prefix + (name,)))
     return leaves
+
+
+def iter_group_paths(described: dict, prefix: tuple[str, ...] = ()) -> list[tuple[str, ...]]:
+    """Yield the argv path of every group in a described tree, root included."""
+    if described["kind"] != "group":
+        return []
+    groups = [prefix]
+    for name, sub in described["commands"].items():
+        groups.extend(iter_group_paths(sub, prefix + (name,)))
+    return groups
 
 
 def _serialize(surface: dict) -> str:
@@ -175,6 +228,12 @@ def test_cli_surface_matches_snapshot():
     surface = build_surface()
 
     if os.environ.get(UPDATE_ENV_VAR):
+        # Never let a stray env var turn CI green by rewriting the baseline.
+        assert not os.environ.get("CI"), (
+            f"{UPDATE_ENV_VAR} must not be set in CI: it would rewrite the "
+            "baseline instead of checking against it. Re-record the snapshot "
+            "locally and commit the diff."
+        )
         SNAPSHOT_PATH.write_text(_serialize(surface), encoding="utf-8")
         pytest.skip(f"{UPDATE_ENV_VAR} set: refreshed {SNAPSHOT_PATH.name}")
 
@@ -212,6 +271,29 @@ def test_leaf_command_help_renders(argv):
     assert "Usage:" in result.output
 
 
-def test_leaf_command_inventory_is_non_trivial():
+GROUP_PATHS = iter_group_paths(build_surface())
+
+
+@pytest.mark.parametrize(
+    "argv",
+    GROUP_PATHS,
+    ids=["/".join(path) or "gpio" for path in GROUP_PATHS],
+)
+def test_group_help_renders(argv):
+    """``--help`` renders for every group, including default-dispatch groups.
+
+    The groups built by ``create_default_group`` intercept ``--help`` in their
+    own ``parse_args`` before falling through to the default subcommand, so
+    this covers a branch the leaf cases never reach.
+    """
+    result = CliRunner().invoke(cli, [*argv, "--help"])
+    assert result.exit_code == 0, (
+        f"gpio {' '.join(argv)} --help exited {result.exit_code}\n{result.output}"
+    )
+    assert "Usage:" in result.output
+
+
+def test_command_inventory_is_non_trivial():
     """Guard against the walker silently collecting nothing."""
     assert len(LEAF_PATHS) > 40
+    assert len(GROUP_PATHS) > 10


### PR DESCRIPTION
Suite 1 of #664. A characterization snapshot of the `gpio` CLI surface, so the
`cli/main.py` split can proceed with any user-visible drift failing loudly and
by name.

## What the snapshot pins

`tests/test_cli_surface.py` walks the built-in Click tree into
`tests/data/cli_surface.json` — **58 leaf commands, 12 groups, 800+ parameters**.
Per parameter: name, `opts` + `secondary_opts` (sorted), a structural type
descriptor, default, `required`, `is_flag`, `multiple`, `hidden`, `nargs`.

A few details that took deliberate handling:

- **Types are described structurally, not via `str()`.** `str(click.Path(...))`
  renders `<click.types.Path object at 0x10e16e010>`, which would have baked ~40
  memory addresses into the snapshot and failed on every run. Types record as
  `path[exists=…,file_okay=…,…]`, `choice[a|b|c,case_sensitive=…]`,
  `integer range[min=…,max=…,…]`. 35 params are case-insensitive choices today.
- **A stable `<unset>` token** replaces click's "no default declared" sentinel.
  225 of the recorded defaults hit it; pinning `repr(Sentinel.UNSET)` would have
  churned the whole file on a click bump. An explicitly declared `None` still
  records as `'None'`, so the unset-vs-explicit-`None` distinction stays visible.
- **Default-dispatch subcommands are recovered.** `create_default_group` builds
  `check`, `inspect` and `extract` from a factory, so all three recorded the same
  `_DefaultGroup` class name while the configured subcommand lived only in a
  closure — rebuilding a group with the wrong default during the split would have
  been invisible. Instead of reading `__closure__` cells, the walker asks each
  group what it does with an empty argv through the public `parse_args` API:
  default-dispatch groups rewrite argv to their default (`check` → `all`,
  `inspect` → `summary`, `extract`/`convert` → `geoparquet`), plain groups raise
  `NoArgsIsHelpError` and record `null`. The probe is side-effect free — it only
  rewrites argv into a throwaway `Context` — and catches `UsageError` narrowly so
  a genuine parse error surfaces rather than silently recording `null`.

Help prose is deliberately **not** pinned, so wording can be reflowed freely
during the split.

## Tests — 73 cases, 0.45s

- `test_cli_surface_matches_snapshot` — a mismatch names the exact drifted path,
  e.g. `/commands/add/commands/h3/params/resolution/default: expected '9', got '8'`.
- `test_leaf_command_help_renders` — 58 cases, ids like `check/spatial`, `add/h3`.
- `test_group_help_renders` — 12 cases, covering the `--help` interception branch
  at the top of `_DefaultGroup.parse_args` that the leaf cases never reach.
- `test_command_inventory_is_non_trivial` — stops a walker that collects nothing
  from making the help cases vacuously green.

Plugin-contributed commands (the `gpio.plugins` entry point group) are filtered
out by module origin, so an installed plugin cannot break the test. Filtering is
by origin rather than a hardcoded allowlist, so a *new* built-in group is picked
up automatically and surfaces as a reviewable diff.

Refresh an intentional change with
`GPIO_UPDATE_SNAPSHOT=1 uv run pytest tests/test_cli_surface.py`, then review the
diff. The update path **refuses to run when `CI` is set**, so a stray env var
cannot turn CI green by rewriting the baseline instead of checking against it
(verified: snapshot md5 identical before and after a `CI=true
GPIO_UPDATE_SNAPSHOT=1` run — the guard fires ahead of the write).

## Sabotage evidence

These tests pin current behavior, so they pass on green code by construction.
Non-vacuity was proven by breaking the pinned behavior and confirming a useful
failure, then reverting:

| Sabotage | Result |
|---|---|
| `add h3 --resolution` `default=9 → 8`, `IntRange(0,15) → (0,14)` | both drifted fields named with exact paths |
| `--h3-name` renamed to `--h3-column` | reported as `removed` + `added` param entries |
| `--fix-output` (recorded `<unset>`) given `default=None` | `expected '<unset>', got 'None'` — the two are not collapsed |
| `create_default_group("all", …)` → `("spatial", …)` | `check/default_subcommand: expected 'all', got 'spatial'` |

The last two are the cases that were invisible before this PR.

## Deferred to #666

- **Bare default-dispatch behavior** — this PR pins the dispatch *target*
  (`check` → `all`); actually running `gpio check <file>` and asserting it
  behaves as `check all` is behavioral coverage that belongs with the
  consolidation work. Noted in a code comment on the probe.
- **Two independent Click walkers now exist** — this one and the one in
  `tests/test_cli_api_default_parity.py`. They could be unified when #666 lands.
- The ~40 scattered `--help` tests this suite supersedes are intentionally left
  in place; removing them is #666's scope.

## Verification

- Full fast suite: **4032 passed, 40 skipped**, coverage 78.48% (gate 67%).
- `pre-commit` clean on changed files; `pre-commit --hook-stage pre-push
  --all-files` clean (xenon, import-linter, deptry, vulture).
- No production code changed — `geoparquet_io/` is untouched by this branch.

Refs #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression coverage for the built-in CLI command structure, options, arguments, defaults, flags, and dispatch behavior.
  * Added automated help-rendering checks for all built-in commands and command groups.
  * Added safeguards for intentional snapshot updates and compatibility across supported Click versions.

* **Documentation**
  * Documented the new CLI surface regression coverage and snapshot maintenance process in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->