### PR TITLE
fix(write): honor row-group sizing in the disk-rewrite strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,16 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   pages — the same silently-wrong-output failure mode reached by a different
   route.
 
+- **`--row-group-rows` / `--row-group-size-mb` now apply to the `disk-rewrite`
+  write strategy.** `DiskRewriteStrategy` accepted both sizing options and used
+  neither, so anything routed through it (including the fallback path) got
+  default row groups no matter what the caller asked for — a silent divergence
+  from the other three strategies that showed up later as `gpio check row-group`
+  failures. The strategy now sizes both its DuckDB `COPY` and the PyArrow
+  metadata rewrite from the request, converting an MB target to a row count with
+  the same sampling logic `duckdb-kv` uses (now shared in
+  `core/write_strategies/row_group_sizing.py` instead of living in `duckdb_kv`).
+  Non-geo writes through the strategy honour the options too.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,6 +436,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the same sampling logic `duckdb-kv` uses (now shared in
   `core/write_strategies/row_group_sizing.py` instead of living in `duckdb_kv`).
   Non-geo writes through the strategy honour the options too.
+
+  The MB-to-rows estimate samples the query with its trailing `ORDER BY`
+  removed, so the sample's `LIMIT` pushes down instead of re-sorting (and
+  re-downloading) the whole source. That scanner tracks `''` and `""` state and
+  nothing else — the hand-rolled quote walker #657 removed from the `--where`
+  path — so a query carrying a line comment, block comment, dollar quote or
+  `E''` escape is now left alone rather than truncated mid-construct. Three of
+  those produced SQL that no longer parsed (recovered by the fallback, losing
+  the MB target); the `E''` case produced SQL that still parsed but with a
+  different `WHERE` clause, estimating from a different row set. Skipping the
+  speed-up is always safe; guessing is not.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -426,6 +426,16 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   pages — the same silently-wrong-output failure mode reached by a different
   route.
 
+- **`--row-group-rows` / `--row-group-size-mb` now apply to the `disk-rewrite`
+  write strategy.** `DiskRewriteStrategy` accepted both sizing options and used
+  neither, so anything routed through it (including the fallback path) got
+  default row groups no matter what the caller asked for — a silent divergence
+  from the other three strategies that showed up later as `gpio check row-group`
+  failures. The strategy now sizes both its DuckDB `COPY` and the PyArrow
+  metadata rewrite from the request, converting an MB target to a row count with
+  the same sampling logic `duckdb-kv` uses (now shared in
+  `core/write_strategies/row_group_sizing.py` instead of living in `duckdb_kv`).
+  Non-geo writes through the strategy honour the options too.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -436,6 +436,17 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the same sampling logic `duckdb-kv` uses (now shared in
   `core/write_strategies/row_group_sizing.py` instead of living in `duckdb_kv`).
   Non-geo writes through the strategy honour the options too.
+
+  The MB-to-rows estimate samples the query with its trailing `ORDER BY`
+  removed, so the sample's `LIMIT` pushes down instead of re-sorting (and
+  re-downloading) the whole source. That scanner tracks `''` and `""` state and
+  nothing else — the hand-rolled quote walker #657 removed from the `--where`
+  path — so a query carrying a line comment, block comment, dollar quote or
+  `E''` escape is now left alone rather than truncated mid-construct. Three of
+  those produced SQL that no longer parsed (recovered by the fallback, losing
+  the MB target); the `E''` case produced SQL that still parsed but with a
+  different `WHERE` clause, estimating from a different row set. Skipping the
+  speed-up is always safe; guessing is not.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -26,6 +26,10 @@ from geoparquet_io.core.duckdb_utils import (
 )
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy, build_geo_metadata
+from geoparquet_io.core.write_strategies.row_group_sizing import (
+    _resolve_row_group_rows,
+    _resolve_row_group_rows_for_table,
+)
 
 if TYPE_CHECKING:
     import duckdb
@@ -75,10 +79,23 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         configure_verbose(verbose)
         self._validate_output_path(output_path)
 
+        # DuckDB COPY TO sizes row groups by row count, so translate any MB target
+        # into rows before it can take effect on this strategy (fixes #689 — both
+        # sizing options were accepted and then ignored entirely).
+        resolved_row_group_rows = _resolve_row_group_rows(
+            con, query, row_group_size_mb, row_group_rows, verbose
+        )
+
         # Handle non-geo queries: write plain Parquet without geo metadata
         if geometry_column is None:
             self._write_plain_parquet_from_query(
-                con, query, output_path, compression, compression_level, verbose
+                con,
+                query,
+                output_path,
+                compression,
+                compression_level,
+                verbose,
+                resolved_row_group_rows,
             )
             return
 
@@ -115,10 +132,13 @@ class DiskRewriteStrategy(BaseWriteStrategy):
             final_query = _wrap_query_with_wkb_conversion(query, geometry_column, con)
 
             escaped_temp = _escape_sql_string(temp_path)
+            copy_options = ["FORMAT PARQUET", f"COMPRESSION {duckdb_compression}"]
+            if resolved_row_group_rows:
+                copy_options.append(f"ROW_GROUP_SIZE {resolved_row_group_rows}")
             copy_query = f"""
                 COPY ({final_query})
                 TO '{escaped_temp}'
-                (FORMAT PARQUET, COMPRESSION {duckdb_compression})
+                ({", ".join(copy_options)})
             """
 
             if verbose:
@@ -151,6 +171,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
                 compression_level=validated_level,
                 verbose=verbose,
                 extra_kv_metadata=extra_kv_metadata,
+                row_group_rows=resolved_row_group_rows,
             )
 
             os.unlink(temp_path)
@@ -188,7 +209,14 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         # Handle non-geo tables: write plain Parquet without geo metadata
         if geometry_column is None:
             self._write_plain_parquet_from_table(
-                table, output_path, compression, compression_level, verbose
+                table,
+                output_path,
+                compression,
+                compression_level,
+                verbose,
+                _resolve_row_group_rows_for_table(
+                    table, row_group_size_mb, row_group_rows, verbose
+                ),
             )
             return
 
@@ -232,6 +260,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         compression: str,
         compression_level: int | None,
         verbose: bool,
+        row_group_rows: int | None = None,
     ) -> None:
         """Write plain Parquet (no geo metadata) from an Arrow table."""
         from geoparquet_io.core.common import validate_compression_settings
@@ -245,6 +274,8 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         writer_kwargs = {"compression": pa_compression}
         if validated_level is not None and pa_compression:
             writer_kwargs["compression_level"] = validated_level
+        if row_group_rows:
+            writer_kwargs["row_group_size"] = row_group_rows
 
         is_remote = is_remote_url(output_path)
         work_dir = tempfile.mkdtemp(prefix="gpio_disk_rewrite_") if is_remote else None
@@ -276,6 +307,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         compression: str,
         compression_level: int | None,  # noqa: ARG002 - DuckDB COPY doesn't support compression_level
         verbose: bool,
+        row_group_rows: int | None = None,
     ) -> None:
         """Write plain Parquet (no geo metadata) from a query.
 
@@ -306,10 +338,14 @@ class DiskRewriteStrategy(BaseWriteStrategy):
             local_path = os.path.join(work_dir, "output.parquet") if is_remote else output_path
             escaped_path = _escape_sql_string(local_path)
 
+            copy_options = ["FORMAT PARQUET", f"COMPRESSION {duckdb_compression}"]
+            if row_group_rows:
+                copy_options.append(f"ROW_GROUP_SIZE {row_group_rows}")
+
             copy_query = f"""
                 COPY ({query})
                 TO '{escaped_path}'
-                (FORMAT PARQUET, COMPRESSION {duckdb_compression})
+                ({", ".join(copy_options)})
             """
 
             if verbose:
@@ -337,8 +373,15 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         compression_level: int | None,
         verbose: bool,
         extra_kv_metadata: dict[str, str] | None = None,
+        row_group_rows: int | None = None,
     ) -> None:
-        """Rewrite file with proper geo metadata, row group by row group."""
+        """Rewrite file with proper geo metadata, row group by row group.
+
+        ``row_group_rows`` is the already-resolved rows-per-group request. The
+        DuckDB COPY that produced ``input_path`` was given the same value, so the
+        source groups are normally already the right size; passing it to the
+        writer keeps the requested shape even if DuckDB emitted a larger group.
+        """
         pf = pq.ParquetFile(input_path)
         schema = pf.schema_arrow
 
@@ -361,11 +404,13 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         if compression_level is not None and pa_compression:
             writer_kwargs["compression_level"] = compression_level
 
+        write_table_kwargs = {"row_group_size": row_group_rows} if row_group_rows else {}
+
         with pq.ParquetWriter(output_path, new_schema, **writer_kwargs) as writer:
             for i in range(pf.metadata.num_row_groups):
                 table = pf.read_row_group(i)
                 table = table.replace_schema_metadata(new_meta)
-                writer.write_table(table)
+                writer.write_table(table, **write_table_kwargs)
 
                 if verbose and (i + 1) % 10 == 0:
                     debug(f"Rewrote {i + 1}/{pf.metadata.num_row_groups} row groups...")

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -25,6 +25,7 @@ import pyarrow.parquet as pq
 from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
 from geoparquet_io.core.logging_config import configure_verbose, debug, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy, build_geo_metadata
+from geoparquet_io.core.write_strategies.row_group_sizing import _resolve_row_group_rows
 
 if TYPE_CHECKING:
     import duckdb
@@ -160,115 +161,6 @@ def _detect_bbox_column_name(schema_names: list[str]) -> str | None:
         if name in ["bbox", "bounds", "extent"] or name.endswith("_bbox"):
             return name
     return None
-
-
-# Rows sampled to estimate average row size when converting an MB target to a
-# row count. Large enough to be representative, small enough to stay cheap.
-_MB_ESTIMATE_SAMPLE_ROWS = 20000
-
-# Clauses that must not follow a trailing ORDER BY for it to be safely strippable
-# (they change which/how many rows a LIMIT would return).
-_ORDER_BY_TAIL_STOPWORDS = re.compile(r"(?i)\b(limit|offset|union|except|intersect|fetch)\b")
-
-
-def _strip_trailing_order_by(query: str) -> str:
-    """Drop a trailing top-level ``ORDER BY`` clause for cheap row sampling.
-
-    Estimating bytes-per-row does not need ordered rows, and a ``LIMIT`` layered
-    over an ``ORDER BY`` forces DuckDB to scan (and sort) the *entire* source —
-    re-downloading remote inputs and recomputing expensive ordering keys (e.g.
-    ``ST_Hilbert``) just to size row groups. Without the ordering the sample's
-    ``LIMIT`` pushes down, so DuckDB stops after a few row groups.
-
-    Returns the query unchanged when no strippable top-level trailing ORDER BY is
-    found, so estimation still works — it just skips the speed-up.
-    """
-    depth = 0
-    in_single = in_double = False
-    last_order_by = -1
-    i, n = 0, len(query)
-    while i < n:
-        ch = query[i]
-        if in_single:
-            in_single = ch != "'"
-        elif in_double:
-            in_double = ch != '"'
-        elif ch == "'":
-            in_single = True
-        elif ch == '"':
-            in_double = True
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-        elif depth == 0 and ch in "oO":
-            match = re.match(r"order\s+by\b", query[i:], re.IGNORECASE)
-            prev = query[i - 1] if i else " "
-            if match and not (prev.isalnum() or prev == "_"):
-                last_order_by = i
-                i += match.end()
-                continue
-        i += 1
-
-    if last_order_by == -1:
-        return query
-    # Bail if anything follows the ORDER BY that would alter the sampled rows.
-    if _ORDER_BY_TAIL_STOPWORDS.search(query[last_order_by:]):
-        return query
-    return query[:last_order_by].rstrip()
-
-
-def _resolve_row_group_rows(
-    con: duckdb.DuckDBPyConnection,
-    query: str,
-    row_group_size_mb: float | None,
-    row_group_rows: int | None,
-    verbose: bool,
-) -> int | None:
-    """Resolve an MB row-group target to a row count for DuckDB COPY TO.
-
-    DuckDB's ``ROW_GROUP_SIZE`` is expressed in rows, so a ``--row-group-size-mb``
-    target has to be converted before it can take effect on this strategy (the
-    bytes-based ``ROW_GROUP_SIZE_BYTES`` option is unusable here because it
-    requires disabling insertion-order preservation, which would undo any
-    spatial ordering already applied). An explicit row count always wins; when
-    only an MB target is given we estimate bytes-per-row from a sample and mirror
-    the arrow write path (see ``_write_table_with_settings``).
-    """
-    if row_group_rows:
-        return row_group_rows
-    if not row_group_size_mb:
-        return None
-
-    from geoparquet_io.core.common import _estimate_row_size
-
-    # Sample without the ORDER BY so the LIMIT streams (a LIMIT over an ORDER BY
-    # would rescan/sort the whole source — re-downloading remote inputs and
-    # recomputing the ordering key — just to size row groups).
-    sample_query = _strip_trailing_order_by(query)
-    try:
-        sample = (
-            con.execute(f"SELECT * FROM ({sample_query}) LIMIT {_MB_ESTIMATE_SAMPLE_ROWS}")
-            .arrow()
-            .read_all()
-        )
-    except Exception as exc:  # pragma: no cover - defensive, fall back to default
-        if verbose:
-            debug(f"Could not sample rows for --row-group-size-mb estimate: {exc}")
-        return None
-
-    if sample.num_rows == 0:
-        return None
-
-    bytes_per_row = _estimate_row_size(sample)
-    target_bytes = row_group_size_mb * 1024 * 1024
-    rows = max(1, int(target_bytes // bytes_per_row))
-    if verbose:
-        debug(
-            f"Resolved --row-group-size-mb {row_group_size_mb} to {rows:,} rows/group "
-            f"(~{bytes_per_row} bytes/row)"
-        )
-    return rows
 
 
 def _build_copy_options(

--- a/geoparquet_io/core/write_strategies/row_group_sizing.py
+++ b/geoparquet_io/core/write_strategies/row_group_sizing.py
@@ -27,6 +27,24 @@ _MB_ESTIMATE_SAMPLE_ROWS = 20000
 # (they change which/how many rows a LIMIT would return).
 _ORDER_BY_TAIL_STOPWORDS = re.compile(r"(?i)\b(limit|offset|union|except|intersect|fetch)\b")
 
+# Constructs the scanner below cannot reason about. It tracks '' and "" state and
+# nothing else, which is the hand-rolled quote walker #657 replaced on the
+# --where path: line comments, block comments, dollar quoting and E'' escapes all
+# hide (or fake) text from it. Measured against this scanner, each one mangles
+# the query --
+#     SELECT * FROM t -- keep order by x   ->  SELECT * FROM t --
+#     SELECT * FROM t /* order by x */     ->  SELECT * FROM t /*
+#     SELECT $$order by x$$ AS s FROM t    ->  SELECT $$
+#     ... WHERE s = E'\'order by x'         ->  ... WHERE s = E'\'
+# -- and the last is the dangerous one: it stays *valid* SQL with a different
+# WHERE clause, so the estimate would be drawn from a different row set instead
+# of failing loudly.
+#
+# There is no public DuckDB AST to gate this properly (extract_statements only
+# splits statements), so the scanner stays, and any query carrying one of these
+# is left alone: the optimization is skipped and sizing still works.
+_UNSCANNABLE_SQL = re.compile(r"--|/\*|\$\$|\$[A-Za-z_][A-Za-z0-9_]*\$|(?<![A-Za-z0-9_])[eE]'")
+
 
 def _strip_trailing_order_by(query: str) -> str:
     """Drop a trailing top-level ``ORDER BY`` clause for cheap row sampling.
@@ -38,8 +56,13 @@ def _strip_trailing_order_by(query: str) -> str:
     ``LIMIT`` pushes down, so DuckDB stops after a few row groups.
 
     Returns the query unchanged when no strippable top-level trailing ORDER BY is
-    found, so estimation still works — it just skips the speed-up.
+    found, so estimation still works — it just skips the speed-up. The same is
+    true for a query carrying any construct this scanner cannot track (see
+    ``_UNSCANNABLE_SQL``): skipping the speed-up is always safe, guessing is not.
     """
+    if _UNSCANNABLE_SQL.search(query):
+        return query
+
     depth = 0
     in_single = in_double = False
     last_order_by = -1

--- a/geoparquet_io/core/write_strategies/row_group_sizing.py
+++ b/geoparquet_io/core/write_strategies/row_group_sizing.py
@@ -1,0 +1,153 @@
+"""Shared row-group sizing helpers for the write strategies.
+
+Both DuckDB-backed strategies (``duckdb-kv`` and ``disk-rewrite``) size row
+groups through ``COPY ... (ROW_GROUP_SIZE n)``, which is expressed in *rows*.
+A caller-supplied ``--row-group-size-mb`` target therefore has to be converted
+to a row count first, from a cheap sample of the query. Keeping that conversion
+here means the two strategies (and the plain-Parquet paths inside them) resolve
+sizing identically instead of each carrying its own copy.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from geoparquet_io.core.logging_config import debug
+
+if TYPE_CHECKING:
+    import duckdb
+    import pyarrow as pa
+
+# Rows sampled to estimate average row size when converting an MB target to a
+# row count. Large enough to be representative, small enough to stay cheap.
+_MB_ESTIMATE_SAMPLE_ROWS = 20000
+
+# Clauses that must not follow a trailing ORDER BY for it to be safely strippable
+# (they change which/how many rows a LIMIT would return).
+_ORDER_BY_TAIL_STOPWORDS = re.compile(r"(?i)\b(limit|offset|union|except|intersect|fetch)\b")
+
+
+def _strip_trailing_order_by(query: str) -> str:
+    """Drop a trailing top-level ``ORDER BY`` clause for cheap row sampling.
+
+    Estimating bytes-per-row does not need ordered rows, and a ``LIMIT`` layered
+    over an ``ORDER BY`` forces DuckDB to scan (and sort) the *entire* source —
+    re-downloading remote inputs and recomputing expensive ordering keys (e.g.
+    ``ST_Hilbert``) just to size row groups. Without the ordering the sample's
+    ``LIMIT`` pushes down, so DuckDB stops after a few row groups.
+
+    Returns the query unchanged when no strippable top-level trailing ORDER BY is
+    found, so estimation still works — it just skips the speed-up.
+    """
+    depth = 0
+    in_single = in_double = False
+    last_order_by = -1
+    i, n = 0, len(query)
+    while i < n:
+        ch = query[i]
+        if in_single:
+            in_single = ch != "'"
+        elif in_double:
+            in_double = ch != '"'
+        elif ch == "'":
+            in_single = True
+        elif ch == '"':
+            in_double = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and ch in "oO":
+            match = re.match(r"order\s+by\b", query[i:], re.IGNORECASE)
+            prev = query[i - 1] if i else " "
+            if match and not (prev.isalnum() or prev == "_"):
+                last_order_by = i
+                i += match.end()
+                continue
+        i += 1
+
+    if last_order_by == -1:
+        return query
+    # Bail if anything follows the ORDER BY that would alter the sampled rows.
+    if _ORDER_BY_TAIL_STOPWORDS.search(query[last_order_by:]):
+        return query
+    return query[:last_order_by].rstrip()
+
+
+def _resolve_row_group_rows(
+    con: duckdb.DuckDBPyConnection,
+    query: str,
+    row_group_size_mb: float | None,
+    row_group_rows: int | None,
+    verbose: bool,
+) -> int | None:
+    """Resolve an MB row-group target to a row count for DuckDB COPY TO.
+
+    DuckDB's ``ROW_GROUP_SIZE`` is expressed in rows, so a ``--row-group-size-mb``
+    target has to be converted before it can take effect on these strategies (the
+    bytes-based ``ROW_GROUP_SIZE_BYTES`` option is unusable here because it
+    requires disabling insertion-order preservation, which would undo any
+    spatial ordering already applied). An explicit row count always wins; when
+    only an MB target is given we estimate bytes-per-row from a sample and mirror
+    the arrow write path (see ``_write_table_with_settings``).
+    """
+    if row_group_rows:
+        return row_group_rows
+    if not row_group_size_mb:
+        return None
+
+    # Sample without the ORDER BY so the LIMIT streams (a LIMIT over an ORDER BY
+    # would rescan/sort the whole source — re-downloading remote inputs and
+    # recomputing the ordering key — just to size row groups).
+    sample_query = _strip_trailing_order_by(query)
+    try:
+        sample = (
+            con.execute(f"SELECT * FROM ({sample_query}) LIMIT {_MB_ESTIMATE_SAMPLE_ROWS}")
+            .arrow()
+            .read_all()
+        )
+    except Exception as exc:  # pragma: no cover - defensive, fall back to default
+        if verbose:
+            debug(f"Could not sample rows for --row-group-size-mb estimate: {exc}")
+        return None
+
+    if sample.num_rows == 0:
+        return None
+
+    return _rows_for_mb_target(sample, row_group_size_mb, verbose)
+
+
+def _resolve_row_group_rows_for_table(
+    table: pa.Table,
+    row_group_size_mb: float | None,
+    row_group_rows: int | None,
+    verbose: bool = False,
+) -> int | None:
+    """Resolve row-group sizing for an in-memory Arrow table.
+
+    Same contract as :func:`_resolve_row_group_rows`, but the table itself is the
+    sample so no query has to be re-run.
+    """
+    if row_group_rows:
+        return row_group_rows
+    if not row_group_size_mb or table.num_rows == 0:
+        return None
+
+    rows = _rows_for_mb_target(table, row_group_size_mb, verbose)
+    return min(rows, table.num_rows) if rows else None
+
+
+def _rows_for_mb_target(sample: pa.Table, row_group_size_mb: float, verbose: bool) -> int:
+    """Convert an MB target into a row count using a sample's bytes-per-row."""
+    from geoparquet_io.core.common import _estimate_row_size
+
+    bytes_per_row = _estimate_row_size(sample)
+    target_bytes = row_group_size_mb * 1024 * 1024
+    rows = max(1, int(target_bytes // bytes_per_row))
+    if verbose:
+        debug(
+            f"Resolved --row-group-size-mb {row_group_size_mb} to {rows:,} rows/group "
+            f"(~{bytes_per_row} bytes/row)"
+        )
+    return rows

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -8,6 +8,7 @@ Tests the Strategy Pattern for GeoParquet writes including:
 """
 
 import json
+import struct
 import tempfile
 import uuid
 from pathlib import Path
@@ -217,7 +218,7 @@ class TestStripTrailingOrderBy:
     """Sampling for --row-group-size-mb must not re-run the ordered query."""
 
     def test_strips_top_level_hilbert_order_by(self):
-        from geoparquet_io.core.write_strategies.duckdb_kv import _strip_trailing_order_by
+        from geoparquet_io.core.write_strategies.row_group_sizing import _strip_trailing_order_by
 
         query = "SELECT * FROM t\n        ORDER BY ST_Hilbert(geometry, ST_Extent(x))\n    "
         stripped = _strip_trailing_order_by(query)
@@ -225,26 +226,26 @@ class TestStripTrailingOrderBy:
         assert stripped.strip() == "SELECT * FROM t"
 
     def test_leaves_query_without_order_by(self):
-        from geoparquet_io.core.write_strategies.duckdb_kv import _strip_trailing_order_by
+        from geoparquet_io.core.write_strategies.row_group_sizing import _strip_trailing_order_by
 
         query = "SELECT * FROM t WHERE id > 5"
         assert _strip_trailing_order_by(query) == query
 
     def test_ignores_order_by_inside_subquery(self):
-        from geoparquet_io.core.write_strategies.duckdb_kv import _strip_trailing_order_by
+        from geoparquet_io.core.write_strategies.row_group_sizing import _strip_trailing_order_by
 
         query = "SELECT * FROM (SELECT a FROM t ORDER BY a) sub"
         assert _strip_trailing_order_by(query) == query
 
     def test_keeps_order_by_when_limit_follows(self):
-        from geoparquet_io.core.write_strategies.duckdb_kv import _strip_trailing_order_by
+        from geoparquet_io.core.write_strategies.row_group_sizing import _strip_trailing_order_by
 
         query = "SELECT * FROM t ORDER BY a LIMIT 10"
         assert _strip_trailing_order_by(query) == query
 
     def test_stripped_sample_matches_ordered_row_size(self):
         """The estimate must be unaffected by dropping the ordering."""
-        from geoparquet_io.core.write_strategies.duckdb_kv import (
+        from geoparquet_io.core.write_strategies.row_group_sizing import (
             _resolve_row_group_rows,
             _strip_trailing_order_by,
         )
@@ -659,3 +660,196 @@ class TestWriteStrategiesNoGeometry:
         )
 
         self._assert_valid_empty_plain_parquet(output_file)
+
+
+def _write_points_geoparquet(path: Path, num_rows: int) -> str:
+    """Write a small WKB-point GeoParquet file used as a multi-row-group source."""
+    geo_meta = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+    }
+    points = [struct.pack("<BI2d", 1, 1, float(i), float(i)) for i in range(num_rows)]
+    table = pa.table({"id": list(range(num_rows)), "geometry": points})
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo_meta).encode()})
+    pq.write_table(table, path)
+    return str(path)
+
+
+class TestDiskRewriteRowGroupSizing:
+    """disk-rewrite must honour row-group sizing requests (issue #689).
+
+    The strategy accepted ``row_group_rows``/``row_group_size_mb`` and used
+    neither, so callers silently got DuckDB/PyArrow defaults.
+    """
+
+    def _row_group_sizes(self, path: str) -> list[int]:
+        pf = pq.ParquetFile(path)
+        return [pf.metadata.row_group(i).num_rows for i in range(pf.metadata.num_row_groups)]
+
+    def test_row_group_rows_honored_from_query(self, duckdb_connection, tmp_path, output_file):
+        """An explicit rows-per-group request shapes the written row groups."""
+        src = _write_points_geoparquet(tmp_path / "src.parquet", 40)
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+
+        strategy.write_from_query(
+            con=duckdb_connection,
+            query=f"SELECT * FROM read_parquet('{src}')",
+            output_path=output_file,
+            geometry_column="geometry",
+            original_metadata=None,
+            geoparquet_version="1.1",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=10,
+            input_crs=None,
+            verbose=False,
+        )
+
+        sizes = self._row_group_sizes(output_file)
+        assert sum(sizes) == 40
+        assert len(sizes) == 4, f"expected 4 row groups of 10 rows, got {sizes}"
+        assert max(sizes) <= 10
+
+    def test_no_row_group_settings_leaves_default_shape(
+        self, duckdb_connection, tmp_path, output_file
+    ):
+        """Without sizing options the default single-row-group shape is unchanged."""
+        src = _write_points_geoparquet(tmp_path / "src.parquet", 40)
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+
+        strategy.write_from_query(
+            con=duckdb_connection,
+            query=f"SELECT * FROM read_parquet('{src}')",
+            output_path=output_file,
+            geometry_column="geometry",
+            original_metadata=None,
+            geoparquet_version="1.1",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=None,
+            input_crs=None,
+            verbose=False,
+        )
+
+        assert self._row_group_sizes(output_file) == [40]
+
+    def test_row_group_size_mb_splits_row_groups(self, duckdb_connection, tmp_path, output_file):
+        """A small MB target produces more, smaller row groups than the default."""
+        src = _write_points_geoparquet(tmp_path / "src.parquet", 2000)
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+
+        strategy.write_from_query(
+            con=duckdb_connection,
+            query=f"SELECT * FROM read_parquet('{src}')",
+            output_path=output_file,
+            geometry_column="geometry",
+            original_metadata=None,
+            geoparquet_version="1.1",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=0.01,
+            row_group_rows=None,
+            input_crs=None,
+            verbose=False,
+        )
+
+        sizes = self._row_group_sizes(output_file)
+        assert sum(sizes) == 2000
+        assert len(sizes) > 1, f"MB target should split row groups, got {sizes}"
+        assert max(sizes) < 2000
+
+    def test_write_from_table_honors_row_group_rows(self, tmp_path, output_file):
+        """write_from_table forwards sizing through to the written file."""
+        src = _write_points_geoparquet(tmp_path / "src.parquet", 40)
+        table = pq.read_table(src)
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+
+        strategy.write_from_table(
+            table=table,
+            output_path=output_file,
+            geometry_column="geometry",
+            geoparquet_version="1.1",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=10,
+            verbose=False,
+        )
+
+        sizes = self._row_group_sizes(output_file)
+        assert sum(sizes) == 40
+        assert len(sizes) == 4, f"expected 4 row groups of 10 rows, got {sizes}"
+
+    def test_plain_parquet_query_honors_row_group_rows(self, duckdb_connection, output_file):
+        """Non-geo writes honour sizing too (they take a separate COPY path).
+
+        This path is a bare DuckDB COPY, which flushes at 2048-row vector
+        granularity, so the request is asserted at that scale (same granularity
+        the duckdb-kv strategy gives for non-geo writes).
+        """
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+
+        strategy.write_from_query(
+            con=duckdb_connection,
+            query="SELECT i AS id, i * 2 AS v FROM range(10000) t(i)",
+            output_path=output_file,
+            geometry_column=None,
+            original_metadata=None,
+            geoparquet_version="1.1",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=2048,
+            input_crs=None,
+            verbose=False,
+        )
+
+        sizes = self._row_group_sizes(output_file)
+        assert sum(sizes) == 10000
+        assert max(sizes) <= 2048, f"expected <=2048 rows per group, got {sizes}"
+        assert len(sizes) == 5, f"expected 5 row groups, got {sizes}"
+
+    def test_plain_parquet_table_honors_row_group_size_mb(self, output_file):
+        """Non-geo Arrow-table writes convert an MB target to rows per group."""
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+        table = pa.table({"id": list(range(5000)), "v": [float(i) for i in range(5000)]})
+
+        strategy.write_from_table(
+            table=table,
+            output_path=output_file,
+            geometry_column=None,
+            geoparquet_version="1.1",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=0.01,
+            row_group_rows=None,
+            verbose=False,
+        )
+
+        sizes = self._row_group_sizes(output_file)
+        assert sum(sizes) == 5000
+        assert len(sizes) > 1, f"MB target should split row groups, got {sizes}"
+
+    def test_plain_parquet_table_honors_row_group_rows(self, output_file):
+        """Non-geo Arrow-table writes honour sizing too."""
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+        table = pa.table({"id": list(range(40)), "v": [float(i) for i in range(40)]})
+
+        strategy.write_from_table(
+            table=table,
+            output_path=output_file,
+            geometry_column=None,
+            geoparquet_version="1.1",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=10,
+            verbose=False,
+        )
+
+        sizes = self._row_group_sizes(output_file)
+        assert sum(sizes) == 40
+        assert len(sizes) == 4, f"expected 4 row groups of 10 rows, got {sizes}"

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -786,9 +786,11 @@ class TestDiskRewriteRowGroupSizing:
     def test_plain_parquet_query_honors_row_group_rows(self, duckdb_connection, output_file):
         """Non-geo writes honour sizing too (they take a separate COPY path).
 
-        This path is a bare DuckDB COPY, which flushes at 2048-row vector
-        granularity, so the request is asserted at that scale (same granularity
-        the duckdb-kv strategy gives for non-geo writes).
+        This path is a bare DuckDB COPY, which flushes a row group per input
+        chunk (chunk size capped at 2048 rows), so a request finer than the
+        incoming chunks cannot be honoured exactly. The assertion is therefore
+        made at chunk scale — the same resolution the duckdb-kv strategy gives
+        for non-geo writes.
         """
         strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
 

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -214,6 +214,61 @@ class TestDuckDBKVStrategy:
             strategy._validate_output_path("file;DROP TABLE users;--.parquet")
 
 
+# SQL constructs the ORDER BY scanner cannot track. Each one is a way to hide
+# text from a hand-rolled quote-state walker, and each is named in the #657
+# rationale for replacing exactly this technique on the --where path.
+UNSCANNABLE_QUERIES = [
+    pytest.param("SELECT * FROM t -- keep order by x\n", id="line-comment"),
+    pytest.param("SELECT * FROM t /* order by x */", id="block-comment"),
+    pytest.param("SELECT $$order by x$$ AS s FROM t", id="dollar-quote"),
+    pytest.param("SELECT $tag$order by x$tag$ AS s FROM t", id="tagged-dollar-quote"),
+    pytest.param("SELECT * FROM t WHERE s = E'\\'order by x'", id="e-string-escape"),
+]
+
+
+class TestStripTrailingOrderByLeavesUnscannableQueriesAlone:
+    """The scanner must skip the optimization rather than guess.
+
+    It tracks '' and "" state and nothing else. Before the guard, every query
+    below was truncated mid-construct: three into SQL that no longer parses
+    (recovered by the caller's fallback, losing the MB target), and the
+    E'' case into SQL that still parses but carries a *different* WHERE
+    clause — so the bytes-per-row estimate would silently come from a
+    different row set.
+    """
+
+    @pytest.mark.parametrize("query", UNSCANNABLE_QUERIES)
+    def test_query_is_returned_unchanged(self, query):
+        from geoparquet_io.core.write_strategies.row_group_sizing import _strip_trailing_order_by
+
+        assert _strip_trailing_order_by(query) == query, (
+            "the scanner cannot track this construct, so it must leave the query alone"
+        )
+
+    @pytest.mark.parametrize("query", UNSCANNABLE_QUERIES)
+    def test_unstripped_query_still_parses(self, query):
+        """Whatever comes back must be runnable — that is the point of bailing."""
+        import duckdb
+
+        from geoparquet_io.core.write_strategies.row_group_sizing import _strip_trailing_order_by
+
+        result = _strip_trailing_order_by(query)
+        duckdb.extract_statements(result)  # raises if the strip broke the SQL
+
+    def test_ordinary_generated_queries_are_still_optimized(self):
+        """The guard must not disable the speed-up for the queries gpio emits."""
+        from geoparquet_io.core.write_strategies.row_group_sizing import _strip_trailing_order_by
+
+        query = (
+            "SELECT * FROM read_parquet('in.parquet') WHERE code = 'abc' "
+            "ORDER BY ST_Hilbert(geometry, ST_Extent(ST_MakeEnvelope(0, 0, 1, 1)))"
+        )
+        stripped = _strip_trailing_order_by(query)
+        assert stripped != query, "a plain generated ORDER BY must still be stripped"
+        assert "ORDER BY" not in stripped.upper()
+        assert stripped.endswith("'abc'")
+
+
 class TestStripTrailingOrderBy:
     """Sampling for --row-group-size-mb must not re-run the ordered query."""
 


### PR DESCRIPTION
## The bug

`DiskRewriteStrategy.write_from_query` accepted `row_group_rows` and
`row_group_size_mb` and referenced neither: the DuckDB `COPY` was bare
(`FORMAT PARQUET, COMPRESSION …` only) and the PyArrow rewrite that follows was
never told a row-group size. Callers asking for a specific layout got default
row groups with no warning, while the other three strategies honoured the
request. `write_from_table` forwards to `write_from_query`, so it inherited the
same silence, and the two non-geo plain-Parquet helpers did not even take the
parameters — `duckdb-kv` passes `ROW_GROUP_SIZE` on its plain paths, so those
diverged too.

The symptom surfaces late and confusingly: files that fail `gpio check
row-group` for a reason the caller cannot see from their own arguments.

```
# before                          # after
duckdb-kv    row groups: 1        duckdb-kv    row groups: 1
streaming    row groups: 4        streaming    row groups: 4
in-memory    row groups: 4        in-memory    row groups: 4
disk-rewrite row groups: 1        disk-rewrite row groups: 4
```

(the issue's own repro: 40 rows, `row_group_rows=10`)

## The fix

`core/write_strategies/disk_rewrite.py`

- `write_from_query` resolves the request once, then threads it into **both**
  halves of the strategy: `ROW_GROUP_SIZE n` on the geo `COPY`, and
  `row_group_rows=` into `_rewrite_with_metadata`, which forwards it as
  `writer.write_table(table, row_group_size=n)`. The COPY matters at scale (it
  keeps DuckDB from handing the rewrite groups that are already too coarse); the
  rewrite makes the result exact.
- The non-geo paths take the setting too: `_write_plain_parquet_from_query` adds
  `ROW_GROUP_SIZE` to its COPY, `_write_plain_parquet_from_table` sets
  `row_group_size` on `pq.write_table`.

`core/write_strategies/row_group_sizing.py` (new)

- The MB→rows sampling logic — `_strip_trailing_order_by`,
  `_resolve_row_group_rows` and friends — moves out of `duckdb_kv.py` verbatim
  rather than being copied a second time. `duckdb_kv` now imports it; the moved
  code is byte-equivalent, so its behaviour is unchanged.
- Two additions: `_rows_for_mb_target` (the arithmetic, factored out so both
  resolvers share it) and `_resolve_row_group_rows_for_table` for the Arrow-table
  path, where the table is its own sample and no query has to be re-run.
- A cross-import (`disk_rewrite` → `duckdb_kv`) was rejected: strategies should
  not depend on each other.

Five test imports in `tests/test_write_strategies.py` were repointed to the new
module.

## Tests

Seven new tests in `TestDiskRewriteRowGroupSizing`, all asserting **real**
row-group structure via `pq.ParquetFile(...).metadata.row_group(i).num_rows`
rather than mock call arguments: rows-per-group honoured from query and from
table, an MB target splitting groups, the two non-geo paths, the MB path for
plain tables, and a control asserting the no-settings default shape is
unchanged. Red first — five failed against the old code (`expected 4 row groups
of 10 rows, got [40]`), with the control already passing.

Full fast suite: 3966 passed, 40 skipped. diff-cover vs `main`: 97%.
Pre-commit and pre-push hooks (xenon, import-linter, deptry, vulture, mypy) all
pass.

## Coordination with #693

#693 records this bug as a `KNOWN_` xfail entry in
`tests/test_write_contract.py`
(`test_a2_strategy_shape_contract[disk-rewrite-multi_row_group]`), guarded by a
stale-entry check that fails when a recorded divergence stops reproducing. That
guard now fires for this bug. **Whichever of #693 and this PR merges second must
delete this bug's `KNOWN_` entry and adjust the expected pass/xfail counts during
rebase.**

## Follow-ups

- #697 — the rewrite can split row groups but never merge them: one
  `write_table` per *source* row group means a `row_group_rows` larger than the
  source's groups is silently ignored (`duckdb-kv` identical; the arrow
  strategies coarsen correctly). Same cross-strategy divergence family as this
  bug; suggests a "coarsen" shape for the #693 contract suite.
- `core/common.py` (~:1579) still carries its own MB→rows conversion for the
  arrow write path. It is a candidate to route through the shared helper, left
  out here to keep this change scoped to the reported bug.

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `disk-rewrite` now honors row-group row-count and size settings for DuckDB and PyArrow writes, including non-geospatial Parquet output.
  * MB-based row-group sizing now uses consistent sampling behavior across write strategies.

* **Bug Fixes**
  * Safely preserves queries containing comments, dollar-quoted strings, or escaped literals when removing trailing `ORDER BY` clauses is not reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->