### PR TITLE
fix(stream): write a valid empty stream instead of aborting on a zero-row result

### DIFF
--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -424,6 +424,27 @@ def _rebatch_wkb_under_byte_limit(
     return pa.chunked_array(rebatched, type=geom_col.type)
 
 
+def _ensure_at_least_one_chunk(
+    geom_col: pa.ChunkedArray | pa.Array,
+) -> pa.ChunkedArray | pa.Array:
+    """Give a zero-chunk ChunkedArray a single empty chunk of its own type.
+
+    A DuckDB result with no rows exports its columns as ChunkedArrays holding
+    *zero* chunks. ``geoarrow.pyarrow.as_wkb`` converts chunk by chunk and then
+    rebuilds a ChunkedArray from the results without passing a type, and Arrow
+    C++ aborts the whole process on ``ChunkedArray([])`` with an omitted type
+    ("cannot construct ChunkedArray from empty vector and omitted type",
+    SIGABRT). That is not a Python exception, so it cannot be caught -- the
+    zero-chunk case has to be avoided rather than handled (issue #804).
+
+    One empty chunk of the same type carries the type through the conversion
+    and leaves the column's length at 0.
+    """
+    if isinstance(geom_col, pa.ChunkedArray) and geom_col.num_chunks == 0:
+        return pa.chunked_array([pa.array([], type=geom_col.type)], type=geom_col.type)
+    return geom_col
+
+
 def apply_geoarrow_extension_type(
     table: pa.Table,
     geometry_column: str,
@@ -456,6 +477,11 @@ def apply_geoarrow_extension_type(
 
     try:
         geom_col = table.column(geometry_column)
+
+        # A zero-row result has zero chunks, which aborts the process inside
+        # geoarrow's conversion. Materialize one empty, typed chunk first so an
+        # empty result streams as a valid, correctly-typed empty column (#804).
+        geom_col = _ensure_at_least_one_chunk(geom_col)
 
         # Keep each Arrow chunk under the 32-bit binary offset ceiling before
         # geoarrow re-encodes it. DuckDB exports geometry as 64-bit

--- a/tests/test_pipe_integration.py
+++ b/tests/test_pipe_integration.py
@@ -13,6 +13,7 @@ import tempfile
 import uuid
 from pathlib import Path
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -540,3 +541,149 @@ class TestStdinWithoutGeometryTypes:
         assert result.returncode == 0, result.stderr
         assert "Traceback (most recent call last)" not in result.stderr
         assert pq.read_table(output_file).num_rows > 0
+
+
+class TestZeroRowStreams:
+    """#804: streaming a zero-row result aborted the process with SIGABRT.
+
+    An empty result is an ordinary outcome of a spatial filter, not an error.
+    A DuckDB result with no rows exports an Arrow table whose columns are
+    ChunkedArrays with *zero* chunks; ``geoarrow.pyarrow.as_wkb`` then rebuilds
+    a ChunkedArray from an empty chunk list with no explicit type, which trips
+    an Arrow C++ ``Check failed`` and aborts the interpreter (exit 134). The
+    abort is not a Python exception, so these tests must shell out.
+
+    Note the ``--bbox=VALUE`` form: Windows ``cmd.exe`` does not strip single
+    quotes, so the quoted form only fails on the Windows CI matrix.
+    """
+
+    # Far outside the fixture's extent (Ghana/Burkina Faso), so zero rows match.
+    EMPTY_BBOX = "--bbox=170,-80,171,-79"
+
+    @staticmethod
+    def _read_stream(raw: bytes):
+        import pyarrow.ipc as ipc
+
+        return ipc.RecordBatchStreamReader(pa.BufferReader(pa.py_buffer(raw))).read_all()
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_extract_zero_rows_to_stdout(self):
+        """`gpio extract <empty bbox> in.parquet -` must emit a valid empty stream."""
+        result = subprocess.run(
+            f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} -",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, (
+            f"exit={result.returncode} (134 == SIGABRT): {result.stderr.decode(errors='replace')}"
+        )
+        assert result.stdout, "zero-row stream must still carry a schema, not zero bytes"
+
+        table = self._read_stream(result.stdout)
+        assert table.num_rows == 0
+        assert "geometry" in table.column_names
+        assert "name" in table.column_names
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_zero_row_stream_matches_file_output_schema(self, output_file):
+        """The stream's schema must match what the file path writes for the same filter."""
+        file_result = subprocess.run(
+            f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} {output_file}",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert file_result.returncode == 0, file_result.stderr.decode(errors="replace")
+        file_table = pq.read_table(output_file)
+        assert file_table.num_rows == 0
+
+        stream_result = subprocess.run(
+            f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} -",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert stream_result.returncode == 0, stream_result.stderr.decode(errors="replace")
+
+        stream_table = self._read_stream(stream_result.stdout)
+        assert stream_table.column_names == file_table.column_names
+        # Types, not fields: the geometry field carries an extra
+        # ARROW:extension:name entry on the stream side only.
+        assert [f.type for f in stream_table.schema] == [f.type for f in file_table.schema]
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_zero_row_pipe_to_add_bbox(self, output_file):
+        """A zero-row stream must be readable by the next stage of a pipe."""
+        result = run_pipeline(
+            [
+                f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} -",
+                f"gpio add bbox --bbox-name bbox_test - {output_file}",
+            ]
+        )
+
+        assert result.returncode == 0, f"Pipeline failed: {result.stderr}"
+        table = pq.read_table(output_file)
+        assert table.num_rows == 0
+        assert "bbox_test" in table.column_names
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_zero_row_pipe_stays_a_stream_through_two_stages(self):
+        """Two streaming stages in a row, ending on stdout, still produce a stream."""
+        result = subprocess.run(
+            f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} - | "
+            "gpio add bbox --bbox-name bbox_test - -",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr.decode(errors="replace")
+        table = self._read_stream(result.stdout)
+        assert table.num_rows == 0
+        assert "bbox_test" in table.column_names
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_zero_row_sort_hilbert_to_stdout(self, tmp_path):
+        """`sort` shares the streaming writer, so it must survive zero rows too."""
+        empty = tmp_path / "empty.parquet"
+        prep = subprocess.run(
+            f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} {empty}",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert prep.returncode == 0, prep.stderr.decode(errors="replace")
+
+        result = subprocess.run(
+            f"gpio sort hilbert {empty} -",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr.decode(errors="replace")
+        assert self._read_stream(result.stdout).num_rows == 0
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_zero_row_reproject_to_stdout(self, tmp_path):
+        """`convert reproject` shares the streaming writer as well."""
+        empty = tmp_path / "empty.parquet"
+        prep = subprocess.run(
+            f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} {empty}",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert prep.returncode == 0, prep.stderr.decode(errors="replace")
+
+        result = subprocess.run(
+            f"gpio convert reproject {empty} - --dst-crs EPSG:3857",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr.decode(errors="replace")
+        assert self._read_stream(result.stdout).num_rows == 0

--- a/tests/test_pipe_integration.py
+++ b/tests/test_pipe_integration.py
@@ -586,6 +586,44 @@ class TestZeroRowStreams:
         assert "geometry" in table.column_names
         assert "name" in table.column_names
 
+    @staticmethod
+    def _narrow(type_: pa.DataType) -> pa.DataType:
+        """Reduce a type to the shape that is stable across readers.
+
+        Two differences here are real but orthogonal to this fix:
+
+        * DuckDB exports strings and blobs as ``large_string``/``large_binary``
+          while the Parquet writer stores the 32-bit forms -- for *every*
+          result, empty or not, so it is not a zero-row artifact.
+        * Whether ``geoarrow.pyarrow`` happens to be imported in *this* process
+          decides if the stream's ``ARROW:extension:name`` resolves into a
+          registered ``WkbType`` or stays a bare ``binary`` field carrying
+          metadata. Under ``pytest -n auto`` that depends on which other tests
+          share the worker, so comparing the raw types is order-dependent.
+
+        Unwrapping to storage type and narrowing the offsets leaves the part
+        the assertion is actually about: which columns there are, and what
+        they hold.
+        """
+        if isinstance(type_, pa.ExtensionType):
+            type_ = type_.storage_type
+        if type_ == pa.large_string():
+            return pa.string()
+        if type_ == pa.large_binary():
+            return pa.binary()
+        return type_
+
+    @staticmethod
+    def _extension_name(field: pa.Field) -> str:
+        """The geoarrow extension name, however this process chose to expose it.
+
+        A registered extension type carries it as ``extension_name``; an
+        unregistered one leaves it in the field metadata. See ``_narrow``.
+        """
+        if isinstance(field.type, pa.ExtensionType):
+            return field.type.extension_name
+        return (field.metadata or {}).get(b"ARROW:extension:name", b"").decode()
+
     @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
     def test_zero_row_stream_matches_file_output_schema(self, output_file):
         """The stream's schema must match what the file path writes for the same filter."""
@@ -611,7 +649,45 @@ class TestZeroRowStreams:
         assert stream_table.column_names == file_table.column_names
         # Types, not fields: the geometry field carries an extra
         # ARROW:extension:name entry on the stream side only.
-        assert [f.type for f in stream_table.schema] == [f.type for f in file_table.schema]
+        assert [self._narrow(f.type) for f in stream_table.schema] == [
+            self._narrow(f.type) for f in file_table.schema
+        ]
+
+    @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
+    def test_zero_row_stream_schema_matches_a_non_empty_stream(self):
+        """The empty stream must be the same stream, minus the rows.
+
+        The bug this guards was a *typing* failure -- geoarrow rebuilding the
+        geometry column with no type at all -- so an empty result that merely
+        parses is not enough. Compared stream-to-stream, with no normalizing,
+        every field including the geoarrow extension metadata must be identical
+        to what the same command emits when rows do match.
+        """
+        empty = subprocess.run(
+            f"gpio extract {self.EMPTY_BBOX} {PLACES_PARQUET} -",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert empty.returncode == 0, empty.stderr.decode(errors="replace")
+
+        populated = subprocess.run(
+            f"gpio extract --limit 5 {PLACES_PARQUET} -",
+            shell=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert populated.returncode == 0, populated.stderr.decode(errors="replace")
+
+        empty_table = self._read_stream(empty.stdout)
+        populated_table = self._read_stream(populated.stdout)
+        assert empty_table.num_rows == 0
+        assert populated_table.num_rows == 5
+
+        empty_geometry = empty_table.schema.field("geometry")
+        assert empty_geometry == populated_table.schema.field("geometry")
+        assert self._extension_name(empty_geometry) == "geoarrow.wkb"
+        assert list(empty_table.schema) == list(populated_table.schema)
 
     @pytest.mark.skipif(not PLACES_PARQUET.exists(), reason="Test data not available")
     def test_zero_row_pipe_to_add_bbox(self, output_file):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -752,6 +752,58 @@ class TestApplyGeoArrowExtensionType:
         table = pa.table({"id": [1, 2]})
         assert apply_geoarrow_extension_type(table, "geometry") is table
 
+    def _zero_chunk_table(self, geom_type=pa.large_binary()):
+        """A zero-row table whose geometry column holds zero chunks.
+
+        This is exactly what ``con.execute(...).arrow().read_all()`` returns for
+        a DuckDB result with no rows -- not one empty chunk, but none at all.
+        """
+        table = pa.table(
+            {
+                "id": pa.chunked_array([], type=pa.int64()),
+                "geometry": pa.chunked_array([], type=geom_type),
+            }
+        )
+        assert table.column("geometry").num_chunks == 0
+        return table
+
+    def test_zero_chunk_column_converts_without_aborting(self):
+        """A zero-row (zero-chunk) geometry column yields a typed empty column.
+
+        Regression guard for #804: geoarrow rebuilt a ChunkedArray from an empty
+        chunk list with no type, which aborted the interpreter (SIGABRT) instead
+        of raising. Streaming an empty spatial filter must be ordinary.
+        """
+        table = self._zero_chunk_table()
+
+        result = apply_geoarrow_extension_type(table, "geometry")
+
+        geom = result.column("geometry")
+        assert getattr(geom.type, "extension_name", "") == "geoarrow.wkb"
+        assert result.num_rows == 0
+        assert geom.num_chunks == 1
+        assert result.column_names == ["id", "geometry"]
+
+    def test_zero_chunk_column_keeps_crs(self):
+        """The CRS branch also has to survive the zero-chunk case."""
+        table = self._zero_chunk_table()
+
+        result = apply_geoarrow_extension_type(table, "geometry", crs="EPSG:4326")
+
+        geom_type = result.column("geometry").type
+        assert getattr(geom_type, "extension_name", "") == "geoarrow.wkb"
+        assert geom_type.crs is not None
+        assert result.num_rows == 0
+
+    def test_zero_chunk_binary_column_converts(self):
+        """32-bit ``binary`` WKB (a re-read stream) hits the same path."""
+        table = self._zero_chunk_table(geom_type=pa.binary())
+
+        result = apply_geoarrow_extension_type(table, "geometry")
+
+        assert getattr(result.column("geometry").type, "extension_name", "") == "geoarrow.wkb"
+        assert result.num_rows == 0
+
     def test_rebatches_when_chunk_exceeds_limit(self, monkeypatch):
         """A chunk above the byte budget is split before conversion and survives.
 


### PR DESCRIPTION
## What changed

`apply_geoarrow_extension_type` now materializes one empty, typed chunk before
handing the geometry column to geoarrow, so a zero-row result streams as a
valid, correctly-typed empty Arrow IPC stream instead of aborting the process.

The whole fix is a four-line guard in `core/streaming.py`
(`_ensure_at_least_one_chunk`), applied at the single point where the
zero-chunk column reaches geoarrow.

## Why

Streaming a zero-row result to stdout hard-aborted the process (SIGABRT, exit
134) and left a 0-byte output. An empty result is an ordinary outcome of a
spatial filter, not an error: a caller piping `gpio extract` into another stage
got a signal-killed process that no exit-code check can distinguish from a real
crash, while the *file* path wrote a perfectly good zero-row GeoParquet for the
same filter.

**Root cause, confirmed rather than assumed.** A DuckDB result with no rows
exports Arrow columns as ChunkedArrays holding *zero* chunks — not one empty
chunk. `geoarrow.pyarrow.as_wkb` converts chunk by chunk and then rebuilds a
ChunkedArray from the resulting list without passing a type, and Arrow C++
aborts on `ChunkedArray([])` with an omitted type. Reduced to three lines, with
no gpio involved at all:

```
$ python -c "import pyarrow as pa, geoarrow.pyarrow as ga; ga.as_wkb(pa.chunked_array([], type=pa.binary()))"
/…/arrow/cpp/src/arrow/chunked_array.cc:54:  Check failed: (chunks_.size()) > (static_cast<size_t>(0))
  cannot construct ChunkedArray from empty vector and omitted type
exit=134
```

The same call with a single *empty* chunk succeeds and returns a
`geoarrow.wkb` column of length 0 — so the zero-chunk case has to be avoided,
not handled. Being a C++ `Check failed` and not a Python exception, it cannot
be caught: the existing `except Exception` around the conversion never runs,
which is also why the regression tests here have to shell out via
`subprocess` rather than assert in-process.

## Verification

**Before** (on `main` @ `25a3e2d`):

```
$ uv run gpio extract --bbox=170,-80,171,-79 tests/data/canonical/places.parquet - > empty.arrows
/…/arrow/cpp/src/arrow/chunked_array.cc:54:  Check failed: (chunks_.size()) > (static_cast<size_t>(0))
  cannot construct ChunkedArray from empty vector and omitted type
exit=134
-rw-r--r--  1 …  0 …  empty.arrows
```

**After**:

```
$ uv run gpio extract --bbox=170,-80,171,-79 tests/data/canonical/places.parquet - > empty.arrows
exit=0
$ wc -c < empty.arrows
    1008
$ python -c "import pyarrow.ipc as i; t=i.RecordBatchStreamReader('empty.arrows').read_all(); print(t.num_rows, t.column_names, t.schema.field('geometry').type)"
0 ['fsq_place_id', 'name', 'address', 'placemaker_url', 'geometry', 'bbox'] binary
  -- ARROW:extension:name: 'geoarrow.wkb'

$ uv run gpio extract --bbox=170,-80,171,-79 tests/data/canonical/places.parquet - | uv run gpio add bbox - empty_out.parquet
Successfully added bbox column 'bbox' to: empty_out.parquet
pipe exit=0
$ python -c "import pyarrow.parquet as pq; print(pq.read_table('empty_out.parquet').num_rows)"
0
```

Note the `--bbox=VALUE` form (no shell quotes) in every test that shells out:
Windows `cmd.exe` does not strip single quotes, so the quoted form would fail
only on the Windows matrix.

### Zero-row surface checked beyond `extract`

The same streaming writer backs several commands, so the new tests exercise it
from more than one entry point, and through a full pipe in both directions:

| command | zero-row check |
|---|---|
| `gpio extract <empty bbox> in.parquet -` | valid empty stream, schema matches the file-output path *and* a non-empty stream |
| `gpio sort hilbert empty.parquet -` | exit 0, 0 rows |
| `gpio convert reproject empty.parquet - --dst-crs EPSG:3857` | exit 0, 0 rows |
| `gpio extract … - \| gpio add bbox - out.parquet` | downstream reader gets 0 rows, `bbox` column present |
| `gpio extract … - \| gpio add bbox - -` | two streaming stages, still a valid stream on stdout |

Tests (the six that shell out all failed with exit 134 / -6 before the fix, all
pass after):

- `tests/test_pipe_integration.py::TestZeroRowStreams` — seven subprocess tests
  covering the table above.
- `tests/test_streaming.py::TestApplyGeoArrowExtensionType` — three in-process
  unit tests on the zero-chunk column (plain `binary`, `large_binary`, and the
  CRS branch). These exist because the subprocess tests run uninstrumented, so
  they would leave the new lines uncovered for the diff-cover gate.

Two of the seven assert on the schema rather than just on "it parsed", since
the bug was a *typing* failure and an empty result that merely reads back is
not evidence the column came out right:

- `test_zero_row_stream_matches_file_output_schema` — column names **and**
  types against what the file path writes for the same filter.
- `test_zero_row_stream_schema_matches_a_non_empty_stream` — the empty stream
  field for field against `extract --limit 5` on the same input, geoarrow
  extension metadata included. It must be the same stream, minus the rows.

Both normalize away two differences that are real but orthogonal to this fix,
each checked rather than assumed: DuckDB exports `large_string`/`large_binary`
where the Parquet writer stores the 32-bit forms (true of *every* result, empty
or not), and whether `geoarrow.pyarrow` is imported in the reading process
decides if `ARROW:extension:name` resolves into a registered `WkbType` or stays
a bare `binary` field carrying metadata — which under `-n auto` depends on
which other tests share the worker, so asserting on the raw type or on
`field.metadata` is order-dependent.

Suite runs, on this branch (rebased onto `main` @ `f4939b0`):

```
$ uv run pytest tests/ -q -k "stream or pipe or empty or zero" -m "not slow and not network and not meta"
449 passed, 4 skipped, 5219 deselected in 31.34s

$ uv run pytest tests/test_pipe_integration.py tests/test_streaming.py -q -m "not slow and not network"
86 passed, 9 deselected in 13.70s

$ uv run pytest tests -n auto -q -m "not slow and not network and not meta"
5082 passed, 87 skipped, 2 xfailed in 127.76s
```

No flakes in the final run, and nothing needed a serial re-run.

`uv run pre-commit run --all-files` and `--hook-stage pre-push` both fully green
(including mypy, vulture, xenon, import-linter, deptry and the fast-tests hook).

## Overlap with #801 — now rebased, not anticipated

#801 has since merged, and this branch is rebased onto it. The predicted
outcome held: `core/streaming.py` auto-merged, `core/stream_io.py` did not
conflict at all (this PR never touches it), and the only conflict was the
trivial both-branches-appended-a-class-at-EOF shape in
`tests/test_pipe_integration.py` — resolved by keeping both classes plus the
`import pyarrow as pa` this PR adds.

**`backfill_derived_stats` on a zero-row table is fine**, now verified on the
real rebased tree rather than on a trial merge. Both of its helpers guard the
empty case (`_compute_geometry_types` returns `[]`, `_compute_bbox_from_data`
returns `None` when `table.num_rows == 0`), so the zero-row stream comes out
carrying `"geometry_types": []` and no `bbox` — what GeoParquet 1.1 wants for
an empty column. All 26 tests in `tests/test_pipe_integration.py` (both PRs'
sets) and all 60 fast tests in `tests/test_streaming.py` pass, and the zero-row
stream's metadata reads:

```json
{"version": "1.1.0", "primary_column": "geometry",
 "columns": {"geometry": {"encoding": "WKB", "covering": {...}, "geometry_types": []}}}
```

The two changes are complementary: #801 made a filtered stream's metadata
honest, this one makes an *empty* filtered stream exist at all.

## Follow-up filed: #823

#804 expected an empty result to flow through a pipeline with the next stage
exiting cleanly. This PR delivers the producing half. Two commands still crash
on the *consuming* half, with raw tracebacks:

- `gpio partition string` — `TypeError: '>' not supported between 'NoneType'
  and 'int'` at `core/partition/common.py:131`, because `total_rows` comes back
  `None` for a zero-row input.
- `gpio check all` — bare `KeyError: 'geometry'` at
  `core/check_parquet_structure.py:590`.

Both are **pre-existing on `main` and independent of streaming** — they
reproduce from a zero-row file on disk with no pipe involved, and this PR
touches neither file (`git diff origin/main -- geoparquet_io/core/partition/
geoparquet_io/core/check_parquet_structure.py` is empty). Filed separately as
#823 rather than bolted onto this branch.

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming workflows for empty, zero-row geometry results.
  * Empty results now retain valid geometry schemas and GeoArrow metadata.
  * Improved compatibility of bounding-box calculation, Hilbert sorting, reprojection, and pipeline operations with empty streams.
  * Ensured empty outputs remain consistent with file-based results and non-empty streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->