### PR TITLE
test(slow): re-align two slow-lane assertions with current behavior

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -220,20 +220,27 @@ class TestConvertCore:
         # File should still be valid, just not Hilbert ordered
         # (We can't easily test for lack of ordering without larger dataset)
 
-    def test_convert_verbose(self, shapefile_input, temp_output_file, capsys):
-        """Test verbose output."""
-        convert_to_geoparquet(
-            shapefile_input,
-            temp_output_file,
-            skip_hilbert=False,
-            verbose=True,
-        )
+    def test_convert_verbose(self, shapefile_input, temp_output_file, caplog):
+        """Test verbose output.
 
-        captured = capsys.readouterr()
-        # Logging output goes to stderr
-        assert "Detecting geometry column" in captured.err
-        assert "Dataset bounds" in captured.err
-        assert "bbox" in captured.err.lower()
+        Asserted via ``caplog``, not ``capsys``: under pytest the root logger
+        already has handlers (pytest's capture), so gpio's library bootstrap
+        attaches only a NullHandler and log records propagate to pytest's
+        capture instead of being written to stderr.
+        """
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+            convert_to_geoparquet(
+                shapefile_input,
+                temp_output_file,
+                skip_hilbert=False,
+                verbose=True,
+            )
+
+        assert "Detecting geometry column" in caplog.text
+        assert "Dataset bounds" in caplog.text
+        assert "bbox" in caplog.text.lower()
 
     def test_convert_custom_compression(self, shapefile_input, temp_output_file):
         """Test custom compression settings."""

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -347,7 +347,9 @@ class TestStreamIO:
 
         query = "SELECT * FROM data"
         result = _wrap_query_with_wkb_conversion(query, "geometry")
-        assert "ST_AsWKB(geometry)" in result
+        # The geometry column is an identifier and is quoted at every raw SQL
+        # interpolation (see CLAUDE.md's DuckDB patterns; enforced since #662).
+        assert 'ST_AsWKB("geometry")' in result
         assert "__stream_source" in result
 
     def test_wrap_query_with_wkb_conversion_no_geom(self):


### PR DESCRIPTION
Main's slow lane has been failing (three matrix legs red on every push to main). The full failure list is exactly two tests, both stale assertions rather than product bugs:

- `tests/test_streaming.py::test_wrap_query_with_wkb_conversion` still expected the unquoted `ST_AsWKB(geometry)` form; #662 quotes the geometry column at every raw SQL interpolation (the enforced pattern in CLAUDE.md), so the wrapper now emits `ST_AsWKB("geometry")`. The assertion now expects the quoted form.
- `tests/test_convert.py::test_convert_verbose` asserted debug logging appears on `capsys` stderr. Under pytest the root logger already has handlers (pytest's capture), so gpio's library bootstrap attaches only a `NullHandler` and records propagate to pytest's capture instead of stderr — the test saw `''`. It now asserts via `caplog.at_level(DEBUG)`, matching the repo's existing convention (e.g. `tests/test_crs_null_vs_default.py`).

Both tests are slow-lane-only, which is why PR CI stayed green while every push to main went red. Labeled `run-slow-tests` so this PR proves the slow matrix green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLN6JAz97UT1gGygg7EVTN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated verbose logging coverage to reliably verify diagnostic messages.
  * Adjusted SQL conversion expectations to reflect quoted geometry column names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->