### PR TITLE
fix(validate): accept the GeoArrow encodings GeoParquet 1.1 permits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,6 +380,21 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   Arrow-table paths in the same module, which already quoted them. Computed
   quadkey values are unchanged for ordinary column names.
 
+- **Validation accepts the GeoArrow encodings GeoParquet 1.1 permits.**
+  `gpio check spec` (and `validate_geoparquet()`) only recognised `"WKB"`, so a
+  file gpio itself writes with `--geoparquet-version 1.1-geoarrow` failed its
+  own spec check with six errors — four of them raw DuckDB binder errors from
+  calling `ST_GeomFromWKB()` on a nested coordinate struct. The single-geometry
+  type encodings (`point`, `linestring`, `polygon`, `multipoint`,
+  `multilinestring`, `multipolygon`) are now valid for 1.1, and every check
+  that reads the column is layout-aware: the `BYTE_ARRAY` requirement applies
+  only to WKB columns (native columns are checked for the DOUBLE coordinate
+  group the spec requires instead), and the encoding, geometry-type, bbox and
+  CRS data scans read GeoArrow coordinates directly rather than parsing WKB.
+  Empty and null geometries no longer skew those scans. 1.0 and 2.0 remain
+  WKB-only per their spec text, so a file claiming a GeoArrow encoding under
+  either version is still rejected — now with a message naming the version
+  requirement rather than a binder error.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   WKB-only per their spec text, so a file claiming a GeoArrow encoding under
   either version is still rejected — now with a message naming the version
   requirement rather than a binder error.
+
+  The layout check does not stop at nesting depth. `linestring`/`multipoint`
+  and `polygon`/`multilinestring` store identical coordinate data at identical
+  depth, so a column relabelled as its twin would otherwise pass every check;
+  the field names on the coordinate nesting (`vertices`, `points`, `rings`,
+  `linestrings`, `polygons`) are matched as well, which separates all six
+  encodings. A type string that does not carry geoarrow's names — the generic
+  `list<element: ...>`, or the typeless group node `parquet_schema()` reports
+  for remote files — is not evidence of a wrong encoding and is not failed on.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -380,6 +380,21 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   Arrow-table paths in the same module, which already quoted them. Computed
   quadkey values are unchanged for ordinary column names.
 
+- **Validation accepts the GeoArrow encodings GeoParquet 1.1 permits.**
+  `gpio check spec` (and `validate_geoparquet()`) only recognised `"WKB"`, so a
+  file gpio itself writes with `--geoparquet-version 1.1-geoarrow` failed its
+  own spec check with six errors — four of them raw DuckDB binder errors from
+  calling `ST_GeomFromWKB()` on a nested coordinate struct. The single-geometry
+  type encodings (`point`, `linestring`, `polygon`, `multipoint`,
+  `multilinestring`, `multipolygon`) are now valid for 1.1, and every check
+  that reads the column is layout-aware: the `BYTE_ARRAY` requirement applies
+  only to WKB columns (native columns are checked for the DOUBLE coordinate
+  group the spec requires instead), and the encoding, geometry-type, bbox and
+  CRS data scans read GeoArrow coordinates directly rather than parsing WKB.
+  Empty and null geometries no longer skew those scans. 1.0 and 2.0 remain
+  WKB-only per their spec text, so a file claiming a GeoArrow encoding under
+  either version is still rejected — now with a message naming the version
+  requirement rather than a binder error.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -395,6 +395,15 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   WKB-only per their spec text, so a file claiming a GeoArrow encoding under
   either version is still rejected — now with a message naming the version
   requirement rather than a binder error.
+
+  The layout check does not stop at nesting depth. `linestring`/`multipoint`
+  and `polygon`/`multilinestring` store identical coordinate data at identical
+  depth, so a column relabelled as its twin would otherwise pass every check;
+  the field names on the coordinate nesting (`vertices`, `points`, `rings`,
+  `linestrings`, `polygons`) are matched as well, which separates all six
+  encodings. A type string that does not carry geoarrow's names — the generic
+  `list<element: ...>`, or the typeless group node `parquet_schema()` reports
+  for remote files — is not evidence of a wrong encoding and is not failed on.
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -259,6 +259,15 @@ Validates file structure and metadata against the GeoParquet specification:
   suffixes (`"Point Z"`, `"LineString ZM"`), and validation matches declared
   suffixes against the actual coordinate dimensions in both directions
   (declared-but-absent and present-but-undeclared).
+- **GeoArrow encodings** — the single-geometry type encodings (`point`,
+  `linestring`, `polygon`, `multipoint`, `multilinestring`, `multipolygon`)
+  are valid for GeoParquet 1.1, so files written with
+  `--geoparquet-version 1.1-geoarrow` validate. The checks are layout-aware:
+  the `BYTE_ARRAY` requirement applies only to `WKB` columns, native columns
+  are checked for the DOUBLE coordinate group the spec requires, and the data
+  scans read GeoArrow coordinates directly. GeoParquet 1.0 and 2.0 are
+  WKB-only per their spec text, so a file claiming a GeoArrow encoding under
+  either version fails.
 
 **Exit codes:**
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -773,29 +773,29 @@ def _check_geometry_not_grouped(
 
 # GeoArrow encoding -> number of LIST levels wrapping the coordinate struct.
 #
-# Depth is not a unique key. Two pairs share a level and hold identical
-# coordinate data, so depth alone cannot tell them apart:
+# Depth alone is not a unique key. Two pairs share a level and hold identical
+# coordinate data:
 #   linestring <-> multipoint      (depth 1)
 #   polygon    <-> multilinestring (depth 2)
-# A column mislabeled as its twin is therefore not caught here. That is a
-# *missed detection*, never a false rejection: a correctly labeled file always
-# passes.
 #
-# They are distinguishable, though, and cheaply. The nested list fields are
-# named per encoding, and those names are already inside the type string this
-# module reads via get_schema_info():
+# What separates them is the set of names on the coordinate nesting, which
+# geoarrow renders into the type string this module already reads via
+# get_schema_info():
 #   linestring       list<vertices: struct<x,y>>
 #   multipoint       list<points:   struct<x,y>>
 #   polygon          list<vertices: list<rings:       struct<x,y>>>
 #   multilinestring  list<vertices: list<linestrings: struct<x,y>>>
-# Matching those names would be the zero-cost strengthening.
+#   multipolygon     list<vertices: list<rings: list<polygons: struct<x,y>>>>
+# _GEOARROW_LIST_FIELDS below pins those, so a column labelled "multipoint" but
+# stored as a linestring is rejected rather than passing on equal depth.
 #
-# Note the names are not stored in the Parquet file (its fields are the
-# generic "element"); they are how geoarrow.pyarrow renders the extension
-# type, which it resolves from the ARROW:extension:name field metadata that
-# gpio's writer does emit ("geoarrow.linestring"). So the names are available
-# on the pyarrow schema path only — on the DuckDB path the type is None and
-# neither signal is present.
+# The names are not stored in the Parquet file (its fields are the generic
+# "element"); they are how geoarrow.pyarrow renders the extension type, which it
+# resolves from the ARROW:extension:name field metadata gpio's writer emits. So
+# both signals exist only on get_schema_info()'s local/pyarrow path. On the
+# DuckDB path (remote files) parquet_schema() reports the group node with no
+# type at all, and neither check can run — absence of the name is therefore
+# never treated as a mismatch.
 _GEOARROW_LIST_DEPTH = {
     "point": 0,
     "linestring": 1,
@@ -804,6 +804,48 @@ _GEOARROW_LIST_DEPTH = {
     "multilinestring": 2,
     "multipolygon": 3,
 }
+
+
+# The set of LIST field names each encoding's coordinate nesting carries, as
+# get_schema_info() renders it. This is what separates the two pairs that share
+# a list depth and are therefore invisible to _GEOARROW_LIST_DEPTH alone:
+# linestring/multipoint (depth 1) and polygon/multilinestring (depth 2).
+#
+# Matched as a SET, deliberately. get_schema_info()'s pyarrow path renders the
+# names in the reverse of geoarrow.pyarrow's own nesting order -- a polygon
+# reads as list<vertices: list<rings: ...>> here but as
+# list<rings: list<vertices: ...>> from arr.type.storage_type -- so an ordered
+# comparison would encode that quirk and break if it were ever normalised. The
+# five sets are pairwise distinct, so order buys no discrimination anyway.
+#
+# "point" has no list level and needs no entry: depth 0 already identifies it.
+_GEOARROW_LIST_FIELDS = {
+    "linestring": frozenset({"vertices"}),
+    "multipoint": frozenset({"points"}),
+    "polygon": frozenset({"vertices", "rings"}),
+    "multilinestring": frozenset({"vertices", "linestrings"}),
+    "multipolygon": frozenset({"vertices", "rings", "polygons"}),
+}
+
+_GEOARROW_FIELDS_ENCODING = {v: k for k, v in _GEOARROW_LIST_FIELDS.items()}
+
+# Every name the map above can produce. A type string naming anything outside
+# this set came from a source that does not use geoarrow's names (the generic
+# list<element: ...>, or DuckDB's typeless group node), and is not evidence of a
+# wrong encoding either way.
+_KNOWN_LIST_FIELDS = {name.upper() for names in _GEOARROW_LIST_FIELDS.values() for name in names}
+
+
+def _list_field_names(physical_type: str) -> frozenset[str] | None:
+    """The LIST field names in a type string, when they are geoarrow's own.
+
+    Returns None when any LIST level carries a name geoarrow never emits, which
+    must not be read as a mismatch.
+    """
+    found = re.findall(r"LIST<\s*([A-Za-z_][A-Za-z0-9_]*)\s*:", physical_type)
+    if not found or any(name.upper() not in _KNOWN_LIST_FIELDS for name in found):
+        return None
+    return frozenset(name.lower() for name in found)
 
 
 def _check_geoarrow_layout(physical_type: str, geom_col: str, encoding: str) -> ValidationCheck:
@@ -837,6 +879,25 @@ def _check_geoarrow_layout(physical_type: str, geom_col: str, encoding: str) -> 
                 message=f'geometry column "{geom_col}" layout does not match GeoArrow '
                 f'encoding "{encoding}" (expected {expected} list level(s) around a '
                 f"DOUBLE coordinate struct, got {physical_type})",
+                category="parquet_schema",
+            )
+
+        # Depth ties linestring/multipoint and polygon/multilinestring, so the
+        # coordinate nesting's field names are what actually separate them.
+        # Only judge them when they are names geoarrow emits: a generic or
+        # absent field name says nothing about the encoding either way.
+        expected_fields = _GEOARROW_LIST_FIELDS.get(encoding)
+        found_fields = _list_field_names(physical_type)
+        if expected_fields and found_fields is not None and found_fields != expected_fields:
+            mislabelled = _GEOARROW_FIELDS_ENCODING.get(found_fields)
+            stored_as = f" (the layout of {mislabelled!r})" if mislabelled else ""
+            return ValidationCheck(
+                name=name,
+                status=CheckStatus.FAILED,
+                message=f"geometry column {geom_col!r} declares GeoArrow encoding "
+                f"{encoding!r}, whose coordinates nest under "
+                f"{sorted(expected_fields)}, but the stored column nests under "
+                f"{sorted(found_fields)}{stored_as}",
                 category="parquet_schema",
             )
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -772,6 +772,17 @@ def _check_geometry_not_grouped(
 
 
 # GeoArrow encoding -> number of LIST levels wrapping the coordinate struct.
+#
+# Depth is not a unique key: two pairs share a level and are therefore
+# structurally identical in Parquet, storing exactly the same bytes —
+#   linestring <-> multipoint      (depth 1, STRUCT(x,y)[])
+#   polygon    <-> multilinestring (depth 2, STRUCT(x,y)[][])
+# so a column mislabeled as its twin cannot be caught from the layout alone.
+# That is a *missed detection*, never a false positive: a correctly labeled
+# file always passes. Only the extension name in the Arrow field metadata
+# ("geoarrow.multipoint") distinguishes them, and reading it would mean a
+# pq.read_schema() call (pyarrow.parquet is already imported in this module's
+# callers) — a possible future strengthening, not a correctness gap today.
 _GEOARROW_LIST_DEPTH = {
     "point": 0,
     "linestring": 1,
@@ -831,7 +842,9 @@ def _check_geometry_byte_array(
     """Check 15: WKB geometry columns must be stored using BYTE_ARRAY parquet type."""
     for col in schema_info:
         if col.get("name") == geom_col:
-            physical_type = col.get("type", "").upper()
+            # parquet_schema() reports a group node's type as an explicit None,
+            # so the "" default never applies: `or ""` is the guard, not `get`.
+            physical_type = (col.get("type") or "").upper()
             if _is_geoarrow_encoding(encoding):
                 return _check_geoarrow_layout(physical_type, geom_col, encoding)
             # BYTE_ARRAY is represented as BYTE_ARRAY or sometimes as a binary type
@@ -1136,6 +1149,12 @@ def _check_geoarrow_geometry_types(
     A single-geometry-type encoding pins the geometry type of every value in the
     column, and the coordinate struct pins its dimensionality, so the types
     present follow from the column type rather than from a per-value scan.
+
+    The type therefore comes from the *declared* encoding, which check 15 has
+    already reconciled against the stored nesting depth. Since depth does not
+    separate linestring from multipoint (nor polygon from multilinestring, see
+    _GEOARROW_LIST_DEPTH), a column mislabeled as its structural twin is
+    reported here as that twin — a missed detection, not a false positive.
     """
     quoted_geom = quote_identifier(geom_col)
     found = _GEOARROW_ENCODING_TYPE[encoding] + _geoarrow_zm_suffix(
@@ -1206,8 +1225,11 @@ def _check_geometry_types_match_data(
 
         return _compare_geometry_types(normalized_found, declared_types, total_count, geom_col)
     except Exception as e:
+        check_name = f"geometry_types_match_data_{geom_col}"
+        if _is_geoarrow_encoding(encoding):
+            return _geoarrow_layout_error(check_name, encoding, "geometry types", e)
         return ValidationCheck(
-            name=f"geometry_types_match_data_{geom_col}",
+            name=check_name,
             status=CheckStatus.FAILED,
             message=f"failed to validate geometry types: {e}",
             category="data_validation",
@@ -1367,6 +1389,10 @@ def _check_bbox_contains_data(
         # Check if DuckDB already has it as a GEOMETRY type
         col_type = _describe_geom_type(con, safe_url, geom_col)
 
+        # NOTE: bbox[:4] mishandles the spec's 6-element 3D form
+        # [xmin,ymin,zmin,xmax,ymax,zmax], comparing against
+        # [xmin,ymin,zmin,xmax]. Pre-existing and equally wrong for WKB;
+        # tracked as #603 item 1 (same line), so it is not fixed here.
         query = _build_bbox_query(
             safe_url, geom_col, col_type, tuple(bbox[:4]), limit_clause, encoding
         )

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -773,16 +773,29 @@ def _check_geometry_not_grouped(
 
 # GeoArrow encoding -> number of LIST levels wrapping the coordinate struct.
 #
-# Depth is not a unique key: two pairs share a level and are therefore
-# structurally identical in Parquet, storing exactly the same bytes —
-#   linestring <-> multipoint      (depth 1, STRUCT(x,y)[])
-#   polygon    <-> multilinestring (depth 2, STRUCT(x,y)[][])
-# so a column mislabeled as its twin cannot be caught from the layout alone.
-# That is a *missed detection*, never a false positive: a correctly labeled
-# file always passes. Only the extension name in the Arrow field metadata
-# ("geoarrow.multipoint") distinguishes them, and reading it would mean a
-# pq.read_schema() call (pyarrow.parquet is already imported in this module's
-# callers) — a possible future strengthening, not a correctness gap today.
+# Depth is not a unique key. Two pairs share a level and hold identical
+# coordinate data, so depth alone cannot tell them apart:
+#   linestring <-> multipoint      (depth 1)
+#   polygon    <-> multilinestring (depth 2)
+# A column mislabeled as its twin is therefore not caught here. That is a
+# *missed detection*, never a false rejection: a correctly labeled file always
+# passes.
+#
+# They are distinguishable, though, and cheaply. The nested list fields are
+# named per encoding, and those names are already inside the type string this
+# module reads via get_schema_info():
+#   linestring       list<vertices: struct<x,y>>
+#   multipoint       list<points:   struct<x,y>>
+#   polygon          list<vertices: list<rings:       struct<x,y>>>
+#   multilinestring  list<vertices: list<linestrings: struct<x,y>>>
+# Matching those names would be the zero-cost strengthening.
+#
+# Note the names are not stored in the Parquet file (its fields are the
+# generic "element"); they are how geoarrow.pyarrow renders the extension
+# type, which it resolves from the ARROW:extension:name field metadata that
+# gpio's writer does emit ("geoarrow.linestring"). So the names are available
+# on the pyarrow schema path only — on the DuckDB path the type is None and
+# neither signal is present.
 _GEOARROW_LIST_DEPTH = {
     "point": 0,
     "linestring": 1,
@@ -1153,8 +1166,9 @@ def _check_geoarrow_geometry_types(
     The type therefore comes from the *declared* encoding, which check 15 has
     already reconciled against the stored nesting depth. Since depth does not
     separate linestring from multipoint (nor polygon from multilinestring, see
-    _GEOARROW_LIST_DEPTH), a column mislabeled as its structural twin is
-    reported here as that twin — a missed detection, not a false positive.
+    _GEOARROW_LIST_DEPTH for both the limitation and the way to close it), a
+    column mislabeled as its structural twin is reported here as that twin — a
+    missed detection, never a false rejection.
     """
     quoted_geom = quote_identifier(geom_col)
     found = _GEOARROW_ENCODING_TYPE[encoding] + _geoarrow_zm_suffix(
@@ -1625,7 +1639,9 @@ def _check_covering_bbox_field_types(
             num_children = col.get("num_children") or 0
             for j in range(1, min(num_children + 1, 5)):  # Check first 4 children
                 if i + j < len(schema_info):
-                    child_type = schema_info[i + j].get("type", "").upper()
+                    # Same trap as _check_geometry_byte_array: a group child's
+                    # type is an explicit None, so `or ""` is the guard here too.
+                    child_type = (schema_info[i + j].get("type") or "").upper()
                     field_types.add(child_type)
             break
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -6,6 +6,7 @@ geospatial types according to their respective specifications.
 """
 
 import json
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -15,7 +16,11 @@ from rich.console import Console
 
 from geoparquet_io.core.common import split_zm_suffix, zm_suffix_sql
 from geoparquet_io.core.crs_utils import NULL_CRS_HINT, get_crs_display_name, is_geographic_crs
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    _geoarrow_coord_exprs,
+    quote_identifier,
+)
 from geoparquet_io.core.exceptions import GeoParquetError
 
 
@@ -71,6 +76,31 @@ class ValidationResult:
 
 # Valid values according to GeoParquet specification
 VALID_ENCODINGS = ["WKB", "wkb"]
+
+# The single-geometry-type GeoArrow encodings. GeoParquet 1.1 permits these
+# alongside "WKB" ("Supported values: "WKB"; one of "point", "linestring",
+# "polygon", "multipoint", "multilinestring", "multipolygon""). 1.0 and the
+# 2.0 draft are both WKB-only, so they stay rejected there.
+GEOARROW_ENCODINGS = [
+    "point",
+    "linestring",
+    "polygon",
+    "multipoint",
+    "multilinestring",
+    "multipolygon",
+]
+
+# GeoArrow encoding -> the spec geometry_types name it can hold. The encoding
+# fixes the geometry type of every value in the column, so a data scan does not
+# need to reconstruct geometries to know what is in there.
+_GEOARROW_ENCODING_TYPE = {
+    "point": "Point",
+    "linestring": "LineString",
+    "polygon": "Polygon",
+    "multipoint": "MultiPoint",
+    "multilinestring": "MultiLineString",
+    "multipolygon": "MultiPolygon",
+}
 VALID_ORIENTATIONS = ["counterclockwise"]
 VALID_EDGES_GEOPARQUET = ["planar", "spherical"]
 VALID_EDGES_PARQUET_GEO = ["spherical", "vincenty", "thomas", "andoyer", "karney"]
@@ -223,10 +253,40 @@ def _check_primary_column_in_columns(geo_meta: dict) -> ValidationCheck:
 # =============================================================================
 
 
-def _check_encoding_valid(col_meta: dict, col_name: str) -> ValidationCheck:
+def _is_geoarrow_encoding(encoding: Any) -> bool:
+    """True for one of the spec's single-geometry-type GeoArrow encodings.
+
+    The spec spells these lowercase, and unlike "WKB"/"wkb" there is no
+    established lenient casing to honour, so the match is exact.
+    """
+    return isinstance(encoding, str) and encoding in GEOARROW_ENCODINGS
+
+
+def _geoarrow_encoding_allowed(geo_version: Any) -> bool:
+    """True for versions whose spec text permits the GeoArrow encodings.
+
+    Only GeoParquet 1.1 does: 1.0 says WKB "is the only current option" and
+    the 2.0 draft says "The only supported value is "WKB"".
+    """
+    return _version_at_least(geo_version, 1, 1) and not _version_at_least(geo_version, 2, 0)
+
+
+def _check_encoding_valid(
+    col_meta: dict, col_name: str, geo_version: Any = "1.0.0"
+) -> ValidationCheck:
     """Check 7: column metadata must include a valid 'encoding' string."""
     encoding = col_meta.get("encoding")
-    is_valid = encoding in VALID_ENCODINGS
+
+    if _is_geoarrow_encoding(encoding) and not _geoarrow_encoding_allowed(geo_version):
+        return ValidationCheck(
+            name=f"encoding_valid_{col_name}",
+            status=CheckStatus.FAILED,
+            message=f'column "{col_name}" uses GeoArrow encoding "{encoding}", '
+            f"which requires GeoParquet 1.1 (file declares {geo_version})",
+            category="column_metadata",
+        )
+
+    is_valid = encoding in VALID_ENCODINGS or _is_geoarrow_encoding(encoding)
     return ValidationCheck(
         name=f"encoding_valid_{col_name}",
         status=CheckStatus.PASSED if is_valid else CheckStatus.FAILED,
@@ -666,11 +726,27 @@ def _check_version_features(parquet_file: str, geo_meta: dict) -> ValidationChec
 # =============================================================================
 
 
-def _check_geometry_not_grouped(schema_info: list, geom_col: str) -> ValidationCheck:
-    """Check 14: geometry columns must not be grouped."""
+def _check_geometry_not_grouped(
+    schema_info: list, geom_col: str, encoding: Any = "WKB"
+) -> ValidationCheck:
+    """Check 14: geometry columns must not be grouped.
+
+    The spec's "MUST NOT be a group field" rule is about nesting the geometry
+    inside another column; the GeoArrow encodings store coordinates in a
+    (repeated) group by design, so for those the requirement that survives is
+    that the column sits at the root of the schema.
+    """
     # Find the geometry column in schema
     for col in schema_info:
         if col.get("name") == geom_col:
+            if _is_geoarrow_encoding(encoding):
+                return ValidationCheck(
+                    name=f"geometry_not_grouped_{geom_col}",
+                    status=CheckStatus.PASSED,
+                    message=f'geometry column "{geom_col}" is a "{encoding}" GeoArrow '
+                    "group at the schema root",
+                    category="parquet_schema",
+                )
             # Check if it has children (would indicate a struct/group)
             num_children = col.get("num_children") or 0
             if num_children > 0:
@@ -695,11 +771,69 @@ def _check_geometry_not_grouped(schema_info: list, geom_col: str) -> ValidationC
     )
 
 
-def _check_geometry_byte_array(schema_info: list, geom_col: str) -> ValidationCheck:
-    """Check 15: geometry columns must be stored using BYTE_ARRAY parquet type."""
+# GeoArrow encoding -> number of LIST levels wrapping the coordinate struct.
+_GEOARROW_LIST_DEPTH = {
+    "point": 0,
+    "linestring": 1,
+    "multipoint": 1,
+    "polygon": 2,
+    "multilinestring": 2,
+    "multipolygon": 3,
+}
+
+
+def _check_geoarrow_layout(physical_type: str, geom_col: str, encoding: str) -> ValidationCheck:
+    """Check 15 for GeoArrow columns: a (repeated) group of DOUBLE coordinates.
+
+    The BYTE_ARRAY requirement the spec states is scoped to WKB columns; native
+    encodings instead MUST store "the actual coordinates ... as native numbers,
+    i.e. using the DOUBLE parquet type in a (repeated) group of fields".
+    """
+    name = f"geometry_byte_array_{geom_col}"
+
+    if "BYTE_ARRAY" in physical_type or physical_type == "BINARY":
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.FAILED,
+            message=f'geometry column "{geom_col}" declares GeoArrow encoding "{encoding}" '
+            f"but is stored as {physical_type} (native encodings require a group of "
+            "DOUBLE coordinate fields)",
+            category="parquet_schema",
+        )
+
+    # Only Arrow-style type strings expose the nesting; the parquet_schema()
+    # path reports the group node with no type, and cannot be checked here.
+    if "STRUCT<" in physical_type:
+        expected = _GEOARROW_LIST_DEPTH[encoding]
+        found = physical_type.count("LIST<")
+        if found != expected or "DOUBLE" not in physical_type:
+            return ValidationCheck(
+                name=name,
+                status=CheckStatus.FAILED,
+                message=f'geometry column "{geom_col}" layout does not match GeoArrow '
+                f'encoding "{encoding}" (expected {expected} list level(s) around a '
+                f"DOUBLE coordinate struct, got {physical_type})",
+                category="parquet_schema",
+            )
+
+    return ValidationCheck(
+        name=name,
+        status=CheckStatus.PASSED,
+        message=f'geometry column "{geom_col}" uses the native "{encoding}" '
+        "GeoArrow coordinate layout",
+        category="parquet_schema",
+    )
+
+
+def _check_geometry_byte_array(
+    schema_info: list, geom_col: str, encoding: Any = "WKB"
+) -> ValidationCheck:
+    """Check 15: WKB geometry columns must be stored using BYTE_ARRAY parquet type."""
     for col in schema_info:
         if col.get("name") == geom_col:
             physical_type = col.get("type", "").upper()
+            if _is_geoarrow_encoding(encoding):
+                return _check_geoarrow_layout(physical_type, geom_col, encoding)
             # BYTE_ARRAY is represented as BYTE_ARRAY or sometimes as a binary type
             if "BYTE_ARRAY" in physical_type or physical_type == "BINARY":
                 return ValidationCheck(
@@ -755,6 +889,102 @@ def _check_geometry_not_repeated(schema_info: list, geom_col: str) -> Validation
 # =============================================================================
 
 
+def _describe_geom_type(con, safe_url: str, geom_col: str) -> str:
+    """DuckDB's type string for a geometry column ('' when unavailable)."""
+    type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
+    type_result = con.execute(type_query).fetchone()
+    return type_result[1] if type_result else ""
+
+
+def _geoarrow_zm_suffix(col_type: str) -> str:
+    """Dimension suffix implied by a GeoArrow coordinate struct's fields.
+
+    GeoArrow keeps dimensionality in the struct layout (x/y/z/m fields), not in
+    a per-value header, so the suffix is a property of the column type.
+    """
+    match = re.search(r"STRUCT\(([^)]*)\)", col_type or "", re.IGNORECASE)
+    if not match:
+        return ""
+    fields = {field.strip().split(" ")[0].strip('"').lower() for field in match.group(1).split(",")}
+    has_z, has_m = "z" in fields, "m" in fields
+    if has_z and has_m:
+        return " ZM"
+    if has_z:
+        return " Z"
+    if has_m:
+        return " M"
+    return ""
+
+
+def _geoarrow_bounds_subquery(
+    safe_url: str, geom_col: str, encoding: str, limit_clause: str
+) -> str:
+    """Per-row GeoArrow coordinate bounds, with empty geometries filtered out.
+
+    Empty GeoArrow values are either an empty coordinate list (NULL bounds) or,
+    for "point", NaN coordinates; neither has an extent to compare, so the
+    isfinite() guard drops both instead of poisoning MIN/MAX.
+    """
+    quoted_geom = quote_identifier(geom_col)
+    xmin, ymin, xmax, ymax, _, _ = _geoarrow_coord_exprs(quoted_geom, encoding)
+    return f"""
+        SELECT {xmin} AS xmin, {ymin} AS ymin, {xmax} AS xmax, {ymax} AS ymax
+        FROM read_parquet('{safe_url}')
+        WHERE {quoted_geom} IS NOT NULL
+          AND isfinite({xmin}) AND isfinite({ymin})
+        {limit_clause}
+    """
+
+
+def _geoarrow_layout_error(
+    check_name: str, encoding: str, subject: str, error: Exception
+) -> ValidationCheck:
+    """Report a GeoArrow coordinate path that does not resolve, not the raw SQL error."""
+    return ValidationCheck(
+        name=check_name,
+        status=CheckStatus.FAILED,
+        message=f"cannot read {subject}: the stored column layout does not match "
+        f'GeoArrow encoding "{encoding}"',
+        details=str(error),
+        category="data_validation",
+    )
+
+
+def _check_geoarrow_encoding_matches_data(
+    safe_url: str, geom_col: str, encoding: str, con, limit_clause: str
+) -> ValidationCheck:
+    """Check 17 for GeoArrow columns: the stored nesting must fit the encoding.
+
+    There is nothing to parse per value — a native column either exposes the
+    coordinate path its encoding implies (a "polygon" column being a list of
+    rings of x/y structs) or it does not, which is the mismatch this reports.
+    """
+    name = f"encoding_matches_data_{geom_col}"
+    quoted_geom = quote_identifier(geom_col)
+    xmin, _, _, _, _, _ = _geoarrow_coord_exprs(quoted_geom, encoding)
+    query = f"""
+        SELECT COUNT(*) FROM (
+            SELECT {xmin} AS xmin
+            FROM read_parquet('{safe_url}')
+            WHERE {quoted_geom} IS NOT NULL
+            {limit_clause}
+        )
+    """
+
+    try:
+        result = con.execute(query).fetchone()
+    except Exception as e:
+        return _geoarrow_layout_error(name, encoding, "geometry coordinates", e)
+
+    total = result[0] if result else 0
+    return ValidationCheck(
+        name=name,
+        status=CheckStatus.PASSED,
+        message=f'all geometry values match "{encoding}" encoding ({total} checked)',
+        category="data_validation",
+    )
+
+
 def _check_encoding_matches_data(
     parquet_file: str, geom_col: str, encoding: str, con, sample_size: int
 ) -> ValidationCheck:
@@ -766,6 +996,11 @@ def _check_encoding_matches_data(
 
     # For WKB encoding, verify we can parse geometries as WKB
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
+
+    if _is_geoarrow_encoding(encoding):
+        return _check_geoarrow_encoding_matches_data(
+            safe_url, geom_col, encoding, con, limit_clause
+        )
 
     try:
         # First check if DuckDB already has it as a GEOMETRY type
@@ -857,8 +1092,71 @@ def _normalize_found_geometry_type(raw: str) -> str:
     return _GEOM_TYPE_DISPLAY.get(base, base) + suffix
 
 
+def _compare_geometry_types(
+    normalized_found: set, declared_types: list, total_count: int, geom_col: str
+) -> ValidationCheck:
+    """Compare the geometry types found in the data against the declared list."""
+    name = f"geometry_types_match_data_{geom_col}"
+    declared_set = set(declared_types) if declared_types else set()
+
+    # If declared_types is empty, any type is allowed
+    if not declared_set:
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.PASSED,
+            message=f"geometry_types is empty (all types allowed), "
+            f"found: {normalized_found} ({total_count} checked)",
+            category="data_validation",
+        )
+
+    # Check if all found types are in declared types
+    undeclared = normalized_found - declared_set
+    if undeclared:
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.FAILED,
+            message=f"found undeclared geometry types: {undeclared} ({total_count} checked)",
+            details=f"Declared: {declared_set}, Found: {normalized_found}",
+            category="data_validation",
+        )
+
+    return ValidationCheck(
+        name=name,
+        status=CheckStatus.PASSED,
+        message=f'all geometry types match declared "geometry_types" ({total_count} checked)',
+        category="data_validation",
+    )
+
+
+def _check_geoarrow_geometry_types(
+    safe_url: str, geom_col: str, declared_types: list, con, limit_clause: str, encoding: str
+) -> ValidationCheck:
+    """Check 18 for GeoArrow columns.
+
+    A single-geometry-type encoding pins the geometry type of every value in the
+    column, and the coordinate struct pins its dimensionality, so the types
+    present follow from the column type rather than from a per-value scan.
+    """
+    quoted_geom = quote_identifier(geom_col)
+    found = _GEOARROW_ENCODING_TYPE[encoding] + _geoarrow_zm_suffix(
+        _describe_geom_type(con, safe_url, geom_col)
+    )
+    count_query = f"""
+        SELECT COUNT(*) FROM read_parquet('{safe_url}')
+        WHERE {quoted_geom} IS NOT NULL {limit_clause}
+    """
+    count_result = con.execute(count_query).fetchone()
+    total_count = count_result[0] if count_result else 0
+    return _compare_geometry_types({found}, declared_types, total_count, geom_col)
+
+
 def _check_geometry_types_match_data(
-    parquet_file: str, geom_col: str, declared_types: list, con, sample_size: int
+    parquet_file: str,
+    geom_col: str,
+    declared_types: list,
+    con,
+    sample_size: int,
+    encoding: Any = "WKB",
 ) -> ValidationCheck:
     """Check 18: all geometry types must be included in 'geometry_types' metadata."""
     from geoparquet_io.core.file_utils import safe_file_url
@@ -867,10 +1165,13 @@ def _check_geometry_types_match_data(
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
     try:
+        if _is_geoarrow_encoding(encoding):
+            return _check_geoarrow_geometry_types(
+                safe_url, geom_col, declared_types, con, limit_clause, encoding
+            )
+
         # Check if DuckDB already has it as a GEOMETRY type
-        type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
-        type_result = con.execute(type_query).fetchone()
-        col_type = type_result[1] if type_result else ""
+        col_type = _describe_geom_type(con, safe_url, geom_col)
 
         # Build the geometry expression based on column type
         if "GEOMETRY" in col_type.upper():
@@ -903,35 +1204,7 @@ def _check_geometry_types_match_data(
 
         normalized_found = {_normalize_found_geometry_type(t) for t in found_types.keys() if t}
 
-        declared_set = set(declared_types) if declared_types else set()
-
-        # If declared_types is empty, any type is allowed
-        if not declared_set:
-            return ValidationCheck(
-                name=f"geometry_types_match_data_{geom_col}",
-                status=CheckStatus.PASSED,
-                message=f"geometry_types is empty (all types allowed), "
-                f"found: {normalized_found} ({total_count} checked)",
-                category="data_validation",
-            )
-
-        # Check if all found types are in declared types
-        undeclared = normalized_found - declared_set
-        if undeclared:
-            return ValidationCheck(
-                name=f"geometry_types_match_data_{geom_col}",
-                status=CheckStatus.FAILED,
-                message=f"found undeclared geometry types: {undeclared} ({total_count} checked)",
-                details=f"Declared: {declared_set}, Found: {normalized_found}",
-                category="data_validation",
-            )
-
-        return ValidationCheck(
-            name=f"geometry_types_match_data_{geom_col}",
-            status=CheckStatus.PASSED,
-            message=f'all geometry types match declared "geometry_types" ({total_count} checked)',
-            category="data_validation",
-        )
+        return _compare_geometry_types(normalized_found, declared_types, total_count, geom_col)
     except Exception as e:
         return ValidationCheck(
             name=f"geometry_types_match_data_{geom_col}",
@@ -964,7 +1237,12 @@ def _check_orientation_matches_data(
 
 
 def _build_bbox_query(
-    safe_url: str, geom_col: str, col_type: str, bbox: tuple, limit_clause: str
+    safe_url: str,
+    geom_col: str,
+    col_type: str,
+    bbox: tuple,
+    limit_clause: str,
+    encoding: Any = "WKB",
 ) -> str:
     """Build SQL query to check if geometries fall within bbox.
 
@@ -974,11 +1252,24 @@ def _build_bbox_query(
         col_type: DuckDB column type (to determine if GEOMETRY or binary)
         bbox: Tuple of (xmin, ymin, xmax, ymax)
         limit_clause: SQL LIMIT clause or empty string
+        encoding: Declared GeoParquet encoding for the column
 
     Returns:
         SQL query string that returns (total, within_bbox) counts
     """
     xmin, ymin, xmax, ymax = bbox
+
+    if _is_geoarrow_encoding(encoding):
+        # Native columns carry coordinates, not serialized geometries: compare
+        # the per-row coordinate bounds directly instead of parsing WKB.
+        return f"""
+            SELECT COUNT(*) as total,
+                   COUNT(CASE WHEN
+                       xmin >= {xmin} AND ymin >= {ymin} AND
+                       xmax <= {xmax} AND ymax <= {ymax}
+                   THEN 1 END) as within_bbox
+            FROM ({_geoarrow_bounds_subquery(safe_url, geom_col, encoding, limit_clause)})
+        """
 
     # Use geometry column directly if native type, otherwise convert from WKB
     quoted_geom = quote_identifier(geom_col)
@@ -1051,7 +1342,12 @@ def _interpret_bbox_result(result: tuple | None, geom_col: str) -> ValidationChe
 
 
 def _check_bbox_contains_data(
-    parquet_file: str, geom_col: str, bbox: list | None, con, sample_size: int
+    parquet_file: str,
+    geom_col: str,
+    bbox: list | None,
+    con,
+    sample_size: int,
+    encoding: Any = "WKB",
 ) -> ValidationCheck:
     """Check 20: all geometries must fall within 'bbox' metadata."""
     if bbox is None:
@@ -1069,17 +1365,20 @@ def _check_bbox_contains_data(
 
     try:
         # Check if DuckDB already has it as a GEOMETRY type
-        type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
-        type_result = con.execute(type_query).fetchone()
-        col_type = type_result[1] if type_result else ""
+        col_type = _describe_geom_type(con, safe_url, geom_col)
 
-        query = _build_bbox_query(safe_url, geom_col, col_type, tuple(bbox[:4]), limit_clause)
+        query = _build_bbox_query(
+            safe_url, geom_col, col_type, tuple(bbox[:4]), limit_clause, encoding
+        )
         result = con.execute(query).fetchone()
         return _interpret_bbox_result(result, geom_col)
 
     except Exception as e:
+        check_name = f"bbox_contains_data_{geom_col}"
+        if _is_geoarrow_encoding(encoding):
+            return _geoarrow_layout_error(check_name, encoding, "geometry bounds", e)
         return ValidationCheck(
-            name=f"bbox_contains_data_{geom_col}",
+            name=check_name,
             status=CheckStatus.FAILED,
             message=f"failed to validate bbox: {e}",
             category="data_validation",
@@ -2549,13 +2848,23 @@ def _detect_geographic_in_projected(
 
 
 def _get_geometry_bounds(
-    con, safe_url: str, geom_col: str, limit_clause: str
+    con, safe_url: str, geom_col: str, limit_clause: str, encoding: Any = "WKB"
 ) -> tuple[float, float, float, float, int] | None:
     """Query actual coordinate bounds from geometry data."""
+    if _is_geoarrow_encoding(encoding):
+        query = f"""
+            SELECT MIN(xmin) as min_x, MAX(xmax) as max_x,
+                   MIN(ymin) as min_y, MAX(ymax) as max_y,
+                   COUNT(*) as total
+            FROM ({_geoarrow_bounds_subquery(safe_url, geom_col, encoding, limit_clause)})
+        """
+        result = con.execute(query).fetchone()
+        if result is None or result[0] is None:
+            return None
+        return result[0], result[1], result[2], result[3], result[4]
+
     # Check if DuckDB already has it as a GEOMETRY type
-    type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
-    type_result = con.execute(type_query).fetchone()
-    col_type = type_result[1] if type_result else ""
+    col_type = _describe_geom_type(con, safe_url, geom_col)
 
     geom_expr = (
         quote_identifier(geom_col)
@@ -2591,6 +2900,7 @@ def _check_coordinates_valid_for_crs(
     crs: Any,
     con,
     sample_size: int,
+    encoding: Any = "WKB",
 ) -> ValidationCheck:
     """Check that geometry coordinates are within valid bounds for the declared CRS."""
     from geoparquet_io.core.file_utils import safe_file_url
@@ -2611,7 +2921,7 @@ def _check_coordinates_valid_for_crs(
         )
 
     try:
-        bounds_result = _get_geometry_bounds(con, safe_url, geom_col, limit_clause)
+        bounds_result = _get_geometry_bounds(con, safe_url, geom_col, limit_clause, encoding)
         if bounds_result is None:
             return ValidationCheck(
                 name=check_name,
@@ -2665,6 +2975,8 @@ def _check_coordinates_valid_for_crs(
         )
 
     except Exception as e:
+        if _is_geoarrow_encoding(encoding):
+            return _geoarrow_layout_error(check_name, encoding, "geometry coordinates", e)
         return ValidationCheck(
             name=check_name,
             status=CheckStatus.FAILED,
@@ -3112,7 +3424,16 @@ def _run_geoparquet_checks(
 
     # Column metadata checks for each geometry column
     for col_name, col_meta in columns.items():
-        checks.append(_check_encoding_valid(col_meta, col_name))
+        # The declared encoding decides how the column is laid out, so the
+        # schema and data checks below all have to read it.
+        encoding = col_meta.get("encoding", "WKB")
+        # A GeoArrow encoding the file's version does not permit is reported by
+        # _check_encoding_valid; the layout-aware checks must not then treat the
+        # column as native, or they would endorse the invalid combination.
+        if _is_geoarrow_encoding(encoding) and not _geoarrow_encoding_allowed(geo_version):
+            encoding = "WKB"
+
+        checks.append(_check_encoding_valid(col_meta, col_name, geo_version))
         checks.append(_check_geometry_types_list(col_meta, col_name))
         checks.append(_check_crs_valid(col_meta, col_name))
         checks.append(_check_orientation_valid(col_meta, col_name))
@@ -3121,13 +3442,12 @@ def _run_geoparquet_checks(
         checks.append(_check_epoch_valid(col_meta, col_name))
 
         # Parquet schema checks
-        checks.append(_check_geometry_not_grouped(schema_info, col_name))
-        checks.append(_check_geometry_byte_array(schema_info, col_name))
+        checks.append(_check_geometry_not_grouped(schema_info, col_name, encoding))
+        checks.append(_check_geometry_byte_array(schema_info, col_name, encoding))
         checks.append(_check_geometry_not_repeated(schema_info, col_name))
 
         # Data validation checks
         if validate_data and con:
-            encoding = col_meta.get("encoding", "WKB")
             checks.append(
                 _check_encoding_matches_data(parquet_file, col_name, encoding, con, sample_size)
             )
@@ -3135,7 +3455,7 @@ def _run_geoparquet_checks(
             geometry_types = col_meta.get("geometry_types", [])
             checks.append(
                 _check_geometry_types_match_data(
-                    parquet_file, col_name, geometry_types, con, sample_size
+                    parquet_file, col_name, geometry_types, con, sample_size, encoding
                 )
             )
 
@@ -3147,12 +3467,16 @@ def _run_geoparquet_checks(
             )
 
             bbox = col_meta.get("bbox")
-            checks.append(_check_bbox_contains_data(parquet_file, col_name, bbox, con, sample_size))
+            checks.append(
+                _check_bbox_contains_data(parquet_file, col_name, bbox, con, sample_size, encoding)
+            )
 
             # Check coordinates are valid for declared CRS
             crs = col_meta.get("crs")
             checks.append(
-                _check_coordinates_valid_for_crs(parquet_file, col_name, crs, con, sample_size)
+                _check_coordinates_valid_for_crs(
+                    parquet_file, col_name, crs, con, sample_size, encoding
+                )
             )
 
     # Version-specific checks

--- a/tests/test_validate_geoarrow_encodings.py
+++ b/tests/test_validate_geoarrow_encodings.py
@@ -23,6 +23,7 @@ from geoparquet_io.core.common import (
 from geoparquet_io.core.validate import (
     CheckStatus,
     _check_encoding_valid,
+    _geoarrow_zm_suffix,
     validate_geoparquet,
 )
 
@@ -296,3 +297,33 @@ class TestGeoArrowEdgeCases:
             f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
         ]
         assert failures == [], failures
+
+    def test_all_empty_geometries_skip_the_coordinate_scans(self, tmp_path):
+        """With no extent anywhere, the scans must skip rather than claim a pass."""
+        out = _write_geoarrow(tmp_path, "allempty", ["POLYGON EMPTY"], ["Polygon"])
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        checks = _checks_by_name(result)
+        assert checks["coordinates_valid_for_crs_geometry"].status == CheckStatus.SKIPPED
+        failures = [
+            f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
+        ]
+        assert failures == [], failures
+
+
+class TestGeoArrowDimensionSuffix:
+    """GeoArrow keeps dimensionality in the coordinate struct, not per value."""
+
+    @pytest.mark.parametrize(
+        ("col_type", "expected"),
+        [
+            ("STRUCT(x DOUBLE, y DOUBLE)", ""),
+            ("STRUCT(x DOUBLE, y DOUBLE, z DOUBLE)", " Z"),
+            ("STRUCT(x DOUBLE, y DOUBLE, m DOUBLE)", " M"),
+            ("STRUCT(x DOUBLE, y DOUBLE, z DOUBLE, m DOUBLE)", " ZM"),
+            ("STRUCT(x DOUBLE, y DOUBLE, z DOUBLE)[][]", " Z"),
+            ("BLOB", ""),
+            ("", ""),
+        ],
+    )
+    def test_suffix_from_column_type(self, col_type, expected):
+        assert _geoarrow_zm_suffix(col_type) == expected

--- a/tests/test_validate_geoarrow_encodings.py
+++ b/tests/test_validate_geoarrow_encodings.py
@@ -447,3 +447,84 @@ class TestGeoArrowDimensionSuffix:
     )
     def test_suffix_from_column_type(self, col_type, expected):
         assert _geoarrow_zm_suffix(col_type) == expected
+
+
+# Encodings that share a list depth, and therefore cannot be told apart by
+# nesting level alone: swapping the labels within a pair leaves a file whose
+# coordinate data is byte-identical to a valid file of the other encoding.
+DEPTH_TWIN_SWAPS = [
+    ("linestring", "multipoint"),
+    ("multipoint", "linestring"),
+    ("polygon", "multilinestring"),
+    ("multilinestring", "polygon"),
+]
+
+
+class TestGeoArrowDepthTwinsAreDistinguished:
+    """A mislabelled encoding must fail even when its list depth is right.
+
+    `_GEOARROW_LIST_DEPTH` cannot separate linestring from multipoint (both one
+    list level) or polygon from multilinestring (both two). Without a second
+    signal, relabelling a column as its twin produces a file that validates
+    clean, because every depth-based check agrees with the lie. The outer list
+    field name geoarrow.pyarrow renders (`vertices` / `points` / `rings` /
+    `linestrings`) is what actually separates them.
+    """
+
+    @pytest.mark.parametrize("real,claimed", DEPTH_TWIN_SWAPS)
+    def test_relabelled_twin_is_rejected(self, tmp_path, real, claimed):
+        wkts, geometry_types = GEOARROW_CASES[real]
+        source = _write_geoarrow(tmp_path, f"{real}_real", wkts, geometry_types)
+
+        _, claimed_types = GEOARROW_CASES[claimed]
+
+        def relabel(geo):
+            col = geo["columns"][geo["primary_column"]]
+            col["encoding"] = claimed
+            col["geometry_types"] = claimed_types
+
+        lying = _rewrite_geo_metadata(source, tmp_path / f"{real}_as_{claimed}.parquet", relabel)
+
+        result = validate_geoparquet(str(lying))
+        assert not result.is_valid, (
+            f"a {real} column relabelled as {claimed} validated clean; the two share a "
+            f"list depth, so depth-based checks alone cannot catch this"
+        )
+
+        layout = _checks_by_name(result)["geometry_byte_array_geometry"]
+        assert layout.status == CheckStatus.FAILED, layout.message
+        # The message must name both sides, so the report says which is wrong.
+        assert claimed in layout.message, layout.message
+        assert real in layout.message, layout.message
+
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_honestly_labelled_file_still_passes(self, tmp_path, encoding):
+        """The discriminator must not reject correctly labelled files."""
+        wkts, geometry_types = GEOARROW_CASES[encoding]
+        path = _write_geoarrow(tmp_path, f"{encoding}_honest", wkts, geometry_types)
+
+        result = validate_geoparquet(str(path))
+        layout = _checks_by_name(result)["geometry_byte_array_geometry"]
+        assert layout.status == CheckStatus.PASSED, layout.message
+
+    def test_unnamed_list_field_is_not_treated_as_a_mismatch(self):
+        """A type string without a recognised field name says nothing either way.
+
+        `get_schema_info()` only renders geoarrow's field names on its local
+        pyarrow path. The DuckDB path used for remote files reports the group
+        node with no type at all, and a plain-Arrow list renders the generic
+        `element`. Neither is evidence of a wrong encoding, so neither may fail.
+        """
+        from geoparquet_io.core.validate import _check_geoarrow_layout, _list_field_names
+
+        assert _list_field_names("LIST<ELEMENT: STRUCT<X: DOUBLE, Y: DOUBLE>>") is None
+        assert _list_field_names("STRUCT<X: DOUBLE, Y: DOUBLE>") is None
+        assert _list_field_names("LIST<VERTICES: STRUCT<X: DOUBLE, Y: DOUBLE>>") == frozenset(
+            {"vertices"}
+        )
+        # A mix of known and unknown names is still not geoarrow's rendering.
+        assert _list_field_names("LIST<VERTICES: LIST<ELEMENT: STRUCT<X: DOUBLE>>>") is None
+
+        generic = "LIST<ELEMENT: STRUCT<X: DOUBLE, Y: DOUBLE>>"
+        check = _check_geoarrow_layout(generic, "geometry", "multipoint")
+        assert check.status == CheckStatus.PASSED, check.message

--- a/tests/test_validate_geoarrow_encodings.py
+++ b/tests/test_validate_geoarrow_encodings.py
@@ -1,0 +1,298 @@
+"""Validation of GeoArrow-encoded GeoParquet 1.1 files (gpio #691).
+
+GeoParquet 1.1 permits the single-geometry-type GeoArrow encodings
+("point", "linestring", "polygon", "multipoint", "multilinestring",
+"multipolygon") alongside "WKB". 1.0 and 2.0 are WKB-only per their spec
+text. gpio's own ``--geoparquet-version 1.1-geoarrow`` output must therefore
+pass ``validate_geoparquet`` end-to-end, and no check may crash (DuckDB binder
+error) on a nested GeoArrow column.
+"""
+
+import json
+
+import pyarrow.parquet as pq
+import pytest
+import shapely
+from shapely import wkt
+
+from geoparquet_io.core.common import (
+    get_duckdb_connection,
+    get_parquet_metadata,
+    write_parquet_with_metadata,
+)
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_encoding_valid,
+    validate_geoparquet,
+)
+
+# encoding -> (WKTs, declared geometry_types)
+GEOARROW_CASES = {
+    "point": (["POINT (1 2)", "POINT (3 4)"], ["Point"]),
+    "linestring": (["LINESTRING (0 0, 1 1, 2 0)"], ["LineString"]),
+    "polygon": (["POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"], ["Polygon"]),
+    "multipoint": (["MULTIPOINT ((0 0), (1 1))"], ["MultiPoint"]),
+    "multilinestring": (["MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))"], ["MultiLineString"]),
+    "multipolygon": (
+        ["MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 2)))"],
+        ["MultiPolygon"],
+    ),
+}
+
+
+def _write_wkb_source(path, wkts, geometry_types, version="1.1.0"):
+    """Write a plain WKB GeoParquet file (the input the writer converts from)."""
+    import pyarrow as pa
+
+    geo = {
+        "version": version,
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "geometry_types": geometry_types}},
+    }
+    geoms = [None if w is None else shapely.to_wkb(wkt.loads(w), flavor="iso") for w in wkts]
+    table = pa.table({"id": list(range(len(geoms))), "geometry": geoms})
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), path)
+    return path
+
+
+def _write_geoarrow(tmp_path, name, wkts, geometry_types):
+    """Produce a 1.1-geoarrow file through gpio's own write path."""
+    src = _write_wkb_source(tmp_path / f"{name}_src.parquet", wkts, geometry_types)
+    out = tmp_path / f"{name}.parquet"
+    con = get_duckdb_connection()
+    try:
+        metadata, _ = get_parquet_metadata(str(src))
+        write_parquet_with_metadata(
+            con,
+            f"SELECT * FROM read_parquet('{src.as_posix()}')",
+            str(out),
+            original_metadata=metadata,
+            geoparquet_version="1.1-geoarrow",
+            input_file=str(src),
+        )
+    finally:
+        con.close()
+    return out
+
+
+def _rewrite_geo_metadata(path, out_path, mutate):
+    """Copy a parquet file, mutating only its 'geo' schema metadata."""
+    table = pq.read_table(path)
+    geo = json.loads(table.schema.metadata[b"geo"])
+    mutate(geo)
+    other = {k: v for k, v in (table.schema.metadata or {}).items() if k != b"geo"}
+    other[b"geo"] = json.dumps(geo).encode()
+    pq.write_table(table.replace_schema_metadata(other), out_path)
+    return out_path
+
+
+def _checks_by_name(result):
+    return {c.name: c for c in result.checks}
+
+
+def _binder_errors(result):
+    return [c.name for c in result.checks if "Binder Error" in (c.message or "")]
+
+
+@pytest.fixture(scope="module")
+def geoarrow_files(tmp_path_factory):
+    """One 1.1-geoarrow file per permitted GeoArrow encoding."""
+    base = tmp_path_factory.mktemp("geoarrow")
+    return {
+        encoding: _write_geoarrow(base, encoding, wkts, types)
+        for encoding, (wkts, types) in GEOARROW_CASES.items()
+    }
+
+
+class TestGeoArrowFilesValidate:
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_geoarrow_file_passes_validation(self, geoarrow_files, encoding):
+        path = geoarrow_files[encoding]
+        written = json.loads(pq.read_schema(path).metadata[b"geo"])
+        assert written["columns"]["geometry"]["encoding"] == encoding
+
+        result = validate_geoparquet(str(path), validate_data=True, sample_size=0)
+        failures = [
+            f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
+        ]
+        assert failures == [], failures
+        assert result.is_valid
+
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_no_check_hits_a_duckdb_binder_error(self, geoarrow_files, encoding):
+        result = validate_geoparquet(
+            str(geoarrow_files[encoding]), validate_data=True, sample_size=0
+        )
+        assert _binder_errors(result) == []
+
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_data_checks_actually_run(self, geoarrow_files, encoding):
+        """The data scans must report on the column, not silently vanish."""
+        result = validate_geoparquet(
+            str(geoarrow_files[encoding]), validate_data=True, sample_size=0
+        )
+        checks = _checks_by_name(result)
+        for name in (
+            "encoding_matches_data_geometry",
+            "geometry_types_match_data_geometry",
+            "bbox_contains_data_geometry",
+            "coordinates_valid_for_crs_geometry",
+        ):
+            assert name in checks, sorted(checks)
+            assert checks[name].status != CheckStatus.FAILED, checks[name].message
+
+
+class TestEncodingVersionGating:
+    """1.1 permits GeoArrow encodings; 1.0 and 2.0 are WKB-only per spec text."""
+
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_geoarrow_accepted_for_1_1(self, encoding):
+        check = _check_encoding_valid({"encoding": encoding}, "geometry", "1.1.0")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_geoarrow_rejected_for_1_0(self, encoding):
+        check = _check_encoding_valid({"encoding": encoding}, "geometry", "1.0.0")
+        assert check.status == CheckStatus.FAILED
+        assert "1.1" in check.message
+
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_geoarrow_rejected_for_2_0(self, encoding):
+        check = _check_encoding_valid({"encoding": encoding}, "geometry", "2.0.0")
+        assert check.status == CheckStatus.FAILED
+
+    @pytest.mark.parametrize("version", ["1.0.0", "1.1.0", "2.0.0"])
+    def test_wkb_always_accepted(self, version):
+        check = _check_encoding_valid({"encoding": "WKB"}, "geometry", version)
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize("encoding", ["WKT", "geoarrow.point", "Point", "", None])
+    def test_unknown_encodings_still_rejected(self, encoding):
+        check = _check_encoding_valid({"encoding": encoding}, "geometry", "1.1.0")
+        assert check.status == CheckStatus.FAILED
+
+    def test_1_0_file_claiming_geoarrow_encoding_fails_end_to_end(self, tmp_path):
+        """A 1.0 file may not claim a GeoArrow encoding, even with matching data."""
+        src = _write_wkb_source(
+            tmp_path / "v10_src.parquet", ["POINT (1 2)"], ["Point"], version="1.0.0"
+        )
+        out = _rewrite_geo_metadata(
+            src,
+            tmp_path / "v10_geoarrow_claim.parquet",
+            lambda geo: geo["columns"]["geometry"].update({"encoding": "point"}),
+        )
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        check = _checks_by_name(result)["encoding_valid_geometry"]
+        assert check.status == CheckStatus.FAILED
+        assert not result.is_valid
+
+
+class TestWkbBehaviorUnchanged:
+    def test_wkb_file_still_validates(self, tmp_path):
+        src = _write_wkb_source(tmp_path / "wkb.parquet", ["POINT (1 2)", "POINT (3 4)"], ["Point"])
+        result = validate_geoparquet(str(src), validate_data=True, sample_size=0)
+        checks = _checks_by_name(result)
+        assert checks["encoding_valid_geometry"].status == CheckStatus.PASSED
+        assert checks["geometry_byte_array_geometry"].status == CheckStatus.PASSED
+        assert checks["encoding_matches_data_geometry"].status == CheckStatus.PASSED
+        assert checks["geometry_types_match_data_geometry"].status == CheckStatus.PASSED
+
+    def test_byte_array_column_may_not_claim_a_geoarrow_encoding(self, tmp_path):
+        """encoding "point" over a BYTE_ARRAY column contradicts the spec layout."""
+        src = _write_wkb_source(tmp_path / "wkb_src.parquet", ["POINT (1 2)"], ["Point"])
+        out = _rewrite_geo_metadata(
+            src,
+            tmp_path / "wkb_claiming_point.parquet",
+            lambda geo: geo["columns"]["geometry"].update({"encoding": "point"}),
+        )
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        checks = _checks_by_name(result)
+        assert checks["geometry_byte_array_geometry"].status == CheckStatus.FAILED
+        assert not result.is_valid
+        assert _binder_errors(result) == []
+
+
+class TestGeoArrowDataChecksStillCatchErrors:
+    def test_undeclared_geometry_type_is_detected(self, geoarrow_files, tmp_path):
+        out = _rewrite_geo_metadata(
+            geoarrow_files["polygon"],
+            tmp_path / "polygon_wrong_types.parquet",
+            lambda geo: geo["columns"]["geometry"].update({"geometry_types": ["Point"]}),
+        )
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        check = _checks_by_name(result)["geometry_types_match_data_geometry"]
+        assert check.status == CheckStatus.FAILED, check.message
+
+    def test_bbox_not_containing_data_is_detected(self, geoarrow_files, tmp_path):
+        out = _rewrite_geo_metadata(
+            geoarrow_files["polygon"],
+            tmp_path / "polygon_wrong_bbox.parquet",
+            lambda geo: geo["columns"]["geometry"].update({"bbox": [10.0, 10.0, 11.0, 11.0]}),
+        )
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        check = _checks_by_name(result)["bbox_contains_data_geometry"]
+        assert check.status == CheckStatus.FAILED, check.message
+
+    def test_encoding_not_matching_the_stored_layout_is_detected(self, geoarrow_files, tmp_path):
+        """A struct-of-points column may not claim the "polygon" nesting."""
+        out = _rewrite_geo_metadata(
+            geoarrow_files["point"],
+            tmp_path / "point_claiming_polygon.parquet",
+            lambda geo: geo["columns"]["geometry"].update(
+                {"encoding": "polygon", "geometry_types": ["Polygon"]}
+            ),
+        )
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        check = _checks_by_name(result)["encoding_matches_data_geometry"]
+        assert check.status == CheckStatus.FAILED, check.message
+        assert "Binder Error" not in check.message
+
+
+class TestGeoArrowEdgeCases:
+    def test_z_dimension_is_reported_in_geometry_types(self, tmp_path):
+        out = _write_geoarrow(tmp_path, "pointz", ["POINT Z (1 2 3)"], ["Point Z"])
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        failures = [
+            f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
+        ]
+        assert failures == [], failures
+
+    def test_z_dimension_missing_from_declaration_is_detected(self, tmp_path):
+        src = _write_geoarrow(tmp_path, "pointz2", ["POINT Z (1 2 3)"], ["Point Z"])
+        out = _rewrite_geo_metadata(
+            src,
+            tmp_path / "pointz_flat_claim.parquet",
+            lambda geo: geo["columns"]["geometry"].update({"geometry_types": ["Point"]}),
+        )
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        check = _checks_by_name(result)["geometry_types_match_data_geometry"]
+        assert check.status == CheckStatus.FAILED, check.message
+
+    def test_empty_and_null_geometries_do_not_break_checks(self, tmp_path):
+        out = _write_geoarrow(
+            tmp_path,
+            "empties",
+            ["POLYGON EMPTY", "POLYGON ((0 0, 1 0, 1 1, 0 0))"],
+            ["Polygon"],
+        )
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        failures = [
+            f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
+        ]
+        assert failures == [], failures
+
+    def test_empty_point_nan_coordinates_do_not_break_checks(self, tmp_path):
+        out = _write_geoarrow(tmp_path, "emptypoint", ["POINT EMPTY", "POINT (1 2)"], ["Point"])
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        failures = [
+            f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
+        ]
+        assert failures == [], failures
+
+    def test_null_geometry_rows_do_not_break_checks(self, tmp_path):
+        out = _write_geoarrow(tmp_path, "nullgeom", [None, "POINT (1 2)"], ["Point"])
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        failures = [
+            f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
+        ]
+        assert failures == [], failures

--- a/tests/test_validate_geoarrow_encodings.py
+++ b/tests/test_validate_geoarrow_encodings.py
@@ -22,6 +22,7 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.validate import (
     CheckStatus,
+    _check_covering_bbox_field_types,
     _check_encoding_valid,
     _check_geometry_byte_array,
     _check_geometry_not_grouped,
@@ -360,6 +361,53 @@ class TestDuckDBSchemaPath:
         check = _check_geometry_byte_array(schema_info, "geometry", "WKB")
         assert check.status == CheckStatus.FAILED
         assert "BYTE_ARRAY" in check.message
+
+    def test_covering_bbox_field_types_survives_typeless_children(self):
+        """Same bug class: a covering.bbox naming a group column, DuckDB path.
+
+        The child rows of a group are themselves groups with type=None, so the
+        field-type scan hit the same `.get("type", "")` trap.
+        """
+        schema_info = [
+            {"name": "geometry", "type": None, "num_children": 1},
+            {"name": "list", "type": None, "num_children": 1},
+            {"name": "element", "type": None, "num_children": 2},
+            {"name": "x", "type": "DOUBLE", "num_children": None},
+            {"name": "y", "type": "DOUBLE", "num_children": None},
+        ]
+        col_meta = {
+            "covering": {
+                "bbox": {
+                    "xmin": ["geometry", "xmin"],
+                    "ymin": ["geometry", "ymin"],
+                    "xmax": ["geometry", "xmax"],
+                    "ymax": ["geometry", "ymax"],
+                }
+            }
+        }
+        check = _check_covering_bbox_field_types(col_meta, "geometry", schema_info)
+        assert check.status == CheckStatus.FAILED, check.message
+
+    def test_covering_bbox_field_types_still_accepts_a_real_bbox_column(self):
+        schema_info = [
+            {"name": "bbox", "type": None, "num_children": 4},
+            {"name": "xmin", "type": "DOUBLE", "num_children": None},
+            {"name": "ymin", "type": "DOUBLE", "num_children": None},
+            {"name": "xmax", "type": "DOUBLE", "num_children": None},
+            {"name": "ymax", "type": "DOUBLE", "num_children": None},
+        ]
+        col_meta = {
+            "covering": {
+                "bbox": {
+                    "xmin": ["bbox", "xmin"],
+                    "ymin": ["bbox", "ymin"],
+                    "xmax": ["bbox", "xmax"],
+                    "ymax": ["bbox", "ymax"],
+                }
+            }
+        }
+        check = _check_covering_bbox_field_types(col_meta, "geometry", schema_info)
+        assert check.status == CheckStatus.PASSED, check.message
 
     @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
     def test_real_duckdb_schema_of_a_geoarrow_file(self, geoarrow_files, encoding):

--- a/tests/test_validate_geoarrow_encodings.py
+++ b/tests/test_validate_geoarrow_encodings.py
@@ -23,6 +23,8 @@ from geoparquet_io.core.common import (
 from geoparquet_io.core.validate import (
     CheckStatus,
     _check_encoding_valid,
+    _check_geometry_byte_array,
+    _check_geometry_not_grouped,
     _geoarrow_zm_suffix,
     validate_geoparquet,
 )
@@ -234,6 +236,31 @@ class TestGeoArrowDataChecksStillCatchErrors:
         check = _checks_by_name(result)["bbox_contains_data_geometry"]
         assert check.status == CheckStatus.FAILED, check.message
 
+    def test_metadata_naming_an_absent_column_reports_cleanly(self, tmp_path):
+        """Every GeoArrow data scan must explain itself, never leak a binder error."""
+        import pyarrow as pa
+
+        out = tmp_path / "missing_col.parquet"
+        geo = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "point", "geometry_types": ["Point"]}},
+        }
+        # The metadata names "geometry"; the file has no such column.
+        table = pa.table({"id": [1], "other": [b"\x00"]})
+        pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), out)
+
+        result = validate_geoparquet(str(out), validate_data=True, sample_size=0)
+        checks = _checks_by_name(result)
+        for name in (
+            "encoding_matches_data_geometry",
+            "geometry_types_match_data_geometry",
+            "coordinates_valid_for_crs_geometry",
+        ):
+            assert checks[name].status == CheckStatus.FAILED, checks[name].message
+            assert "does not match GeoArrow encoding" in checks[name].message
+        assert _binder_errors(result) == []
+
     def test_encoding_not_matching_the_stored_layout_is_detected(self, geoarrow_files, tmp_path):
         """A struct-of-points column may not claim the "polygon" nesting."""
         out = _rewrite_geo_metadata(
@@ -308,6 +335,51 @@ class TestGeoArrowEdgeCases:
             f"{c.name}: {c.message}" for c in result.checks if c.status == CheckStatus.FAILED
         ]
         assert failures == [], failures
+
+
+class TestDuckDBSchemaPath:
+    """The schema checks must survive parquet_schema()'s group nodes.
+
+    get_schema_info() falls back to DuckDB whenever the pyarrow reader bails —
+    which happens locally, not just for remote files (an ``srid:``-style CRS
+    makes geoarrow-pyarrow raise, see duckdb_metadata._pyarrow_get_schema_info).
+    That path reports a nested column as a group node whose "type" is None,
+    where a native GeoArrow column has children and no type string at all.
+    """
+
+    def test_schema_checks_survive_a_typeless_group_node(self):
+        """type=None is present-but-None, so .get("type", "") returns None."""
+        schema_info = [{"name": "geometry", "type": None, "num_children": 1}]
+        byte_array = _check_geometry_byte_array(schema_info, "geometry", "polygon")
+        assert byte_array.status == CheckStatus.PASSED, byte_array.message
+        not_grouped = _check_geometry_not_grouped(schema_info, "geometry", "polygon")
+        assert not_grouped.status == CheckStatus.PASSED, not_grouped.message
+
+    def test_wkb_column_with_no_type_string_does_not_crash(self):
+        schema_info = [{"name": "geometry", "type": None, "num_children": 0}]
+        check = _check_geometry_byte_array(schema_info, "geometry", "WKB")
+        assert check.status == CheckStatus.FAILED
+        assert "BYTE_ARRAY" in check.message
+
+    @pytest.mark.parametrize("encoding", sorted(GEOARROW_CASES))
+    def test_real_duckdb_schema_of_a_geoarrow_file(self, geoarrow_files, encoding):
+        """End-to-end over the actual parquet_schema() rows, not a stand-in."""
+        from geoparquet_io.core.duckdb_metadata import get_schema_info
+
+        con = get_duckdb_connection()
+        try:
+            schema_info = get_schema_info(str(geoarrow_files[encoding]), con=con)
+        finally:
+            con.close()
+
+        # Guard the guard: this must really be the group-node shape.
+        geom_rows = [c for c in schema_info if c.get("name") == "geometry"]
+        assert geom_rows and geom_rows[0].get("type") is None, geom_rows
+
+        byte_array = _check_geometry_byte_array(schema_info, "geometry", encoding)
+        assert byte_array.status == CheckStatus.PASSED, byte_array.message
+        not_grouped = _check_geometry_not_grouped(schema_info, "geometry", encoding)
+        assert not_grouped.status == CheckStatus.PASSED, not_grouped.message
 
 
 class TestGeoArrowDimensionSuffix:


### PR DESCRIPTION
## The bug

`validate.py` hardcoded `VALID_ENCODINGS = ["WKB", "wkb"]`, so a file gpio itself writes with `--geoparquet-version 1.1-geoarrow` failed gpio's own spec check with six errors. Four of them were raw DuckDB binder errors rather than spec messages: once the encoding check rejected the column, the data scans still called `ST_GeomFromWKB()` on what is a nested coordinate struct.

```
encoding_valid_geometry        | column "geometry" must have valid encoding (got: point)
geometry_byte_array_geometry   | geometry column "geometry" must use BYTE_ARRAY (got STRUCT<X: DOUBLE NOT NULL, Y: DOUBLE NOT NULL>)
encoding_matches_data_geometry | failed to validate encoding: Binder Error: No function matches ... 'st_geomfromwkb(STRUCT(x DOUBLE, y DOUBLE))'
geometry_types_match_data_...  | failed to validate geometry types: Binder Error: ...
bbox_contains_data_geometry    | failed to validate bbox: Binder Error: ...
coordinates_valid_for_crs_...  | failed to validate coordinates: Binder Error: ...
```

The written file was correct; the validator was wrong about it. Reproduced for all six GeoArrow encodings, not just `point`.

Fixes #691

## Spec adjudication

Adjudicated against the spec text rather than against gpio's prior behaviour or the corpus. Independently re-verified during review.

- **1.1.0** — "Supported values: `"WKB"`; one of `"point"`, `"linestring"`, `"polygon"`, `"multipoint"`, `"multilinestring"`, `"multipolygon"`." → the six GeoArrow encodings are valid.
- **1.0.0** — WKB "is the only current option" → WKB-only.
- **2.0 draft** — "The only supported value is `"WKB"`." → WKB-only.

So the gate is **`>= 1.1 AND < 2.0`**, not simply `>= 1.1`. A plain "1.1 or newer" test would have wrongly admitted GeoArrow encodings for 2.0.

Two more scoping decisions came straight from the text:

- "**WKB** geometry columns MUST be stored using the `BYTE_ARRAY` parquet type" — explicitly scoped to WKB. Native columns instead MUST store coordinates "using the `DOUBLE` parquet type in a (repeated) group of fields".
- The general "A geometry MUST NOT be a group field" (§Nesting) is contradicted for native columns by the spec's own example in the same document (`optional group geometry { required double x; required double y; }`). The more specific, later section wins; what survives for native columns is "at the root of the schema".

## Layout-aware checks

Every check that reads the column now understands the declared encoding:

- **Encoding validity** — the six names accepted for 1.1; under 1.0/2.0 the failure message names the version requirement instead of emitting a generic "must have valid encoding".
- **BYTE_ARRAY (check 15)** — applies only to WKB. Native columns are instead checked for the DOUBLE coordinate group at the nesting depth their encoding implies (point 0 list levels, linestring/multipoint 1, polygon/multilinestring 2, multipolygon 3 — each verified against the GeoArrow spec and against real writer output).
- **Not-grouped (check 14)** — native columns pass as "GeoArrow group at the schema root". Without this the remote/DuckDB schema path would have started failing valid files, since it reports `num_children > 0` for the group.
- **Data scans** (encoding, geometry types, bbox, CRS) read GeoArrow coordinates through the existing `_geoarrow_coord_exprs()` helper — already used by `convert.py` and `geo_metadata.py` — instead of parsing WKB. An unresolvable coordinate path is reported as an encoding/layout mismatch, never as a raw binder error.
- **Z/M** — dimensionality is a property of the coordinate struct in GeoArrow, so the suffix (` Z`/` M`/` ZM`) is derived from the struct's `z`/`m` fields.
- **Empty and null geometries** — empty lists yield NULL bounds and `POINT EMPTY` yields NaN; both are filtered with `isfinite()` so they neither poison MIN/MAX nor get counted as outside the bbox.

### Rejected design: SQL geometry reconstruction

I prototyped full GeoArrow → `GEOMETRY` reconstruction in SQL (`ST_MakePolygon(ST_MakeLine(list_transform(...)))`) and confirmed it works for all six encodings, then rejected it:

- empty multi-geometries collapse to `GEOMETRYCOLLECTION EMPTY`, which would report a bogus undeclared `GeometryCollection`
- empty polygons reconstruct to `NULL`
- DuckDB's GEOMETRY constructors are XY-only (`ST_Point(x,y,z)` does not bind), so Z/M would be silently dropped and `["Point Z"]` would look undeclared

Reading coordinates directly is both more correct and less new code.

## Crash guards

Two sites shared one bug: `col.get("type", "").upper()`. For a present-but-`None` key the `""` default never applies, so `.upper()` raises `AttributeError`. `validate_geoparquet` has no `except` around the schema checks, so this escaped the function entirely — `gpio check spec` hard-crashed rather than reporting a failed check.

`parquet_schema()` reports group nodes with `type=None`, and **that path is reachable locally, not only for remote files**: `get_schema_info()` falls back to DuckDB whenever the pyarrow reader bails, as it does for `srid:`-style CRS values that geoarrow-pyarrow cannot parse.

- `_check_geometry_byte_array` — any GeoArrow file read through the DuckDB schema path.
- `_check_covering_bbox_field_types` — a `covering.bbox` naming a group column, whose child rows are themselves groups. I had first inspected this site and judged it unreachable, reasoning that a covering's children are typed leaves; that holds only for a *well-formed* bbox column, and this check exists to judge ones that are not.

Both now use the `or ""` idiom already established at the `logical_type` site. Covered by tests over synthetic group nodes and the real `parquet_schema()` rows for all six encodings, plus a test that a well-formed bbox column still passes.

## Documented limitations

- **Two structurally ambiguous encoding pairs.** `linestring`↔`multipoint` (1 list level) and `polygon`↔`multilinestring` (2 levels) hold identical coordinate data, so depth alone cannot separate them. A column mislabeled as its twin is a **missed detection, never a false rejection** — a correctly labeled file always passes. They are distinguishable cheaply: the nested list fields are named per encoding (`vertices`/`points`, `rings`/`linestrings`) and those names already sit in the type string this module reads, so **field-name matching is the strengthening path**. The comment records that those names are how geoarrow.pyarrow renders the `ARROW:extension:name` metadata gpio's writer emits, so both signals exist on the pyarrow schema path and neither on the DuckDB path.
- **3D bbox truncation.** `_check_bbox_contains_data` does `tuple(bbox[:4])`, which mishandles the spec's 6-element `[xmin,ymin,zmin,xmax,ymax,zmax]` form. Pre-existing and equally wrong for WKB; already tracked as **#603 item 1** (same line), so this PR adds a comment pointing there rather than a duplicate issue.
- `_check_orientation_matches_data` remains a pre-existing no-op stub. It does no SQL, so it cannot crash on GeoArrow columns, but it does not verify ring order for them either — same as for WKB.

## Coordination with #693

Open PR #693 (`test/write-contract`, unmerged) records this bug as an xfail entry in `tests/test_write_contract.py`, with a stale-entry guard that **fails when a recorded divergence stops reproducing**. This fix makes that entry stop reproducing.

**Whichever of the two merges second must delete this bug's `KNOWN_` entry and adjust the expected pass/xfail counts during rebase.** This branch does not touch #693.

## Testing

- 74 new tests in `tests/test_validate_geoarrow_encodings.py`, red-first throughout (first run: 50 failed / 5 passed).
- Full fast suite: **4033 passed, 40 skipped**.
- diff-cover: 100% of changed lines.
- pre-commit and pre-push (deptry, mypy, vulture, xenon, import-linter, menard-check) all pass.

Also updated: root `CHANGELOG.md` under unreleased **Fixed**, and `docs/guide/check.md` with a "GeoArrow encodings" bullet (which additionally cleared a pre-existing menard-check staleness on that file).

## Related

- #603 — same false-positive family (validator rejecting verified-correct output); item 1 there covers the 3D bbox line noted above
- #688 — CRS/state cases in this same validator area, deliberately not addressed here
- #704
- The issue's note that #664's claim "1.1-geoarrow is only writable by the streaming strategy" is stale: `write_parquet_with_metadata` auto-routes WKB input to arrow-streaming regardless of requested strategy, so all four strategies produce identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx
