### PR TITLE
docs: correct guide examples that use nonexistent CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,6 +386,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Guide examples no longer use flags the CLI does not accept.** Three
+  documented examples failed immediately with `No such option`. `docs/guide/check.md`
+  advertised `gpio check all DIR --check-all` and `--check-sample N`; the real
+  flags are `--all-files` and `--sample-files N`, and the quoted runtime notice
+  was stale to match. `docs/guide/geojson.md` and `docs/cli/convert.md`
+  documented a `--lco KEY=VALUE` passthrough for GDAL layer creation options on
+  `gpio convert geojson`; no such option has ever existed, so the section now
+  explains that the writer sets layer creation options internally and points at
+  `ogr2ogr` for driver options with no dedicated flag. `docs/guide/sub-partitioning.md`
+  showed `gpio partition a5 DIR --min-size … --in-place`; `partition a5` supports
+  neither flag (`sub_partition_directory` only registers `h3`, `s2` and
+  `quadkey`), so the A5 tab is replaced by a note naming the three commands that
+  do support sub-partitioning. Also corrects `docs/cli/inspect.md`, which listed
+  `inspect summary`'s `--check-all` under its Python parameter name
+  (`--check-all-files`), and fills in the `--keep-crs` / `--no-repair-geometry`
+  rows missing from both `convert geojson` option tables.
+
 - **`tests/test_wfs.py` no longer reaches the network.** Nine tests made live
   requests against the fake host. Six exercise `wfs_to_table` and mocked the
   version negotiation, layer lookup and feature fetch, but not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,7 +393,7 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   was stale to match. `docs/guide/geojson.md` and `docs/cli/convert.md`
   documented a `--lco KEY=VALUE` passthrough for GDAL layer creation options on
   `gpio convert geojson`; no such option has ever existed, so the section now
-  explains that the writer sets layer creation options internally and points at
+  explains that the GeoJSON writer does not use GDAL at all and points at
   `ogr2ogr` for driver options with no dedicated flag. `docs/guide/sub-partitioning.md`
   showed `gpio partition a5 DIR --min-size … --in-place`; `partition a5` supports
   neither flag (`sub_partition_directory` only registers `h3`, `s2` and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -386,6 +386,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Guide examples no longer use flags the CLI does not accept.** Three
+  documented examples failed immediately with `No such option`. `docs/guide/check.md`
+  advertised `gpio check all DIR --check-all` and `--check-sample N`; the real
+  flags are `--all-files` and `--sample-files N`, and the quoted runtime notice
+  was stale to match. `docs/guide/geojson.md` and `docs/cli/convert.md`
+  documented a `--lco KEY=VALUE` passthrough for GDAL layer creation options on
+  `gpio convert geojson`; no such option has ever existed, so the section now
+  explains that the writer sets layer creation options internally and points at
+  `ogr2ogr` for driver options with no dedicated flag. `docs/guide/sub-partitioning.md`
+  showed `gpio partition a5 DIR --min-size … --in-place`; `partition a5` supports
+  neither flag (`sub_partition_directory` only registers `h3`, `s2` and
+  `quadkey`), so the A5 tab is replaced by a note naming the three commands that
+  do support sub-partitioning. Also corrects `docs/cli/inspect.md`, which listed
+  `inspect summary`'s `--check-all` under its Python parameter name
+  (`--check-all-files`), and fills in the `--keep-crs` / `--no-repair-geometry`
+  rows missing from both `convert geojson` option tables.
+
 - **`tests/test_wfs.py` no longer reaches the network.** Nine tests made live
   requests against the fake host. Six exercise `wfs_to_table` and mocked the
   version negotiation, layer lookup and feature fetch, but not

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -393,7 +393,7 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   was stale to match. `docs/guide/geojson.md` and `docs/cli/convert.md`
   documented a `--lco KEY=VALUE` passthrough for GDAL layer creation options on
   `gpio convert geojson`; no such option has ever existed, so the section now
-  explains that the writer sets layer creation options internally and points at
+  explains that the GeoJSON writer does not use GDAL at all and points at
   `ogr2ogr` for driver options with no dedicated flag. `docs/guide/sub-partitioning.md`
   showed `gpio partition a5 DIR --min-size … --in-place`; `partition a5` supports
   neither flag (`sub_partition_directory` only registers `h3`, `s2` and

--- a/docs/cli/convert.md
+++ b/docs/cli/convert.md
@@ -62,7 +62,8 @@ gpio convert geojson data.parquet output.geojson
 | `--description TEXT` | none | Add description to FeatureCollection |
 | `--feature-collection` | false | Output FeatureCollection instead of GeoJSONSeq |
 | `--pretty` | false | Pretty-print with indentation |
-| `--lco KEY=VALUE` | none | GDAL layer creation option (repeatable) |
+| `--keep-crs` | false | Keep original CRS instead of reprojecting to WGS84 |
+| `--no-repair-geometry` | false | Preserve invalid geometry instead of repairing it |
 | `--verbose` | false | Show debug output |
 | `--aws-profile NAME` | none | AWS profile for S3 |
 

--- a/docs/cli/inspect.md
+++ b/docs/cli/inspect.md
@@ -26,7 +26,8 @@ This will show all available options for the `inspect` command.
 
 ### inspect summary Options
 
-- `--check-all-files` - For partitioned datasets, check all files
+- `--check-all` - For partitioned datasets, aggregate info from all files
+- `--markdown` - Output as Markdown for README files
 
 ### inspect meta Options
 

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -334,13 +334,13 @@ When checking a directory containing partitioned data, you can control how many 
 ```bash
 # By default, checks only the first file
 gpio check all partitions/
-# Output: Checking first file (of 4 total). Use --check-all or --check-sample N for more.
+# Output: Checking first file (of 4 total). Use --all-files or --sample-files N for more.
 
 # Check all files in the partition
-gpio check all partitions/ --check-all
+gpio check all partitions/ --all-files
 
 # Check a sample of files (first N files)
-gpio check all partitions/ --check-sample 3
+gpio check all partitions/ --sample-files 3
 ```
 
 !!! note "--fix not available for partitions"

--- a/docs/guide/geojson.md
+++ b/docs/guide/geojson.md
@@ -336,7 +336,8 @@ File output uses DuckDB's GDAL integration to produce properly formatted GeoJSON
 | `--description TEXT` | none | Add a description to the FeatureCollection |
 | `--feature-collection` | false | Output a FeatureCollection instead of GeoJSONSeq (streaming only) |
 | `--pretty` | false | Pretty-print the JSON output with indentation |
-| `--lco KEY=VALUE` | none | GDAL layer creation option (may be repeated) |
+| `--keep-crs` | false | Keep the original CRS instead of reprojecting to WGS84 |
+| `--no-repair-geometry` | false | Preserve invalid geometry instead of repairing it with `ST_MakeValid` |
 | `--verbose` | false | Show debug output |
 | `--aws-profile NAME` | none | AWS profile for S3 files |
 
@@ -398,21 +399,13 @@ By default, streaming outputs newline-delimited GeoJSONSeq. To output a complete
 gpio convert geojson data.parquet --feature-collection > output.geojson
 ```
 
-### Advanced GDAL Options
+### GDAL Layer Creation Options
 
-For advanced use cases, pass GDAL layer creation options directly with `--lco`:
-
-```bash
-# Disable writing the layer name
-gpio convert geojson data.parquet out.geojson --lco WRITE_NAME=NO
-
-# Multiple options
-gpio convert geojson data.parquet out.geojson --lco WRITE_NAME=NO --lco SIGNIFICANT_FIGURES=10
-```
-
-See the [GDAL GeoJSON driver documentation](https://gdal.org/drivers/vector/geojson.html#layer-creation-options) for all available options.
-
-Note: Using `--lco` with the same option as a dedicated flag (e.g., `--lco COORDINATE_PRECISION=5` with `--precision 7`) will raise an error.
+`gpio convert geojson` does not expose GDAL layer creation options. The GeoJSON
+writer sets them internally, and the settings that matter for GeoJSON output are
+available as dedicated flags (`--precision`, `--write-bbox`, `--id-field`,
+`--feature-collection`, `--pretty`). If you need a driver option that has no
+dedicated flag, use `ogr2ogr` directly on the output file.
 
 ## Performance Tips
 

--- a/docs/guide/geojson.md
+++ b/docs/guide/geojson.md
@@ -323,7 +323,7 @@ To write a standard GeoJSON FeatureCollection, specify an output file:
     geojson_str = gpio.read('data.parquet').to_geojson()
     ```
 
-File output uses DuckDB's GDAL integration to produce properly formatted GeoJSON with RFC 7946 compliance.
+File output is generated directly from query results as RFC 7946-compliant GeoJSON; no GDAL is involved.
 
 ## Options Reference
 
@@ -399,13 +399,14 @@ By default, streaming outputs newline-delimited GeoJSONSeq. To output a complete
 gpio convert geojson data.parquet --feature-collection > output.geojson
 ```
 
-### GDAL Layer Creation Options
+### No GDAL Layer Creation Options
 
-`gpio convert geojson` does not expose GDAL layer creation options. The GeoJSON
-writer sets them internally, and the settings that matter for GeoJSON output are
-available as dedicated flags (`--precision`, `--write-bbox`, `--id-field`,
-`--feature-collection`, `--pretty`). If you need a driver option that has no
-dedicated flag, use `ogr2ogr` directly on the output file.
+`gpio convert geojson` does not use GDAL, so there are no layer creation
+options to pass: the writer generates GeoJSON directly from query results. The
+settings that matter for GeoJSON output are available as dedicated flags
+(`--precision`, `--write-bbox`, `--id-field`, `--feature-collection`,
+`--pretty`). If you need a GDAL driver option that has no dedicated flag, run
+`ogr2ogr` on the output file.
 
 ## Performance Tips
 

--- a/docs/guide/sub-partitioning.md
+++ b/docs/guide/sub-partitioning.md
@@ -46,18 +46,17 @@ by_country/
 | `--resolution` / `--level` | Spatial index resolution (or use `--auto`) |
 | `--auto` | Auto-calculate optimal resolution |
 
+Sub-partitioning is available on `gpio partition h3`, `gpio partition s2`, and
+`gpio partition quadkey`. `gpio partition a5` does not accept `--min-size` or
+`--in-place` yet ([#733](https://github.com/geoparquet/geoparquet-io/issues/733));
+partition A5 files one at a time instead.
+
 ## Examples
 
 === "H3"
 
     ```bash
     gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place
-    ```
-
-=== "A5"
-
-    ```bash
-    gpio partition a5 by_country/ --min-size 100MB --resolution 12 --in-place
     ```
 
 === "S2"


### PR DESCRIPTION
Closes #730.

Three guide examples invoked flags the CLI does not accept, so each failed at argument parsing before doing any work. Every corrected example in this PR was executed against a real fixture; the evidence is below.

## What changed

| File | Was | Now |
|---|---|---|
| `docs/guide/check.md` | `gpio check all DIR --check-all`, `--check-sample 3` | `--all-files`, `--sample-files 3` |
| `docs/guide/check.md` | Quoted notice `Use --check-all or --check-sample N for more.` | Matches `core/partition/reader.py:217` byte for byte |
| `docs/guide/geojson.md`, `docs/cli/convert.md` | `--lco KEY=VALUE` option row plus an "Advanced GDAL Options" section | Removed; replaced with a note on why there is no passthrough |
| `docs/guide/sub-partitioning.md` | `=== "A5"` tab using `--min-size` and `--in-place` | Tab removed; note names the three commands that do support sub-partitioning, linking #733 |
| `docs/cli/inspect.md` | `--check-all-files` | `--check-all` (the actual flag; the old text was the Python parameter name), plus the missing `--markdown` row |
| both `convert geojson` tables | — | Added the missing `--keep-crs` and `--no-repair-geometry` rows |

## Why removal rather than implementation

- **`--lco`**: there is no code history for it. `core/format_writers.py:195-203` assembles `LAYER_CREATION_OPTIONS` internally from the layer name and encoding; no user-facing passthrough has ever existed on `gpio convert geojson`. Adding one is a feature, not a doc repair, and the settings that matter for GeoJSON already have dedicated flags.
- **`partition a5 --in-place`**: unsupported at two layers, not one. `partition_a5` is decorated with `@partition_options_base` (no `--min-size` / `--in-place`), and `core/sub_partition.py:105` registers only `h3`, `s2` and `quadkey`, so wiring the flags alone would raise `Unknown partition type: a5`. Filed as #733 — the issue flagged this as a product decision, and it is not mine to make in a docs PR.

## Verification

Built a 2-file quadkey partition from the 766-point places fixture and ran each corrected example verbatim:

```
$ gpio check all partitions/
📁 Checking first file (of 2 total). Use --all-files or --sample-files N for more.

$ gpio check all partitions/ --all-files
Summary: 2 passed (2 files checked)

$ gpio check all partitions/ --sample-files 3
Summary: 2 passed (2 files checked)

$ gpio convert geojson input.parquet g1.geojson --keep-crs
Created GeoJSON: g1.geojson

$ gpio convert geojson input.parquet g2.geojson --no-repair-geometry
Created GeoJSON: g2.geojson

$ gpio inspect summary partitions/ --check-all --markdown
## Partition Summary
```

`gpio partition {h3,s2,quadkey} partitions/ --min-size 100MB --in-place …` all accept the flags and report `No files found exceeding 100.0MB`; `partition a5` still errors with `No such option '--min-size'`, which is what the new note documents.

Repo-wide grep over `docs/`, `README.md`, `skills/` and `examples/` for `--check-all`, `--check-sample`, `--lco` and `--check-all-files` leaves only the `inspect summary --check-all` occurrences in `docs/guide/inspect.md`, all of which were run and work.

## Found while verifying

- #733 — `partition a5` lacks `--min-size` / `--in-place` sub-partitioning support (the product decision the issue asked for).
- #734 — `convert geojson --write-bbox` crashes on file output while the stdout stream emits truncated features. That flag exists, it just does not work, so it was out of scope here; `geojson.md` documents the broken file form twice.

## Coordination with #732

Open PR #732 (docs-as-tests) carries skip directives on these exact blocks whose reasons cite the nonexistent flags. Whichever lands second rebases, and #732's coverage guard will then flag the now-working fences so the stale directives get removed during that rebase. This branch deliberately adds no doctest directives — that vocabulary only exists on #732's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dJzA17TYiysJ19Y35E1Cx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected CLI option names and examples across the documentation.
  * Added documentation for missing `inspect summary` and GeoJSON conversion options.
  * Clarified GeoJSON CRS preservation and geometry-repair settings.
  * Updated partitioned-data checking guidance with current options.
  * Clarified sub-partitioning support, including A5 limitations and processing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->