### PR TITLE
fix(geoarrow): detect the extension name from field metadata everywhere, not just in the writers

### DIFF
--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -572,6 +572,12 @@ explicit `--geoparquet-version` always wins. The Python API resolves the
 version the same way, so `gpio.read('native.parquet').write('out.parquet')`
 writes true 2.0 native output just like the CLI.
 
+The "bare native geo types" rule holds for an in-memory Arrow table too: a table
+with no `geo` metadata whose geometry field declares a GeoArrow extension type —
+whether PyArrow resolved that type or it arrives as an `ARROW:extension:name`
+field-metadata key — is the same shape as a native-geo file, and auto mode
+writes it as 2.0. A `geo` block that declares a version still wins over both.
+
 === "CLI"
 
     ```bash

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -47,7 +47,10 @@ from geoparquet_io.core.geo_metadata import (
     prune_geo_metadata_to_columns,
     strip_derived_stats,
 )
-from geoparquet_io.core.geoarrow_encoding import is_geoarrow_extension_field
+from geoparquet_io.core.geoarrow_encoding import (
+    is_geoarrow_extension_field,
+    is_wkb_extension_field,
+)
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
     _detect_geometry_from_query,
@@ -1125,13 +1128,19 @@ def _strip_geoarrow_to_plain_wkb(table, geometry_column: str, verbose: bool):
 
     geom_col = table.column(geometry_column)
 
-    # Check if it's a geoarrow extension type, in EITHER carrier shape: the
-    # resolved Arrow type, or a plain binary type whose field metadata declares
+    # Check if it's a WKB extension type, in EITHER carrier shape: the resolved
+    # Arrow type, or a plain binary type whose field metadata declares
     # `ARROW:extension:name`. Reading only the type left the metadata-declared
     # shape in place, so the same column got a different carrier depending on
     # whether the process had imported geoarrow.pyarrow (#792).
-    if not is_geoarrow_extension_field(table.schema.field(geometry_column)):
-        return table  # Already plain binary
+    #
+    # WKB names only, not any geoarrow.* name: this rewrites the column to plain
+    # `binary`, which is a lossless re-carrier for WKB bytes and destructive for
+    # anything else -- `geoarrow.point` over `struct<x, y>` cannot be cast at all,
+    # and `geoarrow.wkt` over `string` casts into a binary column still declared
+    # `encoding: WKT`. A native carrier is simply not this function's business.
+    if not is_wkb_extension_field(table.schema.field(geometry_column)):
+        return table  # Already plain binary, or a non-WKB carrier to leave alone
 
     if verbose:
         debug("v1.x: stripping geoarrow extension type to plain binary WKB")
@@ -1247,9 +1256,13 @@ def _process_geometry_column_for_version(
             col_index = table.schema.get_field_index(geometry_column)
             table = table.set_column(col_index, geometry_column, wkb_arr)
         else:
-            # For v1.x: ensure plain binary WKB (strip geoarrow if present)
-            # CRS goes only in metadata, not in schema
-            if is_geoarrow_extension_field(table.schema.field(geometry_column)):
+            # For v1.x: ensure plain binary WKB (strip a WKB extension carrier if
+            # present). CRS goes only in metadata, not in schema.
+            # A non-WKB geoarrow carrier is left alone: casting it here is either
+            # impossible (`geoarrow.point` over `struct<x, y>`) or silently wrong
+            # (`geoarrow.wkt` over `string`), so the broad geoarrow predicate is
+            # the wrong gate for a rewrite (#792).
+            if is_wkb_extension_field(table.schema.field(geometry_column)):
                 table = _strip_geoarrow_to_plain_wkb(table, geometry_column, verbose)
             elif verbose:
                 debug("v1.x: geometry is already plain binary WKB (CRS in metadata only)")

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -47,6 +47,7 @@ from geoparquet_io.core.geo_metadata import (
     prune_geo_metadata_to_columns,
     strip_derived_stats,
 )
+from geoparquet_io.core.geoarrow_encoding import is_geoarrow_extension_field
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
     _detect_geometry_from_query,
@@ -980,14 +981,12 @@ def _detect_version_from_table(table, verbose: bool = False) -> str | None:
     """
     import json
 
-    from geoparquet_io.core.streaming import is_geoarrow_type
-
-    # Check for native geoarrow extension types (indicates v2.0 or parquet-geo-only)
-    has_native_geo = False
-    for field in table.schema:
-        if is_geoarrow_type(field.type):
-            has_native_geo = True
-            break
+    # Check for native geoarrow extension types (indicates v2.0 or parquet-geo-only).
+    # `is_geoarrow_extension_field` reads the field, not just the type, so a
+    # metadata-declared geoarrow column is detected too -- without that, the
+    # same table resolved to "parquet-geo-only" or to the 1.1 default purely
+    # according to whether geoarrow.pyarrow had been imported (#792).
+    has_native_geo = any(is_geoarrow_extension_field(field) for field in table.schema)
 
     # Check schema metadata for geo version
     metadata = table.schema.metadata
@@ -1115,13 +1114,6 @@ def _get_geometry_type_name(code: int) -> str:
     return base_name + suffix
 
 
-def _is_geoarrow_extension_type(arrow_type) -> bool:
-    """Check if an Arrow type is a geoarrow extension type."""
-    if hasattr(arrow_type, "extension_name"):
-        return arrow_type.extension_name.startswith("geoarrow")
-    return False
-
-
 def _strip_geoarrow_to_plain_wkb(table, geometry_column: str, verbose: bool):
     """
     Convert geoarrow extension type back to plain binary WKB.
@@ -1132,10 +1124,13 @@ def _strip_geoarrow_to_plain_wkb(table, geometry_column: str, verbose: bool):
     import pyarrow as pa
 
     geom_col = table.column(geometry_column)
-    geom_type = geom_col.type
 
-    # Check if it's a geoarrow extension type
-    if not _is_geoarrow_extension_type(geom_type):
+    # Check if it's a geoarrow extension type, in EITHER carrier shape: the
+    # resolved Arrow type, or a plain binary type whose field metadata declares
+    # `ARROW:extension:name`. Reading only the type left the metadata-declared
+    # shape in place, so the same column got a different carrier depending on
+    # whether the process had imported geoarrow.pyarrow (#792).
+    if not is_geoarrow_extension_field(table.schema.field(geometry_column)):
         return table  # Already plain binary
 
     if verbose:
@@ -1154,6 +1149,10 @@ def _strip_geoarrow_to_plain_wkb(table, geometry_column: str, verbose: bool):
     try:
         plain_col = _to_plain_wkb_array(geom_col)
         col_index = table.schema.get_field_index(geometry_column)
+        # Passing the bare name rebuilds the field from scratch, which is what
+        # drops a stale `ARROW:extension:name` on the metadata-declared shape --
+        # left behind, DuckDB reads it back off `register()` and the COPY writes
+        # a native Parquet GEOMETRY type into a 1.x file (#706, #727).
         return table.set_column(col_index, geometry_column, plain_col)
 
     except (TypeError, ValueError, AttributeError, pa.ArrowInvalid) as e:
@@ -1250,7 +1249,7 @@ def _process_geometry_column_for_version(
         else:
             # For v1.x: ensure plain binary WKB (strip geoarrow if present)
             # CRS goes only in metadata, not in schema
-            if _is_geoarrow_extension_type(geom_col.type):
+            if is_geoarrow_extension_field(table.schema.field(geometry_column)):
                 table = _strip_geoarrow_to_plain_wkb(table, geometry_column, verbose)
             elif verbose:
                 debug("v1.x: geometry is already plain binary WKB (CRS in metadata only)")

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -28,6 +28,7 @@ from geoparquet_io.core.duckdb_utils import (
     _get_query_column_type,
     quote_identifier,
 )
+from geoparquet_io.core.geoarrow_encoding import is_geoarrow_extension_field
 from geoparquet_io.core.logging_config import debug, warn
 
 if TYPE_CHECKING:
@@ -755,15 +756,10 @@ def _detect_version_from_table(table: pa.Table, verbose: bool = False) -> str | 
     Returns:
         Version string (e.g., "1.1", "2.0", "parquet-geo-only") or None
     """
-    # Lazy import to avoid circular dependency
-    from geoparquet_io.core.streaming import is_geoarrow_type
-
-    # Check for native geoarrow extension types (indicates v2.0 or parquet-geo-only)
-    has_native_geo = False
-    for field in table.schema:
-        if is_geoarrow_type(field.type):
-            has_native_geo = True
-            break
+    # Check for native geoarrow extension types (indicates v2.0 or parquet-geo-only).
+    # Reads the field, not just the type, so the metadata-declared carrier shape
+    # is detected too and this agrees with its twin in common.py (#792).
+    has_native_geo = any(is_geoarrow_extension_field(field) for field in table.schema)
 
     # Check schema metadata for geo version
     metadata = table.schema.metadata
@@ -980,21 +976,6 @@ def _get_geometry_type_name(code: int) -> str:
 
     suffix = _DIMENSION_SUFFIXES.get(dimension, "")
     return base_name + suffix
-
-
-def _is_geoarrow_extension_type(arrow_type) -> bool:
-    """
-    Check if an Arrow type is a geoarrow extension type.
-
-    Args:
-        arrow_type: PyArrow type to check
-
-    Returns:
-        True if the type is a geoarrow extension type
-    """
-    if hasattr(arrow_type, "extension_name"):
-        return arrow_type.extension_name.startswith("geoarrow")
-    return False
 
 
 # =============================================================================

--- a/geoparquet_io/core/geoarrow_encoding.py
+++ b/geoparquet_io/core/geoarrow_encoding.py
@@ -1,13 +1,61 @@
-"""WKB-to-native GeoArrow conversion helpers for GeoParquet 1.1-geoarrow output.
+"""GeoArrow field introspection, and WKB-to-native conversion for 1.1-geoarrow output.
 
-Pure pyarrow/geoarrow utilities (no DuckDB, no Click). Used by the
-arrow-streaming write strategy to emit nested-coordinate GeoArrow encoding.
+Pure pyarrow/geoarrow utilities (no DuckDB, no Click). The conversion half is
+used by the arrow-streaming write strategy to emit nested-coordinate GeoArrow
+encoding; the introspection half (``arrow_extension_name``,
+``is_geoarrow_extension_field``) is the single definition of "is this field
+GeoArrow?" shared by the write strategies, the metadata paths and streaming.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from geoparquet_io.core.crs_utils import is_default_crs
 from geoparquet_io.core.logging_config import debug
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+def arrow_extension_name(field: pa.Field) -> str | None:
+    """Extension name of a field, whether PyArrow resolved it or left it as metadata.
+
+    ``geoarrow.pyarrow`` registers its extension types process-globally on
+    import, so the same column arrives either as a resolved extension type
+    (registered) or as plain storage carrying ``ARROW:extension:name`` in the
+    field metadata (not registered). Some producers -- DuckDB's Arrow export,
+    and gpio's own ``add`` operations -- hand back the metadata-only shape even
+    when the type is registered.
+
+    Both shapes are the same column, and DuckDB honours the field metadata on
+    ``register()``, so any decision keyed on "is this geoarrow?" has to read
+    both (#688, #727, #792).
+
+    Args:
+        field: PyArrow field to inspect
+
+    Returns:
+        The extension name, or None when the field declares none.
+    """
+    name = getattr(field.type, "extension_name", None)
+    if name is not None:
+        return str(name)
+    raw = (field.metadata or {}).get(b"ARROW:extension:name")
+    return raw.decode("utf-8") if raw else None
+
+
+def is_geoarrow_extension_field(field: pa.Field) -> bool:
+    """True when a field declares a GeoArrow extension type, in either carrier shape.
+
+    Takes a *field* rather than a type on purpose: shape (2) puts the marker on
+    the field's metadata, which a bare ``pa.DataType`` cannot see. Keying off
+    the resolved type alone made the answer depend on whether anything in the
+    process had imported ``geoarrow.pyarrow`` (#792).
+    """
+    name = arrow_extension_name(field)
+    return name is not None and name.startswith("geoarrow")
+
 
 # GeoParquet geometry_types base names (including Multi* types) -> geoarrow.pyarrow
 # factory attribute names. geometry_type_common handles promotion and unification.

--- a/geoparquet_io/core/geoarrow_encoding.py
+++ b/geoparquet_io/core/geoarrow_encoding.py
@@ -3,8 +3,9 @@
 Pure pyarrow/geoarrow utilities (no DuckDB, no Click). The conversion half is
 used by the arrow-streaming write strategy to emit nested-coordinate GeoArrow
 encoding; the introspection half (``arrow_extension_name``,
-``is_geoarrow_extension_field``) is the single definition of "is this field
-GeoArrow?" shared by the write strategies, the metadata paths and streaming.
+``is_geoarrow_extension_field``, ``is_wkb_extension_field``) is the single
+definition of "is this field GeoArrow?" -- and of the narrower "is it WKB
+bytes?" -- shared by the write strategies, the metadata paths and streaming.
 """
 
 from __future__ import annotations
@@ -45,6 +46,13 @@ def arrow_extension_name(field: pa.Field) -> str | None:
     return raw.decode("utf-8") if raw else None
 
 
+# Extension names that mean "this column holds WKB bytes", as opposed to a
+# native nested GeoArrow geometry (``geoarrow.point`` over ``struct<x, y>``) or a
+# text one (``geoarrow.wkt`` over ``string``). Only these carry bytes that a
+# plain-``binary`` field can hold unchanged.
+WKB_EXTENSION_NAMES = frozenset({"geoarrow.wkb", "ogc.wkb"})
+
+
 def is_geoarrow_extension_field(field: pa.Field) -> bool:
     """True when a field declares a GeoArrow extension type, in either carrier shape.
 
@@ -52,9 +60,30 @@ def is_geoarrow_extension_field(field: pa.Field) -> bool:
     the field's metadata, which a bare ``pa.DataType`` cannot see. Keying off
     the resolved type alone made the answer depend on whether anything in the
     process had imported ``geoarrow.pyarrow`` (#792).
+
+    Deliberately broad -- *any* ``geoarrow.*`` name. This answers "is there
+    native geo in this table?", which is what version detection needs. It is the
+    wrong question for anything that then rewrites the column: use
+    ``is_wkb_extension_field`` there.
     """
     name = arrow_extension_name(field)
-    return name is not None and name.startswith("geoarrow")
+    return name is not None and name.startswith("geoarrow.")
+
+
+def is_wkb_extension_field(field: pa.Field) -> bool:
+    """True when a field declares a WKB extension type, in either carrier shape.
+
+    The narrow counterpart of ``is_geoarrow_extension_field``, and the right gate
+    for every path that rewrites the column to plain ``binary``. A GeoArrow name
+    alone does not mean WKB bytes, and casting on the broad predicate is
+    destructive in two different ways:
+
+    * ``geoarrow.point`` over ``struct<x, y>`` cannot be cast to binary at all --
+      PyArrow raises ``ArrowNotImplementedError`` mid-write;
+    * ``geoarrow.wkt`` over ``string`` casts happily, and leaves WKT *text* in a
+      binary column whose ``geo`` block still says ``encoding: WKT``.
+    """
+    return arrow_extension_name(field) in WKB_EXTENSION_NAMES
 
 
 # GeoParquet geometry_types base names (including Multi* types) -> geoarrow.pyarrow

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -576,41 +576,13 @@ def strip_geoarrow_extension_type(
     if geometry_column not in table.column_names:
         return table
 
-    geom_col = table.column(geometry_column)
-    geom_type = geom_col.type
+    # One implementation, so this path cannot drift from the metadata path's.
+    # It also has to unwrap the metadata-declared carrier shape, whose storage
+    # is `large_binary` and whose stale `ARROW:extension:name` has to come off
+    # the field -- neither of which the old inline unwrap here did (#792).
+    from geoparquet_io.core.common import _strip_geoarrow_to_plain_wkb
 
-    # Check if it's a geoarrow extension type
-    if not hasattr(geom_type, "extension_name"):
-        return table  # Already plain binary
-
-    if not geom_type.extension_name.startswith("geoarrow"):
-        return table  # Not a geoarrow type
-
-    try:
-        # Extract storage (plain binary) from extension type
-        new_chunks = []
-        for chunk in geom_col.chunks:
-            if hasattr(chunk, "storage"):
-                new_chunks.append(chunk.storage)
-            else:
-                new_chunks.append(chunk)
-
-        # Create new binary column
-        plain_col = pa.chunked_array(new_chunks, type=pa.binary())
-
-        # Replace in table
-        col_index = table.schema.get_field_index(geometry_column)
-        return table.set_column(col_index, geometry_column, plain_col)
-
-    except (TypeError, ValueError, AttributeError):
-        return table
-
-
-def is_geoarrow_type(arrow_type) -> bool:
-    """Check if an Arrow type is a geoarrow extension type."""
-    if hasattr(arrow_type, "extension_name"):
-        return arrow_type.extension_name.startswith("geoarrow")
-    return False
+    return _strip_geoarrow_to_plain_wkb(table, geometry_column, verbose=False)
 
 
 def extract_version_from_metadata(metadata: dict | None) -> str | None:
@@ -660,10 +632,12 @@ def has_geoarrow_extension_in_table(table: pa.Table) -> bool:
     Returns:
         True if table has geoarrow extension type columns
     """
-    for field in table.schema:
-        if is_geoarrow_type(field.type):
-            return True
-    return False
+    from geoparquet_io.core.geoarrow_encoding import is_geoarrow_extension_field
+
+    # Field, not type: the extension name may be carried in the field metadata
+    # instead of a resolved extension type, and both shapes are the same
+    # column (#792).
+    return any(is_geoarrow_extension_field(field) for field in table.schema)
 
 
 def detect_version_for_output(

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -556,35 +556,6 @@ def extract_crs_from_table(
     return None
 
 
-def strip_geoarrow_extension_type(
-    table: pa.Table,
-    geometry_column: str,
-) -> pa.Table:
-    """
-    Convert geoarrow extension type back to plain binary WKB.
-
-    Used when writing GeoParquet 1.x output which uses plain binary
-    geometry with CRS only in metadata.
-
-    Args:
-        table: PyArrow Table with geoarrow geometry column
-        geometry_column: Name of the geometry column
-
-    Returns:
-        Table with geometry column as plain binary
-    """
-    if geometry_column not in table.column_names:
-        return table
-
-    # One implementation, so this path cannot drift from the metadata path's.
-    # It also has to unwrap the metadata-declared carrier shape, whose storage
-    # is `large_binary` and whose stale `ARROW:extension:name` has to come off
-    # the field -- neither of which the old inline unwrap here did (#792).
-    from geoparquet_io.core.common import _strip_geoarrow_to_plain_wkb
-
-    return _strip_geoarrow_to_plain_wkb(table, geometry_column, verbose=False)
-
-
 def extract_version_from_metadata(metadata: dict | None) -> str | None:
     """
     Extract GeoParquet version string from schema metadata.

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -19,8 +19,9 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
-from geoparquet_io.core.write_strategies.base import BaseWriteStrategy, arrow_extension_name
+from geoparquet_io.core.write_strategies.base import BaseWriteStrategy
 
 if TYPE_CHECKING:
     import duckdb

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -19,7 +19,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.duckdb_utils import quote_identifier
-from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
+from geoparquet_io.core.geoarrow_encoding import WKB_EXTENSION_NAMES, arrow_extension_name
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy
 
@@ -29,15 +29,11 @@ if TYPE_CHECKING:
 # Default batch size for streaming (100K rows per batch)
 DEFAULT_BATCH_SIZE = 100_000
 
-# Extension names that mean "these are WKB bytes", not a native nested GeoArrow
-# geometry. Only these are safe to unwrap back to plain binary.
-_WKB_EXTENSION_NAMES = frozenset({"geoarrow.wkb", "ogc.wkb"})
-
 
 def _is_wkb_carrier(field: pa.Field) -> bool:
     """True when a field holds WKB bytes, in any shape DuckDB's Arrow export emits."""
     name = arrow_extension_name(field)
-    if name is not None and name not in _WKB_EXTENSION_NAMES:
+    if name is not None and name not in WKB_EXTENSION_NAMES:
         return False  # native nested GeoArrow (geoarrow.point, ...) — not WKB bytes
     storage = field.type.storage_type if isinstance(field.type, pa.ExtensionType) else field.type
     return pa.types.is_binary(storage) or pa.types.is_large_binary(storage)

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -23,27 +23,6 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 
-def arrow_extension_name(field: pa.Field) -> str | None:
-    """Extension name of a field, whether PyArrow resolved it or left it as metadata.
-
-    ``geoarrow.pyarrow`` registers its extension types process-globally on
-    import, so the same column arrives either as a resolved extension type
-    (registered) or as plain storage carrying ``ARROW:extension:name`` in the
-    field metadata (not registered). Some producers -- DuckDB's Arrow export,
-    and gpio's own ``add`` operations -- hand back the metadata-only shape even
-    when the type is registered.
-
-    Both shapes are the same column, and DuckDB honours the field metadata on
-    ``register()``, so any writer decision keyed on "is this geoarrow?" has to
-    read both (#688, #727).
-    """
-    name = getattr(field.type, "extension_name", None)
-    if name is not None:
-        return str(name)
-    raw = (field.metadata or {}).get(b"ARROW:extension:name")
-    return raw.decode("utf-8") if raw else None
-
-
 def resolve_geometry_columns(
     geometry_column: str,
     geometry_info: dict | None = None,

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -24,10 +24,10 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
 )
+from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.write_strategies.base import (
     BaseWriteStrategy,
-    arrow_extension_name,
     build_geo_metadata,
 )
 from geoparquet_io.core.write_strategies.row_group_sizing import (

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -29,10 +29,10 @@ from geoparquet_io.core.duckdb_utils import (
     validate_compression_level,
 )
 from geoparquet_io.core.geo_metadata import declare_carried_bbox_column
+from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
 from geoparquet_io.core.logging_config import configure_verbose, debug, success
 from geoparquet_io.core.write_strategies.base import (
     BaseWriteStrategy,
-    arrow_extension_name,
     build_geo_metadata,
     resolve_geometry_columns,
 )

--- a/tests/test_geoarrow_extension_detection.py
+++ b/tests/test_geoarrow_extension_detection.py
@@ -32,18 +32,18 @@ _EXTENSION_MARKER = {
 }
 
 
-def _geo_metadata(version: str = "1.1") -> dict:
+def _geo_metadata(version: str = "1.1", encoding: str = "WKB") -> dict:
     return {
         "version": version,
         "primary_column": "geometry",
-        "columns": {"geometry": {"encoding": "WKB", "geometry_types": []}},
+        "columns": {"geometry": {"encoding": encoding, "geometry_types": []}},
     }
 
 
-def _schema_metadata(with_geo: bool, version: str = "1.1"):
+def _schema_metadata(with_geo: bool, version: str = "1.1", encoding: str = "WKB"):
     if not with_geo:
         return None
-    return {b"geo": json.dumps(_geo_metadata(version)).encode()}
+    return {b"geo": json.dumps(_geo_metadata(version, encoding)).encode()}
 
 
 def resolved_extension_table(with_geo: bool = True) -> pa.Table:
@@ -70,7 +70,69 @@ def metadata_only_table(with_geo: bool = True) -> pa.Table:
     return pa.table({"id": [1], "geometry": [WKB_POINT]}, schema=schema)
 
 
+def metadata_only_native_point_table(with_geo: bool = True) -> pa.Table:
+    """A NON-WKB geoarrow carrier: ``geoarrow.point`` over ``struct<x, y>``.
+
+    Declared in field metadata only, which is the shape gpio sees whenever
+    nothing in the process registered ``geoarrow.pyarrow``'s types. There are no
+    WKB bytes here at all -- the coordinates live in the struct -- so a cast to
+    binary is not a re-carrier, it is impossible (PyArrow raises).
+    """
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field(
+                "geometry",
+                pa.struct([("x", pa.float64()), ("y", pa.float64())]),
+                metadata={
+                    b"ARROW:extension:name": b"geoarrow.point",
+                    b"ARROW:extension:metadata": b"{}",
+                },
+            ),
+        ],
+        metadata=_schema_metadata(with_geo, encoding="point"),
+    )
+    return pa.table({"id": [1], "geometry": [{"x": 1.0, "y": 2.0}]}, schema=schema)
+
+
+def metadata_only_wkt_table(with_geo: bool = True) -> pa.Table:
+    """A NON-WKB geoarrow carrier: ``geoarrow.wkt`` over ``string``.
+
+    Casting this to ``binary`` succeeds -- and produces WKT *text* in a column
+    the ``geo`` block still declares as ``encoding: WKT``. Nothing downstream
+    notices, which is why the cast has to be gated on the WKB names, not on
+    "is this geoarrow at all?".
+    """
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field(
+                "geometry",
+                pa.string(),
+                metadata={
+                    b"ARROW:extension:name": b"geoarrow.wkt",
+                    b"ARROW:extension:metadata": b"{}",
+                },
+            ),
+        ],
+        metadata=_schema_metadata(with_geo, encoding="WKT"),
+    )
+    return pa.table({"id": [1], "geometry": ["POINT (1 2)"]}, schema=schema)
+
+
 BOTH_SHAPES = pytest.mark.parametrize("with_geo", [True, False])
+
+
+def _storage_type(field: pa.Field) -> pa.DataType:
+    """The field's underlying storage, whichever carrier shape it arrived in.
+
+    A round trip through Parquet resolves the extension type whenever
+    ``geoarrow.pyarrow`` happens to be imported, so assertions about the carrier
+    have to look past that -- which is the whole point of #792.
+    """
+    if isinstance(field.type, pa.ExtensionType):
+        return field.type.storage_type
+    return field.type
 
 
 def _carrier_facts(table: pa.Table) -> dict:
@@ -116,6 +178,40 @@ class TestSharedPredicate:
         field = pa.field("geometry", pa.binary())
         assert arrow_extension_name(field) is None
         assert is_geoarrow_extension_field(field) is False
+
+    def test_geoarrow_prefix_needs_the_dot(self):
+        """``geoarrowesque.thing`` is a different namespace, not a GeoArrow type."""
+        from geoparquet_io.core.geoarrow_encoding import is_geoarrow_extension_field
+
+        field = pa.field(
+            "geometry",
+            pa.large_binary(),
+            metadata={b"ARROW:extension:name": b"geoarrowesque.thing"},
+        )
+        assert is_geoarrow_extension_field(field) is False
+
+    def test_wkb_predicate_accepts_only_the_wkb_names(self):
+        """The strip gate is narrower than the version-detection gate (see #807 review)."""
+        from geoparquet_io.core.geoarrow_encoding import is_wkb_extension_field
+
+        def marked(name: bytes, storage=pa.large_binary()):
+            return pa.field("geometry", storage, metadata={b"ARROW:extension:name": name})
+
+        assert is_wkb_extension_field(marked(b"geoarrow.wkb")) is True
+        assert is_wkb_extension_field(marked(b"ogc.wkb")) is True
+        assert is_wkb_extension_field(marked(b"geoarrow.wkt", pa.string())) is False
+        assert (
+            is_wkb_extension_field(
+                marked(b"geoarrow.point", pa.struct([("x", pa.float64()), ("y", pa.float64())]))
+            )
+            is False
+        )
+        assert is_wkb_extension_field(pa.field("geometry", pa.binary())) is False
+
+    def test_wkb_predicate_sees_the_resolved_shape_too(self):
+        from geoparquet_io.core.geoarrow_encoding import is_wkb_extension_field
+
+        assert is_wkb_extension_field(resolved_extension_table().schema.field("geometry")) is True
 
     def test_non_geoarrow_extension_is_not_geoarrow(self):
         """A non-geoarrow extension marker in field metadata must not be mistaken for one."""
@@ -259,20 +355,6 @@ class TestStreamingPathAgrees:
             detect_version_for_output(meta_only.schema.metadata, meta_only)
         )
 
-    def test_strip_geoarrow_extension_type_agrees(self):
-        from geoparquet_io.core.streaming import strip_geoarrow_extension_type
-
-        resolved = strip_geoarrow_extension_type(resolved_extension_table(), "geometry")
-        meta_only = strip_geoarrow_extension_type(metadata_only_table(), "geometry")
-        assert _carrier_facts(resolved) == _carrier_facts(meta_only)
-        assert resolved.column("geometry").to_pylist() == meta_only.column("geometry").to_pylist()
-
-    def test_strip_geoarrow_extension_type_is_a_noop_without_the_column(self):
-        from geoparquet_io.core.streaming import strip_geoarrow_extension_type
-
-        table = pa.table({"id": [1]})
-        assert strip_geoarrow_extension_type(table, "geometry") is table
-
 
 class TestWriteRoundTripAgrees:
     """End to end: the same table in both shapes writes the same 1.1 file."""
@@ -308,3 +390,97 @@ class TestWriteRoundTripAgrees:
             }
         assert written["resolved"] == written["meta_only"]
         assert written["meta_only"]["geo"].startswith("1.1")
+
+
+class TestNonWkbCarriersSurviveTheStrip:
+    """A geoarrow name is not a licence to cast to WKB bytes.
+
+    The 1.x "strip geoarrow to plain WKB" paths turn the carrier into
+    ``pa.binary()``. That is only meaningful for a column that already holds WKB
+    bytes -- ``geoarrow.wkb`` or ``ogc.wkb``. Gating them on "is this geoarrow at
+    all?" reaches two carriers it must not touch:
+
+    * ``geoarrow.point`` over ``struct<x, y>`` -- PyArrow cannot cast it, so the
+      write dies mid-flight with ``ArrowNotImplementedError``;
+    * ``geoarrow.wkt`` over ``string`` -- PyArrow *can* cast it, and the result is
+      WKT text sitting in a binary column the ``geo`` block still labels
+      ``encoding: WKT``. Nothing downstream notices.
+
+    Both only bite the metadata-declared shape, which is exactly the shape the
+    predicate was widened to see (#792, #807 review).
+    """
+
+    def test_native_point_is_not_cast_by_strip(self):
+        from geoparquet_io.core.common import _strip_geoarrow_to_plain_wkb
+
+        table = metadata_only_native_point_table()
+        out = _strip_geoarrow_to_plain_wkb(table, "geometry", False)
+        assert out.schema.field("geometry").type == table.schema.field("geometry").type
+        assert out.column("geometry").to_pylist() == [{"x": 1.0, "y": 2.0}]
+
+    def test_wkt_is_not_cast_by_strip(self):
+        from geoparquet_io.core.common import _strip_geoarrow_to_plain_wkb
+
+        out = _strip_geoarrow_to_plain_wkb(metadata_only_wkt_table(), "geometry", False)
+        assert out.schema.field("geometry").type == pa.string()
+        assert out.column("geometry").to_pylist() == ["POINT (1 2)"]
+
+    @pytest.mark.parametrize("version", ["1.0", "1.1"])
+    def test_native_point_survives_version_processing(self, version):
+        from geoparquet_io.core.common import _process_geometry_column_for_version
+
+        table = metadata_only_native_point_table()
+        out = _process_geometry_column_for_version(table, "geometry", version, None, False)
+        assert out.schema.field("geometry").type == table.schema.field("geometry").type
+
+    @pytest.mark.parametrize("version", ["1.0", "1.1"])
+    def test_wkt_survives_version_processing(self, version):
+        from geoparquet_io.core.common import _process_geometry_column_for_version
+
+        out = _process_geometry_column_for_version(
+            metadata_only_wkt_table(), "geometry", version, None, False
+        )
+        assert out.schema.field("geometry").type == pa.string()
+        assert out.column("geometry").to_pylist() == ["POINT (1 2)"]
+
+    def test_native_point_write_does_not_crash(self, tmp_path):
+        """Writing a 1.1 file used to die with ArrowNotImplementedError here."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.common import write_geoparquet_table
+        from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
+
+        out = str(tmp_path / "native_point.parquet")
+        write_geoparquet_table(
+            metadata_only_native_point_table(), out, "geometry", geoparquet_version="1.1"
+        )
+
+        field = pq.read_schema(out).field("geometry")
+        assert arrow_extension_name(field) == "geoarrow.point"
+        assert pa.types.is_struct(_storage_type(field))
+
+    def test_wkt_write_keeps_the_text_carrier(self, tmp_path):
+        """A binary column full of WKT text under ``encoding: WKT`` is silent corruption."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.common import write_geoparquet_table
+        from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
+
+        out = str(tmp_path / "wkt.parquet")
+        write_geoparquet_table(metadata_only_wkt_table(), out, "geometry", geoparquet_version="1.1")
+
+        schema = pq.read_schema(out)
+        assert json.loads(schema.metadata[b"geo"].decode())["columns"]["geometry"]["encoding"] == (
+            "WKT"
+        )
+        field = schema.field("geometry")
+        assert arrow_extension_name(field) == "geoarrow.wkt"
+        assert pa.types.is_string(_storage_type(field))
+
+    def test_native_point_still_detects_as_native_geo(self):
+        """The version-detection predicate stays broad: any geoarrow name counts."""
+        from geoparquet_io.core.common import _detect_version_from_table
+
+        assert _detect_version_from_table(metadata_only_native_point_table(with_geo=False)) == (
+            "parquet-geo-only"
+        )

--- a/tests/test_geoarrow_extension_detection.py
+++ b/tests/test_geoarrow_extension_detection.py
@@ -1,0 +1,310 @@
+"""The geoarrow extension name is carried in two shapes, and every path must agree (#792).
+
+``geoarrow.pyarrow`` registers its extension types process-globally on import, so
+the same WKB column reaches gpio either as
+
+1. a resolved ``geoarrow.wkb`` extension type
+   (``field.type.extension_name == "geoarrow.wkb"``), or
+2. plain ``large_binary`` carrying ``ARROW:extension:name`` in the FIELD METADATA.
+
+Which one arrives depends on whether anything in the process imported
+``geoarrow.pyarrow`` -- an unstable thing to key behaviour on. #791 fixed the
+write strategies; these tests are the standing guard that the *shared* predicate
+and its metadata/streaming callers see both shapes too.
+
+Every test here builds the same column in both shapes and asserts the two paths
+agree. Agreement is the property; which branch is taken is secondary.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow as pa
+import pytest
+
+# A single POINT (1 2) in little-endian WKB.
+WKB_POINT = b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@"
+
+_EXTENSION_MARKER = {
+    b"ARROW:extension:name": b"geoarrow.wkb",
+    b"ARROW:extension:metadata": b"{}",
+}
+
+
+def _geo_metadata(version: str = "1.1") -> dict:
+    return {
+        "version": version,
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "geometry_types": []}},
+    }
+
+
+def _schema_metadata(with_geo: bool, version: str = "1.1"):
+    if not with_geo:
+        return None
+    return {b"geo": json.dumps(_geo_metadata(version)).encode()}
+
+
+def resolved_extension_table(with_geo: bool = True) -> pa.Table:
+    """Shape (1): PyArrow resolved the geoarrow.wkb extension type."""
+    import geoarrow.pyarrow as ga
+
+    array = ga.as_wkb(pa.array([WKB_POINT], pa.binary()))
+    schema = pa.schema(
+        [pa.field("id", pa.int64()), pa.field("geometry", array.type)],
+        metadata=_schema_metadata(with_geo),
+    )
+    return pa.table({"id": [1], "geometry": array}, schema=schema)
+
+
+def metadata_only_table(with_geo: bool = True) -> pa.Table:
+    """Shape (2): plain large_binary carrying ARROW:extension:name in field metadata."""
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("geometry", pa.large_binary(), metadata=_EXTENSION_MARKER),
+        ],
+        metadata=_schema_metadata(with_geo),
+    )
+    return pa.table({"id": [1], "geometry": [WKB_POINT]}, schema=schema)
+
+
+BOTH_SHAPES = pytest.mark.parametrize("with_geo", [True, False])
+
+
+def _carrier_facts(table: pa.Table) -> dict:
+    """The observable carrier facts a 1.x reader would see for the geometry field."""
+    field = table.schema.field("geometry")
+    return {
+        "type": str(field.type),
+        "extension_name": getattr(field.type, "extension_name", None),
+        "field_metadata": dict(field.metadata or {}),
+    }
+
+
+class TestSharedPredicate:
+    """One predicate, both shapes."""
+
+    def test_shapes_are_actually_different(self):
+        """Guard the fixtures: the two tables really are the two different shapes."""
+        resolved = resolved_extension_table().schema.field("geometry")
+        meta_only = metadata_only_table().schema.field("geometry")
+        assert getattr(resolved.type, "extension_name", None) == "geoarrow.wkb"
+        assert getattr(meta_only.type, "extension_name", None) is None
+        assert (meta_only.metadata or {}).get(b"ARROW:extension:name") == b"geoarrow.wkb"
+
+    def test_extension_name_agrees(self):
+        from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
+
+        assert arrow_extension_name(resolved_extension_table().schema.field("geometry")) == (
+            arrow_extension_name(metadata_only_table().schema.field("geometry"))
+        )
+
+    def test_predicate_agrees(self):
+        from geoparquet_io.core.geoarrow_encoding import is_geoarrow_extension_field
+
+        assert is_geoarrow_extension_field(resolved_extension_table().schema.field("geometry"))
+        assert is_geoarrow_extension_field(metadata_only_table().schema.field("geometry"))
+
+    def test_plain_binary_is_not_geoarrow(self):
+        from geoparquet_io.core.geoarrow_encoding import (
+            arrow_extension_name,
+            is_geoarrow_extension_field,
+        )
+
+        field = pa.field("geometry", pa.binary())
+        assert arrow_extension_name(field) is None
+        assert is_geoarrow_extension_field(field) is False
+
+    def test_non_geoarrow_extension_is_not_geoarrow(self):
+        """A non-geoarrow extension marker in field metadata must not be mistaken for one."""
+        from geoparquet_io.core.geoarrow_encoding import (
+            arrow_extension_name,
+            is_geoarrow_extension_field,
+        )
+
+        field = pa.field(
+            "payload",
+            pa.large_binary(),
+            metadata={b"ARROW:extension:name": b"arrow.json"},
+        )
+        assert arrow_extension_name(field) == "arrow.json"
+        assert is_geoarrow_extension_field(field) is False
+
+
+class TestMetadataPathAgrees:
+    """core/common.py and core/geo_metadata.py: the 1.x carrier decision."""
+
+    @pytest.mark.parametrize("version", ["1.0", "1.1"])
+    def test_process_geometry_column_agrees(self, version):
+        from geoparquet_io.core.common import _process_geometry_column_for_version
+
+        resolved = _process_geometry_column_for_version(
+            resolved_extension_table(), "geometry", version, None, False
+        )
+        meta_only = _process_geometry_column_for_version(
+            metadata_only_table(), "geometry", version, None, False
+        )
+        assert _carrier_facts(resolved) == _carrier_facts(meta_only)
+
+    @pytest.mark.parametrize("version", ["1.0", "1.1"])
+    def test_process_geometry_column_leaves_plain_wkb(self, version):
+        """Shape (2) must lose the stale ARROW:extension:name for a 1.x output."""
+        from geoparquet_io.core.common import _process_geometry_column_for_version
+
+        out = _process_geometry_column_for_version(
+            metadata_only_table(), "geometry", version, None, False
+        )
+        field = out.schema.field("geometry")
+        assert field.type == pa.binary()
+        assert b"ARROW:extension:name" not in (field.metadata or {})
+
+    def test_strip_to_plain_wkb_agrees(self):
+        from geoparquet_io.core.common import _strip_geoarrow_to_plain_wkb
+
+        resolved = _strip_geoarrow_to_plain_wkb(resolved_extension_table(), "geometry", False)
+        meta_only = _strip_geoarrow_to_plain_wkb(metadata_only_table(), "geometry", False)
+        assert _carrier_facts(resolved) == _carrier_facts(meta_only)
+        assert resolved.column("geometry").to_pylist() == meta_only.column("geometry").to_pylist()
+
+    def test_geo_metadata_apply_agrees(self):
+        """core/geo_metadata.py has no _canonicalize_wkb_columns backstop of its own."""
+        from geoparquet_io.core.geo_metadata import _apply_geoparquet_metadata
+
+        resolved = _apply_geoparquet_metadata(
+            resolved_extension_table(), "geometry", "1.1", None, None, None, False
+        )
+        meta_only = _apply_geoparquet_metadata(
+            metadata_only_table(), "geometry", "1.1", None, None, None, False
+        )
+        assert _carrier_facts(resolved) == _carrier_facts(meta_only)
+        assert b"ARROW:extension:name" not in (meta_only.schema.field("geometry").metadata or {})
+
+
+class TestVersionDetectionAgrees:
+    """core/common.py and core/geo_metadata.py: auto-mode version detection."""
+
+    @BOTH_SHAPES
+    def test_detect_version_from_table_agrees(self, with_geo):
+        from geoparquet_io.core.common import _detect_version_from_table
+
+        assert _detect_version_from_table(resolved_extension_table(with_geo)) == (
+            _detect_version_from_table(metadata_only_table(with_geo))
+        )
+
+    @BOTH_SHAPES
+    def test_geo_metadata_detect_version_agrees(self, with_geo):
+        from geoparquet_io.core.geo_metadata import _detect_version_from_table
+
+        assert _detect_version_from_table(resolved_extension_table(with_geo)) == (
+            _detect_version_from_table(metadata_only_table(with_geo))
+        )
+
+    @BOTH_SHAPES
+    def test_resolve_version_from_table_agrees(self, with_geo):
+        from geoparquet_io.core.common import resolve_geoparquet_version_from_table
+
+        assert resolve_geoparquet_version_from_table(resolved_extension_table(with_geo)) == (
+            resolve_geoparquet_version_from_table(metadata_only_table(with_geo))
+        )
+
+    def test_declared_geoarrow_without_geo_metadata_is_native(self):
+        """No geo block + a geoarrow column is the in-memory parquet-geo-only shape."""
+        from geoparquet_io.core.common import (
+            _detect_version_from_table,
+            resolve_geoparquet_version_from_table,
+        )
+
+        table = metadata_only_table(with_geo=False)
+        assert _detect_version_from_table(table) == "parquet-geo-only"
+        assert resolve_geoparquet_version_from_table(table) == "2.0"
+
+    def test_carried_geo_version_still_wins(self):
+        """A declared version in the geo block is unchanged by the wider detection."""
+        from geoparquet_io.core.common import _detect_version_from_table
+
+        assert _detect_version_from_table(metadata_only_table(with_geo=True)) == "1.1"
+
+
+class TestStreamingPathAgrees:
+    """core/streaming.py: table-level geoarrow detection and stripping."""
+
+    @BOTH_SHAPES
+    def test_has_geoarrow_extension_in_table_agrees(self, with_geo):
+        from geoparquet_io.core.streaming import has_geoarrow_extension_in_table
+
+        assert has_geoarrow_extension_in_table(resolved_extension_table(with_geo)) == (
+            has_geoarrow_extension_in_table(metadata_only_table(with_geo))
+        )
+
+    def test_has_geoarrow_extension_in_table_sees_metadata_shape(self):
+        from geoparquet_io.core.streaming import has_geoarrow_extension_in_table
+
+        assert has_geoarrow_extension_in_table(metadata_only_table()) is True
+
+    def test_plain_wkb_table_is_not_geoarrow(self):
+        from geoparquet_io.core.streaming import has_geoarrow_extension_in_table
+
+        table = pa.table({"id": [1], "geometry": pa.array([WKB_POINT], pa.binary())})
+        assert has_geoarrow_extension_in_table(table) is False
+
+    @BOTH_SHAPES
+    def test_detect_version_for_output_agrees(self, with_geo):
+        from geoparquet_io.core.streaming import detect_version_for_output
+
+        resolved = resolved_extension_table(with_geo)
+        meta_only = metadata_only_table(with_geo)
+        assert detect_version_for_output(resolved.schema.metadata, resolved) == (
+            detect_version_for_output(meta_only.schema.metadata, meta_only)
+        )
+
+    def test_strip_geoarrow_extension_type_agrees(self):
+        from geoparquet_io.core.streaming import strip_geoarrow_extension_type
+
+        resolved = strip_geoarrow_extension_type(resolved_extension_table(), "geometry")
+        meta_only = strip_geoarrow_extension_type(metadata_only_table(), "geometry")
+        assert _carrier_facts(resolved) == _carrier_facts(meta_only)
+        assert resolved.column("geometry").to_pylist() == meta_only.column("geometry").to_pylist()
+
+    def test_strip_geoarrow_extension_type_is_a_noop_without_the_column(self):
+        from geoparquet_io.core.streaming import strip_geoarrow_extension_type
+
+        table = pa.table({"id": [1]})
+        assert strip_geoarrow_extension_type(table, "geometry") is table
+
+
+class TestWriteRoundTripAgrees:
+    """End to end: the same table in both shapes writes the same 1.1 file."""
+
+    @pytest.mark.parametrize("strategy", ["duckdb-kv", "disk-rewrite", "streaming", "in-memory"])
+    def test_write_from_table_agrees(self, strategy, tmp_path):
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.write_strategies import WriteStrategy, WriteStrategyFactory
+
+        written = {}
+        for label, table in (
+            ("resolved", resolved_extension_table()),
+            ("meta_only", metadata_only_table()),
+        ):
+            out = str(tmp_path / f"{strategy}_{label}.parquet")
+            WriteStrategyFactory.get_strategy(WriteStrategy(strategy)).write_from_table(
+                table=table,
+                output_path=out,
+                geometry_column="geometry",
+                geoparquet_version="1.1",
+                compression="ZSTD",
+                compression_level=None,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                verbose=False,
+            )
+            schema = pq.read_schema(out)
+            written[label] = {
+                "physical": str(pq.ParquetFile(out).schema_arrow.field("geometry").type),
+                "logical": str(schema.field("geometry").type),
+                "geo": json.loads(schema.metadata[b"geo"].decode()).get("version"),
+            }
+        assert written["resolved"] == written["meta_only"]
+        assert written["meta_only"]["geo"].startswith("1.1")


### PR DESCRIPTION
## What changed

`arrow_extension_name()` — added by #791 in `core/write_strategies/base.py` — moves to
`core/geoarrow_encoding.py`, where both `core/` and `core/write_strategies/` can import it
without a cycle, joined by a new `is_geoarrow_extension_field()`. Both take a **field**, not a
type: shape (2) puts `ARROW:extension:name` somewhere a bare `pa.DataType` cannot see it.

Three copies of the old blind predicate are gone:

| Removed | Replaced by |
|---|---|
| `common._is_geoarrow_extension_type` | `is_geoarrow_extension_field` |
| `geo_metadata._is_geoarrow_extension_type` (dead — no callers) | deleted |
| `streaming.is_geoarrow_type` | `is_geoarrow_extension_field` |
| `duckdb_kv._drop_metadata_declared_geoarrow` (#791) | `_strip_geoarrow_to_plain_wkb` now covers it |
| `streaming.strip_geoarrow_extension_type` (dead — no production callers) | deleted |

A widened predicate is only safe where the caller is *asking a question*. Where the caller then
**rewrites the column**, the broad "is this geoarrow at all?" is the wrong gate, so
`geoarrow_encoding` also gains the narrow `is_wkb_extension_field()` — `geoarrow.wkb` and
`ogc.wkb` only, from a `WKB_EXTENSION_NAMES` set moved here out of `arrow_streaming` so the
writers and the metadata paths agree on what a WKB carrier is. The two rewriting gates
(`common._strip_geoarrow_to_plain_wkb`, and the 1.x branch of
`common._process_geometry_column_for_version`) use it; version detection keeps the broad one.

Without that split, widening the predicate would have introduced two new bugs of its own, both
reachable only through the metadata-declared carrier — i.e. both new:

- `geoarrow.point` over `struct<x, y>`: the cast to plain `binary` is not implementable, and
  `write_geoparquet_table` died mid-write with `ArrowNotImplementedError`.
- `geoarrow.wkt` over `string`: the cast *succeeds*, leaving WKT **text** in a binary column
  whose `geo` block still says `encoding: WKT`. Silent corruption; nothing downstream notices.

`is_geoarrow_extension_field`'s prefix check also gained its missing dot, so
`geoarrowesque.thing` is no longer treated as a GeoArrow type.

## Why

`geoarrow.pyarrow` registers its extension types process-globally on import, so the same WKB
column reaches gpio as either a resolved `geoarrow.wkb` type or plain `large_binary` carrying
`ARROW:extension:name` in the field metadata. Which one you get depends on what the process
happened to import. #791 fixed the writers and deliberately left the shared predicate alone, so
the metadata and streaming paths kept the blind spot.

**The audit — every caller, and what changes for it:**

| Caller | Behaviour once shape (2) is recognised | Correct? |
|---|---|---|
| `common._strip_geoarrow_to_plain_wkb` | Now strips the metadata-declared **WKB** carrier to plain `binary` and drops the stale marker (`set_column` with a bare name rebuilds the field). A non-WKB GeoArrow carrier is left alone. | **Yes** — this is #706/#727's failure mode. |
| `common._process_geometry_column_for_version` (1.x branch) | Enters the strip for shape (2). In `common.apply_geoparquet_metadata` a later `_canonicalize_wkb_columns` pass already cleaned this up, so no net change there. | **Yes**, and now the fix is at the decision rather than in a downstream sweep. |
| `geo_metadata._apply_geoparquet_metadata` | Same flip, and this path has no `_canonicalize_wkb_columns` backstop of its own. **But it is dead code**: every live caller (`arrow_memory`, `arrow_streaming`, `disk_rewrite`, `duckdb_kv`) imports the `common.py` copy, and `geo_metadata._detect_version_from_table` is called only from this uncalled function. Correcting it changes nothing in production; the duplicates want deleting in their own PR — filed as #824. | **Yes**, but zero blast radius. |
| `common._detect_version_from_table` and its twin in `geo_metadata.py` | A table with **no `geo` block** and a metadata-declared geoarrow column now resolves to `parquet-geo-only` instead of falling through to the 1.1 default. | **Yes** — the resolved shape *already* returned `parquet-geo-only` here, so the two shapes disagreed purely on import state. Agreeing on `parquet-geo-only` also matches `resolve_geoparquet_version_from_file` for the equivalent file. A version declared in the `geo` block still wins, so the real `Table.add_kdtree()` flow (which keeps its geo metadata — verified) is untouched. |
| `duckdb_kv.write_from_table` / `disk_rewrite.write_from_table` (`geoparquet_version=None` → `_detect_version_from_table`) | Same flip, same reasoning; already import-state-dependent before this change. | **Yes** |
| `streaming.has_geoarrow_extension_in_table` → `detect_version_for_output` | Now sees shape (2). The one production caller (`stream_io.py:352`) calls `detect_version_for_output(original_metadata)` with **no table**, so the changed branch is unreachable there; tests are the only callers that pass a table. | **Yes**, and effectively zero blast radius. |
| `api/table.py:1061` (1.1-geoarrow routing) | Not a caller — its `is_wkb` check already accepts plain `binary`/`large_binary`. | n/a |

### Deliberate behaviour change

**Auto version-detection:** `resolve_geoparquet_version_from_table` now returns `"2.0"` (was
`None`, i.e. the 1.1 default) for an in-memory table that has **no `geo` block** and whose
geometry field declares a GeoArrow extension type in field metadata only. That is the same
answer the resolved-extension shape already gave, and the same answer
`resolve_geoparquet_version_from_file` gives for the equivalent native-geo file — the point of
the change is that the three now agree regardless of import state. An explicit
`geoparquet_version=`, or a version in the table's own `geo` block, still wins.
`docs/guide/convert.md` documents it under **GeoParquet Version**.

## Verification

Tests were written first and watched fail. The original round — 23 of 31 failed against the
parent branch:

```
FAILED tests/test_geoarrow_extension_detection.py::TestSharedPredicate::test_extension_name_agrees
FAILED tests/test_geoarrow_extension_detection.py::TestSharedPredicate::test_predicate_agrees
FAILED tests/test_geoarrow_extension_detection.py::TestMetadataPathAgrees::test_process_geometry_column_agrees[1.0]
FAILED tests/test_geoarrow_extension_detection.py::TestMetadataPathAgrees::test_process_geometry_column_agrees[1.1]
FAILED tests/test_geoarrow_extension_detection.py::TestMetadataPathAgrees::test_strip_to_plain_wkb_agrees
FAILED tests/test_geoarrow_extension_detection.py::TestMetadataPathAgrees::test_geo_metadata_apply_agrees
FAILED tests/test_geoarrow_extension_detection.py::TestVersionDetectionAgrees::test_detect_version_from_table_agrees[False]
FAILED tests/test_geoarrow_extension_detection.py::TestVersionDetectionAgrees::test_geo_metadata_detect_version_agrees[False]
FAILED tests/test_geoarrow_extension_detection.py::TestVersionDetectionAgrees::test_resolve_version_from_table_agrees[False]
FAILED tests/test_geoarrow_extension_detection.py::TestStreamingPathAgrees::test_has_geoarrow_extension_in_table_agrees[True]
FAILED tests/test_geoarrow_extension_detection.py::TestStreamingPathAgrees::test_has_geoarrow_extension_in_table_agrees[False]
... (23 total)
========================= 23 failed, 8 passed in 3.15s =========================
```

And the review round, for the two non-WKB carriers — 11 failing before the narrow predicate
existed, including the crash and the silent WKT corruption:

```
FAILED ...::TestSharedPredicate::test_geoarrow_prefix_needs_the_dot
FAILED ...::TestSharedPredicate::test_wkb_predicate_accepts_only_the_wkb_names
FAILED ...::TestSharedPredicate::test_wkb_predicate_sees_the_resolved_shape_too
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_native_point_is_not_cast_by_strip
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_wkt_is_not_cast_by_strip
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_native_point_survives_version_processing[1.0]
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_native_point_survives_version_processing[1.1]
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_wkt_survives_version_processing[1.0]
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_wkt_survives_version_processing[1.1]
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_native_point_write_does_not_crash
FAILED ...::TestNonWkbCarriersSurviveTheStrip::test_wkt_write_keeps_the_text_carrier
======================== 11 failed, 30 passed in 0.91s =========================

E   pyarrow.lib.ArrowNotImplementedError: Unsupported cast from struct<x: double, y: double> to binary using function cast_binary
E   assert False +  where False = is_string(DataType(binary))   # geoarrow.wkt, under encoding: WKT
```

After:

```
$ uv run pytest tests/test_geoarrow_extension_detection.py -q
============================== 41 passed in 0.89s ==============================

$ uv run pytest tests/test_geoarrow_extension_detection.py tests/test_secondary_geometry_carriers.py \
      tests/test_write_strategies.py tests/test_kdtree.py -q -m "not slow and not network"
========== 210 passed, 1 skipped, 9 deselected, 8 warnings in 11.04s ===========
```

Fast lane, rebased on `main`:

```
$ uv run pytest tests -n auto -q -m "not slow and not network and not meta"
FAILED tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe
= 1 failed, 5112 passed, 87 skipped, 2 xfailed, 111 warnings in 153.09s (0:02:33) =
```

That is the known `-n auto` cold-run flake. Re-run serially, it passes:

```
$ uv run pytest tests/test_geojson_stream.py -q
============================== 52 passed in 1.88s ==============================
```

Hooks — both stages, all files, all green:

```
$ uv run pre-commit run --all-files
ruff ... Passed / ruff format ... Passed / codespell ... Passed / zizmor ... Passed
duckdb-antipatterns ... Passed / no-click-echo ... Passed / doc-sync ... Passed  (20/20)

$ uv run pre-commit run --all-files --hook-stage pre-push
deptry ... Passed
mypy ... Passed
vulture ... Passed
xenon ... Passed
import-linter ... Passed
menard-check ... Passed
fast-tests ... Passed
```

## Stacking

**Unstacked.** #791 has merged; this branch is now rebased onto `main` and targets `main`, so it
gets full CI. Its first commit became empty in the rebase (its content shipped with #791) and was
dropped; `duckdb_kv._plain_wkb_for_secondary_columns` keeps `main`'s
`_canonicalize_wkb_columns` body, and this PR contributes only the `arrow_extension_name` import
move there.

Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of GeoArrow geometry columns in in-memory Arrow tables, including columns identified through field metadata.
  * Ensured WKB columns are handled consistently across supported writing methods.
  * Preserved native point and WKT geometry types instead of incorrectly converting them to binary.
  * Improved automatic GeoParquet version selection, including version 2.0 for recognized native GeoArrow data while respecting explicit metadata.

* **Documentation**
  * Clarified GeoParquet version detection behavior for in-memory Arrow tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->