### PR TITLE
fix(wfs): surface failed feature-count probes instead of swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,7 +415,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   log a warning naming the cause and the consequence; programming errors are no
   longer swallowed and surface as the bugs they are. The "count unavailable"
   return contract is unchanged, so extraction still degrades rather than
-  aborting.
+  aborting. The speculative WFS 2.0.0 count attempt — which falls back to the
+  negotiated version by construction — stays quiet, so a 1.1.0-only server
+  rejecting it does not warn on an otherwise healthy extraction.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,6 +419,13 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   negotiated version by construction — stays quiet, so a 1.1.0-only server
   rejecting it does not warn on an otherwise healthy extraction.
 
+  `_probe_startindex_limit`, the sibling probe that detects servers rejecting a
+  `startIndex` above some cap, swallowed failures the same way and now follows
+  the same contract. Its silent `None` meant "no cap known", which re-enables
+  unbounded pagination against a server that will reject or truncate the later
+  pages — the same silently-wrong-output failure mode reached by a different
+  route.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   encodings. A type string that does not carry geoarrow's names — the generic
   `list<element: ...>`, or the typeless group node `parquet_schema()` reports
   for remote files — is not evidence of a wrong encoding and is not failed on.
+
+- **`gpio extract wfs` no longer hides a failed feature-count probe.** The
+  `resultType=hits` probe that drives auto-tiling wrapped its whole body in a
+  bare `except Exception: pass`, so any server hiccup, unreachable host, or bug
+  inside the probe returned "no count" indistinguishably from a server that
+  genuinely does not report one — silently disabling auto-tiling and
+  pagination, the exact path that yields a **silently truncated** table plus a
+  success message. Expected failures (`WFSError`, transport, and OS errors) now
+  log a warning naming the cause and the consequence; programming errors are no
+  longer swallowed and surface as the bugs they are. The "count unavailable"
+  return contract is unchanged, so extraction still degrades rather than
+  aborting.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -415,7 +415,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   log a warning naming the cause and the consequence; programming errors are no
   longer swallowed and surface as the bugs they are. The "count unavailable"
   return contract is unchanged, so extraction still degrades rather than
-  aborting.
+  aborting. The speculative WFS 2.0.0 count attempt — which falls back to the
+  negotiated version by construction — stays quiet, so a 1.1.0-only server
+  rejecting it does not warn on an otherwise healthy extraction.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -419,6 +419,13 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   negotiated version by construction — stays quiet, so a 1.1.0-only server
   rejecting it does not warn on an otherwise healthy extraction.
 
+  `_probe_startindex_limit`, the sibling probe that detects servers rejecting a
+  `startIndex` above some cap, swallowed failures the same way and now follows
+  the same contract. Its silent `None` meant "no cap known", which re-enables
+  unbounded pagination against a server that will reject or truncate the later
+  pages — the same silently-wrong-output failure mode reached by a different
+  route.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -404,6 +404,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   encodings. A type string that does not carry geoarrow's names — the generic
   `list<element: ...>`, or the typeless group node `parquet_schema()` reports
   for remote files — is not evidence of a wrong encoding and is not failed on.
+
+- **`gpio extract wfs` no longer hides a failed feature-count probe.** The
+  `resultType=hits` probe that drives auto-tiling wrapped its whole body in a
+  bare `except Exception: pass`, so any server hiccup, unreachable host, or bug
+  inside the probe returned "no count" indistinguishably from a server that
+  genuinely does not report one — silently disabling auto-tiling and
+  pagination, the exact path that yields a **silently truncated** table plus a
+  success message. Expected failures (`WFSError`, transport, and OS errors) now
+  log a warning naming the cause and the consequence; programming errors are no
+  longer swallowed and surface as the bugs they are. The "count unavailable"
+  return contract is unchanged, so extraction still degrades rather than
+  aborting.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -55,6 +55,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
 )
+from geoparquet_io.core.exceptions import RemoteAccessError
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.http_retry import (
     get_shared_http_client as _get_shared_http_client_base,
@@ -1188,10 +1189,14 @@ def _get_feature_count(
         axis_order: Bbox axis order ("auto", "xy", "latlon")
 
     Returns:
-        Feature count or None if not supported
+        Feature count, or None if the server does not report one *or* the probe
+        failed. A failed probe is logged as a warning (see below) so the
+        resulting loss of auto-tiling / pagination is visible in the logs.
     """
     if version == "1.0.0":
         return None  # resultType=hits not supported in WFS 1.0.0
+
+    import httpx
 
     clean_url = _clean_service_url(service_url)
     params = {
@@ -1207,22 +1212,32 @@ def _get_feature_count(
 
     try:
         content = _make_request(clean_url, params=params)
+    except (WFSError, RemoteAccessError, httpx.HTTPError, OSError) as e:
+        # Expected failure modes: the service is down, unreachable, rejecting us,
+        # or timing out. Degrade to "count unknown" rather than aborting the
+        # extraction, but say so — a silent None disables auto-tiling and
+        # pagination, which is how servers return silently truncated results
+        # (issue #678). Programming errors are not caught: they must surface.
+        warn(
+            f"Feature count probe (resultType=hits) failed for '{typename}' "
+            f"at WFS {version}: {type(e).__name__}: {e}. Continuing without a "
+            "server feature count — auto-tiling and pagination cannot engage, "
+            "so results from a server that caps responses may be incomplete."
+        )
+        return None
 
-        # Parse XML response to find numberOfFeatures
-        import re
+    # Parse XML response to find numberOfFeatures
+    match = re.search(rb'numberOfFeatures="(\d+)"', content)
+    if match:
+        return int(match.group(1))
 
-        match = re.search(rb'numberOfFeatures="(\d+)"', content)
-        if match:
-            return int(match.group(1))
+    # Try alternative attribute name
+    match = re.search(rb'numberMatched="(\d+)"', content)
+    if match:
+        return int(match.group(1))
 
-        # Try alternative attribute name
-        match = re.search(rb'numberMatched="(\d+)"', content)
-        if match:
-            return int(match.group(1))
-
-    except Exception:
-        pass
-
+    # Server answered but reported no count — a normal outcome, not a failure.
+    debug(f"WFS {version} hits response for '{typename}' carried no feature count")
     return None
 
 

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -55,7 +55,6 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
 )
-from geoparquet_io.core.exceptions import RemoteAccessError
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.http_retry import (
     get_shared_http_client as _get_shared_http_client_base,
@@ -1174,6 +1173,7 @@ def _get_feature_count(
     bbox: tuple[float, float, float, float] | None = None,
     crs: str | None = None,
     axis_order: str = "auto",
+    warn_on_failure: bool = True,
 ) -> int | None:
     """
     Try to get feature count using resultType=hits.
@@ -1187,11 +1187,16 @@ def _get_feature_count(
         bbox: Optional bounding box filter (xmin, ymin, xmax, ymax)
         crs: CRS for bbox parameter
         axis_order: Bbox axis order ("auto", "xy", "latlon")
+        warn_on_failure: Log a warning when the probe fails. Pass False for
+            speculative probes that have a fallback by construction (see the
+            2.0.0-then-negotiated-version probe in ``wfs_to_table``), where a
+            failure is an expected answer rather than a loss of capability.
 
     Returns:
         Feature count, or None if the server does not report one *or* the probe
-        failed. A failed probe is logged as a warning (see below) so the
-        resulting loss of auto-tiling / pagination is visible in the logs.
+        failed. A failed probe is logged as a warning (unless suppressed via
+        ``warn_on_failure``) so the resulting loss of auto-tiling / pagination
+        is visible in the logs.
     """
     if version == "1.0.0":
         return None  # resultType=hits not supported in WFS 1.0.0
@@ -1212,15 +1217,22 @@ def _get_feature_count(
 
     try:
         content = _make_request(clean_url, params=params)
-    except (WFSError, RemoteAccessError, httpx.HTTPError, OSError) as e:
+    except (WFSError, httpx.HTTPError, OSError) as e:
         # Expected failure modes: the service is down, unreachable, rejecting us,
         # or timing out. Degrade to "count unknown" rather than aborting the
         # extraction, but say so — a silent None disables auto-tiling and
         # pagination, which is how servers return silently truncated results
         # (issue #678). Programming errors are not caught: they must surface.
+        detail = f"{type(e).__name__}: {e}"
+        if not warn_on_failure:
+            debug(
+                f"Speculative feature count probe failed for '{typename}' "
+                f"at WFS {version}: {detail}"
+            )
+            return None
         warn(
             f"Feature count probe (resultType=hits) failed for '{typename}' "
-            f"at WFS {version}: {type(e).__name__}: {e}. Continuing without a "
+            f"at WFS {version}: {detail}. Continuing without a "
             "server feature count — auto-tiling and pagination cannot engage, "
             "so results from a server that caps responses may be incomplete."
         )
@@ -2429,8 +2441,14 @@ def wfs_to_table(
     # Try WFS 2.0.0 first for count query since it often has higher/no limits
     expected_count = None
     if auto_tile and version != "1.0.0":
-        # Try WFS 2.0.0 count first (higher limits), fall back to requested version
-        expected_count = _get_feature_count(service_url, layer_info.typename, "2.0.0")
+        # Try WFS 2.0.0 count first (higher limits), fall back to requested
+        # version. The 2.0.0 attempt is speculative — a 1.1.0-only server
+        # rejecting it is an expected answer, not a degradation, so it stays
+        # quiet; the fallback below is the probe whose failure actually costs
+        # us auto-tiling, and it warns.
+        expected_count = _get_feature_count(
+            service_url, layer_info.typename, "2.0.0", warn_on_failure=False
+        )
         if not expected_count:
             expected_count = _get_feature_count(service_url, layer_info.typename, version)
         if expected_count:

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1898,7 +1898,11 @@ def _probe_startindex_limit(
     threshold (e.g., 50,000). This sends a lightweight probe request
     to detect that limit before attempting full pagination.
 
-    Returns the limit value if detected, or None if no limit found.
+    Returns the limit value if detected, or None if no limit found *or* the
+    probe failed. A failed probe is logged as a warning: a silent None here
+    means pagination proceeds past a cap the server would have rejected, which
+    is the same silently-truncated-results failure mode as a lost feature count
+    (issue #678).
     """
     import httpx
 
@@ -1930,7 +1934,16 @@ def _probe_startindex_limit(
                         pass
                 return 50000
         return None
-    except httpx.HTTPError:
+    except (WFSError, httpx.HTTPError, OSError) as e:
+        # Same contract as _get_feature_count: expected transport failures
+        # degrade to "no limit known" but say so, because that answer silently
+        # re-enables unbounded pagination. Programming errors still surface.
+        warn(
+            f"startIndex limit probe failed for '{typename}' at WFS {version}: "
+            f"{type(e).__name__}: {e}. Continuing without a known startIndex "
+            "cap — pagination past a server's limit may return truncated or "
+            "rejected pages."
+        )
         return None
 
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -3768,6 +3768,92 @@ class TestGetFeatureCountErrorVisibility:
 
         assert len(tiles) == 4
 
+    def test_warn_on_failure_false_stays_silent(self):
+        """Speculative callers can opt out of the warning but still get None."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs._make_request",
+                side_effect=WFSError("HTTP error 400: version not supported"),
+            ),
+            patch("geoparquet_io.core.wfs.warn") as mock_warn,
+        ):
+            result = _get_feature_count("http://mock/wfs", "layer", "2.0.0", warn_on_failure=False)
+
+        assert result is None
+        mock_warn.assert_not_called()
+
+
+def _mock_layer_info():
+    """Minimal layer info for driving wfs_to_table in tests."""
+    return MagicMock(
+        typename="layer",
+        title="Layer",
+        crs_list=["EPSG:4326"],
+        default_crs="EPSG:4326",
+        available_formats=["application/json"],
+        bbox=(3.0, 50.0, 7.0, 54.0),
+    )
+
+
+class TestSpeculativeCountProbeIsQuiet:
+    """wfs_to_table probes at 2.0.0 first and falls back to the negotiated
+    version by construction. A 1.1.0-only server rejecting the 2.0.0 probe is a
+    healthy extraction, not a degradation — it must not warn (#678 review)."""
+
+    def _run_wfs_to_table(self, fake_request, caplog):
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import wfs_to_table
+
+        mock_table = pa.table(
+            {
+                "geometry": pa.array([b"\x01"], type=pa.binary()),
+                "name": pa.array(["a"]),
+            }
+        )
+
+        with (
+            patch("geoparquet_io.core.wfs._make_request", side_effect=fake_request),
+            patch(
+                "geoparquet_io.core.wfs.negotiate_wfs_version", return_value=("1.1.0", MagicMock())
+            ),
+            patch("geoparquet_io.core.wfs.get_layer_info", return_value=_mock_layer_info()),
+            patch("geoparquet_io.core.wfs._probe_startindex_limit", return_value=None),
+            patch("geoparquet_io.core.wfs.fetch_all_features_duckdb", return_value=mock_table),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            wfs_to_table("http://mock/wfs", "layer", auto_tile=True)
+
+        return [
+            r.message
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and "Feature count probe" in r.message
+        ]
+
+    def test_healthy_2_0_0_fallback_does_not_warn(self, caplog):
+        """2.0.0 rejected, negotiated 1.1.0 answers: no probe warning at all."""
+
+        def fake_request(url, params=None, **kwargs):
+            if params.get("version") == "2.0.0":
+                raise WFSError("HTTP error 400: version 2.0.0 not supported")
+            return b'numberOfFeatures="42"'
+
+        assert self._run_wfs_to_table(fake_request, caplog) == []
+
+    def test_real_probe_failure_still_warns(self, caplog):
+        """When the negotiated-version probe fails too, the count is genuinely
+        lost — that one must still be loud."""
+
+        def fake_request(url, params=None, **kwargs):
+            raise WFSError("Request failed after 3 attempts: connection refused")
+
+        warnings = self._run_wfs_to_table(fake_request, caplog)
+        assert len(warnings) == 1, warnings
+        assert "connection refused" in warnings[0]
+        assert "1.1.0" in warnings[0]
+
 
 class TestDeduplicateTiles:
     """Test deduplication of features across tile boundaries."""

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -5,6 +5,7 @@ Tests use mocked HTTP responses to avoid network dependencies.
 Network tests are marked separately for optional integration testing.
 """
 
+import logging
 import os
 from unittest.mock import MagicMock, patch
 
@@ -3661,6 +3662,111 @@ class TestGetFeatureCountWithBbox:
         assert result == 100
         call_params = mock_req.call_args[1]["params"]
         assert "bbox" not in call_params
+
+
+class TestGetFeatureCountErrorVisibility:
+    """A failed count probe must be visible, not silently degrade auto-tiling (#678)."""
+
+    def test_wfs_error_returns_none_and_warns(self, caplog):
+        """A WFSError from the probe returns None but logs a warning naming the cause."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs._make_request",
+                side_effect=WFSError("Request failed after 3 attempts: connection refused"),
+            ),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            result = _get_feature_count("http://mock/wfs", "layer", "1.1.0")
+
+        assert result is None
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("connection refused" in m for m in warnings), warnings
+        assert any("count" in m.lower() for m in warnings), warnings
+
+    def test_transport_error_returns_none_and_warns(self, caplog):
+        """An httpx transport error is expected — warn and degrade, do not raise."""
+        import httpx
+
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs._make_request",
+                side_effect=httpx.ConnectError("nodename nor servname provided"),
+            ),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            result = _get_feature_count("http://mock/wfs", "layer", "2.0.0")
+
+        assert result is None
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("nodename nor servname provided" in m for m in warnings), warnings
+
+    def test_programming_error_propagates(self):
+        """A TypeError is a bug in gpio, not a server problem — it must surface."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs._make_request",
+                side_effect=TypeError("_make_request() got an unexpected keyword argument"),
+            ),
+            pytest.raises(TypeError),
+        ):
+            _get_feature_count("http://mock/wfs", "layer", "1.1.0")
+
+    def test_successful_probe_does_not_warn(self, caplog):
+        """The happy path is unchanged and silent."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with (
+            patch("geoparquet_io.core.wfs._make_request", return_value=b'numberMatched="7"'),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            result = _get_feature_count("http://mock/wfs", "layer", "2.0.0")
+
+        assert result == 7
+        assert [r.message for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+    def test_server_without_count_returns_none_without_warning(self, caplog):
+        """ "Server reports no count" is a normal answer, distinct from a failed probe."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with (
+            patch("geoparquet_io.core.wfs._make_request", return_value=b"<wfs:FeatureCollection/>"),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            result = _get_feature_count("http://mock/wfs", "layer", "1.1.0")
+
+        assert result is None
+        assert [r.message for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+    def test_auto_tiling_still_engages_when_probe_succeeds(self):
+        """Regression guard: a working probe still drives the auto-tiling decision."""
+        from geoparquet_io.core.wfs import _refine_tiles_adaptive
+
+        seen = []
+
+        def fake_request(url, params=None, **kwargs):
+            # Root tile is over the limit; every quadrant is under it.
+            seen.append(params.get("bbox", ""))
+            n = 500 if len(seen) == 1 else 10
+            return f'numberOfFeatures="{n}"'.encode()
+
+        with patch("geoparquet_io.core.wfs._make_request", side_effect=fake_request):
+            tiles = _refine_tiles_adaptive(
+                [(0.0, 0.0, 4.0, 4.0)],
+                "http://mock/wfs",
+                "layer",
+                "1.1.0",
+                "EPSG:4326",
+                "xy",
+                max_per_tile=100,
+            )
+
+        assert len(tiles) == 4
 
 
 class TestDeduplicateTiles:

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -4407,3 +4407,82 @@ class TestMultiLayerExtraction:
 
         # Colons should be replaced with underscores in filename
         assert (output_dir / "ns_layer_name.parquet").exists()
+
+
+class TestStartIndexProbeErrorVisibility:
+    """The sibling probe swallowed failures the same way `_get_feature_count` did.
+
+    `_probe_startindex_limit` detects servers that reject a `startIndex` above
+    some cap. Returning a silent `None` on a failed probe means "no cap known",
+    which re-enables unbounded pagination against a server that will reject or
+    truncate the later pages — the same silently-wrong-output failure mode as a
+    lost feature count (#678), reached by a different route.
+    """
+
+    def test_transport_error_returns_none_and_warns(self, caplog):
+        """A transport failure degrades to "no cap known" but says so."""
+        import httpx
+
+        from geoparquet_io.core.wfs import _probe_startindex_limit
+
+        with (
+            patch(
+                "geoparquet_io.core.wfs._get_shared_http_client",
+                side_effect=httpx.ConnectError("nodename nor servname provided"),
+            ),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            result = _probe_startindex_limit("http://mock/wfs", "layer", "2.0.0")
+
+        assert result is None
+        warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("nodename nor servname provided" in m for m in warnings), warnings
+        assert any("startindex" in m.lower() for m in warnings), warnings
+
+    def test_programming_error_propagates(self):
+        """A bug inside the probe must surface, not be reported as "no cap"."""
+        from geoparquet_io.core.wfs import _probe_startindex_limit
+
+        with patch(
+            "geoparquet_io.core.wfs._build_wfs_url",
+            side_effect=AttributeError("'NoneType' object has no attribute 'rstrip'"),
+        ):
+            with pytest.raises(AttributeError, match="rstrip"):
+                _probe_startindex_limit("http://mock/wfs", "layer", "2.0.0")
+
+    def test_server_without_a_cap_returns_none_without_warning(self, caplog):
+        """A healthy server that imposes no cap is not a failure — stay quiet."""
+        from geoparquet_io.core.wfs import _probe_startindex_limit
+
+        response = MagicMock()
+        response.status_code = 200
+        client = MagicMock()
+        client.get.return_value = response
+
+        with (
+            patch("geoparquet_io.core.wfs._get_shared_http_client", return_value=client),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            result = _probe_startindex_limit("http://mock/wfs", "layer", "2.0.0")
+
+        assert result is None
+        assert [r.message for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+    def test_detected_cap_is_returned_without_warning(self, caplog):
+        """The success path still parses the cap out of the 400 body."""
+        from geoparquet_io.core.wfs import _probe_startindex_limit
+
+        response = MagicMock()
+        response.status_code = 400
+        response.text = "startIndex must not exceed 50,000"
+        client = MagicMock()
+        client.get.return_value = response
+
+        with (
+            patch("geoparquet_io.core.wfs._get_shared_http_client", return_value=client),
+            caplog.at_level(logging.WARNING, logger="geoparquet_io"),
+        ):
+            result = _probe_startindex_limit("http://mock/wfs", "layer", "2.0.0")
+
+        assert result == 50000
+        assert [r.message for r in caplog.records if r.levelno >= logging.WARNING] == []


### PR DESCRIPTION
## The bug

`_get_feature_count` in `geoparquet_io/core/wfs.py` wrapped its entire body — the
`_make_request` call *and* the regex parse — in a bare `except Exception: pass`,
then fell through to `return None`.

`None` is how the function reports "the server does not publish a count", so
every caller read a transient server hiccup, an unreachable host, a malformed
response, or a plain bug inside the probe as a perfectly ordinary answer.
`wfs_to_table` uses that value as its auto-tiling probe, so a failed probe
silently disabled auto-tiling and pagination — the exact silent-truncation class
the `auto_tile` CHANGELOG entry already warns about:

> With it off, a server that caps responses (`maxFeatures` / `startIndex` limits)
> returned a **silently truncated** table and reported success.

The user got a short table, a success message, and nothing in the logs.

**Discovery context:** this surfaced while fixing the `tests/test_wfs.py`
timings in #665 / #676 — six tests mocked the fetch path but not
`_get_feature_count`, so they issued real HTTP GETs at a fake host and burned
~6.15s each in DNS-failure retry backoff. The bare `except` swallowed every
failure, so those tests **passed while unknowingly making live network calls**.
The same property hides real server failures in production.

## The fix

- The `try` now wraps only `_make_request`, and the catch is narrowed to
  `(WFSError, httpx.HTTPError, OSError)` — the service being down, unreachable,
  rejecting us, or timing out. `WFSError` covers everything `_make_request`
  raises deliberately (`WFSAuthenticationError` and `LayerNotFoundError`
  subclass it; retry exhaustion raises it directly).
- A caught failure now logs a `warn()` naming both the cause and the
  consequence, so the degradation is visible instead of silent.
- **Programming errors propagate.** `TypeError`, `AttributeError` and friends are
  no longer swallowed and surface as the bugs they are.
- The parse block moved out of the `try` (regex + `int()` over `\d+` cannot
  raise). A response that parses fine but carries no count logs at `debug`, not
  `warn` — that is a normal server answer, not a failed probe.
- **The speculative 2.0.0 probe alone stays quiet.** `wfs_to_table` probes at a
  hardcoded WFS 2.0.0 first (higher server limits) and falls back to the
  negotiated version by construction, so a 1.1.0-only server answering HTTP 400
  there is an expected answer, not a lost capability — it would otherwise cry
  degradation on a healthy extraction that immediately gets a good count. New
  `warn_on_failure: bool = True` parameter; that one call site passes `False` and
  logs at `debug` instead. The consequence-bearing sites stay loud:

  | call site | warns |
  |---|---|
  | `_refine_tiles_adaptive` per-tile probe | yes |
  | `fetch_all_features_duckdb` count query | yes |
  | `wfs_to_table` speculative 2.0.0 probe | **no** (`warn_on_failure=False`) |
  | `wfs_to_table` negotiated-version fallback | yes |

- The `None`-means-"count unavailable" return contract is unchanged, so
  extraction still degrades gracefully rather than aborting.

## Tests

9 red-first regression tests, fully mocked, no network marks — every one was
watched failing against the old code before the fix landed.

`TestGetFeatureCountErrorVisibility`
- `WFSError` from the probe → returns `None` **and** warns, naming the cause
- `httpx.ConnectError` → returns `None` and warns
- `TypeError` → **propagates** (was silently swallowed)
- successful probe → returns the count, warns nothing
- server answers without a count → `None`, no warning (distinct from a failure)
- working probe still splits a 500-feature root tile into 4 quadrants
- `warn_on_failure=False` → `None`, `warn` not called

`TestSpeculativeCountProbeIsQuiet` drives the **real** `_get_feature_count`
through `wfs_to_table` (mocking only `_make_request` and the surrounding I/O), so
it exercises the actual call site rather than asserting on spied kwargs:
- 2.0.0 rejected + 1.1.0 answering → zero probe warnings
- every version failing → exactly **one** warning, naming the cause and version

Full fast suite: 3968 passed, 40 skipped. `pre-commit` clean at both the commit
and pre-push stages (deptry, mypy, vulture, xenon, import-linter).

## Deferred

- **Per-tile warning dedupe.** `_refine_tiles_adaptive` probes once per tile, so
  a persistently failing server can emit one warning per tile. Deliberately loud
  for now — that is the point of the fix — but a once-per-extraction dedupe is
  the remedy if it proves noisy in the field.
- **Caller distinguishing failed-vs-countless probe.** Both still return `None`,
  so `wfs_to_table` cannot treat them differently (e.g. abort, or force tiling on
  a failed probe). That is a user-visible behavior change beyond this bugfix; the
  warning at least makes the situation diagnosable.
- **Promoting #676's `offline_wfs_probes` tripwire to `tests/conftest.py`** to
  prove hermeticity for the whole file. #676 is not on this base and touches the
  same test file, so this should follow after it lands.
- **Pre-existing falsy-zero re-probe.** The 2.0.0 fallback is guarded by
  `if not expected_count:`, so a legitimate count of **0** triggers a redundant
  re-probe at the negotiated version. Untouched here — it predates this fix and
  is harmless beyond one wasted request.

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WFS extraction reliability when feature-count requests fail.
  - Extraction now warns when count information is unavailable, while preserving adaptive tiling and pagination fallback behavior.
  - Unexpected programming errors are surfaced instead of being silently ignored.
  - Successful extractions and servers without count support remain quiet and functional.
  - Improved WFS capability probing with clearer failure reporting and more reliable fallback behavior.
- **Documentation**
  - Documented support for quoted Quadkey identifiers and GeoParquet 1.1 GeoArrow-aware validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->