### PR TITLE
fix(geojson): read stdin into a named GeoJSON output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Fixed
 
+- **`gpio convert geojson - out.geojson` now reads stdin into a named output file** instead of failing with `File not found: -`. The other four converters still reject `-`; they have no stdin-consuming path to route to ([#749](https://github.com/geoparquet/geoparquet-io/issues/749)). ([#723](https://github.com/geoparquet/geoparquet-io/issues/723))
 - **`convert geojson --write-bbox` and `--id-field` no longer truncate every Feature,** and no longer abort the whole conversion on a NULL id value or an EMPTY geometry — each member is omitted instead. ([#726](https://github.com/geoparquet/geoparquet-io/issues/726))
 - **Windows native-geo statistics: the zeros are a read, not a write.** pyarrow reads the real bounds from the same file DuckDB's `parquet_metadata()` reports as `[0, 0, 0, 0]`, so files gpio writes on Windows are correct and it is gpio's own reader that misreports them. ([#721](https://github.com/geoparquet/geoparquet-io/issues/721), [#748](https://github.com/geoparquet/geoparquet-io/issues/748))
 - **Guide examples no longer use flags the CLI does not accept.** Nonexistent options are corrected and missing option-table rows filled in. ([#735](https://github.com/geoparquet/geoparquet-io/issues/735))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Fixed
 
+- **`gpio convert geojson - out.geojson` now reads stdin into a named output file** instead of failing with `File not found: -`. The other four converters still reject `-`; they have no stdin-consuming path to route to ([#749](https://github.com/geoparquet/geoparquet-io/issues/749)). ([#723](https://github.com/geoparquet/geoparquet-io/issues/723))
 - **`convert geojson --write-bbox` and `--id-field` no longer truncate every Feature,** and no longer abort the whole conversion on a NULL id value or an EMPTY geometry — each member is omitted instead. ([#726](https://github.com/geoparquet/geoparquet-io/issues/726))
 - **Windows native-geo statistics: the zeros are a read, not a write.** pyarrow reads the real bounds from the same file DuckDB's `parquet_metadata()` reports as `[0, 0, 0, 0]`, so files gpio writes on Windows are correct and it is gpio's own reader that misreports them. ([#721](https://github.com/geoparquet/geoparquet-io/issues/721), [#748](https://github.com/geoparquet/geoparquet-io/issues/748))
 - **Guide examples no longer use flags the CLI does not accept.** Nonexistent options are corrected and missing option-table rows filled in. ([#735](https://github.com/geoparquet/geoparquet-io/issues/735))

--- a/docs/guide/geojson.md
+++ b/docs/guide/geojson.md
@@ -257,6 +257,16 @@ gpio extract data.parquet --where "population > 10000" | \
   tippecanoe -P -o cities.pmtiles
 ```
 
+```bash
+# End the pipeline in a GeoJSON file instead of a pipe
+gpio extract data.parquet --limit 1000 | \
+  gpio convert geojson - sample.geojson
+```
+
+Reading from stdin with `-` works in both modes: pipe onward without an output
+file to get newline-delimited GeoJSON, or name an output file to get a
+`FeatureCollection` written there.
+
 ### Select Specific Columns
 
 Reduce output size by selecting only needed columns:

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1693,11 +1693,13 @@ def convert_geojson(
       Streams newline-delimited GeoJSON (GeoJSONSeq) to stdout with RFC 8142
       record separators. Designed for piping to tippecanoe for PMTiles/MBTiles.
       Use --feature-collection to output a FeatureCollection instead.
-      Supports reading from stdin with "-" for pipeline use.
 
     \b
     FILE MODE (with output file):
       Writes a standard GeoJSON FeatureCollection to the specified file.
+
+    \b
+    Either mode reads from stdin with "-" (Arrow IPC), for pipeline use.
 
     \b
     Examples:
@@ -1706,6 +1708,9 @@ def convert_geojson(
 
       # Pipeline with filtering
       gpio extract data.parquet --bbox "-122.5,37.5,-122,38" | gpio convert geojson - | tippecanoe -P -o sf.pmtiles
+
+      # Pipeline ending in a GeoJSON file
+      gpio extract data.parquet --bbox "-122.5,37.5,-122,38" | gpio convert geojson - sf.geojson
 
       # Write to GeoJSON file
       gpio convert geojson data.parquet output.geojson

--- a/geoparquet_io/core/format_writers.py
+++ b/geoparquet_io/core/format_writers.py
@@ -438,6 +438,7 @@ def write_geojson(
     from pathlib import Path
 
     from geoparquet_io.core.geojson_stream import convert_to_geojson
+    from geoparquet_io.core.streaming import is_stdin
 
     configure_verbose(verbose)
 
@@ -454,17 +455,25 @@ def write_geojson(
     validate_profile_for_urls(profile, input_path)
     setup_aws_profile_if_needed(profile, input_path)
 
-    # Check if input has geometry column using GeoParquet metadata first
-    input_url = resolve_file_url(input_path, verbose)
-    has_geometry = detect_parquet_geometry_column(input_url, verbose=verbose) is not None
+    # "-" is an Arrow IPC stream on stdin, not a path: there is nothing to
+    # resolve or probe, and the stream can only be consumed once. Skip the
+    # input inspection and let the streaming converter read it -- it writes a
+    # FeatureCollection to a named output just as well, and raises its own
+    # geometry-column error if the stream has none. Probing here instead
+    # reported "File not found: -" about the input the user had just piped in
+    # (#723).
+    if not is_stdin(input_path):
+        # Check if input has geometry column using GeoParquet metadata first
+        input_url = resolve_file_url(input_path, verbose)
+        has_geometry = detect_parquet_geometry_column(input_url, verbose=verbose) is not None
 
-    if not has_geometry:
-        # Reject GeoJSON export without geometry data
-        raise GeoParquetError(
-            "Cannot export to GeoJSON: no geometry column found. "
-            "GeoJSON requires geometry data. Expected column named 'geom', 'geometry', 'wkb_geometry', or 'shape'. "
-            "To export data without geometry, use CSV format instead: gpio convert input.parquet output.csv"
-        )
+        if not has_geometry:
+            # Reject GeoJSON export without geometry data
+            raise GeoParquetError(
+                "Cannot export to GeoJSON: no geometry column found. "
+                "GeoJSON requires geometry data. Expected column named 'geom', 'geometry', 'wkb_geometry', or 'shape'. "
+                "To export data without geometry, use CSV format instead: gpio convert input.parquet output.csv"
+            )
 
     progress(f"Converting to GeoJSON: {output_path}")
 

--- a/geoparquet_io/core/format_writers.py
+++ b/geoparquet_io/core/format_writers.py
@@ -417,7 +417,9 @@ def write_geojson(
     Automatically reprojects to WGS84 unless keep_crs is True.
 
     Args:
-        input_path: Path to input GeoParquet file
+        input_path: Path to input GeoParquet file, or "-" to read an Arrow
+            IPC stream from stdin (the FeatureCollection is still written
+            to output_path)
         output_path: Path to output GeoJSON file (must be local)
         precision: Coordinate decimal precision (default: 7)
         write_bbox: Include bbox property for features (default: False)

--- a/tests/e2e/test_journeys.py
+++ b/tests/e2e/test_journeys.py
@@ -207,9 +207,10 @@ def test_journey_04_stdout_format_bridge(tmp_path):
     # Shape taken from piping.md's "Supported Commands" table, which records
     # `convert geojson` as stdin-capable but stdout-only ("No (outputs GeoJSON
     # to stdout)"); the redirect is this test's own, not a quoted example.
-    # `convert geojson -` reads stdin only in that streaming mode: passing an
-    # OUTPUT argument alongside `-` fails with a misleading "File not found: -"
-    # (error-message bug #723), so the bridge is a redirect.
+    # The redirect is what makes this a *streaming* bridge: it is the GeoJSONSeq
+    # record-separator stream that the assertions below check. `convert geojson
+    # - out.geojson` also works now (#723) but writes a FeatureCollection, which
+    # would not exercise this path; tests/test_pipe_integration.py covers it.
     run_pipeline(
         [
             f"gpio add bbox --force {q(PLACES)} -",

--- a/tests/test_pipe_integration.py
+++ b/tests/test_pipe_integration.py
@@ -240,3 +240,51 @@ class TestEdgeCases:
         assert "address" in table.column_names
         assert "geometry" in table.column_names
         assert "bbox_test" in table.column_names
+
+
+class TestStdinToNamedGeoJsonOutput:
+    """#723: `gpio convert geojson - out.geojson` failed with "File not found: -".
+
+    The message was wrong about what happened -- `-` is understood a moment
+    earlier in the redirect form, and the named path is the *output*. The
+    streaming converter already writes a FeatureCollection to a named path, so
+    the pipeline works once the CLI stops routing stdin through the file-mode
+    writer that can only open a path.
+    """
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_stdin_to_named_geojson_file(self, tmp_path):
+        import json
+
+        output = tmp_path / "out.geojson"
+        result = run_pipeline(
+            [
+                f"gpio extract --limit 5 {PLACES_PARQUET} -",
+                f"gpio convert geojson - {output}",
+            ]
+        )
+
+        assert result.returncode == 0, f"Pipeline failed: {result.stderr}"
+
+        data = json.loads(output.read_text())
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) == 5
+        assert all(f["geometry"] is not None for f in data["features"])
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_stdin_redirect_form_still_works(self, tmp_path):
+        """The documented form must keep working."""
+        import json
+
+        output = tmp_path / "out.geojson"
+        result = subprocess.run(
+            f"gpio extract --limit 5 {PLACES_PARQUET} - | "
+            f"gpio convert geojson - --feature-collection --no-rs > {output}",
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, f"Pipeline failed: {result.stderr}"
+        assert json.loads(output.read_text())["type"] == "FeatureCollection"

--- a/tests/test_pipe_integration.py
+++ b/tests/test_pipe_integration.py
@@ -288,3 +288,32 @@ class TestStdinToNamedGeoJsonOutput:
 
         assert result.returncode == 0, f"Pipeline failed: {result.stderr}"
         assert json.loads(output.read_text())["type"] == "FeatureCollection"
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_stdin_to_named_file_with_bbox_and_id_field(self, tmp_path):
+        """The combination neither #723 nor #726 covered on its own.
+
+        Routing stdin into file mode sends it through `_build_feature_query`,
+        the function #726 fixed. Before that fix this pipeline did not fail --
+        it silently wrote truncated, unparsable GeoJSON, which is worse than
+        the `File not found: -` it replaced. Guard the intersection.
+        """
+        import json
+
+        output = tmp_path / "out.geojson"
+        result = run_pipeline(
+            [
+                f"gpio extract --limit 5 {PLACES_PARQUET} -",
+                f"gpio convert geojson - {output} --write-bbox --id-field name",
+            ]
+        )
+
+        assert result.returncode == 0, f"Pipeline failed: {result.stderr}"
+
+        data = json.loads(output.read_text())
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) == 5
+        for feature in data["features"]:
+            assert len(feature["bbox"]) == 4
+            assert feature["geometry"] is not None
+            assert "properties" in feature


### PR DESCRIPTION
Fixes #723.

## The bug

```bash
# works
gpio add bbox --force places.parquet - | gpio convert geojson - > out.geojson

# fails
gpio add bbox --force places.parquet - | gpio convert geojson - out.geojson
Error: File not found: -
```

The message is wrong about what happened. `-` was understood in the working invocation a moment earlier, and the file the user named is the *output*. It sends people looking for a path problem.

## The fix

The issue offered a choice: fix the diagnostic, or support the combination if it's cheap. It's cheap — the capability was already there. `convert_to_geojson_stream()` already handles stdin with a named `output_path` and writes a `FeatureCollection` to it. Only the CLI's file-mode routing was in the way: it sent every named-output run through `write_geojson()`, which resolves the input as a URL and probes it for a geometry column — impossible for `-`, which is an Arrow IPC stream that can only be consumed once.

`write_geojson()` now skips that input inspection for stdin and hands off to the streaming converter, which raises its own clear error if the stream has no geometry column. Fixing the routing rather than the message means the obvious command just works:

```bash
gpio extract data.parquet --bbox "-122.5,37.5,-122,38" | gpio convert geojson - sf.geojson
```

The output-exists/`--overwrite` check still runs, so the named output is protected as before. Direct `core.format_writers.write_geojson()` callers get this too, since the fix is there rather than in the CLI. The public Python API does not reach it: `api/ops.py` and `api/table.py` both materialize a temp parquet first, so no API caller can pass `"-"`.

## Docs

`--help` advertised stdin only under `STREAMING MODE`, which invited the confusion; it now says stdin works in either mode, with an example. The GeoJSON guide's pipeline section gains the file-ending form.

## Tests

New `TestStdinToNamedGeoJsonOutput` in `tests/test_pipe_integration.py`, using the existing real-subprocess pipeline harness: stdin into a named file produces a parseable 5-feature `FeatureCollection` with geometry intact, and the documented redirect form keeps working.

Fast suite green (remaining failures are the known `test_commitizen` / pipeline parallel-run flakes — all 40 tests in the two affected files pass serially); pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131ZaoMzLmembS7nUkz5sB3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `convert geojson` now accepts piped input from stdin when writing to a named GeoJSON file.
  - Stdin input works in both streaming and file output modes.
  - Updated command help and documentation with usage examples.

- **Bug Fixes**
  - Fixed the misleading “File not found: -” error when converting stdin to a GeoJSON file.
  - GeoJSON output remains available as either a FeatureCollection or newline-delimited stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->