### PR TITLE
fix(metadata): preserve input non-geo KV metadata in convert and Table.write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,6 +524,22 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   for a native GEOMETRY column, so that check fails there for a platform reason
   unrelated to this fix (#721). Every other validator check stays enforced on
   every platform.
+
+- **`gpio convert geoparquet` and `Table.write` keep the input's non-geo
+  key/value metadata.** A GeoParquet file's file-level KV metadata carries
+  sidecar payloads — `fiboa`, `vecorel`, STAC fragments, collection records —
+  and `write_parquet_with_metadata` already merged them into its output. The two
+  highest-level entry points never reached that merge: `convert` hardcoded
+  `original_metadata=None` and passed no KV metadata at all (every strategy
+  dropped the keys), while `Table.write` called the write strategy directly, so
+  preservation depended on the strategy — the Arrow strategies copied the keys
+  off the table schema incidentally, and the DuckDB COPY paths (`duckdb-kv`,
+  the default, and `disk-rewrite`) rebuilt the KV block from scratch and lost
+  them. Both entry points now hand the input's preserved keys to the writer, so
+  sidecar metadata survives on every entry point and every write strategy. The
+  `geo` key itself is never copied — it is regenerated from the written data —
+  and neither are Arrow's own `ARROW:schema` / `pandas` keys.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -538,7 +538,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   them. Both entry points now hand the input's preserved keys to the writer, so
   sidecar metadata survives on every entry point and every write strategy. The
   `geo` key itself is never copied — it is regenerated from the written data —
-  and neither are Arrow's own `ARROW:schema` / `pandas` keys.
+  and neither are Arrow's own `ARROW:schema` / `pandas` keys. Which keys those
+  are is the single `_CARRIED_SCHEMA_METADATA_KEYS` constant the
+  parquet-geo-only path already uses, not a second copy of the same list.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -524,6 +524,22 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   for a native GEOMETRY column, so that check fails there for a platform reason
   unrelated to this fix (#721). Every other validator check stays enforced on
   every platform.
+
+- **`gpio convert geoparquet` and `Table.write` keep the input's non-geo
+  key/value metadata.** A GeoParquet file's file-level KV metadata carries
+  sidecar payloads — `fiboa`, `vecorel`, STAC fragments, collection records —
+  and `write_parquet_with_metadata` already merged them into its output. The two
+  highest-level entry points never reached that merge: `convert` hardcoded
+  `original_metadata=None` and passed no KV metadata at all (every strategy
+  dropped the keys), while `Table.write` called the write strategy directly, so
+  preservation depended on the strategy — the Arrow strategies copied the keys
+  off the table schema incidentally, and the DuckDB COPY paths (`duckdb-kv`,
+  the default, and `disk-rewrite`) rebuilt the KV block from scratch and lost
+  them. Both entry points now hand the input's preserved keys to the writer, so
+  sidecar metadata survives on every entry point and every write strategy. The
+  `geo` key itself is never copied — it is regenerated from the written data —
+  and neither are Arrow's own `ARROW:schema` / `pandas` keys.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -538,7 +538,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   them. Both entry points now hand the input's preserved keys to the writer, so
   sidecar metadata survives on every entry point and every write strategy. The
   `geo` key itself is never copied — it is regenerated from the written data —
-  and neither are Arrow's own `ARROW:schema` / `pandas` keys.
+  and neither are Arrow's own `ARROW:schema` / `pandas` keys. Which keys those
+  are is the single `_CARRIED_SCHEMA_METADATA_KEYS` constant the
+  parquet-geo-only path already uses, not a second copy of the same list.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1078,6 +1078,16 @@ class Table:
 
                 input_crs = parse_crs_string_to_projjson(input_crs)
 
+            # Carry the table's non-geo file-level KV metadata (fiboa, vecorel,
+            # STAC fragments) into the write. The Arrow strategies copied it
+            # incidentally off the schema while the DuckDB COPY strategies —
+            # including the default — rebuilt the KV block from scratch and
+            # dropped it, so preservation depended on the strategy (#690).
+            # 'geo' is deliberately excluded: it is regenerated from the table.
+            from geoparquet_io.core.common import extract_preserved_kv_metadata
+
+            preserved_kv = extract_preserved_kv_metadata(self._table.schema.metadata)
+
             strategy.write_from_table(
                 table=self._table,
                 output_path=str(local_path),
@@ -1089,6 +1099,7 @@ class Table:
                 row_group_rows=row_group_rows,
                 verbose=verbose,
                 input_crs=input_crs,
+                extra_kv_metadata=preserved_kv or None,
             )
 
             # Upload to remote if needed

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -2297,6 +2297,70 @@ def _prune_metadata_to_output_columns(
     return pruned
 
 
+def extract_preserved_kv_metadata(metadata: dict | None) -> dict[str, str]:
+    """Return an input's non-geo file-level KV metadata as ``{str: str}``.
+
+    Sidecar payloads (``fiboa``, ``vecorel``, STAC fragments, collection
+    records) live in Parquet's file-level key/value metadata next to ``geo``.
+    Every write path that rebuilds the KV block must carry them over, so this
+    is the single definition of which keys survive a rewrite (#690).
+
+    Keys and values that are not valid UTF-8 are skipped: the write paths pass
+    KV metadata as text (DuckDB ``KV_METADATA`` takes SQL string literals), so a
+    binary payload cannot be round-tripped and dropping it beats failing the
+    write.
+
+    Args:
+        metadata: KV metadata dict from a Parquet file or Arrow schema. Keys
+            and values may be ``bytes`` or ``str``; ``None`` is accepted.
+
+    Returns:
+        Decoded ``{key: value}`` for every key outside
+        ``_CARRIED_SCHEMA_METADATA_KEYS``.
+    """
+    if not metadata:
+        return {}
+
+    preserved: dict[str, str] = {}
+    for key, value in metadata.items():
+        # The key is decoded inside the try as well: Parquet KV keys are
+        # arbitrary bytes, and a non-UTF-8 key must skip like a non-UTF-8
+        # value rather than raise out of a metadata-preservation helper.
+        try:
+            key_str = key.decode("utf-8") if isinstance(key, bytes) else key
+            if key_str in _CARRIED_SCHEMA_METADATA_KEYS:
+                continue
+            val_str = value.decode("utf-8") if isinstance(value, bytes) else value
+        except UnicodeDecodeError:
+            debug(f"Skipping non-UTF-8 KV metadata entry {key!r} (cannot be preserved as text)")
+            continue
+        preserved[key_str] = val_str
+    return preserved
+
+
+def read_preserved_kv_metadata(parquet_file: str, verbose: bool = False) -> dict[str, str]:
+    """Read a Parquet input's preservable non-geo KV metadata.
+
+    Returns an empty dict when the file cannot be inspected (e.g. a remote
+    input without credentials): losing sidecar keys is bad, but failing an
+    otherwise valid conversion because of them would be worse.
+    """
+    from geoparquet_io.core.duckdb_metadata import get_kv_metadata
+
+    try:
+        # Both the read and the decode are guarded: a malformed KV block is an
+        # input-data problem, and losing sidecar keys must never be the reason
+        # an otherwise valid write fails.
+        preserved = extract_preserved_kv_metadata(get_kv_metadata(parquet_file))
+    except Exception as e:  # noqa: BLE001 - any read failure degrades to "nothing to preserve"
+        warn(f"Could not read input KV metadata from {parquet_file}: {e}")
+        return {}
+
+    if verbose and preserved:
+        debug(f"Preserving input KV metadata keys: {sorted(preserved)}")
+    return preserved
+
+
 def write_parquet_with_metadata(
     con,
     query,
@@ -2420,17 +2484,10 @@ def write_parquet_with_metadata(
     # Build a merged local dict rather than mutating the caller-supplied
     # extra_kv_metadata: partition loops reuse one dict across writes, and
     # writing into it in place leaked prior files' keys into later ones.
-    if original_metadata:
-        preserved_keys = {}
-        for key, value in original_metadata.items():
-            key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-            if key_str in _CARRIED_SCHEMA_METADATA_KEYS:
-                continue
-            val_str = value.decode("utf-8") if isinstance(value, bytes) else value
-            preserved_keys[key_str] = val_str
-        if preserved_keys:
-            # Caller-supplied entries win over preserved keys of the same name.
-            extra_kv_metadata = {**preserved_keys, **(extra_kv_metadata or {})}
+    preserved_keys = extract_preserved_kv_metadata(original_metadata)
+    if preserved_keys:
+        # Caller-supplied entries win over preserved keys of the same name.
+        extra_kv_metadata = {**preserved_keys, **(extra_kv_metadata or {})}
 
     if extra_kv_metadata:
         rewrite_needed = True

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import duckdb
 
-from geoparquet_io.core.common import format_size, write_parquet_with_metadata
+from geoparquet_io.core.common import (
+    format_size,
+    read_preserved_kv_metadata,
+    write_parquet_with_metadata,
+)
 from geoparquet_io.core.crs_utils import (
     _format_crs_display,
     detect_crs_from_spatial_file,
@@ -2023,11 +2027,19 @@ def convert_to_geoparquet(
             geom_col = "geometry" if is_csv else geometry_info["primary"]
             query = repair_query_geometry(con, query, geom_col, repair=repair_geometry)
 
+        # Sidecar KV payloads (fiboa, vecorel, STAC fragments) live next to the
+        # 'geo' key and are rebuilt from scratch by every write strategy, so a
+        # parquet→parquet convert has to hand them to the writer explicitly or
+        # they vanish (#690). Only the non-geo keys travel: 'geo' is regenerated
+        # from the converted data, never copied.
+        preserved_kv = read_preserved_kv_metadata(input_file, verbose) if is_parquet else {}
+
         write_parquet_with_metadata(
             con,
             query,
             output_file,
             original_metadata=None,
+            extra_kv_metadata=preserved_kv or None,
             compression=compression,
             compression_level=compression_level,
             row_group_rows=row_group_rows,

--- a/geoparquet_io/core/write_strategies/arrow_memory.py
+++ b/geoparquet_io/core/write_strategies/arrow_memory.py
@@ -143,6 +143,7 @@ class ArrowMemoryStrategy(BaseWriteStrategy):
         verbose: bool,
         input_crs: dict | None = None,
         custom_metadata: dict | None = None,
+        extra_kv_metadata: dict[str, str] | None = None,
     ) -> None:
         """Write Arrow table to GeoParquet file."""
         from geoparquet_io.core.common import (
@@ -175,6 +176,14 @@ class ArrowMemoryStrategy(BaseWriteStrategy):
                 custom_metadata=custom_metadata,
                 verbose=verbose,
             )
+
+        if extra_kv_metadata:
+            existing_meta = dict(table.schema.metadata or {})
+            for key, value in extra_kv_metadata.items():
+                bkey = key.encode("utf-8") if isinstance(key, str) else key
+                bval = value.encode("utf-8") if isinstance(value, str) else value
+                existing_meta[bkey] = bval
+            table = table.replace_schema_metadata(existing_meta)
 
         _write_table_with_settings(
             table,

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -659,6 +659,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         verbose: bool,
         input_crs: dict | None = None,
         custom_metadata: dict | None = None,
+        extra_kv_metadata: dict[str, str] | None = None,
     ) -> None:
         """Write Arrow table to GeoParquet using batch streaming."""
         from geoparquet_io.core.common import (
@@ -751,6 +752,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             input_crs=input_crs,
             geom_types=geo_meta["columns"][geometry_column]["geometry_types"] if geo_meta else [],
             verbose=verbose,
+            extra_kv_metadata=extra_kv_metadata,
             geoarrow_target_type=geoarrow_target_type,
         )
 

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -280,6 +280,7 @@ class BaseWriteStrategy(ABC):
         verbose: bool,
         input_crs: dict | None = None,
         custom_metadata: dict | None = None,
+        extra_kv_metadata: dict[str, str] | None = None,
     ) -> None:
         """
         Write Arrow table to GeoParquet file.
@@ -296,6 +297,10 @@ class BaseWriteStrategy(ABC):
             verbose: Enable verbose logging
             input_crs: CRS dict to apply to geometry column
             custom_metadata: Optional dict with custom metadata (e.g., H3 covering info)
+            extra_kv_metadata: Additional Parquet file-level KV metadata as
+                {key: json_string}, written alongside 'geo'. Callers pass the
+                input's preserved non-geo keys here so sidecar payloads
+                (fiboa, vecorel, STAC) survive on every strategy (#690).
         """
         ...
 

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -199,6 +199,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         verbose: bool,
         input_crs: dict | None = None,
         custom_metadata: dict | None = None,
+        extra_kv_metadata: dict[str, str] | None = None,
     ) -> None:
         """Write Arrow table to GeoParquet using temporary file and rewrite."""
         from geoparquet_io.core.common import _detect_version_from_table
@@ -249,6 +250,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
                 input_crs=input_crs,
                 verbose=verbose,
                 custom_metadata=custom_metadata,
+                extra_kv_metadata=extra_kv_metadata,
             )
         finally:
             con.close()

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -495,6 +495,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         verbose: bool,
         input_crs: dict | None = None,
         custom_metadata: dict | None = None,
+        extra_kv_metadata: dict[str, str] | None = None,
     ) -> None:
         """Write Arrow table to GeoParquet using DuckDB COPY TO with KV_METADATA."""
         from geoparquet_io.core.common import _detect_version_from_table
@@ -545,6 +546,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
                 input_crs=input_crs,
                 verbose=verbose,
                 custom_metadata=custom_metadata,
+                extra_kv_metadata=extra_kv_metadata,
             )
         finally:
             con.close()

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -1867,12 +1867,24 @@ class TestCarriedSchemaMetadataKeysHasOneDefinition:
         )
 
     def test_both_write_paths_reference_the_constant(self):
+        """Both paths must reach the one constant — directly or through the helper.
+
+        The query path no longer names the constant itself: it filters through
+        ``extract_preserved_kv_metadata``, which is where the comparison now
+        lives. Following that indirection keeps the guard honest; asserting the
+        literal name in ``write_parquet_with_metadata`` would only have been
+        satisfiable by inlining the loop back into it.
+        """
         import inspect
 
         from geoparquet_io.core.common import (
             _strip_geo_metadata_key,
+            extract_preserved_kv_metadata,
             write_parquet_with_metadata,
         )
 
+        # parquet-geo-only path: compares bytes keys straight off a pyarrow schema.
         assert "_CARRIED_SCHEMA_METADATA_KEYS_BYTES" in inspect.getsource(_strip_geo_metadata_key)
-        assert "_CARRIED_SCHEMA_METADATA_KEYS" in inspect.getsource(write_parquet_with_metadata)
+        # Query path: delegates to the helper, which owns the comparison.
+        assert "extract_preserved_kv_metadata" in inspect.getsource(write_parquet_with_metadata)
+        assert "_CARRIED_SCHEMA_METADATA_KEYS" in inspect.getsource(extract_preserved_kv_metadata)

--- a/tests/test_kv_metadata_preservation.py
+++ b/tests/test_kv_metadata_preservation.py
@@ -1,0 +1,291 @@
+"""
+Regression tests for issue #690 — non-geo key/value metadata must survive a write.
+
+A GeoParquet file's file-level KV metadata carries sidecar payloads (``fiboa``,
+``vecorel``, STAC fragments, collection records). ``write_parquet_with_metadata``
+already merges those keys into the output, but the two highest-level entry
+points did not reach that merge:
+
+1. ``gpio convert geoparquet`` hardcoded ``original_metadata=None`` and passed
+   no KV metadata at all, so every strategy dropped the keys.
+2. ``api.Table.write`` calls the strategy's ``write_from_table`` directly. The
+   Arrow strategies preserved the table's schema metadata incidentally, while
+   the DuckDB COPY paths (``duckdb-kv`` — the default — and ``disk-rewrite``)
+   rebuilt the KV block from scratch and dropped them.
+
+These tests assert preservation on the DEFAULT path for both entry points, and
+consistency across all four write strategies.
+"""
+
+import json
+import logging
+import struct
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+import geoparquet_io.api as api
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.common import extract_preserved_kv_metadata, read_preserved_kv_metadata
+
+WRITE_STRATEGIES = ["duckdb-kv", "in-memory", "streaming", "disk-rewrite"]
+
+FIBOA_VALUE = '{"schemas": ["https://fiboa.org/specification/v0.2.0/schema.yaml"]}'
+CUSTOM_VALUE = '{"hello": "world"}'
+
+
+def _geo_metadata() -> dict:
+    return {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+            }
+        },
+    }
+
+
+def _point_wkb(x: float, y: float) -> bytes:
+    return struct.pack("<BI2d", 1, 1, x, y)
+
+
+@pytest.fixture
+def kv_source(tmp_path):
+    """A tiny GeoParquet file carrying two non-geo KV keys next to ``geo``."""
+    src = tmp_path / "kv_source.parquet"
+    table = pa.table(
+        {
+            "id": [1, 2, 3],
+            "geometry": [_point_wkb(1.0, 2.0), _point_wkb(3.0, 4.0), _point_wkb(5.0, 6.0)],
+        }
+    )
+    metadata = {
+        b"geo": json.dumps(_geo_metadata()).encode("utf-8"),
+        b"fiboa": FIBOA_VALUE.encode("utf-8"),
+        b"custom_note": CUSTOM_VALUE.encode("utf-8"),
+    }
+    pq.write_table(table.replace_schema_metadata(metadata), src)
+    return src
+
+
+def kv_keys(path) -> set[str]:
+    metadata = pq.ParquetFile(str(path)).schema_arrow.metadata or {}
+    return {k.decode("utf-8") if isinstance(k, bytes) else k for k in metadata}
+
+
+def kv_value(path, key: str) -> str:
+    metadata = pq.ParquetFile(str(path)).schema_arrow.metadata or {}
+    return metadata[key.encode("utf-8")].decode("utf-8")
+
+
+def assert_single_valid_geo(path):
+    """The geo key is regenerated exactly once and is still parseable."""
+    metadata = pq.ParquetFile(str(path)).schema_arrow.metadata or {}
+    geo_keys = [k for k in kv_keys(path) if k == "geo"]
+    assert geo_keys == ["geo"], f"expected exactly one geo key, got {sorted(kv_keys(path))}"
+    geo = json.loads(metadata[b"geo"].decode("utf-8"))
+    assert geo["primary_column"] == "geometry"
+    assert "geometry" in geo["columns"]
+
+
+class TestExtractPreservedKvMetadata:
+    """Unit tests for the shared preserved-keys filter."""
+
+    def test_none_and_empty(self):
+        assert extract_preserved_kv_metadata(None) == {}
+        assert extract_preserved_kv_metadata({}) == {}
+
+    def test_excludes_geo_and_arrow_noise(self):
+        preserved = extract_preserved_kv_metadata(
+            {
+                b"geo": b"{}",
+                b"ARROW:schema": b"base64noise",
+                b"pandas": b"{}",
+                b"fiboa": FIBOA_VALUE.encode("utf-8"),
+            }
+        )
+        assert preserved == {"fiboa": FIBOA_VALUE}
+
+    def test_decodes_str_and_bytes_keys(self):
+        preserved = extract_preserved_kv_metadata({"custom_note": CUSTOM_VALUE, b"fiboa": b"{}"})
+        assert preserved == {"custom_note": CUSTOM_VALUE, "fiboa": "{}"}
+
+    def test_skips_undecodable_values(self):
+        """Binary payloads that are not UTF-8 are dropped, not fatal."""
+        preserved = extract_preserved_kv_metadata({b"binary_blob": b"\xff\xfe", b"fiboa": b"{}"})
+        assert preserved == {"fiboa": "{}"}
+
+    def test_skips_undecodable_keys(self):
+        """Parquet KV keys are arbitrary bytes; a non-UTF-8 key must not raise."""
+        preserved = extract_preserved_kv_metadata({b"\xff\xfe": b"{}", b"fiboa": b"{}"})
+        assert preserved == {"fiboa": "{}"}
+
+    def test_undecodable_key_survives_the_read_path(self, tmp_path):
+        """The same skip applies when the key comes off a real file."""
+        src = tmp_path / "binary_key.parquet"
+        table = pa.table({"id": [1], "geometry": [_point_wkb(1.0, 2.0)]})
+        pq.write_table(
+            table.replace_schema_metadata(
+                {
+                    b"geo": json.dumps(_geo_metadata()).encode("utf-8"),
+                    b"\xff\xfe": b"{}",
+                    b"fiboa": FIBOA_VALUE.encode("utf-8"),
+                }
+            ),
+            src,
+        )
+        assert read_preserved_kv_metadata(str(src)) == {"fiboa": FIBOA_VALUE}
+
+
+class TestReadPreservedKvMetadata:
+    """Reading an input's preservable keys must degrade, never abort a write."""
+
+    @pytest.mark.parametrize("verbose", [False, True])
+    def test_reads_keys_from_file(self, kv_source, verbose):
+        preserved = read_preserved_kv_metadata(str(kv_source), verbose=verbose)
+        assert preserved == {"fiboa": FIBOA_VALUE, "custom_note": CUSTOM_VALUE}
+
+    def test_unreadable_input_warns_and_returns_empty(self, caplog, monkeypatch):
+        from geoparquet_io.core import duckdb_metadata
+
+        def _boom(*args, **kwargs):
+            raise OSError("simulated metadata read failure")
+
+        monkeypatch.setattr(duckdb_metadata, "get_kv_metadata", _boom)
+
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            assert read_preserved_kv_metadata("s3://bucket/unreachable.parquet") == {}
+
+        assert any(
+            "metadata" in rec.message.lower() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), f"expected a warning; got {[r.message for r in caplog.records]}"
+
+
+class TestConvertPreservesKv:
+    """``gpio convert geoparquet`` — parquet input, default write strategy."""
+
+    def test_default_path_preserves_non_geo_keys(self, kv_source, tmp_path):
+        out = tmp_path / "converted.parquet"
+        result = CliRunner().invoke(
+            cli,
+            [
+                "convert",
+                "geoparquet",
+                str(kv_source),
+                str(out),
+                "--skip-hilbert",
+                "--geoparquet-version",
+                "1.1",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert {"fiboa", "custom_note"} <= kv_keys(out)
+        assert kv_value(out, "fiboa") == FIBOA_VALUE
+        assert kv_value(out, "custom_note") == CUSTOM_VALUE
+        assert_single_valid_geo(out)
+
+    def test_auto_version_path_preserves_non_geo_keys(self, kv_source, tmp_path):
+        """No --geoparquet-version: the version is auto-resolved from the input."""
+        out = tmp_path / "converted_auto.parquet"
+        result = CliRunner().invoke(
+            cli, ["convert", "geoparquet", str(kv_source), str(out), "--skip-hilbert"]
+        )
+        assert result.exit_code == 0, result.output
+        assert {"fiboa", "custom_note"} <= kv_keys(out)
+        assert_single_valid_geo(out)
+
+    def test_hilbert_sorted_path_preserves_non_geo_keys(self, kv_source, tmp_path):
+        out = tmp_path / "converted_hilbert.parquet"
+        result = CliRunner().invoke(
+            cli,
+            ["convert", "geoparquet", str(kv_source), str(out), "--geoparquet-version", "1.1"],
+        )
+        assert result.exit_code == 0, result.output
+        assert {"fiboa", "custom_note"} <= kv_keys(out)
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["fields_v2_file", "austria_bbox_covering_file"],
+        ids=["v2_fast_path", "bbox_covering"],
+    )
+    def test_sidecar_keys_do_not_change_geo_metadata(self, request, tmp_path, fixture_name):
+        """KV keys force the metadata-rewrite path; geo output must be identical.
+
+        Two inputs, two things being pinned:
+
+        - ``fields_v2_file`` (GeoParquet 2.0, no bbox column) normally takes the
+          no-rewrite fast path. Sidecar keys send it down the rewrite path
+          instead, so the geo metadata that path produces has to match what the
+          fast path wrote — otherwise preservation would silently trade one kind
+          of metadata for another.
+        - ``austria_bbox_covering_file`` carries a bbox column and a ``covering``
+          block, so the rewrite path runs ``_add_bbox_covering_if_present``. That
+          is the assignment #694 is about; this pins that carrying sidecar keys
+          does not cost the output its covering.
+        """
+        source_file = request.getfixturevalue(fixture_name)
+        with_kv = tmp_path / "source_with_kv.parquet"
+        source = pq.read_table(source_file)
+        metadata = dict(source.schema.metadata or {})
+        metadata[b"fiboa"] = FIBOA_VALUE.encode("utf-8")
+        pq.write_table(source.replace_schema_metadata(metadata), with_kv)
+
+        outputs = {}
+        for label, inp in (("plain", source_file), ("with_kv", with_kv)):
+            out = tmp_path / f"converted_{label}.parquet"
+            result = CliRunner().invoke(
+                cli, ["convert", "geoparquet", str(inp), str(out), "--skip-hilbert"]
+            )
+            assert result.exit_code == 0, result.output
+            outputs[label] = json.loads(kv_value(out, "geo"))
+
+        assert outputs["with_kv"] == outputs["plain"]
+        assert "fiboa" in kv_keys(tmp_path / "converted_with_kv.parquet")
+
+        # The covering fixture must actually exercise the covering assignment,
+        # otherwise this test would pass vacuously if the fixture ever changed.
+        if fixture_name == "austria_bbox_covering_file":
+            primary = outputs["with_kv"]["primary_column"]
+            assert "covering" in outputs["with_kv"]["columns"][primary]
+
+    def test_non_parquet_input_still_converts(self, geojson_input, tmp_path):
+        """A non-parquet input has no KV metadata to preserve — must not break."""
+        out = tmp_path / "from_geojson.parquet"
+        result = CliRunner().invoke(
+            cli, ["convert", "geoparquet", str(geojson_input), str(out), "--skip-hilbert"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "geo" in kv_keys(out)
+
+
+class TestTableWritePreservesKv:
+    """``api.read(...).write(...)`` — default and explicit strategies."""
+
+    def test_default_strategy_preserves_non_geo_keys(self, kv_source, tmp_path):
+        out = tmp_path / "api_default.parquet"
+        api.read(str(kv_source)).write(str(out), geoparquet_version="1.1")
+        assert {"fiboa", "custom_note"} <= kv_keys(out)
+        assert kv_value(out, "fiboa") == FIBOA_VALUE
+        assert kv_value(out, "custom_note") == CUSTOM_VALUE
+        assert_single_valid_geo(out)
+
+    @pytest.mark.parametrize("strategy", WRITE_STRATEGIES)
+    def test_every_strategy_preserves_non_geo_keys(self, kv_source, tmp_path, strategy):
+        out = tmp_path / f"api_{strategy}.parquet"
+        api.read(str(kv_source)).write(str(out), geoparquet_version="1.1", write_strategy=strategy)
+        assert {"fiboa", "custom_note"} <= kv_keys(out), f"{strategy} dropped keys"
+        assert kv_value(out, "fiboa") == FIBOA_VALUE
+        assert_single_valid_geo(out)
+
+    def test_written_geo_metadata_is_not_the_stale_input_copy(self, kv_source, tmp_path):
+        """Preserving KV must not smuggle the input's geo key through verbatim."""
+        out = tmp_path / "api_geo.parquet"
+        api.read(str(kv_source)).write(str(out), geoparquet_version="1.0")
+        metadata = pq.ParquetFile(str(out)).schema_arrow.metadata
+        geo = json.loads(metadata[b"geo"].decode("utf-8"))
+        assert geo["version"].startswith("1.0")


### PR DESCRIPTION
## The bug (#690)

A GeoParquet file's file-level key/value metadata carries sidecar payloads —
`fiboa`, `vecorel`, STAC fragments, collection records. `write_parquet_with_metadata`
already merged those keys into its output, but neither of the two highest-level
entry points reached that merge, so the metadata silently disappeared on exactly
the paths users are most likely to call:

```
source          : ['custom_note', 'fiboa', 'geo']
Table.write     : ['geo']
convert         : ['geo']
```

Two mechanisms behind one symptom:

1. **`gpio convert geoparquet`** hardcoded `original_metadata=None` and passed no
   KV metadata at all — the preservation loop had nothing to preserve, on every
   strategy.
2. **`api.Table.write`** calls the strategy's `write_from_table` directly, bypassing
   the merge, so preservation depended on which strategy ran. The Arrow strategies
   (`in-memory`, `streaming`) copied the keys off the table schema incidentally;
   the DuckDB COPY paths (`duckdb-kv` — **the default** — and `disk-rewrite`)
   rebuilt the KV block from scratch and lost them.

## The fix

**One shared definition, applied at the entry points.**

- `extract_preserved_kv_metadata()` (`core/common.py`) is now the single answer to
  "which keys survive a rewrite": everything except `geo` (regenerated from the
  written data), `ARROW:schema` and `pandas` (regenerated by Arrow). It is a
  refactor of the loop that already lived inside `write_parquet_with_metadata`,
  so #660's "never mutate the caller's dict" behaviour is unchanged — the merged
  dict is still local, with caller entries winning. Keys and values that are not
  valid UTF-8 are skipped rather than raising: the write paths pass KV metadata as
  text, so a binary payload cannot round-trip.
- `read_preserved_kv_metadata()` reads a parquet input's preservable keys and
  degrades to `{}` with a warning if the input cannot be read — losing sidecar keys
  is bad, failing an otherwise valid conversion because of them is worse.
- `core/convert.py` passes the input's preserved keys for parquet inputs.
  `original_metadata` stays `None` deliberately: handing over the full metadata
  would also carry geo bbox / geometry_types / covering / crs, a much larger
  behavioural change than this bug needs.
- `api/table.py` does the same from the table's schema metadata.
- `write_from_table` grows `extra_kv_metadata` on the abstract base and all four
  strategies, so the **entry point** decides what is preserved and every strategy
  obeys. `geo` is never copied through — always regenerated.

## Tests

`tests/test_kv_metadata_preservation.py`, 21 tests, written red-first. The initial
red matched the strategy split in the issue exactly — 6 failed, 8 passed, with
`in-memory` and `streaming` green from the start because they already preserved
incidentally:

```
FAILED ...::TestConvertPreservesKv::test_default_path_preserves_non_geo_keys
FAILED ...::TestConvertPreservesKv::test_hilbert_sorted_path_preserves_non_geo_keys
FAILED ...::TestConvertPreservesKv::test_auto_version_path_preserves_non_geo_keys
FAILED ...::TestTableWritePreservesKv::test_every_strategy_preserves_non_geo_keys[disk-rewrite]
FAILED ...::TestTableWritePreservesKv::test_every_strategy_preserves_non_geo_keys[duckdb-kv]
FAILED ...::TestTableWritePreservesKv::test_default_strategy_preserves_non_geo_keys
```

Coverage: end-to-end convert (default, auto-version, hilbert-sorted, non-parquet
input) and `Table.write` (default plus all four strategies parametrized), the
`geo` key regenerated exactly once and not doubled, the shared filter's exclusions
and its non-UTF-8 key/value skips, and the read path's warn-and-degrade.

Full fast suite: **3980 passed, 40 skipped**. diff-cover vs `main`: **100%** of 41
changed lines. All pre-commit and pre-push hooks (ruff, mypy, vulture, xenon,
import-linter, deptry, doc-sync) pass.

## Performance note

`extra_kv_metadata` forces the metadata-rewrite path, so an input carrying sidecar
keys no longer takes the plain-COPY fast path — it pays one extra bbox/geometry-type
scan. Correctness is pinned:
`test_sidecar_keys_do_not_change_geo_metadata` converts both a GeoParquet 2.0
fixture (the fast-path case) and a bbox-covering fixture (which exercises
`_add_bbox_covering_if_present`) with and without a sidecar key, and asserts the
resulting `geo` metadata is identical either way. Removing the extra scan by
teaching `_plain_copy_to` to emit `KV_METADATA` is filed as **#709**.

## Residual divergence

The Arrow strategies still write a slightly larger KV block than the DuckDB ones —
they carry Arrow's own `pandas` key, which the shared filter deliberately excludes
from preservation. Sidecar preservation itself, which is what this PR is about, is
now consistent across all four.

## Related issues filed from this work

- **#708** (bug) — `Table.write` on `duckdb-kv` still drops KV metadata for tables
  with **no geometry column**: the plain-Parquet short-circuit COPYs without
  `KV_METADATA` while the other three strategies retain it (measured `[]` vs
  `['fiboa']`). Same shape as this bug, out of scope here.
- **#709** (enhancement) — carry preserved keys on the fast path, per the
  performance note above.

## Coordination with #693

Open PR #693 (branch `test/write-contract`, untouched by this PR) records this bug
as xfail entries in `tests/test_write_contract.py`:
`test_a3_input_kv_metadata_survives` and `test_a3_table_write_kv_depends_on_strategy`
— **two `KNOWN_KV` entries**. Both divergences stop reproducing with this PR, so
whichever of the two merges second must delete both `KNOWN_KV` entries and update
the expected pass/xfail counts during rebase; #693's stale-entry guard fails
otherwise.

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserves non-GeoParquet file-level metadata during conversion and table writes across all write strategies.
  * Retains metadata such as fiboa, Vecorel, STAC, and custom key/value entries.
  * Regenerates current `geo` metadata while excluding internal schema descriptors and managed metadata.

* **Bug Fixes**
  * Prevents loss of supported metadata during metadata rewrites, sorting, versioning, and bounding-box updates.

* **Documentation**
  * Added changelog entries describing metadata preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->