### PR TITLE
fix(convert): omit the 1.1-only covering key from GeoParquet 1.0 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,6 +447,21 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the MB target); the `E''` case produced SQL that still parsed but with a
   different `WHERE` clause, estimating from a different row set. Skipping the
   speed-up is always safe; guessing is not.
+
+- **GeoParquet 1.0 output no longer carries the 1.1-only `covering` key.**
+  `gpio convert geoparquet --geoparquet-version 1.0` keyed the covering
+  metadata off bbox-column presence alone, so it wrote a file declaring version
+  1.0.0 with a `covering` entry — a field that does not exist in the GeoParquet
+  1.0.0 specification (it was introduced in 1.1) — which gpio's own
+  `gpio check spec` then rejected while `convert` still exited 0. The covering
+  metadata is now version-gated at the shared metadata-assembly points, so every
+  write strategy inherits the gate, including coverings carried in from a 1.1
+  source file or supplied as `custom_metadata` (h3/s2/a5/quadkey). The bbox
+  **column** is still written and remains fully functional for 1.0 output —
+  only the metadata key is 1.1+. Relatedly, `gpio check bbox` no longer reports
+  a 1.0 file's bbox column as "missing metadata covering"; for those files the
+  actionable advice is the version upgrade it already recommends.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,9 +458,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   write strategy inherits the gate, including coverings carried in from a 1.1
   source file or supplied as `custom_metadata` (h3/s2/a5/quadkey). The bbox
   **column** is still written and remains fully functional for 1.0 output —
-  only the metadata key is 1.1+. Relatedly, `gpio check bbox` no longer reports
-  a 1.0 file's bbox column as "missing metadata covering"; for those files the
-  actionable advice is the version upgrade it already recommends.
+  only the metadata key is 1.1+.
+  The two entry points that exist *solely* to write that key —
+  `gpio add bbox-metadata` and `Table.add_bbox_metadata()` — now fail with a
+  clear error naming the conflict when the file or table declares 1.0, instead
+  of silently producing a file their own validator rejects. **This is a
+  behavior change**: those calls previously "succeeded" on a 1.0 input.
+  Convert to 1.1 first (`gpio convert geoparquet in.parquet out.parquet
+  --geoparquet-version 1.1`). Note that `gpio add bbox` with the default
+  version is unaffected — it writes 1.1 output, covering included.
+  Relatedly, `gpio check bbox` no longer reports a 1.0 file's bbox column as
+  "missing metadata covering" (for those files the actionable advice is the
+  version upgrade it already recommends), and it now flags — rather than
+  affirming with a ✓ — a pre-1.1 file that carries a covering key anyway.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -447,6 +447,21 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the MB target); the `E''` case produced SQL that still parsed but with a
   different `WHERE` clause, estimating from a different row set. Skipping the
   speed-up is always safe; guessing is not.
+
+- **GeoParquet 1.0 output no longer carries the 1.1-only `covering` key.**
+  `gpio convert geoparquet --geoparquet-version 1.0` keyed the covering
+  metadata off bbox-column presence alone, so it wrote a file declaring version
+  1.0.0 with a `covering` entry — a field that does not exist in the GeoParquet
+  1.0.0 specification (it was introduced in 1.1) — which gpio's own
+  `gpio check spec` then rejected while `convert` still exited 0. The covering
+  metadata is now version-gated at the shared metadata-assembly points, so every
+  write strategy inherits the gate, including coverings carried in from a 1.1
+  source file or supplied as `custom_metadata` (h3/s2/a5/quadkey). The bbox
+  **column** is still written and remains fully functional for 1.0 output —
+  only the metadata key is 1.1+. Relatedly, `gpio check bbox` no longer reports
+  a 1.0 file's bbox column as "missing metadata covering"; for those files the
+  actionable advice is the version upgrade it already recommends.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -458,9 +458,19 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   write strategy inherits the gate, including coverings carried in from a 1.1
   source file or supplied as `custom_metadata` (h3/s2/a5/quadkey). The bbox
   **column** is still written and remains fully functional for 1.0 output —
-  only the metadata key is 1.1+. Relatedly, `gpio check bbox` no longer reports
-  a 1.0 file's bbox column as "missing metadata covering"; for those files the
-  actionable advice is the version upgrade it already recommends.
+  only the metadata key is 1.1+.
+  The two entry points that exist *solely* to write that key —
+  `gpio add bbox-metadata` and `Table.add_bbox_metadata()` — now fail with a
+  clear error naming the conflict when the file or table declares 1.0, instead
+  of silently producing a file their own validator rejects. **This is a
+  behavior change**: those calls previously "succeeded" on a 1.0 input.
+  Convert to 1.1 first (`gpio convert geoparquet in.parquet out.parquet
+  --geoparquet-version 1.1`). Note that `gpio add bbox` with the default
+  version is unaffected — it writes 1.1 output, covering included.
+  Relatedly, `gpio check bbox` no longer reports a 1.0 file's bbox column as
+  "missing metadata covering" (for those files the actionable advice is the
+  version upgrade it already recommends), and it now flags — rather than
+  affirming with a ✓ — a pre-1.1 file that carries a covering key anyway.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1151,6 +1151,10 @@ table_with_bbox = table.add_bbox().add_bbox_metadata()
 table_with_meta = table.add_bbox_metadata()
 ```
 
+Raises `ValueError` when the table declares GeoParquet 1.0: the `covering` key was
+introduced in 1.1, so writing it at 1.0 would produce a file that fails validation.
+Write the table at 1.1 first (`table.write(path, geoparquet_version='1.1')`).
+
 #### `check()` / `check_spatial()` / `check_compression()` / `check_bbox()` / `check_row_groups()`
 
 Run best-practice checks on the table.

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -81,6 +81,12 @@ If your file already has a bbox column but lacks covering metadata (e.g., from e
 
     This modifies the file in-place to add only the metadata, without creating a new file.
 
+    !!! note "Requires GeoParquet 1.1+"
+
+        The `covering` key was introduced in GeoParquet 1.1, so this command fails on a
+        file declaring 1.0 rather than writing metadata that version cannot carry.
+        Convert it first: `gpio convert geoparquet in.parquet out.parquet --geoparquet-version 1.1`.
+
 === "Python"
 
     ```python

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -2822,6 +2822,19 @@ class Table:
                 "columns": {},
             }
 
+        # 'covering' was introduced in GeoParquet 1.1. This method exists solely to
+        # write that key, so a 1.0 table gets a clear error naming the conflict
+        # rather than silently returning a table without the metadata it asked for.
+        from geoparquet_io.core.geo_metadata import covering_supported
+
+        table_version = geo_meta.get("version", "")
+        if not covering_supported(table_version):
+            raise ValueError(
+                f"Cannot add bbox covering metadata: this table declares GeoParquet "
+                f"{table_version}, and the 'covering' key requires GeoParquet 1.1 or later. "
+                f"Write the table at 1.1 first (e.g. write(..., geoparquet_version='1.1'))."
+            )
+
         # Add covering metadata for the geometry column
         if geom_col not in geo_meta["columns"]:
             geo_meta["columns"][geom_col] = {}

--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -25,6 +25,25 @@ from geoparquet_io.core.streaming import (
 )
 
 
+def _bbox_metadata_advice(parquet_file: str) -> str:
+    """Advice for a file that has a bbox column but no covering metadata.
+
+    'covering' is 1.1-only, so a 1.0 file cannot be fixed by 'add bbox-metadata'
+    (which refuses) — it needs a version upgrade first.
+    """
+    from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.geo_metadata import covering_supported
+
+    geo_meta = get_geo_metadata(parquet_file) or {}
+    version = geo_meta.get("version", "")
+    if covering_supported(version):
+        return "Run 'gpio add bbox-metadata' to add metadata, or use --force to replace."
+    return (
+        f"'covering' requires GeoParquet 1.1+ (this file is {version}). Convert first: "
+        "gpio convert geoparquet IN.parquet OUT.parquet --geoparquet-version 1.1"
+    )
+
+
 def add_bbox_table(
     table: pa.Table,
     bbox_column_name: str = "bbox",
@@ -348,7 +367,7 @@ def _add_bbox_file_based(
                 replace_column = _handle_existing_bbox_force(bbox_column_name, existing_bbox_col)
             else:
                 progress(f"File has bbox column '{existing_bbox_col}' but lacks covering metadata.")
-                progress("Run 'gpio add bbox-metadata' to add metadata, or use --force to replace.")
+                progress(_bbox_metadata_advice(input_parquet))
                 return
 
     # Get geometry column for the SQL expression

--- a/geoparquet_io/core/add/bbox.py
+++ b/geoparquet_io/core/add/bbox.py
@@ -39,7 +39,8 @@ def _bbox_metadata_advice(parquet_file: str) -> str:
     if covering_supported(version):
         return "Run 'gpio add bbox-metadata' to add metadata, or use --force to replace."
     return (
-        f"'covering' requires GeoParquet 1.1+ (this file is {version}). Convert first: "
+        f"'covering' requires GeoParquet 1.1+ (this file is {version}). Use --force to "
+        "rewrite the bbox column at 1.1 with covering, or convert first: "
         "gpio convert geoparquet IN.parquet OUT.parquet --geoparquet-version 1.1"
     )
 
@@ -205,7 +206,9 @@ def add_bbox_column(
         memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
 
     Note:
-        Bbox covering metadata is automatically added when the file is written.
+        Bbox covering metadata is automatically added when the file is written,
+        except for GeoParquet 1.0 output: 'covering' was introduced in 1.1, so a
+        1.0 file gets the bbox column without the covering key.
     """
     # Check for streaming mode (stdin input or stdout output)
     is_streaming = is_stdin(input_parquet) or should_stream_output(output_parquet)

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -25,7 +25,7 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.exceptions import GeoParquetError
 from geoparquet_io.core.file_utils import safe_file_url
-from geoparquet_io.core.geo_metadata import parse_geo_metadata
+from geoparquet_io.core.geo_metadata import covering_supported, parse_geo_metadata
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, error, success
 
@@ -169,6 +169,19 @@ def add_bbox_metadata(
 
     if not geo_meta:
         geo_meta = {"version": "1.1.0", "primary_column": "geometry", "columns": {}}
+
+    # 'covering' was introduced in GeoParquet 1.1. Unlike the write paths — where
+    # covering is an implicit side effect of writing a bbox column and is simply
+    # omitted — this command exists solely to write that key, so a 1.0 file gets a
+    # clear error naming the conflict rather than a silent no-op reporting success.
+    file_version = geo_meta.get("version", "")
+    if not covering_supported(file_version):
+        raise GeoParquetError(
+            f"Cannot add bbox covering metadata: this file declares GeoParquet "
+            f"{file_version}, and the 'covering' key requires GeoParquet 1.1 or later.\n"
+            f"Convert the file first: gpio convert geoparquet {parquet_file} out.parquet "
+            f"--geoparquet-version 1.1"
+        )
 
     # Find primary geometry column
     primary_col = find_primary_geometry_column(safe_url, verbose)

--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -404,6 +404,13 @@ def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, 
         issues.append("Bbox column exists but missing metadata covering")
         recommendations.append("Add bbox covering to metadata")
 
+    # The inverse mismatch: a pre-1.1 file that carries the 1.1-only key anyway.
+    # 'gpio check spec' rejects such a file, so don't affirm it here.
+    has_illegal_covering = bbox_info["has_bbox_metadata"] and not covering_supported(version)
+    if has_illegal_covering:
+        issues.append(f"Metadata covering present but version {version} predates 'covering' (1.1)")
+        recommendations.append("Upgrade to version 1.1.0+ to keep the bbox covering")
+
     passed = version >= "1.1.0" and not needs_bbox_column and not needs_bbox_metadata
 
     # Always suggest v2.0 upgrade for v1.x files
@@ -422,7 +429,13 @@ def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, 
             warn(f"⚠️ Version {version} (upgrade to 1.1.0+ recommended)")
 
         if bbox_info["has_bbox_column"]:
-            if bbox_info["has_bbox_metadata"]:
+            if has_illegal_covering:
+                error(
+                    f"❌ Found bbox column '{bbox_info['bbox_column_name']}' with covering "
+                    f"metadata, but 'covering' requires GeoParquet 1.1+ (this file is {version}) "
+                    "— run 'gpio check spec' for details"
+                )
+            elif bbox_info["has_bbox_metadata"]:
                 success(
                     f"✓ Found bbox column '{bbox_info['bbox_column_name']}' "
                     "with proper metadata covering"

--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -373,6 +373,7 @@ def _check_geoparquet_v2(parquet_file, file_type_info, verbose, return_results, 
 def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, quiet=False):
     """Check GeoParquet 1.x file (existing logic, bbox IS recommended)."""
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.geo_metadata import covering_supported
 
     geo_meta = get_geo_metadata(parquet_file)
     version = geo_meta.get("version", "0.0.0") if geo_meta else "0.0.0"
@@ -387,7 +388,13 @@ def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, 
         recommendations.append("Upgrade to version 1.1.0+")
 
     needs_bbox_column = not bbox_info["has_bbox_column"]
-    needs_bbox_metadata = bbox_info["has_bbox_column"] and not bbox_info["has_bbox_metadata"]
+    # 'covering' is 1.1-only, so a 1.0 file with a bbox column is not missing anything
+    # it is allowed to have — the "outdated version" issue above is the actionable one.
+    needs_bbox_metadata = (
+        covering_supported(version)
+        and bbox_info["has_bbox_column"]
+        and not bbox_info["has_bbox_metadata"]
+    )
 
     if needs_bbox_column:
         issues.append("No bbox column found")
@@ -420,10 +427,15 @@ def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, 
                     f"✓ Found bbox column '{bbox_info['bbox_column_name']}' "
                     "with proper metadata covering"
                 )
-            else:
+            elif needs_bbox_metadata:
                 warn(
                     f"⚠️  Found bbox column '{bbox_info['bbox_column_name']}' but missing "
                     "bbox covering metadata (add to metadata to help inform clients)"
+                )
+            else:
+                info(
+                    f"ℹ️  Found bbox column '{bbox_info['bbox_column_name']}'; the 'covering' "
+                    f"key that advertises it needs GeoParquet 1.1+ (this file is {version})"
                 )
         else:
             error("❌ No bbox column found (recommended for better performance)")

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -191,6 +191,36 @@ def _add_bbox_covering(
         debug(f"Added bbox covering metadata for column '{bbox_info['bbox_column_name']}'")
 
 
+def covering_supported(version: str | None) -> bool:
+    """Whether a GeoParquet version may carry the ``covering`` column key.
+
+    ``covering`` was introduced in GeoParquet 1.1 — the word does not appear
+    anywhere in the v1.0.0 specification — so 1.0 output must omit it. The bbox
+    *column* itself is an ordinary Parquet column and stays legal at 1.0; only
+    the metadata key is gated.
+
+    Accepts both the short option form ("1.0", "1.1") and the metadata form
+    ("1.0.0", "1.1.0"). Unknown/absent versions are treated as supporting it.
+    """
+    return not str(version or "").startswith("1.0")
+
+
+def strip_unsupported_covering(geo_meta: dict, version: str | None, verbose: bool = False) -> dict:
+    """Drop ``covering`` from every column when ``version`` predates 1.1.
+
+    Single gate shared by every write path, applied after metadata assembly so it
+    also catches coverings carried in from a 1.1 source file or supplied through
+    ``custom_metadata`` (h3/s2/a5/quadkey).
+    """
+    if covering_supported(version):
+        return geo_meta
+
+    for col_name, col_meta in geo_meta.get("columns", {}).items():
+        if isinstance(col_meta, dict) and col_meta.pop("covering", None) is not None and verbose:
+            debug(f"Dropped 1.1-only covering metadata for column '{col_name}' (version {version})")
+    return geo_meta
+
+
 def _add_custom_covering(
     geo_meta: dict, geom_col: str, custom_metadata: dict | None, verbose: bool
 ) -> None:
@@ -420,7 +450,7 @@ def create_geo_metadata(
             if key != "covering":
                 geo_meta[key] = value
 
-    return geo_meta
+    return strip_unsupported_covering(geo_meta, version, verbose)
 
 
 # =============================================================================

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -206,19 +206,41 @@ def covering_supported(version: str | None) -> bool:
 
 
 def strip_unsupported_covering(geo_meta: dict, version: str | None, verbose: bool = False) -> dict:
-    """Drop ``covering`` from every column when ``version`` predates 1.1.
+    """Return ``geo_meta`` without ``covering`` on any column when ``version`` predates 1.1.
 
     Single gate shared by every write path, applied after metadata assembly so it
     also catches coverings carried in from a 1.1 source file or supplied through
     ``custom_metadata`` (h3/s2/a5/quadkey).
+
+    Never mutates its input. The assembled metadata still aliases the caller's
+    column dicts through the shallow copy in ``_initialize_geo_metadata``, and
+    partition loops reuse one ``original_metadata`` dict across many writes, so
+    popping in place would strip the shared dict permanently and silently cost a
+    later 1.1 write its covering.
     """
     if covering_supported(version):
         return geo_meta
 
-    for col_name, col_meta in geo_meta.get("columns", {}).items():
-        if isinstance(col_meta, dict) and col_meta.pop("covering", None) is not None and verbose:
-            debug(f"Dropped 1.1-only covering metadata for column '{col_name}' (version {version})")
-    return geo_meta
+    columns = geo_meta.get("columns")
+    if not isinstance(columns, dict):
+        return geo_meta
+    if not any(isinstance(col, dict) and "covering" in col for col in columns.values()):
+        return geo_meta
+
+    stripped = {}
+    for col_name, col_meta in columns.items():
+        if isinstance(col_meta, dict) and "covering" in col_meta:
+            col_meta = {k: v for k, v in col_meta.items() if k != "covering"}
+            if verbose:
+                debug(
+                    f"Dropped 1.1-only covering metadata for column '{col_name}' "
+                    f"(version {version})"
+                )
+        stripped[col_name] = col_meta
+
+    result = dict(geo_meta)
+    result["columns"] = stripped
+    return result
 
 
 def _add_custom_covering(

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -56,7 +56,7 @@ def build_geo_metadata(
         dict: Complete geo metadata structure ready for embedding in Parquet
     """
     from geoparquet_io.core.crs_utils import apply_output_crs
-    from geoparquet_io.core.geo_metadata import GEOPARQUET_VERSIONS
+    from geoparquet_io.core.geo_metadata import GEOPARQUET_VERSIONS, strip_unsupported_covering
 
     version_config = GEOPARQUET_VERSIONS.get(geoparquet_version, GEOPARQUET_VERSIONS["1.1"])
     metadata_version = version_config.get("metadata_version", "1.1.0")
@@ -120,7 +120,8 @@ def build_geo_metadata(
             if "encoding" not in sec_meta:
                 sec_meta["encoding"] = "WKB"
 
-    return geo_meta
+    # 'covering' is 1.1-only: drop whatever the source file or custom_metadata carried
+    return strip_unsupported_covering(geo_meta, geoparquet_version)
 
 
 def _parse_existing_geo_metadata(original_metadata: dict | None) -> dict | None:

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -388,7 +388,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
 
         col_meta = geo_meta["columns"][geometry_column]
         self._compute_missing_metadata(con, query, geometry_column, col_meta, verbose)
-        self._add_bbox_covering_if_present(con, query, col_meta, verbose)
+        self._add_bbox_covering_if_present(con, query, col_meta, verbose, geoparquet_version)
 
         # For v1.x: Cast to BLOB so DuckDB writes plain binary WKB.
         # For v2.0: Keep native GEOMETRY type with CRS — DuckDB writes native
@@ -454,8 +454,19 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         query: str,
         col_meta: dict,
         verbose: bool,
+        geoparquet_version: str,
     ) -> None:
-        """Add bbox covering metadata if bbox column is present."""
+        """Add bbox covering metadata if a bbox column is present and the version allows it.
+
+        The bbox column is still written for 1.0 — only the 'covering' key is 1.1+.
+        """
+        from geoparquet_io.core.geo_metadata import covering_supported
+
+        if not covering_supported(geoparquet_version):
+            if verbose:
+                debug(f"Skipping 1.1-only covering metadata for version {geoparquet_version}")
+            return
+
         schema_result = con.execute(f"SELECT * FROM ({query}) LIMIT 0").arrow()
         bbox_col_name = _detect_bbox_column_name(schema_result.schema.names)
 

--- a/geoparquet_io/skills/geoparquet.md
+++ b/geoparquet_io/skills/geoparquet.md
@@ -136,7 +136,8 @@ gpio sort quadkey <input> <output>
 # Add bounding box column (required for many tools)
 gpio add bbox <input> <output>
 
-# Add bbox covering metadata to existing bbox column
+# Add bbox covering metadata to existing bbox column (needs GeoParquet 1.1+:
+# 'covering' was introduced in 1.1, so this refuses on a 1.0 file)
 gpio add bbox-metadata <file>
 
 # Add admin division columns (country, state, etc.) based on geometry location

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,29 @@ def places_test_file():
 
 
 @pytest.fixture
+def places_v11_file(tmp_path):
+    """A GeoParquet 1.1 copy of the places file: bbox column, no covering key.
+
+    ``places_test.parquet`` declares 1.0.0, which cannot carry the 1.1-only
+    ``covering`` key (gpio #686). Tests that exercise *adding* a covering need a
+    1.1 input. Written with ``store_schema=False`` so no ``ARROW:schema`` key is
+    added — ``add bbox-metadata``'s KV_METADATA clause does not quote key names,
+    so a key containing ':' would make DuckDB's parser reject the rewrite.
+    """
+    import json
+
+    import pyarrow.parquet as pq
+
+    path = tmp_path / "places_v11.parquet"
+    table = pq.read_table(str(PLACES_TEST_FILE))
+    geo = json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
+    geo["version"] = "1.1.0"
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode("utf-8")})
+    pq.write_table(table, str(path), store_schema=False)
+    return str(path)
+
+
+@pytest.fixture
 def buildings_test_file():
     """Return the path to the buildings test parquet file."""
     return str(BUILDINGS_TEST_FILE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,24 +101,49 @@ def places_test_file():
 
 @pytest.fixture
 def places_v11_file(tmp_path):
-    """A GeoParquet 1.1 copy of the places file: bbox column, no covering key.
+    """A real GeoParquet 1.1 copy of the places file: bbox column, no covering key.
 
     ``places_test.parquet`` declares 1.0.0, which cannot carry the 1.1-only
     ``covering`` key (gpio #686). Tests that exercise *adding* a covering need a
-    1.1 input. Written with ``store_schema=False`` so no ``ARROW:schema`` key is
-    added — ``add bbox-metadata``'s KV_METADATA clause does not quote key names,
-    so a key containing ':' would make DuckDB's parser reject the rewrite.
-    """
-    import json
+    1.1 input.
 
-    import pyarrow.parquet as pq
+    Written through DuckDB's KV_METADATA rather than pyarrow: ``write_table``
+    with ``store_schema=False`` drops the whole schema-metadata block (geo key
+    included, leaving plain Parquet that silently exercises the synthetic-metadata
+    fallback), while the default ``store_schema=True`` adds an ``ARROW:schema``
+    key that ``add bbox-metadata``'s unquoted KV_METADATA clause cannot survive.
+    The connection deliberately does not load the spatial extension, so the WKB
+    geometry column is copied as BLOB instead of being auto-converted to a native
+    GEOMETRY type.
+    """
+    from geoparquet_io.core.common import get_duckdb_connection
+    from geoparquet_io.core.geo_metadata import parse_geo_metadata
 
     path = tmp_path / "places_v11.parquet"
-    table = pq.read_table(str(PLACES_TEST_FILE))
-    geo = json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
+
+    source_meta = pq.read_metadata(str(PLACES_TEST_FILE)).metadata
+    geo = json.loads(source_meta[b"geo"].decode("utf-8"))
     geo["version"] = "1.1.0"
-    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode("utf-8")})
-    pq.write_table(table, str(path), store_schema=False)
+    geo["columns"][geo["primary_column"]].pop("covering", None)
+    geo_json = json.dumps(geo).replace("'", "''")
+
+    con = get_duckdb_connection(load_spatial=False)
+    con.execute(f"""
+        COPY (SELECT * FROM '{PLACES_TEST_FILE.as_posix()}')
+        TO '{path.as_posix()}'
+        (FORMAT PARQUET, GEOPARQUET_VERSION 'NONE', KV_METADATA {{geo: '{geo_json}'}})
+    """)
+    con.close()
+
+    # Non-vacuity: this must be a real 1.1 GeoParquet file with a bbox column and
+    # no covering, not plain Parquet that quietly takes a fallback path.
+    written = pq.read_metadata(str(path)).metadata
+    written_geo = parse_geo_metadata(written, False)
+    assert written_geo, "places_v11_file lost its geo metadata"
+    assert written_geo["version"].startswith("1.1"), written_geo["version"]
+    primary = written_geo["primary_column"]
+    assert "covering" not in written_geo["columns"][primary]
+    assert "bbox" in pq.ParquetFile(str(path)).schema_arrow.names
     return str(path)
 
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -156,8 +156,14 @@ class TestAddCommands:
         assert "covering" in geo_meta["columns"]["geometry"]
         assert "bbox" in geo_meta["columns"]["geometry"]["covering"]
 
-    def test_add_bbox_metadata_to_existing_bbox(self, temp_output_dir):
-        """Test add bbox-metadata command for files with bbox column."""
+    def test_add_bbox_metadata_on_v10_file_with_bbox_errors(self, temp_output_dir):
+        """add bbox-metadata refuses a 1.0 file, whose version cannot carry covering.
+
+        places_test.parquet declares GeoParquet 1.0.0 and has a bbox column but no
+        covering. This used to "succeed" by writing the 1.1-only covering key into a
+        1.0 file, producing output that `gpio check spec` rejects (gpio #686). The
+        1.1 success path is covered by tests/test_v10_covering_gate.py.
+        """
         import shutil
 
         # Use places file which has a bbox column
@@ -169,11 +175,12 @@ class TestAddCommands:
 
         runner = CliRunner()
         result = runner.invoke(add, ["bbox-metadata", temp_file])
-        assert result.exit_code == 0, (
-            f"Command failed: {result.output}\nException: {result.exception}"
-        )
-        # Should either add metadata or report it already exists
-        assert "Added bbox covering metadata" in result.output or "already exists" in result.output
+        assert result.exit_code != 0
+        assert "1.1" in result.output
+
+        # The file must be left untouched, not half-updated.
+        with open(temp_file, "rb") as fh, open(places_path, "rb") as original:
+            assert fh.read() == original.read()
 
     def test_add_bbox_metadata_no_bbox_column(self, buildings_test_file):
         """Test add bbox-metadata when there's no bbox column."""
@@ -721,6 +728,14 @@ class TestAddBboxMetadataPreservesFileProperties:
             f"SELECT value FROM parquet_kv_metadata('{test_file}') WHERE key = 'geo'"
         ).fetchone()
         geo_meta_value = geo_meta_row[0].decode("utf-8") if geo_meta_row else "{}"
+
+        # DuckDB's 'V1' declares GeoParquet 1.0.0, which cannot carry the 1.1-only
+        # covering key (gpio #686). This test is about KV preservation during the
+        # rewrite, so declare 1.1.0 to keep the rewrite reachable.
+        geo_meta_value = geo_meta_value.replace('"version":"1.0.0"', '"version":"1.1.0"').replace(
+            '"version": "1.0.0"', '"version": "1.1.0"'
+        )
+        assert '"1.1.0"' in geo_meta_value
 
         # Now rewrite with additional custom metadata
         temp_file = str(tmp_path / "temp_with_meta.parquet")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1253,10 +1253,16 @@ class TestTableAddBboxMetadata:
         with pytest.raises(ValueError, match="not found"):
             sample_table.add_bbox_metadata(bbox_column="nonexistent_bbox")
 
-    def test_add_bbox_metadata_with_bbox_column(self, sample_table):
+    def test_add_bbox_metadata_with_bbox_column(self, sample_table, tmp_path):
         """Test add_bbox_metadata() works with bbox column."""
+        # The places fixture declares GeoParquet 1.0.0, which cannot carry the
+        # 1.1-only covering key (gpio #686) — restate it at 1.1 first.
+        v11_path = tmp_path / "places_v11.parquet"
+        sample_table.write(str(v11_path), geoparquet_version="1.1")
+        table_v11 = read(str(v11_path))
+
         # First add the bbox column, then add metadata
-        with_bbox = sample_table.add_bbox()
+        with_bbox = table_v11.add_bbox()
         with_meta = with_bbox.add_bbox_metadata()
         assert isinstance(with_meta, Table)
 

--- a/tests/test_check_fixes_core.py
+++ b/tests/test_check_fixes_core.py
@@ -96,29 +96,33 @@ class TestFixBboxColumn:
 class TestFixBboxMetadata:
     """Tests for fix_bbox_metadata function."""
 
-    def test_adds_bbox_metadata(self, places_test_file, temp_output_dir):
-        """Test adding bbox metadata to file with bbox column."""
+    def test_adds_bbox_metadata(self, places_v11_file, temp_output_dir):
+        """Test adding bbox metadata to file with bbox column.
+
+        Uses the 1.1 places fixture: covering is a 1.1-only key, so adding it to
+        the 1.0 original is now refused outright (gpio #686).
+        """
         test_file = os.path.join(temp_output_dir, "test.parquet")
-        shutil.copy2(places_test_file, test_file)
+        shutil.copy2(places_v11_file, test_file)
 
         fix_result = fix_bbox_metadata(test_file, test_file, verbose=False)
 
         assert fix_result["success"] is True
         assert "bbox" in fix_result["fix_applied"].lower()
 
-    def test_copies_file_if_output_different(self, places_test_file, temp_output_dir):
+    def test_copies_file_if_output_different(self, places_v11_file, temp_output_dir):
         """Test that file is copied when output differs from input."""
         output_file = os.path.join(temp_output_dir, "output.parquet")
 
-        fix_result = fix_bbox_metadata(places_test_file, output_file, verbose=False)
+        fix_result = fix_bbox_metadata(places_v11_file, output_file, verbose=False)
 
         assert fix_result["success"] is True
         assert os.path.exists(output_file)
 
-    def test_with_verbose(self, places_test_file, temp_output_dir):
+    def test_with_verbose(self, places_v11_file, temp_output_dir):
         """Test fix_bbox_metadata with verbose flag."""
         test_file = os.path.join(temp_output_dir, "test.parquet")
-        shutil.copy2(places_test_file, test_file)
+        shutil.copy2(places_v11_file, test_file)
 
         fix_result = fix_bbox_metadata(test_file, test_file, verbose=True)
         assert fix_result["success"] is True

--- a/tests/test_check_fixes_helpers.py
+++ b/tests/test_check_fixes_helpers.py
@@ -180,8 +180,12 @@ class TestFixBboxAll:
         assert fix_result["success"] is True
         assert os.path.exists(output_file)
 
-    def test_metadata_only_fix(self, places_test_file, temp_output_dir):
-        """Test fixing only bbox metadata."""
+    def test_metadata_only_fix(self, places_v11_file, temp_output_dir):
+        """Test fixing only bbox metadata.
+
+        Uses the 1.1 places fixture: covering is a 1.1-only key, so adding it to
+        the 1.0 original is now refused outright (gpio #686).
+        """
         import os
         import shutil
 
@@ -189,7 +193,7 @@ class TestFixBboxAll:
 
         # Copy file first
         input_file = os.path.join(temp_output_dir, "input.parquet")
-        shutil.copy2(places_test_file, input_file)
+        shutil.copy2(places_v11_file, input_file)
         output_file = os.path.join(temp_output_dir, "fixed.parquet")
 
         fix_result = fix_bbox_all(

--- a/tests/test_v10_covering_gate.py
+++ b/tests/test_v10_covering_gate.py
@@ -1,0 +1,193 @@
+"""GeoParquet 1.0 output must not carry the 1.1-only ``covering`` key (gpio #686).
+
+``covering`` is a column-metadata field introduced in GeoParquet 1.1 — it does not
+appear anywhere in the v1.0.0 specification. The bbox *column* itself is an ordinary
+Parquet column and stays legal at 1.0; only the metadata key is version-gated.
+
+Before the fix, ``convert geoparquet --geoparquet-version 1.0`` wrote a file declaring
+version 1.0.0 with a ``covering`` entry, which gpio's own validator rejects, while the
+command still exited 0.
+"""
+
+import json
+
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.convert import convert_to_geoparquet
+from geoparquet_io.core.geo_metadata import create_geo_metadata
+from geoparquet_io.core.validate import validate_geoparquet
+from geoparquet_io.core.write_strategies.base import build_geo_metadata
+from tests.conftest import get_geo_metadata, get_geoparquet_version
+
+
+@pytest.fixture
+def points_input(tmp_path):
+    """A small native-geometry parquet input with no bbox column."""
+    path = tmp_path / "src.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT * FROM (VALUES
+            (1, ST_GeomFromText('POINT (30 10)')),
+            (2, ST_GeomFromText('POINT (40 40)'))
+          ) t(id, geometry)
+        ) TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V1')
+    """)
+    con.close()
+    return path
+
+
+def _covering(parquet_file) -> dict | None:
+    geo = get_geo_metadata(str(parquet_file))
+    primary = geo["primary_column"]
+    return geo["columns"][primary].get("covering")
+
+
+def test_convert_v10_omits_covering_but_keeps_bbox_column(points_input, tmp_path):
+    """1.0 output: no covering key, bbox column still written, validator clean."""
+    out = tmp_path / "out_10.parquet"
+    convert_to_geoparquet(str(points_input), str(out), skip_hilbert=True, geoparquet_version="1.0")
+
+    assert get_geoparquet_version(str(out)) == "1.0.0"
+    assert _covering(out) is None, "covering is 1.1-only and must not appear in 1.0 output"
+
+    # The bbox column itself stays — it is a plain column, legal at any version.
+    assert "bbox" in pq.ParquetFile(str(out)).schema_arrow.names
+
+    result = validate_geoparquet(str(out))
+    failures = [c.message for c in result.checks if c.status.value == "failed"]
+    assert result.is_valid, f"1.0 output failed validation: {failures}"
+
+
+def test_check_bbox_does_not_demand_covering_on_v10(points_input, tmp_path):
+    """`check bbox` must not ask a 1.0 file for a key that version cannot carry."""
+    from geoparquet_io.core.check_parquet_structure import check_metadata_and_bbox
+
+    out = tmp_path / "check_10.parquet"
+    convert_to_geoparquet(str(points_input), str(out), skip_hilbert=True, geoparquet_version="1.0")
+
+    results = check_metadata_and_bbox(str(out), return_results=True, quiet=True)
+    assert results["has_bbox_column"]
+    assert not results["needs_bbox_metadata"]
+    assert not any("covering" in issue for issue in results["issues"])
+    # The actionable advice for 1.0 stays the version upgrade, which is already reported.
+    assert any("outdated" in issue for issue in results["issues"])
+
+
+def test_convert_v11_still_writes_covering(points_input, tmp_path):
+    """1.1 output keeps the covering key pointing at the bbox column."""
+    out = tmp_path / "out_11.parquet"
+    convert_to_geoparquet(str(points_input), str(out), skip_hilbert=True, geoparquet_version="1.1")
+
+    assert get_geoparquet_version(str(out)) == "1.1.0"
+    covering = _covering(out)
+    assert covering is not None and covering["bbox"]["xmin"] == ["bbox", "xmin"]
+    assert validate_geoparquet(str(out)).is_valid
+
+
+def test_convert_v20_output_valid(points_input, tmp_path):
+    """2.0 output stays valid (native geo types, no bbox column)."""
+    out = tmp_path / "out_20.parquet"
+    convert_to_geoparquet(str(points_input), str(out), skip_hilbert=True, geoparquet_version="2.0")
+    assert get_geoparquet_version(str(out)) == "2.0.0"
+    assert validate_geoparquet(str(out)).is_valid
+
+
+def test_cli_convert_v10_exits_zero_and_passes_check_spec(points_input, tmp_path):
+    """CLI parity for the issue's repro: exit 0 and a file its own checker accepts."""
+    out = tmp_path / "cli_10.parquet"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "convert",
+            "geoparquet",
+            str(points_input),
+            str(out),
+            "--geoparquet-version",
+            "1.0",
+            "--skip-hilbert",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "did not pass GeoParquet metadata validation" not in result.output
+    assert _covering(out) is None
+
+    check = runner.invoke(cli, ["check", "spec", str(out)])
+    assert check.exit_code == 0, check.output
+    assert "covering" not in check.output
+
+
+def test_v10_downgrade_drops_covering_carried_from_source(points_input, tmp_path):
+    """A 1.1 file with covering, re-converted to 1.0, must lose the covering key."""
+    v11 = tmp_path / "v11.parquet"
+    convert_to_geoparquet(str(points_input), str(v11), skip_hilbert=True, geoparquet_version="1.1")
+    assert _covering(v11) is not None
+
+    out = tmp_path / "downgraded.parquet"
+    convert_to_geoparquet(str(v11), str(out), skip_hilbert=True, geoparquet_version="1.0")
+    assert get_geoparquet_version(str(out)) == "1.0.0"
+    assert _covering(out) is None
+    assert validate_geoparquet(str(out)).is_valid
+
+
+def test_build_geo_metadata_gates_covering_by_version():
+    """The shared assembly point drops covering for 1.0 and keeps it for 1.1/2.0."""
+    source = {
+        "geo": json.dumps(
+            {
+                "version": "1.1.0",
+                "primary_column": "geometry",
+                "columns": {
+                    "geometry": {
+                        "encoding": "WKB",
+                        "covering": {
+                            "bbox": {
+                                "xmin": ["bbox", "xmin"],
+                                "ymin": ["bbox", "ymin"],
+                                "xmax": ["bbox", "xmax"],
+                                "ymax": ["bbox", "ymax"],
+                            }
+                        },
+                    }
+                },
+            }
+        )
+    }
+
+    v10 = build_geo_metadata("geometry", "1.0", original_metadata=source)
+    assert "covering" not in v10["columns"]["geometry"]
+
+    for version in ("1.1", "2.0"):
+        kept = build_geo_metadata("geometry", version, original_metadata=source)
+        assert "covering" in kept["columns"]["geometry"], version
+
+
+def test_create_geo_metadata_gates_covering_by_version():
+    """The Arrow-table assembly point applies the same gate."""
+    bbox_info = {"has_bbox_column": True, "bbox_column_name": "bbox"}
+
+    v10 = create_geo_metadata(None, "geometry", bbox_info, version="1.0.0")
+    assert "covering" not in v10["columns"]["geometry"]
+
+    v11 = create_geo_metadata(None, "geometry", bbox_info, version="1.1.0")
+    assert v11["columns"]["geometry"]["covering"]["bbox"]["xmin"] == ["bbox", "xmin"]
+
+    # Verbose mode reports the drop rather than silently changing the output.
+    verbose_v10 = create_geo_metadata(None, "geometry", bbox_info, None, True, version="1.0.0")
+    assert "covering" not in verbose_v10["columns"]["geometry"]
+
+
+def test_create_geo_metadata_drops_custom_covering_for_v10():
+    """Spatial-index coverings (h3/s2/...) are also 1.1-only."""
+    custom = {"covering": {"h3": {"column": "h3", "resolution": 8}}}
+
+    v10 = create_geo_metadata(None, "geometry", None, custom, version="1.0.0")
+    assert "covering" not in v10["columns"]["geometry"]
+
+    v11 = create_geo_metadata(None, "geometry", None, custom, version="1.1.0")
+    assert "h3" in v11["columns"]["geometry"]["covering"]

--- a/tests/test_v10_covering_gate.py
+++ b/tests/test_v10_covering_gate.py
@@ -386,6 +386,31 @@ def test_check_bbox_flags_v10_file_that_carries_covering(v10_with_bbox_column):
     check_metadata_and_bbox(str(v10_with_bbox_column), return_results=True, quiet=False)
 
 
+def test_add_bbox_on_v10_file_does_not_suggest_a_command_that_refuses(v10_with_bbox_column):
+    """`add bbox` must not send a 1.0 user to `add bbox-metadata`, which now refuses.
+
+    The file already has a bbox column but no covering, so `add bbox` bails with
+    advice. Pointing at `add bbox-metadata` would be a dead end for a 1.0 file.
+    """
+    runner = CliRunner()
+    out = v10_with_bbox_column.parent / "add_bbox_out.parquet"
+    result = runner.invoke(cli, ["add", "bbox", str(v10_with_bbox_column), str(out)])
+
+    assert "1.1" in result.output, result.output
+    assert "add bbox-metadata" not in result.output, (
+        f"1.0 user sent to a command that will refuse: {result.output}"
+    )
+
+
+def test_add_bbox_on_v11_file_still_suggests_bbox_metadata(v11_with_bbox_column):
+    """The 1.1 advice is unchanged — that command does work there."""
+    runner = CliRunner()
+    out = v11_with_bbox_column.parent / "add_bbox_out.parquet"
+    result = runner.invoke(cli, ["add", "bbox", str(v11_with_bbox_column), str(out)])
+
+    assert "add bbox-metadata" in result.output, result.output
+
+
 def test_strip_unsupported_covering_tolerates_malformed_columns():
     """Malformed third-party geo metadata must not crash the gate."""
     from geoparquet_io.core.geo_metadata import strip_unsupported_covering

--- a/tests/test_v10_covering_gate.py
+++ b/tests/test_v10_covering_gate.py
@@ -47,6 +47,64 @@ def _covering(parquet_file) -> dict | None:
     return geo["columns"][primary].get("covering")
 
 
+@pytest.fixture
+def v10_with_bbox_column(points_input, tmp_path):
+    """A valid 1.0 file: bbox column present, no covering key."""
+    path = tmp_path / "v10_bbox.parquet"
+    convert_to_geoparquet(str(points_input), str(path), skip_hilbert=True, geoparquet_version="1.0")
+    assert _covering(path) is None
+    assert validate_geoparquet(str(path)).is_valid
+    return path
+
+
+@pytest.fixture
+def v11_with_bbox_column(tmp_path):
+    """A 1.1 file with a bbox column but no covering — what `add bbox-metadata` is for.
+
+    Written straight through DuckDB rather than by rewriting a converted file with
+    pyarrow: pyarrow adds an ``ARROW:schema`` KV key, and `add bbox-metadata`'s
+    KV_METADATA clause does not quote key names, so a key containing ':' makes
+    DuckDB's parser reject the rewrite. That is a separate pre-existing defect;
+    this fixture keeps the test aimed at the version gate.
+    """
+    path = tmp_path / "v11_bbox.parquet"
+    geo = json.dumps(
+        {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": ["Point"],
+                    "bbox": [30.0, 10.0, 40.0, 40.0],
+                }
+            },
+        }
+    )
+    con = get_duckdb_connection(load_spatial=True)
+    con.execute(f"""
+        COPY (
+          SELECT
+            id,
+            ST_AsWKB(geom)::BLOB AS geometry,
+            {{
+              'xmin': ST_XMin(geom), 'ymin': ST_YMin(geom),
+              'xmax': ST_XMax(geom), 'ymax': ST_YMax(geom)
+            }} AS bbox
+          FROM (VALUES
+            (1, ST_GeomFromText('POINT (30 10)')),
+            (2, ST_GeomFromText('POINT (40 40)'))
+          ) t(id, geom)
+        ) TO '{path.as_posix()}'
+        (FORMAT PARQUET, GEOPARQUET_VERSION 'NONE', KV_METADATA {{geo: '{geo}'}})
+    """)
+    con.close()
+
+    assert get_geoparquet_version(str(path)) == "1.1.0"
+    assert _covering(path) is None
+    return path
+
+
 def test_convert_v10_omits_covering_but_keeps_bbox_column(points_input, tmp_path):
     """1.0 output: no covering key, bbox column still written, validator clean."""
     out = tmp_path / "out_10.parquet"
@@ -191,3 +249,146 @@ def test_create_geo_metadata_drops_custom_covering_for_v10():
 
     v11 = create_geo_metadata(None, "geometry", None, custom, version="1.1.0")
     assert "h3" in v11["columns"]["geometry"]["covering"]
+
+
+# ---------------------------------------------------------------------------
+# Review round 1: the explicit "add the covering" entry points.
+#
+# These differ from the write paths above. There, covering is an *implicit*
+# side effect of writing a bbox column, so silently omitting it at 1.0 is the
+# right call. Here the user has explicitly asked for the covering key, and at
+# 1.0 that request cannot be honored — so these raise rather than quietly
+# doing nothing while reporting success.
+# ---------------------------------------------------------------------------
+
+
+def test_add_bbox_metadata_rejects_v10_file(v10_with_bbox_column):
+    """`add bbox-metadata` on a 1.0 file errors instead of writing an invalid key."""
+    from geoparquet_io.core.add.bbox_metadata import add_bbox_metadata
+    from geoparquet_io.core.exceptions import GeoParquetError
+
+    with pytest.raises(GeoParquetError, match="1.1"):
+        add_bbox_metadata(str(v10_with_bbox_column))
+
+    # The file must be left exactly as valid as it was.
+    assert _covering(v10_with_bbox_column) is None
+    assert validate_geoparquet(str(v10_with_bbox_column)).is_valid
+
+
+def test_add_bbox_metadata_cli_rejects_v10_file(v10_with_bbox_column):
+    """CLI surfaces the conflict as a clean error, not a silent success."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["add", "bbox-metadata", str(v10_with_bbox_column)])
+
+    assert result.exit_code != 0
+    assert "1.1" in result.output
+    assert _covering(v10_with_bbox_column) is None
+    assert validate_geoparquet(str(v10_with_bbox_column)).is_valid
+
+
+def test_add_bbox_metadata_still_works_on_v11_file(v11_with_bbox_column):
+    """The 1.1 path is untouched: the covering key is written as before.
+
+    Deliberately not asserting overall file validity here: `add bbox-metadata`'s
+    DuckDB rewrite re-materializes a v1.x WKB column as a native Parquet GEOMETRY
+    type while leaving the version at 1.1.0, which its own validator rejects. That
+    defect predates this branch (bbox_metadata.py is unchanged from main) and is
+    reported separately rather than pinned here.
+    """
+    from geoparquet_io.core.add.bbox_metadata import add_bbox_metadata
+
+    add_bbox_metadata(str(v11_with_bbox_column))
+
+    covering = _covering(v11_with_bbox_column)
+    assert covering is not None and covering["bbox"]["xmin"] == ["bbox", "xmin"]
+
+
+def test_api_add_bbox_metadata_rejects_v10_table(v10_with_bbox_column):
+    """Table.add_bbox_metadata() applies the same gate as the CLI path."""
+    from geoparquet_io.api import read
+
+    table = read(str(v10_with_bbox_column))
+    with pytest.raises(ValueError, match="1.1"):
+        table.add_bbox_metadata()
+
+
+def test_api_add_bbox_metadata_still_works_on_v11_table(v11_with_bbox_column):
+    """The 1.1 Python API path is untouched."""
+    from geoparquet_io.api import read
+
+    table = read(str(v11_with_bbox_column))
+    with_meta = table.add_bbox_metadata()
+
+    geo_meta = with_meta.metadata().get("geo_metadata", {})
+    columns = geo_meta.get("columns", {})
+    assert columns[with_meta.geometry_column]["covering"]["bbox"]["xmin"] == ["bbox", "xmin"]
+
+
+def test_build_geo_metadata_does_not_mutate_caller_metadata():
+    """The 1.0 gate must not strip covering out of the caller's own dict.
+
+    Partition loops reuse one ``original_metadata`` dict across many writes
+    (see the aliasing note at common.py:2362); popping through the shallow copy
+    in ``_initialize_geo_metadata`` would strip the shared dict permanently and
+    silently cost later 1.1 writes their covering.
+    """
+    covering = {
+        "bbox": {
+            "xmin": ["bbox", "xmin"],
+            "ymin": ["bbox", "ymin"],
+            "xmax": ["bbox", "xmax"],
+            "ymax": ["bbox", "ymax"],
+        }
+    }
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "covering": covering}},
+    }
+    source = {"geo": geo}
+
+    built = build_geo_metadata("geometry", "1.0", original_metadata=source)
+    assert "covering" not in built["columns"]["geometry"]
+    assert "covering" in geo["columns"]["geometry"], "caller's metadata dict was mutated"
+
+    # A later write from the same shared dict must still get its covering.
+    again = build_geo_metadata("geometry", "1.1", original_metadata=source)
+    assert again["columns"]["geometry"]["covering"] == covering
+
+
+def test_check_bbox_flags_v10_file_that_carries_covering(v10_with_bbox_column):
+    """A pre-existing 1.0+covering file is reported as a problem, not affirmed."""
+    from geoparquet_io.core.check_parquet_structure import check_metadata_and_bbox
+
+    # Hand-build the invalid combination this branch no longer produces.
+    table = pq.read_table(str(v10_with_bbox_column))
+    meta = dict(table.schema.metadata)
+    geo = json.loads(meta[b"geo"].decode())
+    geo["columns"][geo["primary_column"]]["covering"] = {
+        "bbox": {
+            "xmin": ["bbox", "xmin"],
+            "ymin": ["bbox", "ymin"],
+            "xmax": ["bbox", "xmax"],
+            "ymax": ["bbox", "ymax"],
+        }
+    }
+    meta[b"geo"] = json.dumps(geo).encode()
+    pq.write_table(table.replace_schema_metadata(meta), str(v10_with_bbox_column))
+    assert not validate_geoparquet(str(v10_with_bbox_column)).is_valid
+
+    results = check_metadata_and_bbox(str(v10_with_bbox_column), return_results=True, quiet=True)
+    assert not results["passed"]
+    assert any("covering" in issue for issue in results["issues"]), (
+        f"check bbox affirmed an invalid 1.0+covering file: {results['issues']}"
+    )
+
+    # The printed report must not show a ✓ for this file either.
+    check_metadata_and_bbox(str(v10_with_bbox_column), return_results=True, quiet=False)
+
+
+def test_strip_unsupported_covering_tolerates_malformed_columns():
+    """Malformed third-party geo metadata must not crash the gate."""
+    from geoparquet_io.core.geo_metadata import strip_unsupported_covering
+
+    malformed = {"version": "1.0.0", "columns": "not-a-dict"}
+    assert strip_unsupported_covering(malformed, "1.0") is malformed


### PR DESCRIPTION
## The bug (#686)

`gpio convert geoparquet --geoparquet-version 1.0` wrote a file declaring version `1.0.0` that carried the `covering` column-metadata key. gpio's own `check spec` rejected the result — and `convert` still exited 0:

```
gpio convert geoparquet src.parquet out.parquet --geoparquet-version 1.0 --skip-hilbert
Output did not pass GeoParquet metadata validation — run 'gpio check spec' for details
exit: 0

gpio check spec out.parquet
  ✗ version 1.0.0 declared but columns use the 1.1-only 'covering' key
Summary: 21 passed, 0 warnings, 1 failed
```

The covering writers keyed off bbox-column presence alone and never consulted the target version.

### Spec citation

Checked against the spec text rather than trusting our own validator:

- `format-specs/geoparquet.md` @ tag **v1.0.0** — the string `covering` appears **0 times**.
- `format-specs/geoparquet.md` @ tag **v1.1.0** — `covering` is a documented column-metadata field: the table row *"covering | object | Object containing bounding box column names to help accelerate spatial data retrieval"* plus a dedicated `#### covering` section and its `bbox` encoding sub-section.

So `covering` is 1.1+. The bbox **struct column** itself is an ordinary Parquet column that 1.0 does not forbid — it is simply not discoverable through metadata there. **The fix keeps writing the bbox column at 1.0 and drops only the metadata key.**

## The fix

One policy function, applied at the shared assembly points so every write strategy inherits it rather than each keeping a copy:

- **`covering_supported(version)`** (`core/geo_metadata.py`) — the single gate. Accepts both the option form (`"1.0"`) and the metadata form (`"1.0.0"`); unknown/absent versions keep prior behaviour.
- **`strip_unsupported_covering(geo_meta, version)`** — drops `covering` from every column entry when the version predates 1.1. Applied *after* assembly, so it also catches coverings carried in from a 1.1 source file and coverings supplied through `custom_metadata` (h3/s2/a5/quadkey), not just the bbox one. It **returns a copy and never mutates its input**: `_initialize_geo_metadata` only shallow-copies, and partition loops reuse one `original_metadata` dict across many writes, so popping in place would strip the shared dict permanently and silently cost a later 1.1 write its covering.
- Wired into **`build_geo_metadata`** (`write_strategies/base.py` — duckdb_kv, disk_rewrite, arrow_streaming all inherit) and **`create_geo_metadata`** (the Arrow-table path), plus the duckdb-kv post-assembly bbox add, which runs after `build_geo_metadata` and so consults the same predicate.

Result on the issue's repro: `22 passed, 0 warnings, 0 failed`, bbox column still present and functional, exit 0 now honest.

## Second-order fixes

**`gpio check bbox` was version-unaware in both directions.**

1. It reported a 1.0 file's bbox column as *"Bbox column exists but missing metadata covering"* and advertised `fix_available: True` — so `check bbox --fix` would have re-created the exact invalid key this PR removes. `needs_bbox_metadata` is now gated by `covering_supported()`; for those files the actionable advice is the version upgrade it already recommends. (This surfaced as a genuine failure in `test_conversion_end_to_end.py[1.0]` once the gate landed.)
2. The inverse case printed a ✓ for a pre-1.1 file that carries a covering key anyway — a file `check spec` exits 1 on. It is now flagged with a message naming the conflict.

**The explicit "add the covering" entry points now refuse at 1.0** — `gpio add bbox-metadata` and `Table.add_bbox_metadata()` wrote the key straight into existing geo metadata without consulting the version, which turned this branch's own valid 1.0 output back into an invalid file.

These **raise** rather than silently skipping, unlike the write paths, and the distinction is deliberate: in `convert`, covering is an *implicit* side effect of writing a bbox column, so omitting it at 1.0 gives the user exactly the 1.0 file they asked for. These two commands exist *solely* to write that key — silently skipping would mean printing "Added bbox covering metadata" while doing nothing, which is the same failure mode as the original bug, just quieter. The error names the conflict and the remedy:

```
Cannot add bbox covering metadata: this file declares GeoParquet 1.0.0, and the
'covering' key requires GeoParquet 1.1 or later.
Convert the file first: gpio convert geoparquet <in> out.parquet --geoparquet-version 1.1
```

> ⚠️ **Behavior change.** Those two calls previously "succeeded" on a 1.0 input by producing a file the validator rejects. Anyone with a 1.0 file in a pipeline will now see a new error. Documented in the CHANGELOG, `docs/guide/add.md` and `docs/api/python-api.md`.

**Version-aware advice.** `add bbox` on a file that already has a bbox column without covering advised *"Run 'gpio add bbox-metadata'"* — which, after the change above, refuses on a 1.0 file. That dead end was introduced by this branch, so it is fixed here: 1.1+ files get the same advice as before, 1.0 files are told covering needs 1.1 and are given both remedies (`--force`, verified to rewrite at 1.1.0 with covering and validate clean, or `convert`).

### Correct wording on defaults

`gpio add bbox` on a 1.0 input **with the default version auto-upgrades to 1.1.0 and keeps covering** (valid output). Only an explicit `--geoparquet-version 1.0` yields a bbox column without covering.

## Tests

28 tests, all red-first, across the gate, the guards and the check paths:

- 19 in the new `tests/test_v10_covering_gate.py` — 1.0 output has no covering but keeps a working bbox column and validates clean; 1.1/2.0 unchanged; CLI parity for the issue's repro; a 1.1→1.0 downgrade drops a carried-in covering; both assembly points gated; custom (h3) coverings gated; the caller's metadata dict is not mutated and a later 1.1 write from the same dict still gets its covering; malformed metadata tolerated; both `add bbox-metadata` paths refuse at 1.0 and still work at 1.1; `check bbox` flags rather than affirms; advice is version-aware.
- The rest update existing tests that were **pinning the bug**: `places_test.parquet` declares 1.0.0 with a bbox column and no covering, so five tests were asserting success for the operation that produces an invalid file. One now asserts refusal plus a byte-identical file; four moved onto a new `places_v11_file` fixture. No assertion was weakened.

Full fast suite **3978 passed, 40 skipped**; **diff-cover 100%** of 57 changed lines; pre-commit and all pre-push hooks (deptry, mypy, vulture, xenon, import-linter, menard-check) clean.

## Issues filed from this work

Found while building fixtures, all reproduced, none caused by this PR (`bbox_metadata.py` is unchanged from main apart from the version guard) and none fixed here:

- **#711** — `add bbox-metadata` fails with a DuckDB parser error on any file carrying an `ARROW:schema` key; KV_METADATA key names are not quoted (adjacent to #690).
- **#712** — `add bbox-metadata` rewrites v1.x WKB geometry as a native Parquet GEOMETRY type while leaving the version at 1.1.0 (same declared-version-vs-reality family as #600/#687).
- **#713** — `add bbox-metadata` on plain Parquet with a bbox column invents an invalid 1.1.0 geo block containing only `covering`, and reports success.
- **#705** — `convert` warns and exits 0 when output validation fails. This PR removes the cause of the #686 instance, but the warn-and-return contract is unchanged, so a *future* validation failure would still exit 0. Deliberately deferred: it changes the contract of every convert path and deserves its own decision.

## Coordination with #693

PR #693 (`test/write-contract`, unmerged) records this bug as a `KNOWN_COVERING` xfail entry in `tests/test_write_contract.py`, guarded by a stale-entry check that **fails when a recorded divergence stops reproducing**. After this fix, `test_a1_path_version_contract[cli-1.0]` passes and that guard will trip.

**Whichever of #693 and this PR merges second must delete the `KNOWN_COVERING` entry and adjust that file's expected pass/xfail counts during rebase.** That branch was not touched here.

## Merge-order notes

- **#690** (kv plumb) and **#687** share nearby metadata-assembly code. This PR's hunks there are small: one call-site argument and one guard clause at the top of `_add_bbox_covering_if_present` in `duckdb_kv.py`, plus one guard in `api/table.py`. Conflicts should be textual.
- **`CHANGELOG.md` will conflict with every sibling PR in this batch.** Resolve in the **root** `CHANGELOG.md` and let `doc-sync` regenerate `docs/CHANGELOG.md` — never hand-edit the generated copy.

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx
