### PR TITLE
test(geo-stats): record that Windows geo-stat zeros are DuckDB's read, not pyarrow's write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,9 +244,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   xfailed: auto-version resolution splitting four ways on a native-geo input
   (#600), and the validator's `crs_valid` check flipping with geoarrow
   registration (the #603 family). The oracle also excuses
-  `native_geo_stats_contains_data` on Windows only, where pyarrow's wheel
-  writes all-zero geospatial statistics for native GEOMETRY columns (#721);
-  every other oracle check stays enforced on every platform.
+  `native_geo_stats_contains_data` on Windows only, where DuckDB's
+  `parquet_metadata()` misreads native GEOMETRY geospatial statistics as all
+  zeros (#721 — the file on disk is correct; see below); every other oracle
+  check stays enforced on every platform.
 
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with
@@ -479,6 +480,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Windows native-geo statistics: the zeros are a read, not a write (#721).**
+  `gpio check spec` reported `native_geo_stats_contains_data_geometry` failures
+  on Windows for files gpio had just written, and the standing explanation was
+  that pyarrow's Windows wheel wrote all-zero geospatial statistics. It does
+  not. `tests/test_native_geo_statistics.py` reads the *same file* through both
+  readers and asserts each separately; on windows-latest, across Python 3.11,
+  3.12 and 3.13 and both pyarrow write paths, pyarrow reads back the real
+  bounds while DuckDB's `parquet_metadata()` reports `[0, 0, 0, 0]`. A
+  committed corpus fixture — written by neither gpio nor the runner — rules out
+  a symmetrically-wrong write/read pair. **Files gpio writes on Windows are
+  correct and need no rewriting**; what misreports them is gpio's own reader,
+  which takes these statistics from DuckDB (`get_native_geo_statistics`,
+  `get_aggregated_native_geo_stats` and `get_per_row_group_native_geo_stats` in
+  `core/duckdb_metadata.py`). The reader-side fix is tracked in #721; the
+  pyarrow assertion is enforced on every platform, and the two DuckDB-dependent
+  ones are strict xfails on Windows so CI turns red the day the misread stops.
+
 - **Guide examples no longer use flags the CLI does not accept.** Three
   documented examples failed immediately with `No such option`. `docs/guide/check.md`
   advertised `gpio check all DIR --check-all` and `--check-sample N`; the real
@@ -633,9 +651,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   spelling of the set and that both write paths reference it.
 
   The new validator-oracle test excludes `native_geo_stats_contains_data` on
-  Windows only: pyarrow's Windows wheel writes all-zero geospatial statistics
-  for a native GEOMETRY column, so that check fails there for a platform reason
-  unrelated to this fix (#721). Every other validator check stays enforced on
+  Windows only: DuckDB's `parquet_metadata()` misreads a native GEOMETRY
+  column's geospatial statistics as all zeros there, so that check fails for a
+  platform reason unrelated to this fix (#721 — the statistics in the file are
+  correct; it is the read that is wrong). Every other validator check stays enforced on
   every platform.
 
 - **The arrow-streaming write strategy no longer emits a different file
@@ -663,9 +682,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   storage is 32-bit too. (#688)
 
   The validator assertions here exclude `native_geo_stats_contains_data` on
-  Windows only: pyarrow's Windows wheel writes all-zero geospatial statistics
-  for a native GEOMETRY column, so that check fails there for a platform reason
-  unrelated to this fix (#721). Every other validator check stays enforced on
+  Windows only: DuckDB's `parquet_metadata()` misreads a native GEOMETRY
+  column's geospatial statistics as all zeros there, so that check fails for a
+  platform reason unrelated to this fix (#721 — the statistics in the file are
+  correct; it is the read that is wrong). Every other validator check stays enforced on
   every platform.
 
 - **`gpio convert geoparquet` and `Table.write` keep the input's non-geo

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -244,9 +244,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   xfailed: auto-version resolution splitting four ways on a native-geo input
   (#600), and the validator's `crs_valid` check flipping with geoarrow
   registration (the #603 family). The oracle also excuses
-  `native_geo_stats_contains_data` on Windows only, where pyarrow's wheel
-  writes all-zero geospatial statistics for native GEOMETRY columns (#721);
-  every other oracle check stays enforced on every platform.
+  `native_geo_stats_contains_data` on Windows only, where DuckDB's
+  `parquet_metadata()` misreads native GEOMETRY geospatial statistics as all
+  zeros (#721 — the file on disk is correct; see below); every other oracle
+  check stays enforced on every platform.
 
 - **`gpio pmtiles pyramid` (#570)**: bake an aggregate and its overview levels
   into a single zoom-banded PMTiles archive. Each level is tiled once with
@@ -479,6 +480,23 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
 
 ### Fixed
 
+- **Windows native-geo statistics: the zeros are a read, not a write (#721).**
+  `gpio check spec` reported `native_geo_stats_contains_data_geometry` failures
+  on Windows for files gpio had just written, and the standing explanation was
+  that pyarrow's Windows wheel wrote all-zero geospatial statistics. It does
+  not. `tests/test_native_geo_statistics.py` reads the *same file* through both
+  readers and asserts each separately; on windows-latest, across Python 3.11,
+  3.12 and 3.13 and both pyarrow write paths, pyarrow reads back the real
+  bounds while DuckDB's `parquet_metadata()` reports `[0, 0, 0, 0]`. A
+  committed corpus fixture — written by neither gpio nor the runner — rules out
+  a symmetrically-wrong write/read pair. **Files gpio writes on Windows are
+  correct and need no rewriting**; what misreports them is gpio's own reader,
+  which takes these statistics from DuckDB (`get_native_geo_statistics`,
+  `get_aggregated_native_geo_stats` and `get_per_row_group_native_geo_stats` in
+  `core/duckdb_metadata.py`). The reader-side fix is tracked in #721; the
+  pyarrow assertion is enforced on every platform, and the two DuckDB-dependent
+  ones are strict xfails on Windows so CI turns red the day the misread stops.
+
 - **Guide examples no longer use flags the CLI does not accept.** Three
   documented examples failed immediately with `No such option`. `docs/guide/check.md`
   advertised `gpio check all DIR --check-all` and `--check-sample N`; the real
@@ -633,9 +651,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   spelling of the set and that both write paths reference it.
 
   The new validator-oracle test excludes `native_geo_stats_contains_data` on
-  Windows only: pyarrow's Windows wheel writes all-zero geospatial statistics
-  for a native GEOMETRY column, so that check fails there for a platform reason
-  unrelated to this fix (#721). Every other validator check stays enforced on
+  Windows only: DuckDB's `parquet_metadata()` misreads a native GEOMETRY
+  column's geospatial statistics as all zeros there, so that check fails for a
+  platform reason unrelated to this fix (#721 — the statistics in the file are
+  correct; it is the read that is wrong). Every other validator check stays enforced on
   every platform.
 
 - **The arrow-streaming write strategy no longer emits a different file
@@ -663,9 +682,10 @@ This is the first beta release of geoparquet-io 1.0, featuring major new spatial
   storage is 32-bit too. (#688)
 
   The validator assertions here exclude `native_geo_stats_contains_data` on
-  Windows only: pyarrow's Windows wheel writes all-zero geospatial statistics
-  for a native GEOMETRY column, so that check fails there for a platform reason
-  unrelated to this fix (#721). Every other validator check stays enforced on
+  Windows only: DuckDB's `parquet_metadata()` misreads a native GEOMETRY
+  column's geospatial statistics as all zeros there, so that check fails for a
+  platform reason unrelated to this fix (#721 — the statistics in the file are
+  correct; it is the read that is wrong). Every other validator check stays enforced on
   every platform.
 
 - **`gpio convert geoparquet` and `Table.write` keep the input's non-geo

--- a/tests/test_native_geo_statistics.py
+++ b/tests/test_native_geo_statistics.py
@@ -1,51 +1,69 @@
 """Native Parquet geospatial statistics must describe the data they ship with.
 
-Issue #721: on Windows, a file gpio writes with a native GEOMETRY logical type
-through the **pyarrow** writer comes back with geospatial statistics of
-``[0, 0, 0, 0]`` while the geometries are elsewhere. The statistics are
-*present* (``is_geo_stats_set`` is true) — they are just all zeros. Any reader
-using them for predicate pushdown skips row groups that actually match, so the
-result is silently wrong query results rather than an error. The same write path
-produces correct statistics on macOS and Linux, and the DuckDB ``COPY`` write
-strategy is correct on Windows too, which is why only the pyarrow path is
-implicated.
+Issue #721 asked which side zeroes the geospatial statistics of a native
+GEOMETRY column on Windows: pyarrow writing them, or DuckDB's
+``parquet_metadata()`` reading them. CI answered it — run 33193858561, Python
+3.11/3.12/3.13, both pyarrow write paths, 6 of 6 consistent:
 
-The open question the issue poses is **which side the zeros come from**: pyarrow
-writing them, or DuckDB's ``parquet_metadata()`` reading them. Neither can be
-settled on a machine where the bug does not reproduce, so these tests settle it
-in CI instead. They read the *same file* through both readers and assert each
-one separately. On Windows they are non-strict xfail, so CI stays green while
-recording which of the two fails:
+- ``..._via_pyarrow``         XPASS — pyarrow reads back the real bounds
+- ``..._via_duckdb``          XFAIL — DuckDB reports [0, 0, 0, 0] for that same file
+- ``..._both_readers_agree``  XFAIL
 
-- only ``via_duckdb`` xfails  -> pyarrow wrote correct statistics and DuckDB
-  misreads them; the fix belongs in gpio's stats-reading path
-- both xfail                  -> pyarrow wrote zeros; the fix (or workaround)
-  belongs upstream, or in routing Windows native-geo writes through DuckDB COPY
-- both xpass                  -> the platform bug is gone; delete the markers
-  and this docstring's question with them
+So the files gpio writes on Windows are correct on disk; gpio's *reader* is not.
+Everything gpio reports and validates from these statistics goes through DuckDB
+``parquet_metadata()`` — ``get_native_geo_statistics``,
+``get_aggregated_native_geo_stats`` and ``get_per_row_group_native_geo_stats``
+in ``core/duckdb_metadata.py`` — so on Windows those misreport bounds that are
+fine in the file. ``native_geo_stats_contains_data_*`` was flagging a real
+discrepancy all along; it pointed at the reader, not at the file. No rewrite of
+Windows-written files is needed, and routing Windows native-geo writes through
+DuckDB ``COPY`` would have fixed nothing.
+
+``test_duckdb_reads_a_file_it_did_not_write`` closes the one branch the pair
+above leaves open: a writer and reader that are wrong *symmetrically* would also
+agree. It reads a committed corpus fixture, written by neither gpio nor the
+Windows runner, so a failure there is the reader's alone.
+
+The pyarrow assertion is enforced on every platform, Windows included: now that
+the write path is known good there, it is the guard that keeps it good. The
+DuckDB-dependent assertions stay xfail on Windows until the reader is fixed
+(#721). They are strict, so the day DuckDB stops zeroing them CI turns red and
+names the markers — and this docstring — to delete.
 """
 
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
-import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 import shapely
 
-from geoparquet_io.core.common import write_geoparquet_table
+from geoparquet_io.core.common import get_duckdb_connection, write_geoparquet_table
 
 # Far from the origin in every direction, so all-zero statistics cannot contain
-# the data by accident, and a zeroed *single* bound is still caught.
+# the data by accident, and a zeroed *single* bound is still caught. The
+# assertions below assume plain min/max bounds; the Parquet geospatial spec also
+# permits xmin > xmax for antimeridian-wrapping bounds, which these points would
+# qualify for if a writer ever chose to emit them.
 POINTS = [(-122.4, 37.8), (151.2, -33.9), (2.35, 48.85)]
 EXPECTED = {"xmin": -122.4, "ymin": -33.9, "xmax": 151.2, "ymax": 48.85}
 
-windows_xfail = pytest.mark.xfail(
+# A native-geo file written by the geoparquet-testing corpus, not by gpio and not
+# on the runner reading it. Bounds are the file's own, verified from the fixture.
+CORPUS_NATIVE_GEO = Path(__file__).parent / "data" / "geoparquet-testing" / "data" / "encodings"
+CORPUS_EXPECTED = {"xmin": 30.0, "ymin": 10.0, "xmax": 40.0, "ymax": 40.0}
+
+duckdb_windows_xfail = pytest.mark.xfail(
     sys.platform == "win32",
-    reason="#721: pyarrow-written native GEOMETRY carries all-zero geospatial stats on Windows",
-    strict=False,
+    reason=(
+        "#721: DuckDB parquet_metadata() reports [0, 0, 0, 0] on Windows for "
+        "native GEOMETRY columns whose statistics pyarrow reads back correctly "
+        "from the very same file"
+    ),
+    strict=True,
 )
 
 
@@ -129,7 +147,6 @@ def test_native_geo_file_uses_the_geometry_logical_type(native_geo_file):
     assert "Geometry" in schema or "Geography" in schema
 
 
-@windows_xfail
 def test_native_geo_statistics_contain_the_data_via_pyarrow(native_geo_file):
     """The writer's own reader: what pyarrow believes it wrote."""
     pf = pq.ParquetFile(native_geo_file)
@@ -146,10 +163,10 @@ def test_native_geo_statistics_contain_the_data_via_pyarrow(native_geo_file):
         )
 
 
-@windows_xfail
+@duckdb_windows_xfail
 def test_native_geo_statistics_contain_the_data_via_duckdb(native_geo_file):
     """The reader gpio itself uses when it reports and validates these statistics."""
-    con = duckdb.connect()
+    con = get_duckdb_connection()
     try:
         rows = con.execute(
             "SELECT geo_bbox FROM parquet_metadata(?) WHERE path_in_schema = 'geometry'",
@@ -166,25 +183,72 @@ def test_native_geo_statistics_contain_the_data_via_duckdb(native_geo_file):
         )
 
 
-@windows_xfail
+@duckdb_windows_xfail
 def test_both_readers_agree_on_the_statistics(native_geo_file):
     """Whichever side is wrong, the two readers disagreeing is itself the signal."""
     pf = pq.ParquetFile(native_geo_file)
     index = pf.schema_arrow.names.index("geometry")
-    stats = pf.metadata.row_group(0).column(index).geo_statistics
 
-    con = duckdb.connect()
+    con = get_duckdb_connection()
     try:
-        bbox = con.execute(
-            "SELECT geo_bbox FROM parquet_metadata(?) WHERE path_in_schema = 'geometry'",
+        # One row per column chunk, so order it: the comparison below is
+        # positional, and parquet_metadata() promises no ordering of its own.
+        rows = con.execute(
+            "SELECT geo_bbox FROM parquet_metadata(?) "
+            "WHERE path_in_schema = 'geometry' ORDER BY row_group_id",
             [native_geo_file],
-        ).fetchone()[0]
+        ).fetchall()
     finally:
         con.close()
 
-    assert (stats.xmin, stats.ymin, stats.xmax, stats.ymax) == (
-        bbox["xmin"],
-        bbox["ymin"],
-        bbox["xmax"],
-        bbox["ymax"],
+    assert len(rows) == pf.metadata.num_row_groups, (
+        f"DuckDB reported {len(rows)} geometry chunks for {pf.metadata.num_row_groups} row groups"
     )
+
+    for rg, (bbox,) in enumerate(rows):
+        stats = pf.metadata.row_group(rg).column(index).geo_statistics
+        # Exact equality is the property under test, not an approximation of it:
+        # both readers decode the same IEEE-754 doubles out of the same thrift
+        # footer, with no arithmetic in between. Do not relax this to approx().
+        assert (stats.xmin, stats.ymin, stats.xmax, stats.ymax) == (
+            bbox["xmin"],
+            bbox["ymin"],
+            bbox["xmax"],
+            bbox["ymax"],
+        ), f"row group {rg}: pyarrow and DuckDB disagree"
+
+
+@pytest.mark.corpus
+@duckdb_windows_xfail
+def test_duckdb_reads_a_file_it_did_not_write():
+    """Isolate the reader from the writer, on a file neither gpio nor CI wrote.
+
+    The tests above compare pyarrow against DuckDB on files pyarrow just wrote
+    on the same machine. A writer and reader wrong *symmetrically* would agree,
+    which is the one reading under which the zeros would still be a write-side
+    bug. This fixture is committed to the geoparquet-testing submodule and was
+    produced elsewhere, so whatever DuckDB reports about it is the reader's
+    doing alone.
+    """
+    fixture = CORPUS_NATIVE_GEO / "point-native-geometry.parquet"
+    if not fixture.exists():
+        pytest.skip("run: git submodule update --init")
+
+    con = get_duckdb_connection()
+    try:
+        bbox = con.execute(
+            "SELECT geo_bbox FROM parquet_metadata(?) WHERE path_in_schema = 'geometry'",
+            [str(fixture)],
+        ).fetchone()
+    finally:
+        con.close()
+
+    assert bbox is not None, "DuckDB reported no geometry column chunk"
+    bbox = bbox[0]
+    assert bbox is not None, "DuckDB reported no geospatial statistics"
+    assert (bbox["xmin"], bbox["ymin"], bbox["xmax"], bbox["ymax"]) == (
+        CORPUS_EXPECTED["xmin"],
+        CORPUS_EXPECTED["ymin"],
+        CORPUS_EXPECTED["xmax"],
+        CORPUS_EXPECTED["ymax"],
+    ), f"DuckDB reports {bbox} for a fixture whose bounds are {CORPUS_EXPECTED}"

--- a/tests/test_native_geo_statistics.py
+++ b/tests/test_native_geo_statistics.py
@@ -1,0 +1,190 @@
+"""Native Parquet geospatial statistics must describe the data they ship with.
+
+Issue #721: on Windows, a file gpio writes with a native GEOMETRY logical type
+through the **pyarrow** writer comes back with geospatial statistics of
+``[0, 0, 0, 0]`` while the geometries are elsewhere. The statistics are
+*present* (``is_geo_stats_set`` is true) — they are just all zeros. Any reader
+using them for predicate pushdown skips row groups that actually match, so the
+result is silently wrong query results rather than an error. The same write path
+produces correct statistics on macOS and Linux, and the DuckDB ``COPY`` write
+strategy is correct on Windows too, which is why only the pyarrow path is
+implicated.
+
+The open question the issue poses is **which side the zeros come from**: pyarrow
+writing them, or DuckDB's ``parquet_metadata()`` reading them. Neither can be
+settled on a machine where the bug does not reproduce, so these tests settle it
+in CI instead. They read the *same file* through both readers and assert each
+one separately. On Windows they are non-strict xfail, so CI stays green while
+recording which of the two fails:
+
+- only ``via_duckdb`` xfails  -> pyarrow wrote correct statistics and DuckDB
+  misreads them; the fix belongs in gpio's stats-reading path
+- both xfail                  -> pyarrow wrote zeros; the fix (or workaround)
+  belongs upstream, or in routing Windows native-geo writes through DuckDB COPY
+- both xpass                  -> the platform bug is gone; delete the markers
+  and this docstring's question with them
+"""
+
+from __future__ import annotations
+
+import sys
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import shapely
+
+from geoparquet_io.core.common import write_geoparquet_table
+
+# Far from the origin in every direction, so all-zero statistics cannot contain
+# the data by accident, and a zeroed *single* bound is still caught.
+POINTS = [(-122.4, 37.8), (151.2, -33.9), (2.35, 48.85)]
+EXPECTED = {"xmin": -122.4, "ymin": -33.9, "xmax": 151.2, "ymax": 48.85}
+
+windows_xfail = pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="#721: pyarrow-written native GEOMETRY carries all-zero geospatial stats on Windows",
+    strict=False,
+)
+
+
+def _points_table():
+    return pa.table(
+        {
+            "id": pa.array(range(len(POINTS))),
+            "geometry": pa.array(
+                [shapely.to_wkb(shapely.Point(x, y)) for x, y in POINTS], pa.binary()
+            ),
+        }
+    )
+
+
+def _write_via_table_writer(tmp_path):
+    """`write_geoparquet_table` -> pyarrow `write_table` (the #702 path)."""
+    out = tmp_path / "table_writer.parquet"
+    write_geoparquet_table(
+        _points_table(), str(out), geometry_column="geometry", geoparquet_version="2.0"
+    )
+    return str(out)
+
+
+def _write_via_streaming_strategy(tmp_path):
+    """The arrow-streaming write strategy -> pyarrow `ParquetWriter` (the #707 path)."""
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    src = tmp_path / "src.parquet"
+    write_geoparquet_table(
+        _points_table(), str(src), geometry_column="geometry", geoparquet_version="1.1"
+    )
+    out = tmp_path / "streamed.parquet"
+    result = CliRunner().invoke(
+        cli,
+        [
+            "extract",
+            "geoparquet",
+            str(src),
+            str(out),
+            "--geoparquet-version",
+            "2.0",
+            "--write-strategy",
+            "streaming",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return str(out)
+
+
+@pytest.fixture(
+    params=[_write_via_table_writer, _write_via_streaming_strategy],
+    ids=["table-writer", "streaming-strategy"],
+)
+def native_geo_file(request, tmp_path):
+    """A native-geo file at known coordinates, from each implicated pyarrow path."""
+    return request.param(tmp_path)
+
+
+def _contains_data(xmin, ymin, xmax, ymax) -> bool:
+    return (
+        xmin <= EXPECTED["xmin"]
+        and ymin <= EXPECTED["ymin"]
+        and xmax >= EXPECTED["xmax"]
+        and ymax >= EXPECTED["ymax"]
+    )
+
+
+def test_all_zero_statistics_are_recognised_as_not_containing_the_data():
+    """Pin the guard's own logic: [0,0,0,0] is exactly the reported failure."""
+    assert not _contains_data(0.0, 0.0, 0.0, 0.0)
+    assert _contains_data(EXPECTED["xmin"], EXPECTED["ymin"], EXPECTED["xmax"], EXPECTED["ymax"])
+    # A single zeroed bound is caught too.
+    assert not _contains_data(0.0, EXPECTED["ymin"], EXPECTED["xmax"], EXPECTED["ymax"])
+
+
+def test_native_geo_file_uses_the_geometry_logical_type(native_geo_file):
+    """Guard the premise: without the native type there are no statistics to check."""
+    schema = str(pq.ParquetFile(native_geo_file).metadata.schema)
+    assert "Geometry" in schema or "Geography" in schema
+
+
+@windows_xfail
+def test_native_geo_statistics_contain_the_data_via_pyarrow(native_geo_file):
+    """The writer's own reader: what pyarrow believes it wrote."""
+    pf = pq.ParquetFile(native_geo_file)
+    index = pf.schema_arrow.names.index("geometry")
+
+    for rg in range(pf.metadata.num_row_groups):
+        column = pf.metadata.row_group(rg).column(index)
+        assert column.is_geo_stats_set, f"row group {rg} has no geospatial statistics"
+        stats = column.geo_statistics
+        assert _contains_data(stats.xmin, stats.ymin, stats.xmax, stats.ymax), (
+            f"row group {rg} statistics "
+            f"[{stats.xmin}, {stats.ymin}, {stats.xmax}, {stats.ymax}] "
+            f"do not contain the data {EXPECTED}"
+        )
+
+
+@windows_xfail
+def test_native_geo_statistics_contain_the_data_via_duckdb(native_geo_file):
+    """The reader gpio itself uses when it reports and validates these statistics."""
+    con = duckdb.connect()
+    try:
+        rows = con.execute(
+            "SELECT geo_bbox FROM parquet_metadata(?) WHERE path_in_schema = 'geometry'",
+            [native_geo_file],
+        ).fetchall()
+    finally:
+        con.close()
+
+    assert rows, "DuckDB reported no geometry column chunk"
+    for (bbox,) in rows:
+        assert bbox is not None, "DuckDB reported no geospatial statistics"
+        assert _contains_data(bbox["xmin"], bbox["ymin"], bbox["xmax"], bbox["ymax"]), (
+            f"statistics {bbox} do not contain the data {EXPECTED}"
+        )
+
+
+@windows_xfail
+def test_both_readers_agree_on_the_statistics(native_geo_file):
+    """Whichever side is wrong, the two readers disagreeing is itself the signal."""
+    pf = pq.ParquetFile(native_geo_file)
+    index = pf.schema_arrow.names.index("geometry")
+    stats = pf.metadata.row_group(0).column(index).geo_statistics
+
+    con = duckdb.connect()
+    try:
+        bbox = con.execute(
+            "SELECT geo_bbox FROM parquet_metadata(?) WHERE path_in_schema = 'geometry'",
+            [native_geo_file],
+        ).fetchone()[0]
+    finally:
+        con.close()
+
+    assert (stats.xmin, stats.ymin, stats.xmax, stats.ymax) == (
+        bbox["xmin"],
+        bbox["ymin"],
+        bbox["xmax"],
+        bbox["ymax"],
+    )


### PR DESCRIPTION
Refs #721. **This is the investigation step the issue asks for, not a fix** — read on for why that is the right first move here.

## The question the issue poses

> it is worth confirming from which side the zeros come (pyarrow writing them, or DuckDB's `parquet_metadata()` reading them) before deciding where a fix or a workaround belongs

That cannot be answered on a machine where the bug does not reproduce — on macOS both readers agree exactly:

```
pyarrow  is_geo_stats_set: True   xmin -122.4  ymin -33.9  xmax 151.2  ymax 48.85
duckdb   geo_bbox:               xmin -122.4  ymin -33.9  xmax 151.2  ymax 48.85
```

But CI already runs `windows-latest`. So this PR asks the question there.

## What it adds

`tests/test_native_geo_statistics.py` writes a native-GEOMETRY file at coordinates far from the origin in every direction (so all-zero statistics cannot contain the data by accident, and even a single zeroed bound is caught), then reads the **same file** through both readers and asserts each one **separately**, across both implicated pyarrow entry points:

- `write_geoparquet_table` → `pq.write_table` (the #702 path)
- the arrow-streaming write strategy → `pq.ParquetWriter` (the #707 path)

On Windows the assertions are non-strict `xfail`, so CI stays green while recording the answer:

| Windows result | Meaning | Where the fix belongs |
|---|---|---|
| only `via_duckdb` xfails | pyarrow wrote correct stats, DuckDB misreads them | gpio's stats-reading path |
| both xfail | pyarrow wrote zeros | upstream, or route Windows native-geo writes through DuckDB COPY |
| both xpass | the platform bug is gone | delete the markers |

A third test asserts the two readers *agree* — whichever side is wrong, disagreement is itself the signal. A fourth pins the containment predicate against `[0, 0, 0, 0]`, so the guard cannot rot into one that passes on the very shape it exists to catch.

## Why not just fix it

Both candidate workarounds are wrong if the diagnosis is wrong. Routing Windows writes through DuckDB COPY does nothing if the files were always fine and DuckDB misreads them. Verifying stats after each write via DuckDB would false-alarm on every Windows write in exactly that case. Guessing here buys a change that is either unnecessary or actively misleading, so this lands the discriminator first and the fix follows once CI names the culprit.

## Verification

9 tests pass on macOS (both write paths × both readers, plus the premise and predicate guards). Fast suite green — remaining failures are the known `test_commitizen`/`test_mutmut` parallel-run flakes, which pass serially. Pre-commit hooks pass.

Test-only, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131ZaoMzLmembS7nUkz5sB3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected documentation describing Windows geospatial statistics, clarifying that reported zero values come from metadata reading rather than file creation.
  - Documented that generated files contain correct native geometry statistics.

- **Tests**
  - Added comprehensive coverage for native geospatial statistics across supported readers and writing workflows.
  - Added validation for geometry metadata, geographic bounds, cross-reader consistency, and Windows-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->