### PR TITLE
docs(release): record what the v1.4.0 release actually did

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -177,11 +177,36 @@ Open the printed link and confirm it lands on the heading before you finish.
 
 ## 8. Verify
 
+Check the published artifact, not the local tree:
+
 ```bash
-uv run python -c "import geoparquet_io; print(geoparquet_io.__version__)"
-pip index versions geoparquet-io          # PyPI has the new version
-gh release view v<version>
+uv run --isolated --no-project --with "geoparquet-io==<version>" gpio --version
+gh release view v<version> --json assets --jq '[.assets[].name]'
 ```
+
+The release should carry four assets: the wheel, the sdist, and an
+attestation for each.
+
+## If the publish fails after the tag is pushed
+
+The workflow creates the tag before it uploads, so a failed upload leaves a
+tag with no release and nothing on PyPI. Nothing is half-published — the
+upload is the last step — so do not delete the tag. Fix the cause on `main`,
+then re-run:
+
+```bash
+gh workflow run publish.yml --ref main
+```
+
+That is the documented recovery path: the run sees the tag already exists and
+the release does not, skips tag creation, rebuilds, publishes and creates the
+release.
+
+Seen once, for the record: `gh-action-pypi-publish` v1.14.0 rejected the wheel
+with `InvalidDistribution: '2.5' is not a valid metadata version`, because
+hatchling had started writing `Metadata-Version: 2.5` and the action's bundled
+Twine predated it. Fixed by bumping the action pin, not by downgrading the
+build backend or skipping verification.
 
 ## Conventions this skill enforces
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -106,11 +106,42 @@ work, put the changelog in that pull request and let review happen there.
 the section you just wrote alone.
 
 ```bash
-git checkout -b release/v<version>
+git checkout -b release/bump-v<version>
 uv run cz bump --yes                 # pyproject.toml + [tool.commitizen].version
-git push -u origin release/v<version>
+```
+
+**`cz bump` usually cannot commit here.** A pre-commit hook rewrites files
+mid-run, cz sees a dirty tree and stops, so you get the version edit with no
+commit and no tag. That is fine — make the commit yourself, with cz's own
+message format, because `publish.yml` triggers on a head commit that starts
+with `bump:`:
+
+```bash
+git commit -am "bump: version <previous> → <version>"   # re-run if a hook edits files
+```
+
+Check what you are committing. `cz bump` leaves `uv.lock` alone, so bump the
+`geoparquet-io` package version in it by hand — one line:
+
+```
+[[package]]
+name = "geoparquet-io"
+version = "<version>"
+```
+
+Never run `uv sync` to do that. An older local uv rewrites the whole lockfile
+into an older format (`revision = 3` → `revision = 1`, every `upload-time`
+stripped, thousands of lines) which is a downgrade, not a dependency change.
+`uv lock --check` tells you whether your uv agrees with the committed lock; if
+it does not, upgrade uv rather than committing the churn.
+
+```bash
+git push -u origin release/bump-v<version>
 gh pr create --title "bump: version <previous> → <version>"
 ```
+
+The PR title matters twice: the squash commit is what `publish.yml` matches on,
+and `pr-title` checks it. `bump` is a valid commitizen type, so this passes.
 
 Merging that PR fires `.github/workflows/publish.yml`, which tags `v<version>`,
 publishes to PyPI, and creates the GitHub release.


### PR DESCRIPTION
Three things went differently from what the release skill described when v1.4.0 shipped. Each is now written down, so the next release does not rediscover them.

## `cz bump` cannot commit

The skill said "run `cz bump --yes`". It writes the version into `pyproject.toml`, then its own commit fails, because a pre-commit hook rewrites files mid-run and cz refuses a dirty tree. No commit, no tag. The step now says to expect that and make the commit by hand with cz's message format — which matters, since `publish.yml` triggers on a head commit starting with `bump:`.

## `uv.lock` is a one-line edit

`cz bump` does not touch `uv.lock`, and `uv sync` is the wrong way to fix that. On an older local uv it rewrites the whole file into an older format — `revision = 3` → `revision = 1`, every `upload-time` stripped, ~3,200 lines — which is a format downgrade, not a dependency change. The step now says to edit the one version line, and to run `uv lock --check` to find out whether your uv disagrees with the committed lock (if it does, upgrade uv).

## The publish can fail after the tag exists

It did. `gh-action-pypi-publish` v1.14.0 rejected the wheel with `InvalidDistribution: '2.5' is not a valid metadata version` — hatchling had started writing `Metadata-Version: 2.5` and the action's bundled Twine predated it (fixed in #783). That left tag `v1.4.0` pushed, nothing on PyPI, no release.

There is now a section saying what that state is and what to do: nothing is half-published, since the upload is the last step, so do not delete the tag — fix the cause on `main` and re-run `gh workflow run publish.yml --ref main`, the recovery path the workflow already documents.

Step 8 also verifies the published artifact rather than the local tree:

```
$ uv run --isolated --no-project --with "geoparquet-io==1.4.0" gpio --version
geoparquet-io, version 1.4.0
```

Docs only — no code, no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Koff7G9J4BjzR7zbm4YxG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance for handling version bumps when automated commits fail.
  * Added safeguards for preserving lockfile compatibility during releases.
  * Improved verification steps to validate published artifacts and release assets.
  * Documented recovery steps for publish failures after a release tag is pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->