### PR TITLE
feat(api): add ops.partition_by_* twins for every partition subcommand

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -826,6 +826,8 @@ arrow_table = table.to_arrow()
 
 #### Spatial Partitioning Methods
 
+Each method below has an `ops.partition_by_*` twin taking a `pa.Table` plus the output directory, for callers who are not using the fluent wrapper -- `ops.partition_by_h3(table, 'output/', resolution=7)` does exactly what `Table.partition_by_h3('output/', resolution=7)` does. See [Pure Functions](#pure-functions-ops-module).
+
 All spatial partitioning methods need to be told how finely to split. Give them an explicit resolution (or `level`), or pass `auto=True` to size one from the data -- the same choice `gpio partition` offers, and the same calculation behind it. A call that gives neither raises `InvalidParameterError` rather than picking a default for you. Under `auto=True`, `target_rows` (default 100,000) sets the rows you want per partition and `max_partitions` (default 10,000) caps how many are created; passing `auto=True` together with an explicit resolution is an error.
 
 !!! warning "Breaking change: the implicit resolutions are gone"
@@ -1515,6 +1517,27 @@ pq.write_table(table, 'output.parquet')
 
 > **Note:** `pq.write_table()` may not preserve all GeoParquet metadata (such as the `geo` key with CRS and geometry column info). For proper metadata preservation, wrap the result in `Table(table).write('output.parquet')` or use `write_parquet_with_metadata()` from `geoparquet_io.core.common`. The fluent API's `.write()` method is recommended.
 
+Partitioning is the exception to the `table in -> table out` shape: like the CLI it
+writes a *directory*, so `ops.partition_by_*` takes the table plus an output
+directory and returns the run's statistics.
+
+```python
+import pyarrow.parquet as pq
+from geoparquet_io.api import ops
+
+table = pq.read_table('input.parquet')
+
+# An explicit resolution, or auto=True -- gpio never guesses one for you
+stats = ops.partition_by_h3(table, 'output/', resolution=7)
+stats = ops.partition_by_a5(table, 'output/', auto=True, target_rows=50000)
+
+# Non-spatial schemes
+ops.partition_by_string(table, 'output/', column='region', hive=True)
+ops.partition_by_admin(table, 'output/', levels=['country'])
+
+print(f"Created {stats['file_count']} files")
+```
+
 ### Available Functions
 
 | Function | Description |
@@ -1545,6 +1568,13 @@ pq.write_table(table, 'output.parquet')
 | `ops.from_wfs_layers(service_url, typenames, output_dir, parallel_layers=1, max_workers=1, page_size=100000, ...)` | Fetch multiple WFS layers to directory |
 | `ops.create_overviews(input_parquet, levels=None, max_tile_kb=500, bytes_per_cell=None, cell_column=None, scheme=None, output_dir=None, force=False, ...)` | Build coarser overview levels from an aggregate file |
 | `ops.create_pmtiles_pyramid(input_path, output_path, levels=None, max_tile_kb=500, layer_mode='grouped', include_features=False, features_source=None, max_zoom=None, ...)` | Build a zoom-banded multi-level PMTiles archive from an aggregate file (requires tippecanoe + tile-join) |
+| `ops.partition_by_h3(table, output_dir, resolution=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_h3_column=None, overwrite=False, geometry_column=None)` | Partition into a directory by H3 cell |
+| `ops.partition_by_a5(table, output_dir, resolution=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_a5_column=None, overwrite=False, geometry_column=None)` | Partition into a directory by A5 cell |
+| `ops.partition_by_s2(table, output_dir, level=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_s2_column=None, overwrite=False, geometry_column=None)` | Partition into a directory by S2 cell — **unavailable in this release**, use `ops.partition_by_a5` |
+| `ops.partition_by_quadkey(table, output_dir, resolution=None, partition_resolution=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_quadkey_column=None, overwrite=False, geometry_column=None)` | Partition into a directory by quadkey |
+| `ops.partition_by_kdtree(table, output_dir, iterations=9, hive=False, keep_kdtree_column=None, overwrite=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by KD-tree cell |
+| `ops.partition_by_string(table, output_dir, column, chars=None, hive=False, overwrite=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by string column value |
+| `ops.partition_by_admin(table, output_dir, dataset='gaul', levels=None, hive=False, overwrite=False, vecorel=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by administrative boundaries |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |
 | `ops.explain_analyze(file_path, query=None)` | DuckDB EXPLAIN ANALYZE query plan |

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -856,7 +856,7 @@ schemes:
 | `gpio partition string` | `ops.partition_by_string(table, output_dir, column, chars=...)` |
 | `gpio partition admin` | `ops.partition_by_admin(table, output_dir, dataset=..., levels=...)` |
 
-<!-- doctest: skip="the 766-row sample is too small to partition meaningfully" -->
+<!-- doctest: skip="the 766-row sample is too small to partition meaningfully, has no 'region' column for partition_by_string, and partition_by_admin would download a boundaries dataset" -->
 ```python
 import pyarrow.parquet as pq
 from geoparquet_io.api import ops

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -838,6 +838,46 @@ gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place
 
 See [Sub-Partitioning Large Files](sub-partitioning.md) for details.
 
+## Function-Style API
+
+Every partition subcommand also has an `ops` function, for callers holding a plain
+PyArrow table rather than the fluent `Table` wrapper. Each takes the table plus an
+output directory and accepts the same keywords as the CLI command it mirrors --
+including `auto`, `target_rows` and `max_partitions` on the four spatial-index
+schemes:
+
+| CLI command | `ops` function |
+|-------------|----------------|
+| `gpio partition h3` | `ops.partition_by_h3(table, output_dir, resolution=..., auto=...)` |
+| `gpio partition a5` | `ops.partition_by_a5(table, output_dir, resolution=..., auto=...)` |
+| `gpio partition s2` | `ops.partition_by_s2(table, output_dir, level=..., auto=...)` |
+| `gpio partition quadkey` | `ops.partition_by_quadkey(table, output_dir, resolution=..., partition_resolution=..., auto=...)` |
+| `gpio partition kdtree` | `ops.partition_by_kdtree(table, output_dir, iterations=...)` |
+| `gpio partition string` | `ops.partition_by_string(table, output_dir, column, chars=...)` |
+| `gpio partition admin` | `ops.partition_by_admin(table, output_dir, dataset=..., levels=...)` |
+
+<!-- doctest: skip="the 766-row sample is too small to partition meaningfully" -->
+```python
+import pyarrow.parquet as pq
+from geoparquet_io.api import ops
+
+table = pq.read_table('input.parquet')
+
+# An explicit resolution, or auto=True -- neither front end guesses one for you
+stats = ops.partition_by_h3(table, 'output/', resolution=7)
+stats = ops.partition_by_a5(table, 'output/', auto=True, target_rows=50000)
+
+# Non-spatial schemes
+ops.partition_by_string(table, 'output/', column='region', hive=True)
+ops.partition_by_admin(table, 'output/', levels=['country'])
+
+print(f"Created {stats['file_count']} files")
+```
+
+`ops.partition_by_s2` is wired for symmetry but cannot run in this release -- S2 needs
+the `geography` DuckDB extension (see the [S2 section](#by-s2-cells) above). Use
+`ops.partition_by_a5` instead.
+
 ## See Also
 
 - [CLI Reference](../cli/overview.md) - Full command reference

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -17,6 +17,8 @@ Example:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pyarrow as pa
 
 from geoparquet_io.core.add.a5 import add_a5_table
@@ -33,6 +35,9 @@ from geoparquet_io.core.sort_by_column import sort_by_column_table
 from geoparquet_io.core.sort_quadkey import sort_by_quadkey_table
 from geoparquet_io.core.str_order import DEFAULT_STR_TILE_SIZE, str_order_table
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def add_bbox(
@@ -719,6 +724,445 @@ def reproject(
         source_crs=source_crs,
         geometry_column=geometry_column,
         assume_crs84=assume_crs84,
+    )
+
+
+# --------------------------------------------------------------------------
+# Partitioning
+#
+# Partitioning writes a *directory* rather than returning a table, so these
+# functions break the `table in -> table out` shape the rest of this module
+# has: they take the table plus an output directory and return the same stats
+# dict the `Table` methods do. They exist so a caller holding a plain
+# `pa.Table` has the same front door for partitioning that `add`, `sort`,
+# `convert`, `extract` and `process` already give them (#799).
+# --------------------------------------------------------------------------
+
+
+def _partition(
+    table: pa.Table,
+    output_dir: str | Path,
+    method: str,
+    geometry_column: str | None,
+    **kwargs,
+) -> dict:
+    """Delegate to the matching ``Table.partition_by_*`` method.
+
+    The partition core functions read a file, and `Table` already owns the
+    temp-file machinery that bridges an in-memory table to them
+    (`_run_partition_with_temp_file`). Delegating keeps both front doors on one
+    code path instead of a second copy that can drift out of step.
+
+    Imported inside the function: `geoparquet_io.api.__init__` imports `ops`
+    before `table`, so a module-level import here would be circular.
+    """
+    from geoparquet_io.api.table import Table
+
+    wrapper = Table(table, geometry_column=geometry_column)
+    return getattr(wrapper, method)(output_dir, **kwargs)
+
+
+def partition_by_h3(
+    table: pa.Table,
+    output_dir: str | Path,
+    *,
+    resolution: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    compression: str = "ZSTD",
+    hive: bool = False,
+    keep_h3_column: bool | None = None,
+    overwrite: bool = False,
+    geometry_column: str | None = None,
+) -> dict:
+    """
+    Partition a table into a directory of files split by H3 cell.
+
+    Function form of `Table.partition_by_h3`, mirroring `gpio partition h3`.
+    Like both of them it refuses to guess: pass a ``resolution``, or pass
+    ``auto=True`` to size one from the data.
+
+    Args:
+        table: Input PyArrow Table with a geometry column
+        output_dir: Output directory path
+        resolution: H3 resolution level 0-15. Required unless ``auto=True``
+        auto: Calculate the resolution from the data (default: False);
+            mutually exclusive with ``resolution``
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        compression: Compression codec (default: ZSTD)
+        hive: Use Hive-style ``h3_cell=value/`` directories (default: False)
+        keep_h3_column: Keep the generated ``h3_cell`` column. None (default)
+            follows ``hive``
+        overwrite: Overwrite an existing output directory
+        geometry_column: Geometry column name (auto-detected if None)
+
+    Returns:
+        dict with output_dir, file_count and hive
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> stats = ops.partition_by_h3(table, 'output/', resolution=6)
+        >>> stats = ops.partition_by_h3(table, 'output/', auto=True)
+    """
+    return _partition(
+        table,
+        output_dir,
+        "partition_by_h3",
+        geometry_column,
+        resolution=resolution,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        compression=compression,
+        hive=hive,
+        keep_h3_column=keep_h3_column,
+        overwrite=overwrite,
+    )
+
+
+def partition_by_a5(
+    table: pa.Table,
+    output_dir: str | Path,
+    *,
+    resolution: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    compression: str = "ZSTD",
+    hive: bool = False,
+    keep_a5_column: bool | None = None,
+    overwrite: bool = False,
+    geometry_column: str | None = None,
+) -> dict:
+    """
+    Partition a table into a directory of files split by A5 cell.
+
+    Function form of `Table.partition_by_a5`, mirroring `gpio partition a5`.
+    Pass a ``resolution``, or ``auto=True`` to size one from the data.
+
+    Args:
+        table: Input PyArrow Table with a geometry column
+        output_dir: Output directory path
+        resolution: A5 resolution level 0-30. Required unless ``auto=True``
+        auto: Calculate the resolution from the data (default: False);
+            mutually exclusive with ``resolution``
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        compression: Compression codec (default: ZSTD)
+        hive: Use Hive-style ``a5_cell=value/`` directories (default: False)
+        keep_a5_column: Keep the generated ``a5_cell`` column. None (default)
+            follows ``hive``
+        overwrite: Overwrite an existing output directory
+        geometry_column: Geometry column name (auto-detected if None)
+
+    Returns:
+        dict with output_dir, file_count and hive
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> stats = ops.partition_by_a5(table, 'output/', resolution=12)
+    """
+    return _partition(
+        table,
+        output_dir,
+        "partition_by_a5",
+        geometry_column,
+        resolution=resolution,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        compression=compression,
+        hive=hive,
+        keep_a5_column=keep_a5_column,
+        overwrite=overwrite,
+    )
+
+
+def partition_by_s2(
+    table: pa.Table,
+    output_dir: str | Path,
+    *,
+    level: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    compression: str = "ZSTD",
+    hive: bool = False,
+    keep_s2_column: bool | None = None,
+    overwrite: bool = False,
+    geometry_column: str | None = None,
+) -> dict:
+    """
+    Partition a table into a directory of files split by S2 cell.
+
+    Function form of `Table.partition_by_s2`, mirroring `gpio partition s2`.
+    Pass a ``level``, or ``auto=True`` to size one from the data.
+
+    **Unavailable in this release**: S2 needs the ``geography`` DuckDB community
+    extension, which is not published for the DuckDB version gpio requires
+    (#737). The call raises with an explanation. Use `partition_by_a5` instead.
+
+    Args:
+        table: Input PyArrow Table with a geometry column
+        output_dir: Output directory path
+        level: S2 level 0-30 (13 is ~1.2 km² cells). Required unless ``auto=True``
+        auto: Calculate the level from the data (default: False); mutually
+            exclusive with ``level``
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        compression: Compression codec (default: ZSTD)
+        hive: Use Hive-style ``s2_cell=value/`` directories (default: False)
+        keep_s2_column: Keep the generated ``s2_cell`` column. None (default)
+            follows ``hive``
+        overwrite: Overwrite an existing output directory
+        geometry_column: Geometry column name (auto-detected if None)
+
+    Returns:
+        dict with output_dir, file_count and hive
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> stats = ops.partition_by_s2(table, 'output/', level=10)
+    """
+    return _partition(
+        table,
+        output_dir,
+        "partition_by_s2",
+        geometry_column,
+        level=level,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        compression=compression,
+        hive=hive,
+        keep_s2_column=keep_s2_column,
+        overwrite=overwrite,
+    )
+
+
+def partition_by_quadkey(
+    table: pa.Table,
+    output_dir: str | Path,
+    *,
+    resolution: int | None = None,
+    partition_resolution: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    compression: str = "ZSTD",
+    hive: bool = False,
+    keep_quadkey_column: bool | None = None,
+    overwrite: bool = False,
+    geometry_column: str | None = None,
+) -> dict:
+    """
+    Partition a table into a directory of files split by quadkey.
+
+    Function form of `Table.partition_by_quadkey`, mirroring
+    `gpio partition quadkey`. Pass both ``resolution`` and
+    ``partition_resolution``, or ``auto=True`` to size them from the data.
+
+    Args:
+        table: Input PyArrow Table with a geometry column
+        output_dir: Output directory path
+        resolution: Quadkey resolution for sorting (0-23). Required unless
+            ``auto=True``
+        partition_resolution: Resolution for partition boundaries (0-23).
+            Required unless ``auto=True``
+        auto: Calculate both resolutions from the data (default: False);
+            mutually exclusive with the two above
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        compression: Compression codec (default: ZSTD)
+        hive: Use Hive-style ``quadkey=value/`` directories (default: False)
+        keep_quadkey_column: Keep the generated ``quadkey`` column. None
+            (default) follows ``hive``
+        overwrite: Overwrite an existing output directory
+        geometry_column: Geometry column name (auto-detected if None)
+
+    Returns:
+        dict with output_dir, file_count and hive
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> stats = ops.partition_by_quadkey(
+        ...     table, 'output/', resolution=13, partition_resolution=6
+        ... )
+    """
+    return _partition(
+        table,
+        output_dir,
+        "partition_by_quadkey",
+        geometry_column,
+        resolution=resolution,
+        partition_resolution=partition_resolution,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        compression=compression,
+        hive=hive,
+        keep_quadkey_column=keep_quadkey_column,
+        overwrite=overwrite,
+    )
+
+
+def partition_by_kdtree(
+    table: pa.Table,
+    output_dir: str | Path,
+    *,
+    iterations: int = 9,
+    hive: bool = False,
+    keep_kdtree_column: bool | None = None,
+    overwrite: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    geometry_column: str | None = None,
+) -> dict:
+    """
+    Partition a table into a directory of files split by KD-tree cell.
+
+    Function form of `Table.partition_by_kdtree`, mirroring
+    `gpio partition kdtree`. Recursively splits the data spatially, producing
+    ``2 ** iterations`` balanced partitions.
+
+    Args:
+        table: Input PyArrow Table with a geometry column
+        output_dir: Output directory path
+        iterations: Number of KD-tree splits (default: 9)
+        hive: Use Hive-style ``kdtree_cell=value/`` directories (default: False)
+        keep_kdtree_column: Keep the generated ``kdtree_cell`` column. None
+            (default) follows ``hive``
+        overwrite: Overwrite an existing output directory
+        compression: Compression codec (default: ZSTD)
+        compression_level: Compression level. None lets the codec pick its own
+        geometry_column: Geometry column name (auto-detected if None)
+
+    Returns:
+        dict with output_dir, file_count and hive
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> stats = ops.partition_by_kdtree(table, 'output/', iterations=6)
+    """
+    return _partition(
+        table,
+        output_dir,
+        "partition_by_kdtree",
+        geometry_column,
+        iterations=iterations,
+        hive=hive,
+        keep_kdtree_column=keep_kdtree_column,
+        overwrite=overwrite,
+        compression=compression,
+        compression_level=compression_level,
+    )
+
+
+def partition_by_string(
+    table: pa.Table,
+    output_dir: str | Path,
+    column: str,
+    *,
+    chars: int | None = None,
+    hive: bool = False,
+    overwrite: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    geometry_column: str | None = None,
+) -> dict:
+    """
+    Partition a table into a directory of files split by a string column.
+
+    Function form of `Table.partition_by_string`, mirroring
+    `gpio partition string`.
+
+    Args:
+        table: Input PyArrow Table
+        output_dir: Output directory path
+        column: Column name to partition by
+        chars: Use the first N characters as the partition key (None: the whole value)
+        hive: Use Hive-style ``column=value/`` directories (default: False)
+        overwrite: Overwrite an existing output directory
+        compression: Compression codec (default: ZSTD)
+        compression_level: Compression level. None lets the codec pick its own
+        geometry_column: Geometry column name (auto-detected if None)
+
+    Returns:
+        dict with output_dir, file_count and hive
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> stats = ops.partition_by_string(table, 'output/', 'country_code', hive=True)
+    """
+    return _partition(
+        table,
+        output_dir,
+        "partition_by_string",
+        geometry_column,
+        column=column,
+        chars=chars,
+        hive=hive,
+        overwrite=overwrite,
+        compression=compression,
+        compression_level=compression_level,
+    )
+
+
+def partition_by_admin(
+    table: pa.Table,
+    output_dir: str | Path,
+    *,
+    dataset: str = "gaul",
+    levels: list[str] | None = None,
+    hive: bool = False,
+    overwrite: bool = False,
+    vecorel: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    geometry_column: str | None = None,
+) -> dict:
+    """
+    Partition a table into a directory of files split by administrative boundaries.
+
+    Function form of `Table.partition_by_admin`, mirroring
+    `gpio partition admin`. Spatially joins against an administrative
+    boundaries dataset, so it downloads that dataset on first use.
+
+    Args:
+        table: Input PyArrow Table with a geometry column
+        output_dir: Output directory path
+        dataset: Boundaries dataset ("gaul", "overture", or a custom URL)
+        levels: Admin levels to partition by (e.g. ["country", "department"]
+            for GAUL, ["country", "region"] for Overture). Defaults to ["country"]
+        hive: Use Hive-style ``level=value/`` directories (default: False)
+        overwrite: Overwrite an existing output directory
+        vecorel: Emit Vecorel-compliant admin columns; forces the Overture
+            dataset with country,region levels (default: False)
+        compression: Compression codec (default: ZSTD)
+        compression_level: Compression level. None lets the codec pick its own
+        geometry_column: Geometry column name (auto-detected if None)
+
+    Returns:
+        dict with output_dir, file_count and hive
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> stats = ops.partition_by_admin(table, 'output/', levels=['country'])
+    """
+    return _partition(
+        table,
+        output_dir,
+        "partition_by_admin",
+        geometry_column,
+        dataset=dataset,
+        levels=levels,
+        hive=hive,
+        overwrite=overwrite,
+        vecorel=vecorel,
+        compression=compression,
+        compression_level=compression_level,
     )
 
 

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1040,7 +1040,9 @@ def partition_by_kdtree(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        dict with output_dir, file_count and hive
+        The core run's result, which for KD-tree is ``{'status': 'completed'}``.
+        Unlike the cell-index partitioners this one does not count the files it
+        wrote, so there is no ``file_count`` here -- read ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -1090,7 +1092,10 @@ def partition_by_string(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        dict with output_dir, file_count and hive
+        The core run's result, which for a string partition is
+        ``{'status': 'completed'}``. Unlike the cell-index partitioners this one
+        does not count the files it wrote, so there is no ``file_count`` here --
+        read ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -1145,7 +1150,11 @@ def partition_by_admin(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        dict with output_dir, file_count and hive
+        The core run's result. The admin partitioner returns the number of
+        partitions it created, so a run that wrote at least one partition
+        returns that ``int``; a run that created none returns
+        ``{'status': 'completed'}``. There is no ``file_count`` here -- read
+        ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -574,3 +574,19 @@ def skip_if_geography_unavailable() -> None:
             f"DuckDB community extension 'geography' (S2) is not published for "
             f"DuckDB {duckdb.__version__}"
         )
+
+
+def skip_if_geography_available() -> None:
+    """Skip a test that pins S2's *unavailability* once 'geography' is published.
+
+    The mirror of `skip_if_geography_unavailable`. A test asserting that S2
+    raises `ExtensionUnavailableError` (#737) is pinning a temporary state: the
+    day the extension is republished for gpio's DuckDB floor, the call starts
+    succeeding and the assertion becomes wrong rather than broken. Skipping is
+    the honest outcome -- the feature tests take over from there.
+    """
+    if _community_extension_available("geography"):
+        pytest.skip(
+            f"DuckDB community extension 'geography' (S2) is published for "
+            f"DuckDB {duckdb.__version__}, so S2 no longer raises"
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from geoparquet_io.api import Table, convert, ops, pipe, read
-from tests.conftest import safe_unlink
+from tests.conftest import safe_unlink, skip_if_geography_available
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 PLACES_PARQUET = TEST_DATA_DIR / "places_test.parquet"
@@ -1872,6 +1872,27 @@ class TestOpsPartition:
         assert kwargs["auto"] is True
         assert kwargs["target_rows"] == 5000
         assert kwargs["max_partitions"] == 50
+
+    def test_partition_by_s2_fails_like_the_table_method(self, arrow_table, tmp_path):
+        """S2's unavailability (#737) must read the same through `ops` and `Table`.
+
+        The forwarding test above patches core away, so it says nothing about
+        what a real caller sees. This one runs the whole path unpatched: an
+        ``ops`` twin that swallowed the error, or re-raised it as something
+        else, would leave a caller unable to tell why S2 failed -- and would do
+        it differently from the method it is supposed to mirror.
+        """
+        skip_if_geography_available()
+        from geoparquet_io.core.exceptions import ExtensionUnavailableError
+
+        with pytest.raises(ExtensionUnavailableError) as via_ops:
+            ops.partition_by_s2(arrow_table, tmp_path / "ops", level=5)
+        with pytest.raises(ExtensionUnavailableError) as via_table:
+            Table(arrow_table).partition_by_s2(tmp_path / "table", level=5)
+
+        assert via_ops.value.name == "geography"
+        assert "geography" in str(via_ops.value)
+        assert str(via_ops.value) == str(via_table.value)
 
     def test_partition_by_admin_forwards_to_core(self, arrow_table, tmp_path):
         """Admin partitioning downloads a boundaries dataset; check the wiring only."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1789,3 +1789,167 @@ class TestReadPartitionS3:
             raise
         except Exception:
             pass
+
+
+class TestOpsPartition:
+    """`ops.partition_by_*` is the function-style twin of every partition subcommand.
+
+    Partitioning used to be reachable from Python only as a ``Table`` method
+    (#799), which made it the one command group without the ``ops`` front door
+    that ``add``, ``sort``, ``convert``, ``extract`` and ``process`` all have.
+    These functions take a plain ``pa.Table`` plus an output directory and must
+    behave exactly like the method they mirror -- including the refusal to guess
+    a resolution that #762 gave the four spatial-index methods.
+    """
+
+    @pytest.fixture
+    def arrow_table(self):
+        """A plain PyArrow table -- the input an ops caller actually holds."""
+        if not PLACES_PARQUET.exists():
+            pytest.skip("Test data not available")
+        return pq.read_table(PLACES_PARQUET)
+
+    @staticmethod
+    def _partition_names(output_dir):
+        files = sorted(Path(output_dir).rglob("*.parquet"))
+        assert files, f"no parquet files written to {output_dir}"
+        return sorted(f.name for f in files)
+
+    # -- each function writes partitions from a bare pa.Table ---------------
+
+    def test_partition_by_h3(self, arrow_table, tmp_path):
+        stats = ops.partition_by_h3(arrow_table, tmp_path / "out", resolution=2)
+
+        assert stats["file_count"] > 0
+        assert self._partition_names(tmp_path / "out")
+
+    def test_partition_by_a5(self, arrow_table, tmp_path):
+        stats = ops.partition_by_a5(arrow_table, tmp_path / "out", resolution=4)
+
+        assert stats["file_count"] > 0
+        assert self._partition_names(tmp_path / "out")
+
+    def test_partition_by_quadkey(self, arrow_table, tmp_path):
+        stats = ops.partition_by_quadkey(
+            arrow_table, tmp_path / "out", resolution=13, partition_resolution=3
+        )
+
+        assert stats["file_count"] > 0
+        assert self._partition_names(tmp_path / "out")
+
+    def test_partition_by_kdtree(self, arrow_table, tmp_path):
+        """kdtree/string/admin return the core result, not the file-count stats."""
+        result = ops.partition_by_kdtree(arrow_table, tmp_path / "out", iterations=2)
+
+        assert isinstance(result, dict)
+        assert len(self._partition_names(tmp_path / "out")) == 4
+
+    def test_partition_by_string(self, arrow_table, tmp_path):
+        # A column with two values: the partition-size guard rejects the tiny
+        # partitions a per-name split of 766 rows would produce.
+        regions = pa.array(["north" if i % 2 else "south" for i in range(arrow_table.num_rows)])
+        table = arrow_table.append_column("region", regions)
+
+        result = ops.partition_by_string(table, tmp_path / "out", column="region")
+
+        assert isinstance(result, dict)
+        assert len(self._partition_names(tmp_path / "out")) == 2
+
+    def test_partition_by_s2_forwards_to_core(self, arrow_table, tmp_path):
+        """`gpio partition s2` cannot run without the 'geography' extension (#737).
+
+        The wiring is still checked: patch core and assert the arguments arrive.
+        """
+        from geoparquet_io.core.partition import by_s2 as core_by_s2
+
+        with patch.object(core_by_s2, "partition_by_s2") as fake:
+            ops.partition_by_s2(
+                arrow_table, tmp_path / "out", auto=True, target_rows=5000, max_partitions=50
+            )
+
+        kwargs = fake.call_args.kwargs
+        assert kwargs["level"] is None
+        assert kwargs["auto"] is True
+        assert kwargs["target_rows"] == 5000
+        assert kwargs["max_partitions"] == 50
+
+    def test_partition_by_admin_forwards_to_core(self, arrow_table, tmp_path):
+        """Admin partitioning downloads a boundaries dataset; check the wiring only."""
+        from geoparquet_io.core.partition import admin_hierarchical as core_admin
+
+        with patch.object(core_admin, "partition_by_admin_hierarchical") as fake:
+            ops.partition_by_admin(
+                arrow_table, tmp_path / "out", dataset="overture", levels=["country"], hive=True
+            )
+
+        kwargs = fake.call_args.kwargs
+        assert kwargs["dataset_name"] == "overture"
+        assert kwargs["levels"] == ["country"]
+        assert kwargs["hive"] is True
+
+    def test_partition_by_admin_vecorel_forces_overture_country_region(self, arrow_table, tmp_path):
+        """Same vecorel shorthand the Table method applies, not a second spelling."""
+        from geoparquet_io.core.partition import admin_hierarchical as core_admin
+
+        with patch.object(core_admin, "partition_by_admin_hierarchical") as fake:
+            ops.partition_by_admin(arrow_table, tmp_path / "out", vecorel=True)
+
+        kwargs = fake.call_args.kwargs
+        assert kwargs["dataset_name"] == "overture"
+        assert kwargs["levels"] == ["country", "region"]
+        assert kwargs["vecorel"] is True
+
+    # -- the ops twin and the Table method are the same operation -----------
+
+    def test_ops_and_table_write_the_same_partitions(self, arrow_table, tmp_path):
+        ops.partition_by_h3(arrow_table, tmp_path / "ops", resolution=2)
+        Table(arrow_table).partition_by_h3(tmp_path / "table", resolution=2)
+
+        assert self._partition_names(tmp_path / "ops") == self._partition_names(tmp_path / "table")
+
+    def test_auto_is_forwarded(self, arrow_table, tmp_path):
+        """`auto=True` sizes the resolution from the data, as `--auto` does."""
+        stats = ops.partition_by_h3(arrow_table, tmp_path / "out", auto=True)
+
+        assert stats["file_count"] > 0
+
+    def test_hive_produces_key_value_directories(self, arrow_table, tmp_path):
+        ops.partition_by_h3(arrow_table, tmp_path / "out", resolution=2, hive=True)
+
+        subdirs = [d for d in (tmp_path / "out").iterdir() if d.is_dir()]
+        assert subdirs and all("h3_cell=" in d.name for d in subdirs)
+
+    def test_keep_column_escape_hatch_is_exposed(self, arrow_table, tmp_path):
+        ops.partition_by_h3(arrow_table, tmp_path / "out", resolution=2, keep_h3_column=True)
+
+        first = sorted(Path(tmp_path / "out").rglob("*.parquet"))[0]
+        assert "h3_cell" in pq.ParquetFile(first).schema_arrow.names
+
+    # -- refuse to guess, exactly as the CLI and the Table methods do -------
+
+    @pytest.mark.parametrize(
+        "function",
+        ["partition_by_h3", "partition_by_a5", "partition_by_s2", "partition_by_quadkey"],
+    )
+    def test_refuses_to_guess_a_resolution(self, arrow_table, tmp_path, function):
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            getattr(ops, function)(arrow_table, tmp_path / function)
+
+    @pytest.mark.parametrize(
+        ("function", "kwargs"),
+        [
+            ("partition_by_h3", {"resolution": 5}),
+            ("partition_by_a5", {"resolution": 5}),
+            ("partition_by_s2", {"level": 5}),
+            ("partition_by_quadkey", {"resolution": 5, "partition_resolution": 3}),
+        ],
+    )
+    def test_auto_and_an_explicit_resolution_are_mutually_exclusive(
+        self, arrow_table, tmp_path, function, kwargs
+    ):
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            getattr(ops, function)(arrow_table, tmp_path / function, auto=True, **kwargs)

--- a/tests/test_cli_api_call_parity_scaffold.py
+++ b/tests/test_cli_api_call_parity_scaffold.py
@@ -215,6 +215,24 @@ def _table(module: Any, attr: str, reference: Callable, call: Callable[[Ctx], An
     )
 
 
+def _ops_via_table(
+    module: Any, attr: str, reference: Callable, call: Callable[[Ctx], Any]
+) -> Frontend:
+    """An `ops` front end that reaches core through `Table`.
+
+    `ops.partition_by_*` delegates to the matching `Table` method rather than
+    keeping a second copy of the temp-file plumbing, and `Table` imports its
+    core function inside the method body -- so this one is patched on the *core*
+    module, like a `Table` front end, not on `ops`.
+    """
+    return Frontend(
+        patch_site=(module, attr),
+        reference=reference,
+        invoke=call,
+        result=ECHO_FIRST_ARG,
+    )
+
+
 def _install_write_strategy(_frontend, recorder: _Recorder):
     """Patch the strategy factory so Table.write's core write call is recorded.
 
@@ -500,7 +518,12 @@ CASES: list[ParityCase] = [
             core_part_h3.partition_by_h3,
             lambda c: ["partition", "h3", c.input_file, c.output_dir, "--resolution", "6"],
         ),
-        # No `ops.partition_by_*`; Table is the only API front end for partitioning.
+        ops=_ops_via_table(
+            core_part_h3,
+            "partition_by_h3",
+            core_part_h3.partition_by_h3,
+            lambda c: ops.partition_by_h3(c.table, c.output_dir),
+        ),
         table=_table(
             core_part_h3,
             "partition_by_h3",
@@ -539,6 +562,12 @@ CASES: list[ParityCase] = [
                 "--partition-resolution",
                 "6",
             ],
+        ),
+        ops=_ops_via_table(
+            core_part_quadkey,
+            "partition_by_quadkey",
+            core_part_quadkey.partition_by_quadkey,
+            lambda c: ops.partition_by_quadkey(c.table, c.output_dir),
         ),
         table=_table(
             core_part_quadkey,

--- a/tests/test_cli_api_call_parity_scaffold.py
+++ b/tests/test_cli_api_call_parity_scaffold.py
@@ -215,22 +215,14 @@ def _table(module: Any, attr: str, reference: Callable, call: Callable[[Ctx], An
     )
 
 
-def _ops_via_table(
-    module: Any, attr: str, reference: Callable, call: Callable[[Ctx], Any]
-) -> Frontend:
-    """An `ops` front end that reaches core through `Table`.
-
-    `ops.partition_by_*` delegates to the matching `Table` method rather than
-    keeping a second copy of the temp-file plumbing, and `Table` imports its
-    core function inside the method body -- so this one is patched on the *core*
-    module, like a `Table` front end, not on `ops`.
-    """
-    return Frontend(
-        patch_site=(module, attr),
-        reference=reference,
-        invoke=call,
-        result=ECHO_FIRST_ARG,
-    )
+# An `ops` front end that reaches core through `Table`.
+#
+# `ops.partition_by_*` delegates to the matching `Table` method rather than keeping a
+# second copy of the temp-file plumbing, and `Table` imports its core function inside
+# the method body -- so this one is patched on the *core* module, like a `Table` front
+# end, not on `ops`. That makes it constructed exactly like `_table`; the alias keeps
+# the call sites at the case list reading as "ops, via Table" without a duplicate body.
+_ops_via_table = _table
 
 
 def _install_write_strategy(_frontend, recorder: _Recorder):
@@ -522,7 +514,7 @@ CASES: list[ParityCase] = [
             core_part_h3,
             "partition_by_h3",
             core_part_h3.partition_by_h3,
-            lambda c: ops.partition_by_h3(c.table, c.output_dir),
+            lambda c: ops.partition_by_h3(c.table, c.output_dir, resolution=6),
         ),
         table=_table(
             core_part_h3,
@@ -531,9 +523,11 @@ CASES: list[ParityCase] = [
             lambda c: c.gpio_table.partition_by_h3(c.output_dir, resolution=6),
         ),
         notes=(
-            "A resolution is supplied on both sides because neither front end accepts a "
+            "A resolution is supplied on all three sides because no front end accepts a "
             "call without one: the CLI errors from core, and the API now errors in front "
-            "of the temp-file write. Every other knob is still left at its default.",
+            "of the temp-file write. `ops.partition_by_h3` inherits that gate by "
+            "delegating to `Table.partition_by_h3`, so it has to be called with a "
+            "resolution too. Every other knob is still left at its default.",
         ),
         normalize={
             "column_name": ("h3_column_name", "h3_column_name"),
@@ -567,7 +561,9 @@ CASES: list[ParityCase] = [
             core_part_quadkey,
             "partition_by_quadkey",
             core_part_quadkey.partition_by_quadkey,
-            lambda c: ops.partition_by_quadkey(c.table, c.output_dir),
+            lambda c: ops.partition_by_quadkey(
+                c.table, c.output_dir, resolution=13, partition_resolution=6
+            ),
         ),
         table=_table(
             core_part_quadkey,
@@ -578,9 +574,11 @@ CASES: list[ParityCase] = [
             ),
         ),
         notes=(
-            "Both resolutions are supplied on both sides because neither front end accepts "
+            "Both resolutions are supplied on all three sides because no front end accepts "
             "a call without them: the CLI errors from core, and the API now errors in front "
-            "of the temp-file write. Every other knob is still left at its default.",
+            "of the temp-file write. `ops.partition_by_quadkey` inherits that gate by "
+            "delegating to `Table.partition_by_quadkey`, so it has to be called with both "
+            "resolutions too. Every other knob is still left at its default.",
         ),
         normalize={
             "column_name": ("quadkey_column_name", "quadkey_column_name"),

--- a/tests/test_cli_api_default_parity.py
+++ b/tests/test_cli_api_default_parity.py
@@ -251,6 +251,41 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str, str, str], str] = {
     ): _GEOMETRY_COLUMN_FROM_TABLE,
     (
         "partition a5",
+        "ops.partition_by_a5",
+        "keep_a5_column",
+        "False",
+        "'<unset>'",
+    ): _KEEP_TRISTATE,
+    (
+        "partition h3",
+        "ops.partition_by_h3",
+        "keep_h3_column",
+        "False",
+        "'<unset>'",
+    ): _KEEP_TRISTATE,
+    (
+        "partition kdtree",
+        "ops.partition_by_kdtree",
+        "keep_kdtree_column",
+        "False",
+        "'<unset>'",
+    ): _KEEP_TRISTATE,
+    (
+        "partition quadkey",
+        "ops.partition_by_quadkey",
+        "keep_quadkey_column",
+        "False",
+        "'<unset>'",
+    ): _KEEP_TRISTATE,
+    (
+        "partition s2",
+        "ops.partition_by_s2",
+        "keep_s2_column",
+        "False",
+        "'<unset>'",
+    ): _KEEP_TRISTATE,
+    (
+        "partition a5",
         "Table.partition_by_a5",
         "keep_a5_column",
         "False",
@@ -355,6 +390,107 @@ class TestEveryCommandHasAnApiTwin:
     def test_every_allowlist_entry_has_a_reason(self):
         for command, reason in NO_API_TWIN.items():
             assert reason and reason.strip(), f"No justification recorded for {command!r}"
+
+
+# --------------------------------------------------------------------------
+# "...and `ops` is the function half of that API" -- allowlisted exceptions
+# --------------------------------------------------------------------------
+
+# `NO_API_TWIN` above only asks for *some* twin, so a `Table` method alone
+# satisfies it and a missing `ops` function is invisible (#799). That is a real
+# gap: `ops` is the front door for callers holding a plain `pa.Table` rather
+# than the fluent wrapper, and "this group is Table-only" should be a decision
+# somebody wrote down, not an accident nobody noticed. Every command that has a
+# `Table` method but no `ops` function needs an entry here with a reason.
+#
+# Commands with no API at all are covered by `NO_API_TWIN` and skipped here, so
+# a twin-less command is recorded in exactly one place.
+
+_REPORT_NOT_A_TABLE = (
+    "Returns a report -- a dict of findings about a file -- not GeoParquet. There is no "
+    "`table in -> table out` shape for an `ops` function to have, and the receiver is "
+    "naturally the Table (or a path). An `ops` twin taking a path would be a thin "
+    "wrapper; if one is ever added, delete this entry."
+)
+_INSPECTION_NOT_A_TABLE = (
+    "Inspection: renders or returns a description of a table (metadata, a preview, "
+    "column statistics) rather than transforming one, so an `ops.<fn>(table) -> table` "
+    "twin would have nothing to return. `Table` is the reviewed home for it."
+)
+
+NO_OPS_TWIN: dict[str, str] = {
+    "check all": _REPORT_NOT_A_TABLE,
+    "check bbox": _REPORT_NOT_A_TABLE,
+    "check compression": _REPORT_NOT_A_TABLE,
+    "check optimization": _REPORT_NOT_A_TABLE,
+    "check row-group": _REPORT_NOT_A_TABLE,
+    "check spatial": _REPORT_NOT_A_TABLE,
+    "check spec": _REPORT_NOT_A_TABLE,
+    "inspect head": _INSPECTION_NOT_A_TABLE,
+    "inspect meta": _INSPECTION_NOT_A_TABLE,
+    "inspect stats": _INSPECTION_NOT_A_TABLE,
+    "inspect summary": _INSPECTION_NOT_A_TABLE,
+    "inspect tail": _INSPECTION_NOT_A_TABLE,
+    "convert geoparquet": (
+        "The API twin is `Table.write`, the terminal step of the fluent chain. A caller "
+        "holding a bare `pa.Table` writes it with `Table(t).write(path)`; an "
+        "`ops.write(table, path)` would only re-spell that constructor."
+    ),
+    "publish upload": (
+        "Uploads a file that already exists on disk to object storage. The unit of work "
+        "is a path, not the in-memory table an `ops` function receives -- `Table.upload` "
+        "writes first and uploads that."
+    ),
+}
+
+
+def commands_without_ops_twin() -> set[str]:
+    """CLI commands that resolve to a `Table` method but to no `ops` function.
+
+    Commands with no API twin at all are excluded: they are already pinned by
+    `NO_API_TWIN`, and listing them twice would mean two allowlists to update
+    when one of them finally grows an API.
+    """
+    out: set[str] = set()
+    for path, _cmd in _walk(cli):
+        twins = _api_twins(path)
+        if not twins:
+            continue
+        if not any(label.startswith("ops.") for label, _fn in twins):
+            out.add(" ".join(path))
+    return out
+
+
+class TestEveryCommandHasAnOpsTwin:
+    """A `Table` method alone is not the whole Python API; `ops` is the other half."""
+
+    def test_ops_less_commands_are_exactly_the_allowlist(self):
+        actual = commands_without_ops_twin()
+        missing = actual - set(NO_OPS_TWIN)
+        stale = set(NO_OPS_TWIN) - actual
+        assert not missing, (
+            "CLI command(s) with a `Table` method but no `ops` function. `ops` is the "
+            "function-style half of the Python API -- add one, or add an entry to "
+            "NO_OPS_TWIN saying why this command is Table-only:\n"
+            + "\n".join(f"  {c}" for c in sorted(missing))
+        )
+        assert not stale, (
+            "NO_OPS_TWIN lists command(s) that now have an `ops` function (or no longer "
+            "exist); delete the entries:\n" + "\n".join(f"  {c}" for c in sorted(stale))
+        )
+
+    def test_every_allowlist_entry_has_a_reason(self):
+        for command, reason in NO_OPS_TWIN.items():
+            assert reason and reason.strip(), f"No justification recorded for {command!r}"
+
+    def test_allowlists_do_not_overlap(self):
+        """A twin-less command belongs to NO_API_TWIN only."""
+        both = set(NO_API_TWIN) & set(NO_OPS_TWIN)
+        assert not both, (
+            "Command(s) listed in both NO_API_TWIN and NO_OPS_TWIN; a command with no "
+            "API at all is recorded once, in NO_API_TWIN:\n"
+            + "\n".join(f"  {c}" for c in sorted(both))
+        )
 
 
 class TestNoNewDefaultDrift:


### PR DESCRIPTION
> **No longer stacked.** #800 has merged, so this branch is rebased onto `main` and
> targets `main`. It now carries only its own commits and gets full CI.

## What changed

`geoparquet_io/api/ops.py` had **no partition functions at all** (36 `def`s, zero
`partition` hits). All seven `gpio partition` subcommands were reachable from Python
only as `Table.partition_by_*` methods, which made partitioning the one command group
without the function-style front door that `add`, `sort`, `convert`, `extract` and
`process` all have.

Seven new functions, each taking a `pa.Table` plus an output directory:

```python
ops.partition_by_h3(table, output_dir, *, resolution=None, auto=False, target_rows=100000,
                    max_partitions=10000, compression='ZSTD', hive=False,
                    keep_h3_column=None, overwrite=False, geometry_column=None)
ops.partition_by_a5(table, output_dir, *, resolution=None, auto=False, target_rows=100000,
                    max_partitions=10000, compression='ZSTD', hive=False,
                    keep_a5_column=None, overwrite=False, geometry_column=None)
ops.partition_by_s2(table, output_dir, *, level=None, auto=False, target_rows=100000,
                    max_partitions=10000, compression='ZSTD', hive=False,
                    keep_s2_column=None, overwrite=False, geometry_column=None)
ops.partition_by_quadkey(table, output_dir, *, resolution=None, partition_resolution=None,
                    auto=False, target_rows=100000, max_partitions=10000,
                    compression='ZSTD', hive=False, keep_quadkey_column=None,
                    overwrite=False, geometry_column=None)
ops.partition_by_kdtree(table, output_dir, *, iterations=9, hive=False,
                    keep_kdtree_column=None, overwrite=False, compression='ZSTD',
                    compression_level=None, geometry_column=None)
ops.partition_by_string(table, output_dir, column, *, chars=None, hive=False,
                    overwrite=False, compression='ZSTD', compression_level=None,
                    geometry_column=None)
ops.partition_by_admin(table, output_dir, *, dataset='gaul', levels=None, hive=False,
                    overwrite=False, vecorel=False, compression='ZSTD',
                    compression_level=None, geometry_column=None)
```

Each mirrors the matching `Table` method argument for argument, **including the
behaviour #800 introduced**: `auto` / `target_rows` / `max_partitions` on the four
spatial-index schemes, and a refusal to guess — no resolution and no `auto=True`
raises `InvalidParameterError`, and `auto=True` alongside an explicit resolution is
an error, exactly as at the command line.

They delegate to the `Table` methods (one private `_partition()` helper) rather than
copying `_run_partition_with_temp_file`, so both front doors run the same code instead
of two implementations that can drift. `Table` is imported inside the helper because
`geoparquet_io.api.__init__` imports `ops` before `table`.

### Closing the enforcement hole

The gap was invisible to both parity suites, which is why it survived:

* `tests/test_cli_api_default_parity.py` resolved a command to *any* twin, so a
  `Table` method alone satisfied `TestEveryCommandHasAnApiTwin`. New
  **`TestEveryCommandHasAnOpsTwin`** asserts that every command with a `Table` method
  also has an `ops` function, pinned to a named **`NO_OPS_TWIN`** allowlist — 14
  entries today (the `check` and `inspect` report/inspection commands, `convert
  geoparquet`, `publish upload`), each with a written reason. A twin-less command
  stays in `NO_API_TWIN` only; a third test asserts the two allowlists never overlap.
  Before this PR the new test fails with exactly the seven partition subcommands.
* `tests/test_cli_api_call_parity_scaffold.py` recorded the fact in a comment
  ("No `ops.partition_by_*`; Table is the only API front end for partitioning").
  That comment is now a real `ops` front end on the `partition h3` and
  `partition quadkey` cases, so both schemes' values are diffed against the CLI for
  `ops` as well as `Table`.

`KNOWN_DIVERGENCES` gains five entries — the `keep_*_column` tri-state, already
allowlisted for the `Table` twins, is inherited by the `ops` twins for the same
intentional reason.

`gpio partition s2` still cannot run in this release (the `geography` extension is
unpublished for `duckdb>=1.5.2`, #737). `ops.partition_by_s2` is wired for symmetry and
covered twice: once by patching core and asserting the arguments arrive, and once
unpatched, pinning the failure to the same `ExtensionUnavailableError` and message
`Table.partition_by_s2` raises — a twin that swallowed the error or wrapped it in
something else would leave a caller unable to tell why S2 failed. A new
`skip_if_geography_available()` in `conftest.py` (the mirror of the existing
`skip_if_geography_unavailable()`) makes that test step aside rather than lie once the
extension is republished. The docs say so too.

Three of the seven return the core run's result rather than the `{output_dir,
file_count, hive}` stats: only the four cell-index partitioners ask
`_run_partition_with_temp_file` to count files. `partition_by_kdtree` and
`partition_by_string` therefore return `{'status': 'completed'}`, and
`partition_by_admin` returns the partition count its core function hands back. The
docstrings say which is which instead of promising `file_count` everywhere.

Docs: `docs/api/python-api.md` gains all seven signatures in the ops function table,
a worked example, and a cross-reference from the Table partitioning section;
`docs/guide/partition.md` gains a "Function-Style API" section mapping each CLI
command to its `ops` function.

## Why

CLAUDE.md's rule is "Every CLI command needs a Python API", and `ops` is the
function-style half of that API — the front door for callers working with plain Arrow
tables rather than the fluent wrapper. Partitioning being method-only was an accident,
not a decision, and nothing enforced it either way.

Closes #799.

## Verification

New tests, watched failing first. `TestEveryCommandHasAnOpsTwin` before the `ops`
functions existed:

```
E   AssertionError: CLI command(s) with a `Table` method but no `ops` function. `ops` is the function-style half of the Python API -- add one, or add an entry to NO_OPS_TWIN saying why this command is Table-only:
E       partition a5
E       partition admin
E       partition h3
E       partition kdtree
E       partition quadkey
E       partition s2
E       partition string
========================= 1 failed, 41 passed in 0.84s =========================
```

`TestOpsPartition` before the implementation: `20 failed in 1.30s` (every test
`AttributeError: module 'geoparquet_io.api.ops' has no attribute 'partition_by_*'`).

After, re-run on the rebase onto `main`:

```
$ uv run pytest tests/test_cli_api_call_parity_scaffold.py tests/test_cli_api_default_parity.py tests/test_api.py -q -m "not slow and not network"
======================= 255 passed, 4 skipped in 11.06s ========================

$ uv run pytest -q -m "not slow and not network and not meta" -k "partition or parity or ops" --no-cov
========= 558 passed, 15 skipped, 5585 deselected in 147.91s (0:02:27) =========

$ uv run pytest -m meta -q --no-cov
===================== 202 passed, 5956 deselected in 9.49s =====================

$ uv run pytest "docs/guide/partition.md" -q --no-cov -m "not network"
=========== 16 passed, 18 skipped, 6 deselected in 267.58s (0:04:27) ===========
```

Hooks, both stages — `--all-files` and `--hook-stage pre-push` (deptry, mypy, vulture,
xenon, import-linter, menard-check, fast-tests) — all `Passed`, `check-api-for-cli`
included.

The doc-example gap an earlier revision of this body reported as pre-existing —
`test_no_skipped_fence_hides_a_working_command[partition.md]` failing on the "Quick
Examples" fence — was fixed in #800 before it merged, and the test passes here
(`1 passed in 16.09s`). The counts above are higher than the pre-rebase ones for the
same reason: more of `partition.md` now runs rather than skipping.

`tests/test_commitizen.py` flaked twice under load (`subprocess.TimeoutExpired` after
30s on `python -m commitizen.cli check`); the same command takes 0.5s standalone and
the file passes serially (`29 passed in 5.12s`). Machine contention, not a change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

