### PR TITLE
fix(add): quote quadkey column identifiers in the file-based path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,16 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   already produced. Measured over the file's fast lane: 12 outbound connection
   attempts and 24 `time.sleep` calls totalling 36.00s of retry backoff both drop
   to zero, and serial runtime goes from 43.4s to 6.3s.
+
+- **`gpio add quadkey --quadkey-name` now accepts any column name Parquet
+  accepts.** The file-based code path interpolated the output column name and
+  the bbox column name into its SQL raw, so `--quadkey-name 'weird name'`
+  died with `Parser Error: syntax error at or near "name"` and a name
+  containing a double quote died with `unterminated quoted identifier`. Both
+  names now go through `quote_identifier()`, matching the streaming and
+  Arrow-table paths in the same module, which already quoted them. Computed
+  quadkey values are unchanged for ordinary column names.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -370,6 +370,16 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   already produced. Measured over the file's fast lane: 12 outbound connection
   attempts and 24 `time.sleep` calls totalling 36.00s of retry backoff both drop
   to zero, and serial runtime goes from 43.4s to 6.3s.
+
+- **`gpio add quadkey --quadkey-name` now accepts any column name Parquet
+  accepts.** The file-based code path interpolated the output column name and
+  the bbox column name into its SQL raw, so `--quadkey-name 'weird name'`
+  died with `Parser Error: syntax error at or near "name"` and a name
+  containing a double quote died with `unterminated quoted identifier`. Both
+  names now go through `quote_identifier()`, matching the streaming and
+  Arrow-table paths in the same module, which already quoted them. Computed
+  quadkey values are unchanged for ordinary column names.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -627,8 +627,9 @@ def _add_quadkey_file_based(
 
         # Build the SQL expression based on calculation method
         if use_bbox:
-            lat_expr = f"(({bbox_col}.ymin + {bbox_col}.ymax) / 2.0)"
-            lon_expr = f"(({bbox_col}.xmin + {bbox_col}.xmax) / 2.0)"
+            quoted_bbox = quote_identifier(bbox_col)
+            lat_expr = f"(({quoted_bbox}.ymin + {quoted_bbox}.ymax) / 2.0)"
+            lon_expr = f"(({quoted_bbox}.xmin + {quoted_bbox}.xmax) / 2.0)"
         else:
             geom_ref = transform_geom_sql(quote_identifier(geom_col), source_crs)
             lat_expr = f"ST_Y(ST_Centroid({geom_ref}))"
@@ -637,7 +638,7 @@ def _add_quadkey_file_based(
         # Build SELECT query with new column
         query = f"""
             SELECT *,
-                   lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quadkey_column_name}
+                   lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quote_identifier(quadkey_column_name)}
             FROM '{input_url}'
         """
 

--- a/tests/test_add_quadkey.py
+++ b/tests/test_add_quadkey.py
@@ -170,8 +170,8 @@ class TestQuadkeyColumnNameQuoting:
 
         from geoparquet_io.core.add.quadkey import add_quadkey_column
 
-        default_out = tmp_path / f"centroid_default_{abs(hash(name))}.parquet"
-        hostile_out = tmp_path / f"centroid_hostile_{abs(hash(name))}.parquet"
+        default_out = tmp_path / "centroid_default.parquet"
+        hostile_out = tmp_path / "centroid_hostile.parquet"
         add_quadkey_column(places_file, str(default_out), resolution=13, use_centroid=True)
         add_quadkey_column(
             places_file,
@@ -216,8 +216,15 @@ class TestQuadkeyColumnNameQuoting:
         assert table[name].to_pylist() == _expected_bbox_quadkeys(pq.read_table(places_file), 13)
 
     @pytest.mark.parametrize("name", ["weird name", 'has"quote'])
-    def test_geo_metadata_survives_hostile_name(self, places_file, tmp_path, name):
-        """Writing a hostile-named quadkey column must not corrupt geo metadata."""
+    def test_geo_metadata_primary_column_survives_hostile_name(self, places_file, tmp_path, name):
+        """Writing a hostile-named quadkey column must not corrupt geo metadata.
+
+        This deliberately does NOT assert that the quadkey `covering` entry
+        survives: on inputs that carry a bbox column the quadkey/h3/s2/a5
+        covering is dropped before the file is written, for every column name
+        including the default. That is a separate pre-existing bug (see issue
+        #694); pin covering survival there once it is fixed.
+        """
         import json
 
         import pyarrow.parquet as pq

--- a/tests/test_add_quadkey.py
+++ b/tests/test_add_quadkey.py
@@ -103,3 +103,175 @@ class TestAddQuadkeyCommand:
         )
         # Should fail - resolution out of range
         assert result.exit_code != 0
+
+
+# Column names that are legal in Parquet but are not bare SQL identifiers.
+# 'weird name' broke the file-based path with a parser error; 'has"quote'
+# broke it with an unterminated-quoted-identifier error (issue #680).
+HOSTILE_QUADKEY_NAMES = ["weird name", 'has"quote', "quad-key", "SELECT"]
+
+
+def _expected_bbox_quadkeys(table, resolution):
+    """Golden quadkeys computed in Python from the bbox struct midpoints."""
+    return [
+        _lat_lon_to_quadkey(
+            (b["ymin"] + b["ymax"]) / 2.0,
+            (b["xmin"] + b["xmax"]) / 2.0,
+            resolution,
+        )
+        for b in table["bbox"].to_pylist()
+    ]
+
+
+class TestQuadkeyColumnNameQuoting:
+    """Regression tests for issue #680: non-identifier --quadkey-name values."""
+
+    @pytest.fixture
+    def places_file(self):
+        """Points fixture that carries a 'bbox' struct column."""
+        return str(Path(__file__).parent / "data" / "places_test.parquet")
+
+    def test_bbox_path_golden_values_with_default_name(self, places_file, tmp_path):
+        """Pin the golden quadkey values the bbox fast path must produce."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.add.quadkey import add_quadkey_column
+
+        out = tmp_path / "default.parquet"
+        add_quadkey_column(places_file, str(out), resolution=13)
+        result = pq.read_table(str(out))
+        source = pq.read_table(places_file)
+
+        assert result["quadkey"].to_pylist() == _expected_bbox_quadkeys(source, 13)
+        # Row 0 is POINT (-0.9247532486915588 9.85634708404541); the literal below
+        # was derived from the Slippy-tile formula independently of this module.
+        assert result["quadkey"][0].as_py() == "0333311123230"
+
+    @pytest.mark.parametrize("name", HOSTILE_QUADKEY_NAMES)
+    def test_file_based_bbox_path_hostile_name(self, places_file, tmp_path, name):
+        """File-based bbox path: hostile names keep the correct quadkey values."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.add.quadkey import add_quadkey_column
+
+        out = tmp_path / "hostile.parquet"
+        add_quadkey_column(places_file, str(out), quadkey_column_name=name, resolution=13)
+
+        result = pq.read_table(str(out))
+        assert name in result.column_names
+        source = pq.read_table(places_file)
+        assert result[name].to_pylist() == _expected_bbox_quadkeys(source, 13)
+        assert result.num_rows == source.num_rows
+
+    @pytest.mark.parametrize("name", ["weird name", 'has"quote'])
+    def test_file_based_centroid_path_hostile_name(self, places_file, tmp_path, name):
+        """File-based centroid path: hostile names keep the correct quadkey values."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.add.quadkey import add_quadkey_column
+
+        default_out = tmp_path / f"centroid_default_{abs(hash(name))}.parquet"
+        hostile_out = tmp_path / f"centroid_hostile_{abs(hash(name))}.parquet"
+        add_quadkey_column(places_file, str(default_out), resolution=13, use_centroid=True)
+        add_quadkey_column(
+            places_file,
+            str(hostile_out),
+            quadkey_column_name=name,
+            resolution=13,
+            use_centroid=True,
+        )
+
+        expected = pq.read_table(str(default_out))["quadkey"].to_pylist()
+        actual = pq.read_table(str(hostile_out))[name].to_pylist()
+        # Points: centroid keying must agree with bbox-midpoint keying.
+        assert expected == _expected_bbox_quadkeys(pq.read_table(places_file), 13)
+        assert actual == expected
+
+    @pytest.mark.parametrize("name", ["weird name", 'has"quote'])
+    def test_cli_hostile_name_end_to_end(self, places_file, tmp_path, name):
+        """CLI e2e: --quadkey-name accepts hostile names and writes correct values."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.cli.main import cli
+
+        out = tmp_path / "cli.parquet"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "quadkey",
+                places_file,
+                str(out),
+                "--resolution",
+                "13",
+                "--quadkey-name",
+                name,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        table = pq.read_table(str(out))
+        assert name in table.column_names
+        assert table[name].to_pylist() == _expected_bbox_quadkeys(pq.read_table(places_file), 13)
+
+    @pytest.mark.parametrize("name", ["weird name", 'has"quote'])
+    def test_geo_metadata_survives_hostile_name(self, places_file, tmp_path, name):
+        """Writing a hostile-named quadkey column must not corrupt geo metadata."""
+        import json
+
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.add.quadkey import add_quadkey_column
+
+        out = tmp_path / "meta.parquet"
+        add_quadkey_column(places_file, str(out), quadkey_column_name=name, resolution=13)
+
+        meta = pq.ParquetFile(str(out)).metadata.metadata or {}
+        geo = json.loads(meta[b"geo"].decode())
+        assert geo["primary_column"] == "geometry"
+        assert "geometry" in geo["columns"]
+
+    @pytest.mark.parametrize("name", ["weird name", 'has"quote'])
+    def test_table_path_hostile_name(self, places_file, name):
+        """Sibling table path already quotes — pin it against regressions."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.add.quadkey import add_quadkey_table
+
+        source = pq.read_table(places_file)
+        result = add_quadkey_table(source, quadkey_column_name=name, resolution=13)
+
+        assert name in result.column_names
+        assert result[name].to_pylist() == _expected_bbox_quadkeys(source, 13)
+
+    @pytest.mark.parametrize("name", ["weird name", 'has"quote'])
+    def test_streaming_path_hostile_name(self, places_file, tmp_path, monkeypatch, name):
+        """Sibling streaming path already quotes — pin it against regressions."""
+        import io
+        import sys
+        from unittest import mock
+
+        import pyarrow.ipc as ipc
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.add.quadkey import add_quadkey_column
+
+        source = pq.read_table(places_file)
+        ipc_buffer = io.BytesIO()
+        writer = ipc.RecordBatchStreamWriter(ipc_buffer, source.schema)
+        writer.write_table(source)
+        writer.close()
+        ipc_buffer.seek(0)
+
+        mock_stdin = mock.MagicMock()
+        mock_stdin.isatty.return_value = False
+        mock_stdin.buffer = ipc_buffer
+        monkeypatch.setattr(sys, "stdin", mock_stdin)
+
+        out = tmp_path / "streamed.parquet"
+        add_quadkey_column("-", str(out), quadkey_column_name=name, resolution=13)
+
+        result = pq.read_table(str(out))
+        assert name in result.column_names
+        assert result[name].to_pylist() == _expected_bbox_quadkeys(source, 13)


### PR DESCRIPTION
## The bug

`gpio add quadkey` failed on any `--quadkey-name` value that is not a bare SQL identifier, even though Parquet accepts such names happily.

```bash
gpio add quadkey input.parquet output.parquet --quadkey-name 'weird name'
# ParserException: Parser Error: syntax error at or near "name"

gpio add quadkey input.parquet output.parquet --quadkey-name 'has"quote'
# ParserException: Parser Error: unterminated quoted identifier at or near ""quote
```

`_add_quadkey_file_based` built its SQL with raw string interpolation:

- `AS {quadkey_column_name}` — the output column name, straight from `--quadkey-name`
- `(({bbox_col}.ymin + {bbox_col}.ymax) / 2.0)` — the bbox column name

Both sub-paths of the file-based writer were affected, because the broken `AS` clause is shared: the bbox fast path and the centroid path each produced the parser error above.

The streaming path (`_add_quadkey_streaming`) and the Arrow-table path (`add_quadkey_table`) in the same module already routed both names through `quote_identifier()`. Only the file-based path had been missed.

## The fix

Route both identifiers through `quote_identifier()` from `core/duckdb_utils.py`, passing the raw value so it is escaped exactly once — matching the three sibling call sites.

```python
quoted_bbox = quote_identifier(bbox_col)
lat_expr = f"(({quoted_bbox}.ymin + {quoted_bbox}.ymax) / 2.0)"
lon_expr = f"(({quoted_bbox}.xmin + {quoted_bbox}.xmax) / 2.0)"
...
lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quote_identifier(quadkey_column_name)}
```

Per the issue, `bbox_col` currently comes from a fixed candidate list (`bbox`, `bounds`, `bounding_box`) and so cannot carry a hostile value today. It is quoted anyway, to keep the call sites uniform and the fix from being half-applied.

### Whole-file audit

I audited every SQL interpolation in `core/add/quadkey.py`, not just the two lines named in the issue:

- `add_quadkey_table` (lines 264-306) and `_add_quadkey_streaming` (lines 472-486): already fully quoted, verified and unchanged.
- All remaining raw interpolations in the module are `debug`/`info`/error message strings, not SQL.
- `source` / `source_ref` are internal literals (`__input_table`, `__input_view`) supplied by the module itself, not user data.
- `FROM '{input_url}'` is a string literal rather than an identifier, and is not run through `_escape_sql_string()`. This is the codebase-wide pattern for `safe_file_url()` output (identical shape in `add/admin_divisions.py` and siblings), so I left it rather than diverging in a single module. A path containing a single quote would break here and in the peer modules alike — worth a separate cross-cutting issue if we want to close it.

## Tests

New `TestQuadkeyColumnNameQuoting` in `tests/test_add_quadkey.py`, hostile names parametrized over `"weird name"`, `'has"quote'`, `"quad-key"`, and `"SELECT"`. Every test asserts **correct quadkey values**, not merely the absence of a crash — a helper recomputes the entire expected column in Python from the fixture's bbox midpoints, so a lat/lon swap or a wrong bbox field would fail the test even though no exception is raised.

Coverage across all three code paths:

| Path | Test | State before fix |
|---|---|---|
| File-based, bbox fast path | `test_file_based_bbox_path_hostile_name` | red |
| File-based, centroid path | `test_file_based_centroid_path_hostile_name` | red |
| File-based, CLI end to end | `test_cli_hostile_name_end_to_end` | red |
| Arrow table | `test_table_path_hostile_name` | green (pins existing behavior) |
| Streaming (stdin IPC) | `test_streaming_path_hostile_name` | green (pins existing behavior) |

**No value drift for ordinary names.** `test_bbox_path_golden_values_with_default_name` pins the default-name output, including the hardcoded literal `"0333311123230"` for row 0. That literal was derived from an independent Slippy-tile/quadkey implementation written from the formula, not read back from this module's UDF — my first hand-typed guess was wrong and the test caught it, so it is a genuine external golden guarding the computed values.

Red before the fix: 9 failed, 6 passed, with the failures reproducing the issue's `ParserException` verbatim on both file-based sub-paths. Green after: 25 passed. Full fast suite: 3974 passed, 40 skipped, coverage 78.48%.

## Related finding

While reviewing this fix I found a separate, pre-existing bug and filed it as #694: the spatial-index `covering` metadata for quadkey, h3, s2, and a5 is dropped whenever the output file has a bbox column. `_add_bbox_covering_if_present` assigns the whole `covering` key after `build_geo_metadata` has already merged the custom entry, clobbering it.

It is unrelated to this PR — it reproduces with default column names and predates the quoting fix — so it is deliberately not fixed here. `test_geo_metadata_primary_column_survives_hostile_name` documents in its docstring why it stops short of asserting covering survival, and points at #694.

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `gpio add quadkey --quadkey-name` for column names containing spaces, quotes, hyphens, or SQL keywords.
  * Preserved existing quadkey values, rows, and geospatial metadata across supported workflows.
  * Improved reliability for bounding-box- and centroid-based processing.

* **Tests**
  * Added regression coverage for unusual column names and validated CLI, table, streaming, and file-based workflows.
  * Added checks for default bounding-box-derived quadkey values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->