### PR TITLE
test(e2e): add the ten-journey end-to-end matrix (#667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   lane (~12s serial), 8 and 10 are slow-marked, 9 is network-marked; journey 6
   skips without tippecanoe (which also covers the Windows leg) and journey 8
   skips with a clear reason when the Overture boundary cache is cold, offline or
-  busy, so it still gates the blocking slow lane when warm. Journey 3b is a
+  busy — so it gates warm machines (typically developers'; CI's ephemeral
+  runners start cold and skip until the slow job caches the admin
+  directory). Journey 3b is a
   strict `xfail` pinning a real break, filed as #722: the documented
   `extract … - | add quadkey - | partition string - dir/` chain dies with an
   unhandled DuckDB error because `extract`'s Arrow IPC stream omits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,33 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   generator's `--output-dir`) and compares SHA-256 against the committed files,
   catching the one failure the rest of the suite cannot see: a change in gpio's
   own output leaving these files stale and the reproducibility claim false.
+- **End-to-end journey matrix (#667)**: `tests/e2e/test_journeys.py` runs ten
+  multi-command user journeys through the *installed* `gpio` binary — GeoJSON
+  round trip via GeoParquet 2.0, H3 index → H3 partition, the piping chains
+  printed in `docs/guide/piping.md` (real shell pipelines, Arrow IPC between
+  stages), the GeoJSONSeq stdout bridge, reproject with CRS assertions, aggregate
+  → overview → PMTiles pyramid, a CSV round trip, admin-division enrichment →
+  admin partition, a remote `extract --limit` over HTTPS, and 200k synthetic
+  points whose Hilbert sort must lift the estimated row-group skip rate from
+  under 10% to over 50%. Each journey ends in `gpio check all` plus concrete
+  value assertions (row conservation, expected columns, cell ids, country codes,
+  bbox extents) — never a bare exit code, because `gpio check all` **exits 0 on a
+  file whose spec validation failed**; the shared oracle in
+  `tests/e2e/journey_support.py` parses the report and cross-checks
+  `validate_geoparquet`, and `test_oracle_rejects_a_damaged_journey_output` fails
+  if that ever stops catching a damaged intermediate. Journeys 1–7 ride the fast
+  lane (~12s serial), 8 and 10 are slow-marked, 9 is network-marked; journey 6
+  skips without tippecanoe (which also covers the Windows leg) and journey 8 is
+  additionally network-marked because the Overture boundaries are downloaded on
+  first use. Journey 3b is a strict `xfail` pinning a real break: the documented
+  `extract … - | add quadkey - | partition string - dir/` chain dies with an
+  unhandled DuckDB error because `extract`'s Arrow IPC stream omits
+  `geometry_types`.
+  `tests/e2e/test_integration_lane.py` gives the `integration` marker enforced
+  semantics — every journey must carry it, no `tests.yml` selection may deselect
+  it, and each journey must land in exactly one CI job — instead of adding a
+  duplicate `-m integration` job that would re-run the fast lane's work.
+
 - **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
   whole Click command tree into a structural snapshot at
   `tests/data/cli_surface.json` — every group, command, option and argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   own output leaving these files stale and the reproducibility claim false.
 - **End-to-end journey matrix (#667)**: `tests/e2e/test_journeys.py` runs ten
   multi-command user journeys through the *installed* `gpio` binary — GeoJSON
-  round trip via GeoParquet 2.0, H3 index → H3 partition, the piping chains
-  printed in `docs/guide/piping.md` (real shell pipelines, Arrow IPC between
-  stages), the GeoJSONSeq stdout bridge, reproject with CRS assertions, aggregate
+  round trip via GeoParquet 2.0, H3 index → H3 partition, piping chains from
+  `docs/guide/piping.md` (real shell pipelines, Arrow IPC between stages), the
+  GeoJSONSeq stdout bridge, reproject with CRS assertions, aggregate
   → overview → PMTiles pyramid, a CSV round trip, admin-division enrichment →
   admin partition, a remote `extract --limit` over HTTPS, and 200k synthetic
   points whose Hilbert sort must lift the estimated row-group skip rate from
@@ -118,12 +118,14 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `validate_geoparquet`, and `test_oracle_rejects_a_damaged_journey_output` fails
   if that ever stops catching a damaged intermediate. Journeys 1–7 ride the fast
   lane (~12s serial), 8 and 10 are slow-marked, 9 is network-marked; journey 6
-  skips without tippecanoe (which also covers the Windows leg) and journey 8 is
-  additionally network-marked because the Overture boundaries are downloaded on
-  first use. Journey 3b is a strict `xfail` pinning a real break: the documented
+  skips without tippecanoe (which also covers the Windows leg) and journey 8
+  skips with a clear reason when the Overture boundary cache is cold, offline or
+  busy, so it still gates the blocking slow lane when warm. Journey 3b is a
+  strict `xfail` pinning a real break, filed as #722: the documented
   `extract … - | add quadkey - | partition string - dir/` chain dies with an
   unhandled DuckDB error because `extract`'s Arrow IPC stream omits
-  `geometry_types`.
+  `geometry_types`. Journey 4 documents #723 (`convert geojson -` with a named
+  output fails with a misleading "File not found: -").
   `tests/e2e/test_integration_lane.py` gives the `integration` marker enforced
   semantics — every journey must carry it, no `tests.yml` selection may deselect
   it, and each journey must land in exactly one CI job — instead of adding a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ not all: commitizen is a `commit-msg`-stage hook and mutmut has no hook, so
 |--------|-------------|
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
-| `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.integration` | marks end-to-end integration tests; runs in the fast suite unless also marked slow/network (see tests/e2e/test_integration_lane.py) |
 | `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 | `@pytest.mark.meta` | repo tooling checks, excluded from the fast suite |
 <!-- END GENERATED: test-markers -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -120,7 +120,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   lane (~12s serial), 8 and 10 are slow-marked, 9 is network-marked; journey 6
   skips without tippecanoe (which also covers the Windows leg) and journey 8
   skips with a clear reason when the Overture boundary cache is cold, offline or
-  busy, so it still gates the blocking slow lane when warm. Journey 3b is a
+  busy — so it gates warm machines (typically developers'; CI's ephemeral
+  runners start cold and skip until the slow job caches the admin
+  directory). Journey 3b is a
   strict `xfail` pinning a real break, filed as #722: the documented
   `extract … - | add quadkey - | partition string - dir/` chain dies with an
   unhandled DuckDB error because `extract`'s Arrow IPC stream omits

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,6 +102,33 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   generator's `--output-dir`) and compares SHA-256 against the committed files,
   catching the one failure the rest of the suite cannot see: a change in gpio's
   own output leaving these files stale and the reproducibility claim false.
+- **End-to-end journey matrix (#667)**: `tests/e2e/test_journeys.py` runs ten
+  multi-command user journeys through the *installed* `gpio` binary — GeoJSON
+  round trip via GeoParquet 2.0, H3 index → H3 partition, the piping chains
+  printed in `docs/guide/piping.md` (real shell pipelines, Arrow IPC between
+  stages), the GeoJSONSeq stdout bridge, reproject with CRS assertions, aggregate
+  → overview → PMTiles pyramid, a CSV round trip, admin-division enrichment →
+  admin partition, a remote `extract --limit` over HTTPS, and 200k synthetic
+  points whose Hilbert sort must lift the estimated row-group skip rate from
+  under 10% to over 50%. Each journey ends in `gpio check all` plus concrete
+  value assertions (row conservation, expected columns, cell ids, country codes,
+  bbox extents) — never a bare exit code, because `gpio check all` **exits 0 on a
+  file whose spec validation failed**; the shared oracle in
+  `tests/e2e/journey_support.py` parses the report and cross-checks
+  `validate_geoparquet`, and `test_oracle_rejects_a_damaged_journey_output` fails
+  if that ever stops catching a damaged intermediate. Journeys 1–7 ride the fast
+  lane (~12s serial), 8 and 10 are slow-marked, 9 is network-marked; journey 6
+  skips without tippecanoe (which also covers the Windows leg) and journey 8 is
+  additionally network-marked because the Overture boundaries are downloaded on
+  first use. Journey 3b is a strict `xfail` pinning a real break: the documented
+  `extract … - | add quadkey - | partition string - dir/` chain dies with an
+  unhandled DuckDB error because `extract`'s Arrow IPC stream omits
+  `geometry_types`.
+  `tests/e2e/test_integration_lane.py` gives the `integration` marker enforced
+  semantics — every journey must carry it, no `tests.yml` selection may deselect
+  it, and each journey must land in exactly one CI job — instead of adding a
+  duplicate `-m integration` job that would re-run the fast lane's work.
+
 - **CLI surface regression test (#664)**: `tests/test_cli_surface.py` walks the
   whole Click command tree into a structural snapshot at
   `tests/data/cli_surface.json` — every group, command, option and argument

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,9 +104,9 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   own output leaving these files stale and the reproducibility claim false.
 - **End-to-end journey matrix (#667)**: `tests/e2e/test_journeys.py` runs ten
   multi-command user journeys through the *installed* `gpio` binary — GeoJSON
-  round trip via GeoParquet 2.0, H3 index → H3 partition, the piping chains
-  printed in `docs/guide/piping.md` (real shell pipelines, Arrow IPC between
-  stages), the GeoJSONSeq stdout bridge, reproject with CRS assertions, aggregate
+  round trip via GeoParquet 2.0, H3 index → H3 partition, piping chains from
+  `docs/guide/piping.md` (real shell pipelines, Arrow IPC between stages), the
+  GeoJSONSeq stdout bridge, reproject with CRS assertions, aggregate
   → overview → PMTiles pyramid, a CSV round trip, admin-division enrichment →
   admin partition, a remote `extract --limit` over HTTPS, and 200k synthetic
   points whose Hilbert sort must lift the estimated row-group skip rate from
@@ -118,12 +118,14 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   `validate_geoparquet`, and `test_oracle_rejects_a_damaged_journey_output` fails
   if that ever stops catching a damaged intermediate. Journeys 1–7 ride the fast
   lane (~12s serial), 8 and 10 are slow-marked, 9 is network-marked; journey 6
-  skips without tippecanoe (which also covers the Windows leg) and journey 8 is
-  additionally network-marked because the Overture boundaries are downloaded on
-  first use. Journey 3b is a strict `xfail` pinning a real break: the documented
+  skips without tippecanoe (which also covers the Windows leg) and journey 8
+  skips with a clear reason when the Overture boundary cache is cold, offline or
+  busy, so it still gates the blocking slow lane when warm. Journey 3b is a
+  strict `xfail` pinning a real break, filed as #722: the documented
   `extract … - | add quadkey - | partition string - dir/` chain dies with an
   unhandled DuckDB error because `extract`'s Arrow IPC stream omits
-  `geometry_types`.
+  `geometry_types`. Journey 4 documents #723 (`convert geojson -` with a named
+  output fails with a misleading "File not found: -").
   `tests/e2e/test_integration_lane.py` gives the `integration` marker enforced
   semantics — every journey must carry it, no `tests.yml` selection may deselect
   it, and each journey must land in exactly one CI job — instead of adding a

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,7 +114,7 @@ Coverage gates (both enforced in CI):
 |--------|-------------|
 | `@pytest.mark.slow` | marks tests as slow (deselect with '-m "not slow"') |
 | `@pytest.mark.network` | marks tests requiring network access (deselect with '-m "not network"') |
-| `@pytest.mark.integration` | marks end-to-end integration tests |
+| `@pytest.mark.integration` | marks end-to-end integration tests; runs in the fast suite unless also marked slow/network (see tests/e2e/test_integration_lane.py) |
 | `@pytest.mark.corpus` | tests against the official geoparquet-testing corpus (requires git submodule) |
 | `@pytest.mark.meta` | repo tooling checks, excluded from the fast suite |
 <!-- END GENERATED: test-markers -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ addopts = [
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "network: marks tests requiring network access (deselect with '-m \"not network\"')",
-    "integration: marks end-to-end integration tests",
+    "integration: marks end-to-end integration tests; runs in the fast suite unless also marked slow/network (see tests/e2e/test_integration_lane.py)",
     "corpus: tests against the official geoparquet-testing corpus (requires git submodule)",
     "meta: repo tooling checks, excluded from the fast suite",
 ]

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end journey tests (issue #667, deliverable 4)."""

--- a/tests/e2e/journey_support.py
+++ b/tests/e2e/journey_support.py
@@ -123,7 +123,12 @@ def run_gpio(args: list[str | Path], journey: int, expect_success: bool = True):
 
 
 def run_pipeline(stages: list[str], journey: int, expect_success: bool = True):
-    """Run a real shell pipeline of ``gpio`` invocations (journeys 3 and 4)."""
+    """Run a real shell pipeline of ``gpio`` invocations (journeys 3 and 4).
+
+    No ``pipefail``: the returncode is the last stage's (and cmd.exe has no
+    equivalent anyway), so an early stage dying quietly is caught by the
+    callers' content assertions on the output, not by the exit code.
+    """
     pipeline = " | ".join(stages)
     result = subprocess.run(
         pipeline,
@@ -155,7 +160,10 @@ def q(path: Path | str) -> str:
 # no-op across the eight journeys it backs. The counts are what carry meaning.
 _SPEC_FAILED = re.compile(r"(\d+)\s+failed")
 _SPEC_PASSED = re.compile(r"(\d+)\s+checks passed")
-_SUMMARY = re.compile(r"Summary:\s+(\d+)\s+passed(?:,\s*(\d+)\s+failed)?")
+# The real summary line may carry a warnings segment between passed and failed
+# ("Summary: 2 passed, 1 warnings, 3 failed"); tolerate it so the failed count
+# is still captured when warnings are present.
+_SUMMARY = re.compile(r"Summary:\s+(\d+)\s+passed(?:,\s*\d+\s+warnings?)?(?:,\s*(\d+)\s+failed)?")
 
 
 def assert_check_all(target: Path, journey: int, *, all_files: bool = False) -> str:
@@ -181,7 +189,15 @@ def assert_check_all(target: Path, journey: int, *, all_files: bool = False) -> 
         assert summary is not None, f"no partition summary in:\n{report}"
         assert summary.group(2) is None, f"partition files failed the check:\n{report}"
     else:
-        assert _SPEC_PASSED.search(report), f"no spec-validation pass line in:\n{report}"
+        # Deliberately warning-intolerant: the CLI prints the plain "N checks
+        # passed" line only when there are zero warnings, so a journey output
+        # that starts warning fails here. That is the point - canonical journey
+        # outputs must be warning-clean, and a new warning deserves a look.
+        assert _SPEC_PASSED.search(report), (
+            f"no clean spec-validation pass line in the report for {target} - "
+            f"either validation failed or it passed with warnings, and journey "
+            f"outputs must be warning-clean:\n{report}"
+        )
         # Cross-check the CLI verdict against the in-process validator.
         validation = validate_geoparquet(str(target))
         assert validation.is_valid, (

--- a/tests/e2e/journey_support.py
+++ b/tests/e2e/journey_support.py
@@ -1,0 +1,199 @@
+"""Shared plumbing for the end-to-end journey suite (issue #667, deliverable 4).
+
+Everything here drives the INSTALLED ``gpio`` binary through ``subprocess`` --
+never the Click test runner -- so the journeys cover the real entry point,
+argument parsing, stdout streaming and process exit codes. It mirrors the
+pattern already used by ``tests/test_pipe_integration.py`` and
+``tests/test_pmtiles.py``.
+
+Oracle note (this is the load-bearing part of the suite): ``gpio check all``
+exits 0 even when spec validation FAILS -- a file with three failed spec checks
+still returns 0 and only prints ``✗ 3 failed, 25 passed``. Asserting on the exit
+code alone would therefore be vacuous, so :func:`assert_check_all` parses the
+report AND cross-checks with the in-process validator.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.validate import validate_geoparquet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "tests" / "data"
+
+# Existing fixtures used as journey inputs.
+# TODO(#667): migrate to tests/data/canonical/ once the canonical-dataset
+# deliverable lands; the triple there replaces these ad-hoc picks.
+PLACES = DATA_DIR / "places_test.parquet"  # 766 points, West Africa (BF/BJ/GH/TG)
+BUILDINGS_GEOJSON = DATA_DIR / "buildings_test.geojson"  # 42 polygons
+# Labelled EPSG:5070 but the data actually sits in Europe (~18E, 47N) -- see
+# journey 5; never assert a CONUS bbox on it.
+FIELDS_5070 = DATA_DIR / "fields_pgo_5070_snappy.parquet"
+
+PLACES_ROWS = 766
+BUILDINGS_ROWS = 42
+FIELDS_ROWS = 100
+
+GPIO_BIN = shutil.which("gpio")
+TIPPECANOE_BIN = shutil.which("tippecanoe")
+TILE_JOIN_BIN = shutil.which("tile-join")
+
+requires_gpio = pytest.mark.skipif(
+    GPIO_BIN is None,
+    reason="gpio binary not on PATH (run under `uv run`, or `uv sync --all-extras`)",
+)
+# Mirrors tests/test_pmtiles.py: tippecanoe has no native Windows build, so this
+# also auto-skips the Windows CI leg.
+requires_tippecanoe = pytest.mark.skipif(
+    TIPPECANOE_BIN is None or TILE_JOIN_BIN is None,
+    reason="tippecanoe/tile-join not installed",
+)
+
+# Runtime budgets from the issue #667 journey table, in seconds. They are NOT
+# asserted as wall-clock (CI runners vary too much for that to be anything but
+# flaky); they are enforced as per-command subprocess timeouts with generous
+# slack, so a hung pipeline fails the test instead of hanging the job. Actual
+# durations surface through pytest's --durations flags, which CI already passes.
+BUDGETS = {
+    1: 5,
+    2: 8,
+    3: 6,
+    4: 4,
+    5: 4,
+    6: 20,
+    7: 4,
+    8: 60,
+    9: 30,
+    10: 120,
+}
+
+_TIMEOUT_SLACK = 10
+
+
+def _timeout(journey: int) -> int:
+    return max(60, BUDGETS[journey] * _TIMEOUT_SLACK)
+
+
+def run_gpio(args: list[str | Path], journey: int, expect_success: bool = True):
+    """Run the installed ``gpio`` binary with ``args`` (no shell)."""
+    cmd = [GPIO_BIN, *[str(a) for a in args]]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=_timeout(journey),
+    )
+    if expect_success:
+        assert result.returncode == 0, (
+            f"`{' '.join(str(a) for a in cmd)}` failed ({result.returncode}):\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+        assert "Traceback (most recent call last)" not in result.stderr, (
+            f"`{' '.join(str(a) for a in cmd)}` printed a traceback:\n{result.stderr}"
+        )
+    return result
+
+
+def run_pipeline(stages: list[str], journey: int, expect_success: bool = True):
+    """Run a real shell pipeline of ``gpio`` invocations (journeys 3 and 4)."""
+    pipeline = " | ".join(stages)
+    result = subprocess.run(
+        pipeline,
+        shell=True,
+        capture_output=True,
+        text=True,
+        timeout=_timeout(journey),
+    )
+    if expect_success:
+        assert result.returncode == 0, (
+            f"pipeline failed ({result.returncode}): {pipeline}\n{result.stdout}\n{result.stderr}"
+        )
+        assert "Traceback (most recent call last)" not in result.stderr, (
+            f"pipeline printed a traceback: {pipeline}\n{result.stderr}"
+        )
+    return result
+
+
+def q(path: Path | str) -> str:
+    """Quote a path for a shell pipeline (works under sh and cmd.exe)."""
+    return f'"{path}"'
+
+
+_SPEC_FAILED = re.compile(r"✗\s+(\d+)\s+failed")
+_SPEC_PASSED = re.compile(r"✓\s+(\d+)\s+checks passed")
+_SUMMARY = re.compile(r"Summary:\s+(\d+)\s+passed(?:,\s*(\d+)\s+failed)?")
+
+
+def assert_check_all(target: Path, journey: int, *, all_files: bool = False) -> str:
+    """Run ``gpio check all`` on a file or partition directory as the oracle.
+
+    Returns the captured stdout so callers can make journey-specific
+    assertions on it (version banner, compression, spatial order, ...).
+    """
+    args: list[str | Path] = ["check", "all", target]
+    if all_files:
+        args.append("--all-files")
+    result = run_gpio(args, journey)
+    report = result.stdout + result.stderr
+
+    failed = _SPEC_FAILED.search(report)
+    assert failed is None, f"`gpio check all {target}` reports spec failures:\n{report}"
+
+    if all_files:
+        summary = _SUMMARY.search(report)
+        assert summary is not None, f"no partition summary in:\n{report}"
+        assert summary.group(2) is None, f"partition files failed the check:\n{report}"
+    else:
+        assert _SPEC_PASSED.search(report), f"no spec-validation pass line in:\n{report}"
+        # Cross-check the CLI verdict against the in-process validator.
+        validation = validate_geoparquet(str(target))
+        assert validation.is_valid, (
+            f"validate_geoparquet flagged {target}: "
+            f"{[c.message for c in validation.checks if c.status.name == 'FAILED']}"
+        )
+    return report
+
+
+def spatial_skip_rate(path: Path, journey: int) -> float:
+    """Return the estimated row-group skip rate (%) from ``gpio check spatial``."""
+    result = run_gpio(["check", "spatial", "--verbose", path], journey)
+    match = re.search(r"Estimated skip rate:\s+([\d.]+)%", result.stdout + result.stderr)
+    assert match is not None, f"no skip-rate line in:\n{result.stdout}\n{result.stderr}"
+    return float(match.group(1))
+
+
+def rows(path: Path) -> int:
+    return pq.read_table(path).num_rows
+
+
+def columns(path: Path) -> list[str]:
+    return pq.read_table(path).column_names
+
+
+def leaf_files(directory: Path) -> list[Path]:
+    return sorted(directory.rglob("*.parquet"))
+
+
+def total_rows(directory: Path) -> int:
+    return sum(rows(leaf) for leaf in leaf_files(directory))
+
+
+def bbox_extent(path: Path, bbox_column: str = "bbox") -> tuple[float, float, float, float]:
+    """Compute the overall extent from a gpio-written bbox struct column."""
+    import pyarrow.compute as pc
+
+    table = pq.read_table(path, columns=[bbox_column])
+    struct = table.column(bbox_column).combine_chunks()
+    return (
+        pc.min(struct.field("xmin")).as_py(),
+        pc.min(struct.field("ymin")).as_py(),
+        pc.max(struct.field("xmax")).as_py(),
+        pc.max(struct.field("ymax")).as_py(),
+    )

--- a/tests/e2e/journey_support.py
+++ b/tests/e2e/journey_support.py
@@ -61,6 +61,13 @@ requires_tippecanoe = pytest.mark.skipif(
 # flaky); they are enforced as per-command subprocess timeouts with generous
 # slack, so a hung pipeline fails the test instead of hanging the job. Actual
 # durations surface through pytest's --durations flags, which CI already passes.
+#
+# Measured against budget on a 2026 laptop (macOS, warm caches), for anyone
+# retuning these: 1 ~1.6s, 2 ~1.3s, 3 ~2.1s, 4 ~1.0s, 5 ~1.6s, 6 ~1.8s,
+# 7 ~1.4s, 8 ~1.6s warm (the first run also downloads ~34MB of boundaries),
+# 9 ~69s (remote server, over its 30s budget), 10 ~3.6s (far under its 120s
+# budget -- it could be promoted to the fast lane if the slow job ever needs
+# trimming).
 BUDGETS = {
     1: 5,
     2: 8,
@@ -75,10 +82,14 @@ BUDGETS = {
 }
 
 _TIMEOUT_SLACK = 10
+# Cap: 10x journey 10's budget would let a wedged command sit for 20 minutes,
+# which on a hung CI runner is indistinguishable from a hang. Journey 10's real
+# cost is ~4s and journey 9's ~69s, so 180s leaves ample headroom.
+_TIMEOUT_CAP = 180
 
 
 def _timeout(journey: int) -> int:
-    return max(60, BUDGETS[journey] * _TIMEOUT_SLACK)
+    return min(_TIMEOUT_CAP, max(60, BUDGETS[journey] * _TIMEOUT_SLACK))
 
 
 def run_gpio(args: list[str | Path], journey: int, expect_success: bool = True):
@@ -88,6 +99,14 @@ def run_gpio(args: list[str | Path], journey: int, expect_success: bool = True):
         cmd,
         capture_output=True,
         text=True,
+        # gpio's reports contain ✓/✗/📁/❌ and the fixtures carry non-ASCII place
+        # names. Without an explicit encoding, Python decodes child output with
+        # the locale codec -- cp1252 on the Windows CI leg -- and a
+        # UnicodeDecodeError there would fail the blocking fast job. errors are
+        # replaced rather than raised: the oracle reads the report's structure,
+        # not its glyphs.
+        encoding="utf-8",
+        errors="replace",
         timeout=_timeout(journey),
     )
     if expect_success:
@@ -109,6 +128,8 @@ def run_pipeline(stages: list[str], journey: int, expect_success: bool = True):
         shell=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",  # see run_gpio: never decode child output with the locale codec
+        errors="replace",
         timeout=_timeout(journey),
     )
     if expect_success:
@@ -126,8 +147,12 @@ def q(path: Path | str) -> str:
     return f'"{path}"'
 
 
-_SPEC_FAILED = re.compile(r"✗\s+(\d+)\s+failed")
-_SPEC_PASSED = re.compile(r"✓\s+(\d+)\s+checks passed")
+# Glyph-free on purpose: with errors="replace" (and on a console that degrades
+# UTF-8), the ✓/✗ prefixes can arrive as U+FFFD, and an oracle that required them
+# would silently stop matching -- turning the "no spec failures" assertion into a
+# no-op across the eight journeys it backs. The counts are what carry meaning.
+_SPEC_FAILED = re.compile(r"(\d+)\s+failed")
+_SPEC_PASSED = re.compile(r"(\d+)\s+checks passed")
 _SUMMARY = re.compile(r"Summary:\s+(\d+)\s+passed(?:,\s*(\d+)\s+failed)?")
 
 
@@ -143,8 +168,11 @@ def assert_check_all(target: Path, journey: int, *, all_files: bool = False) -> 
     result = run_gpio(args, journey)
     report = result.stdout + result.stderr
 
-    failed = _SPEC_FAILED.search(report)
-    assert failed is None, f"`gpio check all {target}` reports spec failures:\n{report}"
+    # Any non-zero "N failed" anywhere in the report is a failure, whether it
+    # came from spec validation or from the per-file partition summary. A zero
+    # count is tolerated so a future "0 failed" line cannot fail a clean run.
+    failures = [int(count) for count in _SPEC_FAILED.findall(report) if int(count) > 0]
+    assert not failures, f"`gpio check all {target}` reports failures:\n{report}"
 
     if all_files:
         summary = _SUMMARY.search(report)

--- a/tests/e2e/journey_support.py
+++ b/tests/e2e/journey_support.py
@@ -65,9 +65,9 @@ requires_tippecanoe = pytest.mark.skipif(
 # Measured against budget on a 2026 laptop (macOS, warm caches), for anyone
 # retuning these: 1 ~1.6s, 2 ~1.3s, 3 ~2.1s, 4 ~1.0s, 5 ~1.6s, 6 ~1.8s,
 # 7 ~1.4s, 8 ~1.6s warm (the first run also downloads ~34MB of boundaries),
-# 9 ~69s (remote server, over its 30s budget), 10 ~3.6s (far under its 120s
-# budget -- it could be promoted to the fast lane if the slow job ever needs
-# trimming).
+# 9 ~69s (remote server; the issue table's 30s was optimistic, so the entry
+# below says 70), 10 ~3.6s (far under its 120s budget -- it could be promoted
+# to the fast lane if the slow job ever needs trimming).
 BUDGETS = {
     1: 5,
     2: 8,
@@ -77,7 +77,9 @@ BUDGETS = {
     6: 20,
     7: 4,
     8: 60,
-    9: 30,
+    # 9 is 70, not the issue table's 30: measured ~69s against the live host.
+    # The budget has to describe reality, since it is what sizes the timeout.
+    9: 70,
     10: 120,
 }
 

--- a/tests/e2e/test_integration_lane.py
+++ b/tests/e2e/test_integration_lane.py
@@ -158,7 +158,12 @@ def test_fast_lane_runs_the_fast_journeys():
     fast = [e for e in _selections() if selects(e, {"integration"})]
     assert fast, "no CI selection admits plain integration-marked tests"
     fast_journeys = {name for name, marks in _journeys().items() if not marks & {"slow", "network"}}
-    assert len(fast_journeys) >= 7, f"expected journeys 1-7 in the fast lane, got {fast_journeys}"
+    # By name, not by count: a count would stay green if a journey were
+    # quietly slow-marked while some helper test padded the number back up.
+    for number in range(1, 8):
+        assert any(f"journey_{number:02d}" in name for name in fast_journeys), (
+            f"journey {number} is no longer in the fast lane: {sorted(fast_journeys)}"
+        )
 
 
 def test_marker_description_documents_the_lane():

--- a/tests/e2e/test_integration_lane.py
+++ b/tests/e2e/test_integration_lane.py
@@ -1,0 +1,139 @@
+"""Keep the `integration` marker meaningful in CI (issue #667, deliverable 4).
+
+The issue asks to "wire ``-m integration`` into CI so the marker is meaningful".
+Investigation of the current workflow shows the marker is ALREADY selected: the
+fast job runs ``-m "not slow and not network and not meta"``, which admits
+integration-marked tests (that is how ``tests/test_geoparquet_corpus.py``
+already runs on every PR). What was missing was not a lane but a guarantee --
+nothing stopped a future selection from excluding it, and nothing tied each
+journey to a lane.
+
+So the smallest change that gives the marker real semantics is this guard plus
+a sharper marker description in ``pyproject.toml``, NOT a new ``-m integration``
+job: a separate job would repeat checkout + ``uv sync --all-extras`` + the
+DuckDB extension install + tippecanoe (several minutes of runner time) only to
+re-run tests the fast job already runs, and the brief says not to restructure
+CI. These tests fail loudly if that reasoning stops holding.
+
+Pattern follows ``tests/test_coverage_job.py``, which guards the coverage leg of
+the same workflow the same way. Deliberately NOT marked ``meta``: it parses a
+file and imports a module (no subprocesses), and it must fail on the PR that
+breaks the wiring, not in the nightly lane.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.e2e import test_journeys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "tests.yml"
+PYPROJECT = PROJECT_ROOT / "pyproject.toml"
+
+LANE_MARKERS = {"slow", "network", "meta", "integration", "corpus"}
+
+# `-m "a and not b"` or a bare `-m network`.
+_SELECTION = re.compile(r"-m\s+(?:\"([^\"]+)\"|(?!-)(\S+))")
+
+
+def _selections() -> list[str]:
+    """Distinct pytest marker selections used by tests.yml.
+
+    Deduplicated: each job repeats its selection once per OS branch (xdist
+    flags differ), and those repeats are the same lane.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    found = list(dict.fromkeys(quoted or bare for quoted, bare in _SELECTION.findall(text)))
+    assert found, "tests.yml has no `-m` marker selections at all"
+    return found
+
+
+def selects(expression: str, marks: set[str]) -> bool:
+    """Evaluate a pytest ``-m`` expression against a set of marker names.
+
+    ``eval`` is safe here: the expression comes from this repo's own workflow
+    file and every name is bound to a bool in an empty builtins namespace.
+    """
+    names = set(re.findall(r"[A-Za-z_][A-Za-z_0-9]*", expression)) - {"and", "or", "not"}
+    return bool(eval(expression, {"__builtins__": {}}, {name: name in marks for name in names}))
+
+
+def _marks_of(func) -> set[str]:
+    marks = {mark.name for mark in getattr(test_journeys, "pytestmark", [])}
+    marks |= {mark.name for mark in getattr(func, "pytestmark", [])}
+    return marks & LANE_MARKERS
+
+
+def _journeys() -> dict[str, set[str]]:
+    return {
+        name: _marks_of(getattr(test_journeys, name))
+        for name in dir(test_journeys)
+        if name.startswith("test_")
+    }
+
+
+def test_selection_evaluator_is_not_vacuous():
+    """The evaluator this module reasons with must actually discriminate."""
+    assert selects("not slow and not network and not meta", {"integration"})
+    assert not selects("not slow and not network and not meta", {"integration", "slow"})
+    assert selects("(slow or meta) and not network", {"slow"})
+    assert not selects("(slow or meta) and not network", {"slow", "network"})
+    assert selects("network", {"network"})
+
+
+def test_every_journey_carries_the_integration_marker():
+    journeys = _journeys()
+    assert len(journeys) >= 10, f"expected the ten journeys plus guards, got {journeys}"
+    for name, marks in journeys.items():
+        assert "integration" in marks, f"{name} is not integration-marked"
+
+
+def test_no_ci_selection_excludes_integration_tests():
+    """No job may deselect the marker; otherwise the journeys run nowhere."""
+    for expression in _selections():
+        assert "integration" not in expression, (
+            f"tests.yml selection {expression!r} mentions `integration`. The journeys are "
+            "meant to ride the existing lanes; naming the marker here (especially as "
+            "`not integration`) would silently strand them."
+        )
+
+
+def test_each_journey_lands_in_exactly_one_ci_job():
+    """Every journey runs in exactly one of the fast / slow / network jobs."""
+    selections = _selections()
+    for name, marks in _journeys().items():
+        matched = [expression for expression in selections if selects(expression, marks)]
+        assert len(matched) == 1, (
+            f"{name} (marks={sorted(marks)}) is selected by {len(matched)} CI jobs: {matched}"
+        )
+
+
+def test_fast_lane_runs_the_fast_journeys():
+    """Journeys 1-7 must run on every PR, i.e. under the fast-suite selection."""
+    fast = [e for e in _selections() if selects(e, {"integration"})]
+    assert fast, "no CI selection admits plain integration-marked tests"
+    fast_journeys = {name for name, marks in _journeys().items() if not marks & {"slow", "network"}}
+    assert len(fast_journeys) >= 7, f"expected journeys 1-7 in the fast lane, got {fast_journeys}"
+
+
+def test_marker_description_documents_the_lane():
+    """`--strict-markers` is on; the description is where the lane is documented."""
+    description = None
+    for line in PYPROJECT.read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith('"integration:'):
+            description = line
+            break
+    assert description is not None, "pyproject.toml lost its `integration` marker"
+    assert "fast suite" in description, (
+        "the `integration` marker description must say which lane it rides, "
+        f"got: {description.strip()}"
+    )
+
+
+@pytest.mark.parametrize("path", [WORKFLOW, PYPROJECT])
+def test_guarded_files_exist(path: Path):
+    assert path.exists(), f"{path} is missing; this guard would silently pass"

--- a/tests/e2e/test_integration_lane.py
+++ b/tests/e2e/test_integration_lane.py
@@ -23,6 +23,7 @@ breaks the wiring, not in the nightly lane.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -36,8 +37,8 @@ PYPROJECT = PROJECT_ROOT / "pyproject.toml"
 
 LANE_MARKERS = {"slow", "network", "meta", "integration", "corpus"}
 
-# `-m "a and not b"` or a bare `-m network`.
-_SELECTION = re.compile(r"-m\s+(?:\"([^\"]+)\"|(?!-)(\S+))")
+# `-m "a and not b"`, `-m 'a and not b'`, or a bare `-m network`.
+_SELECTION = re.compile(r"-m\s+(?:\"([^\"]+)\"|'([^']+)'|(?!-)(\S+))")
 
 
 def _selections() -> list[str]:
@@ -47,19 +48,51 @@ def _selections() -> list[str]:
     flags differ), and those repeats are the same lane.
     """
     text = WORKFLOW.read_text(encoding="utf-8")
-    found = list(dict.fromkeys(quoted or bare for quoted, bare in _SELECTION.findall(text)))
+    found = list(
+        dict.fromkeys(double or single or bare for double, single, bare in _SELECTION.findall(text))
+    )
     assert found, "tests.yml has no `-m` marker selections at all"
     return found
+
+
+_ALLOWED_NODES = (
+    ast.Expression,
+    ast.BoolOp,
+    ast.UnaryOp,
+    ast.And,
+    ast.Or,
+    ast.Not,
+    ast.Name,
+    ast.Load,
+)
 
 
 def selects(expression: str, marks: set[str]) -> bool:
     """Evaluate a pytest ``-m`` expression against a set of marker names.
 
-    ``eval`` is safe here: the expression comes from this repo's own workflow
-    file and every name is bound to a bool in an empty builtins namespace.
+    Walks the parsed expression instead of calling ``eval``: marker expressions
+    are only names combined with and/or/not, so a tiny evaluator covers them,
+    and nothing in this guard can execute whatever a future edit puts in
+    tests.yml. Anything outside that grammar raises rather than being guessed at.
     """
-    names = set(re.findall(r"[A-Za-z_][A-Za-z_0-9]*", expression)) - {"and", "or", "not"}
-    return bool(eval(expression, {"__builtins__": {}}, {name: name in marks for name in names}))
+    tree = ast.parse(expression, mode="eval")
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            raise ValueError(f"unsupported marker expression {expression!r}: {type(node).__name__}")
+
+    def evaluate(node: ast.AST) -> bool:
+        if isinstance(node, ast.Expression):
+            return evaluate(node.body)
+        if isinstance(node, ast.Name):
+            return node.id in marks
+        if isinstance(node, ast.UnaryOp):  # only `not`, per _ALLOWED_NODES
+            return not evaluate(node.operand)
+        if isinstance(node, ast.BoolOp):
+            results = [evaluate(value) for value in node.values]
+            return all(results) if isinstance(node.op, ast.And) else any(results)
+        raise ValueError(f"unsupported node {type(node).__name__}")  # pragma: no cover
+
+    return evaluate(tree)
 
 
 def _marks_of(func) -> set[str]:
@@ -103,7 +136,15 @@ def test_no_ci_selection_excludes_integration_tests():
 
 
 def test_each_journey_lands_in_exactly_one_ci_job():
-    """Every journey runs in exactly one of the fast / slow / network jobs."""
+    """Every journey is selected by exactly one of the fast / slow / network jobs.
+
+    Scope caveat: this counts marker SELECTIONS, not whether the job that owns
+    the selection actually gates a PR. The network job is `continue-on-error`
+    and does not run on pull requests, and the slow job runs on merge/schedule
+    or behind the `run-slow-tests` label -- so "selected" is not "blocking".
+    Adding `network` to a journey moves it from a blocking lane to an advisory
+    one while this test stays green (that is why journey 8 is `slow` only).
+    """
     selections = _selections()
     for name, marks in _journeys().items():
         matched = [expression for expression in selections if selects(expression, marks)]

--- a/tests/e2e/test_journeys.py
+++ b/tests/e2e/test_journeys.py
@@ -350,7 +350,10 @@ _BOUNDARIES_UNAVAILABLE = (
     # and bare "connection", which is a live DuckDB error prefix
     # ("Connection Error: ...").
     "could not resolve",
-    "network",
+    # Not bare "network": any real bug whose message merely mentions the word
+    # would be reported as an environmental skip.
+    "network error",
+    "network is unreachable",
     "timed out",
     "timeout",
     "failed to download",
@@ -405,8 +408,11 @@ def test_journey_08_admin_divisions_then_partition(tmp_path):
     out of the blocking slow job and into the network job, which never runs on
     PRs and is ``continue-on-error`` -- demoting a gate to an advisory signal.
     Instead the fetch is attempted and the test SKIPS with a clear reason when
-    the download or the cache is unavailable: warm runners gate on it, cold or
-    offline ones skip cleanly.
+    the download or the cache is unavailable. In practice that means warm
+    developer machines gate on it, while CI's ephemeral runners start cold and
+    will usually skip (the cold download exceeds the timeout) until the slow
+    job caches ``~/.geoparquet-io/cache/admin`` -- a follow-up, keyed on the
+    pinned Overture release.
 
     Not hermetic, and cannot be: ``gpio add admin-divisions`` caches datasets in
     the machine-global ``~/.geoparquet-io/cache/admin`` (~34MB for Overture

--- a/tests/e2e/test_journeys.py
+++ b/tests/e2e/test_journeys.py
@@ -1,0 +1,461 @@
+"""Ten end-to-end user journeys, run through the installed ``gpio`` binary.
+
+Issue #667, deliverable 4. Each journey chains several real commands the way a
+user (or the guides) would, then finishes with ``gpio check all`` plus concrete
+assertions -- row conservation, expected columns, CRS, spatial-order metrics --
+rather than a bare exit-code check. See ``journey_support`` for why the exit
+code alone would be a vacuous oracle.
+
+Lanes (issue table): journeys 1-7 fast, 8 and 10 slow, 9 network. Journey 6
+skips without tippecanoe, which also covers the Windows CI leg. The module is
+``integration``-marked; see ``test_integration_lane.py`` for how that marker is
+kept meaningful in CI.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow.parquet as pq
+import pytest
+
+from tests.conftest import safe_rmtree
+from tests.e2e.journey_support import (
+    BUILDINGS_GEOJSON,
+    BUILDINGS_ROWS,
+    FIELDS_5070,
+    FIELDS_ROWS,
+    PLACES,
+    PLACES_ROWS,
+    assert_check_all,
+    bbox_extent,
+    columns,
+    leaf_files,
+    q,
+    requires_gpio,
+    requires_tippecanoe,
+    rows,
+    run_gpio,
+    run_pipeline,
+    spatial_skip_rate,
+    total_rows,
+)
+
+pytestmark = [pytest.mark.integration, requires_gpio]
+
+# Public GeoParquet used by docs/guide/extract.md; journey 9 reads it remotely.
+REMOTE_PARQUET_URL = "https://data.source.coop/fiboa/data/si/si-2024.parquet"
+
+
+def geo_metadata(path) -> dict | None:
+    """Return the parsed GeoParquet ``geo`` key, or None for parquet-geo-only files."""
+    metadata = pq.read_schema(path).metadata or {}
+    raw = metadata.get(b"geo")
+    return json.loads(raw) if raw else None
+
+
+# ---------------------------------------------------------------------------
+# Journey 1 -- GeoJSON in, GeoParquet 2.0 out, GeoJSON back (budget 5s, fast)
+# ---------------------------------------------------------------------------
+def test_journey_01_geojson_to_geoparquet_and_back(tmp_path):
+    """geojson -> convert -> sort hilbert (2.0) -> add bbox -> check all -> geojson."""
+    imported = tmp_path / "buildings.parquet"
+    sorted_v2 = tmp_path / "buildings_sorted.parquet"
+    with_bbox = tmp_path / "buildings_bbox.parquet"
+    exported = tmp_path / "buildings_out.geojson"
+
+    run_gpio(["convert", "geoparquet", BUILDINGS_GEOJSON, imported], 1)
+    run_gpio(["sort", "hilbert", "--geoparquet-version", "2.0", imported, sorted_v2], 1)
+    # convert already wrote a bbox column, so re-adding needs --force. That is
+    # documented behaviour ("will inform you and exit successfully"), and it is
+    # exactly why the oracle cannot trust exit codes alone.
+    run_gpio(["add", "bbox", "--force", sorted_v2, with_bbox], 1)
+
+    report = assert_check_all(with_bbox, 1)
+    assert "Version 2.0.0" in report
+    assert "native Parquet GEOMETRY/GEOGRAPHY types" in report
+
+    run_gpio(["convert", "geojson", with_bbox, exported], 1)
+
+    # Row and geometry parity across the whole round trip.
+    assert rows(imported) == rows(with_bbox) == BUILDINGS_ROWS
+    assert geo_metadata(with_bbox)["version"] == "2.0.0"
+    features = json.loads(exported.read_text())["features"]
+    assert len(features) == BUILDINGS_ROWS
+    assert {f["geometry"]["type"] for f in features} == {"Polygon"}
+
+
+# ---------------------------------------------------------------------------
+# Journey 2 -- H3 index then H3 partition (budget 8s, fast)
+# ---------------------------------------------------------------------------
+def test_journey_02_h3_index_then_partition(tmp_path):
+    """parquet -> add h3 -> partition h3 -> check all on every leaf; rows conserved."""
+    indexed = tmp_path / "places_h3.parquet"
+    partitions = tmp_path / "h3_partitions"
+
+    # Resolution 2 keeps the 766 West-African points in a handful of cells;
+    # finer resolutions trip the command's tiny-partition guard. `partition h3`
+    # reuses an existing h3_cell column, so index and partition resolutions
+    # have to agree.
+    run_gpio(["add", "h3", "--resolution", "2", PLACES, indexed], 2)
+    assert "h3_cell" in columns(indexed)
+    assert rows(indexed) == PLACES_ROWS
+
+    run_gpio(["partition", "h3", "--resolution", "2", indexed, partitions], 2)
+
+    leaves = leaf_files(partitions)
+    assert len(leaves) > 1, f"expected several H3 partitions, got {leaves}"
+    assert total_rows(partitions) == PLACES_ROWS
+    # Every leaf is named after a 15-character H3 cell id.
+    assert all(len(leaf.stem) == 15 for leaf in leaves), [leaf.name for leaf in leaves]
+
+    assert_check_all(partitions, 2, all_files=True)
+    safe_rmtree(partitions)
+
+
+# ---------------------------------------------------------------------------
+# Journey 3 -- documented piping chains (budget 6s, fast)
+# ---------------------------------------------------------------------------
+def test_journey_03_documented_piping_chains(tmp_path):
+    """The chains printed in docs/guide/piping.md, run verbatim through a shell."""
+    partitions = tmp_path / "quadkey_partitions"
+    multi_index = tmp_path / "multi_index.parquet"
+
+    # piping.md "Partition from a pipe": add quadkey -> partition string.
+    run_pipeline(
+        [
+            f"gpio add quadkey {q(PLACES)} -",
+            f"gpio partition string --column quadkey --chars 2 - {q(partitions)}",
+        ],
+        3,
+    )
+    leaves = leaf_files(partitions)
+    assert {leaf.stem for leaf in leaves} == {"03", "12"}
+    assert total_rows(partitions) == PLACES_ROWS
+    assert_check_all(partitions, 3, all_files=True)
+
+    # piping.md "Add Multiple Spatial Indices": four stages, three of them
+    # reading Arrow IPC from stdin.
+    run_pipeline(
+        [
+            f"gpio add bbox --force {q(PLACES)}",
+            "gpio add h3 --resolution 9 -",
+            "gpio add quadkey -",
+            f"gpio sort hilbert - {q(multi_index)}",
+        ],
+        3,
+    )
+    assert rows(multi_index) == PLACES_ROWS
+    for expected in ("bbox", "h3_cell", "quadkey"):
+        assert expected in columns(multi_index)
+    assert_check_all(multi_index, 3)
+    safe_rmtree(partitions)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "KNOWN BUG: `gpio extract ... - | gpio add quadkey - | gpio partition string - dir/` "
+        "-- the chain documented in docs/guide/piping.md 'Spatial Filter and Partition' -- "
+        "dies with an unhandled DuckDB error, 'Geoparquet column geometry does not have "
+        "geometry types'. extract's Arrow IPC stream omits geometry_types metadata; the "
+        "file-writing path recomputes it, which is why only the piped-into-partition case "
+        "breaks. Filed separately from #667 per the cross-cutting-fix rule; flip this test "
+        "to a plain assertion when it is fixed."
+    ),
+)
+def test_journey_03b_extract_into_partition_chain(tmp_path):
+    """The one documented piping chain that does not work end to end."""
+    partitions = tmp_path / "bbox_partitions"
+    result = run_pipeline(
+        [
+            f'gpio extract --bbox "-0.5,10.0,1.0,12.0" {q(PLACES)} -',
+            "gpio add quadkey -",
+            f"gpio partition string --column quadkey --chars 4 - {q(partitions)}",
+        ],
+        3,
+        expect_success=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Traceback (most recent call last)" not in result.stderr
+    assert total_rows(partitions) > 0
+
+
+# ---------------------------------------------------------------------------
+# Journey 4 -- stdout format bridge (budget 4s, fast)
+# ---------------------------------------------------------------------------
+def test_journey_04_stdout_format_bridge(tmp_path):
+    """Arrow IPC -> `convert geojson` on stdout -> back to GeoParquet; parity."""
+    bridge = tmp_path / "bridge.geojson"
+    round_tripped = tmp_path / "round_tripped.parquet"
+
+    # `convert geojson -` reads stdin only in streaming mode: passing an OUTPUT
+    # argument alongside `-` fails with "File not found: -", so the bridge is a
+    # redirect, exactly as docs/guide/piping.md shows it.
+    run_pipeline(
+        [
+            f"gpio add bbox --force {q(PLACES)} -",
+            f"gpio convert geojson - > {q(bridge)}",
+        ],
+        4,
+    )
+    stream = bridge.read_text()
+    assert "\x1e" in stream, "expected RFC 8142 record separators in the GeoJSONSeq stream"
+    assert len([line for line in stream.splitlines() if line.strip()]) == PLACES_ROWS
+
+    run_gpio(["convert", "geoparquet", bridge, round_tripped], 4)
+    assert rows(round_tripped) == PLACES_ROWS
+    # Attribute columns survive the GeoJSON hop (geometry is renamed by GDAL).
+    for expected in ("fsq_place_id", "name", "address"):
+        assert expected in columns(round_tripped)
+    assert_check_all(round_tripped, 4)
+
+
+# ---------------------------------------------------------------------------
+# Journey 5 -- reprojection and CRS metadata (budget 4s, fast)
+# ---------------------------------------------------------------------------
+def test_journey_05_reproject_crs_metadata(tmp_path):
+    """reproject -> add bbox -> check all, with CRS metadata and round-trip parity."""
+    wgs84 = tmp_path / "fields_4326.parquet"
+    wgs84_bbox = tmp_path / "fields_4326_bbox.parquet"
+    back_to_5070 = tmp_path / "fields_5070.parquet"
+    back_bbox = tmp_path / "fields_5070_bbox.parquet"
+
+    source_meta = run_gpio(["inspect", "meta", "--parquet-geo", FIELDS_5070], 5).stdout
+    assert "NAD83 / Conus Albers" in source_meta  # the file's declared CRS
+
+    run_gpio(["convert", "reproject", "--dst-crs", "EPSG:4326", FIELDS_5070, wgs84], 5)
+    run_gpio(["add", "bbox", wgs84, wgs84_bbox], 5)
+    assert_check_all(wgs84_bbox, 5)
+    assert rows(wgs84_bbox) == FIELDS_ROWS
+
+    # An absent/null `crs` in GeoParquet 1.1 means the OGC:CRS84 default -- that
+    # is the CRS assertion, not a bbox check: this fixture is LABELLED EPSG:5070 but
+    # its data actually lies in Europe (~18E, 47N), so a CONUS bbox assertion
+    # would be wrong. Assert the real, degree-valued extent instead.
+    assert geo_metadata(wgs84_bbox)["columns"]["geometry"].get("crs") is None
+    xmin, ymin, xmax, ymax = bbox_extent(wgs84_bbox)
+    assert (18.0 < xmin < 18.1) and (18.0 < xmax < 18.1)
+    assert (47.1 < ymin < 47.2) and (47.1 < ymax < 47.2)
+
+    # Reprojection consistency: 5070 -> 4326 -> 5070 returns the source extent.
+    run_gpio(["convert", "reproject", "--dst-crs", "EPSG:5070", wgs84, back_to_5070], 5)
+    run_gpio(["add", "bbox", back_to_5070, back_bbox], 5)
+    projected = bbox_extent(back_bbox)
+    assert projected[0] == pytest.approx(6753224.77, abs=1.0)
+    assert projected[1] == pytest.approx(7301719.76, abs=1.0)
+    assert projected[2] == pytest.approx(6758125.10, abs=1.0)
+    assert projected[3] == pytest.approx(7306052.75, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Journey 6 -- aggregate, overview, PMTiles pyramid (budget 20s, fast)
+# ---------------------------------------------------------------------------
+@requires_tippecanoe
+def test_journey_06_aggregate_overview_pyramid(tmp_path):
+    """process aggregate h3 -> process overview -> pmtiles pyramid; header sanity."""
+    cells = tmp_path / "cells.parquet"
+    pmtiles = tmp_path / "cells.pmtiles"
+
+    run_gpio(["process", "aggregate", "h3", PLACES, cells, "--resolution", "6"], 6)
+    assert "h3_cell" in columns(cells)
+    assert "count" in columns(cells)
+    cell_count = rows(cells)
+    assert 0 < cell_count < PLACES_ROWS  # 766 points collapse into fewer cells
+    counts = pq.read_table(cells, columns=["count"]).column("count").to_pylist()
+    assert sum(counts) == PLACES_ROWS  # aggregation conserves the input rows
+    assert_check_all(cells, 6)
+
+    # The base level fits the tile budget here, so ask for a coarser level
+    # explicitly rather than relying on auto-selection.
+    run_gpio(["process", "overview", cells, "--levels", "4"], 6)
+    overview = tmp_path / "cells_r4.parquet"
+    assert overview.exists()
+    assert 0 < rows(overview) < cell_count
+    overview_counts = pq.read_table(overview, columns=["count"]).column("count").to_pylist()
+    assert sum(overview_counts) == PLACES_ROWS  # roll-up is exact
+
+    run_gpio(["pmtiles", "pyramid", cells, pmtiles], 6)
+    header = pmtiles.read_bytes()[:8]
+    assert header[:7] == b"PMTiles", header
+    assert header[7] == 3, "expected a PMTiles v3 archive"
+
+
+# ---------------------------------------------------------------------------
+# Journey 7 -- CSV round trip (budget 4s, fast)
+# ---------------------------------------------------------------------------
+def test_journey_07_csv_roundtrip(tmp_path):
+    """CSV -> convert geoparquet -> add bbox -> sort hilbert -> check all."""
+    exported_csv = tmp_path / "places.csv"
+    imported = tmp_path / "from_csv.parquet"
+    with_bbox = tmp_path / "from_csv_bbox.parquet"
+    sorted_out = tmp_path / "from_csv_sorted.parquet"
+
+    # --no-bbox: a re-imported JSON-encoded bbox string cannot back covering
+    # metadata, and the import then fails GeoParquet metadata validation.
+    run_gpio(["convert", "csv", "--no-bbox", PLACES, exported_csv], 7)
+    header = exported_csv.read_text().splitlines()[0]
+    assert "wkt" in header
+
+    run_gpio(["convert", "geoparquet", exported_csv, imported], 7)
+    run_gpio(["add", "bbox", "--force", imported, with_bbox], 7)
+    run_gpio(["sort", "hilbert", with_bbox, sorted_out], 7)
+
+    assert rows(sorted_out) == PLACES_ROWS
+    assert "bbox" in columns(sorted_out)
+    report = assert_check_all(sorted_out, 7)
+    assert "spatially ordered" in report
+
+
+# ---------------------------------------------------------------------------
+# Journey 8 -- admin divisions then admin partition (budget 60s, slow)
+# ---------------------------------------------------------------------------
+@pytest.mark.slow
+@pytest.mark.network
+def test_journey_08_admin_divisions_then_partition(tmp_path):
+    """add admin-divisions -> partition admin -> check every leaf.
+
+    Also network-marked, which the issue's table does not say: the Overture
+    boundaries are fetched on first use (~34MB for country level) and only then
+    cached under ~/.geoparquet-io/cache/admin, so on a cold CI runner this
+    journey genuinely needs the network and belongs in the network job.
+    """
+    enriched = tmp_path / "places_admin.parquet"
+    partitions = tmp_path / "admin_partitions"
+
+    run_gpio(
+        [
+            "add",
+            "admin-divisions",
+            "--dataset",
+            "overture",
+            "--levels",
+            "country",
+            PLACES,
+            enriched,
+        ],
+        8,
+    )
+    assert "overture_country" in columns(enriched)
+    assert rows(enriched) == PLACES_ROWS
+
+    run_gpio(
+        [
+            "partition",
+            "admin",
+            "--dataset",
+            "overture",
+            "--levels",
+            "country",
+            enriched,
+            partitions,
+        ],
+        8,
+    )
+    # The 766 places straddle Burkina Faso, Benin, Ghana and Togo.
+    assert {leaf.stem for leaf in leaf_files(partitions)} == {"BF", "BJ", "GH", "TG"}
+    assert total_rows(partitions) == PLACES_ROWS
+    assert_check_all(partitions, 8, all_files=True)
+    safe_rmtree(partitions)
+
+
+# ---------------------------------------------------------------------------
+# Journey 9 -- remote extract (budget 30s, network)
+# ---------------------------------------------------------------------------
+@pytest.mark.network
+def test_journey_09_remote_extract_then_sort(tmp_path):
+    """extract --limit from a public URL -> sort hilbert -> check all; meta over HTTP."""
+    subset = tmp_path / "remote_subset.parquet"
+    sorted_out = tmp_path / "remote_sorted.parquet"
+
+    run_gpio(["extract", REMOTE_PARQUET_URL, subset, "--limit", "500"], 9)
+    assert rows(subset) == 500
+
+    run_gpio(["sort", "hilbert", subset, sorted_out], 9)
+    assert rows(sorted_out) == 500
+    assert_check_all(sorted_out, 9)
+
+    remote_meta = run_gpio(["inspect", "meta", REMOTE_PARQUET_URL], 9).stdout
+    assert "GeoParquet" in remote_meta or "Geo" in remote_meta
+
+
+# ---------------------------------------------------------------------------
+# Journey 10 -- 200k synthetic points, sort, partition (budget 120s, slow)
+# ---------------------------------------------------------------------------
+@pytest.mark.slow
+def test_journey_10_sorting_improves_spatial_pushdown(tmp_path):
+    """200k random points -> sort hilbert -> partition quadkey; skip rate improves."""
+    import csv
+    import random
+
+    source_csv = tmp_path / "points.csv"
+    unsorted = tmp_path / "unsorted.parquet"
+    hilbert = tmp_path / "hilbert.parquet"
+    partitions = tmp_path / "quadkey_partitions"
+    point_count = 200_000
+
+    random.seed(667)
+    with open(source_csv, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["id", "wkt"])
+        for i in range(point_count):
+            lon = random.uniform(-180, 180)
+            lat = random.uniform(-85, 85)
+            writer.writerow([i, f"POINT ({lon:.5f} {lat:.5f})"])
+
+    # --skip-hilbert keeps the input in random order; small row groups give the
+    # spatial-order check enough row groups to produce a meaningful metric.
+    run_gpio(
+        [
+            "convert",
+            "geoparquet",
+            "--skip-hilbert",
+            "--row-group-size",
+            "10000",
+            source_csv,
+            unsorted,
+        ],
+        10,
+    )
+    assert rows(unsorted) == point_count
+    before = spatial_skip_rate(unsorted, 10)
+
+    run_gpio(["sort", "hilbert", "--row-group-size", "10000", unsorted, hilbert], 10)
+    assert rows(hilbert) == point_count
+    after = spatial_skip_rate(hilbert, 10)
+
+    assert before < 10.0, f"randomly ordered input should barely skip, got {before}%"
+    assert after > 50.0, f"Hilbert order should skip most row groups, got {after}%"
+    assert after > before + 40.0
+
+    run_gpio(["partition", "quadkey", "--auto", "--target-rows", "50000", hilbert, partitions], 10)
+    leaves = leaf_files(partitions)
+    assert len(leaves) > 1
+    assert total_rows(partitions) == point_count
+    assert_check_all(leaves[0], 10)
+    safe_rmtree(partitions)
+
+
+# ---------------------------------------------------------------------------
+# Oracle non-vacuity guard
+# ---------------------------------------------------------------------------
+def test_oracle_rejects_a_damaged_journey_output(tmp_path):
+    """The oracle must FAIL on a damaged intermediate, not just on a non-zero exit.
+
+    `gpio check all` exits 0 on the file below (it reports "✗ 3 failed, 25
+    passed" and still returns 0), so this guards the assertion that actually
+    does the work in :func:`assert_check_all`. Without it every journey could
+    pass against corrupt output.
+    """
+    good = tmp_path / "good.parquet"
+    damaged = tmp_path / "damaged.parquet"
+    run_gpio(["convert", "geoparquet", BUILDINGS_GEOJSON, good], 1)
+    assert_check_all(good, 1)
+
+    payload = bytearray(good.read_bytes())
+    del payload[len(payload) // 2 : len(payload) // 2 + 1500]
+    damaged.write_bytes(bytes(payload))
+
+    assert run_gpio(["check", "all", damaged], 1, expect_success=False).returncode == 0
+    with pytest.raises(AssertionError):
+        assert_check_all(damaged, 1)

--- a/tests/e2e/test_journeys.py
+++ b/tests/e2e/test_journeys.py
@@ -129,9 +129,9 @@ def test_journey_03_documented_piping_chains(tmp_path):
     multi_index = tmp_path / "multi_index.parquet"
 
     # DERIVED, not quoted: piping.md has no such example. It documents that
-    # `partition string` can read from stdin but only writes to a directory
-    # ("Command Compatibility" table, and the "Partition commands" bullet under
-    # "How It Works"). This is the smallest chain that exercises that claim, and
+    # `partition string` can read from stdin but only writes to a directory (the
+    # "Supported Commands" table, and the "Partition commands" bullet under
+    # "Limitations"). This is the smallest chain that exercises that claim, and
     # it is the piped half of the broken chain pinned below, which makes the
     # break attributable to `extract` rather than to `partition string`.
     run_pipeline(
@@ -204,7 +204,7 @@ def test_journey_04_stdout_format_bridge(tmp_path):
     bridge = tmp_path / "bridge.geojson"
     round_tripped = tmp_path / "round_tripped.parquet"
 
-    # Shape taken from piping.md's "Command Compatibility" table, which records
+    # Shape taken from piping.md's "Supported Commands" table, which records
     # `convert geojson` as stdin-capable but stdout-only ("No (outputs GeoJSON
     # to stdout)"); the redirect is this test's own, not a quoted example.
     # `convert geojson -` reads stdin only in that streaming mode: passing an
@@ -332,21 +332,24 @@ def test_journey_07_csv_roundtrip(tmp_path):
 # opposed to "gpio is broken". Matched case-insensitively against the failed
 # command's output.
 _BOUNDARIES_UNAVAILABLE = (
-    # Anything that names the machine-global cache: a concurrent gpio process
-    # (another checkout, another agent, the developer's own shell) downloading
-    # the same release holds a DuckDB lock on its temp file, and a partially
-    # written cache errors the same way. Observed verbatim:
+    # A concurrent gpio process (another checkout, another agent, the
+    # developer's own shell) downloading the same release holds a DuckDB lock on
+    # its temp file. Observed verbatim:
     #   IO Error: Could not set lock on file
     #   "~/.geoparquet-io/cache/admin/tmp_overture-2026-07-22.0-country-land.parquet":
     #   Conflicting lock is held in ... (PID 63436)
-    ".geoparquet-io",
-    "conflicting lock",
     "could not set lock",
-    # ... and anything that means the download itself did not happen. Bare "io
-    # error" is deliberately NOT in this list: it would swallow a genuine
-    # read/write bug on the fixture or the output and report it as a skip.
+    "conflicting lock",
+    # ... and anything meaning the download itself did not happen. Observed:
+    #   IO Error: Timeout was reached error for HTTP GET to
+    #   'https://overturemaps-us-west-2.s3.../release/2026-07-22.0/...'
+    #
+    # Deliberately NOT in this list, because each would swallow a real bug and
+    # report it as a skip: bare "io error"; the cache path itself (the SUCCESS
+    # path prints it, so a later genuine failure in the same run would match);
+    # and bare "connection", which is a live DuckDB error prefix
+    # ("Connection Error: ...").
     "could not resolve",
-    "connection",
     "network",
     "timed out",
     "timeout",
@@ -489,7 +492,7 @@ def test_journey_10_sorting_improves_spatial_pushdown(tmp_path):
     point_count = 200_000
 
     random.seed(667)
-    with open(source_csv, "w", newline="") as handle:
+    with open(source_csv, "w", newline="", encoding="utf-8") as handle:
         writer = csv.writer(handle)
         writer.writerow(["id", "wkt"])
         for i in range(point_count):

--- a/tests/e2e/test_journeys.py
+++ b/tests/e2e/test_journeys.py
@@ -15,6 +15,7 @@ kept meaningful in CI.
 from __future__ import annotations
 
 import json
+import subprocess
 
 import pyarrow.parquet as pq
 import pytest
@@ -80,7 +81,9 @@ def test_journey_01_geojson_to_geoparquet_and_back(tmp_path):
     # Row and geometry parity across the whole round trip.
     assert rows(imported) == rows(with_bbox) == BUILDINGS_ROWS
     assert geo_metadata(with_bbox)["version"] == "2.0.0"
-    features = json.loads(exported.read_text())["features"]
+    # Explicit encoding: gpio writes UTF-8, and these fixtures carry non-ASCII
+    # place names that the Windows locale codec (cp1252) cannot decode.
+    features = json.loads(exported.read_text(encoding="utf-8"))["features"]
     assert len(features) == BUILDINGS_ROWS
     assert {f["geometry"]["type"] for f in features} == {"Polygon"}
 
@@ -117,11 +120,20 @@ def test_journey_02_h3_index_then_partition(tmp_path):
 # Journey 3 -- documented piping chains (budget 6s, fast)
 # ---------------------------------------------------------------------------
 def test_journey_03_documented_piping_chains(tmp_path):
-    """The chains printed in docs/guide/piping.md, run verbatim through a shell."""
+    """Two piping chains from docs/guide/piping.md, run through a real shell.
+
+    The second chain is the documented one, near-verbatim; the first is derived
+    rather than quoted -- see the comments on each.
+    """
     partitions = tmp_path / "quadkey_partitions"
     multi_index = tmp_path / "multi_index.parquet"
 
-    # piping.md "Partition from a pipe": add quadkey -> partition string.
+    # DERIVED, not quoted: piping.md has no such example. It documents that
+    # `partition string` can read from stdin but only writes to a directory
+    # ("Command Compatibility" table, and the "Partition commands" bullet under
+    # "How It Works"). This is the smallest chain that exercises that claim, and
+    # it is the piped half of the broken chain pinned below, which makes the
+    # break attributable to `extract` rather than to `partition string`.
     run_pipeline(
         [
             f"gpio add quadkey {q(PLACES)} -",
@@ -134,8 +146,10 @@ def test_journey_03_documented_piping_chains(tmp_path):
     assert total_rows(partitions) == PLACES_ROWS
     assert_check_all(partitions, 3, all_files=True)
 
-    # piping.md "Add Multiple Spatial Indices": four stages, three of them
-    # reading Arrow IPC from stdin.
+    # piping.md "Add Multiple Spatial Indices" (lines 105-109), reproduced with
+    # one change: `--force` on the first stage, because places_test.parquet
+    # already carries a bbox column and `add bbox` otherwise exits 0 without
+    # emitting anything. Four stages, three of them reading Arrow IPC from stdin.
     run_pipeline(
         [
             f"gpio add bbox --force {q(PLACES)}",
@@ -155,13 +169,14 @@ def test_journey_03_documented_piping_chains(tmp_path):
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "KNOWN BUG: `gpio extract ... - | gpio add quadkey - | gpio partition string - dir/` "
-        "-- the chain documented in docs/guide/piping.md 'Spatial Filter and Partition' -- "
-        "dies with an unhandled DuckDB error, 'Geoparquet column geometry does not have "
-        "geometry types'. extract's Arrow IPC stream omits geometry_types metadata; the "
-        "file-writing path recomputes it, which is why only the piped-into-partition case "
-        "breaks. Filed separately from #667 per the cross-cutting-fix rule; flip this test "
-        "to a plain assertion when it is fixed."
+        "KNOWN BUG #722: `gpio extract ... - | gpio add quadkey - | gpio partition string "
+        "- dir/` -- the chain documented in docs/guide/piping.md 'Spatial Filter and "
+        "Partition' (lines 86-90) -- dies with an unhandled DuckDB error, 'Geoparquet "
+        "column geometry does not have geometry types'. extract's Arrow IPC stream omits "
+        "geometry_types metadata; the file-writing path recomputes it, which is why only "
+        "the piped-into-partition case breaks. Filed separately from #667 per the "
+        "cross-cutting-fix rule; when #722 is fixed this goes red -- drop the xfail and "
+        "keep the assertions."
     ),
 )
 def test_journey_03b_extract_into_partition_chain(tmp_path):
@@ -189,9 +204,12 @@ def test_journey_04_stdout_format_bridge(tmp_path):
     bridge = tmp_path / "bridge.geojson"
     round_tripped = tmp_path / "round_tripped.parquet"
 
-    # `convert geojson -` reads stdin only in streaming mode: passing an OUTPUT
-    # argument alongside `-` fails with "File not found: -", so the bridge is a
-    # redirect, exactly as docs/guide/piping.md shows it.
+    # Shape taken from piping.md's "Command Compatibility" table, which records
+    # `convert geojson` as stdin-capable but stdout-only ("No (outputs GeoJSON
+    # to stdout)"); the redirect is this test's own, not a quoted example.
+    # `convert geojson -` reads stdin only in that streaming mode: passing an
+    # OUTPUT argument alongside `-` fails with a misleading "File not found: -"
+    # (error-message bug #723), so the bridge is a redirect.
     run_pipeline(
         [
             f"gpio add bbox --force {q(PLACES)} -",
@@ -199,7 +217,7 @@ def test_journey_04_stdout_format_bridge(tmp_path):
         ],
         4,
     )
-    stream = bridge.read_text()
+    stream = bridge.read_text(encoding="utf-8")
     assert "\x1e" in stream, "expected RFC 8142 record separators in the GeoJSONSeq stream"
     assert len([line for line in stream.splitlines() if line.strip()]) == PLACES_ROWS
 
@@ -294,7 +312,7 @@ def test_journey_07_csv_roundtrip(tmp_path):
     # --no-bbox: a re-imported JSON-encoded bbox string cannot back covering
     # metadata, and the import then fails GeoParquet metadata validation.
     run_gpio(["convert", "csv", "--no-bbox", PLACES, exported_csv], 7)
-    header = exported_csv.read_text().splitlines()[0]
+    header = exported_csv.read_text(encoding="utf-8").splitlines()[0]
     assert "wkt" in header
 
     run_gpio(["convert", "geoparquet", exported_csv, imported], 7)
@@ -310,20 +328,95 @@ def test_journey_07_csv_roundtrip(tmp_path):
 # ---------------------------------------------------------------------------
 # Journey 8 -- admin divisions then admin partition (budget 60s, slow)
 # ---------------------------------------------------------------------------
+# Substrings that mean "the boundaries dataset could not be obtained", as
+# opposed to "gpio is broken". Matched case-insensitively against the failed
+# command's output.
+_BOUNDARIES_UNAVAILABLE = (
+    # Anything that names the machine-global cache: a concurrent gpio process
+    # (another checkout, another agent, the developer's own shell) downloading
+    # the same release holds a DuckDB lock on its temp file, and a partially
+    # written cache errors the same way. Observed verbatim:
+    #   IO Error: Could not set lock on file
+    #   "~/.geoparquet-io/cache/admin/tmp_overture-2026-07-22.0-country-land.parquet":
+    #   Conflicting lock is held in ... (PID 63436)
+    ".geoparquet-io",
+    "conflicting lock",
+    "could not set lock",
+    # ... and anything that means the download itself did not happen. Bare "io
+    # error" is deliberately NOT in this list: it would swallow a genuine
+    # read/write bug on the fixture or the output and report it as a skip.
+    "could not resolve",
+    "connection",
+    "network",
+    "timed out",
+    "timeout",
+    "failed to download",
+    "http error",
+    "urlopen",
+    "temporary failure",
+)
+
+
+def _skip_if_boundaries_unavailable(result) -> None:
+    """Skip (never fail) when the admin cache cannot be downloaded or is locked."""
+    if result.returncode == 0:
+        return
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    for needle in _BOUNDARIES_UNAVAILABLE:
+        if needle in output:
+            pytest.skip(
+                "Overture admin boundaries unavailable (offline, download failed, or "
+                f"~/.geoparquet-io/cache/admin busy): matched {needle!r}"
+            )
+
+
+def _run_boundary_command(args: list, description: str):
+    """Run a cache-dependent journey-8 step, turning unavailability into a skip.
+
+    A cold cache downloads the dataset, and a fresh Overture release can make
+    that take longer than the journey's timeout -- measured: ~1.6s warm, minutes
+    cold. A timeout here therefore means "the boundaries were not available in
+    reasonable time", which is a skip; only a real, prompt failure fails.
+    """
+    try:
+        result = run_gpio(args, 8, expect_success=False)
+    except subprocess.TimeoutExpired:
+        pytest.skip(
+            f"{description} exceeded its timeout -- the Overture cache is cold and the "
+            "download did not finish in time. Warm it once with "
+            "`gpio add admin-divisions --dataset overture --levels country <file> <out>`."
+        )
+    _skip_if_boundaries_unavailable(result)
+    assert result.returncode == 0, (
+        f"{description} failed for a non-cache reason:\n{result.stdout}\n{result.stderr}"
+    )
+    return result
+
+
 @pytest.mark.slow
-@pytest.mark.network
 def test_journey_08_admin_divisions_then_partition(tmp_path):
     """add admin-divisions -> partition admin -> check every leaf.
 
-    Also network-marked, which the issue's table does not say: the Overture
-    boundaries are fetched on first use (~34MB for country level) and only then
-    cached under ~/.geoparquet-io/cache/admin, so on a cold CI runner this
-    journey genuinely needs the network and belongs in the network job.
+    Lane: ``slow`` ONLY, deliberately not ``network``. The boundaries do need
+    fetching on a cold machine, but marking this ``network`` too would move it
+    out of the blocking slow job and into the network job, which never runs on
+    PRs and is ``continue-on-error`` -- demoting a gate to an advisory signal.
+    Instead the fetch is attempted and the test SKIPS with a clear reason when
+    the download or the cache is unavailable: warm runners gate on it, cold or
+    offline ones skip cleanly.
+
+    Not hermetic, and cannot be: ``gpio add admin-divisions`` caches datasets in
+    the machine-global ``~/.geoparquet-io/cache/admin`` (~34MB for Overture
+    country level; GAUL would be ~724MB, which is why this uses Overture). That
+    directory is shared with the developer's own runs and with any concurrent
+    gpio process, so a first run costs a download and a concurrent run can hit a
+    cache-lock conflict -- both are skips, not failures, via
+    :func:`_skip_if_boundaries_unavailable`.
     """
     enriched = tmp_path / "places_admin.parquet"
     partitions = tmp_path / "admin_partitions"
 
-    run_gpio(
+    _run_boundary_command(
         [
             "add",
             "admin-divisions",
@@ -334,12 +427,13 @@ def test_journey_08_admin_divisions_then_partition(tmp_path):
             PLACES,
             enriched,
         ],
-        8,
+        "add admin-divisions",
     )
     assert "overture_country" in columns(enriched)
     assert rows(enriched) == PLACES_ROWS
 
-    run_gpio(
+    # `partition admin` re-reads the same cache, so it needs the same guard.
+    _run_boundary_command(
         [
             "partition",
             "admin",
@@ -350,7 +444,7 @@ def test_journey_08_admin_divisions_then_partition(tmp_path):
             enriched,
             partitions,
         ],
-        8,
+        "partition admin",
     )
     # The 766 places straddle Burkina Faso, Benin, Ghana and Togo.
     assert {leaf.stem for leaf in leaf_files(partitions)} == {"BF", "BJ", "GH", "TG"}


### PR DESCRIPTION
Deliverable 4 of #667: a compact matrix of real user journeys, run end to end against the **installed `gpio` binary**, with `gpio check all` / `validate_geoparquet` as the oracle.

## What this adds

`tests/e2e/test_journeys.py` — ten journeys, each chaining several commands the way a user (or the guides) would, then asserting concrete values rather than exit codes:

| # | Journey | Lane |
|---|---|---|
| 1 | GeoJSON → convert → `sort hilbert --geoparquet-version 2.0` → `add bbox` → check → GeoJSON back; row + geometry-type parity | fast |
| 2 | `add h3` → `partition h3` → `check all --all-files` on every leaf; 766 rows conserved across 5 leaves | fast |
| 3 | Piping chains from `docs/guide/piping.md` as real shell pipelines (Arrow IPC between stages), incl. the 4-stage multi-index chain | fast |
| 4 | Arrow IPC → `convert geojson` on stdout (RFC 8142 separators asserted) → back to GeoParquet | fast |
| 5 | reproject → `add bbox` → check; CRS metadata asserted and a 5070→4326→5070 round trip that returns the source extent to 1m | fast |
| 6 | `process aggregate h3` → `process overview` → `pmtiles pyramid`; counts roll up exactly, PMTiles v3 header checked | fast, skips w/o tippecanoe |
| 7 | CSV out → CSV back in → `add bbox` → `sort hilbert` → check | fast |
| 8 | `add admin-divisions` → `partition admin`; leaves are exactly `{BF,BJ,GH,TG}` | slow |
| 9 | `extract --limit 500` from a public HTTPS parquet → `sort hilbert` → check; `inspect meta` over the URL | network |
| 10 | 200k synthetic points → `sort hilbert` → `partition quadkey`; estimated row-group skip rate goes **0% → 87%** | slow |

Fast lane cost: **~12s serial**, absorbed under xdist (full fast suite measured 92.9s before and 97.9s after, inside run-to-run noise). Journeys 8 and 10 are slow-marked, 9 network-marked.

`tests/e2e/test_integration_lane.py` — guards that make the `integration` marker mean something: every journey must carry it, no `tests.yml` selection may deselect it, each journey must be selected by exactly one CI job, and the marker description must document its lane.

## The oracle discovery worth highlighting

**`gpio check all` exits 0 on a file whose spec validation failed.** A truncated GeoParquet prints `✗ 3 failed, 25 passed` and still returns 0. Every journey here would have passed against corrupt output if it asserted exit codes — which is what an e2e suite naively does.

So `assert_check_all` parses the report *and* cross-checks the in-process `validate_geoparquet`. `test_oracle_rejects_a_damaged_journey_output` pins that: it asserts the CLI exits 0 on a damaged file **and** that the oracle still raises. Sabotage-checked during development by corrupting an intermediate in journey 1 — the oracle caught it at the report parse, not the exit code.

## Two real bugs found on day one

- **#722** — the chain documented in `piping.md` under "Spatial Filter and Partition" (`extract --bbox … - | add quadkey - | partition string - dir/`) dies with an unhandled `_duckdb.InvalidInputException: Geoparquet column 'geometry' does not have geometry types`. `extract`'s Arrow IPC stream omits `geometry_types`; the file-writing path recomputes it, which is why only the fully-piped case breaks. Captured here as `xfail(strict=True)`, so fixing #722 turns this red and forces the xfail to be replaced with a plain assertion.
- **#723** — `convert geojson - out.geojson` (stdin + named output) fails with a misleading `Error: File not found: -`; only the streaming redirect form works. Journey 4 uses the working form and points at the issue.

## Windows-proofing

The fast job is blocking on Windows, and both the reports and the fixtures contain non-ASCII (`✓ ✗ 📁`, accented place names). Both subprocess helpers decode with `encoding="utf-8", errors="replace"` instead of the locale codec (cp1252 would raise `UnicodeDecodeError`), every `read_text`/`open` that touches gpio output pins UTF-8, and the oracle regexes are **glyph-free** — with `errors="replace"` the ✓/✗ can arrive as U+FFFD, and a glyph-dependent pattern would silently stop matching, turning the assertion that backs eight journeys into a no-op. Partition directories are torn down with the conftest-safe deleters.

## Journey 8's honest limits

`gpio add admin-divisions` caches boundaries in the **machine-global** `~/.geoparquet-io/cache/admin` (~34MB for Overture country level; GAUL would be ~724MB). That is not hermetic: a cold runner downloads, and a concurrent gpio process holds a DuckDB lock on the temp file. The journey therefore skips — never fails — when the cache is cold, locked, or the fetch fails, and a timeout is a skip too. All three paths were verified live during development (lock conflict, cold-download timeout, and an upstream Overture S3 `Timeout was reached` for release `2026-07-22.0`).

Consequence, stated plainly: on cold CI runners this journey will most likely **skip rather than gate**. It is kept `slow`-only rather than `slow` + `network` because the network job never runs on PRs and is `continue-on-error` — adding that marker would demote it further while every guard stayed green. If a gating admin journey is wanted, the right fix is a fixture-backed boundaries file, not a marker choice.

## CI wiring

`.github/workflows/tests.yml` is **untouched**. The `integration` marker is already selected by the fast job (`-m "not slow and not network and not meta"`) — that is how the corpus suite runs today — so a dedicated `-m integration` job would repeat checkout, `uv sync --all-extras`, the DuckDB extension install and tippecanoe purely to re-run the same tests. The guard tests above give the marker enforceable semantics instead. Note the guards count marker *selections*, not whether the owning job blocks a PR; that caveat is in the docstring.

## Follow-ups and merge order

- Fixtures are the existing `places_test.parquet` / `buildings_test.geojson` / `fields_pgo_5070_snappy.parquet`. A `TODO(#667)` marks the migration to `tests/data/canonical/` once #719 merges.
- Shared-file contact is minimal: **one line in `pyproject.toml`** (the `integration` marker description, which doc-sync mirrors into `CLAUDE.md` / `docs/contributing.md`). The `CHANGELOG.md` entry will conflict with sibling PRs — resolve by keeping both entries.

## Verification

- `uv run pytest tests/e2e -m "not slow and not network"` → 16 passed, 1 xfailed, 12.4s
- Full fast suite `-n 4 -m "not slow and not network and not meta"` → 4071 passed, 51 skipped, 4 xfailed
- `pre-commit run --hook-stage pre-push --all-files` → all passed (deptry, mypy, vulture, xenon, import-linter)

Refs #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for common `gpio` workflows, including conversion, sorting, partitioning, extraction, processing, PMTiles generation, remote inputs, and large datasets.
  * Added validation for output integrity, row counts, metadata, spatial behavior, and command-line checks.
  * Added safeguards ensuring integration tests are correctly selected and assigned across test lanes.
  * Documented handling for optional tools, unavailable data, and known limitations.

* **Documentation**
  * Clarified integration-test marker behavior and expanded the changelog with the new journey coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->