### PR TITLE
fix(metadata): keep the bbox covering on GeoParquet 2.0 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,6 +685,28 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   are is the single `_CARRIED_SCHEMA_METADATA_KEYS` constant the
   parquet-geo-only path already uses, not a second copy of the same list.
 
+- **GeoParquet 2.0 output no longer drops the `bbox` covering (#738).** A 2.0
+  write whose input was already 2.x took a fast path that let DuckDB regenerate
+  the `geo` key from scratch, discarding every `covering` entry. So
+  `gpio sort hilbert --add-bbox` on a 2.0 file wrote the bbox column, reported
+  success, and declared nothing — bytes on disk no reader could use — and any
+  2.0→2.0 operation silently stripped a covering the input carried. Writes now
+  rewrite the metadata whenever the output should declare a covering (the input
+  declares one, or the output schema carries a bbox struct column), so the
+  covering survives every command and every write strategy. GeoParquet 2.0 keeps
+  1.1's optional bbox covering ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302));
+  it prunes *pages* within a row group where 2.0's native statistics only prune
+  whole row groups. Two consequences of the same premise: `gpio check` now
+  accepts a declared bbox covering on a 2.0 file instead of flagging it and
+  offering to delete it (an *undeclared* bbox column is still flagged — that is
+  the real defect — and `--fix` now only removes those); and `gpio sort hilbert`
+  no longer advises "consider `--geoparquet-version 2.0`" when auto mode is
+  already writing 2.0, a warning that assumed 1.1 output instead of resolving
+  the version the write would actually use. The three divergent bbox-column
+  detectors in `common.py`, `geo_metadata.py` and the DuckDB-KV write strategy
+  are now one shared `detect_bbox_column_from_schema()`, so the decision to
+  write a covering and the covering itself can never disagree.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -699,14 +699,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   metadata of the *original* input while the query read the working copy that
   `add_bbox` had just extended with the covering.
 
-  A covering is only ever written for a bbox column gpio computed in that same
-  statement, or one the input's own metadata already declared. gpio does not
-  infer a covering from a column's name: a `covering` asserts that a column's
-  values bound the geometry, and a covering pointing at unrelated values makes
-  readers prune away rows that genuinely match — worse than declaring nothing.
-  An undeclared bbox column is therefore left undeclared, and `gpio check`
-  flags it and points at `gpio add bbox-metadata`, where that assertion is made
-  deliberately.
+  A covering is written only where gpio can stand behind the claim: for a bbox
+  column it computed from the geometry in that same statement, for one the
+  input's own metadata already declared, or for a carried conventional `bbox`
+  struct column — the shape every GeoParquet 1.0 writer emitted before
+  `covering` existed, which is what lets a 1.0 → 1.1 upgrade declare it. Any
+  other name is left undeclared. A `covering` asserts that a column's values
+  bound the geometry, and one pointing at unrelated values makes readers prune
+  away rows that genuinely match, which is worse than declaring nothing:
+  matching *anything* ending in `bbox`/`bounds`/`extent` had let an unrelated
+  `tile_bounds` column become a geometry's declared covering. `gpio check`
+  flags an undeclared bbox column and points at `gpio add bbox-metadata`, where
+  that assertion is made deliberately.
+
+  `compression_level` is validated (integer, 1–22) before it reaches SQL:
+  the CLI constrains it with `IntRange`, but `write_parquet_with_metadata` and
+  the write strategies are public entry points a Python caller reaches directly,
+  where nothing had checked it.
 
   `gpio check` now accepts a *declared* bbox covering on a 2.0 file instead of
   flagging it and offering to delete it, and `--fix` only removes undeclared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -690,22 +690,44 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the `geo` key from scratch, discarding every `covering` entry. So
   `gpio sort hilbert --add-bbox` on a 2.0 file wrote the bbox column, reported
   success, and declared nothing — bytes on disk no reader could use — and any
-  2.0→2.0 operation silently stripped a covering the input carried. Writes now
-  rewrite the metadata whenever the output should declare a covering (the input
-  declares one, or the output schema carries a bbox struct column), so the
-  covering survives every command and every write strategy. GeoParquet 2.0 keeps
-  1.1's optional bbox covering ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302));
-  it prunes *pages* within a row group where 2.0's native statistics only prune
-  whole row groups. Two consequences of the same premise: `gpio check` now
-  accepts a declared bbox covering on a 2.0 file instead of flagging it and
-  offering to delete it (an *undeclared* bbox column is still flagged — that is
-  the real defect — and `--fix` now only removes those); and `gpio sort hilbert`
-  no longer advises "consider `--geoparquet-version 2.0`" when auto mode is
-  already writing 2.0, a warning that assumed 1.1 output instead of resolving
-  the version the write would actually use. The three divergent bbox-column
-  detectors in `common.py`, `geo_metadata.py` and the DuckDB-KV write strategy
-  are now one shared `detect_bbox_column_from_schema()`, so the decision to
-  write a covering and the covering itself can never disagree.
+  2.0→2.0 operation silently stripped a covering the input carried. The fast
+  path now writes the input's own `geo` block verbatim when it declares a
+  covering, alongside DuckDB's native geo types: the covering survives, and so
+  do the native GEOMETRY logical type and its geospatial statistics, with no
+  change to threads, memory or `--compression-level`.
+  `gpio sort hilbert --add-bbox` is fixed at its actual source — it read the
+  metadata of the *original* input while the query read the working copy that
+  `add_bbox` had just extended with the covering.
+
+  A covering is only ever written for a bbox column gpio computed in that same
+  statement, or one the input's own metadata already declared. gpio does not
+  infer a covering from a column's name: a `covering` asserts that a column's
+  values bound the geometry, and a covering pointing at unrelated values makes
+  readers prune away rows that genuinely match — worse than declaring nothing.
+  An undeclared bbox column is therefore left undeclared, and `gpio check`
+  flags it and points at `gpio add bbox-metadata`, where that assertion is made
+  deliberately.
+
+  `gpio check` now accepts a *declared* bbox covering on a 2.0 file instead of
+  flagging it and offering to delete it, and `--fix` only removes undeclared
+  columns, so a legitimate covering is never deleted. A covering is only counted
+  as declaring the file's bbox column when it actually names it — a covering
+  pointing at a missing column used to pass `check` while the success message
+  named a different column entirely. `gpio check spec` now runs its four
+  covering checks at 1.1 *and* 2.0; they were gated "1.1 only", so gpio
+  validated a dangling covering at 1.1 and waved the identical file through at
+  2.0. `gpio sort hilbert` no longer advises "consider `--geoparquet-version
+  2.0`" when auto mode is already writing 2.0, and stays silent rather than
+  guessing when the version cannot be established (a stdin stream, or an input
+  that will not open — a failed read is not evidence of a 1.1 input).
+
+  `covering` is not part of the GeoParquet 2.0 specification text: it was
+  introduced in 1.1 and removed in 2.0 in favour of the native statistics.
+  2.0 readers must tolerate unknown fields, so carrying one stays legal, and
+  [geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302)
+  proposes reinstating it as an option (open at time of writing). The
+  motivation holds either way: native statistics prune whole row groups, while
+  a bbox column's page index also prunes pages within one.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -685,6 +685,28 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   are is the single `_CARRIED_SCHEMA_METADATA_KEYS` constant the
   parquet-geo-only path already uses, not a second copy of the same list.
 
+- **GeoParquet 2.0 output no longer drops the `bbox` covering (#738).** A 2.0
+  write whose input was already 2.x took a fast path that let DuckDB regenerate
+  the `geo` key from scratch, discarding every `covering` entry. So
+  `gpio sort hilbert --add-bbox` on a 2.0 file wrote the bbox column, reported
+  success, and declared nothing — bytes on disk no reader could use — and any
+  2.0→2.0 operation silently stripped a covering the input carried. Writes now
+  rewrite the metadata whenever the output should declare a covering (the input
+  declares one, or the output schema carries a bbox struct column), so the
+  covering survives every command and every write strategy. GeoParquet 2.0 keeps
+  1.1's optional bbox covering ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302));
+  it prunes *pages* within a row group where 2.0's native statistics only prune
+  whole row groups. Two consequences of the same premise: `gpio check` now
+  accepts a declared bbox covering on a 2.0 file instead of flagging it and
+  offering to delete it (an *undeclared* bbox column is still flagged — that is
+  the real defect — and `--fix` now only removes those); and `gpio sort hilbert`
+  no longer advises "consider `--geoparquet-version 2.0`" when auto mode is
+  already writing 2.0, a warning that assumed 1.1 output instead of resolving
+  the version the write would actually use. The three divergent bbox-column
+  detectors in `common.py`, `geo_metadata.py` and the DuckDB-KV write strategy
+  are now one shared `detect_bbox_column_from_schema()`, so the decision to
+  write a covering and the covering itself can never disagree.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -699,14 +699,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   metadata of the *original* input while the query read the working copy that
   `add_bbox` had just extended with the covering.
 
-  A covering is only ever written for a bbox column gpio computed in that same
-  statement, or one the input's own metadata already declared. gpio does not
-  infer a covering from a column's name: a `covering` asserts that a column's
-  values bound the geometry, and a covering pointing at unrelated values makes
-  readers prune away rows that genuinely match — worse than declaring nothing.
-  An undeclared bbox column is therefore left undeclared, and `gpio check`
-  flags it and points at `gpio add bbox-metadata`, where that assertion is made
-  deliberately.
+  A covering is written only where gpio can stand behind the claim: for a bbox
+  column it computed from the geometry in that same statement, for one the
+  input's own metadata already declared, or for a carried conventional `bbox`
+  struct column — the shape every GeoParquet 1.0 writer emitted before
+  `covering` existed, which is what lets a 1.0 → 1.1 upgrade declare it. Any
+  other name is left undeclared. A `covering` asserts that a column's values
+  bound the geometry, and one pointing at unrelated values makes readers prune
+  away rows that genuinely match, which is worse than declaring nothing:
+  matching *anything* ending in `bbox`/`bounds`/`extent` had let an unrelated
+  `tile_bounds` column become a geometry's declared covering. `gpio check`
+  flags an undeclared bbox column and points at `gpio add bbox-metadata`, where
+  that assertion is made deliberately.
+
+  `compression_level` is validated (integer, 1–22) before it reaches SQL:
+  the CLI constrains it with `IntRange`, but `write_parquet_with_metadata` and
+  the write strategies are public entry points a Python caller reaches directly,
+  where nothing had checked it.
 
   `gpio check` now accepts a *declared* bbox covering on a 2.0 file instead of
   flagging it and offering to delete it, and `--fix` only removes undeclared

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -690,22 +690,44 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   the `geo` key from scratch, discarding every `covering` entry. So
   `gpio sort hilbert --add-bbox` on a 2.0 file wrote the bbox column, reported
   success, and declared nothing — bytes on disk no reader could use — and any
-  2.0→2.0 operation silently stripped a covering the input carried. Writes now
-  rewrite the metadata whenever the output should declare a covering (the input
-  declares one, or the output schema carries a bbox struct column), so the
-  covering survives every command and every write strategy. GeoParquet 2.0 keeps
-  1.1's optional bbox covering ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302));
-  it prunes *pages* within a row group where 2.0's native statistics only prune
-  whole row groups. Two consequences of the same premise: `gpio check` now
-  accepts a declared bbox covering on a 2.0 file instead of flagging it and
-  offering to delete it (an *undeclared* bbox column is still flagged — that is
-  the real defect — and `--fix` now only removes those); and `gpio sort hilbert`
-  no longer advises "consider `--geoparquet-version 2.0`" when auto mode is
-  already writing 2.0, a warning that assumed 1.1 output instead of resolving
-  the version the write would actually use. The three divergent bbox-column
-  detectors in `common.py`, `geo_metadata.py` and the DuckDB-KV write strategy
-  are now one shared `detect_bbox_column_from_schema()`, so the decision to
-  write a covering and the covering itself can never disagree.
+  2.0→2.0 operation silently stripped a covering the input carried. The fast
+  path now writes the input's own `geo` block verbatim when it declares a
+  covering, alongside DuckDB's native geo types: the covering survives, and so
+  do the native GEOMETRY logical type and its geospatial statistics, with no
+  change to threads, memory or `--compression-level`.
+  `gpio sort hilbert --add-bbox` is fixed at its actual source — it read the
+  metadata of the *original* input while the query read the working copy that
+  `add_bbox` had just extended with the covering.
+
+  A covering is only ever written for a bbox column gpio computed in that same
+  statement, or one the input's own metadata already declared. gpio does not
+  infer a covering from a column's name: a `covering` asserts that a column's
+  values bound the geometry, and a covering pointing at unrelated values makes
+  readers prune away rows that genuinely match — worse than declaring nothing.
+  An undeclared bbox column is therefore left undeclared, and `gpio check`
+  flags it and points at `gpio add bbox-metadata`, where that assertion is made
+  deliberately.
+
+  `gpio check` now accepts a *declared* bbox covering on a 2.0 file instead of
+  flagging it and offering to delete it, and `--fix` only removes undeclared
+  columns, so a legitimate covering is never deleted. A covering is only counted
+  as declaring the file's bbox column when it actually names it — a covering
+  pointing at a missing column used to pass `check` while the success message
+  named a different column entirely. `gpio check spec` now runs its four
+  covering checks at 1.1 *and* 2.0; they were gated "1.1 only", so gpio
+  validated a dangling covering at 1.1 and waved the identical file through at
+  2.0. `gpio sort hilbert` no longer advises "consider `--geoparquet-version
+  2.0`" when auto mode is already writing 2.0, and stays silent rather than
+  guessing when the version cannot be established (a stdin stream, or an input
+  that will not open — a failed read is not evidence of a 1.1 input).
+
+  `covering` is not part of the GeoParquet 2.0 specification text: it was
+  introduced in 1.1 and removed in 2.0 in favour of the native statistics.
+  2.0 readers must tolerate unknown fields, so carrying one stays legal, and
+  [geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302)
+  proposes reinstating it as an option (open at time of writing). The
+  motivation holds either way: native statistics prune whole row groups, while
+  a bbox column's page index also prunes pages within one.
 
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -38,7 +38,7 @@ Add precomputed bounding boxes for faster spatial queries:
     gpio.read('input.parquet').add_bbox(column_name='bounds').write('output.parquet')
     ```
 
-Creates a struct column with `{xmin, ymin, xmax, ymax}` for each feature. Bbox covering metadata is automatically added to comply with GeoParquet 1.1 spec.
+Creates a struct column with `{xmin, ymin, xmax, ymax}` for each feature, plus the `covering` metadata that points at it — at every output version. GeoParquet 1.1 introduced the covering, and 2.0 keeps it as an option ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302)): 2.0's native statistics prune whole row groups, while the covering column's page index also prunes pages within a row group.
 
 ### Existing Bbox Detection
 

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -38,7 +38,7 @@ Add precomputed bounding boxes for faster spatial queries:
     gpio.read('input.parquet').add_bbox(column_name='bounds').write('output.parquet')
     ```
 
-Creates a struct column with `{xmin, ymin, xmax, ymax}` for each feature, plus the `covering` metadata that points at it — at every output version. GeoParquet 1.1 introduced the covering, and 2.0 keeps it as an option ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302)): 2.0's native statistics prune whole row groups, while the covering column's page index also prunes pages within a row group.
+Creates a struct column with `{xmin, ymin, xmax, ymax}` for each feature, plus the `covering` metadata that points at it. Because gpio computes the column from the geometry in the same statement, it can declare the covering; a bbox column gpio did not compute is left undeclared, since a covering asserts a relationship gpio cannot verify from a column name. The `covering` key is not part of the GeoParquet 2.0 specification text — it was introduced in 1.1 and removed in 2.0 in favour of the native statistics. 2.0 readers must tolerate unknown fields, so a covering stays legal to carry, and [geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302) *proposes* reinstating it as an option (still open at time of writing). The motivation is real either way: native statistics prune whole row groups, while a bbox column's page index also prunes pages within one.
 
 ### Existing Bbox Detection
 

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -117,6 +117,11 @@ Verifies:
 - GeoParquet metadata version
 - Bbox covering metadata
 
+A bbox column is optional in GeoParquet 2.0, but it must be declared: a bbox
+column that no `covering` entry points at costs file size and cannot be used by
+any reader, so `check bbox` fails the file and suggests `gpio add bbox-metadata`
+(or `--fix` to drop the column).
+
 ### Row Groups
 
 === "CLI"
@@ -253,7 +258,7 @@ Validates file structure and metadata against the GeoParquet specification:
 - **Version sanity** — an unknown `geo` metadata version (e.g. `99.0.0`) fails
   validation, even in auto mode. Version/feature mismatches also fail: a file
   declaring version 1.0 while using GeoParquet 2.0 native Parquet geo types, or
-  the 1.1-only `covering` key, is flagged as inconsistent.
+  the `covering` key that 1.1 introduced, is flagged as inconsistent.
 - **CRS structure** — PROJJSON `crs` objects must carry the required `type`
   member, and it must be a known PROJJSON CRS type.
 - **Datum-aware epoch validation** — a coordinate `epoch` on a datum ensemble

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -117,10 +117,22 @@ Verifies:
 - GeoParquet metadata version
 - Bbox covering metadata
 
-A bbox column is optional in GeoParquet 2.0, but it must be declared: a bbox
-column that no `covering` entry points at costs file size and cannot be used by
-any reader, so `check bbox` fails the file and suggests `gpio add bbox-metadata`
-(or `--fix` to drop the column).
+A bbox column is optional in GeoParquet 2.0, but it must be declared, and the
+declaration must be true:
+
+- A bbox column that no `covering` entry points at costs file size and cannot be
+  used by any reader, so `check bbox` fails the file and suggests
+  `gpio add bbox-metadata` (or `--fix` to drop the column). `--fix` only ever
+  removes an *undeclared* column — a covering the file legitimately declares is
+  never deleted.
+- A `covering` that names a column the file does not contain is treated as
+  undeclared rather than accepted. Such a covering makes readers prune away rows
+  that genuinely match, so it is worse than none at all.
+
+`check spec` runs its four `covering` checks — paths well-formed, column
+present, struct shape, field types — at GeoParquet 1.1 **and** 2.0. They were
+previously gated to 1.1 only, so an identical broken covering failed at 1.1 and
+passed at 2.0.
 
 ### Row Groups
 

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -297,6 +297,24 @@ GeoParquet files can have multiple geometry columns (e.g., `geometry` for point 
 !!! note "Bbox and Hilbert Ordering"
     Bbox computation and Hilbert spatial ordering use the **primary geometry column only**. Secondary geometry columns are preserved but do not influence spatial indexing.
 
+!!! note "When the `covering` metadata is written"
+    A `covering` entry tells readers that a bbox column's values bound the
+    geometry, so engines prune on it. `gpio convert` declares one only when it
+    can stand behind the claim:
+
+    - it computed the bbox column itself, from the geometry, during this convert
+    - the input's own metadata already declared a covering for the column being
+      preserved
+    - the output carries a conventional `bbox` struct column (the shape every
+      GeoParquet 1.0 writer emitted, before `covering` existed) — this is what
+      makes a 1.0 → 1.1 upgrade declare it
+
+    A preserved column with any other name — `bounds`, `parcel_extent`,
+    `tile_bounds` — is left undeclared, because its name is not evidence that
+    its values bound the geometry, and a wrong covering makes readers skip rows
+    that genuinely match. Declare such a column deliberately with
+    [`gpio add bbox-metadata`](add.md); `gpio check bbox` will point this out.
+
 ### Custom Geometry Column Names
 
 GeoParquet files can use non-standard geometry column names (e.g., `the_geom`, `my_geometry`). These names are preserved during conversion:

--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -52,10 +52,10 @@ Reorders rows using a [Hilbert space-filling curve](https://en.wikipedia.org/wik
     gpio sort hilbert input.parquet output.parquet --geoparquet-version 2.0
 
     # A bbox covering column instead (or as well — it also prunes pages within a row group)
-    gpio sort hilbert input.parquet output.parquet --add-bbox
+    gpio sort hilbert input.parquet output-bbox.parquet --add-bbox
     ```
 
-    `--add-bbox` writes the column *and* the `covering` metadata that points at it, at every output version. GeoParquet 2.0 keeps 1.1's optional bbox covering ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302)) precisely because the native statistics only prune whole row groups, while a covering column's page index prunes pages inside one.
+    `--add-bbox` writes the column *and* the `covering` metadata that points at it, because gpio computed that column from the geometry here and can vouch for it. The `covering` key is not part of the GeoParquet 2.0 specification text — it was introduced in 1.1 and removed in 2.0 in favour of the native statistics. 2.0 readers must tolerate unknown fields, so a covering stays legal to carry, and [geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302) *proposes* reinstating it as an option (still open at time of writing). The motivation is real either way: native statistics prune whole row groups, while a bbox column's page index also prunes pages within one.
 
 ## Options
 

--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -45,11 +45,17 @@ Reorders rows using a [Hilbert space-filling curve](https://en.wikipedia.org/wik
 - Enhances query performance
 
 !!! warning "GeoParquet version matters"
-    Hilbert sorting to GeoParquet v1.1 (the default) provides **no spatial filter pushdown benefit** because v1.1 files lack native `geo_bbox` row group statistics. Use `--geoparquet-version 2.0` to enable native geo stats that allow query engines to skip irrelevant row groups.
+    Sorting only pays off if readers can *use* the resulting spatial locality. Without `--geoparquet-version`, the output keeps the input's version, so a v1.1 file stays v1.1 — and v1.1 has no native `geo_bbox` row group statistics. Either write v2.0 for native statistics, or add a `bbox` covering column that engines can push predicates down onto:
 
     ```bash
+    # Native row group statistics (recommended)
     gpio sort hilbert input.parquet output.parquet --geoparquet-version 2.0
+
+    # A bbox covering column instead (or as well — it also prunes pages within a row group)
+    gpio sort hilbert input.parquet output.parquet --add-bbox
     ```
+
+    `--add-bbox` writes the column *and* the `covering` metadata that points at it, at every output version. GeoParquet 2.0 keeps 1.1's optional bbox covering ([geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302)) precisely because the native statistics only prune whole row groups, while a covering column's page index prunes pages inside one.
 
 ## Options
 

--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -317,23 +317,29 @@ def _check_parquet_geo_only(parquet_file, file_type_info, verbose, return_result
 
 
 def _check_geoparquet_v2(parquet_file, file_type_info, verbose, return_results, quiet=False):
-    """Check GeoParquet 2.0 file (bbox not recommended)."""
+    """Check GeoParquet 2.0 file (a bbox column is optional, but must be declared)."""
     bbox_info = check_bbox_structure(parquet_file, verbose)
     stats_info = has_parquet_geo_row_group_stats(parquet_file)
 
     issues = []
     recommendations = []
 
-    # For v2, bbox column is NOT recommended
-    if bbox_info["has_bbox_column"]:
+    # GeoParquet 2.0 keeps 1.1's optional bbox covering
+    # (opengeospatial/geoparquet#302): the native geo types give row group
+    # statistics, while a covering also prunes pages within a row group. So a
+    # bbox column is a legitimate choice here -- but only if a `covering` entry
+    # declares it. An undeclared one costs bytes and no reader can use it (#738).
+    undeclared_bbox = bbox_info["has_bbox_column"] and not bbox_info["has_bbox_metadata"]
+    if undeclared_bbox:
         issues.append(
-            f"Bbox column '{bbox_info['bbox_column_name']}' found (not needed for GeoParquet 2.0)"
+            f"Bbox column '{bbox_info['bbox_column_name']}' is not declared in the "
+            "'covering' metadata, so no reader can use it"
         )
         recommendations.append(
-            "Remove bbox column with --fix (native geo types provide row group stats)"
+            "Declare it with 'gpio add bbox-metadata', or remove the column with --fix"
         )
 
-    passed = not bbox_info["has_bbox_column"]
+    passed = not undeclared_bbox
 
     # Print results (skip if quiet mode)
     if not quiet:
@@ -341,14 +347,20 @@ def _check_geoparquet_v2(parquet_file, file_type_info, verbose, return_results, 
         success(f"✓ Version {file_type_info['geo_version']}")
         success("✓ Uses native Parquet GEOMETRY/GEOGRAPHY types")
 
-        if bbox_info["has_bbox_column"]:
+        if undeclared_bbox:
             warn(
-                f"⚠️  Bbox column '{bbox_info['bbox_column_name']}' found (not recommended for 2.0)"
+                f"⚠️  Bbox column '{bbox_info['bbox_column_name']}' found but not declared "
+                "in 'covering' metadata"
             )
-            info("   Native Parquet geo types provide row group stats for spatial filtering.")
-            info("   Use --fix to remove the bbox column")
+            info("   As written, it costs file size and no reader can use it.")
+            info("   Declare it with 'gpio add bbox-metadata', or use --fix to remove it.")
+        elif bbox_info["has_bbox_column"]:
+            success(
+                f"✓ Bbox covering column '{bbox_info['bbox_column_name']}' declared "
+                "(optional in 2.0; enables page-level pruning)"
+            )
         else:
-            success("✓ No bbox column (correct for GeoParquet 2.0)")
+            success("✓ No bbox column (native geo statistics are enough for most files)")
 
         if stats_info["has_stats"]:
             success("✓ Row group statistics available for spatial filtering")
@@ -363,10 +375,12 @@ def _check_geoparquet_v2(parquet_file, file_type_info, verbose, return_results, 
             "has_bbox_column": bbox_info["has_bbox_column"],
             "bbox_column_name": bbox_info.get("bbox_column_name"),
             "has_row_group_stats": stats_info["has_stats"],
-            "needs_bbox_removal": bbox_info["has_bbox_column"],
+            # Only an *undeclared* bbox column is removable: --fix must not
+            # delete a covering the file legitimately declares.
+            "needs_bbox_removal": undeclared_bbox,
             "issues": issues,
             "recommendations": recommendations,
-            "fix_available": bbox_info["has_bbox_column"],
+            "fix_available": undeclared_bbox,
         }
 
 

--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -324,11 +324,13 @@ def _check_geoparquet_v2(parquet_file, file_type_info, verbose, return_results, 
     issues = []
     recommendations = []
 
-    # GeoParquet 2.0 keeps 1.1's optional bbox covering
-    # (opengeospatial/geoparquet#302): the native geo types give row group
-    # statistics, while a covering also prunes pages within a row group. So a
-    # bbox column is a legitimate choice here -- but only if a `covering` entry
-    # declares it. An undeclared one costs bytes and no reader can use it (#738).
+    # `covering` is not in the 2.0 spec text -- it was introduced in 1.1 and
+    # dropped in 2.0 in favour of the native statistics -- but 2.0 readers must
+    # tolerate unknown fields, and opengeospatial/geoparquet#302 proposes
+    # reinstating it (still open). Since files carrying one exist and the
+    # motivation holds (native stats prune row groups, a covering also prunes
+    # pages within one), a declared bbox column is not a defect here. An
+    # *undeclared* one is: it costs bytes and no reader can use it (#738).
     undeclared_bbox = bbox_info["has_bbox_column"] and not bbox_info["has_bbox_metadata"]
     if undeclared_bbox:
         issues.append(

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1014,9 +1014,8 @@ def _detect_bbox_column_from_table(table, verbose: bool = False) -> str | None:
     Returns:
         str: Name of bbox column if found, None otherwise
     """
-    import pyarrow as pa
-
     from geoparquet_io.core.crs_utils import parse_geo_metadata_from_schema
+    from geoparquet_io.core.geo_metadata import detect_bbox_column_from_schema
 
     geo_meta = parse_geo_metadata_from_schema(table.schema.metadata)
     covering_column = _bbox_column_from_covering(geo_meta)
@@ -1025,27 +1024,7 @@ def _detect_bbox_column_from_table(table, verbose: bool = False) -> str | None:
             debug(f"Found bbox column from covering metadata: {covering_column}")
         return covering_column
 
-    conventional_suffixes = ["bbox", "bounds", "extent"]
-    required_fields = {"xmin", "ymin", "xmax", "ymax"}
-
-    for field in table.schema:
-        name = field.name
-        field_type = field.type
-
-        # Check if column name ends with conventional suffixes
-        is_bbox_name = any(name.endswith(suffix) for suffix in conventional_suffixes)
-        if not is_bbox_name:
-            continue
-
-        # Check if it's a struct with the required fields
-        if pa.types.is_struct(field_type):
-            struct_field_names = {f.name for f in field_type}
-            if required_fields.issubset(struct_field_names):
-                if verbose:
-                    debug(f"Found bbox column in table: {name}")
-                return name
-
-    return None
+    return detect_bbox_column_from_schema(table.schema, verbose)
 
 
 # WKB geometry type codes to GeoParquet base names (2D types)
@@ -2360,6 +2339,38 @@ def read_preserved_kv_metadata(parquet_file: str, verbose: bool = False) -> dict
         debug(f"Preserving input KV metadata keys: {sorted(preserved)}")
     return preserved
 
+def _output_carries_covering(
+    con,
+    query: str,
+    original_metadata: dict | None,
+    verbose: bool,
+) -> bool:
+    """Whether the written file should declare a ``covering`` for its geometry.
+
+    True when the input's geo metadata already declares one (pruning has
+    already dropped coverings whose column the output does not emit), or when
+    the output schema contains a bbox struct column that no covering names yet.
+
+    Best-effort: a schema probe that fails answers False, leaving the write on
+    whatever path it was already taking rather than aborting it.
+    """
+    from geoparquet_io.core.geo_metadata import (
+        detect_bbox_column_from_schema,
+        geo_metadata_declares_covering,
+    )
+
+    if geo_metadata_declares_covering(original_metadata):
+        return True
+
+    try:
+        schema = con.execute(f"SELECT * FROM ({query}) AS __subq LIMIT 0").arrow().schema
+    except (duckdb.Error, RuntimeError, ValueError, AttributeError) as e:
+        if verbose:
+            debug(f"Could not read output schema to check for a bbox column: {e}")
+        return False
+
+    return detect_bbox_column_from_schema(schema, verbose) is not None
+
 
 def write_parquet_with_metadata(
     con,
@@ -2479,6 +2490,20 @@ def write_parquet_with_metadata(
         rewrite_needed = True
         if verbose:
             debug("Forcing metadata rewrite for covering metadata")
+
+    # Same reason, for a covering nobody passed in custom_metadata: a 2.0 output
+    # otherwise takes the plain COPY TO fast path, where DuckDB regenerates the
+    # `geo` key from scratch and drops every `covering` entry -- the one
+    # describing a bbox column `--add-bbox` just wrote, or one carried in from
+    # the input. GeoParquet 2.0 keeps 1.1's optional bbox covering
+    # (opengeospatial/geoparquet#302) precisely because it prunes *pages* where
+    # the native row-group statistics only prune row groups; a bbox column that
+    # nothing declares costs bytes and tells readers nothing (#738).
+    if not rewrite_needed and effective_version != "parquet-geo-only":
+        if _output_carries_covering(con, query, original_metadata, verbose):
+            rewrite_needed = True
+            if verbose:
+                debug("Forcing metadata rewrite to describe the output's bbox covering")
 
     # Preserve non-geo KV metadata from input (e.g., vecorel, fiboa).
     # Build a merged local dict rather than mutating the caller-supplied

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import re
@@ -39,6 +40,7 @@ from geoparquet_io.core.geo_metadata import (
     DEFAULT_GEOPARQUET_VERSION,
     GEOPARQUET_VERSIONS,
     create_geo_metadata,
+    detect_bbox_column_from_schema,
     prune_geo_metadata_to_columns,
     strip_derived_stats,
 )
@@ -1015,7 +1017,6 @@ def _detect_bbox_column_from_table(table, verbose: bool = False) -> str | None:
         str: Name of bbox column if found, None otherwise
     """
     from geoparquet_io.core.crs_utils import parse_geo_metadata_from_schema
-    from geoparquet_io.core.geo_metadata import detect_bbox_column_from_schema
 
     geo_meta = parse_geo_metadata_from_schema(table.schema.metadata)
     covering_column = _bbox_column_from_covering(geo_meta)
@@ -2157,6 +2158,7 @@ def _plain_copy_to(
     row_group_rows: int | None = None,
     input_crs: dict | None = None,
     geometry_column: str | None = None,
+    carry_geo_metadata: dict | None = None,
 ) -> None:
     """
     Execute a plain DuckDB COPY TO without geo metadata manipulation.
@@ -2178,6 +2180,12 @@ def _plain_copy_to(
         row_group_rows: Target number of rows per row group
         input_crs: PROJJSON dict with CRS information (optional)
         geometry_column: Name of the geometry column (required if input_crs is set)
+        carry_geo_metadata: A `geo` block to write verbatim instead of the one
+            DuckDB would generate. Used to preserve a `covering` the input
+            declared, which DuckDB's own generated metadata does not include.
+            Supplying it alongside GEOPARQUET_VERSION 'V2' keeps the native
+            GEOMETRY logical type and its geospatial statistics — only the KV
+            entry is replaced.
     """
     compression_map = {
         "zstd": "ZSTD",
@@ -2206,11 +2214,15 @@ def _plain_copy_to(
         f"COMPRESSION {duckdb_compression}",
         f"GEOPARQUET_VERSION '{duckdb_version}'",
     ]
-    # Only add compression level for codecs that support it (ZSTD, GZIP, BROTLI)
-    if compression_level is not None and duckdb_compression in ("ZSTD", "GZIP", "BROTLI"):
+    # DuckDB accepts COMPRESSION_LEVEL for ZSTD only; pairing it with GZIP or
+    # BROTLI is a binder error, not a silently ignored option.
+    if compression_level is not None and duckdb_compression.upper() == "ZSTD":
         options.append(f"COMPRESSION_LEVEL {compression_level}")
     if row_group_rows is not None:
         options.append(f"ROW_GROUP_SIZE {row_group_rows}")
+    if carry_geo_metadata is not None:
+        geo_json = _escape_sql_string(json.dumps(carry_geo_metadata))
+        options.append(f"KV_METADATA {{'geo': '{geo_json}'}}")
 
     copy_query = f"""
         COPY ({final_query})
@@ -2339,37 +2351,58 @@ def read_preserved_kv_metadata(parquet_file: str, verbose: bool = False) -> dict
         debug(f"Preserving input KV metadata keys: {sorted(preserved)}")
     return preserved
 
-def _output_carries_covering(
-    con,
-    query: str,
+
+# Fields a carried `geo` block must still have for the 2.0 fast path to be able
+# to write it verbatim. When a caller invalidated the derived stats (reproject,
+# a row filter, a multi-file merge) they are stripped, and only the rewrite path
+# can recompute them — so we fall back to it rather than ship a thinner block
+# than DuckDB would have generated.
+_REQUIRED_CARRIED_GEO_FIELDS = ("encoding", "geometry_types")
+
+
+def _covering_to_carry_on_fast_path(
     original_metadata: dict | None,
-    verbose: bool,
-) -> bool:
-    """Whether the written file should declare a ``covering`` for its geometry.
+    geometry_column: str | None,
+    effective_version: str,
+) -> dict | None:
+    """The `geo` block the 2.0 fast path must write to keep a declared covering.
 
-    True when the input's geo metadata already declares one (pruning has
-    already dropped coverings whose column the output does not emit), or when
-    the output schema contains a bbox struct column that no covering names yet.
+    DuckDB regenerates the `geo` key on the fast path and its generated block
+    has no `covering`, so a covering the input declared is silently dropped
+    (#738). Returning the carried block here lets `_plain_copy_to` write it
+    verbatim, keeping the fast path's write configuration intact — forcing the
+    rewrite instead would clamp threads and memory, drop `--compression-level`,
+    and can add a full stats rescan.
 
-    Best-effort: a schema probe that fails answers False, leaving the write on
-    whatever path it was already taking rather than aborting it.
+    Returns None when nothing needs carrying, when the version is not 2.0 (1.x
+    already rewrites), or when the carried block is too thin to stand in for
+    DuckDB's — the caller then keeps its existing behaviour.
+
+    A covering is only ever taken from the input's own metadata: it asserts a
+    relationship between a bbox column and the geometry that gpio cannot verify
+    from a column name, and a covering pointing at unrelated values makes
+    readers prune away rows that genuinely match.
     """
-    from geoparquet_io.core.geo_metadata import (
-        detect_bbox_column_from_schema,
-        geo_metadata_declares_covering,
-    )
+    from geoparquet_io.core.geo_metadata import _decode_geo_value
 
-    if geo_metadata_declares_covering(original_metadata):
-        return True
+    if effective_version != "2.0" or not geometry_column or not original_metadata:
+        return None
 
-    try:
-        schema = con.execute(f"SELECT * FROM ({query}) AS __subq LIMIT 0").arrow().schema
-    except (duckdb.Error, RuntimeError, ValueError, AttributeError) as e:
-        if verbose:
-            debug(f"Could not read output schema to check for a bbox column: {e}")
-        return False
-
-    return detect_bbox_column_from_schema(schema, verbose) is not None
+    for geo_key in ("geo", b"geo"):
+        if geo_key not in original_metadata:
+            continue
+        geo_dict = _decode_geo_value(original_metadata[geo_key])
+        if not geo_dict:
+            return None
+        col_meta = (geo_dict.get("columns") or {}).get(geometry_column)
+        if not isinstance(col_meta, dict) or not col_meta.get("covering"):
+            return None
+        if any(field not in col_meta for field in _REQUIRED_CARRIED_GEO_FIELDS):
+            return None
+        carried = copy.deepcopy(geo_dict)
+        carried["version"] = "2.0.0"
+        return carried
+    return None
 
 
 def write_parquet_with_metadata(
@@ -2491,20 +2524,6 @@ def write_parquet_with_metadata(
         if verbose:
             debug("Forcing metadata rewrite for covering metadata")
 
-    # Same reason, for a covering nobody passed in custom_metadata: a 2.0 output
-    # otherwise takes the plain COPY TO fast path, where DuckDB regenerates the
-    # `geo` key from scratch and drops every `covering` entry -- the one
-    # describing a bbox column `--add-bbox` just wrote, or one carried in from
-    # the input. GeoParquet 2.0 keeps 1.1's optional bbox covering
-    # (opengeospatial/geoparquet#302) precisely because it prunes *pages* where
-    # the native row-group statistics only prune row groups; a bbox column that
-    # nothing declares costs bytes and tells readers nothing (#738).
-    if not rewrite_needed and effective_version != "parquet-geo-only":
-        if _output_carries_covering(con, query, original_metadata, verbose):
-            rewrite_needed = True
-            if verbose:
-                debug("Forcing metadata rewrite to describe the output's bbox covering")
-
     # Preserve non-geo KV metadata from input (e.g., vecorel, fiboa).
     # Build a merged local dict rather than mutating the caller-supplied
     # extra_kv_metadata: partition loops reuse one dict across writes, and
@@ -2549,6 +2568,9 @@ def write_parquet_with_metadata(
                 geoparquet_version=effective_version,
                 input_crs=input_crs,
                 geometry_column=geometry_column,
+                carry_geo_metadata=_covering_to_carry_on_fast_path(
+                    original_metadata, geometry_column, effective_version
+                ),
             )
         else:
             # Metadata rewrite needed - use strategy pattern
@@ -2933,13 +2955,19 @@ def _find_bbox_column_in_schema(schema_info, verbose):
     return None
 
 
-def _check_bbox_metadata_covering(geo_meta, has_bbox_column, verbose):
+def _check_bbox_metadata_covering(geo_meta, has_bbox_column, verbose, bbox_column_name=None):
     """Check if geo metadata contains proper bbox covering.
 
     Args:
         geo_meta: Parsed geo metadata dict (from get_geo_metadata())
         has_bbox_column: Whether a bbox column was found in schema
         verbose: Whether to print verbose output
+        bbox_column_name: The bbox column actually present in the file. A
+            covering only counts as declaring *this* file's bbox column when it
+            names it; a covering pointing at some other (or absent) column is a
+            dangling reference, and treating it as "declared" let a broken file
+            pass `check` while the success message named a different column
+            entirely (#738).
     """
     if not (geo_meta and has_bbox_column):
         return False
@@ -2960,6 +2988,14 @@ def _check_bbox_metadata_covering(geo_meta, has_bbox_column, verbose):
                     and all(isinstance(ref, list) and len(ref) == 2 for ref in bbox_refs.values())
                 ):
                     referenced_bbox_column = bbox_refs["xmin"][0]
+                    if bbox_column_name is not None and referenced_bbox_column != bbox_column_name:
+                        if verbose:
+                            debug(
+                                f"Covering references column '{referenced_bbox_column}', "
+                                f"but the file's bbox column is '{bbox_column_name}' - "
+                                "treating the bbox column as undeclared"
+                            )
+                        continue
                     if verbose:
                         debug(
                             f"Found bbox covering in metadata referencing column: {referenced_bbox_column}"
@@ -3033,7 +3069,9 @@ def check_bbox_structure(parquet_file, verbose=False) -> BboxInfo:
     has_bbox_column = bbox_column_name is not None
 
     # Check for bbox covering in the geo metadata
-    has_bbox_metadata = _check_bbox_metadata_covering(geo_meta, has_bbox_column, verbose)
+    has_bbox_metadata = _check_bbox_metadata_covering(
+        geo_meta, has_bbox_column, verbose, bbox_column_name
+    )
 
     # Determine status and message
     status, message = _determine_bbox_status(has_bbox_column, bbox_column_name, has_bbox_metadata)
@@ -3480,6 +3518,23 @@ def add_bbox(parquet_file, bbox_column_name="bbox", verbose=False):
 
     try:
         # Use add_computed_column to write to temp file
+        # Declare the covering explicitly rather than leaving a writer to infer
+        # it from the column's name. gpio computed this column from the geometry
+        # in this same statement, so the assertion "these values bound that
+        # geometry" is one we can actually make here -- and nowhere else (#738).
+        # `custom_metadata` is the existing route for that, and it is already
+        # version-gated: strip_unsupported_covering drops the key for 1.0 output.
+        bbox_covering = {
+            "covering": {
+                "bbox": {
+                    "xmin": [bbox_column_name, "xmin"],
+                    "ymin": [bbox_column_name, "ymin"],
+                    "xmax": [bbox_column_name, "xmax"],
+                    "ymax": [bbox_column_name, "ymax"],
+                }
+            }
+        }
+
         add_computed_column(
             input_parquet=parquet_file,
             output_parquet=temp_file,
@@ -3493,6 +3548,7 @@ def add_bbox(parquet_file, bbox_column_name="bbox", verbose=False):
             row_group_size_mb=None,
             row_group_rows=None,
             dry_run_description=None,
+            custom_metadata=bbox_covering,
         )
 
         # Replace original file with updated file

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -24,6 +24,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
     quote_identifier,
+    validate_compression_level,
 )
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
@@ -39,6 +40,7 @@ from geoparquet_io.core.file_utils import (
 from geoparquet_io.core.geo_metadata import (
     DEFAULT_GEOPARQUET_VERSION,
     GEOPARQUET_VERSIONS,
+    build_bbox_covering,
     create_geo_metadata,
     detect_bbox_column_from_schema,
     prune_geo_metadata_to_columns,
@@ -2217,7 +2219,7 @@ def _plain_copy_to(
     # DuckDB accepts COMPRESSION_LEVEL for ZSTD only; pairing it with GZIP or
     # BROTLI is a binder error, not a silently ignored option.
     if compression_level is not None and duckdb_compression.upper() == "ZSTD":
-        options.append(f"COMPRESSION_LEVEL {compression_level}")
+        options.append(f"COMPRESSION_LEVEL {validate_compression_level(compression_level)}")
     if row_group_rows is not None:
         options.append(f"ROW_GROUP_SIZE {row_group_rows}")
     if carry_geo_metadata is not None:
@@ -3524,16 +3526,7 @@ def add_bbox(parquet_file, bbox_column_name="bbox", verbose=False):
         # geometry" is one we can actually make here -- and nowhere else (#738).
         # `custom_metadata` is the existing route for that, and it is already
         # version-gated: strip_unsupported_covering drops the key for 1.0 output.
-        bbox_covering = {
-            "covering": {
-                "bbox": {
-                    "xmin": [bbox_column_name, "xmin"],
-                    "ymin": [bbox_column_name, "ymin"],
-                    "xmax": [bbox_column_name, "xmax"],
-                    "ymax": [bbox_column_name, "ymax"],
-                }
-            }
-        }
+        bbox_covering = {"covering": {"bbox": build_bbox_covering(bbox_column_name)}}
 
         add_computed_column(
             input_parquet=parquet_file,

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -36,6 +36,7 @@ from geoparquet_io.core.file_utils import (
     safe_file_url,
     validate_output_path,
 )
+from geoparquet_io.core.geo_metadata import build_bbox_covering
 from geoparquet_io.core.geometry_repair import (
     repair_arrow_table_geometry,
     repair_query_geometry,
@@ -1047,7 +1048,7 @@ def _convert_csv_path(
         con, input_file, delimiter, wkt_column, lat_column, lon_column, verbose
     )
     if geom_info is None:
-        return None
+        return None, None
 
     # Validate geometry
     if geom_info["type"] == "wkt":
@@ -1103,7 +1104,10 @@ def _convert_csv_path(
         con.execute(f"CREATE OR REPLACE TEMP TABLE _gpio_csv_parsed AS {query}")
         query = "SELECT * FROM _gpio_csv_parsed"
 
-    return query
+    # The bbox column, when written, is computed from the geometry right here,
+    # so this path can vouch for it. Report it rather than leaving a writer to
+    # infer a covering from the column's name (#738).
+    return query, (None if skip_bbox else "bbox")
 
 
 def _bounds_with_curve_fallback(
@@ -1192,7 +1196,7 @@ def _convert_spatial_path(
         }
 
     if geom_column is None:
-        return None, None
+        return None, None, None
 
     # Curved geometries cannot pass through the ST_Read-based query below;
     # detected up front (GPKG pre-scan, issue #643) they are read once via
@@ -1219,6 +1223,7 @@ def _convert_spatial_path(
     # Check for existing bbox column if input is parquet
     existing_bbox_col = None
     preserve_existing_bbox = False
+    bbox_info = {"has_bbox_metadata": False}
     if is_parquet:
         bbox_info = check_bbox_structure(input_file, verbose=False)
         if bbox_info["has_bbox_column"]:
@@ -1284,7 +1289,18 @@ def _convert_spatial_path(
         table_expr=table_expr,
     )
 
-    return query, geom_info
+    # Provenance for the covering. Two things justify declaring one: gpio
+    # computed the column from the geometry in this query, or the input's own
+    # metadata already declared it for the column being preserved. A column that
+    # merely looks like a bbox justifies nothing (#738).
+    if skip_bbox:
+        bbox_covering_column = None
+    elif preserve_existing_bbox:
+        bbox_covering_column = existing_bbox_col if bbox_info["has_bbox_metadata"] else None
+    else:
+        bbox_covering_column = "bbox"
+
+    return query, geom_info, bbox_covering_column
 
 
 def read_spatial_to_arrow(
@@ -1962,7 +1978,7 @@ def convert_to_geoparquet(
         )
 
         if is_csv:
-            query = _convert_csv_path(
+            query, bbox_covering_column = _convert_csv_path(
                 con,
                 input_url,
                 delimiter,
@@ -1977,7 +1993,7 @@ def convert_to_geoparquet(
             )
             geometry_info = None
         else:
-            query, geometry_info = _convert_spatial_path(
+            query, geometry_info, bbox_covering_column = _convert_spatial_path(
                 con,
                 input_url,
                 skip_hilbert,
@@ -2034,11 +2050,22 @@ def convert_to_geoparquet(
         # from the converted data, never copied.
         preserved_kv = read_preserved_kv_metadata(input_file, verbose) if is_parquet else {}
 
+        # A covering is declared only for a column this conversion computed, or
+        # one the input's metadata already declared -- never inferred from a
+        # column name by the writer. strip_unsupported_covering drops the key
+        # for 1.0 output, and 2.0/parquet-geo-only carry no bbox column at all.
+        custom_metadata = (
+            {"covering": {"bbox": build_bbox_covering(bbox_covering_column)}}
+            if has_geometry and bbox_covering_column
+            else None
+        )
+
         write_parquet_with_metadata(
             con,
             query,
             output_file,
             original_metadata=None,
+            custom_metadata=custom_metadata,
             extra_kv_metadata=preserved_kv or None,
             compression=compression,
             compression_level=compression_level,

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -91,6 +91,40 @@ def _escape_sql_string(value: str) -> str:
     return value.replace("'", "''")
 
 
+def validate_compression_level(value: int) -> int:
+    """Validate a compression level before interpolating it into SQL.
+
+    ``COMPRESSION_LEVEL`` takes no parameter binding, so the value is formatted
+    straight into the ``COPY … (…)`` option list. The CLI constrains it with
+    ``click.IntRange(1, 22)``, but ``write_parquet_with_metadata`` and the write
+    strategies are public entry points that a Python caller reaches directly,
+    where nothing has checked it. DuckDB's ``execute`` runs multi-statement
+    strings, so an unvalidated value is an injection surface as well as a
+    confusing error.
+
+    ``bool`` is rejected explicitly: it is an ``int`` subclass, and
+    ``COMPRESSION_LEVEL True`` is not something a caller meant.
+
+    Args:
+        value: Candidate ZSTD compression level.
+
+    Returns:
+        The level as an ``int``.
+
+    Raises:
+        ValueError: If the value is not an integer in DuckDB's 1-22 range.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"Invalid compression_level {value!r}; expected an integer between 1 and 22."
+        )
+    if not 1 <= value <= 22:
+        raise ValueError(
+            f"Invalid compression_level {value}; expected an integer between 1 and 22."
+        )
+    return value
+
+
 def quote_identifier(name: str) -> str:
     """
     Quote a SQL identifier for safe use in DuckDB queries.

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -371,6 +371,27 @@ def _covering_column(covering_entry) -> str | None:
     return None
 
 
+def geo_metadata_declares_covering(metadata: dict | None) -> bool:
+    """True when KV ``metadata``'s geo block declares a ``covering`` on any column.
+
+    Used to decide whether a write that would otherwise skip the metadata
+    rewrite has to perform one anyway: the fast path lets DuckDB regenerate the
+    ``geo`` key, which would drop a covering the input carried.
+    """
+    if not metadata:
+        return False
+    for geo_key in ("geo", b"geo"):
+        if geo_key not in metadata:
+            continue
+        geo_dict = _decode_geo_value(metadata[geo_key])
+        if not geo_dict:
+            continue
+        for col_meta in (geo_dict.get("columns") or {}).values():
+            if isinstance(col_meta, dict) and col_meta.get("covering"):
+                return True
+    return False
+
+
 def _prune_coverings(col_meta, columns: set[str]) -> None:
     """Drop ``covering`` entries pointing at columns not in ``columns``."""
     covering = col_meta.get("covering") if isinstance(col_meta, dict) else None
@@ -752,15 +773,26 @@ def _detect_version_from_table(table: pa.Table, verbose: bool = False) -> str | 
         return None
 
 
-def _detect_bbox_column_from_table(table: pa.Table, verbose: bool = False) -> str | None:
-    """
-    Detect bbox struct column from Arrow table schema.
+# Column-name suffixes that conventionally denote a bbox covering column, and
+# the struct fields such a column must expose to be one (GeoParquet
+# "Bounding Box Columns").
+_BBOX_COLUMN_SUFFIXES = ("bbox", "bounds", "extent")
+_BBOX_STRUCT_FIELDS = frozenset({"xmin", "ymin", "xmax", "ymax"})
 
-    Looks for columns with conventional names (bbox, bounds, extent) that have
-    the required struct fields (xmin, ymin, xmax, ymax).
+
+def detect_bbox_column_from_schema(schema: pa.Schema, verbose: bool = False) -> str | None:
+    """
+    Detect a bbox covering column in an Arrow schema.
+
+    Looks for columns with conventional names (bbox, bounds, extent) that are
+    structs carrying the required xmin/ymin/xmax/ymax fields.
+
+    This is the single detector every writer and every "does this output need a
+    covering?" decision shares, so the decision to write a ``covering`` entry
+    and the entry itself can never disagree.
 
     Args:
-        table: PyArrow Table to check
+        schema: PyArrow Schema to check
         verbose: Whether to print verbose output
 
     Returns:
@@ -768,27 +800,22 @@ def _detect_bbox_column_from_table(table: pa.Table, verbose: bool = False) -> st
     """
     import pyarrow as pa
 
-    conventional_suffixes = ["bbox", "bounds", "extent"]
-    required_fields = {"xmin", "ymin", "xmax", "ymax"}
-
-    for field in table.schema:
-        name = field.name
-        field_type = field.type
-
-        # Check if column name ends with conventional suffixes
-        is_bbox_name = any(name.endswith(suffix) for suffix in conventional_suffixes)
-        if not is_bbox_name:
+    for field in schema:
+        if not field.name.endswith(_BBOX_COLUMN_SUFFIXES):
             continue
-
-        # Check if it's a struct with the required fields
-        if pa.types.is_struct(field_type):
-            struct_field_names = {f.name for f in field_type}
-            if required_fields.issubset(struct_field_names):
-                if verbose:
-                    debug(f"Found bbox column in table: {name}")
-                return name
+        if not pa.types.is_struct(field.type):
+            continue
+        if _BBOX_STRUCT_FIELDS.issubset({f.name for f in field.type}):
+            if verbose:
+                debug(f"Found bbox column in table: {field.name}")
+            return field.name
 
     return None
+
+
+def _detect_bbox_column_from_table(table: pa.Table, verbose: bool = False) -> str | None:
+    """Detect bbox struct column from an Arrow table's schema."""
+    return detect_bbox_column_from_schema(table.schema, verbose)
 
 
 # =============================================================================

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -767,6 +767,18 @@ _BBOX_COLUMN_SUFFIXES = ("_bbox",)
 _BBOX_STRUCT_FIELDS = frozenset({"xmin", "ymin", "xmax", "ymax"})
 
 
+def build_bbox_covering(column: str) -> dict:
+    """The ``covering.bbox`` entry describing ``column``'s four struct fields.
+
+    One constructor so every writer emits the same shape. Callers must only use
+    it for a column whose values are known to bound the geometry -- one gpio
+    computed in this write, or one the input's own metadata already declared.
+    A covering derived from a column *name* asserts a relationship nothing
+    checked, and readers prune on it (#738).
+    """
+    return {axis: [column, axis] for axis in ("xmin", "ymin", "xmax", "ymax")}
+
+
 def _is_bbox_column_name(name: str) -> bool:
     """Whether ``name`` conventionally denotes a bbox covering column."""
     return name in _BBOX_COLUMN_NAMES or name.endswith(_BBOX_COLUMN_SUFFIXES)

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -371,27 +371,6 @@ def _covering_column(covering_entry) -> str | None:
     return None
 
 
-def geo_metadata_declares_covering(metadata: dict | None) -> bool:
-    """True when KV ``metadata``'s geo block declares a ``covering`` on any column.
-
-    Used to decide whether a write that would otherwise skip the metadata
-    rewrite has to perform one anyway: the fast path lets DuckDB regenerate the
-    ``geo`` key, which would drop a covering the input carried.
-    """
-    if not metadata:
-        return False
-    for geo_key in ("geo", b"geo"):
-        if geo_key not in metadata:
-            continue
-        geo_dict = _decode_geo_value(metadata[geo_key])
-        if not geo_dict:
-            continue
-        for col_meta in (geo_dict.get("columns") or {}).values():
-            if isinstance(col_meta, dict) and col_meta.get("covering"):
-                return True
-    return False
-
-
 def _prune_coverings(col_meta, columns: set[str]) -> None:
     """Drop ``covering`` entries pointing at columns not in ``columns``."""
     covering = col_meta.get("covering") if isinstance(col_meta, dict) else None
@@ -773,23 +752,42 @@ def _detect_version_from_table(table: pa.Table, verbose: bool = False) -> str | 
         return None
 
 
-# Column-name suffixes that conventionally denote a bbox covering column, and
-# the struct fields such a column must expose to be one (GeoParquet
-# "Bounding Box Columns").
-_BBOX_COLUMN_SUFFIXES = ("bbox", "bounds", "extent")
+# What makes a column a bbox covering column: a conventional name, and the
+# struct fields GeoParquet's "Bounding Box Columns" requires.
+#
+# The name rule is deliberately conservative — exact `bbox`/`bounds`/`extent`,
+# or an explicit `_bbox` suffix. A bare `endswith(("bbox","bounds","extent"))`
+# also swallows unrelated columns like `tile_bounds` or `parcel_extent`, and a
+# `covering` is an assertion that those values bound the geometry. gpio cannot
+# verify that from a name, and a covering pointing at unrelated values makes
+# readers prune away rows that genuinely match — strictly worse than declaring
+# nothing (#738).
+_BBOX_COLUMN_NAMES = frozenset({"bbox", "bounds", "extent"})
+_BBOX_COLUMN_SUFFIXES = ("_bbox",)
 _BBOX_STRUCT_FIELDS = frozenset({"xmin", "ymin", "xmax", "ymax"})
+
+
+def _is_bbox_column_name(name: str) -> bool:
+    """Whether ``name`` conventionally denotes a bbox covering column."""
+    return name in _BBOX_COLUMN_NAMES or name.endswith(_BBOX_COLUMN_SUFFIXES)
 
 
 def detect_bbox_column_from_schema(schema: pa.Schema, verbose: bool = False) -> str | None:
     """
     Detect a bbox covering column in an Arrow schema.
 
-    Looks for columns with conventional names (bbox, bounds, extent) that are
-    structs carrying the required xmin/ymin/xmax/ymax fields.
+    Looks for a column with a conventional name (see ``_is_bbox_column_name``)
+    that is a struct carrying the required xmin/ymin/xmax/ymax fields.
 
-    This is the single detector every writer and every "does this output need a
-    covering?" decision shares, so the decision to write a ``covering`` entry
-    and the entry itself can never disagree.
+    Shared by every writer so that where a covering *is* written, the entry and
+    the column it names cannot disagree. It is deliberately not used to decide
+    *whether* to declare a covering: that requires knowing the values bound the
+    geometry, which only the input's own metadata or a gpio-computed column can
+    establish.
+
+    When several columns qualify, an exact ``bbox`` wins — it is the name gpio
+    itself writes, so preferring it avoids picking some other file's
+    ``centroid_bbox`` over the geometry's real envelope.
 
     Args:
         schema: PyArrow Schema to check
@@ -800,21 +798,30 @@ def detect_bbox_column_from_schema(schema: pa.Schema, verbose: bool = False) -> 
     """
     import pyarrow as pa
 
-    for field in schema:
-        if not field.name.endswith(_BBOX_COLUMN_SUFFIXES):
-            continue
-        if not pa.types.is_struct(field.type):
-            continue
-        if _BBOX_STRUCT_FIELDS.issubset({f.name for f in field.type}):
-            if verbose:
-                debug(f"Found bbox column in table: {field.name}")
-            return field.name
+    matches = [
+        field.name
+        for field in schema
+        if _is_bbox_column_name(field.name)
+        and pa.types.is_struct(field.type)
+        and _BBOX_STRUCT_FIELDS.issubset({f.name for f in field.type})
+    ]
+    if not matches:
+        return None
 
-    return None
+    name = "bbox" if "bbox" in matches else matches[0]
+    if verbose:
+        debug(f"Found bbox column in table: {name}")
+    return name
 
 
-def _detect_bbox_column_from_table(table: pa.Table, verbose: bool = False) -> str | None:
-    """Detect bbox struct column from an Arrow table's schema."""
+def _detect_bbox_column_by_convention(table: pa.Table, verbose: bool = False) -> str | None:
+    """Detect a bbox struct column from an Arrow table's schema, by name convention only.
+
+    Distinct from ``common._detect_bbox_column_from_table``, which consults the
+    table's ``covering`` metadata first and only falls back to the convention.
+    The two answer different questions and used to share a name, which is a
+    trap when both are imported from sibling modules.
+    """
     return detect_bbox_column_from_schema(table.schema, verbose)
 
 
@@ -1132,7 +1139,7 @@ def _apply_geoparquet_metadata(
         return table
 
     # Detect bbox column from table schema
-    bbox_column = _detect_bbox_column_from_table(table, verbose)
+    bbox_column = _detect_bbox_column_by_convention(table, verbose)
     bbox_info = {
         "has_bbox_column": bbox_column is not None,
         "bbox_column_name": bbox_column,

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 
 from geoparquet_io.core.common import (
     add_bbox,
+    extract_version_from_metadata,
     get_bbox_advice,
     get_dataset_bounds,
     get_parquet_metadata,
@@ -44,26 +45,37 @@ def _resolve_output_version(
     input_parquet: str,
     geoparquet_version: str | None,
     verbose: bool,
-) -> str:
-    """The GeoParquet version this run will actually write.
+    profile: str | None = None,
+) -> str | None:
+    """The GeoParquet version this run will actually write, or None if unknowable.
 
-    Mirrors ``write_parquet_with_metadata``: an explicit version wins, auto mode
-    preserves the input's version, and anything unreadable falls back to the
-    default. Guessing "1.1" for auto mode instead told users sorting a 2.0 file
-    to "consider --geoparquet-version 2.0" -- noise that hides real gaps (#738).
+    Mirrors ``write_parquet_with_metadata``: an explicit version wins, and auto
+    mode preserves the input's version. Guessing "1.1" for auto mode instead
+    told users sorting a 2.0 file to "consider --geoparquet-version 2.0" --
+    noise that hides real gaps (#738).
+
+    Returns None rather than a default when the version cannot be established:
+    a stdin stream (whose version the writer resolves from the stream's own
+    metadata, not from anything visible here) or an input that will not open.
+    Callers use None to stay silent. Defaulting instead is what produced the
+    original wrong warning -- a failed read is not evidence of a 1.1 input.
     """
     if geoparquet_version:
         return geoparquet_version
     if is_stdin(input_parquet):
-        return DEFAULT_GEOPARQUET_VERSION
+        return None
 
-    from geoparquet_io.core.common import extract_version_from_metadata
+    # Authenticate before probing: the probe reads the input, and without the
+    # profile a remote read fails, which previously degraded to "1.1" and
+    # printed the very warning this function exists to suppress.
+    if profile:
+        setup_aws_profile_if_needed(profile, input_parquet, None)
 
     try:
         metadata, _ = get_parquet_metadata(input_parquet, verbose)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - any read failure means "stay quiet"
         debug(f"Could not read {input_parquet} to resolve output version: {e}")
-        return DEFAULT_GEOPARQUET_VERSION
+        return None
     return extract_version_from_metadata(metadata) or DEFAULT_GEOPARQUET_VERSION
 
 
@@ -263,7 +275,7 @@ def hilbert_order(
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
         memory_limit: DuckDB memory limit for streaming writes (e.g., '2GB', '512MB')
     """
-    effective_version = _resolve_output_version(input_parquet, geoparquet_version, verbose)
+    effective_version = _resolve_output_version(input_parquet, geoparquet_version, verbose, profile)
     if effective_version == "1.1":
         warn(
             "Hilbert sorting to GeoParquet v1.1 provides no spatial filter pushdown benefit. "
@@ -480,7 +492,12 @@ def _hilbert_order_file_based(
     show_remote_read_message(working_parquet, verbose)
 
     safe_url = safe_file_url(working_parquet, verbose)
-    metadata, _ = get_parquet_metadata(input_parquet, verbose)
+    # Read the metadata of the file the query actually reads. With --add-bbox
+    # that is the working copy, whose `geo` block `add_bbox` just extended with
+    # the `covering` describing the column it wrote. Reading the *original*
+    # input here threw that covering away before the write could carry it, so
+    # the output shipped a bbox column nothing declared (#738).
+    metadata, _ = get_parquet_metadata(working_parquet, verbose)
 
     if geometry_column == "geometry":
         geometry_column = find_primary_geometry_column(working_parquet, verbose)

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -40,6 +40,33 @@ from geoparquet_io.core.streaming import (
 )
 
 
+def _resolve_output_version(
+    input_parquet: str,
+    geoparquet_version: str | None,
+    verbose: bool,
+) -> str:
+    """The GeoParquet version this run will actually write.
+
+    Mirrors ``write_parquet_with_metadata``: an explicit version wins, auto mode
+    preserves the input's version, and anything unreadable falls back to the
+    default. Guessing "1.1" for auto mode instead told users sorting a 2.0 file
+    to "consider --geoparquet-version 2.0" -- noise that hides real gaps (#738).
+    """
+    if geoparquet_version:
+        return geoparquet_version
+    if is_stdin(input_parquet):
+        return DEFAULT_GEOPARQUET_VERSION
+
+    from geoparquet_io.core.common import extract_version_from_metadata
+
+    try:
+        metadata, _ = get_parquet_metadata(input_parquet, verbose)
+    except Exception as e:
+        debug(f"Could not read {input_parquet} to resolve output version: {e}")
+        return DEFAULT_GEOPARQUET_VERSION
+    return extract_version_from_metadata(metadata) or DEFAULT_GEOPARQUET_VERSION
+
+
 def hilbert_order_table(
     table: pa.Table,
     geometry_column: str | None = None,
@@ -236,7 +263,7 @@ def hilbert_order(
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
         memory_limit: DuckDB memory limit for streaming writes (e.g., '2GB', '512MB')
     """
-    effective_version = geoparquet_version or DEFAULT_GEOPARQUET_VERSION
+    effective_version = _resolve_output_version(input_parquet, geoparquet_version, verbose)
     if effective_version == "1.1":
         warn(
             "Hilbert sorting to GeoParquet v1.1 provides no spatial filter pushdown benefit. "

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -3584,8 +3584,14 @@ def _run_geoparquet_checks(
 
     # Version-specific checks
     # GeoParquet 1.1 checks - covering was removed in 2.0, so only run for 1.x
-    is_v1_1 = _version_at_least(geo_version, 1, 1) and not _version_at_least(geo_version, 2, 0)
-    if is_v1_1:
+    # `covering` was introduced in 1.1 and is not part of the 2.0 spec text, but
+    # 2.0 readers must tolerate unknown fields -- so a 2.0 file may still carry
+    # one. Where it does, it has to be *correct*: a covering naming a column that
+    # does not exist makes readers prune away rows that genuinely match. Gating
+    # these checks at "1.1 only" meant gpio validated coverings at 1.1 and
+    # skipped the identical defect at 2.0 (#738).
+    covering_checks_apply = _version_at_least(geo_version, 1, 1)
+    if covering_checks_apply:
         for col_name, col_meta in columns.items():
             checks.append(_check_covering_is_object(col_meta, col_name))
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -665,7 +665,7 @@ def _check_version_known(geo_meta: dict) -> ValidationCheck:
 
 
 def _columns_declaring_covering(geo_meta: dict) -> list[str]:
-    """Names of geometry columns whose metadata declares the 1.1-only 'covering' key."""
+    """Names of geometry columns whose metadata declares the 'covering' key (added in 1.1)."""
     return sorted(
         name
         for name, col in (geo_meta.get("columns") or {}).items()

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -92,10 +92,22 @@ def build_geo_metadata(
     # value carried from the source) when the output is the spec default.
     apply_output_crs(col_meta, input_crs)
 
-    # Merge custom metadata into geometry column
+    # Merge custom metadata into geometry column.
+    #
+    # `covering` is merged one entry deep rather than replaced: it holds one
+    # entry per covering kind (bbox, h3, s2, a5, quadkey), and callers supply
+    # only the one they just produced. Replacing the dict made `gpio sort
+    # quadkey` destroy the bbox covering its input declared while adding its own
+    # (#738). Individual entries still win, so a caller can correct one.
     if custom_metadata:
         for key, value in custom_metadata.items():
-            col_meta[key] = value
+            if key == "covering" and isinstance(value, dict):
+                existing = col_meta.get("covering")
+                col_meta["covering"] = (
+                    {**existing, **value} if isinstance(existing, dict) else dict(value)
+                )
+            else:
+                col_meta[key] = value
 
     # Handle secondary geometry columns from geometry_info
     if geometry_info:

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -22,7 +22,11 @@ from typing import TYPE_CHECKING
 
 import pyarrow.parquet as pq
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    quote_identifier,
+    validate_compression_level,
+)
 from geoparquet_io.core.logging_config import configure_verbose, debug, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy, build_geo_metadata
 from geoparquet_io.core.write_strategies.row_group_sizing import _resolve_row_group_rows
@@ -174,7 +178,7 @@ def _build_copy_options(
     # --compression-level and fell back to DuckDB's ZSTD default of 3 against
     # gpio's default of 15 -- ~15% larger output on every write through here.
     if compression_level is not None and compression.upper() == "ZSTD":
-        options.append(f"COMPRESSION_LEVEL {compression_level}")
+        options.append(f"COMPRESSION_LEVEL {validate_compression_level(compression_level)}")
     kv_pairs = {}
     if geo_meta_escaped:
         kv_pairs["geo"] = geo_meta_escaped
@@ -362,6 +366,58 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             debug(f"DuckDB memory limit: {effective_limit}")
         return saved
 
+    #: The only column name a writer will treat as self-evidently the geometry's
+    #: bounding box. `covering` asserts that a column's values bound the
+    #: geometry, and a name is weak evidence -- but `bbox`, as a struct of
+    #: xmin/ymin/xmax/ymax, is the universal GeoParquet convention and is what
+    #: every 1.0-era writer emitted before `covering` existed. Broader matching
+    #: (`bounds`, `extent`, `*_bbox`) let an unrelated `tile_bounds` column
+    #: become the declared covering, so readers pruned away rows that genuinely
+    #: matched; those names now require explicit provenance (#738).
+    _SELF_EVIDENT_BBOX_COLUMN = "bbox"
+
+    def _declare_carried_bbox_column(
+        self,
+        con: duckdb.DuckDBPyConnection,
+        query: str,
+        col_meta: dict,
+        verbose: bool,
+        geoparquet_version: str,
+    ) -> None:
+        """Declare a conventional ``bbox`` column the output carries but nothing declared.
+
+        This is the 1.0 -> 1.1 upgrade path: a 1.0 file cannot declare a
+        covering, so its bbox column arrives undeclared and would otherwise stay
+        that way forever. Callers that *computed* a bbox column, or read a
+        covering from the input, supply it through ``custom_metadata`` instead
+        and never reach the branch below.
+        """
+        import pyarrow as pa
+
+        from geoparquet_io.core.geo_metadata import build_bbox_covering, covering_supported
+
+        if not covering_supported(geoparquet_version):
+            if verbose:
+                debug(f"Skipping 1.1-only covering metadata for version {geoparquet_version}")
+            return
+        # Never override a covering that arrived with provenance.
+        if isinstance(col_meta.get("covering"), dict) and "bbox" in col_meta["covering"]:
+            return
+
+        name = self._SELF_EVIDENT_BBOX_COLUMN
+        schema = con.execute(f"SELECT * FROM ({query}) LIMIT 0").arrow().schema
+        if name not in schema.names:
+            return
+        field = schema.field(name)
+        if not pa.types.is_struct(field.type):
+            return
+        if not {"xmin", "ymin", "xmax", "ymax"}.issubset({f.name for f in field.type}):
+            return
+
+        col_meta.setdefault("covering", {})["bbox"] = build_bbox_covering(name)
+        if verbose:
+            debug(f"Declared the carried conventional bbox column '{name}'")
+
     def _get_local_path(self, output_path: str, is_remote: bool) -> str:
         """Get local path for writing (temp file if remote)."""
         if is_remote:
@@ -439,7 +495,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
 
         col_meta = geo_meta["columns"][geometry_column]
         self._compute_missing_metadata(con, query, geometry_column, col_meta, verbose)
-        self._add_bbox_covering_if_present(con, query, col_meta, verbose, geoparquet_version)
+        self._declare_carried_bbox_column(con, query, col_meta, verbose, geoparquet_version)
 
         # For v1.x: Cast to BLOB so DuckDB writes plain binary WKB.
         # For v2.0: Keep native GEOMETRY type with CRS — DuckDB writes native
@@ -498,52 +554,6 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             col_meta["bbox"] = bbox
         if need_types:
             col_meta["geometry_types"] = geometry_types
-
-    def _add_bbox_covering_if_present(
-        self,
-        con: duckdb.DuckDBPyConnection,
-        query: str,
-        col_meta: dict,
-        verbose: bool,
-        geoparquet_version: str,
-    ) -> None:
-        """Add bbox covering metadata if a bbox column is present and the version allows it.
-
-        The bbox column is still written for 1.0 — only the 'covering' key is 1.1+.
-        """
-        from geoparquet_io.core.geo_metadata import (
-            covering_supported,
-            detect_bbox_column_from_schema,
-        )
-
-        if not covering_supported(geoparquet_version):
-            if verbose:
-                debug(f"Skipping 1.1-only covering metadata for version {geoparquet_version}")
-            return
-
-        schema_result = con.execute(f"SELECT * FROM ({query}) LIMIT 0").arrow()
-        bbox_col_name = detect_bbox_column_from_schema(schema_result.schema, verbose)
-
-        if bbox_col_name:
-            # Merge, never replace: `covering` also carries non-bbox entries
-            # (h3/s2/a5/quadkey), and assigning a fresh dict destroyed an h3
-            # covering the input declared. Do not overwrite an existing `bbox`
-            # entry either -- one carried in or supplied through custom_metadata
-            # came from something that could vouch for it, unlike this
-            # name-based detection.
-            covering = col_meta.setdefault("covering", {})
-            if "bbox" in covering:
-                if verbose:
-                    debug(f"Keeping the bbox covering already declared for '{bbox_col_name}'")
-                return
-            covering["bbox"] = {
-                "xmin": [bbox_col_name, "xmin"],
-                "ymin": [bbox_col_name, "ymin"],
-                "xmax": [bbox_col_name, "xmax"],
-                "ymax": [bbox_col_name, "ymax"],
-            }
-            if verbose:
-                debug(f"Added bbox covering metadata for column '{bbox_col_name}'")
 
     def write_from_table(
         self,

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -155,13 +155,12 @@ def _wrap_query_with_crs(
     return _common_wrap_query_with_crs(query, geometry_column, input_crs)
 
 
-
-
 def _build_copy_options(
     compression: str,
     row_group_rows: int | None,
     geo_meta_escaped: str | None = None,
     extra_kv_metadata: dict[str, str] | None = None,
+    compression_level: int | None = None,
 ) -> list[str]:
     """Build COPY TO options list."""
     options = [
@@ -169,6 +168,13 @@ def _build_copy_options(
         f"COMPRESSION {compression}",
         "GEOPARQUET_VERSION 'NONE'",
     ]
+    # DuckDB accepts COMPRESSION_LEVEL for ZSTD only ("Compression level is only
+    # supported for the ZSTD compression codec"); naming any other codec with a
+    # level is a binder error. Omitting it entirely silently dropped the user's
+    # --compression-level and fell back to DuckDB's ZSTD default of 3 against
+    # gpio's default of 15 -- ~15% larger output on every write through here.
+    if compression_level is not None and compression.upper() == "ZSTD":
+        options.append(f"COMPRESSION_LEVEL {compression_level}")
     kv_pairs = {}
     if geo_meta_escaped:
         kv_pairs["geo"] = geo_meta_escaped
@@ -241,7 +247,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             )
             return
 
-        self._configure_duckdb_memory(con, memory_limit, verbose)
+        saved_settings = self._configure_duckdb_memory(con, memory_limit, verbose)
 
         is_remote = is_remote_url(output_path)
         local_path = self._get_local_path(output_path, is_remote)
@@ -284,16 +290,63 @@ class DuckDBKVStrategy(BaseWriteStrategy):
                 upload_if_remote(local_path, output_path, is_directory=False, verbose=verbose)
 
         finally:
+            self._restore_duckdb_settings(con, saved_settings, verbose)
             if is_remote and Path(local_path).exists():
                 Path(local_path).unlink()
+
+    #: Session settings this strategy overrides for the duration of one write.
+    _MANAGED_SETTINGS = ("threads", "preserve_insertion_order", "memory_limit")
+
+    def _restore_duckdb_settings(
+        self,
+        con: duckdb.DuckDBPyConnection,
+        saved: dict[str, object],
+        verbose: bool,
+    ) -> None:
+        """Put back the session settings this strategy clamped.
+
+        The connection belongs to the caller, not to this write. Leaving
+        threads=1 and a halved memory_limit behind meant one write pinned every
+        later query on that connection -- partition loops finalize N files on a
+        shared connection, so the first partition throttled the whole run, and
+        the Python API holds a connection across operations.
+        """
+        for key, value in saved.items():
+            try:
+                if isinstance(value, str):
+                    con.execute(f"SET {key} = '{_escape_sql_string(value)}'")
+                else:
+                    con.execute(f"SET {key} = {value}")
+                # DuckDB reports sizes as rounded display strings ("14.3 GiB"),
+                # so writing one back can land a hair off and drift further on
+                # every write in a partition loop. A value that will not
+                # round-trip was the engine's own default, so ask for that
+                # instead of an approximation of it.
+                if con.execute(f"SELECT current_setting('{key}')").fetchone()[0] != value:
+                    con.execute(f"RESET {key}")
+            except duckdb.Error as e:  # pragma: no cover - defensive
+                if verbose:
+                    debug(f"Could not restore DuckDB setting {key}: {e}")
 
     def _configure_duckdb_memory(
         self,
         con: duckdb.DuckDBPyConnection,
         memory_limit: str | None,
         verbose: bool,
-    ) -> None:
-        """Configure DuckDB memory settings for streaming."""
+    ) -> dict[str, object]:
+        """Configure DuckDB memory settings for streaming.
+
+        Returns the prior values so the caller can restore them; see
+        ``_restore_duckdb_settings``.
+        """
+        saved: dict[str, object] = {}
+        for key in self._MANAGED_SETTINGS:
+            try:
+                saved[key] = con.execute(f"SELECT current_setting('{key}')").fetchone()[0]
+            except duckdb.Error as e:  # pragma: no cover - defensive
+                if verbose:
+                    debug(f"Could not read DuckDB setting {key}: {e}")
+
         con.execute("SET threads = 1")  # Required for memory control (DuckDB #8270)
         # Let COPY TO parquet flush row groups to disk instead of buffering the
         # entire result to preserve order. Without this the writer holds the whole
@@ -307,6 +360,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         con.execute(f"SET memory_limit = '{effective_limit}'")
         if verbose:
             debug(f"DuckDB memory limit: {effective_limit}")
+        return saved
 
     def _get_local_path(self, output_path: str, is_remote: bool) -> str:
         """Get local path for writing (temp file if remote)."""
@@ -341,7 +395,10 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         escaped_path = _escape_sql_string(local_path)
 
         copy_options = _build_copy_options(
-            compression, row_group_rows, extra_kv_metadata=extra_kv_metadata
+            compression,
+            row_group_rows,
+            extra_kv_metadata=extra_kv_metadata,
+            compression_level=compression_level,
         )
         copy_query = f"COPY ({final_query}) TO '{escaped_path}' ({', '.join(copy_options)})"
         con.execute(copy_query)
@@ -396,7 +453,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         geo_meta_escaped = _escape_sql_string(json.dumps(geo_meta))
 
         copy_options = _build_copy_options(
-            compression, row_group_rows, geo_meta_escaped, extra_kv_metadata
+            compression, row_group_rows, geo_meta_escaped, extra_kv_metadata, compression_level
         )
         copy_query = f"COPY ({final_query}) TO '{escaped_path}' ({', '.join(copy_options)})"
 

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -155,12 +155,6 @@ def _wrap_query_with_crs(
     return _common_wrap_query_with_crs(query, geometry_column, input_crs)
 
 
-def _detect_bbox_column_name(schema_names: list[str]) -> str | None:
-    """Detect bbox column name from schema using common naming conventions."""
-    for name in schema_names:
-        if name in ["bbox", "bounds", "extent"] or name.endswith("_bbox"):
-            return name
-    return None
 
 
 def _build_copy_options(
@@ -460,7 +454,10 @@ class DuckDBKVStrategy(BaseWriteStrategy):
 
         The bbox column is still written for 1.0 — only the 'covering' key is 1.1+.
         """
-        from geoparquet_io.core.geo_metadata import covering_supported
+        from geoparquet_io.core.geo_metadata import (
+            covering_supported,
+            detect_bbox_column_from_schema,
+        )
 
         if not covering_supported(geoparquet_version):
             if verbose:
@@ -468,7 +465,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             return
 
         schema_result = con.execute(f"SELECT * FROM ({query}) LIMIT 0").arrow()
-        bbox_col_name = _detect_bbox_column_name(schema_result.schema.names)
+        bbox_col_name = detect_bbox_column_from_schema(schema_result.schema, verbose)
 
         if bbox_col_name:
             col_meta["covering"] = {

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -525,13 +525,22 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         bbox_col_name = detect_bbox_column_from_schema(schema_result.schema, verbose)
 
         if bbox_col_name:
-            col_meta["covering"] = {
-                "bbox": {
-                    "xmin": [bbox_col_name, "xmin"],
-                    "ymin": [bbox_col_name, "ymin"],
-                    "xmax": [bbox_col_name, "xmax"],
-                    "ymax": [bbox_col_name, "ymax"],
-                }
+            # Merge, never replace: `covering` also carries non-bbox entries
+            # (h3/s2/a5/quadkey), and assigning a fresh dict destroyed an h3
+            # covering the input declared. Do not overwrite an existing `bbox`
+            # entry either -- one carried in or supplied through custom_metadata
+            # came from something that could vouch for it, unlike this
+            # name-based detection.
+            covering = col_meta.setdefault("covering", {})
+            if "bbox" in covering:
+                if verbose:
+                    debug(f"Keeping the bbox covering already declared for '{bbox_col_name}'")
+                return
+            covering["bbox"] = {
+                "xmin": [bbox_col_name, "xmin"],
+                "ymin": [bbox_col_name, "ymin"],
+                "xmax": [bbox_col_name, "xmax"],
+                "ymax": [bbox_col_name, "ymax"],
             }
             if verbose:
                 debug(f"Added bbox covering metadata for column '{bbox_col_name}'")

--- a/tests/test_covering_v2.py
+++ b/tests/test_covering_v2.py
@@ -519,3 +519,62 @@ def test_a_non_bbox_covering_survives_a_write_that_adds_a_bbox_covering(tmp_path
 
     covering = _geometry_column_meta(out)["covering"]
     assert covering.get("h3") == {"column": "h3", "resolution": 9}
+
+
+def test_convert_to_1_1_declares_the_bbox_column_it_computes(tmp_path):
+    """Convert computes the bbox column itself, so it can vouch for the covering."""
+    src = _write_v2_wkb(tmp_path / "in.parquet")
+    out = tmp_path / "out.parquet"
+
+    _run("convert", "geoparquet", src, out, "--geoparquet-version", "1.1")
+
+    assert "bbox" in pq.ParquetFile(str(out)).schema_arrow.names
+    assert _geometry_column_meta(out)["covering"]["bbox"] == BBOX_COVERING
+
+
+def test_convert_to_1_1_leaves_a_preserved_undeclared_bbox_column_undeclared(tmp_path):
+    """A preserved bbox column gpio did not compute gains no covering.
+
+    Convert passes it through untouched; nothing established that its values
+    bound the geometry, so gpio does not assert that they do.
+    """
+    src = _write_v2_wkb(
+        tmp_path / "in.parquet", with_bbox_column=True, with_covering=False, bbox_name="bounds"
+    )
+    out = tmp_path / "out.parquet"
+
+    _run("convert", "geoparquet", src, out, "--geoparquet-version", "1.1")
+
+    assert "covering" not in _geometry_column_meta(out)
+
+
+@pytest.mark.parametrize("bbox_name", ["tile_bounds", "parcel_extent", "mybbox", "geom_bbox"])
+def test_only_a_column_named_bbox_is_self_evident_at_1_1(tmp_path, bbox_name):
+    """The 1.0 -> 1.1 upgrade declares a carried `bbox`, and nothing else.
+
+    `bbox` as a struct of xmin/ymin/xmax/ymax is the universal GeoParquet
+    convention and is what every 1.0-era writer emitted before `covering`
+    existed, so upgrading declares it. Any other name -- including the
+    `tile_bounds` that made readers prune away matching rows -- needs a caller
+    that can vouch for it (#738).
+    """
+    src = _write_v2_wkb(
+        tmp_path / "in.parquet",
+        with_bbox_column=True,
+        with_covering=False,
+        bbox_name=bbox_name,
+    )
+    out = tmp_path / "out.parquet"
+
+    _run("extract", "geoparquet", src, out, "--geoparquet-version", "1.1")
+
+    assert "covering" not in _geometry_column_meta(out)
+
+
+def test_a_carried_conventional_bbox_column_is_declared_at_1_1(tmp_path):
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=False)
+    out = tmp_path / "out.parquet"
+
+    _run("extract", "geoparquet", src, out, "--geoparquet-version", "1.1")
+
+    assert _geometry_column_meta(out)["covering"]["bbox"] == BBOX_COVERING

--- a/tests/test_covering_v2.py
+++ b/tests/test_covering_v2.py
@@ -157,7 +157,10 @@ def test_existing_covering_survives_v2_roundtrip(tmp_path, command):
     _run(*command, src, out)
 
     assert "bbox" in pq.ParquetFile(str(out)).schema_arrow.names
-    assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
+    # The bbox entry survives unchanged. Asserting the whole dict would pin a
+    # command's *other* coverings out of existence: `sort quadkey` legitimately
+    # adds a `quadkey` entry alongside this one.
+    assert _geometry_column_meta(out)["covering"]["bbox"] == BBOX_COVERING
 
 
 def test_undeclared_bbox_column_is_not_silently_declared_at_v2(tmp_path):
@@ -485,3 +488,34 @@ def test_fast_path_carry_declines_when_no_covering_is_declared():
         )
     }
     assert _covering_to_carry_on_fast_path(plain, "geometry", "2.0") is None
+
+
+def test_a_non_bbox_covering_survives_a_write_that_adds_a_bbox_covering(tmp_path):
+    """`covering` is a dict of entries, not just `bbox`.
+
+    Assigning a fresh dict destroyed an `h3` covering the input declared, on a
+    write that was only meant to add the `bbox` entry beside it.
+    """
+    table = _points_table()
+    table = table.append_column("bbox", _bbox_struct(table))
+    table = table.append_column("h3", pa.array(["8928308280fffff"] * table.num_rows, pa.string()))
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "crs": {"id": {"authority": "OGC", "code": "CRS84"}},
+                "covering": {"h3": {"column": "h3", "resolution": 9}},
+            }
+        },
+    }
+    src = tmp_path / "in.parquet"
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), str(src))
+    out = tmp_path / "out.parquet"
+
+    _run("extract", "geoparquet", src, out, "--geoparquet-version", "1.1")
+
+    covering = _geometry_column_meta(out)["covering"]
+    assert covering.get("h3") == {"column": "h3", "resolution": 9}

--- a/tests/test_covering_v2.py
+++ b/tests/test_covering_v2.py
@@ -1,0 +1,277 @@
+"""GeoParquet 2.0 outputs must keep their spatial access metadata.
+
+GeoParquet 2.0 gets row-group bounds for free from the native Parquet
+GEOMETRY/GEOGRAPHY geospatial statistics, and it keeps 1.1's optional ``bbox``
+covering (opengeospatial/geoparquet#302) for page-level pruning. Writes that
+took the 2.0 "no metadata rewrite needed" fast path let DuckDB regenerate the
+``geo`` key from scratch, which silently dropped the covering — a bbox column
+that costs bytes and tells readers nothing (issue #738).
+
+These tests pin both halves of the contract:
+
+- a bbox column in a 2.0 output is always described by a ``covering`` entry
+- a 2.0 output always carries native geospatial statistics
+"""
+
+from __future__ import annotations
+
+import json
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import shapely
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from tests.conftest import get_geo_metadata
+
+BBOX_COVERING = {
+    "xmin": ["bbox", "xmin"],
+    "ymin": ["bbox", "ymin"],
+    "xmax": ["bbox", "xmax"],
+    "ymax": ["bbox", "ymax"],
+}
+
+
+def _points_table(count: int = 400) -> pa.Table:
+    side = int(count**0.5)
+    pts = [shapely.Point(x / 10.0, y / 10.0) for x in range(side) for y in range(side)]
+    return pa.table(
+        {
+            "id": pa.array(range(len(pts))),
+            "geometry": pa.array([shapely.to_wkb(p) for p in pts], pa.binary()),
+        }
+    )
+
+
+def _bbox_struct(table: pa.Table) -> pa.Array:
+    geoms = [shapely.from_wkb(v.as_py()) for v in table.column("geometry")]
+    bounds = [g.bounds for g in geoms]
+    return pa.StructArray.from_arrays(
+        [
+            pa.array([b[0] for b in bounds], pa.float64()),
+            pa.array([b[1] for b in bounds], pa.float64()),
+            pa.array([b[2] for b in bounds], pa.float64()),
+            pa.array([b[3] for b in bounds], pa.float64()),
+        ],
+        names=["xmin", "ymin", "xmax", "ymax"],
+    )
+
+
+def _write_v2_wkb(path, with_bbox_column: bool = False, with_covering: bool = False) -> str:
+    """Write a WKB-encoded GeoParquet 2.0.0 file, optionally with a bbox column."""
+    table = _points_table()
+    col_meta: dict = {
+        "encoding": "WKB",
+        "geometry_types": ["Point"],
+        "crs": {"id": {"authority": "OGC", "code": "CRS84"}},
+    }
+    if with_bbox_column:
+        table = table.append_column("bbox", _bbox_struct(table))
+    if with_covering:
+        col_meta["covering"] = {"bbox": BBOX_COVERING}
+    geo = {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": col_meta}}
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode()})
+    pq.write_table(table, str(path))
+    return str(path)
+
+
+def _geometry_column_meta(path) -> dict:
+    geo = get_geo_metadata(str(path))
+    assert geo is not None, f"{path} has no geo metadata"
+    return geo["columns"][geo["primary_column"]]
+
+
+def _has_native_geo_statistics(path) -> bool:
+    """True when the geometry column chunk carries Parquet geospatial statistics."""
+    con = duckdb.connect()
+    try:
+        rows = con.execute(
+            "SELECT geo_bbox FROM parquet_metadata(?) WHERE path_in_schema = 'geometry'",
+            [str(path)],
+        ).fetchall()
+    finally:
+        con.close()
+    return bool(rows) and all(row[0] is not None for row in rows)
+
+
+def _run(*args) -> None:
+    result = CliRunner().invoke(cli, [str(a) for a in args])
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# covering is written for a bbox column the command itself adds
+# ---------------------------------------------------------------------------
+
+
+def test_sort_hilbert_add_bbox_writes_covering_at_v2(tmp_path):
+    """#738: --add-bbox on a 2.0 input must describe the bbox column it adds."""
+    src = _write_v2_wkb(tmp_path / "in.parquet")
+    out = tmp_path / "out.parquet"
+
+    _run("sort", "hilbert", src, out, "--add-bbox")
+
+    assert "bbox" in pq.ParquetFile(str(out)).schema_arrow.names
+    assert get_geo_metadata(str(out))["version"] == "2.0.0"
+    assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
+
+
+@pytest.mark.parametrize("strategy", ["duckdb-kv", "in-memory", "streaming", "disk-rewrite"])
+def test_every_write_strategy_declares_the_bbox_column_at_v2(tmp_path, strategy):
+    """The covering must survive whichever strategy actually writes the file."""
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=True)
+    out = tmp_path / "out.parquet"
+
+    _run("extract", "geoparquet", src, out, "--write-strategy", strategy)
+
+    assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
+
+
+# ---------------------------------------------------------------------------
+# covering carried on the input survives a 2.0 -> 2.0 rewrite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["sort", "hilbert"],
+        ["sort", "quadkey"],
+        ["extract", "geoparquet"],
+    ],
+)
+def test_existing_covering_survives_v2_roundtrip(tmp_path, command):
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=True)
+    out = tmp_path / "out.parquet"
+
+    _run(*command, src, out)
+
+    assert "bbox" in pq.ParquetFile(str(out)).schema_arrow.names
+    assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
+
+
+def test_bbox_column_without_covering_gains_one_at_v2(tmp_path):
+    """A 2.0 input whose bbox column is undeclared comes out declared."""
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=False)
+    out = tmp_path / "out.parquet"
+
+    _run("sort", "hilbert", src, out)
+
+    assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
+
+
+# ---------------------------------------------------------------------------
+# spatial statistics on every 2.0 output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("add_bbox", [True, False])
+def test_v2_output_has_native_geo_statistics(tmp_path, add_bbox):
+    src = _write_v2_wkb(tmp_path / "in.parquet")
+    out = tmp_path / "out.parquet"
+
+    args = ["sort", "hilbert", src, out]
+    if add_bbox:
+        args.append("--add-bbox")
+    _run(*args)
+
+    assert _has_native_geo_statistics(out)
+
+
+def test_explicit_v2_output_has_native_geo_statistics(tmp_path):
+    """A 1.1 input asked for 2.0 output gets the native types (and their stats)."""
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=True)
+    out = tmp_path / "out.parquet"
+
+    _run("sort", "hilbert", src, out, "--geoparquet-version", "2.0")
+
+    assert _has_native_geo_statistics(out)
+    assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
+
+
+# ---------------------------------------------------------------------------
+# parquet-geo-only must stay metadata-free
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_geo_only_output_gains_no_geo_metadata(tmp_path):
+    """A bbox column must not talk gpio into writing a 'geo' key for pgo output."""
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=True)
+    out = tmp_path / "out.parquet"
+
+    _run("sort", "hilbert", src, out, "--geoparquet-version", "parquet-geo-only")
+
+    metadata = pq.ParquetFile(str(out)).metadata.metadata or {}
+    assert b"geo" not in metadata
+
+
+# ---------------------------------------------------------------------------
+# auto mode must not advise a version the output already has
+# ---------------------------------------------------------------------------
+
+
+def test_auto_mode_on_v2_input_does_not_advise_upgrading_to_v2(tmp_path):
+    """#738: the v1.1 pushdown warning fired on 2.0 output, hiding the real gap."""
+    from unittest.mock import patch
+
+    src = _write_v2_wkb(tmp_path / "in.parquet")
+    out = tmp_path / "out.parquet"
+
+    with patch("geoparquet_io.core.hilbert_order.warn") as mock_warn:
+        from geoparquet_io.core.hilbert_order import hilbert_order
+
+        hilbert_order(src, str(out), geoparquet_version=None)
+
+    assert get_geo_metadata(str(out))["version"] == "2.0.0"
+    for call in mock_warn.call_args_list:
+        assert "no spatial filter pushdown" not in str(call)
+
+
+# ---------------------------------------------------------------------------
+# `gpio check` must not fight the covering it now writes
+# ---------------------------------------------------------------------------
+
+
+def _check_bbox(path) -> dict:
+    from geoparquet_io.core.check_parquet_structure import check_metadata_and_bbox
+
+    return check_metadata_and_bbox(str(path), verbose=False, return_results=True)
+
+
+def test_check_accepts_a_declared_bbox_covering_at_v2(tmp_path):
+    """2.0 keeps the optional bbox covering, so a declared one is not a defect."""
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=True)
+
+    result = _check_bbox(src)
+
+    assert result["file_type"] == "geoparquet_v2"
+    assert result["has_bbox_column"] is True
+    assert result["passed"] is True
+    assert result["needs_bbox_removal"] is False
+    assert result["fix_available"] is False
+    assert result["issues"] == []
+
+
+def test_check_flags_an_undeclared_bbox_column_at_v2(tmp_path):
+    """The #738 shape: bytes on disk that no covering points at."""
+    src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=False)
+
+    result = _check_bbox(src)
+
+    assert result["passed"] is False
+    assert result["needs_bbox_removal"] is True
+    assert result["fix_available"] is True
+    assert "covering" in result["issues"][0]
+
+
+def test_sort_hilbert_add_bbox_output_passes_check_at_v2(tmp_path):
+    """End to end: what gpio writes, gpio accepts."""
+    src = _write_v2_wkb(tmp_path / "in.parquet")
+    out = tmp_path / "out.parquet"
+
+    _run("sort", "hilbert", src, out, "--add-bbox")
+
+    assert _check_bbox(out)["passed"] is True

--- a/tests/test_covering_v2.py
+++ b/tests/test_covering_v2.py
@@ -1,8 +1,10 @@
 """GeoParquet 2.0 outputs must keep their spatial access metadata.
 
 GeoParquet 2.0 gets row-group bounds for free from the native Parquet
-GEOMETRY/GEOGRAPHY geospatial statistics, and it keeps 1.1's optional ``bbox``
-covering (opengeospatial/geoparquet#302) for page-level pruning. Writes that
+GEOMETRY/GEOGRAPHY geospatial statistics. ``covering`` is not in the 2.0 spec
+text (introduced in 1.1, dropped in 2.0), but unknown fields are tolerated and
+opengeospatial/geoparquet#302 proposes reinstating it, so a carried covering
+stays meaningful for page-level pruning. Writes that
 took the 2.0 "no metadata rewrite needed" fast path let DuckDB regenerate the
 ``geo`` key from scratch, which silently dropped the covering — a bbox column
 that costs bytes and tells readers nothing (issue #738).
@@ -60,7 +62,12 @@ def _bbox_struct(table: pa.Table) -> pa.Array:
     )
 
 
-def _write_v2_wkb(path, with_bbox_column: bool = False, with_covering: bool = False) -> str:
+def _write_v2_wkb(
+    path,
+    with_bbox_column: bool = False,
+    with_covering: bool = False,
+    bbox_name: str = "bbox",
+) -> str:
     """Write a WKB-encoded GeoParquet 2.0.0 file, optionally with a bbox column."""
     table = _points_table()
     col_meta: dict = {
@@ -69,7 +76,7 @@ def _write_v2_wkb(path, with_bbox_column: bool = False, with_covering: bool = Fa
         "crs": {"id": {"authority": "OGC", "code": "CRS84"}},
     }
     if with_bbox_column:
-        table = table.append_column("bbox", _bbox_struct(table))
+        table = table.append_column(bbox_name, _bbox_struct(table))
     if with_covering:
         col_meta["covering"] = {"bbox": BBOX_COVERING}
     geo = {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": col_meta}}
@@ -153,14 +160,39 @@ def test_existing_covering_survives_v2_roundtrip(tmp_path, command):
     assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
 
 
-def test_bbox_column_without_covering_gains_one_at_v2(tmp_path):
-    """A 2.0 input whose bbox column is undeclared comes out declared."""
+def test_undeclared_bbox_column_is_not_silently_declared_at_v2(tmp_path):
+    """An undeclared bbox column stays undeclared -- gpio cannot vouch for it.
+
+    A ``covering`` asserts that a column's values bound the geometry. For a
+    column gpio did not compute it has no evidence of that beyond the name, and
+    a covering pointing at unrelated values makes readers prune away rows that
+    genuinely match -- strictly worse than declaring nothing. ``gpio check``
+    flags the column and points at ``gpio add bbox-metadata``, which is where a
+    user asserts the relationship deliberately (#738).
+    """
     src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=False)
     out = tmp_path / "out.parquet"
 
     _run("sort", "hilbert", src, out)
 
-    assert _geometry_column_meta(out)["covering"] == {"bbox": BBOX_COVERING}
+    assert "covering" not in _geometry_column_meta(out)
+
+
+def test_unrelated_bbox_shaped_column_never_becomes_a_covering(tmp_path):
+    """A struct column that merely looks like a bbox is not declared.
+
+    Regression test for the review finding: a ``tile_bounds`` column of zeros
+    was being declared as the geometry's covering, so a reader pruning on it
+    returned no rows at all for a query over the data's own extent.
+    """
+    src = _write_v2_wkb(
+        tmp_path / "in.parquet", with_bbox_column=True, with_covering=False, bbox_name="tile_bounds"
+    )
+    out = tmp_path / "out.parquet"
+
+    _run("extract", "geoparquet", src, out)
+
+    assert "covering" not in _geometry_column_meta(out)
 
 
 # ---------------------------------------------------------------------------
@@ -242,7 +274,7 @@ def _check_bbox(path) -> dict:
 
 
 def test_check_accepts_a_declared_bbox_covering_at_v2(tmp_path):
-    """2.0 keeps the optional bbox covering, so a declared one is not a defect."""
+    """A declared covering is not a defect at 2.0, even though 2.0 does not specify it."""
     src = _write_v2_wkb(tmp_path / "in.parquet", with_bbox_column=True, with_covering=True)
 
     result = _check_bbox(src)
@@ -275,3 +307,181 @@ def test_sort_hilbert_add_bbox_output_passes_check_at_v2(tmp_path):
     _run("sort", "hilbert", src, out, "--add-bbox")
 
     assert _check_bbox(out)["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# a covering must name a column that is really there
+# ---------------------------------------------------------------------------
+
+
+def _write_v2_with_covering_named(path, referenced_column: str, bbox_name: str = "bbox") -> str:
+    """A 2.0 file with a real bbox column whose covering names ``referenced_column``."""
+    table = _points_table()
+    table = table.append_column(bbox_name, _bbox_struct(table))
+    covering = {axis: [referenced_column, axis] for axis in ("xmin", "ymin", "xmax", "ymax")}
+    geo = {
+        "version": "2.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "crs": {"id": {"authority": "OGC", "code": "CRS84"}},
+                "covering": {"bbox": covering},
+            }
+        },
+    }
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), str(path))
+    return str(path)
+
+
+def test_check_flags_a_covering_that_names_a_missing_column(tmp_path):
+    """A dangling covering is not a declaration.
+
+    ``has_bbox_metadata`` used to mean "some structurally valid covering exists
+    somewhere", so a covering pointing at a column that is not in the file made
+    `check` pass and print a success line naming a *different* column (#738).
+    """
+    src = _write_v2_with_covering_named(tmp_path / "dangling.parquet", "ghost")
+
+    result = CliRunner().invoke(cli, ["check", "bbox", src])
+
+    assert "not declared" in result.output
+    assert "ghost" not in result.output
+
+
+def test_check_accepts_a_covering_that_names_the_real_column(tmp_path):
+    src = _write_v2_with_covering_named(tmp_path / "good.parquet", "bbox")
+
+    result = CliRunner().invoke(cli, ["check", "bbox", src])
+
+    assert "not declared" not in result.output
+
+
+def test_check_spec_validates_coverings_at_v2(tmp_path):
+    """The covering checks are gated at 1.1+, not "1.1 only".
+
+    They were skipped entirely for 2.0, so gpio validated a dangling covering
+    at 1.1 and waved the identical file through at 2.0 (#738).
+    """
+    src = _write_v2_with_covering_named(tmp_path / "dangling.parquet", "ghost")
+
+    result = CliRunner().invoke(cli, ["check", "spec", src])
+
+    assert 'bbox column "ghost" not found at schema root' in result.output
+
+
+# ---------------------------------------------------------------------------
+# a covering is never inferred from a column name alone
+# ---------------------------------------------------------------------------
+
+
+def test_non_struct_column_named_bbox_never_becomes_a_covering(tmp_path):
+    """The struct-type guard is load-bearing: a covering must point at a struct.
+
+    Exercised at 1.1, where a write still derives the covering from the output
+    schema. Without the guard gpio emits a covering whose four paths resolve to
+    a string column, i.e. to nothing a reader can prune on.
+    """
+    table = _points_table()
+    table = table.append_column("bbox", pa.array(["not-a-struct"] * table.num_rows, pa.string()))
+    geo = {
+        "version": "2.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "crs": {"id": {"authority": "OGC", "code": "CRS84"}},
+            }
+        },
+    }
+    src = tmp_path / "in.parquet"
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), str(src))
+    out = tmp_path / "out.parquet"
+
+    _run("extract", "geoparquet", src, out, "--geoparquet-version", "1.1")
+
+    assert "covering" not in _geometry_column_meta(out)
+
+
+@pytest.mark.parametrize("bbox_name", ["tile_bounds", "parcel_extent", "mybbox"])
+def test_bbox_shaped_columns_gpio_did_not_compute_stay_undeclared(tmp_path, bbox_name):
+    """Names that merely end in bbox/bounds/extent are not evidence of anything.
+
+    ``tile_bounds`` holding tile extents was being declared as the geometry's
+    covering, so a reader pruning on it dropped rows that genuinely matched.
+    """
+    src = _write_v2_wkb(
+        tmp_path / "in.parquet",
+        with_bbox_column=True,
+        with_covering=False,
+        bbox_name=bbox_name,
+    )
+    out = tmp_path / "out.parquet"
+
+    _run("extract", "geoparquet", src, out)
+
+    assert "covering" not in _geometry_column_meta(out)
+
+
+# ---------------------------------------------------------------------------
+# resolution helpers: stay silent rather than guess
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_output_version_is_silent_for_stdin():
+    """A stdin stream's version is not knowable here, so nothing is claimed.
+
+    Returning the default instead made `sort hilbert -` advise "consider
+    --geoparquet-version 2.0" while it was already writing 2.0 (#738).
+    """
+    from geoparquet_io.core.hilbert_order import _resolve_output_version
+
+    assert _resolve_output_version("-", None, verbose=False) is None
+
+
+def test_resolve_output_version_is_silent_for_an_unreadable_input(tmp_path):
+    """A failed read is not evidence of a 1.1 input."""
+    from geoparquet_io.core.hilbert_order import _resolve_output_version
+
+    assert _resolve_output_version(str(tmp_path / "nope.parquet"), None, verbose=False) is None
+
+
+def test_resolve_output_version_honours_an_explicit_version():
+    from geoparquet_io.core.hilbert_order import _resolve_output_version
+
+    assert _resolve_output_version("-", "2.0", verbose=False) == "2.0"
+
+
+def test_fast_path_carry_declines_a_geo_block_too_thin_to_stand_in(tmp_path):
+    """Carrying a block that lacks the fields DuckDB would have written is worse
+    than letting DuckDB write it, so the carry declines and the write falls back."""
+    from geoparquet_io.core.common import _covering_to_carry_on_fast_path
+
+    thin = {
+        "geo": json.dumps(
+            {
+                "version": "2.0.0",
+                "primary_column": "geometry",
+                # covering present, but no encoding/geometry_types
+                "columns": {"geometry": {"covering": {"bbox": BBOX_COVERING}}},
+            }
+        )
+    }
+    assert _covering_to_carry_on_fast_path(thin, "geometry", "2.0") is None
+
+
+def test_fast_path_carry_declines_when_no_covering_is_declared():
+    from geoparquet_io.core.common import _covering_to_carry_on_fast_path
+
+    plain = {
+        "geo": json.dumps(
+            {
+                "version": "2.0.0",
+                "primary_column": "geometry",
+                "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+            }
+        )
+    }
+    assert _covering_to_carry_on_fast_path(plain, "geometry", "2.0") is None

--- a/tests/test_metadata_bbox_invalidation.py
+++ b/tests/test_metadata_bbox_invalidation.py
@@ -152,8 +152,14 @@ def _make_mixed_types(path):
 
 
 def _make_bbox_column_file(path):
-    """Write a file with a struct ``bbox`` column so covering metadata is added."""
+    """Write a file with a struct ``bbox`` column and the covering describing it.
+
+    The covering is declared explicitly, the way production callers do: the
+    query below computes the bbox from the geometry, so this fixture can vouch
+    for it. Writers no longer infer a covering from a column's name (#738).
+    """
     from geoparquet_io.core.common import write_parquet_with_metadata
+    from geoparquet_io.core.geo_metadata import build_bbox_covering
 
     con = duckdb.connect()
     con.execute("INSTALL spatial; LOAD spatial;")
@@ -174,7 +180,13 @@ def _make_bbox_column_file(path):
         ) AS t(id, geometry)
     """
     try:
-        write_parquet_with_metadata(con, query, str(path), geoparquet_version="1.1")
+        write_parquet_with_metadata(
+            con,
+            query,
+            str(path),
+            geoparquet_version="1.1",
+            custom_metadata={"covering": {"bbox": build_bbox_covering("bbox")}},
+        )
     finally:
         con.close()
 

--- a/tests/test_performance_baseline.py
+++ b/tests/test_performance_baseline.py
@@ -266,8 +266,15 @@ class TestFileSize:
             print(f"  {version:20s}: {size:,} bytes ({size / 1024:.1f} KB)")
 
         # DuckDB 1.5+ native geometry shredding compresses v2.0/parquet-geo-only
-        # ~30% smaller than v1.x WKB blobs. Split assertions to distinguish
-        # expected cross-encoding variance from unexpected regressions.
+        # smaller than v1.x WKB blobs. Split assertions to distinguish expected
+        # cross-encoding variance from unexpected regressions.
+        #
+        # The lower bound was 10% while the duckdb-kv write path silently dropped
+        # `--compression-level`: v1.x files were written at DuckDB's ZSTD default
+        # of 3 against gpio's default of 15, so part of the measured "shredding
+        # benefit" was really v1.x being under-compressed. With the level
+        # honored on both paths the honest margin on this fixture is ~9%, so the
+        # bound is set below that rather than restored by re-inflating v1.x.
 
         # 1. Expected: v2/parquet-geo-only should be smaller than v1.x (shredding benefit)
         v1_sizes = [s for v, s in sizes.items() if v in ("1.0", "1.1")]
@@ -277,7 +284,7 @@ class TestFileSize:
             avg_v2 = sum(v2_sizes) / len(v2_sizes)
             if avg_v1 > 0:
                 improvement = (avg_v1 - avg_v2) / avg_v1
-                assert improvement > 0.10, (
+                assert improvement > 0.05, (
                     f"Expected v2 to be smaller than v1 due to geometry shredding, "
                     f"but improvement is only {improvement:.1%}"
                 )

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -988,3 +988,44 @@ class TestDuckDBKVWriteConfiguration:
         )
 
         assert snapshot() == before
+
+
+class TestCompressionLevelValidation:
+    """`COMPRESSION_LEVEL` is formatted into SQL, so the value must be checked."""
+
+    @pytest.mark.parametrize("bad", ["1; DROP TABLE t", 3.5, True, 0, 23, -1, "15", None, object()])
+    def test_rejects_values_that_are_not_a_duckdb_level(self, bad):
+        from geoparquet_io.core.duckdb_utils import validate_compression_level
+
+        with pytest.raises(ValueError):
+            validate_compression_level(bad)
+
+    @pytest.mark.parametrize("level", [1, 15, 22])
+    def test_accepts_the_documented_range(self, level):
+        from geoparquet_io.core.duckdb_utils import validate_compression_level
+
+        assert validate_compression_level(level) == level
+
+    def test_library_callers_are_checked_not_just_the_cli(self, tmp_path):
+        """The CLI has IntRange(1, 22); a Python caller reaches the writer directly."""
+        from geoparquet_io.core.common import write_parquet_with_metadata
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+        con = get_duckdb_connection()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        src = tmp_path / "src.parquet"
+        con.execute(
+            f"""COPY (SELECT ST_Point(i * 0.1, i * 0.1) AS geometry FROM range(10) t(i))
+                TO '{src}' (FORMAT PARQUET)"""
+        )
+
+        with pytest.raises(ValueError, match="compression_level"):
+            write_parquet_with_metadata(
+                con,
+                f"SELECT * FROM read_parquet('{src}')",
+                str(tmp_path / "out.parquet"),
+                geoparquet_version="1.1",
+                compression="ZSTD",
+                compression_level="1; DROP TABLE t",
+                verbose=False,
+            )

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -910,3 +910,81 @@ class TestDiskRewriteRowGroupSizing:
         sizes = self._row_group_sizes(output_file)
         assert sum(sizes) == 40
         assert len(sizes) == 4, f"expected 4 row groups of 10 rows, got {sizes}"
+
+
+class TestDuckDBKVWriteConfiguration:
+    """The duckdb-kv strategy must not silently change the write it was asked for."""
+
+    @staticmethod
+    def _points_query(con, path: str, rows: int = 60000) -> str:
+        """A compressible table on disk; returns a query selecting from it."""
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute(
+            f"""COPY (SELECT (i % 50)::VARCHAR AS cat, 'region_' || (i % 20) AS reg,
+                    ST_Point((i % 500) * 0.001, (i % 499) * 0.001) AS geometry
+                FROM range({rows}) t(i))
+                TO '{path}' (FORMAT PARQUET)"""
+        )
+        return f"SELECT * FROM read_parquet('{path}')"
+
+    def test_compression_level_reaches_the_writer(self, tmp_path):
+        """`--compression-level` must not be dropped on this path.
+
+        `_build_copy_options` never emitted COMPRESSION_LEVEL, so every write
+        through this strategy silently fell back to DuckDB's ZSTD default of 3
+        while gpio's own default is 15 — materially larger files, with no
+        indication the option had been ignored.
+        """
+        from geoparquet_io.core.common import write_parquet_with_metadata
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+        con = get_duckdb_connection()
+        query = self._points_query(con, str(tmp_path / "src.parquet"))
+
+        sizes = {}
+        for level in (1, 22):
+            out = tmp_path / f"out{level}.parquet"
+            write_parquet_with_metadata(
+                con,
+                query,
+                str(out),
+                geoparquet_version="1.1",
+                compression="ZSTD",
+                compression_level=level,
+                verbose=False,
+            )
+            sizes[level] = out.stat().st_size
+
+        assert sizes[22] < sizes[1], (
+            f"compression level ignored: level 1 = {sizes[1]}, level 22 = {sizes[22]}"
+        )
+
+    def test_session_settings_are_restored_after_a_write(self, tmp_path):
+        """The connection belongs to the caller, not to one write.
+
+        The strategy clamps threads=1, preserve_insertion_order=false and
+        memory_limit for its own COPY. Leaving them behind meant one write
+        throttled every later query on a shared connection — partition loops
+        finalize N files on one connection, and the Python API holds a
+        connection across operations.
+        """
+        from geoparquet_io.core.common import write_parquet_with_metadata
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+        con = get_duckdb_connection()
+        query = self._points_query(con, str(tmp_path / "src.parquet"), rows=500)
+
+        managed = ("threads", "preserve_insertion_order", "memory_limit")
+
+        def snapshot():
+            return {
+                key: con.execute(f"SELECT current_setting('{key}')").fetchone()[0]
+                for key in managed
+            }
+
+        before = snapshot()
+        write_parquet_with_metadata(
+            con, query, str(tmp_path / "out.parquet"), geoparquet_version="1.1", verbose=False
+        )
+
+        assert snapshot() == before


### PR DESCRIPTION
Fixes #738.

## The bug

A 2.0 write whose input was already 2.x takes the "no metadata rewrite needed" fast path, where DuckDB regenerates the `geo` key from scratch — discarding every `covering` entry. Two ways that bites:

- `gpio sort hilbert --add-bbox` on a 2.0 file writes the bbox column, prints "Output includes bbox column and metadata for optimal performance", and declares nothing. The column costs bytes and no reader can use it.
- Any 2.0→2.0 operation (`sort hilbert`, `sort quadkey`, `extract geoparquet`) silently strips a covering the input carried.

## The fix

The fast path now writes the input's own `geo` block verbatim when it declares a covering. DuckDB accepts `GEOPARQUET_VERSION 'V2'` and `KV_METADATA {'geo': …}` together — our block wins, and the native GEOMETRY logical type plus its geospatial statistics are still written. So the covering survives with **no change to write configuration**: no thread clamp, no memory clamp, no dropped `--compression-level`, no extra statistics rescan.

`--add-bbox` turned out to have a narrower root cause than "the fast path drops coverings": `hilbert_order.py` read the metadata of the *original input* while the query read the working copy that `add_bbox` had just extended with a correct covering. That line threw the covering away before the write could carry it.

## Where a `covering` may come from

A `covering` asserts that a column's values bound the geometry. Readers prune on it, so a wrong one makes them skip rows that genuinely match — worse than declaring nothing. gpio therefore declares one only where it can stand behind the claim:

- **it computed the column** from the geometry in that same statement (`add bbox`, `--add-bbox`, `convert`'s own bbox), or
- **the input's metadata already declared it** for the column being carried, or
- **the output carries a conventional `bbox` struct** of xmin/ymin/xmax/ymax — the shape every GeoParquet 1.0 writer emitted before `covering` existed, which is what lets a 1.0 → 1.1 upgrade declare it rather than leave the column dead forever.

Any other name — `bounds`, `parcel_extent`, `tile_bounds`, `geom_bbox` — is left undeclared and flagged by `gpio check`, which points at `gpio add bbox-metadata` where a user makes that assertion deliberately.

| carried column | → 1.1 | → 2.0 |
|---|---|---|
| `bbox` | declared | none |
| `tile_bounds` / `parcel_extent` / `geom_bbox` | none | none |

## Consequences for `check` and `validate`

- **`gpio check`** flagged a bbox column on a 2.0 file as an issue and offered `--fix` to delete it — it would have fought the covering this PR writes. It now accepts a *declared* covering, still flags an *undeclared* column, and `--fix`/`needs_bbox_removal` fire only for the undeclared case so a legitimate covering is never deleted. A covering now only counts as declaring the file's bbox column when it actually **names** it: a covering pointing at a missing column used to pass while the success message named a different column.
- **`gpio check spec`** ran its four covering checks at "1.1 only", so an identical dangling covering failed at 1.1 and passed at 2.0. They now run at 1.1 **and** 2.0.
- **`gpio sort hilbert`** warned "consider `--geoparquet-version 2.0`" while auto mode was already writing 2.0. It now mirrors the writer's resolution, and stays **silent** rather than guessing when the version cannot be established — a stdin stream, or an input that will not open. A failed read is not evidence of a 1.1 input.

## Fixed along the way

Each found by adversarial review of the first version of this PR:

- `_build_copy_options` never emitted `COMPRESSION_LEVEL`, so every write through the duckdb-kv strategy silently fell back to DuckDB's ZSTD default of 3 against gpio's default of 15 — measurably larger files. Both write paths now emit it, and restrict it to ZSTD, which is the only codec DuckDB accepts it for.
- The strategy clamped `threads`, `preserve_insertion_order` and `memory_limit` on the **caller's** connection and never restored them, so one write throttled every later query — partition loops finalize N files on one connection, and the Python API holds a connection across operations.
- `custom_metadata` replaced the whole `covering` dict rather than merging one entry deep, so `gpio sort quadkey` destroyed the bbox covering its input declared while adding its own.
- `compression_level` is validated (integer, 1–22) before reaching SQL. The CLI constrains it with `IntRange`, but `write_parquet_with_metadata` and the write strategies are public entry points a Python caller reaches directly.

## On the spec

`covering` is **not** in the GeoParquet 2.0 specification text — it was introduced in 1.1 and removed in 2.0 in favour of the native statistics. 2.0 readers must tolerate unknown fields, so carrying one stays legal, and [geoparquet#302](https://github.com/opengeospatial/geoparquet/pull/302) *proposes* reinstating it as an option (open at time of writing). An earlier draft of this PR asserted that as settled spec; it is not. The motivation holds either way: native statistics prune whole row groups, while a bbox column's page index also prunes pages within one.

## Tests

`tests/test_covering_v2.py` (38 tests): the `--add-bbox` case from the issue; covering survival across `sort hilbert` / `sort quadkey` / `extract geoparquet`; all four write strategies agreeing in both directions; native geospatial statistics on 2.0 output; `parquet-geo-only` gaining no `geo` key; a dangling covering rejected by both `check bbox` and `check spec`; the 1.1-vs-2.0 inference boundary; and the version-resolution helpers. Plus `TestDuckDBKVWriteConfiguration` and `TestCompressionLevelValidation` in `tests/test_write_strategies.py`.

`tests/test_performance_baseline.py`'s v1-vs-v2 size floor drops from 10% to 5%: part of the old margin was v1.x being written at ZSTD 3 by the dropped compression level, not a shredding benefit.

Fast suite 4810 passed; e2e journeys green serially; diff coverage 94% against the 90% gate; pre-commit and pre-push hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtzWuw75BJrM6mKkonfje3
