### PR TITLE
fix(geojson): stop --write-bbox and --id-field truncating every Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Fixed
 
+- **`convert geojson --write-bbox` and `--id-field` no longer truncate every Feature,** and no longer abort the whole conversion on a NULL id value or an EMPTY geometry — each member is omitted instead. ([#726](https://github.com/geoparquet/geoparquet-io/issues/726))
 - **Windows native-geo statistics: the zeros are a read, not a write.** pyarrow reads the real bounds from the same file DuckDB's `parquet_metadata()` reports as `[0, 0, 0, 0]`, so files gpio writes on Windows are correct and it is gpio's own reader that misreports them. ([#721](https://github.com/geoparquet/geoparquet-io/issues/721), [#748](https://github.com/geoparquet/geoparquet-io/issues/748))
 - **Guide examples no longer use flags the CLI does not accept.** Nonexistent options are corrected and missing option-table rows filled in. ([#735](https://github.com/geoparquet/geoparquet-io/issues/735))
 - **`tests/test_wfs.py` no longer reaches the network.** Nine tests silently made live requests; a tripwire now fails any unmocked request. ([#676](https://github.com/geoparquet/geoparquet-io/issues/676))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Fixed
 
+- **`convert geojson --write-bbox` and `--id-field` no longer truncate every Feature,** and no longer abort the whole conversion on a NULL id value or an EMPTY geometry — each member is omitted instead. ([#726](https://github.com/geoparquet/geoparquet-io/issues/726))
 - **Windows native-geo statistics: the zeros are a read, not a write.** pyarrow reads the real bounds from the same file DuckDB's `parquet_metadata()` reports as `[0, 0, 0, 0]`, so files gpio writes on Windows are correct and it is gpio's own reader that misreports them. ([#721](https://github.com/geoparquet/geoparquet-io/issues/721), [#748](https://github.com/geoparquet/geoparquet-io/issues/748))
 - **Guide examples no longer use flags the CLI does not accept.** Nonexistent options are corrected and missing option-table rows filled in. ([#735](https://github.com/geoparquet/geoparquet-io/issues/735))
 - **`tests/test_wfs.py` no longer reaches the network.** Nine tests silently made live requests; a tripwire now fails any unmocked request. ([#676](https://github.com/geoparquet/geoparquet-io/issues/676))

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -177,13 +177,15 @@ gpio convert data.parquet output.geojson --precision 5
 gpio convert data.parquet output.geojson --pretty
 ```
 
-<!-- doctest: skip="gpio convert geojson --write-bbox/--id-field crash on valid input" -->
 ```bash
 # Include bbox for each feature
 gpio convert data.parquet output.geojson --write-bbox
+```
 
+<!-- doctest: skip="uses an attribute column the sample dataset does not carry" -->
+```bash
 # Use specific field as feature ID
-gpio convert data.parquet output.geojson --id-field osm_id
+gpio convert data.parquet with-ids.geojson --id-field osm_id
 ```
 
 ### Cloud Output Support

--- a/docs/guide/geojson.md
+++ b/docs/guide/geojson.md
@@ -321,7 +321,6 @@ To write a standard GeoJSON FeatureCollection, specify an output file:
     gpio convert geojson data.parquet output.geojson
     ```
 
-    <!-- doctest: skip="gpio convert geojson --write-bbox/--id-field crash on valid input" -->
     ```bash
     # With options
     gpio convert geojson data.parquet output.geojson --precision 5 --write-bbox
@@ -329,7 +328,6 @@ To write a standard GeoJSON FeatureCollection, specify an output file:
 
 === "Python"
 
-    <!-- doctest: skip="gpio convert geojson --write-bbox/--id-field crash on valid input" -->
     ```python
     import geoparquet_io as gpio
 
@@ -397,7 +395,6 @@ This is useful for feature state in map rendering or for joining data.
 
 Include per-feature bounding boxes with `--write-bbox`:
 
-<!-- doctest: skip="gpio convert geojson --write-bbox/--id-field crash on valid input" -->
 ```bash
 gpio convert geojson data.parquet output.geojson --write-bbox
 ```

--- a/geoparquet_io/core/geojson_stream.py
+++ b/geoparquet_io/core/geojson_stream.py
@@ -157,6 +157,10 @@ def _build_feature_query(
     Returns:
         SQL query string
     """
+    # Interpolated into SQL below. The CLI declares --precision as an int, but
+    # the Python API takes it from a free-form format_options dict, so coerce
+    # rather than trust it.
+    precision = int(precision)
     quoted_geom = quote_identifier(geometry_column)
 
     # Reproject first, in a subquery, so everything below sees the geometry in
@@ -199,38 +203,49 @@ def _build_feature_query(
     else:
         props_expr = "'{}'"
 
-    # Build id expression if specified
-    id_expr = ""
+    # Optional members are whole expressions, joined into the `||` chain below
+    # rather than carrying their own trailing separator. A fragment that ended
+    # in a bare comma is what split the SELECT into several columns and
+    # truncated every Feature (#726).
+    fragments = ['\'{"type":"Feature",\'']
+
+    # DuckDB's `||` yields NULL if any operand is NULL, which would null the
+    # whole Feature string and abort the conversion when the writer tried to
+    # parse it. Both optional members can go NULL on perfectly ordinary input,
+    # so each is wrapped to degrade to "member omitted" instead.
     if id_field:
         quoted_id = quote_identifier(id_field)
-        # Ends in `||`, not a bare comma: this fragment is spliced into a
-        # concatenation chain, and a trailing comma would separate SELECT items
-        # instead of landing in the JSON, truncating every Feature (#726).
-        id_expr = f"'\"id\":' || to_json({quoted_id}) || ',' ||"
+        # to_json() of a NULL id is NULL. Omitting the member is also what
+        # RFC 7946 wants -- `id` must be a string or a number, never null.
+        fragments.append(f"""COALESCE('"id":' || to_json({quoted_id}) || ',', '')""")
 
-    # Build bbox expression if requested (use reprojected geometry)
-    # Bbox coordinates honor the precision parameter via ROUND()
-    bbox_expr = ""
+    # Bbox coordinates honor the precision parameter via ROUND().
     if write_bbox:
-        bbox_expr = (
-            f"'\"bbox\":[' || "
+        # ST_XMin of an EMPTY geometry is NULL, and EMPTY passes the
+        # `IS NOT NULL` filter below -- ST_ReducePrecision and ST_MakeValid can
+        # both produce it from valid input, so this is reachable without a
+        # malformed file.
+        fragments.append(
+            f"""COALESCE('"bbox":[' || """
             f"ROUND(ST_XMin({geom_for_output}), {precision}) || ',' || "
             f"ROUND(ST_YMin({geom_for_output}), {precision}) || ',' || "
             f"ROUND(ST_XMax({geom_for_output}), {precision}) || ',' || "
-            f"ROUND(ST_YMax({geom_for_output}), {precision}) || '],' ||"
+            f"""ROUND(ST_YMax({geom_for_output}), {precision}) || '],', '')"""
         )
 
+    fragments += [
+        "'\"geometry\":'",
+        f"COALESCE({geom_expr}, 'null')",
+        "',\"properties\":'",
+        props_expr,
+        "'}'",
+    ]
+
     # Build complete Feature JSON using string concatenation
+    joined = " ||\n            ".join(fragments)
     query = f"""
         SELECT
-            '{{\"type\":\"Feature\",' ||
-            {id_expr}
-            {bbox_expr}
-            '\"geometry\":' ||
-            COALESCE({geom_expr}, 'null') ||
-            ',\"properties\":' ||
-            {props_expr} ||
-            '}}' AS feature
+            {joined} AS feature
         FROM {source_ref}
         WHERE {quoted_geom} IS NOT NULL
     """

--- a/geoparquet_io/core/geojson_stream.py
+++ b/geoparquet_io/core/geojson_stream.py
@@ -203,7 +203,10 @@ def _build_feature_query(
     id_expr = ""
     if id_field:
         quoted_id = quote_identifier(id_field)
-        id_expr = f"'\"id\":' || to_json({quoted_id}) || ',',"
+        # Ends in `||`, not a bare comma: this fragment is spliced into a
+        # concatenation chain, and a trailing comma would separate SELECT items
+        # instead of landing in the JSON, truncating every Feature (#726).
+        id_expr = f"'\"id\":' || to_json({quoted_id}) || ',' ||"
 
     # Build bbox expression if requested (use reprojected geometry)
     # Bbox coordinates honor the precision parameter via ROUND()
@@ -214,7 +217,7 @@ def _build_feature_query(
             f"ROUND(ST_XMin({geom_for_output}), {precision}) || ',' || "
             f"ROUND(ST_YMin({geom_for_output}), {precision}) || ',' || "
             f"ROUND(ST_XMax({geom_for_output}), {precision}) || ',' || "
-            f"ROUND(ST_YMax({geom_for_output}), {precision}) || '],',"
+            f"ROUND(ST_YMax({geom_for_output}), {precision}) || '],' ||"
         )
 
     # Build complete Feature JSON using string concatenation

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -685,12 +685,72 @@ class TestFeatureMembersEmitValidJson:
             assert len(feature["bbox"]) == 4
             assert feature["geometry"] is not None
 
-    def test_option_fragments_end_in_a_concatenation_operator(self):
-        """The fragments are spliced into a `||` chain, so they must continue it."""
-        from geoparquet_io.core.geojson_stream import _build_feature_query
+    def test_feature_query_is_one_column_in_every_option_combination(self):
+        """The regression itself: a stray comma makes this several columns."""
+        import duckdb
 
-        query = _build_feature_query("t", "geometry", ["name"], write_bbox=True, id_field="name")
-        # A stray SELECT-list comma would make this parse as several columns.
-        assert query.count(" AS feature") == 1
-        assert "',' ||" in query
-        assert "'],' ||" in query
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute("CREATE TABLE t AS SELECT ST_Point(1, 2) AS geometry, 'a' AS name")
+
+        for options in (
+            {},
+            {"write_bbox": True},
+            {"id_field": "name"},
+            {"write_bbox": True, "id_field": "name"},
+        ):
+            query = _build_feature_query("t", "geometry", ["name"], **options)
+            assert len(con.execute(query).description) == 1, options
+
+    def test_null_id_value_omits_the_member(self):
+        """A NULL id must not null the whole Feature (`||` propagates NULL).
+
+        An optional key with a missing value is ordinary data, and the failure
+        was not a bad `id` -- it aborted the entire conversion, because the
+        writer got `None` where it expected a Feature string.
+        """
+        import duckdb
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute(
+            "CREATE TABLE t AS SELECT * FROM (VALUES "
+            "(ST_Point(1, 2), 'has-id'), "
+            "(ST_Point(3, 4), NULL)) AS v(geometry, name)"
+        )
+        query = _build_feature_query("t", "geometry", ["name"], id_field="name")
+
+        rows = [row[0] for row in con.execute(query).fetchall()]
+
+        assert len(rows) == 2
+        assert all(row is not None for row in rows), "a NULL id nulled the Feature"
+        features = [json.loads(row) for row in rows]
+        assert features[0]["id"] == "has-id"
+        # RFC 7946 wants `id` to be a string or a number, so omit rather than null.
+        assert "id" not in features[1]
+        assert features[1]["geometry"] is not None
+
+    def test_empty_geometry_omits_the_bbox(self):
+        """ST_XMin of an EMPTY geometry is NULL, which nulled the whole Feature.
+
+        EMPTY is not NULL, so it passes the query's `IS NOT NULL` filter, and
+        --precision or geometry repair can produce it from valid input.
+        """
+        import duckdb
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute(
+            "CREATE TABLE t AS SELECT * FROM (VALUES "
+            "(ST_Point(1, 2), 'point'), "
+            "(ST_GeomFromText('POLYGON EMPTY'), 'empty')) AS v(geometry, name)"
+        )
+        query = _build_feature_query("t", "geometry", ["name"], write_bbox=True)
+
+        rows = [row[0] for row in con.execute(query).fetchall()]
+
+        assert len(rows) == 2
+        assert all(row is not None for row in rows), "an EMPTY geometry nulled the Feature"
+        features = [json.loads(row) for row in rows]
+        assert features[0]["bbox"] == [1, 2, 1, 2]
+        assert "bbox" not in features[1]

--- a/tests/test_geojson_stream.py
+++ b/tests/test_geojson_stream.py
@@ -637,3 +637,60 @@ class TestRepairAfterReprojection:
         rows = con.execute(query).fetchall()
         assert len(rows) == 1
         assert json.loads(rows[0][0])["properties"]["name"] == "kept"
+
+
+class TestFeatureMembersEmitValidJson:
+    """#726: --write-bbox and --id-field appended a comma *outside* the SQL
+    string literal, so it split the feature SELECT into two columns instead of
+    landing in the JSON. Every Feature came out truncated after the option's
+    own member, and the writer failed to parse its own output."""
+
+    @staticmethod
+    def _convert(tmp_path, places_test_file, *extra_args):
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        out = tmp_path / "out.geojson"
+        result = CliRunner().invoke(
+            cli, ["convert", "geojson", places_test_file, str(out), *extra_args]
+        )
+        assert result.exit_code == 0, result.output
+        return json.loads(out.read_text())
+
+    def test_write_bbox_emits_parseable_features(self, tmp_path, places_test_file):
+        data = self._convert(tmp_path, places_test_file, "--write-bbox")
+
+        assert data["type"] == "FeatureCollection"
+        assert data["features"]
+        for feature in data["features"]:
+            assert len(feature["bbox"]) == 4
+            assert feature["geometry"] is not None
+            assert "properties" in feature
+
+    def test_id_field_emits_parseable_features(self, tmp_path, places_test_file):
+        data = self._convert(tmp_path, places_test_file, "--id-field", "name")
+
+        assert data["features"]
+        for feature in data["features"]:
+            assert feature["id"] == feature["properties"]["name"]
+            assert feature["geometry"] is not None
+
+    def test_bbox_and_id_field_together(self, tmp_path, places_test_file):
+        data = self._convert(tmp_path, places_test_file, "--write-bbox", "--id-field", "name")
+
+        assert data["features"]
+        for feature in data["features"]:
+            assert "id" in feature
+            assert len(feature["bbox"]) == 4
+            assert feature["geometry"] is not None
+
+    def test_option_fragments_end_in_a_concatenation_operator(self):
+        """The fragments are spliced into a `||` chain, so they must continue it."""
+        from geoparquet_io.core.geojson_stream import _build_feature_query
+
+        query = _build_feature_query("t", "geometry", ["name"], write_bbox=True, id_field="name")
+        # A stray SELECT-list comma would make this parse as several columns.
+        assert query.count(" AS feature") == 1
+        assert "',' ||" in query
+        assert "'],' ||" in query


### PR DESCRIPTION
Fixes #726.

## The bug

```
$ gpio convert geojson tests/data/places_test.parquet out.geojson --write-bbox
Converting to GeoJSON: out.geojson
Error: Failed to create GeoJSON: Expecting property name enclosed in double quotes: line 1 column 70 (char 69)
```

Both options built their SQL fragment with the trailing comma *outside* the string literal:

```python
id_expr = f"'\"id\":' || to_json({quoted_id}) || ',',"      # <- that last comma
... ROUND(ST_YMax(...), {precision}) || '],',"              # <- and that one
```

These fragments are spliced into a `||` chain that builds one `feature` column. A bare comma there separates SELECT items instead, so the expression became two columns: every Feature ended right after the option's own member, losing its geometry and properties, and the writer failed to parse its own output.

## The fix

Both fragments now end in `|| ` so they continue the chain they are spliced into. One character each; the diff is small because the bug was.

## Verification

`--write-bbox`, `--id-field`, and both together now emit valid GeoJSON — to a file (`FeatureCollection`) and to stdout (newline-delimited), 766/766 features with geometry, properties, `bbox` and `id` intact.

## Tests

New `TestFeatureMembersEmitValidJson` in `tests/test_geojson_stream.py`: each option alone and both together, parsing the written file and asserting each Feature keeps its geometry, properties and the option's member; plus a query-shape guard that the fragments end in a concatenation operator and the query still yields exactly one `AS feature` column, so a stray SELECT-list comma cannot come back.

Fast suite green (the only failures are the known `test_commitizen` parallel-run flakes, which pass serially); pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131ZaoMzLmembS7nUkz5sB3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed GeoJSON conversion with `--write-bbox` and `--id-field` so output remains valid, complete, and parseable.
  - NULL IDs and empty geometries now omit only their respective optional members.
  - Precision values are handled consistently during conversion.

- **Documentation**
  - Added guidance for bounding boxes, custom feature IDs, and related metadata.
  - Corrected examples and re-enabled documentation tests for supported conversion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Added during review

Two ordinary inputs still aborted the whole conversion, because DuckDB's `||` yields NULL if any operand is NULL and the writer then received `None` where it expected a Feature string:

- a NULL value in the `--id-field` column made `to_json()` NULL;
- `--write-bbox` on an EMPTY geometry made `ST_XMin()` NULL. EMPTY is not NULL, so it passes the query's `IS NOT NULL` filter, and both `ST_ReducePrecision` and geometry repair can produce it from valid input.

In streaming mode the second Feature took the process down with a bare `TypeError` traceback. Each member now degrades to "member omitted" instead — which is what RFC 7946 wants for `id` anyway.

The Feature is also assembled from a list of complete expressions joined into one `||` chain, rather than fragments each carrying their own trailing separator — the shape that caused this bug. `--precision` is coerced to an int before interpolation, since the Python API takes it from a free-form `format_options` dict rather than a Click `int` option.

The unit-level guard was replaced: two thirds of it was vacuous (the ` AS feature` count held on the broken code, and the `',' ||` check was satisfied by the bbox fragment's own separators, leaving the `--id-field` half unguarded). It now executes the query in all four option combinations and asserts a single output column.

Finally, this retires the `docs: skip` opt-outs the bug forced on four guide examples, and splits the `convert.md` block whose two commands wrote the same output file so the `--write-bbox` half runs under the docs-as-tests harness.
