### PR TITLE
fix(ci): accept metadata 2.5 when publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,7 +104,12 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.release_check.outputs.release_exists == 'false'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        # v1.14.2 or newer is required: hatchling now writes
+        # Metadata-Version: 2.5, and the Twine bundled in v1.14.0 rejects it
+        # with "InvalidDistribution: '2.5' is not a valid metadata version",
+        # which failed the v1.4.0 publish after the tag was already pushed.
+        # v1.14.2 ships Twine 7, which accepts 2.5.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true
 


### PR DESCRIPTION
**The v1.4.0 release is half-done and this unblocks it.** The tag `v1.4.0` is pushed and the wheel built, but the publish step failed, so there is nothing on PyPI and no GitHub release yet.

## The failure

```
Checking dist/geoparquet_io-1.4.0-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling now writes `Metadata-Version: 2.5`. Reproduced locally:

```
$ uv build --out-dir /tmp/distcheck
$ python3 -c "..."   # read METADATA out of the wheel
geoparquet_io-1.3.0-py3-none-any.whl
Metadata-Version: 2.5
Name: geoparquet-io
```

The Twine bundled inside `gh-action-pypi-publish` v1.14.0 (April 2026) predates that. v1.14.2's release notes name this exactly: *"update of Twine to v7 that we use internally. This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI."*

## The fix

Pin bumped to v1.14.2 (`dc37677`, the annotated tag dereferenced to its commit, matching the repo's SHA-pinning convention).

Nothing about the artifact is wrong — the wheel is fine and PyPI accepts 2.5. Only the action's client-side check was stale, so this is an action bump rather than a hatchling downgrade or a skipped verification.

## After this merges

The Release workflow gets re-run through `workflow_dispatch`, which is the recovery path it documents: the tag already exists and the release does not, so it skips tag creation, rebuilds, publishes to PyPI and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Koff7G9J4BjzR7zbm4YxG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to support packages using the latest metadata format.
  * Improved publishing reliability by upgrading the package upload tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->