### PR TITLE
bump: version 1.3.0 → 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geoparquet-io"
-version = "1.3.0"
+version = "1.4.0"
 description = "Fast I/O and transformation tools for GeoParquet files"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -327,7 +327,7 @@ skips = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.3.0"
+version = "1.4.0"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 # Off: the changelog is generated from merged pull requests by

--- a/uv.lock
+++ b/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump for the v1.4.0 release. The changelog section landed in #780; this is the two-line version change that fires the publish workflow.

- `pyproject.toml`: `[project].version` and `[tool.commitizen].version` → `1.4.0`
- `uv.lock`: the `geoparquet-io` package version → `1.4.0`

Merging this puts a commit starting with `bump:` on `main`, which `.github/workflows/publish.yml` picks up to tag `v1.4.0`, build, publish to PyPI, and open the GitHub release.

`cz bump --yes` produced the pyproject change but could not commit it: a pre-commit hook rewrote files mid-run, so the commit is made by hand with commitizen's own message format.

**`uv.lock` is hand-edited to one line on purpose.** Running `uv sync` locally rewrote the whole lock — `revision = 3` → `revision = 1`, every `upload-time` field stripped — because this machine has uv 0.6.6, older than whatever wrote the committed lock. That downgrade is noise, not a dependency change, so only the version line is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Koff7G9J4BjzR7zbm4YxG