### PR TITLE
feat(sort): add Sort-Tile-Recursive ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Added
 
+- **Sort-Tile-Recursive spatial ordering.** `gpio sort str`, `ops.sort_str`, and `Table.sort_str` pack geometry-envelope centers into row-group-sized X/Y tiles as an alternative to Hilbert ordering.
 - **The guides' examples now run as tests.** Every fenced bash/python block in `docs/guide/*.md` runs verbatim as a pytest item, which found and fixed real bugs in the docs. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#732](https://github.com/geoparquet/geoparquet-io/issues/732))
 - **Honest notebook CI signal.** The `notebooks` job no longer reports green for notebooks that execute no real `gpio` call. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#720](https://github.com/geoparquet/geoparquet-io/issues/720))
 - **Canonical sample dataset.** `tests/data/canonical/` holds one small, spec-clean dataset (~405 KB) shared by the docs examples, e2e journeys and notebooks. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#719](https://github.com/geoparquet/geoparquet-io/issues/719))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Added
 
-- **Sort-Tile-Recursive spatial ordering.** `gpio sort str`, `ops.sort_str`, and `Table.sort_str` pack geometry-envelope centers into row-group-sized X/Y tiles as an alternative to Hilbert ordering.
+- **Sort-Tile-Recursive spatial ordering.** `gpio sort str`, `ops.sort_str` and `Table.sort_str` sort geometry-envelope centers into X strips and sort each strip on Y, alternating direction between strips, as an alternative to Hilbert ordering. ([#766](https://github.com/geoparquet/geoparquet-io/issues/766))
 - **The guides' examples now run as tests.** Every fenced bash/python block in `docs/guide/*.md` runs verbatim as a pytest item, which found and fixed real bugs in the docs. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#732](https://github.com/geoparquet/geoparquet-io/issues/732))
 - **Honest notebook CI signal.** The `notebooks` job no longer reports green for notebooks that execute no real `gpio` call. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#720](https://github.com/geoparquet/geoparquet-io/issues/720))
 - **Canonical sample dataset.** `tests/data/canonical/` holds one small, spec-clean dataset (~405 KB) shared by the docs examples, e2e journeys and notebooks. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#719](https://github.com/geoparquet/geoparquet-io/issues/719))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ geoparquet_io/
 | `gpio process` | aggregate, overview | Transform or reduce GeoParquet data (aggregate, overview, |
 | `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata, cloud uploads) |
 | `gpio skills` |  | List and access LLM skills for gpio |
-| `gpio sort` | column, hilbert, quadkey | Commands for sorting GeoParquet files |
+| `gpio sort` | column, hilbert, quadkey, str | Commands for sorting GeoParquet files |
 <!-- END GENERATED: cli-commands -->
 
 <!-- BEGIN GENERATED: core-modules -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Added
 
+- **Sort-Tile-Recursive spatial ordering.** `gpio sort str`, `ops.sort_str`, and `Table.sort_str` pack geometry-envelope centers into row-group-sized X/Y tiles as an alternative to Hilbert ordering.
 - **The guides' examples now run as tests.** Every fenced bash/python block in `docs/guide/*.md` runs verbatim as a pytest item, which found and fixed real bugs in the docs. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#732](https://github.com/geoparquet/geoparquet-io/issues/732))
 - **Honest notebook CI signal.** The `notebooks` job no longer reports green for notebooks that execute no real `gpio` call. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#720](https://github.com/geoparquet/geoparquet-io/issues/720))
 - **Canonical sample dataset.** `tests/data/canonical/` holds one small, spec-clean dataset (~405 KB) shared by the docs examples, e2e journeys and notebooks. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#719](https://github.com/geoparquet/geoparquet-io/issues/719))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,7 @@ long run of write-path, metadata and CRS correctness fixes.
 
 ### Added
 
-- **Sort-Tile-Recursive spatial ordering.** `gpio sort str`, `ops.sort_str`, and `Table.sort_str` pack geometry-envelope centers into row-group-sized X/Y tiles as an alternative to Hilbert ordering.
+- **Sort-Tile-Recursive spatial ordering.** `gpio sort str`, `ops.sort_str` and `Table.sort_str` sort geometry-envelope centers into X strips and sort each strip on Y, alternating direction between strips, as an alternative to Hilbert ordering. ([#766](https://github.com/geoparquet/geoparquet-io/issues/766))
 - **The guides' examples now run as tests.** Every fenced bash/python block in `docs/guide/*.md` runs verbatim as a pytest item, which found and fixed real bugs in the docs. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#732](https://github.com/geoparquet/geoparquet-io/issues/732))
 - **Honest notebook CI signal.** The `notebooks` job no longer reports green for notebooks that execute no real `gpio` call. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#720](https://github.com/geoparquet/geoparquet-io/issues/720))
 - **Canonical sample dataset.** `tests/data/canonical/` holds one small, spec-clean dataset (~405 KB) shared by the docs examples, e2e journeys and notebooks. ([#667](https://github.com/geoparquet/geoparquet-io/issues/667), [#719](https://github.com/geoparquet/geoparquet-io/issues/719))

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -636,6 +636,16 @@ Reorder rows using Hilbert curve ordering for better spatial locality.
 table = gpio.read('input.parquet').sort_hilbert()
 ```
 
+#### `sort_str(tile_size=100000)`
+
+Pack rows into spatially compact Sort-Tile-Recursive tiles. Match `tile_size`
+to the row-group rows used when writing.
+
+```python
+table = gpio.read('input.parquet').sort_str(tile_size=50000)
+table.write('output.parquet', row_group_rows=50000)
+```
+
 #### `sort_column(column_name, descending=False)`
 
 Sort rows by a specified column.
@@ -1455,6 +1465,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.add_admin_divisions(table, dataset='gaul', levels=None, vecorel=False)` | Add admin division columns via spatial join |
 | `ops.add_kdtree(table, column_name='kdtree_cell', iterations=9, sample_size=100000, geometry_column=None)` | Add KD-tree cell column |
 | `ops.sort_hilbert(table, geometry_column=None)` | Reorder by Hilbert curve |
+| `ops.sort_str(table, geometry_column=None, tile_size=100000)` | Pack rows with Sort-Tile-Recursive ordering |
 | `ops.sort_column(table, column, descending=False)` | Sort by column(s) |
 | `ops.sort_quadkey(table, column_name='quadkey', resolution=13, use_centroid=False, remove_column=False)` | Sort by quadkey |
 | `ops.reproject(table, target_crs='EPSG:4326', source_crs=None, geometry_column=None, assume_crs84=False)` | Reproject geometry (`assume_crs84` treats an unknown/null CRS as OGC:CRS84) |

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -638,8 +638,11 @@ table = gpio.read('input.parquet').sort_hilbert()
 
 #### `sort_str(tile_size=100000)`
 
-Pack rows into spatially compact Sort-Tile-Recursive tiles. Match `tile_size`
-to the row-group rows used when writing.
+Reorder rows with Sort-Tile-Recursive packing: X strips, each sorted on Y with
+alternating direction. `tile_size` only selects the number of strips, as
+`ceil(sqrt(num_rows / tile_size))`, so set it to roughly the rows you intend to
+put in a row group and expect a coarse response - see
+[the sort guide](../guide/sort.md#what-row-group-size-does-here).
 
 ```python
 table = gpio.read('input.parquet').sort_str(tile_size=50000)
@@ -1465,7 +1468,7 @@ pq.write_table(table, 'output.parquet')
 | `ops.add_admin_divisions(table, dataset='gaul', levels=None, vecorel=False)` | Add admin division columns via spatial join |
 | `ops.add_kdtree(table, column_name='kdtree_cell', iterations=9, sample_size=100000, geometry_column=None)` | Add KD-tree cell column |
 | `ops.sort_hilbert(table, geometry_column=None)` | Reorder by Hilbert curve |
-| `ops.sort_str(table, geometry_column=None, tile_size=100000)` | Pack rows with Sort-Tile-Recursive ordering |
+| `ops.sort_str(table, geometry_column=None, tile_size=100000)` | Reorder with Sort-Tile-Recursive ordering (`tile_size` picks the strip count) |
 | `ops.sort_column(table, column, descending=False)` | Sort by column(s) |
 | `ops.sort_quadkey(table, column_name='quadkey', resolution=13, use_centroid=False, remove_column=False)` | Sort by quadkey |
 | `ops.reproject(table, target_crs='EPSG:4326', source_crs=None, geometry_column=None, assume_crs84=False)` | Reproject geometry (`assume_crs84` treats an unknown/null CRS as OGC:CRS84) |

--- a/docs/cli/sort.md
+++ b/docs/cli/sort.md
@@ -43,10 +43,17 @@ Pack rows with Sort-Tile-Recursive ordering for compact row-group bounding boxes
 gpio sort str input.parquet output.parquet --row-group-size 50000 [OPTIONS]
 ```
 
-STR uses geometry bounding-box centers, creates approximately square X strips,
-and sorts each strip on Y with alternating direction. `--row-group-size`
-controls both the spatial tile capacity and the output row-group target, so an
-exact row count is recommended.
+STR sorts geometry bounding-box centers into X strips, sorts each strip on Y,
+and alternates the Y direction between strips.
+
+`--row-group-size` does double duty: it is the writer's row-group target, and
+it selects how many X strips STR builds, as
+`ceil(sqrt(num_rows / row-group-size))`. That is a coarse control - nearby
+values often produce an identical ordering. STR does not pack rows into
+row-group-sized tiles, and because the writer rounds row groups up to a
+multiple of 2048, strips and row groups only line up when `--row-group-size` is
+itself a multiple of 2048. Pass an exact row count anyway: without it the
+writer emits 122,880-row groups while STR sizes its strips from 100,000.
 
 The `str` subcommand supports the same geometry, bbox, compression, row-group,
 GeoParquet version, overwrite, verbosity, and SQL-display options as `hilbert`.

--- a/docs/cli/sort.md
+++ b/docs/cli/sort.md
@@ -35,6 +35,22 @@ Options:
 | `--verbose` | - | Verbose output |
 | `--show-sql` | - | Show generated SQL |
 
+### str
+
+Pack rows with Sort-Tile-Recursive ordering for compact row-group bounding boxes:
+
+```bash
+gpio sort str input.parquet output.parquet --row-group-size 50000 [OPTIONS]
+```
+
+STR uses geometry bounding-box centers, creates approximately square X strips,
+and sorts each strip on Y with alternating direction. `--row-group-size`
+controls both the spatial tile capacity and the output row-group target, so an
+exact row count is recommended.
+
+The `str` subcommand supports the same geometry, bbox, compression, row-group,
+GeoParquet version, overwrite, verbosity, and SQL-display options as `hilbert`.
+
 ### quadkey
 
 Sort by quadkey for spatial locality:

--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -5,7 +5,7 @@ The `sort` command reorders GeoParquet files for optimal performance and query e
 ## Sorting Methods
 
 - **Hilbert curve** - Optimal spatial ordering using Hilbert space-filling curve
-- **Sort-Tile-Recursive (STR)** - Pack approximately square spatial tiles aligned to row groups
+- **Sort-Tile-Recursive (STR)** - Snake through X strips, each sorted on Y
 - **Column** - Sort by any column(s) for non-spatial ordering needs
 
 ## Hilbert Curve Ordering
@@ -104,10 +104,9 @@ gpio sort hilbert input.parquet output.parquet --row-group-size-mb 1GB
 
 ## Sort-Tile-Recursive Ordering
 
-STR is an alternative spatial packing strategy that explicitly builds tiles at
-the output row-group capacity. It sorts geometry bounding-box centers into
-approximately square X strips, sorts each strip on Y, and alternates the Y
-direction between strips to keep neighboring tiles close.
+STR is an alternative spatial ordering. It sorts geometry bounding-box centers
+into X strips, sorts each strip on Y, and alternates the Y direction between
+strips so that neighbouring strips stay close.
 
 === "CLI"
 
@@ -125,14 +124,37 @@ direction between strips to keep neighboring tiles close.
         .write('output.parquet', row_group_rows=50000)
     ```
 
-The tile size and written row-group size should match. The CLI derives STR's
-tile capacity from `--row-group-size`; both default to 100,000 rows when the
-option is omitted. With `--row-group-size-mb`, STR still uses 100,000 rows per
-tile because the final number of rows in a byte-sized group cannot be known
-before writing; set an exact row count when strict alignment matters.
+### What `--row-group-size` does here
 
-STR is especially useful for uneven spatial distributions where rectangular
-row-group tiles have less overlap than a single space-filling-curve order. The
+`--row-group-size` does two separate things, and only one of them is exact:
+
+- It is the writer's row-group target, as it is for every other gpio command.
+- It selects how many X strips STR builds, as
+  `ceil(sqrt(num_rows / row-group-size))`.
+
+The second use is coarse. The strip count is a rounded square root, so nearby
+values collapse onto the same layout: on 20,000 points, `--row-group-size 800`
+and `--row-group-size 1000` produce a byte-identical ordering, as do 1,500 and
+2,000. STR does not pack rows into row-group-sized tiles either - within a
+strip, rows are simply sorted on Y.
+
+Strips and row groups do not line up in general. The writer rounds the
+row-group size up to a multiple of 2048, so `--row-group-size 100000` writes
+100,352-row groups; strips are a whole number of `--row-group-size` rows, which
+means they land on row-group boundaries only when you pass a multiple of 2048
+(for example `--row-group-size 102400`).
+
+Passing an exact row count is still worth doing. Without `--row-group-size` the
+writer emits DuckDB's 122,880-row groups while STR sizes its strips from
+100,000, so nothing lines up at all. With `--row-group-size-mb`, STR falls back
+to 100,000 rows per tile, because the row count of a byte-sized group is not
+known before writing.
+
+### How much does it help?
+
+Modestly, and it depends on the data. On 2 million uniformly distributed points
+written with `--row-group-size 100000`, STR's mean row-group bounding-box area
+was 3,846 square degrees against Hilbert's 4,426 - about 13% tighter. The
 [benchmark linked from the design presentation](https://github.com/Kanahiro/spatial-sort-benchmark)
 reports lower row-group bbox overlap and fewer candidate row groups than
 Hilbert on its 30-million-row POI dataset. Results depend on the dataset, so

--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -5,6 +5,7 @@ The `sort` command reorders GeoParquet files for optimal performance and query e
 ## Sorting Methods
 
 - **Hilbert curve** - Optimal spatial ordering using Hilbert space-filling curve
+- **Sort-Tile-Recursive (STR)** - Pack approximately square spatial tiles aligned to row groups
 - **Column** - Sort by any column(s) for non-spatial ordering needs
 
 ## Hilbert Curve Ordering
@@ -100,6 +101,53 @@ gpio sort hilbert input.parquet output.parquet --row-group-size-mb 1GB
 
 !!! tip "Optimal row group size for spatial queries"
     For GeoParquet 2.0 or parquet-geo-only files with Hilbert sorting, use **10,000-50,000 rows per group**. Smaller row groups create tighter bounding boxes that enable more row group skipping during spatial queries. Benchmarks show 10k rows + Hilbert + v2.0 enables ~67% row group skipping vs 0% with large row groups.
+
+## Sort-Tile-Recursive Ordering
+
+STR is an alternative spatial packing strategy that explicitly builds tiles at
+the output row-group capacity. It sorts geometry bounding-box centers into
+approximately square X strips, sorts each strip on Y, and alternates the Y
+direction between strips to keep neighboring tiles close.
+
+=== "CLI"
+
+    ```bash
+    gpio sort str input.parquet output.parquet --row-group-size 50000
+    ```
+
+=== "Python"
+
+    ```python
+    import geoparquet_io as gpio
+
+    gpio.read('input.parquet') \
+        .sort_str(tile_size=50000) \
+        .write('output.parquet', row_group_rows=50000)
+    ```
+
+The tile size and written row-group size should match. The CLI derives STR's
+tile capacity from `--row-group-size`; both default to 100,000 rows when the
+option is omitted. With `--row-group-size-mb`, STR still uses 100,000 rows per
+tile because the final number of rows in a byte-sized group cannot be known
+before writing; set an exact row count when strict alignment matters.
+
+STR is especially useful for uneven spatial distributions where rectangular
+row-group tiles have less overlap than a single space-filling-curve order. The
+[benchmark linked from the design presentation](https://github.com/Kanahiro/spatial-sort-benchmark)
+reports lower row-group bbox overlap and fewer candidate row groups than
+Hilbert on its 30-million-row POI dataset. Results depend on the dataset, so
+Hilbert remains a good general default.
+
+Like Hilbert sorting, STR places empty and NULL geometries at the end and can
+write GeoParquet 2.0 native row-group statistics or add a bbox covering:
+
+```bash
+gpio sort str input.parquet output.parquet \
+  --row-group-size 50000 \
+  --geoparquet-version 2.0
+
+gpio sort str input.parquet output-bbox.parquet --add-bbox
+```
 
 ## Column Ordering
 

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -30,6 +30,7 @@ from geoparquet_io.core.hilbert_order import hilbert_order_table
 from geoparquet_io.core.reproject import reproject_table
 from geoparquet_io.core.sort_by_column import sort_by_column_table
 from geoparquet_io.core.sort_quadkey import sort_by_quadkey_table
+from geoparquet_io.core.str_order import DEFAULT_STR_TILE_SIZE, str_order_table
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
 
 
@@ -181,6 +182,29 @@ def sort_hilbert(
     return hilbert_order_table(
         table,
         geometry_column=geometry_column,
+    )
+
+
+def sort_str(
+    table: pa.Table,
+    geometry_column: str | None = None,
+    tile_size: int = DEFAULT_STR_TILE_SIZE,
+) -> pa.Table:
+    """Reorder table rows using Sort-Tile-Recursive packing.
+
+    Args:
+        table: Input PyArrow Table
+        geometry_column: Geometry column name (auto-detected if None)
+        tile_size: Target rows per spatial tile; match this to the output row
+            group size (default: 100,000)
+
+    Returns:
+        New table with rows reordered into spatially compact tiles
+    """
+    return str_order_table(
+        table,
+        geometry_column=geometry_column,
+        tile_size=tile_size,
     )
 
 

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -195,8 +195,10 @@ def sort_str(
     Args:
         table: Input PyArrow Table
         geometry_column: Geometry column name (auto-detected if None)
-        tile_size: Target rows per spatial tile; match this to the output row
-            group size (default: 100,000)
+        tile_size: Roughly the rows you intend to put in a row group. STR uses
+            it only to choose the number of X strips, as
+            ``ceil(sqrt(num_rows / tile_size))``, so it is a coarse control
+            rather than an exact tile capacity (default: 100,000)
 
     Returns:
         New table with rows reordered into spatially compact tiles

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -20,6 +20,7 @@ import pyarrow.parquet as pq
 from geoparquet_io.core.check_parquet_structure import CheckProfile
 from geoparquet_io.core.common import write_geoparquet_table
 from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.str_order import DEFAULT_STR_TILE_SIZE
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
 
 if TYPE_CHECKING:
@@ -1352,15 +1353,22 @@ class Table:
         )
         return self._wrap(result, self._geometry_column)
 
-    def sort_str(self, tile_size: int = 100_000) -> Table:
+    def sort_str(self, tile_size: int = DEFAULT_STR_TILE_SIZE) -> Table:
         """Reorder rows using Sort-Tile-Recursive packing.
 
         Args:
-            tile_size: Target rows per spatial tile. Match this to the Parquet
-                row group size used when writing (default: 100,000).
+            tile_size: Roughly the number of rows you intend to put in a Parquet
+                row group. STR uses it only to pick the number of X strips
+                (default: 100,000).
 
         Returns:
             New Table with rows packed into spatially compact tiles
+
+        Note:
+            The default is imported from ``core.str_order`` rather than spelled
+            out, because the CLI has no ``tile_size`` option: the CLI<->API
+            default-parity harness has nothing to compare this against and so
+            cannot catch it drifting from ``ops.sort_str``.
         """
         from geoparquet_io.core.str_order import str_order_table
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -460,6 +460,7 @@ class Table:
     - add_bbox(): Add bounding box column
     - add_quadkey(): Add quadkey column
     - sort_hilbert(): Reorder by Hilbert curve
+    - sort_str(): Reorder with Sort-Tile-Recursive packing
     - extract(): Filter columns and rows
 
     All methods return a new Table, preserving immutability.
@@ -1348,6 +1349,25 @@ class Table:
         result = hilbert_order_table(
             self._table,
             geometry_column=self._geometry_column,
+        )
+        return self._wrap(result, self._geometry_column)
+
+    def sort_str(self, tile_size: int = 100_000) -> Table:
+        """Reorder rows using Sort-Tile-Recursive packing.
+
+        Args:
+            tile_size: Target rows per spatial tile. Match this to the Parquet
+                row group size used when writing (default: 100,000).
+
+        Returns:
+            New Table with rows packed into spatially compact tiles
+        """
+        from geoparquet_io.core.str_order import str_order_table
+
+        result = str_order_table(
+            self._table,
+            geometry_column=self._geometry_column,
+            tile_size=tile_size,
         )
         return self._wrap(result, self._geometry_column)
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -90,6 +90,7 @@ from geoparquet_io.core.process.overview import create_overviews as create_overv
 from geoparquet_io.core.reproject import reproject as reproject_core
 from geoparquet_io.core.sort_by_column import sort_by_column as sort_by_column_impl
 from geoparquet_io.core.sort_quadkey import sort_by_quadkey as sort_by_quadkey_impl
+from geoparquet_io.core.str_order import str_order as str_impl
 from geoparquet_io.core.upload import check_credentials
 from geoparquet_io.core.upload import upload as upload_impl
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
@@ -3695,6 +3696,76 @@ def hilbert_order(
         row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
 
         hilbert_impl(
+            input_parquet,
+            output_parquet,
+            geometry_column,
+            add_bbox,
+            verbose,
+            compression.upper(),
+            compression_level,
+            row_group_mb,
+            row_group_size,
+            None,
+            geoparquet_version,
+            overwrite,
+            memory_limit=write_memory,
+        )
+
+
+@sort.command(name="str", cls=SingleFileCommand)
+@click.argument("input_parquet")
+@click.argument("output_parquet", type=click.Path(), required=False, default=None)
+@click.option(
+    "--geometry-column",
+    "-g",
+    default="geometry",
+    help="Name of the geometry column (default: geometry)",
+)
+@click.option(
+    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
+)
+@output_format_options
+@geoparquet_version_option
+@overwrite_option
+@verbose_option
+@any_extension_option
+@show_sql_option
+@click.pass_context
+def str_order_command(
+    ctx,
+    input_parquet,
+    output_parquet,
+    geometry_column,
+    add_bbox,
+    compression,
+    compression_level,
+    row_group_size,
+    row_group_size_mb,
+    write_memory,
+    geoparquet_version,
+    overwrite,
+    verbose,
+    any_extension,
+    show_sql,
+):
+    """Pack GeoParquet rows with Sort-Tile-Recursive ordering.
+
+    STR builds approximately square X strips from geometry bounding-box
+    centers, sorts each strip on Y, and aligns spatial tiles to Parquet row
+    groups. This can produce tighter row-group bounds than a space-filling
+    curve for uneven spatial distributions.
+    """
+    with _activate_s3(ctx):
+        from geoparquet_io.core.streaming import StreamingError, validate_output
+
+        try:
+            validate_output(output_parquet)
+        except StreamingError as e:
+            raise click.ClickException(str(e)) from None
+
+        validate_parquet_extension(output_parquet, any_extension)
+        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        str_impl(
             input_parquet,
             output_parquet,
             geometry_column,

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3750,10 +3750,17 @@ def str_order_command(
 ):
     """Pack GeoParquet rows with Sort-Tile-Recursive ordering.
 
-    STR builds approximately square X strips from geometry bounding-box
-    centers, sorts each strip on Y, and aligns spatial tiles to Parquet row
-    groups. This can produce tighter row-group bounds than a space-filling
-    curve for uneven spatial distributions.
+    STR sorts geometry bounding-box centers into X strips, sorts each strip on
+    Y, and alternates the Y direction between strips. This can produce tighter
+    row-group bounding boxes than a space-filling curve.
+
+    --row-group-size does double duty: it is the writer's row-group target, and
+    it selects how many X strips STR builds, as
+    ceil(sqrt(num_rows / row-group-size)). That makes it a coarse control -
+    nearby values often produce an identical ordering. Rows are not packed into
+    row-group-sized tiles, and because the writer rounds row groups up to a
+    multiple of 2048, tiles and row groups only line up when --row-group-size
+    is itself a multiple of 2048.
     """
     with _activate_s3(ctx):
         from geoparquet_io.core.streaming import StreamingError, validate_output
@@ -3768,16 +3775,16 @@ def str_order_command(
         str_impl(
             input_parquet,
             output_parquet,
-            geometry_column,
-            add_bbox,
-            verbose,
-            compression.upper(),
-            compression_level,
-            row_group_mb,
-            row_group_size,
-            None,
-            geoparquet_version,
-            overwrite,
+            geometry_column=geometry_column,
+            add_bbox_flag=add_bbox,
+            verbose=verbose,
+            compression=compression.upper(),
+            compression_level=compression_level,
+            row_group_size_mb=row_group_mb,
+            row_group_rows=row_group_size,
+            profile=None,
+            geoparquet_version=geoparquet_version,
+            overwrite=overwrite,
             memory_limit=write_memory,
         )
 

--- a/geoparquet_io/core/str_order.py
+++ b/geoparquet_io/core/str_order.py
@@ -14,16 +14,24 @@ from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_m
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import InvalidParameterError, RemoteAccessError
 from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.geo_metadata import parse_geo_metadata
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
     find_primary_geometry_column,
 )
+
+# These three helpers are private to hilbert_order.py but are shared by convention
+# between the two spatial-sort commands: both run the same prepare/write/cleanup
+# pipeline. Extracting them (with the rest of the duplicated pipeline) into a
+# core/sort_common.py is tracked in #776, because it also rewrites the sibling
+# `sort hilbert` command and this project keeps cross-cutting refactors in their
+# own PR.
 from geoparquet_io.core.hilbert_order import (
     _cleanup_temp_file,
     _prepare_working_file,
     _resolve_output_version,
 )
-from geoparquet_io.core.logging_config import debug, info, success, warn
+from geoparquet_io.core.logging_config import configure_verbose, debug, info, success, warn
 from geoparquet_io.core.parquet_writer import ParquetWriteSettings
 from geoparquet_io.core.partition.reader import require_single_file
 from geoparquet_io.core.remote import (
@@ -50,11 +58,17 @@ def _validate_tile_size(tile_size: int) -> None:
 
 
 def _str_layout(row_count: int, tile_size: int) -> tuple[int, int, int]:
-    """Return ``(tile_count, strip_count, strip_size)`` for a 2D STR pack."""
+    """Return ``(tile_count, strip_count, strip_size)`` for a 2D STR pack.
+
+    ``strip_size`` is rounded up to a whole number of tiles. Deriving it as
+    ``ceil(row_count / strip_count)`` instead leaves a fractional tile at each
+    strip boundary, so the row group that spans the boundary covers two strips
+    and its bounding box stretches across the whole X extent.
+    """
     _validate_tile_size(tile_size)
     tile_count = max(1, math.ceil(row_count / tile_size))
     strip_count = max(1, math.ceil(math.sqrt(tile_count)))
-    strip_size = max(1, math.ceil(row_count / strip_count))
+    strip_size = tile_size * max(1, math.ceil(tile_count / strip_count))
     return tile_count, strip_count, strip_size
 
 
@@ -165,10 +179,15 @@ def str_order_table(
 ) -> pa.Table:
     """Reorder an Arrow Table with 2D Sort-Tile-Recursive leaf packing.
 
-    Geometry envelope centers are sorted into approximately square X strips.
-    Each strip is sorted on Y, alternating direction between strips so adjacent
-    tiles remain close. ``tile_size`` should match the eventual Parquet row
-    group size. Empty and NULL geometries are placed at the end.
+    Geometry envelope centers are sorted into X strips. Each strip is sorted on
+    Y, alternating direction between strips so adjacent strips stay close. Empty
+    and NULL geometries are placed at the end.
+
+    ``tile_size`` does not pack rows into tiles directly: it only selects the
+    number of X strips, as ``ceil(sqrt(ceil(num_rows / tile_size)))``. That is a
+    coarse control -- nearby ``tile_size`` values often produce an identical
+    ordering -- so treat it as "roughly the rows I intend to put in a row
+    group", not as an exact tile capacity.
     """
     _validate_tile_size(tile_size)
     geom_col = geometry_column or find_geometry_column_from_table(table) or "geometry"
@@ -226,6 +245,11 @@ def str_order(
     memory_limit: str | None = None,
 ) -> None:
     """Reorder a GeoParquet file with Sort-Tile-Recursive packing."""
+    configure_verbose(verbose)
+    # Validate the value the user actually typed, so the error names
+    # --row-group-size rather than the internal tile_size it is derived into.
+    if row_group_rows is not None and row_group_rows < 1:
+        raise InvalidParameterError("--row-group-size", "must be at least 1")
     tile_size = DEFAULT_STR_TILE_SIZE if row_group_rows is None else row_group_rows
     _validate_tile_size(tile_size)
     effective_version = _resolve_output_version(input_parquet, geoparquet_version, verbose, profile)
@@ -237,11 +261,16 @@ def str_order(
 
     if row_group_size_mb is not None and row_group_rows is None:
         info(
-            f"STR tile capacity defaults to {DEFAULT_STR_TILE_SIZE:,} rows when "
-            "--row-group-size-mb is used. Set --row-group-size for exact tile/row-group alignment."
+            f"STR falls back to {DEFAULT_STR_TILE_SIZE:,} rows per tile when --row-group-size-mb "
+            "is used, because the row count of a byte-sized group is not known before writing. "
+            "Set --row-group-size to choose the strip count yourself."
         )
 
     if is_stdin(input_parquet) or should_stream_output(output_parquet):
+        if add_bbox_flag:
+            # Same pre-existing gap as `sort hilbert`: the streaming path has no
+            # bbox step. Say so instead of silently dropping the request.
+            warn("--add-bbox is ignored in streaming mode; no bbox column will be added.")
         _str_order_streaming(
             input_parquet,
             output_parquet,
@@ -299,13 +328,23 @@ def _str_order_streaming(
         ]
         geom_col = geometry_column
         if geom_col == "geometry" or geom_col not in column_names:
-            geom_col = next(
-                (name for name in STANDARD_GEOMETRY_NAMES if name in column_names), geom_col
-            )
+            # The stream carries its own `geo` metadata, so prefer the file's
+            # declared primary column over the conventional-name guess. Without
+            # this a file whose primary column is e.g. `footprint` binder-errors
+            # in stream mode while working in file mode.
+            geo_meta = parse_geo_metadata(metadata) or {}
+            primary_column = geo_meta.get("primary_column")
+            if primary_column in column_names:
+                geom_col = primary_column
+            else:
+                geom_col = next(
+                    (name for name in STANDARD_GEOMETRY_NAMES if name in column_names), geom_col
+                )
 
         source = _geometry_source(con, source, geom_col)
         row_count = _count_spatial_rows(con, source, geom_col)
-        if row_count == 0:
+        reordered = row_count > 0
+        if not reordered:
             warn("All geometries are empty or null. Writing file without STR ordering.")
             query = f"SELECT * FROM {source}"
         else:
@@ -333,7 +372,10 @@ def _str_order_streaming(
             memory_limit=memory_limit,
         )
         if not should_stream_output(output_path):
-            success(f"Successfully reordered data using STR to: {output_path}")
+            if reordered:
+                success(f"Successfully reordered data using STR to: {output_path}")
+            else:
+                success(f"Wrote data without STR ordering to: {output_path}")
 
 
 def _str_order_file_based(
@@ -371,7 +413,8 @@ def _str_order_file_based(
     try:
         geometry_source = _geometry_source(con, source, geometry_column)
         row_count = _count_spatial_rows(con, geometry_source, geometry_column)
-        if row_count == 0:
+        reordered = row_count > 0
+        if not reordered:
             warn("All geometries are empty or null. Writing file without STR ordering.")
             query = f"SELECT * FROM {geometry_source}"
         else:
@@ -400,7 +443,10 @@ def _str_order_file_based(
         )
         if add_bbox_flag and temp_file_created:
             success("Output includes bbox column and metadata for optimal performance")
-        success(f"Successfully reordered data using STR to: {output_parquet}")
+        if reordered:
+            success(f"Successfully reordered data using STR to: {output_parquet}")
+        else:
+            success(f"Wrote data without STR ordering to: {output_parquet}")
     except duckdb.IOException as exc:
         if is_remote_url(input_parquet):
             hints = get_remote_error_hint(str(exc), input_parquet)
@@ -409,7 +455,3 @@ def _str_order_file_based(
     finally:
         con.close()
         _cleanup_temp_file(temp_file, verbose)
-
-
-if __name__ == "__main__":
-    str_order()

--- a/geoparquet_io/core/str_order.py
+++ b/geoparquet_io/core/str_order.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+
+"""Sort-Tile-Recursive ordering for spatially compact Parquet row groups."""
+
+from __future__ import annotations
+
+import math
+import uuid
+
+import duckdb
+import pyarrow as pa
+
+from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.exceptions import InvalidParameterError, RemoteAccessError
+from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.geometry_detection import (
+    STANDARD_GEOMETRY_NAMES,
+    find_primary_geometry_column,
+)
+from geoparquet_io.core.hilbert_order import (
+    _cleanup_temp_file,
+    _prepare_working_file,
+    _resolve_output_version,
+)
+from geoparquet_io.core.logging_config import debug, info, success, warn
+from geoparquet_io.core.parquet_writer import ParquetWriteSettings
+from geoparquet_io.core.partition.reader import require_single_file
+from geoparquet_io.core.remote import (
+    get_remote_error_hint,
+    is_remote_url,
+    needs_httpfs,
+    setup_aws_profile_if_needed,
+    show_remote_read_message,
+    validate_profile_for_urls,
+)
+from geoparquet_io.core.stream_io import open_input, write_output
+from geoparquet_io.core.streaming import (
+    find_geometry_column_from_table,
+    is_stdin,
+    should_stream_output,
+)
+
+DEFAULT_STR_TILE_SIZE = ParquetWriteSettings.DEFAULT_ROW_GROUP_ROWS
+
+
+def _validate_tile_size(tile_size: int) -> None:
+    if tile_size < 1:
+        raise InvalidParameterError("tile_size", "must be at least 1")
+
+
+def _str_layout(row_count: int, tile_size: int) -> tuple[int, int, int]:
+    """Return ``(tile_count, strip_count, strip_size)`` for a 2D STR pack."""
+    _validate_tile_size(tile_size)
+    tile_count = max(1, math.ceil(row_count / tile_size))
+    strip_count = max(1, math.ceil(math.sqrt(tile_count)))
+    strip_size = max(1, math.ceil(row_count / strip_count))
+    return tile_count, strip_count, strip_size
+
+
+def _str_order_query(
+    source: str,
+    geometry_column: str,
+    row_count: int,
+    tile_size: int,
+    output_expressions: list[str] | None = None,
+) -> str:
+    """Build the STR leaf-packing query used by all input/output paths."""
+    _, _, strip_size = _str_layout(row_count, tile_size)
+    geom = quote_identifier(geometry_column)
+    suffix = uuid.uuid4().hex
+    input_order = quote_identifier(f"__gpio_str_input_order_{suffix}")
+    center_x = quote_identifier(f"__gpio_str_x_{suffix}")
+    center_y = quote_identifier(f"__gpio_str_y_{suffix}")
+    strip = quote_identifier(f"__gpio_str_strip_{suffix}")
+    selected = (
+        ", ".join(output_expressions)
+        if output_expressions
+        else f"* EXCLUDE ({input_order}, {center_x}, {center_y}, {strip})"
+    )
+    empty_selected = (
+        ", ".join(output_expressions) if output_expressions else f"* EXCLUDE ({input_order})"
+    )
+
+    return f"""
+        WITH indexed AS (
+            SELECT *, row_number() OVER () AS {input_order}
+            FROM {source}
+        ),
+        spatial AS (
+            SELECT
+                *,
+                (ST_XMin({geom}) + ST_XMax({geom})) / 2.0 AS {center_x},
+                (ST_YMin({geom}) + ST_YMax({geom})) / 2.0 AS {center_y}
+            FROM indexed
+            WHERE {geom} IS NOT NULL AND NOT ST_IsEmpty({geom})
+        ),
+        x_ranked AS (
+            SELECT
+                *,
+                floor(
+                    (row_number() OVER (
+                        ORDER BY {center_x}, {center_y}, {input_order}
+                    ) - 1) / {strip_size}
+                )::BIGINT AS {strip}
+            FROM spatial
+        ),
+        ordered AS (
+            SELECT *
+            FROM x_ranked
+            ORDER BY
+                {strip},
+                CASE WHEN {strip} % 2 = 0 THEN {center_y} ELSE -{center_y} END,
+                {center_x},
+                {input_order}
+        ),
+        empty_or_null AS (
+            SELECT *
+            FROM indexed
+            WHERE {geom} IS NULL OR ST_IsEmpty({geom})
+        )
+        SELECT {selected} FROM ordered
+        UNION ALL
+        SELECT {empty_selected} FROM empty_or_null
+    """
+
+
+def _count_spatial_rows(con: duckdb.DuckDBPyConnection, source: str, geometry_column: str) -> int:
+    geom = quote_identifier(geometry_column)
+    result = con.execute(f"""
+        SELECT count(*)
+        FROM {source}
+        WHERE {geom} IS NOT NULL AND NOT ST_IsEmpty({geom})
+    """).fetchone()
+    return int(result[0]) if result else 0
+
+
+def _geometry_source(
+    con: duckdb.DuckDBPyConnection,
+    source: str,
+    geometry_column: str,
+) -> str:
+    """Return a queryable source whose geometry column has DuckDB GEOMETRY type."""
+    columns = con.execute(f"DESCRIBE SELECT * FROM {source}").fetchall()
+    geometry_type = next(
+        (column[1] for column in columns if column[0] == geometry_column),
+        None,
+    )
+    if geometry_type is None or "BLOB" not in geometry_type.upper():
+        return source
+
+    geom = quote_identifier(geometry_column)
+    view_name = quote_identifier(f"__gpio_str_geometry_{uuid.uuid4().hex}")
+    con.execute(
+        f"CREATE TEMP VIEW {view_name} AS "
+        f"SELECT * REPLACE (ST_GeomFromWKB({geom}) AS {geom}) FROM {source}"
+    )
+    return view_name
+
+
+def str_order_table(
+    table: pa.Table,
+    geometry_column: str | None = None,
+    tile_size: int = DEFAULT_STR_TILE_SIZE,
+) -> pa.Table:
+    """Reorder an Arrow Table with 2D Sort-Tile-Recursive leaf packing.
+
+    Geometry envelope centers are sorted into approximately square X strips.
+    Each strip is sorted on Y, alternating direction between strips so adjacent
+    tiles remain close. ``tile_size`` should match the eventual Parquet row
+    group size. Empty and NULL geometries are placed at the end.
+    """
+    _validate_tile_size(tile_size)
+    geom_col = geometry_column or find_geometry_column_from_table(table) or "geometry"
+    geom = quote_identifier(geom_col)
+
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
+    try:
+        con.register("__input_table", table)
+        source = _geometry_source(con, "__input_table", geom_col)
+
+        row_count = _count_spatial_rows(con, source, geom_col)
+        if row_count == 0:
+            warn("All geometries are empty or null. Returning table without STR ordering.")
+            return table
+
+        empty_count = table.num_rows - row_count
+        if empty_count:
+            warn(
+                f"Found {empty_count} empty/null geometries. "
+                "These will be placed at the end of the sorted output."
+            )
+
+        output_expressions = [
+            f"ST_AsWKB({geom}) AS {geom}" if column == geom_col else quote_identifier(column)
+            for column in table.column_names
+        ]
+        query = _str_order_query(
+            source,
+            geom_col,
+            row_count,
+            tile_size,
+            output_expressions=output_expressions,
+        )
+        result = con.execute(query).arrow().read_all()
+        if table.schema.metadata:
+            result = result.replace_schema_metadata(table.schema.metadata)
+        return result
+    finally:
+        con.close()
+
+
+def str_order(
+    input_parquet: str,
+    output_parquet: str | None = None,
+    geometry_column: str = "geometry",
+    add_bbox_flag: bool = False,
+    verbose: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    row_group_size_mb: float | None = None,
+    row_group_rows: int | None = None,
+    profile: str | None = None,
+    geoparquet_version: str | None = None,
+    overwrite: bool = False,
+    memory_limit: str | None = None,
+) -> None:
+    """Reorder a GeoParquet file with Sort-Tile-Recursive packing."""
+    tile_size = DEFAULT_STR_TILE_SIZE if row_group_rows is None else row_group_rows
+    _validate_tile_size(tile_size)
+    effective_version = _resolve_output_version(input_parquet, geoparquet_version, verbose, profile)
+    if effective_version == "1.1":
+        warn(
+            "STR sorting to GeoParquet v1.1 provides no spatial filter pushdown benefit. "
+            "Consider using --geoparquet-version 2.0 to enable native geo_bbox row group statistics."
+        )
+
+    if row_group_size_mb is not None and row_group_rows is None:
+        info(
+            f"STR tile capacity defaults to {DEFAULT_STR_TILE_SIZE:,} rows when "
+            "--row-group-size-mb is used. Set --row-group-size for exact tile/row-group alignment."
+        )
+
+    if is_stdin(input_parquet) or should_stream_output(output_parquet):
+        _str_order_streaming(
+            input_parquet,
+            output_parquet,
+            geometry_column,
+            tile_size,
+            verbose,
+            compression,
+            compression_level,
+            row_group_size_mb,
+            row_group_rows,
+            profile,
+            geoparquet_version,
+            memory_limit,
+        )
+        return
+
+    _str_order_file_based(
+        input_parquet,
+        output_parquet,
+        geometry_column,
+        tile_size,
+        add_bbox_flag,
+        verbose,
+        compression,
+        compression_level,
+        row_group_size_mb,
+        row_group_rows,
+        profile,
+        geoparquet_version,
+        overwrite,
+        memory_limit,
+    )
+
+
+def _str_order_streaming(
+    input_path: str,
+    output_path: str | None,
+    geometry_column: str,
+    tile_size: int,
+    verbose: bool,
+    compression: str,
+    compression_level: int | None,
+    row_group_size_mb: float | None,
+    row_group_rows: int | None,
+    profile: str | None,
+    geoparquet_version: str | None,
+    memory_limit: str | None,
+) -> None:
+    if should_stream_output(output_path):
+        verbose = False
+
+    with open_input(input_path, verbose=verbose) as (source, metadata, _is_stream, con):
+        column_names = [
+            column[0] for column in con.execute(f"SELECT * FROM {source} LIMIT 0").description
+        ]
+        geom_col = geometry_column
+        if geom_col == "geometry" or geom_col not in column_names:
+            geom_col = next(
+                (name for name in STANDARD_GEOMETRY_NAMES if name in column_names), geom_col
+            )
+
+        source = _geometry_source(con, source, geom_col)
+        row_count = _count_spatial_rows(con, source, geom_col)
+        if row_count == 0:
+            warn("All geometries are empty or null. Writing file without STR ordering.")
+            query = f"SELECT * FROM {source}"
+        else:
+            query = _str_order_query(source, geom_col, row_count, tile_size)
+            if verbose:
+                _, strip_count, strip_size = _str_layout(row_count, tile_size)
+                debug(
+                    f"STR layout: {row_count:,} spatial rows, {strip_count:,} strips, "
+                    f"about {strip_size:,} rows per strip"
+                )
+
+        write_output(
+            con,
+            query,
+            output_path,
+            original_metadata=metadata,
+            geometry_column=geom_col,
+            compression=compression,
+            compression_level=compression_level,
+            row_group_size_mb=row_group_size_mb,
+            row_group_rows=row_group_rows,
+            verbose=verbose,
+            profile=profile,
+            geoparquet_version=geoparquet_version,
+            memory_limit=memory_limit,
+        )
+        if not should_stream_output(output_path):
+            success(f"Successfully reordered data using STR to: {output_path}")
+
+
+def _str_order_file_based(
+    input_parquet: str,
+    output_parquet: str | None,
+    geometry_column: str,
+    tile_size: int,
+    add_bbox_flag: bool,
+    verbose: bool,
+    compression: str,
+    compression_level: int | None,
+    row_group_size_mb: float | None,
+    row_group_rows: int | None,
+    profile: str | None,
+    geoparquet_version: str | None,
+    overwrite: bool,
+    memory_limit: str | None,
+) -> None:
+    handle_output_overwrite(output_parquet, overwrite, input_parquet)
+    require_single_file(input_parquet, "sort str")
+    working_parquet, temp_file_created, temp_file = _prepare_working_file(
+        input_parquet, add_bbox_flag, verbose
+    )
+    validate_profile_for_urls(profile, input_parquet, output_parquet)
+    setup_aws_profile_if_needed(profile, input_parquet, output_parquet)
+    show_remote_read_message(working_parquet, verbose)
+
+    safe_url = safe_file_url(working_parquet, verbose)
+    source = f"'{safe_url}'"
+    metadata, _ = get_parquet_metadata(working_parquet, verbose)
+    if geometry_column == "geometry":
+        geometry_column = find_primary_geometry_column(working_parquet, verbose)
+
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(working_parquet))
+    try:
+        geometry_source = _geometry_source(con, source, geometry_column)
+        row_count = _count_spatial_rows(con, geometry_source, geometry_column)
+        if row_count == 0:
+            warn("All geometries are empty or null. Writing file without STR ordering.")
+            query = f"SELECT * FROM {geometry_source}"
+        else:
+            query = _str_order_query(geometry_source, geometry_column, row_count, tile_size)
+            if verbose:
+                tile_count, strip_count, strip_size = _str_layout(row_count, tile_size)
+                debug(
+                    f"STR layout: {row_count:,} spatial rows, {tile_count:,} tiles, "
+                    f"{strip_count:,} strips, about {strip_size:,} rows per strip"
+                )
+
+        write_parquet_with_metadata(
+            con,
+            query,
+            output_parquet,
+            original_metadata=metadata,
+            compression=compression,
+            compression_level=compression_level,
+            row_group_size_mb=row_group_size_mb,
+            row_group_rows=row_group_rows,
+            verbose=verbose,
+            profile=profile,
+            geoparquet_version=geoparquet_version,
+            input_file=input_parquet,
+            memory_limit=memory_limit,
+        )
+        if add_bbox_flag and temp_file_created:
+            success("Output includes bbox column and metadata for optimal performance")
+        success(f"Successfully reordered data using STR to: {output_parquet}")
+    except duckdb.IOException as exc:
+        if is_remote_url(input_parquet):
+            hints = get_remote_error_hint(str(exc), input_parquet)
+            raise RemoteAccessError(input_parquet, f"{hints}\n\nOriginal error: {exc}") from exc
+        raise
+    finally:
+        con.close()
+        _cleanup_temp_file(temp_file, verbose)
+
+
+if __name__ == "__main__":
+    str_order()

--- a/geoparquet_io/skills/geoparquet.md
+++ b/geoparquet_io/skills/geoparquet.md
@@ -40,7 +40,7 @@ Be proactive - analyze the data and make recommendations rather than waiting to 
 | `gpio process` | aggregate, overview | Transform or reduce GeoParquet data (aggregate, overview,... |
 | `gpio publish` | stac, upload | Commands for publishing GeoParquet data (STAC metadata,... |
 | `gpio skills` |  | List and access LLM skills for gpio. Skills are markdown... |
-| `gpio sort` | column, hilbert, quadkey | Commands for sorting GeoParquet files. |
+| `gpio sort` | column, hilbert, quadkey, str | Commands for sorting GeoParquet files. |
 <!-- END GENERATED: skill-commands -->
 
 ---

--- a/geoparquet_io/skills/geoparquet.md
+++ b/geoparquet_io/skills/geoparquet.md
@@ -128,6 +128,11 @@ gpio sort column <input> <output> --column "timestamp"
 
 # Sort by quadkey (alternative spatial ordering)
 gpio sort quadkey <input> <output>
+
+# Sort-Tile-Recursive: X strips, each sorted on Y with alternating direction.
+# --row-group-size sets the writer's row-group target AND picks the strip count
+# as ceil(sqrt(rows / row-group-size)); it is not an exact tile capacity.
+gpio sort str <input> <output> --row-group-size 50000
 ```
 
 ### Adding Columns

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -12534,6 +12534,225 @@
        "type": "text"
       }
      ]
+    },
+    "str": {
+     "class": "SingleFileCommand",
+     "hidden": false,
+     "kind": "command",
+     "params": [
+      {
+       "default": "False",
+       "hidden": false,
+       "is_flag": true,
+       "multiple": false,
+       "name": "add_bbox",
+       "nargs": 1,
+       "opts": [
+        "--add-bbox"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "hidden": false,
+       "is_flag": true,
+       "multiple": false,
+       "name": "any_extension",
+       "nargs": 1,
+       "opts": [
+        "--any-extension"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "boolean"
+      },
+      {
+       "default": "'ZSTD'",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression",
+       "nargs": 1,
+       "opts": [
+        "--compression"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "choice[ZSTD|GZIP|BROTLI|LZ4|SNAPPY|UNCOMPRESSED,case_sensitive=False]"
+      },
+      {
+       "default": "<unset>",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "compression_level",
+       "nargs": 1,
+       "opts": [
+        "--compression-level"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "integer range[min=1,max=22,min_open=False,max_open=False,clamp=False]"
+      },
+      {
+       "default": "'geometry'",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "geometry_column",
+       "nargs": 1,
+       "opts": [
+        "--geometry-column",
+        "-g"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "geoparquet_version",
+       "nargs": 1,
+       "opts": [
+        "--geoparquet-version"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "choice[1.0|1.1|1.1-geoarrow|2.0|parquet-geo-only,case_sensitive=True]"
+      },
+      {
+       "default": "<unset>",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "input_parquet",
+       "nargs": 1,
+       "opts": [
+        "input_parquet"
+       ],
+       "param_type": "Argument",
+       "required": true,
+       "secondary_opts": [],
+       "type": "text"
+      },
+      {
+       "default": "None",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "output_parquet",
+       "nargs": 1,
+       "opts": [
+        "output_parquet"
+       ],
+       "param_type": "Argument",
+       "required": false,
+       "secondary_opts": [],
+       "type": "path[exists=False,file_okay=True,dir_okay=True,writable=False,readable=True,resolve_path=False]"
+      },
+      {
+       "default": "False",
+       "hidden": false,
+       "is_flag": true,
+       "multiple": false,
+       "name": "overwrite",
+       "nargs": 1,
+       "opts": [
+        "--overwrite"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "integer"
+      },
+      {
+       "default": "<unset>",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "row_group_size_mb",
+       "nargs": 1,
+       "opts": [
+        "--row-group-size-mb"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "text"
+      },
+      {
+       "default": "False",
+       "hidden": false,
+       "is_flag": true,
+       "multiple": false,
+       "name": "show_sql",
+       "nargs": 1,
+       "opts": [
+        "--show-sql"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "hidden": false,
+       "is_flag": true,
+       "multiple": false,
+       "name": "verbose",
+       "nargs": 1,
+       "opts": [
+        "--verbose",
+        "-v"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "boolean"
+      },
+      {
+       "default": "None",
+       "hidden": false,
+       "is_flag": false,
+       "multiple": false,
+       "name": "write_memory",
+       "nargs": 1,
+       "opts": [
+        "--write-memory"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "text"
+      }
+     ]
     }
    },
    "default_subcommand": null,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,6 +109,12 @@ class TestTable:
         assert isinstance(result, Table)
         assert result.num_rows == 766
 
+    def test_sort_str(self, sample_table):
+        """Test sort_str() method."""
+        result = sample_table.sort_str(tile_size=100)
+        assert isinstance(result, Table)
+        assert result.num_rows == 766
+
     def test_extract_columns(self, sample_table):
         """Test extract() with column selection."""
         result = sample_table.extract(columns=["name", "address"])
@@ -250,6 +256,12 @@ class TestOps:
     def test_sort_hilbert(self, arrow_table):
         """Test ops.sort_hilbert()."""
         result = ops.sort_hilbert(arrow_table)
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 766
+
+    def test_sort_str(self, arrow_table):
+        """Test ops.sort_str()."""
+        result = ops.sort_str(arrow_table, tile_size=100)
         assert isinstance(result, pa.Table)
         assert result.num_rows == 766
 

--- a/tests/test_cli_api_call_parity_scaffold.py
+++ b/tests/test_cli_api_call_parity_scaffold.py
@@ -87,6 +87,7 @@ from geoparquet_io.core import extract as core_extract
 from geoparquet_io.core import hilbert_order as core_hilbert
 from geoparquet_io.core import sort_by_column as core_sort_column
 from geoparquet_io.core import sort_quadkey as core_sort_quadkey
+from geoparquet_io.core import str_order as core_str
 from geoparquet_io.core import write_strategies as core_write_strategies
 from geoparquet_io.core.add import a5 as core_a5
 from geoparquet_io.core.add import bbox as core_bbox
@@ -367,6 +368,29 @@ CASES: list[ParityCase] = [
         normalize={"geometry_column": ("geometry_column", "geometry_column")},
     ),
     ParityCase(
+        id="sort str",
+        cli=_cli(
+            "str_impl",
+            core_str.str_order,
+            lambda c: ["sort", "str", c.input_file, c.output_file],
+        ),
+        ops=_ops(
+            "str_order_table",
+            core_str.str_order_table,
+            lambda c: ops.sort_str(c.table),
+        ),
+        table=_table(
+            core_str,
+            "str_order_table",
+            core_str.str_order_table,
+            lambda c: c.gpio_table.sort_str(),
+        ),
+        normalize={
+            "geometry_column": ("geometry_column", "geometry_column"),
+            "tile_size": ("row_group_rows", "tile_size"),
+        },
+    ),
+    ParityCase(
         id="sort column",
         cli=_cli(
             "sort_by_column_impl",
@@ -547,6 +571,36 @@ KNOWN_PARITY_GAPS: dict[tuple[str, str, str, str, str], str] = {
         "CLI --geometry-column defaults to the conventional name 'geometry'; ops.sort_hilbert "
         "passes None so core auto-detects. Table.sort_hilbert does not have this gap because a "
         "Table already knows its geometry column. Also listed in the #661 allowlist."
+    ),
+    (
+        "sort str",
+        "ops",
+        "geometry_column",
+        "'geometry'",
+        "None",
+    ): (
+        "CLI --geometry-column defaults to the conventional name 'geometry'; ops.sort_str "
+        "passes None so core auto-detects. Table.sort_str already knows its geometry column."
+    ),
+    (
+        "sort str",
+        "ops",
+        "tile_size",
+        "None",
+        "100000",
+    ): (
+        "The file core resolves row_group_rows=None to the writer's 100,000-row default; the "
+        "in-memory API spells the same effective default explicitly as tile_size=100000."
+    ),
+    (
+        "sort str",
+        "table",
+        "tile_size",
+        "None",
+        "100000",
+    ): (
+        "The file core resolves row_group_rows=None to the writer's 100,000-row default; the "
+        "fluent API spells the same effective default explicitly as tile_size=100000."
     ),
     (
         "add kdtree",
@@ -770,6 +824,7 @@ def test_case_table_covers_the_commands_the_refactors_touch():
         "add quadkey",
         "add kdtree",
         "sort hilbert",
+        "sort str",
         "sort column",
         "sort quadkey",
         "extract geoparquet",

--- a/tests/test_cli_api_default_parity.py
+++ b/tests/test_cli_api_default_parity.py
@@ -250,6 +250,16 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str, str, str], str] = {
         "tracks its geometry column, so None means 'use that one'"
     ),
     (
+        "sort str",
+        "ops.sort_str",
+        "geometry_column",
+        "'geometry'",
+        "'<unset>'",
+    ): (
+        "CLI reads a file and names the conventional column; the API holds a Table that already "
+        "tracks its geometry column, so None means 'use that one'"
+    ),
+    (
         "partition a5",
         "Table.partition_by_a5",
         "keep_a5_column",

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -140,6 +140,24 @@ class TestSortCommands:
         # Should fail with non-zero exit code
         assert result.exit_code != 0
 
+    def test_str_sort_places(self, places_test_file, temp_output_file):
+        """STR is exposed as a file-producing sort alternative."""
+        runner = CliRunner()
+        result = runner.invoke(
+            sort,
+            [
+                "str",
+                places_test_file,
+                temp_output_file,
+                "--row-group-size",
+                "100",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(temp_output_file)
+        assert pq.read_table(temp_output_file).num_rows == 766
+
 
 class TestSortColumnCommands:
     """Test suite for column sort commands."""

--- a/tests/test_str_order.py
+++ b/tests/test_str_order.py
@@ -1,0 +1,226 @@
+"""Tests for Sort-Tile-Recursive spatial ordering."""
+
+from __future__ import annotations
+
+import json
+import io
+import struct
+import sys
+from unittest import mock
+
+import pyarrow as pa
+import pyarrow.ipc as ipc
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import write_geoparquet_table
+from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.str_order import _str_layout, str_order, str_order_table
+
+
+def _point_wkb(x: float, y: float) -> bytes:
+    return struct.pack("<BIdd", 1, 1, x, y)
+
+
+def _empty_collection_wkb() -> bytes:
+    return struct.pack("<BII", 1, 7, 0)
+
+
+def _point_table(coords: list[tuple[int, float, float]]) -> pa.Table:
+    """Build a metadata-bearing WKB point table from ``(id, x, y)`` rows."""
+    metadata = {
+        b"geo": json.dumps(
+            {
+                "version": "1.1.0",
+                "primary_column": "geometry",
+                "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+            }
+        ).encode()
+    }
+    return pa.table(
+        {
+            "id": pa.array([row[0] for row in coords]),
+            "geometry": pa.array(
+                [_point_wkb(row[1], row[2]) for row in coords],
+                type=pa.binary(),
+            ),
+        }
+    ).replace_schema_metadata(metadata)
+
+
+def _group_bbox_area(table: pa.Table, tile_size: int) -> float:
+    """Return the sum of point bounding-box areas for consecutive tiles."""
+    points = [struct.unpack("<BIdd", value)[2:] for value in table["geometry"].to_pylist()]
+    total = 0.0
+    for start in range(0, len(points), tile_size):
+        xs = [point[0] for point in points[start : start + tile_size]]
+        ys = [point[1] for point in points[start : start + tile_size]]
+        total += (max(xs) - min(xs)) * (max(ys) - min(ys))
+    return total
+
+
+def test_str_order_packs_square_grid_into_snaking_tiles():
+    """STR makes X strips and alternates Y direction between adjacent strips."""
+    shuffled = [
+        (15, 3, 3),
+        (0, 0, 0),
+        (10, 2, 2),
+        (5, 1, 1),
+        (12, 3, 0),
+        (3, 0, 3),
+        (9, 2, 1),
+        (6, 1, 2),
+        (13, 3, 1),
+        (2, 0, 2),
+        (8, 2, 0),
+        (7, 1, 3),
+        (14, 3, 2),
+        (1, 0, 1),
+        (11, 2, 3),
+        (4, 1, 0),
+    ]
+
+    result = str_order_table(_point_table(shuffled), tile_size=4)
+
+    assert result["id"].to_pylist() == [0, 4, 1, 5, 2, 6, 3, 7, 11, 15, 10, 14, 9, 13, 8, 12]
+    assert result.schema.metadata == _point_table(shuffled).schema.metadata
+
+
+def test_str_order_reduces_tile_bbox_area_for_adversarial_input():
+    """Consecutive STR tiles are spatially tighter than a deliberately scattered order."""
+    scattered = []
+    next_id = 0
+    for offset in range(8):
+        for x in range(8):
+            scattered.append((next_id, x, (x + offset) % 8))
+            next_id += 1
+    table = _point_table(scattered)
+
+    result = str_order_table(table, tile_size=8)
+
+    assert _group_bbox_area(result, 8) < _group_bbox_area(table, 8) * 0.25
+
+
+def test_str_order_places_empty_and_null_geometries_last():
+    table = pa.table(
+        {
+            "id": ["null", "high", "empty", "low"],
+            "geometry": pa.array(
+                [
+                    None,
+                    _point_wkb(10, 10),
+                    _empty_collection_wkb(),
+                    _point_wkb(0, 0),
+                ],
+                type=pa.binary(),
+            ),
+        }
+    )
+
+    result = str_order_table(table, tile_size=1)
+
+    assert result["id"].to_pylist() == ["low", "high", "null", "empty"]
+
+
+def test_str_order_all_empty_returns_input_unchanged():
+    table = pa.table(
+        {
+            "id": [1, 2],
+            "geometry": pa.array([None, _empty_collection_wkb()], type=pa.binary()),
+        }
+    )
+
+    assert str_order_table(table, tile_size=2).equals(table)
+
+
+def test_str_order_preserves_columns_that_resemble_internal_names():
+    table = _point_table([(1, 1, 1), (2, 0, 0)]).append_column(
+        "__str_input_order", pa.array(["first", "second"])
+    )
+
+    result = str_order_table(table, tile_size=1)
+
+    assert result.column_names == table.column_names
+    assert result["__str_input_order"].to_pylist() == ["second", "first"]
+
+
+@pytest.mark.parametrize("tile_size", [0, -1])
+def test_str_order_rejects_non_positive_tile_size(tile_size):
+    with pytest.raises(InvalidParameterError):
+        str_order_table(_point_table([(1, 0, 0)]), tile_size=tile_size)
+
+
+def test_str_layout_matches_presentation_formula():
+    assert _str_layout(row_count=16, tile_size=4) == (4, 2, 8)
+    assert _str_layout(row_count=17, tile_size=4) == (5, 3, 6)
+
+
+def test_str_order_streams_stdin_to_file(tmp_path, monkeypatch):
+    table = _point_table([(index, index % 4, index // 4) for index in range(16)])
+    stream = io.BytesIO()
+    with ipc.RecordBatchStreamWriter(stream, table.schema) as writer:
+        writer.write_table(table)
+    stream.seek(0)
+    mock_stdin = mock.MagicMock()
+    mock_stdin.isatty.return_value = False
+    mock_stdin.buffer = stream
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+    output = tmp_path / "stdin-str.parquet"
+
+    str_order("-", str(output), row_group_rows=4, geoparquet_version="1.1")
+
+    assert pq.read_table(output).num_rows == 16
+
+
+def test_str_order_streams_file_to_stdout(tmp_path, monkeypatch):
+    table = _point_table([(index, index % 4, index // 4) for index in range(16)])
+    source = tmp_path / "source.parquet"
+    write_geoparquet_table(table, str(source), geometry_column="geometry")
+    output = io.BytesIO()
+    mock_stdout = mock.MagicMock()
+    mock_stdout.isatty.return_value = False
+    mock_stdout.buffer = output
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    str_order(str(source), "-", row_group_rows=4)
+
+    output.seek(0)
+    assert ipc.RecordBatchStreamReader(output).read_all().num_rows == 16
+
+
+def test_str_order_file_adds_bbox_and_handles_byte_sized_groups(tmp_path):
+    source = tmp_path / "source.parquet"
+    output = tmp_path / "str.parquet"
+    write_geoparquet_table(
+        _point_table([(index, index % 4, index // 4) for index in range(16)]),
+        str(source),
+        geometry_column="geometry",
+    )
+
+    str_order(
+        str(source),
+        str(output),
+        add_bbox_flag=True,
+        row_group_size_mb=1,
+        geoparquet_version="1.1",
+    )
+
+    result = pq.read_table(output)
+    assert result.num_rows == 16
+    assert "bbox" in result.column_names
+
+
+def test_str_order_file_passes_through_all_empty_geometries(tmp_path):
+    source = tmp_path / "empty-source.parquet"
+    output = tmp_path / "empty-str.parquet"
+    table = pa.table(
+        {
+            "id": [1, 2],
+            "geometry": pa.array([None, _empty_collection_wkb()], type=pa.binary()),
+        }
+    )
+    write_geoparquet_table(table, str(source), geometry_column="geometry")
+
+    str_order(str(source), str(output), geoparquet_version="1.1")
+
+    assert pq.read_table(output).num_rows == 2

--- a/tests/test_str_order.py
+++ b/tests/test_str_order.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import io
+import json
+import logging
 import struct
 import sys
 from unittest import mock
@@ -48,15 +49,64 @@ def _point_table(coords: list[tuple[int, float, float]]) -> pa.Table:
     ).replace_schema_metadata(metadata)
 
 
-def _group_bbox_area(table: pa.Table, tile_size: int) -> float:
-    """Return the sum of point bounding-box areas for consecutive tiles."""
-    points = [struct.unpack("<BIdd", value)[2:] for value in table["geometry"].to_pylist()]
-    total = 0.0
+def _points(table: pa.Table) -> list[tuple[float, float]]:
+    return [struct.unpack("<BIdd", value)[2:] for value in table["geometry"].to_pylist()]
+
+
+def _tile_boxes(table: pa.Table, tile_size: int) -> list[tuple[float, float, float, float]]:
+    """Return ``(xmin, ymin, xmax, ymax)`` per consecutive ``tile_size`` rows."""
+    points = _points(table)
+    boxes = []
     for start in range(0, len(points), tile_size):
-        xs = [point[0] for point in points[start : start + tile_size]]
-        ys = [point[1] for point in points[start : start + tile_size]]
-        total += (max(xs) - min(xs)) * (max(ys) - min(ys))
-    return total
+        chunk = points[start : start + tile_size]
+        xs = [point[0] for point in chunk]
+        ys = [point[1] for point in chunk]
+        boxes.append((min(xs), min(ys), max(xs), max(ys)))
+    return boxes
+
+
+def _mean_candidate_tiles(
+    boxes: list[tuple[float, float, float, float]],
+    window: float,
+    extent: float,
+) -> float:
+    """Mean tiles a square query window of side ``window`` has to open.
+
+    This is what spatial filter pushdown actually pays for: candidate row
+    groups. Total tile *area* is close to invariant under any ordering that
+    partitions the data (a plain ``ORDER BY x, y`` reaches the same area as
+    STR), so area alone cannot tell a good spatial order from a bad one.
+    """
+    total = 0
+    windows = 0
+    step = 1.0
+    y = 0.0
+    while y < extent:
+        x = 0.0
+        while x < extent:
+            total += sum(
+                1
+                for (xmin, ymin, xmax, ymax) in boxes
+                if not (xmax < x or xmin > x + window or ymax < y or ymin > y + window)
+            )
+            windows += 1
+            x += step
+        y += step
+    return total / windows
+
+
+# 400 points spread over a 20x20 extent by two irrational strides: deterministic,
+# no grid structure, and every x is distinct so a lexicographic order cannot win
+# by producing zero-width tiles.
+_SPREAD_EXTENT = 20.0
+_SPREAD_POINTS = [
+    (
+        index,
+        ((index * 0.6180339887498949) % 1.0) * _SPREAD_EXTENT,
+        ((index * 0.41421356237309515) % 1.0) * _SPREAD_EXTENT,
+    )
+    for index in range(400)
+]
 
 
 def test_str_order_packs_square_grid_into_snaking_tiles():
@@ -86,19 +136,36 @@ def test_str_order_packs_square_grid_into_snaking_tiles():
     assert result.schema.metadata == _point_table(shuffled).schema.metadata
 
 
-def test_str_order_reduces_tile_bbox_area_for_adversarial_input():
-    """Consecutive STR tiles are spatially tighter than a deliberately scattered order."""
-    scattered = []
-    next_id = 0
-    for offset in range(8):
-        for x in range(8):
-            scattered.append((next_id, x, (x + offset) % 8))
-            next_id += 1
-    table = _point_table(scattered)
+def test_str_order_beats_lexicographic_order_on_candidate_tiles():
+    """STR opens measurably fewer tiles per query window than ``ORDER BY x, y``.
 
-    result = str_order_table(table, tile_size=8)
+    The lexicographic baseline is the one that matters: it is what you get for
+    free, it produces tall thin x-slabs, and on total tile *area* it ties with
+    (or narrowly beats) STR - so a test that only measures area passes without
+    proving STR does anything spatial.
+    """
+    tile_size = 20
+    scattered = _point_table(_SPREAD_POINTS)
+    lexicographic = _point_table(sorted(_SPREAD_POINTS, key=lambda row: (row[1], row[2])))
 
-    assert _group_bbox_area(result, 8) < _group_bbox_area(table, 8) * 0.25
+    result = str_order_table(scattered, tile_size=tile_size)
+
+    str_boxes = _tile_boxes(result, tile_size)
+    lex_boxes = _tile_boxes(lexicographic, tile_size)
+    scattered_boxes = _tile_boxes(scattered, tile_size)
+
+    str_candidates = _mean_candidate_tiles(str_boxes, 2.0, _SPREAD_EXTENT)
+    lex_candidates = _mean_candidate_tiles(lex_boxes, 2.0, _SPREAD_EXTENT)
+    scattered_candidates = _mean_candidate_tiles(scattered_boxes, 2.0, _SPREAD_EXTENT)
+
+    # Measured: STR 1.58, lexicographic 2.27, unsorted 19.65 tiles per window.
+    assert str_candidates < lex_candidates * 0.8
+    assert str_candidates < scattered_candidates * 0.25
+
+    # And the point of the new metric: area does not separate the two orders.
+    str_area = sum((b[2] - b[0]) * (b[3] - b[1]) for b in str_boxes)
+    lex_area = sum((b[2] - b[0]) * (b[3] - b[1]) for b in lex_boxes)
+    assert str_area > lex_area * 0.9
 
 
 def test_str_order_places_empty_and_null_geometries_last():
@@ -134,14 +201,21 @@ def test_str_order_all_empty_returns_input_unchanged():
 
 
 def test_str_order_preserves_columns_that_resemble_internal_names():
+    """A user column sharing the real internal prefix survives the EXCLUDE list.
+
+    The internal columns are ``__gpio_str_<role>_<uuid4 hex>``; the uuid suffix
+    is what keeps them from colliding, so the collision has to be tested with a
+    name carrying the real prefix.
+    """
+    collider = "__gpio_str_input_order_deadbeef"
     table = _point_table([(1, 1, 1), (2, 0, 0)]).append_column(
-        "__str_input_order", pa.array(["first", "second"])
+        collider, pa.array(["first", "second"])
     )
 
     result = str_order_table(table, tile_size=1)
 
     assert result.column_names == table.column_names
-    assert result["__str_input_order"].to_pylist() == ["second", "first"]
+    assert result[collider].to_pylist() == ["second", "first"]
 
 
 @pytest.mark.parametrize("tile_size", [0, -1])
@@ -150,9 +224,15 @@ def test_str_order_rejects_non_positive_tile_size(tile_size):
         str_order_table(_point_table([(1, 0, 0)]), tile_size=tile_size)
 
 
-def test_str_layout_matches_presentation_formula():
+def test_str_layout_rounds_strip_size_to_whole_tiles():
+    """``strip_size`` is a multiple of ``tile_size``, so tiles never straddle strips."""
     assert _str_layout(row_count=16, tile_size=4) == (4, 2, 8)
-    assert _str_layout(row_count=17, tile_size=4) == (5, 3, 6)
+    # 5 tiles over 3 strips: 2 tiles per strip (8 rows), not ceil(17 / 3) == 6,
+    # which would leave the third tile spanning the strip-0/strip-1 boundary.
+    assert _str_layout(row_count=17, tile_size=4) == (5, 3, 8)
+    for row_count, tile_size in ((100_000, 10_000), (2_000_000, 122_880), (17, 4)):
+        _, _, strip_size = _str_layout(row_count, tile_size)
+        assert strip_size % tile_size == 0
 
 
 def test_str_order_streams_stdin_to_file(tmp_path, monkeypatch):
@@ -210,17 +290,168 @@ def test_str_order_file_adds_bbox_and_handles_byte_sized_groups(tmp_path):
     assert "bbox" in result.column_names
 
 
-def test_str_order_file_passes_through_all_empty_geometries(tmp_path):
-    source = tmp_path / "empty-source.parquet"
-    output = tmp_path / "empty-str.parquet"
-    table = pa.table(
+def _all_empty_table() -> pa.Table:
+    return pa.table(
         {
             "id": [1, 2],
             "geometry": pa.array([None, _empty_collection_wkb()], type=pa.binary()),
         }
     )
-    write_geoparquet_table(table, str(source), geometry_column="geometry")
 
-    str_order(str(source), str(output), geoparquet_version="1.1")
+
+def test_str_order_file_passes_through_all_empty_geometries(tmp_path, caplog):
+    """The passthrough branch must not claim it reordered anything."""
+    source = tmp_path / "empty-source.parquet"
+    output = tmp_path / "empty-str.parquet"
+    write_geoparquet_table(_all_empty_table(), str(source), geometry_column="geometry")
+
+    with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+        str_order(str(source), str(output), geoparquet_version="1.1")
 
     assert pq.read_table(output).num_rows == 2
+    messages = [record.message for record in caplog.records]
+    assert any("Wrote data without STR ordering to:" in message for message in messages)
+    assert not any("Successfully reordered data using STR" in message for message in messages)
+
+
+def test_str_order_streaming_passthrough_does_not_claim_it_sorted(tmp_path, monkeypatch, caplog):
+    """Same honesty requirement on the streaming dispatch."""
+    table = _all_empty_table()
+    stream = io.BytesIO()
+    with ipc.RecordBatchStreamWriter(stream, table.schema) as writer:
+        writer.write_table(table)
+    stream.seek(0)
+    mock_stdin = mock.MagicMock()
+    mock_stdin.isatty.return_value = False
+    mock_stdin.buffer = stream
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+    output = tmp_path / "empty-stream.parquet"
+
+    with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+        str_order("-", str(output), geoparquet_version="1.1")
+
+    assert pq.read_table(output).num_rows == 2
+    messages = [record.message for record in caplog.records]
+    assert any("Wrote data without STR ordering to:" in message for message in messages)
+    assert not any("Successfully reordered data using STR" in message for message in messages)
+
+
+def test_str_order_verbose_emits_the_layout_it_chose(tmp_path, caplog):
+    """``--verbose`` has to actually raise the logger, or its only new line is dead."""
+    source = tmp_path / "verbose-source.parquet"
+    output = tmp_path / "verbose-str.parquet"
+    write_geoparquet_table(
+        _point_table([(index, index % 4, index // 4) for index in range(16)]),
+        str(source),
+        geometry_column="geometry",
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+        str_order(
+            str(source), str(output), row_group_rows=4, verbose=True, geoparquet_version="1.1"
+        )
+
+    assert any("STR layout" in record.message for record in caplog.records)
+
+
+def test_str_order_streaming_verbose_emits_the_layout_it_chose(tmp_path, monkeypatch, caplog):
+    """The streaming dispatch has its own layout line; it must emit too."""
+    table = _point_table([(index, index % 4, index // 4) for index in range(16)])
+    stream = io.BytesIO()
+    with ipc.RecordBatchStreamWriter(stream, table.schema) as writer:
+        writer.write_table(table)
+    stream.seek(0)
+    mock_stdin = mock.MagicMock()
+    mock_stdin.isatty.return_value = False
+    mock_stdin.buffer = stream
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+    output = tmp_path / "verbose-stream.parquet"
+
+    with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+        str_order("-", str(output), row_group_rows=4, verbose=True, geoparquet_version="1.1")
+
+    assert any("STR layout" in record.message for record in caplog.records)
+
+
+def test_str_order_rejects_zero_row_group_size_by_the_name_the_user_typed(tmp_path):
+    """The error names --row-group-size, not the tile_size it is derived into."""
+    source = tmp_path / "reject-source.parquet"
+    write_geoparquet_table(_point_table([(1, 0, 0)]), str(source), geometry_column="geometry")
+
+    with pytest.raises(InvalidParameterError) as excinfo:
+        str_order(str(source), str(tmp_path / "out.parquet"), row_group_rows=0)
+
+    assert excinfo.value.param_name == "--row-group-size"
+    assert "tile_size" not in str(excinfo.value)
+
+
+def test_str_order_streaming_warns_that_add_bbox_is_ignored(tmp_path, monkeypatch, caplog):
+    """Streaming has no bbox step (same gap as `sort hilbert`), so say so."""
+    table = _point_table([(index, index % 4, index // 4) for index in range(16)])
+    stream = io.BytesIO()
+    with ipc.RecordBatchStreamWriter(stream, table.schema) as writer:
+        writer.write_table(table)
+    stream.seek(0)
+    mock_stdin = mock.MagicMock()
+    mock_stdin.isatty.return_value = False
+    mock_stdin.buffer = stream
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+    output = tmp_path / "stream-bbox.parquet"
+
+    with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+        str_order("-", str(output), add_bbox_flag=True, geoparquet_version="1.1")
+
+    assert any("--add-bbox is ignored in streaming mode" in r.message for r in caplog.records)
+    assert "bbox" not in pq.read_table(output).column_names
+
+
+def test_str_order_streaming_uses_the_streams_own_primary_column(tmp_path, monkeypatch):
+    """A non-standard primary column works in stream mode, as it does in file mode."""
+    metadata = {
+        b"geo": json.dumps(
+            {
+                "version": "1.1.0",
+                "primary_column": "footprint",
+                "columns": {"footprint": {"encoding": "WKB", "geometry_types": ["Point"]}},
+            }
+        ).encode()
+    }
+    table = pa.table(
+        {
+            "id": pa.array(list(range(16))),
+            "footprint": pa.array(
+                [_point_wkb(index % 4, index // 4) for index in range(16)],
+                type=pa.binary(),
+            ),
+        }
+    ).replace_schema_metadata(metadata)
+    stream = io.BytesIO()
+    with ipc.RecordBatchStreamWriter(stream, table.schema) as writer:
+        writer.write_table(table)
+    stream.seek(0)
+    mock_stdin = mock.MagicMock()
+    mock_stdin.isatty.return_value = False
+    mock_stdin.buffer = stream
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+    output = tmp_path / "footprint-str.parquet"
+
+    str_order("-", str(output), row_group_rows=4, geoparquet_version="1.1")
+
+    result = pq.read_table(output)
+    assert result.num_rows == 16
+    assert result.column_names == ["id", "footprint"]
+
+
+def test_str_order_file_write_preserves_the_in_memory_ordering(tmp_path):
+    """The written row order is str_order_table's order - the write does not reshuffle."""
+    source = tmp_path / "order-source.parquet"
+    output = tmp_path / "order-str.parquet"
+    table = _point_table(_SPREAD_POINTS)
+    write_geoparquet_table(table, str(source), geometry_column="geometry")
+
+    str_order(str(source), str(output), row_group_rows=20, geoparquet_version="1.1")
+
+    written = pq.read_table(output)
+    expected = str_order_table(table, tile_size=20)
+    assert written["id"].to_pylist() == expected["id"].to_pylist()
+    assert written["geometry"].to_pylist() == expected["geometry"].to_pylist()


### PR DESCRIPTION
## Summary

- add Sort-Tile-Recursive (STR) as `gpio sort str`, `ops.sort_str()`, and `Table.sort_str()`
- pack geometry-envelope centers into row-group-sized X strips and alternating Y runs, with deterministic input-order tie breaking
- preserve GeoParquet metadata, streaming/file modes, bbox generation, output-version handling, and empty/null geometry behavior
- document when to use STR versus Hilbert and keep the CLI/API parity contracts and generated command references in sync

The implementation follows the algorithm in the linked spatial-sort presentation/benchmark: compute the number of row-group tiles, create `ceil(sqrt(tile_count))` X strips, then order each strip on Y. The Y direction alternates between strips to keep adjacent runs close.

## Real AIS verification

I converted one 518 MB partition from `ais_databricks` (5 July 2025): 22,774,317 positions, written as 227 row groups with a 100,000-row target. Both outputs passed all 24 `gpio check spec` validations, including a scan of every WKB value.

| Metric | Hilbert | STR | Change |
|---|---:|---:|---:|
| Output size | 508.4 MB | 448.6 MB | 11.8% smaller |
| Summed row-group bbox area | 31,655.7 | 15,086.6 | 52.3% lower |
| Pairwise bbox overlap area | 3,587.7 | 162.7 | 95.5% lower |
| Overlap / summed area | 11.3% | 1.1% | 10.5x lower |
| Oslofjord candidate groups | 18 | 15 | 16.7% fewer |
| Lofoten candidate groups | 40 | 36 | 10.0% fewer |
| Sort/write time on this machine | 85.9 s | 231.5 s | STR is 2.7x slower |

The tradeoff on this distribution is clear: STR costs more to build, but produces substantially tighter and less-overlapping row-group bounds.

### Hilbert — Oslofjord

18 / 227 candidate row groups, 1.81M candidate rows.

![Hilbert row-group bounding boxes over Oslofjord](https://i.imgur.com/Op505LI.png)

### Sort-Tile-Recursive — Oslofjord

15 / 227 candidate row groups, 1.51M candidate rows.

![Sort-Tile-Recursive row-group bounding boxes over Oslofjord](https://i.imgur.com/TvrqMEY.png)

[Open both full-resolution screenshots on Imgur](https://imgur.com/a/Hh9SEYH).

## Tests

- `pre-commit run --all-files`
- `pytest -q -n auto -m 'not slow and not network and not meta'`
  - 4,694 passed, 64 skipped, 6 expected xfailed
- focused CLI/API/STR regression surface
  - 315 passed
- executable `docs/guide/sort.md` examples
  - 9 passed, 5 skipped
- synthetic shuffled 460,800-point grid
  - STR produced zero pairwise row-group bbox overlap versus a 30.8% overlap ratio for Hilbert


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Sort-Tile-Recursive (STR) spatial ordering through `gpio sort str`, `ops.sort_str`, and `Table.sort_str`.
  - Supports configurable strip sizing, geometry columns, row groups, compression, bounding boxes, and streaming workflows.
  - Improves spatial locality and places empty or null geometries last.

- **Documentation**
  - Added CLI, Python API, guide, reference, and changelog documentation.

- **Tests**
  - Added coverage for ordering quality, streaming, validation, metadata, and CLI/API consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->