### PR TITLE
fix(geometry): combine Arrow chunks before ST_IsValid to stop a segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,21 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Segfault on chunked Arrow input to geometry repair (#737).** `ST_IsValid`
+  over a *chunked* registered Arrow table crashes DuckDB 1.5.1's spatial
+  extension. The crash lands in the invalid-geometry **count** — before any
+  repair runs — so the `except Exception` guard downstream cannot catch it and
+  the process dies with SIGSEGV; the `finally` block then deletes the temp
+  parquet, so an ArcGIS extraction loses every downloaded feature and the caller
+  sees only a non-zero exit. `pyarrow.parquet.read_table` returns hundreds of
+  chunks for any sizable file (280 for the reporter's 559k-row layer), so this
+  was reached by ordinary use rather than an edge case. Both paths that run
+  `ST_IsValid` over a registered Arrow table — `repair_arrow_table_geometry`
+  (WFS/ArcGIS/BigQuery/Carto extraction) and `extract_table` (the Python API and
+  streaming extract) — now register a single-chunk copy through the new
+  `register_arrow_table_for_spatial()` helper, which carries the reason so
+  future registrations do not have to rediscover it.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -233,6 +233,21 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Segfault on chunked Arrow input to geometry repair (#737).** `ST_IsValid`
+  over a *chunked* registered Arrow table crashes DuckDB 1.5.1's spatial
+  extension. The crash lands in the invalid-geometry **count** — before any
+  repair runs — so the `except Exception` guard downstream cannot catch it and
+  the process dies with SIGSEGV; the `finally` block then deletes the temp
+  parquet, so an ArcGIS extraction loses every downloaded feature and the caller
+  sees only a non-zero exit. `pyarrow.parquet.read_table` returns hundreds of
+  chunks for any sizable file (280 for the reporter's 559k-row layer), so this
+  was reached by ordinary use rather than an edge case. Both paths that run
+  `ST_IsValid` over a registered Arrow table — `repair_arrow_table_geometry`
+  (WFS/ArcGIS/BigQuery/Carto extraction) and `extract_table` (the Python API and
+  streaming extract) — now register a single-chunk copy through the new
+  `register_arrow_table_for_spatial()` helper, which carries the reason so
+  future registrations do not have to rediscover it.
+
 - **Six internal DuckDB connections now route through the shared connection
   factory.** `benchmark_duckdb`, `get_file_info`, `wkb_to_wkt_preview`,
   `get_column_statistics`, `add country-codes`'s connection setup, and the

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -637,6 +637,30 @@ class _DuckDBFieldWrapper:
         self.name = col_info.get("name", "")
 
 
+def register_arrow_table_for_spatial(con, name: str, table):
+    """Register an Arrow table under ``name`` for querying with spatial functions.
+
+    ``ST_IsValid`` over a *chunked* registered Arrow table segfaults DuckDB
+    1.5.1's spatial extension (issue #737). It is a memory-safety fault, not one
+    bad geometry: crash probability rises with the chunk count, and no single
+    chunk reproduces it in isolation. A SIGSEGV takes the process down, so no
+    ``except`` guard downstream can contain it — and `pyarrow.parquet.read_table`
+    returns hundreds of chunks for any sizable file, so ordinary use reaches it.
+
+    Combining costs one copy of the data and removes the crash. Use this
+    wherever a registered Arrow table is queried with spatial functions.
+
+    DuckDB keeps its own reference to the registered object, so the caller does
+    not have to hold the combined copy alive.
+
+    Returns:
+        The single-chunk table that was registered.
+    """
+    combined = table.combine_chunks()
+    con.register(name, combined)
+    return combined
+
+
 def _get_query_columns(con, query: str) -> list[str]:
     """
     Get column names from a SQL query without executing it fully.

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -27,6 +27,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     get_duckdb_connection_for_s3,
     quote_identifier,
+    register_arrow_table_for_spatial,
     validate_where_clause,
 )
 from geoparquet_io.core.exceptions import (
@@ -742,7 +743,10 @@ def extract_table(
 
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
-        con.register("__input_table", table)
+        # Combines chunks first: repair_query_geometry below runs ST_IsValid
+        # over this registered table, which segfaults DuckDB spatial when the
+        # table is chunked (#737).
+        register_arrow_table_for_spatial(con, "__input_table", table)
         source_ref, needs_wkb = _setup_geometry_view(con, table, geom_col)
 
         if needs_wkb and geom_col in selected_columns:

--- a/geoparquet_io/core/geometry_repair.py
+++ b/geoparquet_io/core/geometry_repair.py
@@ -164,7 +164,10 @@ def repair_arrow_table_geometry(table, geometry_column: str = "geometry", *, rep
     if table.num_rows == 0 or geometry_column not in table.column_names:
         return table, 0
 
-    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.duckdb_utils import (
+        get_duckdb_connection,
+        register_arrow_table_for_spatial,
+    )
 
     col = quote_identifier(geometry_column)
     # Decode WKB defensively: TRY() yields NULL on malformed bytes so a bad row
@@ -172,7 +175,11 @@ def repair_arrow_table_geometry(table, geometry_column: str = "geometry", *, rep
     parsed = f"TRY(ST_GeomFromWKB({col}))"
     con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
-        con.register("_gpio_repair_src", table)
+        # Combines chunks first: the ST_IsValid count below segfaults DuckDB
+        # spatial on a chunked registered table (#737). The original `table` is
+        # what we hand back when there is nothing to repair, so the combined
+        # copy is released on return.
+        register_arrow_table_for_spatial(con, "_gpio_repair_src", table)
         # Layered count: the single-WHERE form segfaults on tables containing
         # NULL geometry rows (issue #642) — see _layered_invalid_count_sql.
         n = con.execute(_layered_invalid_count_sql("_gpio_repair_src", parsed)).fetchone()[0]

--- a/tests/test_geometry_repair.py
+++ b/tests/test_geometry_repair.py
@@ -261,3 +261,123 @@ def test_repair_arrow_table_geometry_null_rows_at_scale():
     assert count == expected_invalid
     nulls = sum(1 for v in repaired.column("geometry").to_pylist() if v is None)
     assert nulls == expected_nulls
+
+
+def _chunked_table(con, *wkts, chunks: int = 8, geom_col="geometry"):
+    """Build a table whose columns are split across ``chunks`` Arrow chunks."""
+    import pyarrow as pa
+
+    single = _wkb_table(con, *wkts, geom_col=geom_col)
+    batches = single.to_batches(max_chunksize=max(1, single.num_rows // chunks))
+    table = pa.Table.from_batches(batches, schema=single.schema)
+    assert table.column(geom_col).num_chunks > 1, "fixture must be chunked"
+    return table
+
+
+def test_repair_arrow_table_geometry_combines_chunks_before_registering():
+    """#737: ST_IsValid over a chunked registered table segfaults DuckDB spatial.
+
+    ``pq.read_table()`` returns many chunks for any sizable file (280 for the
+    559k-row layer in the report), and the crash is a SIGSEGV inside the *count*
+    query -- before any repair runs, and past the reach of the ``except
+    Exception`` guard, so the whole process dies with the downloaded data
+    already removed by the ``finally`` block.
+
+    Being memory corruption it is non-deterministic at the margin and needs real
+    geometry to reproduce, so a test cannot provoke it reliably -- the same
+    limitation as the #642 case below. Assert the invariant that avoids it
+    instead: whatever gets registered is a single chunk per column.
+    """
+    from unittest import mock
+
+    con = _con()
+    table = _chunked_table(con, *([BOWTIE_WKT, SQUARE_WKT] * 32))
+    registered = []
+
+    class _RecordingConnection:
+        """Delegates to a real connection, recording what gets registered."""
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def register(self, name, value):
+            registered.append(value)
+            return self._inner.register(name, value)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    with mock.patch(
+        "geoparquet_io.core.duckdb_utils.get_duckdb_connection",
+        side_effect=lambda **kw: _RecordingConnection(get_duckdb_connection(**kw)),
+    ):
+        repaired, n = repair_arrow_table_geometry(table, "geometry", repair=True)
+
+    assert registered, "the helper must register the table it queries"
+    for column in registered[0].columns:
+        assert column.num_chunks <= 1, (
+            f"registered a {column.num_chunks}-chunk column; "
+            "ST_IsValid over chunked Arrow input segfaults DuckDB spatial (#737)"
+        )
+    assert n == 32
+    assert repaired.num_rows == table.num_rows
+
+
+def test_repair_arrow_table_geometry_repairs_a_chunked_table():
+    """Chunked input must come back correct, not merely uncrashed."""
+    con = _con()
+    table = _chunked_table(con, *([BOWTIE_WKT, SQUARE_WKT] * 32))
+
+    repaired, n = repair_arrow_table_geometry(table, "geometry", repair=True)
+
+    assert n == 32
+    assert repaired.num_rows == 64
+    con.register("_repaired", repaired.combine_chunks())
+    remaining = con.execute(
+        "SELECT COUNT(*) FROM _repaired WHERE NOT ST_IsValid(ST_GeomFromWKB(geometry))"
+    ).fetchone()[0]
+    assert remaining == 0
+
+
+def test_repair_arrow_table_geometry_chunked_preserves_schema_metadata():
+    con = _con()
+    table = _chunked_table(con, *([BOWTIE_WKT, SQUARE_WKT] * 32))
+    table = table.replace_schema_metadata({b"geo": b'{"version": "1.1.0"}'})
+
+    repaired, _ = repair_arrow_table_geometry(table, "geometry", repair=True)
+
+    assert repaired.schema.metadata == {b"geo": b'{"version": "1.1.0"}'}
+
+
+def test_extract_table_combines_chunks_before_registering():
+    """#737 again: extract's table path runs the same ST_IsValid over its input.
+
+    `extract_table` registers the caller's Arrow table and then hands the
+    query to `repair_query_geometry`, so a chunked table reaches the same crash
+    through `gpio.read(...).extract(...)` and the streaming path.
+    """
+    from unittest import mock
+
+    from geoparquet_io.core.extract import extract_table
+
+    con = _con()
+    table = _chunked_table(con, *([BOWTIE_WKT, SQUARE_WKT] * 32))
+    registered = []
+
+    real_register = type(con).register
+
+    def _spy(self, name, value):
+        registered.append((name, value))
+        return real_register(self, name, value)
+
+    with mock.patch.object(type(con), "register", _spy):
+        result = extract_table(table)
+
+    assert result.num_rows == 64
+    inputs = [value for name, value in registered if name == "__input_table"]
+    assert inputs, "extract_table must register its input table"
+    for column in inputs[0].columns:
+        assert column.num_chunks <= 1, (
+            f"registered a {column.num_chunks}-chunk column; "
+            "ST_IsValid over chunked Arrow input segfaults DuckDB spatial (#737)"
+        )


### PR DESCRIPTION
Fixes #737.

## The bug

`ST_IsValid` over a **chunked** registered Arrow table crashes DuckDB 1.5.1's spatial extension. The crash lands in the invalid-geometry **count** — before any repair runs — so the `except Exception` guard at the end of `repair_arrow_table_geometry` cannot catch it and the process dies with SIGSEGV. The `finally` block then deletes the temp parquet, so an ArcGIS extraction loses every downloaded feature (6 minutes of paging for the reporter's 559k-feature layer) and the caller sees only a non-zero exit and no error message.

`pq.read_table()` returns hundreds of chunks for any sizable file — 280 in the report — so this is reached by ordinary use, not an edge case.

## Scope: two call sites, not one

The report names `repair_arrow_table_geometry`. Auditing the other Arrow-table registrations found one more path that runs the *same* `ST_IsValid` count over a registered table: `extract_table()` registers the caller's table and hands the query to `repair_query_geometry`, so the crash is also reachable from `gpio.read(...).extract(...)` and the streaming extract. Both are fixed; the remaining registration sites do not run `ST_IsValid` over their registered table.

## The fix

Both now register a single-chunk copy through a new `register_arrow_table_for_spatial()` helper in `core/duckdb_utils.py`. The helper exists rather than two copies of the workaround so the reason lives in one place and future registrations don't have to rediscover it. Combining costs one copy of the data; in both paths the caller already materializes the full table, so it fits the existing memory profile, and `repair_arrow_table_geometry` still hands back the *original* table when there's nothing to repair, so the copy is released on return.

## Tests

Memory corruption can't be provoked reliably in a test — it's non-deterministic at the margin (54 chunks crashed 2 of 3 runs), needs real geometry, and synthetic WKB across 280 chunks does not reproduce it. Following the precedent set for the #642 segfault in this same module, the regression guards assert the **invariant that avoids it**: what gets registered is a single chunk per column. Both guards were sabotage-checked — reverting either call site makes its guard fail.

Alongside them: chunked input is counted (32), repaired (0 invalid remaining), and keeps its schema metadata.

Fast suite green (3961 passed; the two `test_commitizen` failures are the known parallel-run flakes and pass serially). Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131ZaoMzLmembS7nUkz5sB3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when validating geometries in chunked Arrow tables.
  * Improved reliability of WFS, ArcGIS, BigQuery, Carto, Python API, and streaming extractions.
  * Ensured downloaded features are preserved when geometry validation encounters invalid data.
  * Preserved repaired table schemas and row counts for chunked inputs.

* **Tests**
  * Added coverage for chunked geometry repair, extraction, invalid-geometry counts, and metadata preservation.

* **Documentation**
  * Documented the segmentation fault fix in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->