### PR TITLE
test(ci): move repo tooling checks into a meta lane (#665)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -121,7 +121,7 @@ jobs:
           fi
 
           # Run the fast suite to confirm the upgrade didn't break anything.
-          uv run pytest -n 4 -m "not slow and not network" -q --tb=short --no-cov -p no:cacheprovider
+          uv run pytest -n 4 -m "not slow and not network and not meta" -q --tb=short --no-cov -p no:cacheprovider
           TEST_EXIT=$?
 
           if [ $TEST_EXIT -eq 0 ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,11 +199,11 @@ jobs:
           # shellcheck disable=SC2086
           if [ "$RUNNER_OS" == "Windows" ]; then
             # Use loadfile distribution on Windows to reduce DuckDB extension conflicts
-            uv run pytest -n 4 --dist=loadfile -m "not slow and not network" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
+            uv run pytest -n 4 --dist=loadfile -m "not slow and not network and not meta" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            uv run pytest -n 3 -m "not slow and not network" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
+            uv run pytest -n 3 -m "not slow and not network and not meta" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
           else
-            uv run pytest -n 4 -m "not slow and not network" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
+            uv run pytest -n 4 -m "not slow and not network and not meta" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
           fi
 
       - name: Upload coverage to Codecov
@@ -339,11 +339,19 @@ jobs:
             && '--cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0'
             || '--no-cov' }}
         run: |
-          # Security tests (the live pip-audit) are owned by the dedicated
-          # `security` job, which handles CVE ignores and PR blocking. Never run
-          # them here too — that duplication broke main whenever the two pip-audit
-          # ignore lists drifted apart.
-          IGNORE_SECURITY="--ignore=tests/test_security.py"
+          # The selection is "(slow or meta) and not network". `meta` is the
+          # repo-tooling lane (codespell, commitizen, doc-sync, mutmut, mypy,
+          # validate-claude-md, the security-tool availability checks). Those
+          # are excluded from the fast suite -- they spawn subprocesses and
+          # caused its only flakes -- so this job is where they still run.
+          #
+          # tests/test_security.py is NOT excluded here: the marker selection
+          # already skips everything in it except the two `meta`-marked tool
+          # availability checks, and excluding the file outright would leave
+          # those running in no CI job at all. The live pip-audit that used to
+          # justify a file-level ignore no longer lives there -- see the NOTE
+          # in tests/test_security.py, which records why it must stay owned by
+          # the dedicated `security` job and never come back as a pytest test.
 
           # word-splitting intended: COV_ARGS is a flag list (or --no-cov).
           # The directive binds to the NEXT command, so it has to sit here and
@@ -352,11 +360,11 @@ jobs:
           # shellcheck disable=SC2086
           if [ "$RUNNER_OS" == "Windows" ]; then
             # Use loadfile distribution on Windows to reduce DuckDB extension conflicts
-            uv run pytest -n 4 --dist=loadfile -m "slow and not network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
+            uv run pytest -n 4 --dist=loadfile -m "(slow or meta) and not network" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            uv run pytest -n 3 -m "slow and not network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
+            uv run pytest -n 3 -m "(slow or meta) and not network" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
           else
-            uv run pytest -n 4 -m "slow and not network" $IGNORE_SECURITY -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
+            uv run pytest -n 4 -m "(slow or meta) and not network" -v --tb=short --durations=25 --durations-min=0.5 $COV_ARGS
           fi
 
       - name: Upload slow test coverage to Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -323,7 +323,7 @@ repos:
             # Only run if explicitly enabled via environment variable
             if [ "$ENABLE_PRE_PUSH_TESTS" = "1" ]; then
               echo "Running fast tests..."
-              uv run pytest -n auto -m "not slow and not network" --tb=short
+              uv run pytest -n auto -m "not slow and not network and not meta" --tb=short
             else
               # Silent pass - tests not enabled
               exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,7 +275,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `uv run pytest -m meta`. `tests/test_validate_claude_md.py` also drops five of
   its seven `uv run` spawns in favour of calling the validator's `main()` in
   process, keeping the happy path and one detected-error path as real
-  subprocesses.
+  subprocesses. The nightly mutation run picks the lane up too: mutmut's
+  per-mutant selection is now `not slow and not network and not meta`, which
+  replaces the per-file `--ignore` list it needed to keep those subprocesses
+  from resolving the *mutated* package out of mutmut's `mutants/` tree.
 
 - **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
   `gpio check spec` heuristic that flags geographic-looking coordinates (values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,25 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   (`tests/test_coverage_job.py` asserts the flag names a combination the matrix
   actually schedules).
 
+- **Repo-tooling tests moved to a `meta` lane, out of the fast suite (#665).**
+  The codespell, commitizen, doc-sync, mutmut, mypy, validate-CLAUDE.md and
+  security-tool-availability checks now carry `@pytest.mark.meta`. They spawn
+  `uv run` subprocesses and were the fast suite's only source of contention
+  flakes. Most of them re-run something CI checks elsewhere — codespell,
+  doc-sync, mypy and validate-claude-md are pre-commit hooks the lint job runs,
+  and the bandit/pip-audit availability checks are covered for real by the
+  `security` job — while the commitizen and mutmut tests validate configuration
+  that no hook in the lint job touches (commitizen is a `commit-msg`-stage hook,
+  mutmut has no hook at all), which is why the lane still runs in CI rather than
+  being deleted. The fast selection is now
+  `-m "not slow and not network and not meta"` and the slow/nightly job runs
+  `-m "(slow or meta) and not network"` with no file-level exclusions, so
+  nothing stops being checked in CI. Run them locally with
+  `uv run pytest -m meta`. `tests/test_validate_claude_md.py` also drops five of
+  its seven `uv run` spawns in favour of calling the validator's `main()` in
+  process, keeping the happy path and one detected-error path as real
+  subprocesses.
+
 - **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
   `gpio check spec` heuristic that flags geographic-looking coordinates (values
   within ±180/±90) under a projected CRS now reports a WARNING instead of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,8 @@ Additional patterns (not yet enforced):
 Config in `pyproject.toml [tool.pytest.ini_options]`.
 
 ```bash
-uv run pytest -n auto -m "not slow and not network"  # Fast tests (no coverage)
+uv run pytest -n auto -m "not slow and not network and not meta"  # Fast tests (no coverage)
+uv run pytest -m meta                                             # Repo tooling checks
 uv run pytest --cov=geoparquet_io --cov-report=term-missing --cov-fail-under=0  # opt into coverage
 ```
 
@@ -159,6 +160,12 @@ is fast and a partial run can't fail a whole-suite gate. The 67% floor and the 9
 diff-cover gate on changed lines are enforced in CI (the ubuntu/3.11 job in
 `.github/workflows/tests.yml`), which passes the coverage flags explicitly.
 
+The `meta` lane (codespell, commitizen, doc-sync, mutmut, mypy,
+validate-claude-md, security tool checks) is excluded from the fast suite and
+runs in the slow/nightly job instead. Pre-commit covers most of it locally, but
+not all: commitizen is a `commit-msg`-stage hook and mutmut has no hook, so
+`uv run pytest -m meta` is the only local way to check those two.
+
 <!-- BEGIN GENERATED: test-markers -->
 ### Test Markers
 
@@ -168,6 +175,7 @@ diff-cover gate on changed lines are enforced in CI (the ubuntu/3.11 job in
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
 | `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
+| `@pytest.mark.meta` | repo tooling checks, excluded from the fast suite |
 <!-- END GENERATED: test-markers -->
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -275,7 +275,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `uv run pytest -m meta`. `tests/test_validate_claude_md.py` also drops five of
   its seven `uv run` spawns in favour of calling the validator's `main()` in
   process, keeping the happy path and one detected-error path as real
-  subprocesses.
+  subprocesses. The nightly mutation run picks the lane up too: mutmut's
+  per-mutant selection is now `not slow and not network and not meta`, which
+  replaces the per-file `--ignore` list it needed to keep those subprocesses
+  from resolving the *mutated* package out of mutmut's `mutants/` tree.
 
 - **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
   `gpio check spec` heuristic that flags geographic-looking coordinates (values

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -258,6 +258,25 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   (`tests/test_coverage_job.py` asserts the flag names a combination the matrix
   actually schedules).
 
+- **Repo-tooling tests moved to a `meta` lane, out of the fast suite (#665).**
+  The codespell, commitizen, doc-sync, mutmut, mypy, validate-CLAUDE.md and
+  security-tool-availability checks now carry `@pytest.mark.meta`. They spawn
+  `uv run` subprocesses and were the fast suite's only source of contention
+  flakes. Most of them re-run something CI checks elsewhere — codespell,
+  doc-sync, mypy and validate-claude-md are pre-commit hooks the lint job runs,
+  and the bandit/pip-audit availability checks are covered for real by the
+  `security` job — while the commitizen and mutmut tests validate configuration
+  that no hook in the lint job touches (commitizen is a `commit-msg`-stage hook,
+  mutmut has no hook at all), which is why the lane still runs in CI rather than
+  being deleted. The fast selection is now
+  `-m "not slow and not network and not meta"` and the slow/nightly job runs
+  `-m "(slow or meta) and not network"` with no file-level exclusions, so
+  nothing stops being checked in CI. Run them locally with
+  `uv run pytest -m meta`. `tests/test_validate_claude_md.py` also drops five of
+  its seven `uv run` spawns in favour of calling the validator's `main()` in
+  process, keeping the happy path and one detected-error path as real
+  subprocesses.
+
 - **Coordinate/CRS mismatch heuristic downgraded to WARNING.** The
   `gpio check spec` heuristic that flags geographic-looking coordinates (values
   within ±180/±90) under a projected CRS now reports a WARNING instead of

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,9 +65,10 @@ uv run pre-commit install
 ## Tests
 
 ```bash
-uv run pytest                                          # Full suite
-uv run pytest tests/test_yourfile.py -v               # Single file
-uv run pytest -m "not slow and not network"           # Fast tests only
+uv run pytest                                              # Full suite
+uv run pytest tests/test_yourfile.py -v                   # Single file
+uv run pytest -m "not slow and not network and not meta"  # Fast tests only
+uv run pytest -m meta                                     # Repo tooling checks
 uv run pytest --cov=geoparquet_io --cov-report=term-missing --cov-fail-under=0  # With coverage
 ```
 
@@ -82,10 +83,17 @@ though `addopts` no longer requests one.
 
 CI runs three test tiers:
 
-- **Fast tests** (`not slow and not network`) — run on every PR across the full
-  OS/Python matrix and **block merging**.
-- **Slow tests** (`slow and not network`) — run after merge to main and nightly;
-  opt in on a PR by adding the `run-slow-tests` label.
+- **Fast tests** (`not slow and not network and not meta`) — run on every PR
+  across the full OS/Python matrix and **block merging**.
+- **Slow tests** (`(slow or meta) and not network`) — run after merge to main
+  and nightly; opt in on a PR by adding the `run-slow-tests` label. This tier
+  also carries the `meta` lane: repo-tooling checks (codespell, commitizen,
+  doc-sync, mutmut, mypy, validate-claude-md, security tool availability) that
+  shell out to subprocesses. Most re-check something the lint job already runs
+  via pre-commit, so `uv run pytest -m meta` is mainly for when you skip
+  pre-commit — except commitizen (a `commit-msg`-stage hook, which
+  `pre-commit run --all-files` never runs) and mutmut (no hook at all), where
+  it is the only local check.
 - **Network tests** (`network`) — hit live third-party services (ArcGIS, WFS,
   Carto, ...). They are **non-blocking**: failures open/update a tracking issue
   instead of failing CI, because a remote server's behavior is not something a
@@ -108,6 +116,7 @@ Coverage gates (both enforced in CI):
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
 | `@pytest.mark.integration` | marks end-to-end integration tests |
 | `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
+| `@pytest.mark.meta` | repo tooling checks, excluded from the fast suite |
 <!-- END GENERATED: test-markers -->
 
 ## Code Quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ markers = [
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
     "integration: marks end-to-end integration tests",
     "corpus: tests against the official geoparquet-testing corpus (requires git submodule)",
+    "meta: repo tooling checks, excluded from the fast suite",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,10 +278,12 @@ source_paths = ["geoparquet_io/"]
 # overhead and stops [tool.coverage.report].fail_under from failing every mutant.
 # NOTE: mutmut 3 runs pytest in-process and IGNORES a `runner` setting;
 # extra args must go in pytest_add_cli_args.
-# The --ignore'd files are tooling meta-tests that spawn `uv run ...`
-# subprocesses against the project; from mutmut's mutants/ cwd that would
+# `not meta` is what keeps the tooling meta-tests out: they spawn `uv run ...`
+# subprocesses against the project, and from mutmut's mutants/ cwd that would
 # resolve/install the MUTATED package — meaningless for mutation score and
-# fatal to the run.
+# fatal to the run. It replaces the per-file --ignore list those tests used to
+# need. test_import_linter.py is not in the meta lane (it is a fast unit test
+# of the contract config) but shells out the same way, so it keeps its ignore.
 pytest_add_cli_args = [
     "--no-cov",
     # --tb=short (not --tb=no): a failure in mutmut's single-process stats
@@ -289,11 +291,8 @@ pytest_add_cli_args = [
     # (tests that chdir break mutmut's trampoline) and made nightly red with
     # no diagnosable reason. See the tests/ chdir guard in .pre-commit-config.
     "--tb=short",
-    "-m", "not slow and not network",
-    "--ignore=tests/test_codespell.py",
+    "-m", "not slow and not network and not meta",
     "--ignore=tests/test_import_linter.py",
-    "--ignore=tests/test_security.py",
-    "--ignore=tests/test_validate_claude_md.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/"]
 # Everything the test suite reads relative to the repo root must also exist

--- a/tests/test_codespell.py
+++ b/tests/test_codespell.py
@@ -6,10 +6,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
+
+# Repo tooling checks: these shell out to codespell and duplicate what the CI
+# lint job already runs via pre-commit, so they live in the meta lane instead
+# of the fast suite.
+pytestmark = pytest.mark.meta
 
 # Resolve project root relative to this test file, so tests work
 # regardless of the working directory pytest is invoked from.

--- a/tests/test_commitizen.py
+++ b/tests/test_commitizen.py
@@ -11,6 +11,13 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+# Repo tooling checks: these spawn `uv run cz` subprocesses, the fast suite's
+# main source of contention flakes, so they run in the meta lane instead.
+# Unlike most of the lane they are NOT redundant with the lint job: the
+# commitizen hook is `stages: [commit-msg]`, which `pre-commit run --all-files`
+# never invokes, so the meta lane is the only place this is checked.
+pytestmark = pytest.mark.meta
+
 # Root of the repository - resolve once, use everywhere.
 # This avoids dependence on the working directory at test time.
 _REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tests/test_doc_sync.py
+++ b/tests/test_doc_sync.py
@@ -8,6 +8,11 @@ from pathlib import Path
 
 import pytest
 
+# Repo tooling checks: these exercise the doc_sync script that the CI lint job
+# already runs via pre-commit, several of them through subprocesses, so they
+# live in the meta lane instead of the fast suite.
+pytestmark = pytest.mark.meta
+
 # Project root for import resolution
 PROJECT_ROOT = Path(__file__).parent.parent
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "doc_sync.py"

--- a/tests/test_mutmut.py
+++ b/tests/test_mutmut.py
@@ -102,11 +102,13 @@ class TestMutmutConfig:
         mutmut 3 runs pytest in-process and ignores a `runner` string, so the
         marker filter must live in pytest_add_cli_args. Without it, every
         mutant would run slow/network tests (nondeterministic and far too
-        slow).
+        slow) and the meta lane, whose `uv run ...` subprocesses would
+        resolve the mutated package from mutmut's mutants/ cwd.
         """
         args = mutmut_config.get("pytest_add_cli_args", [])
-        assert "not slow and not network" in args, (
-            "mutmut pytest_add_cli_args must filter to fast tests"
+        assert "not slow and not network and not meta" in args, (
+            "mutmut pytest_add_cli_args must filter to the fast suite: the same "
+            "selection CI runs, minus the meta lane"
         )
         assert "--no-cov" in args, (
             "mutmut pytest_add_cli_args must disable coverage (per-mutant "

--- a/tests/test_mutmut.py
+++ b/tests/test_mutmut.py
@@ -13,6 +13,12 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+# Repo tooling checks: mutation-testing and nightly-workflow configuration, not
+# library behaviour. Runs in the meta lane, not the fast suite. mutmut has no
+# pre-commit hook, so unlike most of the lane this is not duplicated by the
+# lint job -- the meta lane is the only place it is checked.
+pytestmark = pytest.mark.meta
+
 PROJECT_ROOT = Path(__file__).parent.parent
 
 

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -12,6 +12,11 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
 
+# Repo tooling checks: these shell out to mypy and duplicate the CI lint job,
+# so they run in the meta lane instead of the fast suite. The full package
+# type-check keeps its own `slow` mark on top of this.
+pytestmark = pytest.mark.meta
+
 # Timeout in seconds for subprocess calls
 _SUBPROCESS_TIMEOUT = 120
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,6 +3,8 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -28,8 +30,15 @@ def _load_pyproject() -> dict:
         return tomllib.load(f)
 
 
+@pytest.mark.meta
 class TestSecurityToolAvailability:
-    """Verify that security tools are installed and runnable."""
+    """Verify that security tools are installed and runnable.
+
+    Tooling checks only: they spawn `uv run` subprocesses and are covered for
+    real by the dedicated `security` job, which actually runs bandit and
+    pip-audit. Marked `meta` so they stay out of the fast suite. The bandit
+    configuration tests below are plain pyproject.toml parsing and stay fast.
+    """
 
     def test_bandit_command_exists(self):
         """Verify bandit is installed and reports its version."""

--- a/tests/test_validate_claude_md.py
+++ b/tests/test_validate_claude_md.py
@@ -15,12 +15,22 @@ import pytest
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Repo tooling checks: this suite validates a maintenance script rather than
+# library behaviour, so it runs in the meta lane instead of the fast suite.
+pytestmark = pytest.mark.meta
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT_PATH = PROJECT_ROOT / "scripts" / "validate_claude_md.py"
 
 
 def _run_validator(*extra_args: str) -> subprocess.CompletedProcess:
-    """Run the validation script and return the CompletedProcess."""
+    """Run the validation script as a subprocess and return the CompletedProcess.
+
+    Only the happy path and one end-to-end failure still go through a
+    subprocess -- enough to prove the script is executable and wires argv,
+    stdout and exit codes together. Every other case calls ``main()`` in
+    process, which is the same code path without the ~1s `uv run` spawn.
+    """
     return subprocess.run(
         ["uv", "run", "python", str(SCRIPT_PATH), *extra_args],
         capture_output=True,
@@ -35,7 +45,12 @@ def _run_validator(*extra_args: str) -> subprocess.CompletedProcess:
 
 
 class TestValidateClaudeMdIntegration:
-    """Integration tests that run the full validation script."""
+    """End-to-end tests that run the full validation flow.
+
+    Two of these spawn the script as a subprocess (happy path and one
+    detected-error path); the rest drive the same ``main()`` entry point
+    in process to avoid a `uv run` spawn per test.
+    """
 
     def test_script_exists(self):
         """Verify validation script exists."""
@@ -49,8 +64,10 @@ class TestValidateClaudeMdIntegration:
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_script_accepts_custom_path(self, tmp_path):
-        """Verify script accepts a custom CLAUDE.md path via --claude-md."""
+    def test_script_accepts_custom_path(self, tmp_path, capsys):
+        """Verify the validator accepts a custom CLAUDE.md path via --claude-md."""
+        from scripts.validate_claude_md import main
+
         fake = tmp_path / "CLAUDE.md"
         fake.write_text(
             "## Project Overview\n"
@@ -58,30 +75,32 @@ class TestValidateClaudeMdIntegration:
             "## Testing with uv\n"
             "## Git Workflow\n"
         )
-        result = _run_validator("--claude-md", str(fake))
-        # Should at least not crash with exit code 2
-        assert result.returncode in (0, 1)
+        rc = main(["--claude-md", str(fake)])
+        out = capsys.readouterr().out
+        # Exit code 2 means "CLAUDE.md not found", so anything else proves the
+        # custom path was located and read.
+        assert rc in (0, 1), f"custom --claude-md path was not read:\n{out}"
 
-    def test_script_accepts_project_root(self, tmp_path):
-        """Verify script accepts --project-root argument."""
+    def test_script_accepts_project_root(self, tmp_path, capsys):
+        """Verify the validator accepts a --project-root argument."""
+        from scripts.validate_claude_md import main
+
         fake_root = tmp_path / "project"
         fake_root.mkdir()
         claude = fake_root / "CLAUDE.md"
         claude.write_text("## Project Overview\n## Architecture\n## Testing\n## Git Workflow\n")
-        result = _run_validator(
-            "--claude-md",
-            str(claude),
-            "--project-root",
-            str(fake_root),
-        )
-        # Should not crash with exit code 2
-        assert result.returncode in (0, 1)
+        rc = main(["--claude-md", str(claude), "--project-root", str(fake_root)])
+        out = capsys.readouterr().out
+        assert rc in (0, 1), f"--project-root was not accepted:\n{out}"
 
-    def test_missing_claude_md(self, tmp_path):
-        """Script returns exit code 2 when CLAUDE.md is missing."""
+    def test_missing_claude_md(self, tmp_path, capsys):
+        """Validator returns exit code 2 when CLAUDE.md is missing."""
+        from scripts.validate_claude_md import main
+
         missing = tmp_path / "nonexistent.md"
-        result = _run_validator("--claude-md", str(missing))
-        assert result.returncode == 2
+        rc = main(["--claude-md", str(missing)])
+        assert rc == 2
+        assert "not found" in capsys.readouterr().out
 
     def test_catches_invalid_command(self, tmp_path):
         """Detects references to non-existent CLI commands."""
@@ -97,8 +116,10 @@ class TestValidateClaudeMdIntegration:
         assert result.returncode == 1
         assert "nonexistent-command" in result.stdout
 
-    def test_catches_invalid_path(self, tmp_path):
+    def test_catches_invalid_path(self, tmp_path, capsys):
         """Detects references to non-existent file paths."""
+        from scripts.validate_claude_md import main
+
         fake = tmp_path / "CLAUDE.md"
         fake.write_text(
             "## Project Overview\n"
@@ -107,12 +128,14 @@ class TestValidateClaudeMdIntegration:
             "## Git Workflow\n"
             "\nCheck `geoparquet_io/core/does_not_exist.py` for details.\n"
         )
-        result = _run_validator("--claude-md", str(fake))
-        assert result.returncode == 1
-        assert "does_not_exist" in result.stdout
+        rc = main(["--claude-md", str(fake)])
+        assert rc == 1
+        assert "does_not_exist" in capsys.readouterr().out
 
-    def test_catches_invalid_marker(self, tmp_path):
+    def test_catches_invalid_marker(self, tmp_path, capsys):
         """Detects references to undefined pytest markers."""
+        from scripts.validate_claude_md import main
+
         fake = tmp_path / "CLAUDE.md"
         fake.write_text(
             "## Project Overview\n"
@@ -121,9 +144,9 @@ class TestValidateClaudeMdIntegration:
             "## Git Workflow\n"
             "\nUse `@pytest.mark.nonexistent` for special tests.\n"
         )
-        result = _run_validator("--claude-md", str(fake))
-        assert result.returncode == 1
-        assert "nonexistent" in result.stdout
+        rc = main(["--claude-md", str(fake)])
+        assert rc == 1
+        assert "nonexistent" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements item 3 of #665: move repo-tooling tests out of the fast suite into a `meta` lane that runs in the slow/nightly job.

## What moved

`test_codespell`, `test_commitizen`, `test_doc_sync`, `test_mutmut`, `test_mypy`, `test_validate_claude_md` and the tool-existence checks in `test_security` now carry `@pytest.mark.meta`. These checks spawn `uv run` subprocesses, duplicate what the CI lint and security jobs already run via pre-commit, occupied the entire top of the parallel durations table via subprocess storms, and were the fast suite's only source of contention flakes.

**156 tests leave the fast suite:**

```
-m "not slow and not network"                 3999/4271 collected
-m "not slow and not network and not meta"    3843/4271 collected
```

Nothing stops being checked in CI — the slow/nightly job picks them up:

```
-m "slow and not network"         110 collected
-m "(slow or meta) and not network"   264 collected
```

Full fast suite green: **3803 passed, 40 skipped in 101s** (`-n 4`). `uv run pytest -m meta -n 2` → **157 passed** (157 vs 156 reconciles: `test_mypy_passes_on_package` is slow+meta, so it was never in the fast selection).

Marker registered in `pyproject.toml` as `meta: repo tooling checks, excluded from the fast suite` (`--strict-markers` is on). All seven `-m` invocations across `.github/workflows/*.yml` updated consistently, plus the opt-in `fast-tests` pre-push hook in `.pre-commit-config.yaml`, `CLAUDE.md`, and `docs/contributing.md`. Marker tables in the generated doc blocks were regenerated via `scripts/doc_sync.py`. ADR 0005 deliberately keeps the old expression as a point-in-time record.

Only `TestSecurityToolAvailability` is marked in `test_security.py` — the bandit-config and dev-dependency tests there are plain `pyproject.toml` parsing and stay in the fast suite.

## `test_validate_claude_md.py` subprocess trim

Cut from **7 `uv run` spawns to 2**, keeping the happy path and one end-to-end detected-error path as real subprocesses (enough to prove the script is executable and wires argv → stdout → exit code together). The other five call the validator's `main()` in process.

**70 tests before, 70 after** — no tests deleted. 1.35s → 0.61s warm-serial; the saving is larger under CI parallelism, where these spawns inflate badly under worker contention.

Three of the converted tests would have become near-duplicates of the existing `TestMainFunction` cases, which assert return codes only, so they got `capsys` assertions on the printed output instead of becoming dead weight. Verified non-vacuous by sabotage: stubbing `validate_file_paths` to `return []` makes the converted in-process test fail with `assert 0 == 1` and captured stdout showing `CLAUDE.md validation passed!`; reverted after.

## Callouts

**(a) ~~The two security tool-existence tests now run in no pytest lane.~~ Fixed in review.** The slow job's `--ignore=tests/test_security.py` was dropped. That ignore guarded against a duplicated live pip-audit that has since been deleted from the file, and with the lane in place it was actively harmful: the two `meta`-marked tool-availability tests were out of the fast selection *and* ignored out of the slow one. The marker selection already deselects the other seven tests in that file, verified by collection: `-m "(slow or meta) and not network"` on `tests/test_security.py` collects exactly `test_bandit_command_exists` and `test_pip_audit_command_exists`, 2/9. This is what makes the changelog's "nothing stops being checked in CI" true rather than aspirational.

**(b) ~~Merge order with #677.~~ Resolved.** #677 merged first and this branch is rebased onto it. The conflicts were the predicted ones and were resolved in favour of #677's `$COV_ARGS` indirection with this PR's marker selections layered on — not keep-both, which would have shipped the superseded literal `--cov` flags. Verified after the rebase: `uv run pytest -m meta` exits 0 with 157 passed, which is only true because #677 took `--cov` out of `addopts`.

**(c) ~~Follow-up: mutmut still runs the meta subprocess tests per mutant.~~ Fixed in review.** `pytest_add_cli_args` now selects `"not slow and not network and not meta"`, and `test_mutmut.py::test_mutmut_excludes_slow_and_network_tests` is updated to pin the new string. The marker replaces the per-file `--ignore` list those tests needed; `tests/test_import_linter.py` keeps its ignore, because it shells out the same way but is a fast unit test of the contract config and is deliberately not in the lane.

Contributors who skip pre-commit lose this local signal (the trade-off #665 flagged for confirmation); `uv run pytest -m meta` is documented in both `CLAUDE.md` and `docs/contributing.md`.

One claim in the original description did not survive review and has been narrowed everywhere it appeared: the lane does **not** uniformly "duplicate what the CI lint job already runs via pre-commit". That holds for codespell, doc-sync, mypy and validate-claude-md, and the bandit/pip-audit availability checks are subsumed by the `security` job — but the commitizen hook is `stages: [commit-msg]`, which `pre-commit run --all-files` never invokes, and mutmut has no hook at all. For those two the meta lane is the only check there is, which is why it runs in CI rather than being deleted.

Refs #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx

