### PR TITLE
ci: replace blanket loadfile with targeted xdist_group on Windows (experiment)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,8 +157,17 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
-            # Use loadfile distribution on Windows to reduce DuckDB extension conflicts
-            uv run pytest -n 4 --dist=loadfile -m "not slow and not network" -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=term-missing --cov-report=xml
+            # EXPERIMENT (#665 item 6): loadgroup replaces the blanket loadfile.
+            # loadfile pinned every file to one worker to dodge concurrent DuckDB
+            # community-extension INSTALLs (duckdb#12589) -- but those INSTALLs are
+            # spread over 13 files, so loadfile never actually serialized them.
+            # loadgroup schedules per test, except for tests carrying an
+            # xdist_group mark, which share a worker. The 13 extension-touching
+            # files carry xdist_group("duckdb-community-extensions"), so exactly
+            # one worker ever INSTALLs -- stricter than loadfile -- while the
+            # remaining ~3.6k tests load-balance instead of queueing behind
+            # 200-test files.
+            uv run pytest -n 4 --dist=loadgroup -m "not slow and not network" -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=term-missing --cov-report=xml
           elif [ "$RUNNER_OS" == "macOS" ]; then
             uv run pytest -n 3 -m "not slow and not network" -v --tb=short --durations=25 --durations-min=0.5 --cov=geoparquet_io --cov-report=term-missing --cov-report=xml
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Changed
 
+- **Windows CI distributes tests per test instead of per file (#665).** The
+  Windows fast-test job used `--dist=loadfile` to avoid concurrent DuckDB
+  community-extension `INSTALL`s racing on the shared extension directory
+  (duckdb#12589). Instrumenting the suite showed the extension installs are
+  spread over 13 test files, so `loadfile` never actually serialized them —
+  `a5` and `h3` were each installed by three workers concurrently. Those 13
+  files now carry `xdist_group("duckdb-community-extensions")` and the job runs
+  `--dist=loadgroup`, which pins exactly that group to one worker while
+  scheduling the other ~3.6k tests individually rather than queueing them
+  behind 200-test files.
+
 - **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
   `gpio check spec` heuristic that flags geographic-looking coordinates (values
   within ±180/±90) under a projected CRS now reports a WARNING instead of

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -196,6 +196,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Changed
 
+- **Windows CI distributes tests per test instead of per file (#665).** The
+  Windows fast-test job used `--dist=loadfile` to avoid concurrent DuckDB
+  community-extension `INSTALL`s racing on the shared extension directory
+  (duckdb#12589). Instrumenting the suite showed the extension installs are
+  spread over 13 test files, so `loadfile` never actually serialized them —
+  `a5` and `h3` were each installed by three workers concurrently. Those 13
+  files now carry `xdist_group("duckdb-community-extensions")` and the job runs
+  `--dist=loadgroup`, which pins exactly that group to one worker while
+  scheduling the other ~3.6k tests individually rather than queueing them
+  behind 200-test files.
+
 - **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
   `gpio check spec` heuristic that flags geographic-looking coordinates (values
   within ±180/±90) under a projected CRS now reports a WARNING instead of

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -10,6 +10,15 @@ from click.testing import CliRunner
 
 from geoparquet_io.cli.main import add
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 class TestAddCommands:
     """Test suite for add commands."""

--- a/tests/test_add_h3.py
+++ b/tests/test_add_h3.py
@@ -15,6 +15,15 @@ from click.testing import CliRunner
 from geoparquet_io.core.add.h3 import add_h3_column, add_h3_table
 from tests.conftest import safe_unlink
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 class TestAddH3Table:
     """Tests for add_h3_table function."""

--- a/tests/test_add_s2.py
+++ b/tests/test_add_s2.py
@@ -15,6 +15,15 @@ from click.testing import CliRunner
 from geoparquet_io.core.add.s2 import add_s2_column, add_s2_table
 from tests.conftest import safe_unlink
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 class TestAddS2Table:
     """Tests for add_s2_table function."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,15 @@ import pytest
 from geoparquet_io.api import Table, convert, ops, pipe, read
 from tests.conftest import safe_unlink
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 TEST_DATA_DIR = Path(__file__).parent / "data"
 PLACES_PARQUET = TEST_DATA_DIR / "places_test.parquet"
 

--- a/tests/test_crs_aware_operations.py
+++ b/tests/test_crs_aware_operations.py
@@ -36,6 +36,15 @@ from geoparquet_io.core.crs_utils import (
 from geoparquet_io.core.duckdb_utils import build_spatial_join_condition
 from geoparquet_io.core.reproject import reproject
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 def _column(parquet_file: str, column: str) -> list:
     con = duckdb.connect()

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -18,6 +18,15 @@ from geoparquet_io.core.crs_utils import (
 )
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 EPSG_28992 = {"id": {"authority": "EPSG", "code": 28992}}
 
 

--- a/tests/test_geometry_identifier_quoting.py
+++ b/tests/test_geometry_identifier_quoting.py
@@ -48,6 +48,15 @@ from geoparquet_io.core.duckdb_metadata import (
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.stream_io import _wrap_query_with_wkb_conversion
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 # A geometry column name with a space -- breaks unquoted identifier
 # interpolation (`ST_XMin(geom col)` is a parse error).
 SPACED_COL = "geom col"

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -10,6 +10,15 @@ from click.testing import CliRunner
 
 from geoparquet_io.cli.main import partition
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 # Shared CliRunner to avoid repeated instantiation
 @pytest.fixture(scope="module")

--- a/tests/test_partition_a5_auto.py
+++ b/tests/test_partition_a5_auto.py
@@ -6,6 +6,15 @@ import pytest
 
 from geoparquet_io.core.partition.by_a5 import partition_by_a5
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 class TestA5AutoResolutionIntegration:
     """Test A5 auto-resolution with real files."""

--- a/tests/test_partition_bounds.py
+++ b/tests/test_partition_bounds.py
@@ -17,6 +17,15 @@ from click.testing import CliRunner
 
 from geoparquet_io.cli.main import partition
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 def get_geo_metadata_bounds(file_path):
     """Extract bounds from GeoParquet geo metadata."""

--- a/tests/test_partition_h3_auto.py
+++ b/tests/test_partition_h3_auto.py
@@ -6,6 +6,15 @@ import pytest
 
 from geoparquet_io.core.partition.by_h3 import partition_by_h3
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 class TestH3AutoResolutionIntegration:
     """Test H3 auto-resolution with real files."""

--- a/tests/test_sub_partition.py
+++ b/tests/test_sub_partition.py
@@ -11,6 +11,15 @@ from click.testing import CliRunner
 
 from geoparquet_io.cli.main import partition
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 @pytest.fixture
 def cli_runner():

--- a/tests/test_write_memory_forwarding.py
+++ b/tests/test_write_memory_forwarding.py
@@ -44,6 +44,15 @@ from click.testing import CliRunner
 from geoparquet_io.cli import main as cli_main
 from geoparquet_io.cli.main import cli
 
+# DuckDB community extensions (a5 / geography / h3) are downloaded and
+# INSTALLed on first use. Concurrent INSTALLs from several xdist workers
+# race on the shared extension directory (duckdb#12589), which is why
+# Windows CI used to serialize whole files via --dist=loadfile. This mark
+# pins every community-extension test onto a single worker under
+# --dist=loadgroup, so exactly one process ever performs the INSTALL,
+# while the rest of the suite is free to load-balance per test.
+pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")
+
 
 def _find_non_geometry_column(parquet_file: str) -> str:
     conn = duckdb.connect()


### PR DESCRIPTION
**Experiment — do not merge without a green Windows matrix and a timing comparison** (issue #665, item 6, the optional one).

## What the rationale research found

`--dist=loadfile` for the Windows fast-test job arrived in #167 (`358e588`) with the comment *"Use loadfile distribution on Windows to reduce DuckDB extension conflicts"*, and was copied to the slow-test job in `0cb159c`. The conflict it targeted is [duckdb#12589](https://github.com/duckdb/duckdb/issues/12589) — concurrent `INSTALL`s racing on the shared extension directory. The same PR also wrapped every `INSTALL` in `try/except` (now `core/duckdb_utils.py:474-500`).

So the intent was: keep a whole test file on one worker so its extension installs do not collide with another worker's.

**Measured, the premise does not hold.** I patched `duckdb.DuckDBPyConnection.execute` and recorded every `INSTALL ... FROM community` executed by the fast suite, together with the xdist worker that ran it:

| dist mode | community `INSTALL` calls | files involved | workers installing `a5` | `geography` | `h3` |
|---|---|---|---|---|---|
| `--dist=loadfile` (today) | 96 | 13 | **3** (gw1, gw2, gw3) | **2** | **3** |
| `--dist=loadgroup` + marks (this PR) | 96 | 13 | **1** (gw0) | **1** | **1** |

The installs are spread over 13 test files, so pinning each *file* to a worker never serialized them — with `-n 4` the files simply land on different workers and race anyway. The protection has been nominal since it was added.

Note also that CI's "Pre-install DuckDB extensions" step covers only `spatial`, `httpfs` and `h3`; `a5` and `geography` are genuinely downloaded during the test run, so they are the live race.

## What this PR changes

1. The 13 files that execute community-extension installs get a module-level `pytestmark = pytest.mark.xdist_group("duckdb-community-extensions")`.
2. The Windows fast-test job runs `--dist=loadgroup` instead of `--dist=loadfile`.

Under `loadgroup`, a test *without* an `xdist_group` mark has its full nodeid as its scope, i.e. it is its own work unit and schedules individually — while every marked test shares one work unit and therefore one worker. The result is strictly stronger isolation than `loadfile` (one installer instead of three) plus per-test load balancing for the other ~3,600 tests, which no longer queue behind 200-test files such as `test_wfs.py` (204 tests, 41.5s serial) or the corpus file.

### Why not `worksteal`, as the issue suggested

`xdist_group` is honoured **only** by the `loadgroup` scheduler. In pytest-xdist 3.8.0, `xdist/remote.py:243` applies group names only when `config.getvalue("loadgroup")` is true, and `WorkStealingScheduling` has no scope concept at all. "worksteal + targeted `xdist_group` marks" is not implementable — under `worksteal` the marks are inert, making it an all-or-nothing removal of the extension-race protection. `loadgroup` is the scheduler that expresses the intent, and it delivers the same fine-grained balancing for everything outside the group.

## Local measurements

macOS, `-n 4`, no coverage, same machine (shared with other jobs, so treat as indicative):

| dist mode | wall | result |
|---|---|---|
| `--dist=loadfile` | 150.9s | 3959 passed, 40 skipped |
| `--dist=loadgroup` + marks | 93.2s | 3959 passed, 40 skipped |

Grouping does not create a tail: the 13 grouped files are 416 tests / ~36s serial, against ~410s of total serial suite CPU.

Expected saving on the 12m18s Windows step: 1–3 minutes. **The Windows matrix in this PR is the actual validation** — if it is red or not faster, the recommendation is to close this and keep `loadfile`.

## Scope and merge order

The edit is deliberately confined to the Windows `--dist` flag plus the `xdist_group` marks. The Windows **slow**-test job keeps `--dist=loadfile` (it ignores the new marks, so it behaves exactly as before).

Two other open PRs touch `.github/workflows/tests.yml`:
- #677 (coverage flags on the test jobs)
- the meta-lane branch (moves repo-tooling tests out of the fast selection)

Both edit the same `Run fast tests with pytest (parallel)` block. This PR should merge **after** them and be rebased onto the result, so the `--dist` change lands on top of their final pytest invocation rather than conflicting with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx
