### PR TITLE
test(notebooks): stop the inert cloud notebook from reporting a false-positive pass (#667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **Honest notebook CI signal (#667)**: the `notebooks` job reported a green
+  check for `examples/05_cloud_workflows.ipynb` while executing nothing — all
+  ten of its code cells were commented out, so nbmake "passed" a notebook that
+  ran zero statements. Every cell there uploads to S3/GCS/Azure and needs live
+  credentials, so the notebook is now explicitly skipped by
+  `examples/conftest.py` and says so in its own opening cell, instead of
+  claiming a pass CI never earned. The skip is a
+  `pytest_collection_modifyitems` hook rather than `collect_ignore`:
+  `collect_ignore` is only consulted when pytest walks a directory, and the CI
+  job passes an expanded `examples/*.ipynb` file list, against which it is
+  silently bypassed. Skipping (not deselecting) keeps the reason visible in the
+  CI log. `tests/test_notebook_signal.py` guards the class of bug: a notebook
+  nbmake runs must execute at least one real `gpio` call, and any notebook
+  whose code cells are mostly commented-out stubs must carry an
+  `<!-- nbsignal: illustrative reason="..." -->` directive — invisible when
+  rendered, mandatory in source. `examples/04_partitioning.ipynb` (8 of 10
+  cells inert, because `gpio` rightly refuses to partition the bundled 42-row
+  sample) now carries that directive. No workflow change was needed.
 - **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
   whole Click command tree into a structural snapshot at
   `tests/data/cli_surface.json` — every group, command, option and argument

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,24 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Added
 
+- **Honest notebook CI signal (#667)**: the `notebooks` job reported a green
+  check for `examples/05_cloud_workflows.ipynb` while executing nothing — all
+  ten of its code cells were commented out, so nbmake "passed" a notebook that
+  ran zero statements. Every cell there uploads to S3/GCS/Azure and needs live
+  credentials, so the notebook is now explicitly skipped by
+  `examples/conftest.py` and says so in its own opening cell, instead of
+  claiming a pass CI never earned. The skip is a
+  `pytest_collection_modifyitems` hook rather than `collect_ignore`:
+  `collect_ignore` is only consulted when pytest walks a directory, and the CI
+  job passes an expanded `examples/*.ipynb` file list, against which it is
+  silently bypassed. Skipping (not deselecting) keeps the reason visible in the
+  CI log. `tests/test_notebook_signal.py` guards the class of bug: a notebook
+  nbmake runs must execute at least one real `gpio` call, and any notebook
+  whose code cells are mostly commented-out stubs must carry an
+  `<!-- nbsignal: illustrative reason="..." -->` directive — invisible when
+  rendered, mandatory in source. `examples/04_partitioning.ipynb` (8 of 10
+  cells inert, because `gpio` rightly refuses to partition the bundled 42-row
+  sample) now carries that directive. No workflow change was needed.
 - **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
   whole Click command tree into a structural snapshot at
   `tests/data/cli_surface.json` — every group, command, option and argument

--- a/examples/04_partitioning.ipynb
+++ b/examples/04_partitioning.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Partitioning GeoParquet Files\n\nThis notebook covers partitioning large datasets:\n- When to partition vs. sort\n- Partitioning by H3 cells\n- Partitioning by quadkey\n- Reading partitioned datasets\n\n**Note**: Partitioning requires datasets with at least 100+ rows per partition to be effective. The examples below show the API patterns - use them with your larger datasets."
+   "source": "# Partitioning GeoParquet Files\n\nThis notebook covers partitioning large datasets:\n- When to partition vs. sort\n- Partitioning by H3 cells\n- Partitioning by quadkey\n- Reading partitioned datasets\n\n**Note**: Partitioning requires datasets with at least 100+ rows per partition to be effective. The examples below show the API patterns - use them with your larger datasets.\n\n> **Most cells here are illustrative.** The bundled `data/sample.parquet` has 42\n> rows, and `gpio` deliberately refuses to partition it — the partition-analysis\n> check rejects an average of 2 rows per partition as \"tiny partitions\" — so the\n> partitioning cells are commented out rather than run. CI executes only the\n> load-and-inspect cell at the top. Substitute a large file of your own to run\n> the rest.\n\n<!-- nbsignal: illustrative reason=\"partitioning needs 100+ rows per partition and the bundled 42-row sample is rejected by the tiny-partition check, so only the load cell executes under nbmake\" -->"
   },
   {
    "cell_type": "code",

--- a/examples/05_cloud_workflows.ipynb
+++ b/examples/05_cloud_workflows.ipynb
@@ -11,7 +11,23 @@
     "- S3-compatible storage (MinIO, source.coop)\n",
     "- Authentication options\n",
     "\n",
-    "**Note**: Cloud operations require appropriate credentials and network access."
+    "**Note**: Cloud operations require appropriate credentials and network access.",
+    "\n",
+    "\n",
+    "> **Illustrative only — this notebook is not executed by CI.**\n",
+    ">\n",
+    "> Every example here uploads to a bucket you own, so there is nothing CI can run\n",
+    "> without live credentials. The cells are deliberately commented out: fill in\n",
+    "> your own bucket and profile, uncomment, and run. Because CI cannot execute it,\n",
+    "> this notebook is skipped by the `notebooks` job (see `examples/conftest.py`)\n",
+    "> rather than reported as passing — a green check on a notebook that executes\n",
+    "> nothing would be a false positive.\n",
+    ">\n",
+    "> The upload path itself is covered by unit tests in `tests/test_upload.py`. For\n",
+    "> pipelines you *can* run end to end, see\n",
+    "> [01_getting_started.ipynb](01_getting_started.ipynb).\n",
+    "\n",
+    "<!-- nbsignal: illustrative reason=\"every cell uploads to S3/GCS/Azure and needs live credentials; excluded from the nbmake job instead of reporting a false-positive pass\" -->"
    ]
   },
   {
@@ -19,7 +35,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Imports the commented-out examples below assume, so that \"uncomment to run\"\n",
+    "# actually works.\n",
+    "import subprocess  # noqa: F401  (used by the download-then-process example)\n",
+    "\n",
+    "import geoparquet_io as gpio  # noqa: F401"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,0 +1,39 @@
+"""Keep nbmake from claiming a green check for notebooks it cannot execute.
+
+The ``notebooks`` CI job runs ``pytest --nbmake examples/*.ipynb``. Any notebook
+listed here is skipped, because every operation it demonstrates needs
+credentials or network access that CI does not have. Running it would either
+fail or -- as happened with ``05_cloud_workflows.ipynb`` before issue #667 --
+pass while executing nothing, which is worse: a false positive.
+
+Excluding a notebook is a claim that CI proves nothing about it, so each entry
+must also say so in its own prose via an ``<!-- nbsignal: illustrative ... -->``
+directive. ``tests/test_notebook_signal.py`` enforces both halves.
+
+Implemented as a skip in ``pytest_collection_modifyitems`` rather than
+``collect_ignore``: ``collect_ignore`` is only consulted when pytest walks a
+directory, and the CI job passes an expanded ``examples/*.ipynb`` file list, for
+which it is silently bypassed. A skip also beats a deselect here, because the
+reason is printed in the CI log instead of the notebook just vanishing from the
+report.
+"""
+
+import pytest
+
+#: Notebooks nbmake must not execute. Keep this list as short as the truth allows.
+ILLUSTRATIVE_NOTEBOOKS = {
+    # Every cell uploads to S3/GCS/Azure. Live-cloud testing (a MinIO service
+    # container) is explicitly out of scope for #667.
+    "05_cloud_workflows.ipynb": (
+        "illustrative only: every cell uploads to cloud storage and needs live "
+        "credentials. See the note at the top of the notebook."
+    ),
+}
+
+
+def pytest_collection_modifyitems(items):
+    """Skip the illustrative notebooks however they were passed to pytest."""
+    for item in items:
+        reason = ILLUSTRATIVE_NOTEBOOKS.get(item.path.name)
+        if reason is not None:
+            item.add_marker(pytest.mark.skip(reason=reason))

--- a/tests/test_notebook_signal.py
+++ b/tests/test_notebook_signal.py
@@ -30,6 +30,7 @@ it belongs in the fast suite where it guards every PR, rather than in the
 from __future__ import annotations
 
 import ast
+import importlib.util
 import json
 import re
 import subprocess
@@ -51,8 +52,10 @@ DIRECTIVE_RE = re.compile(
     r"<!--\s*nbsignal:\s*illustrative\s+reason=\"([^\"]+)\"\s*-->",
 )
 
-#: A cell counts as exercising the library if it calls into the ``gpio`` API.
-GPIO_CALL_RE = re.compile(r"\bgpio\s*\.\s*\w+\s*\(|\bread\s*\(|\bops\s*\.\s*\w+\s*\(")
+#: The repo's convention for an install cell, which ships commented out on
+#: purpose so nbmake does not pip-install anything. It is idiomatic rather than
+#: dead code, so it does not count towards a notebook's inert cells.
+INSTALL_CELL_RE = re.compile(r"^\s*#?\s*[!%]\s*pip\s+install\b", re.MULTILINE)
 
 
 def _notebook_paths() -> list[Path]:
@@ -94,6 +97,68 @@ def _is_inert(source: str) -> bool:
     """
     lines = [line for line in source.splitlines() if line.strip()]
     return not lines or all(line.lstrip().startswith("#") for line in lines)
+
+
+def _is_install_cell(source: str) -> bool:
+    """True for the commented-out ``!pip install`` cell notebooks conventionally open with."""
+    return bool(INSTALL_CELL_RE.search(source))
+
+
+def _safe_parse(source: str) -> ast.Module | None:
+    """Parse a notebook code cell, tolerating IPython magics and partial snippets."""
+    stripped = "\n".join(
+        "" if line.lstrip().startswith(("!", "%")) else line for line in source.splitlines()
+    )
+    try:
+        return ast.parse(stripped)
+    except SyntaxError:
+        return None
+
+
+def _gpio_bound_names(sources: list[str]) -> set[str]:
+    """Names in this notebook that are bound to ``geoparquet_io``.
+
+    Covers both ``import geoparquet_io as gpio`` and
+    ``from geoparquet_io.api import Table, ops, pipe, read``.
+    """
+    bound: set[str] = set()
+    for source in sources:
+        tree = _safe_parse(source)
+        if tree is None:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "geoparquet_io" or alias.name.startswith("geoparquet_io."):
+                        bound.add(alias.asname or alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module == "geoparquet_io" or module.startswith("geoparquet_io."):
+                    for alias in node.names:
+                        bound.add(alias.asname or alias.name)
+    return bound
+
+
+def _root_name(node: ast.expr) -> str | None:
+    """The leftmost identifier of a (possibly dotted) call target."""
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _calls_gpio(source: str, bound: set[str]) -> bool:
+    """True when this cell calls something bound to ``geoparquet_io``.
+
+    Resolved through the AST against the notebook's own imports rather than by
+    regex: a bare ``\\bread\\s*\\(`` pattern also matches ``f.read()``, which
+    would let a notebook with zero gpio usage satisfy the invariant.
+    """
+    tree = _safe_parse(source)
+    if tree is None:
+        return False
+    return any(
+        isinstance(node, ast.Call) and _root_name(node.func) in bound for node in ast.walk(tree)
+    )
 
 
 def _directive_reason(path: Path) -> str | None:
@@ -168,15 +233,118 @@ def test_executed_notebook_runs_real_code(path: Path) -> None:
     if path.name in _load_excluded():
         pytest.skip(f"{path.name} is excluded from nbmake; covered by other tests here")
 
-    live = [src for src in _cells(path, "code") if not _is_inert(src)]
+    code = _cells(path, "code")
+    live = [src for src in code if not _is_inert(src)]
     assert live, (
         f"{path.name} has no executable code cells, so its nbmake green check "
         "would be a false positive. Give it runnable content, or add it to "
         "ILLUSTRATIVE_NOTEBOOKS in examples/conftest.py."
     )
-    assert any(GPIO_CALL_RE.search(src) for src in live), (
-        f"{path.name} executes code but never calls the gpio API, so nbmake "
+    bound = _gpio_bound_names(live)
+    assert bound, (
+        f"{path.name} never imports geoparquet_io, so nbmake proves nothing about this project."
+    )
+    assert any(_calls_gpio(src, bound) for src in live), (
+        f"{path.name} imports geoparquet_io but never calls it, so nbmake "
         "proves nothing about this project."
+    )
+
+
+def test_bare_read_call_does_not_count_as_gpio_usage() -> None:
+    """``f.read()`` must not satisfy the "calls the library" invariant.
+
+    The first version of this guard matched a bare ``\\bread\\s*\\(``, which any
+    file handle satisfies -- a notebook with zero gpio usage would have passed.
+    """
+    cells = ["with open('x.txt') as f:\n    data = f.read()\n"]
+    assert _gpio_bound_names(cells) == set()
+    assert not _calls_gpio(cells[0], {"gpio"})
+
+
+def test_gpio_usage_is_resolved_through_the_notebooks_own_imports() -> None:
+    """Both import spellings the example notebooks actually use are recognised."""
+    aliased = "import geoparquet_io as gpio"
+    from_import = "from geoparquet_io.api import Table, ops, pipe, read"
+
+    bound = _gpio_bound_names([aliased])
+    assert bound == {"gpio"}
+    assert _calls_gpio("t = gpio.read('a.parquet').add_bbox()", bound)
+
+    bound = _gpio_bound_names([from_import])
+    assert {"Table", "ops", "pipe", "read"} <= bound
+    # A bare `read(...)` counts only because this notebook imported it from us.
+    assert _calls_gpio("result = read('a.parquet')", bound)
+    assert _calls_gpio("arrow = ops.add_bbox(arrow)", bound)
+
+
+def test_commented_install_cell_is_not_counted_as_inert() -> None:
+    """A short notebook must not be forced to declare itself over the install cell.
+
+    The convention ships commented out on purpose so nbmake never pip-installs.
+    Counting it as inert made a 2-cell notebook (install + one real cell) read as
+    50% inert and demand an `nbsignal` directive it does not deserve.
+    """
+    install = "# Uncomment to install\n# !pip install geoparquet-io"
+    assert _is_inert(install), "still inert: nothing executes"
+    assert _is_install_cell(install), "but exempt from the inert count"
+
+    # The exemption is narrow: an ordinary commented-out cell still counts.
+    stub = "# gpio.read('x.parquet').upload('s3://bucket/x.parquet')"
+    assert _is_inert(stub)
+    assert not _is_install_cell(stub)
+
+
+class _StubItem:
+    """Minimal stand-in for a collected pytest item, for driving the hook."""
+
+    def __init__(self, name: str) -> None:
+        self.path = Path("/examples") / name
+        self.markers: list[object] = []
+
+    def add_marker(self, marker: object) -> None:
+        self.markers.append(marker)
+
+
+def _load_examples_conftest():
+    """Import ``examples/conftest.py`` by path, the way test_doc_sync.py does."""
+    path = EXAMPLES_DIR / "conftest.py"
+    spec = importlib.util.spec_from_file_location("examples_conftest", str(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skip_hook_actually_applies_the_skip_marker() -> None:
+    """Drive the real hook body and assert it marks the illustrative notebook.
+
+    The nbmake end-to-end proof below is ``meta``-marked (nightly only), so on
+    its own it leaves a ~24h window in which a neutered hook body -- one that
+    matches the notebook but never calls ``add_marker`` -- passes every PR lane.
+    This test closes that window for a few microseconds, by importing the hook
+    and running it against stub items rather than asserting on its source shape.
+    """
+    conftest = _load_examples_conftest()
+    excluded = sorted(conftest.ILLUSTRATIVE_NOTEBOOKS)
+    assert excluded, "nothing to prove: no notebooks are excluded"
+
+    target = _StubItem(excluded[0])
+    healthy = _StubItem("01_getting_started.ipynb")
+    assert healthy.path.name not in conftest.ILLUSTRATIVE_NOTEBOOKS
+
+    conftest.pytest_collection_modifyitems([target, healthy])
+
+    assert target.markers, (
+        f"the hook matched {target.path.name} but never applied a marker, so "
+        "nbmake would execute it and report a false-positive pass"
+    )
+    marker = target.markers[0]
+    assert marker.name == "skip", f"expected a skip marker, got {marker.name!r}"
+    assert len(marker.kwargs.get("reason", "").strip()) >= 20, (
+        f"skip reason must explain itself in the CI log: {marker.kwargs!r}"
+    )
+    assert not healthy.markers, (
+        f"the hook skipped {healthy.path.name}, which is not illustrative; "
+        "that would silently drop real coverage"
     )
 
 
@@ -225,7 +393,9 @@ def test_mostly_inert_notebook_declares_itself(path: Path) -> None:
     the nbmake job whose cells are mostly commented-out stubs.
     """
     code = _cells(path, "code")
-    inert = sum(1 for src in code if _is_inert(src))
+    # The commented-out install cell is a deliberate convention, not dead code,
+    # so it must not push a short but otherwise healthy notebook over the bar.
+    inert = sum(1 for src in code if _is_inert(src) and not _is_install_cell(src))
     excluded = path.name in _load_excluded()
     mostly_inert = bool(code) and inert / len(code) >= MOSTLY_INERT_THRESHOLD
 

--- a/tests/test_notebook_signal.py
+++ b/tests/test_notebook_signal.py
@@ -1,0 +1,246 @@
+"""Guard the honesty of the notebook CI signal.
+
+The ``notebooks`` job in ``.github/workflows/tests.yml`` runs every
+``examples/*.ipynb`` under nbmake and reports a green check. That check is only
+meaningful if the notebooks actually execute something. Before this guard,
+``05_cloud_workflows.ipynb`` had ten code cells of which ten were entirely
+commented out -- nbmake executed zero statements and reported success anyway
+(see issue #667).
+
+Two invariants keep that from recurring silently:
+
+1. A notebook that nbmake *runs* must execute at least one real call into the
+   ``gpio`` API. A notebook with nothing to execute must instead be listed in
+   ``examples/conftest.py::ILLUSTRATIVE_NOTEBOOKS`` so nbmake skips it and no
+   green check is claimed for it.
+2. A notebook whose code cells are mostly commented-out ("uncomment to run")
+   stubs must say so in its own prose, via an HTML-comment directive that is
+   invisible in the rendered notebook. Weak signal is allowed -- silent weak
+   signal is not.
+
+Directive convention (mirrors the docs-example directives in #667)::
+
+    <!-- nbsignal: illustrative reason="..." -->
+
+This is a static check: it parses notebook JSON and never executes a cell, so
+it belongs in the fast suite where it guards every PR, rather than in the
+``meta`` lane which only runs nightly.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+EXAMPLES_DIR = PROJECT_ROOT / "examples"
+
+#: Fraction of code cells that may be inert before a notebook must declare itself
+#: illustrative. Notebooks 01-03 sit near zero; 04 is deliberately above it.
+MOSTLY_INERT_THRESHOLD = 0.5
+
+#: The directive a notebook uses to declare that its examples are illustrative.
+#: ``reason="..."`` is mandatory so the waiver explains itself to the next reader.
+DIRECTIVE_RE = re.compile(
+    r"<!--\s*nbsignal:\s*illustrative\s+reason=\"([^\"]+)\"\s*-->",
+)
+
+#: A cell counts as exercising the library if it calls into the ``gpio`` API.
+GPIO_CALL_RE = re.compile(r"\bgpio\s*\.\s*\w+\s*\(|\bread\s*\(|\bops\s*\.\s*\w+\s*\(")
+
+
+def _notebook_paths() -> list[Path]:
+    return sorted(EXAMPLES_DIR.glob("*.ipynb"))
+
+
+def _load_excluded() -> dict[str, str]:
+    """Read the nbmake exclusion map that ``examples/conftest.py`` declares.
+
+    Parsed with ``ast`` rather than imported: importing a conftest outside of
+    pytest's own collection machinery is fragile, and a static read keeps this
+    test honest about what the file literally says.
+    """
+    conftest = EXAMPLES_DIR / "conftest.py"
+    assert conftest.exists(), (
+        f"Expected {conftest} to declare which notebooks nbmake must skip. "
+        "Without it, an inert notebook produces a false-positive green check."
+    )
+    tree = ast.parse(conftest.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if "ILLUSTRATIVE_NOTEBOOKS" in names:
+            return dict(ast.literal_eval(node.value))
+    pytest.fail("examples/conftest.py does not define ILLUSTRATIVE_NOTEBOOKS")
+
+
+def _cells(path: Path, kind: str) -> list[str]:
+    nb = json.loads(path.read_text(encoding="utf-8"))
+    return ["".join(cell["source"]) for cell in nb["cells"] if cell["cell_type"] == kind]
+
+
+def _is_inert(source: str) -> bool:
+    """True when a code cell has nothing for the kernel to run.
+
+    Blank cells and cells that are entirely ``#`` comments (the "uncomment to
+    run" pattern) execute no statements, so nbmake passing them proves nothing.
+    """
+    lines = [line for line in source.splitlines() if line.strip()]
+    return not lines or all(line.lstrip().startswith("#") for line in lines)
+
+
+def _directive_reason(path: Path) -> str | None:
+    for source in _cells(path, "markdown"):
+        match = DIRECTIVE_RE.search(source)
+        if match:
+            return match.group(1)
+    return None
+
+
+def test_notebooks_exist() -> None:
+    """Sanity: the guard is pointed at real files."""
+    assert _notebook_paths(), f"No notebooks found under {EXAMPLES_DIR}"
+
+
+def test_exclusion_list_has_no_stale_entries() -> None:
+    """Every excluded name must match a notebook that actually exists."""
+    names = {path.name for path in _notebook_paths()}
+    stale = set(_load_excluded()) - names
+    assert not stale, (
+        f"examples/conftest.py excludes notebooks that no longer exist: {sorted(stale)}"
+    )
+
+
+def test_every_exclusion_states_a_reason() -> None:
+    """The skip reason is what a CI reader sees, so it has to be a real sentence."""
+    for name, reason in _load_excluded().items():
+        assert len(reason.strip()) >= 20, (
+            f"{name}: skip reason is too terse to explain itself: {reason!r}"
+        )
+
+
+def test_conftest_skips_via_a_hook_not_collect_ignore() -> None:
+    """The exclusion must survive the file-list invocation CI actually uses.
+
+    ``collect_ignore`` is only consulted when pytest walks a directory. The CI
+    job passes an expanded ``examples/*.ipynb`` file list, against which
+    ``collect_ignore`` is silently bypassed and every notebook runs anyway --
+    exactly the false positive this module exists to prevent. Requiring the
+    ``pytest_collection_modifyitems`` hook keeps the mechanism invocation-proof.
+    """
+    source = (EXAMPLES_DIR / "conftest.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    hooks = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+    assert "pytest_collection_modifyitems" in hooks, (
+        "examples/conftest.py must skip illustrative notebooks from a "
+        "pytest_collection_modifyitems hook"
+    )
+    # Check for a real assignment, not the word appearing in the module docstring.
+    assigned = {
+        target.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    assert "collect_ignore" not in assigned, (
+        "collect_ignore does not work for the file-list invocation the CI "
+        "notebooks job uses; it would give a false sense of exclusion"
+    )
+
+
+@pytest.mark.parametrize(
+    "path", _notebook_paths(), ids=lambda p: p.name if isinstance(p, Path) else str(p)
+)
+def test_executed_notebook_runs_real_code(path: Path) -> None:
+    """A notebook nbmake executes must actually call the library.
+
+    This is the check that ``05_cloud_workflows.ipynb`` failed: nbmake reported
+    it green while executing nothing at all.
+    """
+    if path.name in _load_excluded():
+        pytest.skip(f"{path.name} is excluded from nbmake; covered by other tests here")
+
+    live = [src for src in _cells(path, "code") if not _is_inert(src)]
+    assert live, (
+        f"{path.name} has no executable code cells, so its nbmake green check "
+        "would be a false positive. Give it runnable content, or add it to "
+        "ILLUSTRATIVE_NOTEBOOKS in examples/conftest.py."
+    )
+    assert any(GPIO_CALL_RE.search(src) for src in live), (
+        f"{path.name} executes code but never calls the gpio API, so nbmake "
+        "proves nothing about this project."
+    )
+
+
+@pytest.mark.meta
+def test_illustrative_notebook_is_actually_skipped_by_nbmake() -> None:
+    """Prove the skip fires under the real nbmake invocation, not just in theory.
+
+    The static checks above assert the *shape* of the mechanism; this one runs
+    it. Marked ``meta`` because it spawns a nested pytest, matching how the
+    other subprocess-based tooling checks in this repo are laned.
+    """
+    excluded = sorted(_load_excluded())
+    assert excluded, "nothing to prove: no notebooks are excluded"
+    target = EXAMPLES_DIR / excluded[0]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--nbmake",
+            str(target),
+            "--no-cov",
+            "-q",
+            "-p",
+            "no:randomly",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+    )
+    assert result.returncode == 0, f"nbmake run failed:\n{result.stdout}\n{result.stderr}"
+    assert "1 skipped" in result.stdout, (
+        f"{target.name} was executed by nbmake instead of skipped. Its green "
+        f"check would be a false positive.\n{result.stdout}"
+    )
+
+
+@pytest.mark.parametrize(
+    "path", _notebook_paths(), ids=lambda p: p.name if isinstance(p, Path) else str(p)
+)
+def test_mostly_inert_notebook_declares_itself(path: Path) -> None:
+    """Weak or absent execution signal has to be visible in the notebook's prose.
+
+    Applies to excluded notebooks (which run nothing) and to notebooks kept in
+    the nbmake job whose cells are mostly commented-out stubs.
+    """
+    code = _cells(path, "code")
+    inert = sum(1 for src in code if _is_inert(src))
+    excluded = path.name in _load_excluded()
+    mostly_inert = bool(code) and inert / len(code) >= MOSTLY_INERT_THRESHOLD
+
+    reason = _directive_reason(path)
+    if excluded or mostly_inert:
+        assert reason, (
+            f"{path.name} has {inert}/{len(code)} inert code cells"
+            f"{' and is excluded from nbmake' if excluded else ''}, so it must "
+            'carry a markdown directive: <!-- nbsignal: illustrative reason="..." -->'
+        )
+        assert len(reason.strip()) >= 20, (
+            f"{path.name}: nbsignal reason is too terse to be useful: {reason!r}"
+        )
+    else:
+        assert not reason, (
+            f"{path.name} carries an nbsignal directive but only {inert}/{len(code)} "
+            "of its code cells are inert. Drop the stale directive."
+        )

--- a/tests/test_notebook_signal.py
+++ b/tests/test_notebook_signal.py
@@ -100,8 +100,14 @@ def _is_inert(source: str) -> bool:
 
 
 def _is_install_cell(source: str) -> bool:
-    """True for the commented-out ``!pip install`` cell notebooks conventionally open with."""
-    return bool(INSTALL_CELL_RE.search(source))
+    """True for the commented-out ``!pip install`` cell notebooks conventionally open with.
+
+    The exemption is anchored to the whole-cell shape (a couple of comment
+    lines at most), so a long commented-out stub cell cannot dodge the inert
+    count by merely citing a pip-install line.
+    """
+    lines = [line for line in source.splitlines() if line.strip()]
+    return len(lines) <= 3 and bool(INSTALL_CELL_RE.search(source))
 
 
 def _safe_parse(source: str) -> ast.Module | None:
@@ -317,8 +323,8 @@ def _load_examples_conftest():
 def test_skip_hook_actually_applies_the_skip_marker() -> None:
     """Drive the real hook body and assert it marks the illustrative notebook.
 
-    The nbmake end-to-end proof below is ``meta``-marked (nightly only), so on
-    its own it leaves a ~24h window in which a neutered hook body -- one that
+    The nbmake end-to-end proof below is ``meta``-marked (post-merge slow lane),
+    so on its own it leaves a window in which a neutered hook body -- one that
     matches the notebook but never calls ``add_marker`` -- passes every PR lane.
     This test closes that window for a few microseconds, by importing the hook
     and running it against stub items rather than asserting on its source shape.
@@ -369,11 +375,11 @@ def test_illustrative_notebook_is_actually_skipped_by_nbmake() -> None:
             str(target),
             "--no-cov",
             "-q",
-            "-p",
-            "no:randomly",
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         cwd=str(PROJECT_ROOT),
     )
     assert result.returncode == 0, f"nbmake run failed:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## The bug

The `notebooks` CI job reported a green check for `examples/05_cloud_workflows.ipynb` while executing nothing at all. All ten of its code cells were commented out (one was empty), so nbmake started a kernel, ran zero statements, and reported `1 passed`. The job was asserting nothing about that notebook and had been for its whole life.

## The fix

Every cell in the notebook uploads to S3/GCS/Azure and needs live credentials, and live-cloud testing (a MinIO service container) is explicitly out of scope for #667. So the notebook is now **skipped rather than falsely passed**, and says so in its own opening cell — a reader of the notebook and a reader of the CI log both learn that CI proves nothing about it.

I deliberately did not give it a token executable path. The only thing that could run locally is the pipeline prefix (`read → add_bbox → sort_hilbert → write`), which tests nothing this notebook is *about* while making it look covered — that converts a visible false positive into a disguised one.

**The `collect_ignore` trap.** The first implementation used `collect_ignore` in `examples/conftest.py`. It does not work here: `collect_ignore` is only consulted when pytest walks a directory, and the CI job passes an expanded `examples/*.ipynb` **file list**, against which it is silently bypassed. Verified directly — `--collect-only` returned 5 notebooks with `collect_ignore` in place, and 4 only with the directory form. The exclusion is therefore a `pytest_collection_modifyitems` hook, which is invocation-proof. A skip (not a deselect) keeps the reason in the CI log:

```
examples/05_cloud_workflows.ipynb SKIPPED (illustrative only: every cell uploads
to cloud storage and needs live credentials...)
```

`tests/test_notebook_signal.py::test_conftest_skips_via_a_hook_not_collect_ignore` encodes this trap so nobody "simplifies" it back.

**`.github/workflows/tests.yml` is untouched**, so there is no merge-order conflict with the sibling PRs editing that file. `CHANGELOG.md` is the only shared file touched.

## Audit of all five notebooks

Inert = empty, or every non-blank line is a `#` comment.

| Notebook | Inert / code cells | Verdict |
|---|---|---|
| `01_getting_started.ipynb` | 1 / 14 | Healthy. The one inert cell is the `# !pip install` convention. |
| `02_python_api_chaining.ipynb` | 0 / 11 | Healthy. Exercises `Table`, `ops`, `pipe`, PyArrow interop. |
| `03_spatial_indices.ipynb` | 0 / 9 | Healthy. bbox/H3/quadkey/kdtree all really run. |
| `04_partitioning.ipynb` | 8 / 10 | Weak, but **legitimately so** — and now declared. |
| `05_cloud_workflows.ipynb` | 9 / 10 inert + 1 empty | The false positive. Now illustrative-only and skipped. |

**On 04:** its stated reason checks out. `gpio` deliberately refuses to partition the bundled 42-row `examples/data/sample.parquet`:

```
PartitionError: ❌ Tiny partitions: Average of 2 rows per partition is below
minimum of 100. ... Use --force to override
```

So this is not rot, and forcing it would teach a pattern the tool itself warns against. I did not rewrite it — I added the directive so the weak signal is visible in source. **It becomes genuinely runnable once #667's canonical-dataset deliverable replaces `sample.parquet` with the 766-point `places_test.parquet`,** at which point the directive can be dropped.

## The guard

`tests/test_notebook_signal.py` — parses notebook JSON, executes no cells, runs in ~0.4s, and lives in the **fast suite** so it guards every PR rather than only the nightly `meta` lane. Two invariants:

1. **A notebook nbmake runs must actually call the library.** Resolved through the AST against the notebook's own imports (covering both `import geoparquet_io as gpio` and `from geoparquet_io.api import ... read`), so `f.read()` cannot satisfy it.
2. **A notebook that is excluded, or whose code cells are ≥50% inert, must declare itself** with `<!-- nbsignal: illustrative reason="..." -->` — invisible when rendered (mirroring #667's docs-directive convention), mandatory in source, with a non-trivial reason. A stale directive on a healthy notebook also fails. The `# !pip install` convention is exempt from the inert count, so a short healthy notebook is not dragged over the bar.

Plus consistency checks: no stale exclusion entries, every exclusion states a reason, and the mechanism is a hook not `collect_ignore`.

**PR-lane mechanism test (added in review round 1).** Review caught that the only test proving the hook *body* works spawned a nested pytest and was `meta`-marked, so deleting `item.add_marker(...)` left every PR lane green — a ~24h detection window on the exact false positive this guard prevents. `test_skip_hook_actually_applies_the_skip_marker` now imports the hook and drives it against stub items on the fast lane. It was chosen over unmarking the ~1.2s subprocess test because it runs in microseconds per PR, pinpoints what broke, and keeps a nested pytest out of mutmut's per-mutant runs — which is why `pyproject.toml` lanes subprocess tooling checks as `meta` to begin with. The nbmake end-to-end proof stays `meta` as integration cover.

## Sabotage evidence

Every guard here was verified non-vacuous by breaking the thing it protects and confirming the failure, then reverting.

| Sabotage | Result |
|---|---|
| Remove 05 from `ILLUSTRATIVE_NOTEBOOKS` | **fast lane fails** — *"executes code but never calls the gpio API"* |
| Keep 05 listed, neuter the hook body (`pass` instead of `add_marker`) | **fast lane fails** — *"the hook matched 05_cloud_workflows.ipynb but never applied a marker"*. Before the round-1 fix this sabotage produced **zero** fast-lane failures; the nested nbmake run reproduced the original bug exactly, reporting `1 passed` for a notebook running nothing. |
| Strip the `nbsignal` directive from 04 | **fails** — *"04_partitioning.ipynb has 8/10 inert code cells, so it must carry a markdown directive"* |

## Verification

- Exact CI command `uv run pytest --nbmake examples/*.ipynb -v --nbmake-timeout=120 --no-cov` → **4 passed, 1 skipped**, reason printed.
- Full fast suite → **4072 passed, 52 skipped, 3 xfailed**.
- Guard module → 18 passed, 1 skipped. Meta lane → selected and passing.
- pre-commit → all hooks pass.

No `geoparquet_io/` source lines change, so the diff-cover gate is not engaged.

Refs #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that selected notebooks are illustrative, may require live credentials, or intentionally contain non-executable examples.
  - Added explanations for partitioning limitations and cloud workflow prerequisites.

- **Bug Fixes**
  - Notebook checks now clearly report when an example is skipped instead of appearing to pass without running meaningful code.

- **Tests**
  - Added safeguards to verify notebooks either execute meaningful examples or include clear explanations when they are intentionally illustrative or skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->