### PR TITLE
fix(sql): show the real path, not the SQL-escaped one, in logs and errors

### DIFF
--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -27,7 +27,7 @@ from geoparquet_io.core.duckdb_utils import (
     spatial_join_strategy,
     sql_path,
 )
-from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.file_utils import handle_output_overwrite, resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
 from geoparquet_io.core.partition.reader import require_single_file
@@ -126,21 +126,27 @@ def _build_admin_select_clause(dataset, levels, partition_columns, prefix=None):
     return ", ".join(admin_select_parts)
 
 
-def _format_input_ref(input_url, is_table_ref=False):
+def _format_input_ref(input_source, is_table_ref=False):
     """Format input reference for SQL.
 
-    A DuckDB table/CTE name (``is_table_ref=True``) is emitted bare; a file path
-    or URL is single-quoted. The caller passes the flag explicitly rather than
-    sniffing for a ``_gpio_`` prefix, so a real path beginning with ``_gpio_``
-    can never be emitted unquoted (see todo 017).
+    A DuckDB table/CTE name (``is_table_ref=True``) is emitted bare; a RAW file
+    path or URL goes through :func:`sql_path`, which quotes and escapes it. The
+    caller passes the flag explicitly rather than sniffing for a ``_gpio_``
+    prefix, so a real path beginning with ``_gpio_`` can never be emitted
+    unquoted (see todo 017).
+
+    ``input_source`` alternates between a path and a table name as the per-level
+    chain advances, so the path it carries must be RAW: escaping it earlier
+    would mean the escape survives into the branch that emits a table name
+    (#802).
     """
     if is_table_ref:
-        return input_url
-    return f"'{input_url}'"
+        return input_source
+    return sql_path(input_source)
 
 
 def _build_spatial_join_query(
-    input_url,
+    input_source,
     admin_subquery,
     admin_select_clause,
     input_bbox_col,
@@ -165,9 +171,9 @@ def _build_spatial_join_query(
     All identifiers are quoted via the shared :func:`build_spatial_join_condition`
     helper / :func:`quote_identifier`, so column names sourced from untrusted file
     metadata cannot break out of the generated SQL. ``is_table_ref`` marks
-    ``input_url`` as a DuckDB table/CTE name (per-level chaining) vs a file path.
+    ``input_source`` as a DuckDB table/CTE name (per-level chaining) vs a file path.
     """
-    input_ref = _format_input_ref(input_url, is_table_ref)
+    input_ref = _format_input_ref(input_source, is_table_ref)
 
     # CRS handling for a non-CRS84 input (#525):
     #  - If the admin side was reprojected into the input CRS (it has a bbox), the
@@ -200,7 +206,7 @@ def _build_spatial_join_query(
 
 def _add_extent_filter(
     con,
-    input_url,
+    input_source,
     input_bbox_col,
     input_geom_col,
     admin_bbox_col,
@@ -217,7 +223,7 @@ def _add_extent_filter(
     if not admin_bbox_col:
         return None
 
-    input_ref = _format_input_ref(input_url, is_table_ref)
+    input_ref = _format_input_ref(input_source, is_table_ref)
 
     if input_bbox_col and not source_crs:
         q_input_bbox = quote_identifier(input_bbox_col)
@@ -280,7 +286,7 @@ def _handle_bbox_optimization(input_parquet, input_bbox_info, add_bbox_flag, ver
 
 
 def _print_dry_run_header(
-    input_url,
+    input_path,
     admin_source,
     output_parquet,
     input_geom_col,
@@ -288,9 +294,16 @@ def _print_dry_run_header(
     input_bbox_col,
     admin_bbox_col,
 ):
-    """Print dry-run mode header."""
+    """Print dry-run mode header.
+
+    ``input_path`` is RAW: this is prose for a human, and showing the SQL-escaped
+    ``o''brien/data.parquet`` for ``o'brien/data.parquet`` is confusing to read
+    and wrong to copy-paste (#802).
+    """
     warn("\n=== DRY RUN MODE - SQL Commands that would be executed ===\n")
-    display_input = _sanitize_url_for_logging(input_url) if is_remote_url(input_url) else input_url
+    display_input = (
+        _sanitize_url_for_logging(input_path) if is_remote_url(input_path) else input_path
+    )
     display_admin = (
         _sanitize_url_for_logging(admin_source) if is_remote_url(admin_source) else admin_source
     )
@@ -354,7 +367,10 @@ def _setup_dataset_and_columns(
     dataset.validate_levels(levels)
     partition_columns = dataset.get_partition_columns(levels)
 
-    input_url = safe_file_url(input_parquet, verbose)
+    # RAW path: it is shown in the dry-run header, and it is also chained
+    # through ``current_source``, which alternately holds a temp-table name --
+    # so the escape has to happen at the SQL boundary, not here (#802).
+    input_path = resolve_file_url(input_parquet, verbose)
 
     # Per-level datasets resolve sources per-level in add_admin_divisions_multi
     if dataset.supports_per_level_sources():
@@ -384,7 +400,7 @@ def _setup_dataset_and_columns(
     return (
         dataset,
         partition_columns,
-        input_url,
+        input_path,
         admin_source,
         input_geom_col,
         admin_geom_col,
@@ -430,7 +446,7 @@ def _build_admin_where_clauses_list(
     con,
     dataset,
     levels,
-    input_url,
+    input_source,
     input_bbox_col,
     input_geom_col,
     admin_bbox_col,
@@ -449,7 +465,7 @@ def _build_admin_where_clauses_list(
 
     extent_filter = _add_extent_filter(
         con,
-        input_url,
+        input_source,
         input_bbox_col,
         input_geom_col,
         admin_bbox_col,
@@ -495,7 +511,7 @@ def _build_query_components(
     dataset,
     levels,
     partition_columns,
-    input_url,
+    input_source,
     admin_source,
     admin_geom_col,
     admin_bbox_col,
@@ -513,16 +529,17 @@ def _build_query_components(
     # Quote the path for SQL safety
     read_options = dataset.get_read_parquet_options()
     admin_table_ref = (
-        f"read_parquet('{admin_source}', {', '.join([f'{k}={v}' for k, v in read_options.items()])})"
+        f"read_parquet({sql_path(admin_source)}, "
+        f"{', '.join([f'{k}={v}' for k, v in read_options.items()])})"
         if read_options
-        else f"'{admin_source}'"
+        else sql_path(admin_source)
     )
 
     admin_where_clauses = _build_admin_where_clauses_list(
         con,
         dataset,
         levels,
-        input_url,
+        input_source,
         input_bbox_col,
         input_geom_col,
         admin_bbox_col,
@@ -559,7 +576,7 @@ def _build_query_components(
         )
 
     query = _build_spatial_join_query(
-        input_url,
+        input_source,
         admin_subquery,
         admin_select_clause,
         input_bbox_col,
@@ -575,7 +592,7 @@ def _build_query_components(
 
 def _handle_dry_run_mode(
     dry_run,
-    input_url,
+    input_path,
     admin_source,
     output_parquet,
     input_geom_col,
@@ -593,7 +610,7 @@ def _handle_dry_run_mode(
         return False
 
     _print_dry_run_header(
-        input_url,
+        input_path,
         admin_source,
         output_parquet,
         input_geom_col,
@@ -634,7 +651,7 @@ def _execute_per_level_joins(
     dataset,
     levels,
     partition_columns,
-    input_url,
+    input_source,
     admin_geom_col,
     admin_bbox_col,
     input_geom_col,
@@ -662,7 +679,7 @@ def _execute_per_level_joins(
     temp tables. Per-level caches are non-overlapping, so each plain LEFT JOIN
     normally preserves the row count.
     """
-    current_source = input_url
+    current_source = input_source
 
     for i, (level, col) in enumerate(zip(levels, partition_columns, strict=True)):
         level_admin_source = dataset.get_source_for_level(level, no_cache=no_cache)
@@ -786,7 +803,7 @@ def add_admin_divisions_multi(
     (
         dataset,
         partition_columns,
-        input_url,
+        input_path,
         admin_source,
         input_geom_col,
         admin_geom_col,
@@ -825,7 +842,9 @@ def add_admin_divisions_multi(
         try:
             # Get total input count (skip in dry-run)
             if not dry_run:
-                total_count = con.execute(f"SELECT COUNT(*) FROM '{input_url}'").fetchone()[0]
+                total_count = con.execute(
+                    f"SELECT COUNT(*) FROM {sql_path(input_path)}"
+                ).fetchone()[0]
                 progress(f"Processing {total_count:,} input features...")
 
             # Build Vecorel metadata if requested (applied to whichever write path runs)
@@ -844,7 +863,7 @@ def add_admin_divisions_multi(
                     dataset,
                     levels,
                     partition_columns,
-                    input_url,
+                    input_path,
                     admin_geom_col,
                     admin_bbox_col,
                     input_geom_col,
@@ -874,7 +893,7 @@ def add_admin_divisions_multi(
                     dataset,
                     levels,
                     partition_columns,
-                    input_url,
+                    input_path,
                     admin_source,
                     admin_geom_col,
                     admin_bbox_col,
@@ -889,7 +908,7 @@ def add_admin_divisions_multi(
 
                 if _handle_dry_run_mode(
                     dry_run,
-                    input_url,
+                    input_path,
                     admin_source,
                     output_parquet,
                     input_geom_col,

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -25,11 +25,13 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
 )
 from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
     _wrap_query_with_blob_conversion,
     build_kv_metadata_clause,
+    sql_path,
 )
 from geoparquet_io.core.exceptions import GeoParquetError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geo_metadata import covering_supported, parse_geo_metadata
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, success
@@ -51,16 +53,18 @@ def _detect_native_geometry(
 
     Args:
         conn: DuckDB connection (reused to avoid repeated INSTALL/LOAD)
-        parquet_file: Path to the parquet file
+        parquet_file: RAW (unescaped) path to the parquet file
         geometry_column: Name of the geometry column to check
 
     Returns:
         True if the file has native GEOMETRY type, False otherwise
     """
+    # The column name comes from the file's own `geo` metadata, so it is
+    # untrusted input, not a constant: escape it like any other SQL literal.
     result = conn.execute(f"""
         SELECT logical_type
-        FROM parquet_schema('{parquet_file}')
-        WHERE name = '{geometry_column}'
+        FROM parquet_schema({sql_path(parquet_file)})
+        WHERE name = '{_escape_sql_string(geometry_column)}'
     """).fetchone()
 
     if result and result[0]:
@@ -74,13 +78,13 @@ def _get_existing_kv_metadata(conn: duckdb.DuckDBPyConnection, parquet_file: str
 
     Args:
         conn: DuckDB connection
-        parquet_file: Path to the parquet file
+        parquet_file: RAW (unescaped) path to the parquet file
 
     Returns:
         Dict mapping metadata keys to values (both as strings)
     """
     result = conn.execute(
-        f"SELECT key, value FROM parquet_kv_metadata('{parquet_file}')"
+        f"SELECT key, value FROM parquet_kv_metadata({sql_path(parquet_file)})"
     ).fetchall()
 
     metadata = {}
@@ -282,10 +286,10 @@ def add_bbox_metadata(
             "Download the file locally, modify it, then upload."
         )
 
-    # ``safe_url`` is only for SQL interpolation below. The metadata helpers take
-    # a RAW path -- each escapes its own argument, and pre-escaping here sent
-    # ``bm''s.parquet`` on to pyarrow (issue #718).
-    safe_url = safe_file_url(parquet_file, verbose)
+    # RAW path throughout: the metadata helpers each escape their own argument
+    # (pre-escaping here sent ``bm''s.parquet`` on to pyarrow, issue #718), and
+    # the SQL below escapes at the point of interpolation via ``sql_path``.
+    read_url = resolve_file_url(parquet_file, verbose)
 
     # Check current bbox structure
     bbox_info = check_bbox_structure(parquet_file, verbose)
@@ -358,10 +362,10 @@ def add_bbox_metadata(
 
         # Detect if file uses native GEOMETRY type (GeoParquet 2.0)
         # Pass the actual geometry column name - it might not be 'geometry'
-        has_native_geometry = _detect_native_geometry(conn, safe_url, primary_col)
+        has_native_geometry = _detect_native_geometry(conn, read_url, primary_col)
 
         # Read existing KV metadata to preserve non-geo keys
-        existing_kv = _get_existing_kv_metadata(conn, safe_url)
+        existing_kv = _get_existing_kv_metadata(conn, read_url)
 
         if verbose:
             debug("\nPreserving file properties:")
@@ -401,7 +405,7 @@ def add_bbox_metadata(
         # needs that cast, not just the primary one -- the validator names any
         # native column, and a 1.1 file may carry several. A file that is *already*
         # native is left alone: there the native type is the correct output.
-        source_query = f"SELECT * FROM '{safe_url}'"
+        source_query = f"SELECT * FROM {sql_path(read_url)}"
         if not has_native_geometry:
             secondary_cols = [col for col in geo_meta["columns"] if col != primary_col]
             source_query = _wrap_query_with_blob_conversion(
@@ -410,7 +414,7 @@ def add_bbox_metadata(
 
         copy_sql = f"""
             COPY ({source_query})
-            TO '{temp_file}'
+            TO {sql_path(str(temp_file))}
             ({", ".join(copy_options)})
         """
 

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -414,7 +414,7 @@ def add_bbox_metadata(
 
         copy_sql = f"""
             COPY ({source_query})
-            TO {sql_path(str(temp_file))}
+            TO {sql_path(temp_file)}
             ({", ".join(copy_options)})
         """
 

--- a/geoparquet_io/core/add/country_codes.py
+++ b/geoparquet_io/core/add/country_codes.py
@@ -12,7 +12,6 @@ from geoparquet_io.core.common import (
 from geoparquet_io.core.duckdb_utils import (
     SPATIAL_JOIN_BBOX_PREFILTER,
     SPATIAL_JOIN_NATIVE,
-    _escape_sql_string,
     build_spatial_join_condition,
     get_duckdb_connection,
     quote_identifier,
@@ -20,7 +19,7 @@ from geoparquet_io.core.duckdb_utils import (
     sql_path,
 )
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
 from geoparquet_io.core.remote import _sanitize_url_for_logging, is_remote_url
@@ -35,7 +34,7 @@ def find_country_code_column(con, countries_source, is_subquery=False):
 
     Args:
         con: DuckDB connection
-        countries_source: Either a file path or a subquery
+        countries_source: Either a RAW file path or a subquery
         is_subquery: Whether countries_source is a subquery (True) or file path (False)
 
     Returns:
@@ -48,7 +47,7 @@ def find_country_code_column(con, countries_source, is_subquery=False):
     if is_subquery:
         columns_query = f"SELECT * FROM {countries_source} LIMIT 0;"
     else:
-        columns_query = f"SELECT * FROM '{countries_source}' LIMIT 0;"
+        columns_query = f"SELECT * FROM {sql_path(countries_source)} LIMIT 0;"
 
     countries_columns = [col[0] for col in con.execute(columns_query).description]
 
@@ -82,7 +81,7 @@ def find_subdivision_code_column(con, countries_source, is_subquery=False):
 
     Args:
         con: DuckDB connection
-        countries_source: Either a file path or a subquery
+        countries_source: Either a RAW file path or a subquery
         is_subquery: Whether countries_source is a subquery (True) or file path (False)
 
     Returns:
@@ -92,7 +91,7 @@ def find_subdivision_code_column(con, countries_source, is_subquery=False):
     if is_subquery:
         columns_query = f"SELECT * FROM {countries_source} LIMIT 0;"
     else:
-        columns_query = f"SELECT * FROM '{countries_source}' LIMIT 0;"
+        columns_query = f"SELECT * FROM {sql_path(countries_source)} LIMIT 0;"
 
     countries_columns = [col[0] for col in con.execute(columns_query).description]
 
@@ -170,7 +169,7 @@ def _build_select_clause(country_code_col, subdivision_code_col, using_default):
 
 
 def _build_spatial_join_query(
-    input_url,
+    input_path,
     countries_source,
     select_clause,
     input_geom_col,
@@ -182,7 +181,9 @@ def _build_spatial_join_query(
 
     Identifiers are quoted via the shared :func:`build_spatial_join_condition`
     helper, so a maliciously-named geometry/bbox column from an untrusted input
-    or ``--countries-parquet`` cannot inject SQL.
+    or ``--countries-parquet`` cannot inject SQL. ``input_path`` is RAW and is
+    quoted and escaped here by :func:`sql_path` (#802); ``countries_source`` is
+    already a SQL reference (a table name or a ``sql_path`` literal).
     """
     join_condition = build_spatial_join_condition(
         input_geom_col, countries_geom_col, input_bbox_col, countries_bbox_col
@@ -191,40 +192,50 @@ def _build_spatial_join_query(
     SELECT
         a.*,
         {select_clause}
-    FROM '{input_url}' a
+    FROM {sql_path(input_path)} a
     LEFT JOIN {countries_source} b
     ON {join_condition}
 """
 
 
-def _build_filter_table_sql(table_name, source_url, bbox_col, bounds):
-    """Build SQL to create filtered countries table from bounds."""
+def _build_filter_table_sql(table_name, source_path, bbox_col, bounds):
+    """Build SQL to create filtered countries table from bounds.
+
+    ``source_path`` is the RAW countries path/URL; :func:`sql_path` quotes and
+    escapes it here (#802).
+    """
     xmin, ymin, xmax, ymax = bounds
     q_bbox = quote_identifier(bbox_col)
     if isinstance(xmin, str):  # placeholder values
         return f"""CREATE TEMP TABLE {table_name} AS
-SELECT * FROM '{source_url}'
+SELECT * FROM {sql_path(source_path)}
 WHERE {q_bbox}.xmin <= {xmax}
   AND {q_bbox}.xmax >= {xmin}
   AND {q_bbox}.ymin <= {ymax}
   AND {q_bbox}.ymax >= {ymin};"""
     return f"""CREATE TEMP TABLE {table_name} AS
-SELECT * FROM '{source_url}'
+SELECT * FROM {sql_path(source_path)}
 WHERE {q_bbox}.xmin <= {xmax:.6f}
   AND {q_bbox}.xmax >= {xmin:.6f}
   AND {q_bbox}.ymin <= {ymax:.6f}
   AND {q_bbox}.ymax >= {ymin:.6f};"""
 
 
-def _print_dry_run_bounds_info(input_bbox_col, input_url, input_geom_col):
-    """Print dry-run info for bounds calculation step."""
+def _print_dry_run_bounds_info(input_bbox_col, input_path, input_geom_col):
+    """Print dry-run info for bounds calculation step.
+
+    This one echoes *SQL*, so the path is escaped -- the printed statement has
+    to be runnable. The prose headers elsewhere show the raw path (#802).
+    """
     info("-- Step 1: Calculate bounding box of input data to filter remote countries")
     if input_bbox_col:
         q_input_bbox = quote_identifier(input_bbox_col)
-        bounds_sql = f"SELECT MIN({q_input_bbox}.xmin) as xmin, ... FROM '{input_url}';"
+        bounds_sql = f"SELECT MIN({q_input_bbox}.xmin) as xmin, ... FROM {sql_path(input_path)};"
     else:
         q_input_geom = quote_identifier(input_geom_col)
-        bounds_sql = f"SELECT MIN(ST_XMin({q_input_geom})) as xmin, ... FROM '{input_url}';"
+        bounds_sql = (
+            f"SELECT MIN(ST_XMin({q_input_geom})) as xmin, ... FROM {sql_path(input_path)};"
+        )
     progress(bounds_sql)
     progress("")
     warn("-- Calculating actual bounds...")
@@ -248,7 +259,7 @@ def _get_bounds_for_filtering(input_parquet, input_geom_col, dry_run, verbose):
 
 
 def _create_filtered_countries_table(
-    con, countries_table, default_countries_url, countries_bbox_col, bounds, dry_run, verbose
+    con, countries_table, default_countries_path, countries_bbox_col, bounds, dry_run, verbose
 ):
     """Create the filtered countries temporary table."""
     if dry_run:
@@ -256,7 +267,7 @@ def _create_filtered_countries_table(
         info("-- Step 2: Create filtered countries table")
 
     create_table_sql = _build_filter_table_sql(
-        countries_table, default_countries_url, countries_bbox_col, bounds
+        countries_table, default_countries_path, countries_bbox_col, bounds
     )
 
     if dry_run:
@@ -272,19 +283,28 @@ def _create_filtered_countries_table(
 
 
 def _print_dry_run_header(
-    input_url,
-    countries_url,
+    input_path,
+    countries_path,
     output_parquet,
     input_geom_col,
     countries_geom_col,
     input_bbox_col,
     countries_bbox_col,
 ):
-    """Print dry-run mode header information."""
+    """Print dry-run mode header information.
+
+    ``input_path`` and ``countries_path`` are RAW: this is prose for a human, so
+    showing ``o''brien/data.parquet`` for ``o'brien/data.parquet`` is a bug --
+    it is confusing to read and wrong to copy-paste (#802).
+    """
     warn("\n=== DRY RUN MODE - SQL Commands that would be executed ===\n")
-    display_input = _sanitize_url_for_logging(input_url) if is_remote_url(input_url) else input_url
+    display_input = (
+        _sanitize_url_for_logging(input_path) if is_remote_url(input_path) else input_path
+    )
     display_countries = (
-        _sanitize_url_for_logging(countries_url) if is_remote_url(countries_url) else countries_url
+        _sanitize_url_for_logging(countries_path)
+        if is_remote_url(countries_path)
+        else countries_path
     )
     display_output = (
         _sanitize_url_for_logging(output_parquet)
@@ -301,20 +321,27 @@ def _print_dry_run_header(
 
 
 def _get_countries_config(countries_parquet, using_default, verbose):
-    """Get countries URL, geometry column, and bbox column."""
+    """Get the RAW countries path, its geometry column, and its bbox column.
+
+    The path is returned unescaped. It is shown to the user in the dry-run
+    header and handed to helpers that escape their own argument, so escaping it
+    here would mean every consumer had to know it was pre-escaped -- the shape
+    that produced #718's crashes (#802). The default Overture URL was already
+    returned raw, so this also makes the two branches agree.
+    """
     if using_default:
         from geoparquet_io.core.overture import get_overture_divisions_url
 
         return get_overture_divisions_url(verbose=verbose), "geometry", "bbox"
 
-    countries_url = safe_file_url(countries_parquet, verbose)
+    countries_path = resolve_file_url(countries_parquet, verbose)
     countries_geom_col = find_primary_geometry_column(countries_parquet, verbose)
     countries_bbox_info = check_bbox_structure(countries_parquet, verbose)
-    return countries_url, countries_geom_col, countries_bbox_info["bbox_column_name"]
+    return countries_path, countries_geom_col, countries_bbox_info["bbox_column_name"]
 
 
 def _determine_code_columns(
-    con, countries_url, countries_source, countries_table, using_default, dry_run, verbose
+    con, countries_path, countries_source, countries_table, using_default, dry_run, verbose
 ):
     """Determine country and subdivision code columns."""
     if using_default:
@@ -328,20 +355,20 @@ def _determine_code_columns(
     if dry_run:
         return "admin:country_code", None
 
-    country_code_col = find_country_code_column(con, countries_url, is_subquery=False)
+    country_code_col = find_country_code_column(con, countries_path, is_subquery=False)
     if verbose:
         debug(f"Using country code column: {country_code_col}")
 
-    # `_setup_countries_source` returns the URL ALREADY wrapped in quotes, while
-    # both finders quote it themselves when is_subquery is False -- passing
-    # countries_source straight through produced `FROM ''/path''` and a parser
-    # error for every non-default --countries file. Hand over the same raw URL
-    # the country-code finder above gets, and only use the table name when the
-    # source really is the filtered temp table.
+    # `_setup_countries_source` returns a SQL reference -- a quoted literal or a
+    # temp-table name -- while both finders build the literal themselves when
+    # is_subquery is False; passing countries_source straight through produced
+    # `FROM ''/path''` and a parser error for every non-default --countries
+    # file. Hand over the same RAW path the country-code finder above gets, and
+    # only use the table name when the source really is the filtered temp table.
     is_filtered_table = countries_source == countries_table
     subdivision_code_col = find_subdivision_code_column(
         con,
-        countries_table if is_filtered_table else countries_url,
+        countries_table if is_filtered_table else countries_path,
         is_subquery=is_filtered_table,
     )
     if subdivision_code_col and verbose:
@@ -390,7 +417,7 @@ TO {sql_path(output_parquet)}
     info("-- Original metadata would also be preserved in the output file")
 
 
-def _output_has_subdivision(con, escaped_output):
+def _output_has_subdivision(con, output_parquet):
     """Report whether the written file carries a subdivision column.
 
     The countries file is not the authority: the join is ``SELECT a.*``, so an
@@ -398,14 +425,14 @@ def _output_has_subdivision(con, escaped_output):
     countries file has none. Asking the output is the only answer that is true
     in both directions (#672).
     """
-    described = con.execute(f"SELECT * FROM '{escaped_output}' LIMIT 0").description
+    described = con.execute(f"SELECT * FROM {sql_path(output_parquet)} LIMIT 0").description
     return "admin:subdivision_code" in {column[0] for column in described}
 
 
 def _print_output_stats(con, output_parquet):
     """Query the written file and print the per-column counts."""
-    escaped_output = _escape_sql_string(str(output_parquet))
-    has_subdivision = _output_has_subdivision(con, escaped_output)
+    output_path = str(output_parquet)
+    has_subdivision = _output_has_subdivision(con, output_path)
 
     subdivision_selects = (
         """,
@@ -420,7 +447,7 @@ def _print_output_stats(con, output_parquet):
         COUNT(*) as total_features,
         COUNT(CASE WHEN "admin:country_code" IS NOT NULL THEN 1 END) as features_with_country,
         COUNT(DISTINCT "admin:country_code") as unique_countries{subdivision_selects}
-    FROM '{escaped_output}';
+    FROM {sql_path(output_path)};
     """
     stats = con.execute(stats_query).fetchone()
     total, with_country, unique_countries = stats[0], stats[1], stats[2]
@@ -455,10 +482,10 @@ def _print_results_summary(con, output_parquet):
 def _setup_default_countries(
     con,
     input_parquet,
-    input_url,
+    input_path,
     input_geom_col,
     input_bbox_col,
-    default_countries_url,
+    default_countries_path,
     countries_bbox_col,
     countries_table,
     dry_run,
@@ -466,7 +493,7 @@ def _setup_default_countries(
 ):
     """Setup filtered countries table for default Overture dataset."""
     if dry_run:
-        _print_dry_run_bounds_info(input_bbox_col, input_url, input_geom_col)
+        _print_dry_run_bounds_info(input_bbox_col, input_path, input_geom_col)
 
     if verbose and not dry_run:
         debug("Calculating bounding box of input data to filter remote countries file...")
@@ -474,7 +501,7 @@ def _setup_default_countries(
     bounds = _get_bounds_for_filtering(input_parquet, input_geom_col, dry_run, verbose)
 
     _create_filtered_countries_table(
-        con, countries_table, default_countries_url, countries_bbox_col, bounds, dry_run, verbose
+        con, countries_table, default_countries_path, countries_bbox_col, bounds, dry_run, verbose
     )
 
 
@@ -536,36 +563,40 @@ def _prepare_bbox_columns(
 def _setup_countries_source(
     con,
     using_default,
-    countries_url,
+    countries_path,
     input_parquet,
-    input_url,
+    input_path,
     input_geom_col,
     input_bbox_col,
     countries_bbox_col,
     dry_run,
     verbose,
 ):
-    """Setup countries source - either filtered table or direct file reference."""
+    """Setup countries source - either filtered table or direct file reference.
+
+    Returns a SQL *reference*: a temp-table name, or the RAW countries path
+    turned into a quoted literal by :func:`sql_path` (#802).
+    """
     countries_table = "filtered_countries"
 
     if using_default:
         from geoparquet_io.core.overture import get_overture_divisions_url
 
-        default_countries_url = get_overture_divisions_url(verbose=verbose)
+        default_countries_path = get_overture_divisions_url(verbose=verbose)
         _setup_default_countries(
             con,
             input_parquet,
-            input_url,
+            input_path,
             input_geom_col,
             input_bbox_col,
-            default_countries_url,
+            default_countries_path,
             countries_bbox_col,
             countries_table,
             dry_run,
             verbose,
         )
         return countries_table
-    return f"'{countries_url}'"
+    return sql_path(countries_path)
 
 
 def _create_duckdb_connection(using_default: bool) -> "duckdb.DuckDBPyConnection":
@@ -614,10 +645,12 @@ def add_country_codes(
     row_group_rows=None,
 ):
     """Add country ISO codes to a GeoParquet file based on spatial intersection."""
-    input_url = safe_file_url(input_parquet, verbose)
+    # RAW paths throughout: they are shown to the user in the dry-run header,
+    # and every SQL interpolation escapes at its own boundary via sql_path (#802).
+    input_path = resolve_file_url(input_parquet, verbose)
     using_default = countries_parquet is None
 
-    countries_url, countries_geom_col, _ = _get_countries_config(
+    countries_path, countries_geom_col, _ = _get_countries_config(
         countries_parquet, using_default, verbose
     )
 
@@ -634,8 +667,8 @@ def add_country_codes(
 
     if dry_run:
         _print_dry_run_header(
-            input_url,
-            countries_url,
+            input_path,
+            countries_path,
             output_parquet,
             input_geom_col,
             countries_geom_col,
@@ -652,16 +685,16 @@ def add_country_codes(
     # handle keeps the input file open (breaks cleanup on Windows).
     with _create_duckdb_connection(using_default) as con:
         if not dry_run:
-            total_count = con.execute(f"SELECT COUNT(*) FROM '{input_url}'").fetchone()[0]
+            total_count = con.execute(f"SELECT COUNT(*) FROM {sql_path(input_path)}").fetchone()[0]
             progress(f"Processing {total_count:,} input features...")
 
         countries_table = "filtered_countries"
         countries_source = _setup_countries_source(
             con,
             using_default,
-            countries_url,
+            countries_path,
             input_parquet,
-            input_url,
+            input_path,
             input_geom_col,
             input_bbox_col,
             countries_bbox_col,
@@ -670,7 +703,7 @@ def add_country_codes(
         )
 
         country_code_col, subdivision_code_col = _determine_code_columns(
-            con, countries_url, countries_source, countries_table, using_default, dry_run, verbose
+            con, countries_path, countries_source, countries_table, using_default, dry_run, verbose
         )
 
         select_clause = _build_select_clause(country_code_col, subdivision_code_col, using_default)
@@ -679,7 +712,7 @@ def add_country_codes(
         )
 
         query = _build_spatial_join_query(
-            input_url,
+            input_path,
             countries_source,
             select_clause,
             input_geom_col,

--- a/geoparquet_io/core/add/geometry_metrics.py
+++ b/geoparquet_io/core/add/geometry_metrics.py
@@ -261,8 +261,8 @@ def _add_vecorel_metadata_to_file(
 ) -> None:
     """Add Vecorel schema metadata to an existing file via rewrite."""
     from geoparquet_io.core.common import write_parquet_with_metadata
-    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+    from geoparquet_io.core.file_utils import resolve_file_url
     from geoparquet_io.core.remote import needs_httpfs
 
     metadata, _ = get_parquet_metadata(parquet_file, verbose=False)
@@ -282,7 +282,7 @@ def _add_vecorel_metadata_to_file(
     import os
     import tempfile
 
-    input_url = safe_file_url(parquet_file, verbose=False)
+    input_path = resolve_file_url(parquet_file, verbose=False)
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
 
     fd, temp_out = tempfile.mkstemp(suffix=".parquet")
@@ -293,7 +293,7 @@ def _add_vecorel_metadata_to_file(
         try:
             write_parquet_with_metadata(
                 con,
-                f"SELECT * FROM '{input_url}'",
+                f"SELECT * FROM {sql_path(input_path)}",
                 temp_out,
                 original_metadata=metadata,
                 extra_kv_metadata=extra_kv,

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -8,9 +8,13 @@ import tempfile
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    quote_identifier,
+    sql_path,
+)
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.file_utils import handle_output_overwrite, resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import (
     configure_verbose,
@@ -61,11 +65,14 @@ def _find_optimal_iterations(total_rows, target_rows, verbose=False):
 
 
 def _build_sampling_query(
-    input_url, geom_col, kdtree_column_name, iterations, sample_size, con, verbose=False
+    input_path, geom_col, kdtree_column_name, iterations, sample_size, con, verbose=False
 ):
     """
     Build a sampling-based KD-tree query that computes boundaries on a sample,
     then applies them to the full dataset using iterative CTEs.
+
+    ``input_path`` is a RAW path: ``sql_path`` escapes it at each point of
+    interpolation, so it is never escaped twice (#802).
 
     Strategy:
     1. Sample the data and compute KD-tree to get split boundaries
@@ -82,7 +89,7 @@ def _build_sampling_query(
                 ST_Y(ST_Centroid({quote_identifier(geom_col)})) AS y,
                 '0' AS partition_id,
                 NULL::DOUBLE AS split_value
-            FROM '{input_url}' USING SAMPLE {sample_size} ROWS
+            FROM {sql_path(input_path)} USING SAMPLE {sample_size} ROWS
 
             UNION ALL
 
@@ -145,7 +152,7 @@ def _build_sampling_query(
                 ST_X(ST_Centroid({quote_identifier(geom_col)})) AS _kdtree_x,
                 ST_Y(ST_Centroid({quote_identifier(geom_col)})) AS _kdtree_y,
                 '0' AS _kdtree_partition
-            FROM '{input_url}'
+            FROM {sql_path(input_path)}
         )
     """)
 
@@ -250,11 +257,9 @@ def add_kdtree_table(
         # Process using file-based mode
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         try:
-            input_url = safe_file_url(temp_path, verbose=False)
-
             # Build query using sampling approach
             query = _build_sampling_query(
-                input_url, geom_col, kdtree_column_name, iterations, sample_size, con, verbose=False
+                temp_path, geom_col, kdtree_column_name, iterations, sample_size, con, verbose=False
             )
 
             result = con.execute(query).arrow().read_all()
@@ -354,12 +359,14 @@ def add_kdtree_column(
     # Check for partition input (not supported)
     require_single_file(input_parquet, "add kdtree")
 
-    # Get total row count for auto mode or validation
-    input_url = safe_file_url(input_parquet, verbose)
+    # Get total row count for auto mode or validation.
+    # RAW path: shown to the user in the dry-run header below, and escaped at
+    # each SQL boundary by sql_path (#802).
+    input_path = resolve_file_url(input_parquet, verbose)
 
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
 
-    total_count = con.execute(f"SELECT COUNT(*) FROM '{input_url}'").fetchone()[0]
+    total_count = con.execute(f"SELECT COUNT(*) FROM {sql_path(input_path)}").fetchone()[0]
 
     # Auto-compute iterations if requested
     if iterations is None:
@@ -413,7 +420,7 @@ def add_kdtree_column(
     # Build a query that selects all original columns plus the KD-tree partition ID
 
     # Reconnect for actual processing
-    input_url = safe_file_url(input_parquet, verbose)
+    input_path = resolve_file_url(input_parquet, verbose)
 
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
 
@@ -440,7 +447,7 @@ def add_kdtree_column(
                     ST_Y(ST_Centroid({quote_identifier(geom_col)})) AS y,
                     '0' AS partition_id,
                     ROW_NUMBER() OVER () AS row_id
-                FROM '{input_url}'
+                FROM {sql_path(input_path)}
 
                 UNION ALL
 
@@ -470,7 +477,7 @@ def add_kdtree_column(
             ),
             original_with_rownum AS (
                 SELECT *, ROW_NUMBER() OVER () AS row_id
-                FROM '{input_url}'
+                FROM {sql_path(input_path)}
             )
             SELECT original_with_rownum.* EXCLUDE (row_id), kdtree_final.partition_id AS {kdtree_column_name}
             FROM original_with_rownum
@@ -481,7 +488,7 @@ def add_kdtree_column(
         if verbose:
             debug(f"Step 1/2: Computing split boundaries from {sample_size:,} sample points...")
         query = _build_sampling_query(
-            input_url, geom_col, kdtree_column_name, iterations, sample_size, con, verbose
+            input_path, geom_col, kdtree_column_name, iterations, sample_size, con, verbose
         )
 
     # Prepare KD-tree metadata for GeoParquet spec
@@ -499,7 +506,7 @@ def add_kdtree_column(
     if dry_run:
         warn("\n=== DRY RUN MODE - SQL Commands that would be executed ===\n")
         display_input = (
-            _sanitize_url_for_logging(input_url) if is_remote_url(input_url) else input_url
+            _sanitize_url_for_logging(input_path) if is_remote_url(input_path) else input_path
         )
         display_output = (
             _sanitize_url_for_logging(output_parquet)
@@ -576,7 +583,7 @@ def _add_kdtree_streaming(
             working_file = input_path
 
         # Process the file
-        input_url = safe_file_url(working_file, verbose)
+        working_path = resolve_file_url(working_file, verbose)
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(working_file))
 
         try:
@@ -594,7 +601,7 @@ def _add_kdtree_streaming(
 
             # Build query using sampling approach
             query = _build_sampling_query(
-                input_url, geom_col, kdtree_column_name, iterations, sample_size, con, verbose
+                working_path, geom_col, kdtree_column_name, iterations, sample_size, con, verbose
             )
 
             # Get metadata from input

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -20,9 +20,13 @@ from geoparquet_io.core.crs_utils import (
     transform_geom_sql,
 )
 from geoparquet_io.core.duckdb_metadata import get_column_names, get_geo_metadata
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    quote_identifier,
+    sql_path,
+)
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
-from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.file_utils import handle_output_overwrite, resolve_file_url
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
     find_primary_geometry_column,
@@ -545,8 +549,9 @@ def _add_quadkey_file_based(
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, input_parquet, output_parquet)
 
-    # Get safe URL for input file
-    input_url = safe_file_url(input_parquet, verbose)
+    # RAW path: shown to the user in the dry-run header below, and escaped at
+    # the SQL boundary by sql_path (#802).
+    input_file_path = resolve_file_url(input_parquet, verbose)
 
     # Get geometry column
     geom_col = find_primary_geometry_column(input_parquet, verbose)
@@ -589,7 +594,9 @@ def _add_quadkey_file_based(
     if dry_run:
         warn("\n=== DRY RUN MODE - SQL Commands that would be executed ===\n")
         display_input = (
-            _sanitize_url_for_logging(input_url) if is_remote_url(input_url) else input_url
+            _sanitize_url_for_logging(input_file_path)
+            if is_remote_url(input_file_path)
+            else input_file_path
         )
         display_output = (
             _sanitize_url_for_logging(output_parquet)
@@ -639,7 +646,7 @@ def _add_quadkey_file_based(
         query = f"""
             SELECT *,
                    lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quote_identifier(quadkey_column_name)}
-            FROM '{input_url}'
+            FROM {sql_path(input_file_path)}
         """
 
         if verbose:

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -288,7 +288,7 @@ class AdminDataset(ABC):
                     query = f"SELECT * FROM read_parquet({sql_path(source)})"
 
                 # Write to cache
-                con.execute(f"COPY ({query}) TO {sql_path(str(cache_path))} (FORMAT PARQUET)")
+                con.execute(f"COPY ({query}) TO {sql_path(cache_path)} (FORMAT PARQUET)")
             finally:
                 con.close()
 
@@ -865,7 +865,7 @@ class OvertureAdminDataset(AdminDataset):
 
                     query = self._build_level_cache_query(level, source)
                     con.execute(
-                        f"COPY ({query}) TO {sql_path(str(cache_path))} "
+                        f"COPY ({query}) TO {sql_path(cache_path)} "
                         "(FORMAT PARQUET, COMPRESSION ZSTD)"
                     )
                     info(f"Cached {level} dataset at: {cache_path}")

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import duckdb
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
     InvalidParameterError,
@@ -283,12 +283,12 @@ class AdminDataset(ABC):
                 read_options = self.get_read_parquet_options()
                 if read_options:
                     options_str = ", ".join([f"{k}={v}" for k, v in read_options.items()])
-                    query = f"SELECT * FROM read_parquet('{source}', {options_str})"
+                    query = f"SELECT * FROM read_parquet({sql_path(source)}, {options_str})"
                 else:
-                    query = f"SELECT * FROM read_parquet('{source}')"
+                    query = f"SELECT * FROM read_parquet({sql_path(source)})"
 
                 # Write to cache
-                con.execute(f"COPY ({query}) TO '{cache_path}' (FORMAT PARQUET)")
+                con.execute(f"COPY ({query}) TO {sql_path(str(cache_path))} (FORMAT PARQUET)")
             finally:
                 con.close()
 
@@ -544,21 +544,22 @@ class AdminDataset(ABC):
             con: DuckDB connection to use for queries
 
         Returns:
-            SQL table reference or file path to use in queries
+            A SQL table reference: the source path as a quoted, escaped literal
+            (:func:`sql_path`), ready to interpolate (#802).
         """
         source = self.get_source()
         if self.is_remote():
             # For remote sources, use direct remote access
             if self.verbose:
                 debug(f"Using remote dataset: {source}")
-            return f"'{source}'"
+            return sql_path(source)
         else:
             # For local sources, verify the file exists
             if not os.path.exists(source):
                 raise FileNotFoundGeoParquetError(source, "admin dataset")
             if self.verbose:
                 debug(f"Using local data source: {source}")
-            return f"'{source}'"
+            return sql_path(source)
 
 
 class CurrentAdminDataset(AdminDataset):
@@ -800,7 +801,7 @@ class OvertureAdminDataset(AdminDataset):
         return (
             f"SELECT ST_SimplifyPreserveTopology(geometry, {tol}) as geometry, "
             f"{cols} "
-            f"FROM read_parquet('{source}', hive_partitioning=1) "
+            f"FROM read_parquet({sql_path(source)}, hive_partitioning=1) "
             f"WHERE {where}"
         )
 
@@ -864,7 +865,8 @@ class OvertureAdminDataset(AdminDataset):
 
                     query = self._build_level_cache_query(level, source)
                     con.execute(
-                        f"COPY ({query}) TO '{cache_path}' (FORMAT PARQUET, COMPRESSION ZSTD)"
+                        f"COPY ({query}) TO {sql_path(str(cache_path))} "
+                        "(FORMAT PARQUET, COMPRESSION ZSTD)"
                     )
                     info(f"Cached {level} dataset at: {cache_path}")
             finally:

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -17,7 +17,6 @@ from geoparquet_io.core.crs_utils import (
 )
 from geoparquet_io.core.duckdb_utils import (
     _DuckDBSchemaWrapper,
-    _escape_sql_string,
     _get_query_column_type,
     _get_query_columns,
     _wrap_query_with_wkb_conversion,
@@ -25,6 +24,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
     quote_identifier,
+    sql_path,
     validate_compression_level,
 )
 from geoparquet_io.core.exceptions import (
@@ -36,7 +36,7 @@ from geoparquet_io.core.file_utils import (
     _get_file_cache_key,
     get_first_parquet_file,
     is_partition_path,
-    safe_file_url,
+    resolve_file_url,
 )
 from geoparquet_io.core.geo_metadata import (
     DEFAULT_GEOPARQUET_VERSION,
@@ -285,7 +285,9 @@ def calculate_file_bounds(file_path, geom_column=None, verbose=False):
     if geom_column is None:
         geom_column = find_primary_geometry_column(file_path, verbose=False)
 
-    safe_url = safe_file_url(file_path, verbose=False)
+    # RAW path: sql_path escapes it at the point of interpolation, so nothing
+    # downstream can escape it a second time (#802).
+    read_url = resolve_file_url(file_path, verbose=False)
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(file_path))
 
     try:
@@ -295,7 +297,7 @@ def calculate_file_bounds(file_path, geom_column=None, verbose=False):
                 MIN(ST_YMin({quote_identifier(geom_column)})) as ymin,
                 MAX(ST_XMax({quote_identifier(geom_column)})) as xmax,
                 MAX(ST_YMax({quote_identifier(geom_column)})) as ymax
-            FROM read_parquet('{safe_url}')
+            FROM read_parquet({sql_path(read_url)})
         """
         result = con.execute(bounds_query).fetchone()
 
@@ -2438,8 +2440,6 @@ def _plain_copy_to(
     # Parquet schema during COPY TO — no post-processing file rewrite needed.
     final_query = _wrap_query_with_crs(query, geometry_column, input_crs)
 
-    escaped_path = _escape_sql_string(output_path)
-
     # Build options list
     options = [
         "FORMAT PARQUET",
@@ -2466,7 +2466,7 @@ def _plain_copy_to(
 
     copy_query = f"""
         COPY ({final_query})
-        TO '{escaped_path}'
+        TO {sql_path(output_path)}
         ({", ".join(options)})
     """
 
@@ -3522,8 +3522,12 @@ def get_bbox_advice(
     return result
 
 
-def _build_bounds_query(safe_url, bbox_info, geometry_column, verbose):
-    """Build query for bounds calculation."""
+def _build_bounds_query(parquet_path, bbox_info, geometry_column, verbose):
+    """Build query for bounds calculation.
+
+    ``parquet_path`` is RAW: ``sql_path`` quotes and escapes it here, at the one
+    point it becomes SQL (#802).
+    """
     if bbox_info["has_bbox_column"]:
         bbox_col = bbox_info["bbox_column_name"]
         if verbose:
@@ -3536,7 +3540,7 @@ def _build_bounds_query(safe_url, bbox_info, geometry_column, verbose):
             MIN({q_bbox}.ymin) as ymin,
             MAX({q_bbox}.xmax) as xmax,
             MAX({q_bbox}.ymax) as ymax
-        FROM '{safe_url}'
+        FROM {sql_path(parquet_path)}
         """
     else:
         warn(
@@ -3551,7 +3555,7 @@ def _build_bounds_query(safe_url, bbox_info, geometry_column, verbose):
             MIN(ST_YMin({q_geom})) as ymin,
             MAX(ST_XMax({q_geom})) as xmax,
             MAX(ST_YMax({q_geom})) as ymax
-        FROM '{safe_url}'
+        FROM {sql_path(parquet_path)}
         """
 
 
@@ -3571,7 +3575,7 @@ def get_dataset_bounds(parquet_file, geometry_column=None, verbose=False):
         tuple: (xmin, ymin, xmax, ymax) or None if error
     """
     configure_verbose(verbose)
-    safe_url = safe_file_url(parquet_file, verbose)
+    read_url = resolve_file_url(parquet_file, verbose)
 
     # Get geometry column if not specified
     if not geometry_column:
@@ -3584,7 +3588,7 @@ def get_dataset_bounds(parquet_file, geometry_column=None, verbose=False):
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
 
     try:
-        query = _build_bounds_query(safe_url, bbox_info, geometry_column, verbose)
+        query = _build_bounds_query(read_url, bbox_info, geometry_column, verbose)
         result = con.execute(query).fetchone()
 
         if result and all(v is not None for v in result):
@@ -3665,8 +3669,9 @@ def add_computed_column(
             custom_metadata={'covering': {'h3': {'column': 'h3_cell', 'resolution': 9}}}
         )
     """
-    # Get safe URL for input file
-    input_url = safe_file_url(input_parquet, verbose)
+    # RAW path: the dry-run header below shows it to the user, and every SQL
+    # interpolation escapes it through sql_path (#802).
+    input_path = resolve_file_url(input_parquet, verbose)
 
     # Get geometry column (for reference)
     geom_col = find_primary_geometry_column(input_parquet, verbose)
@@ -3675,7 +3680,7 @@ def add_computed_column(
     if dry_run:
         warn("\n=== DRY RUN MODE - SQL Commands that would be executed ===\n")
         display_input = (
-            _sanitize_url_for_logging(input_url) if is_remote_url(input_url) else input_url
+            _sanitize_url_for_logging(input_path) if is_remote_url(input_path) else input_path
         )
         display_output = (
             _sanitize_url_for_logging(output_parquet)
@@ -3727,7 +3732,7 @@ def add_computed_column(
 
     # Get total count (skip in dry-run)
     if not dry_run:
-        total_count = con.execute(f"SELECT COUNT(*) FROM '{input_url}'").fetchone()[0]
+        total_count = con.execute(f"SELECT COUNT(*) FROM {sql_path(input_path)}").fetchone()[0]
         progress(f"Processing {total_count:,} features...")
 
     # Build the query
@@ -3740,14 +3745,14 @@ def add_computed_column(
         SELECT
             * EXCLUDE ({quote_identifier(replace_column)}),
             {sql_expression} AS {quoted_col}
-        FROM '{input_url}'
+        FROM {sql_path(input_path)}
     """
     else:
         query = f"""
         SELECT
             *,
             {sql_expression} AS {quoted_col}
-        FROM '{input_url}'
+        FROM {sql_path(input_path)}
     """
 
     # Handle dry-run display
@@ -3761,7 +3766,7 @@ def add_computed_column(
             compression.lower() if compression != "UNCOMPRESSED" else "uncompressed"
         )
         display_query = f"""COPY ({query.strip()})
-TO '{output_parquet}'
+TO {sql_path(output_parquet)}
 (FORMAT PARQUET, COMPRESSION '{duckdb_compression}');"""
 
         info("-- Main query:")

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -93,7 +93,7 @@ def _escape_sql_string(value: str) -> str:
     return value.replace("'", "''")
 
 
-def sql_path(path: str) -> str:
+def sql_path(path: str | os.PathLike[str]) -> str:
     """Return a RAW file path as a complete, quoted SQL string literal.
 
     ``sql_path("/data/it's.parquet")`` yields ``'/data/it''s.parquet'`` --
@@ -117,13 +117,18 @@ def sql_path(path: str) -> str:
     For a non-path SQL string literal use :func:`_escape_sql_string` and supply
     your own quotes; for an identifier use :func:`quote_identifier`.
 
+    A ``PathLike`` is accepted as well as a ``str``: callers hold ``Path``
+    objects just as often, and ``str.replace`` on a ``Path`` is the completely
+    unrelated *filesystem rename*, so coercing here is what keeps every call
+    site from having to remember ``str()``.
+
     Args:
-        path: RAW, unescaped file path or URL.
+        path: RAW, unescaped file path or URL, as ``str`` or ``PathLike``.
 
     Returns:
         The path as a quoted, escaped SQL string literal.
     """
-    return f"'{_escape_sql_string(path)}'"
+    return f"'{_escape_sql_string(os.fspath(path))}'"
 
 
 def build_kv_metadata_clause(pairs: Mapping[str, str] | None) -> str | None:

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -25,9 +25,9 @@ from geoparquet_io.core.crs_utils import (
     source_crs_string,
     transform_geom_sql,
 )
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import quote_identifier, sql_path
 from geoparquet_io.core.exceptions import PartitionError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, progress, success, warn
 from geoparquet_io.core.partition.common import sanitize_filename
@@ -44,7 +44,7 @@ from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
 
 def _build_enrichment_query(
-    input_url,
+    input_source,
     admin_table_ref,
     admin_where_clause,
     admin_select_clause,
@@ -59,9 +59,11 @@ def _build_enrichment_query(
 ):
     """Build enrichment query for spatial join.
 
-    ``input_is_table_ref`` marks ``input_url`` as a DuckDB temp-table name
+    ``input_is_table_ref`` marks ``input_source`` as a DuckDB temp-table name
     (per-level chaining) rather than a file path, so it is referenced without
-    surrounding quotes.
+    surrounding quotes. A file path arrives RAW and is quoted and escaped here
+    by :func:`sql_path` -- escaping it earlier would carry the escape into the
+    branch that emits a bare table name (#802).
 
     ``source_crs`` (an ``"AUTH:CODE"`` string) reprojects a non-CRS84 input to
     the admin CRS before ``ST_Intersects`` (#525). When set, the input's stored
@@ -76,7 +78,7 @@ def _build_enrichment_query(
             subquery_cols.append(quote_identifier(col))
     subquery_cols_str = ", ".join(subquery_cols)
 
-    input_ref = input_url if input_is_table_ref else f"'{input_url}'"
+    input_ref = input_source if input_is_table_ref else sql_path(input_source)
 
     q_input_geom = quote_identifier(input_geom_col)
     bbox_filter = f"""
@@ -146,8 +148,10 @@ def _build_enrichment_query(
         """
 
 
-def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source_crs=None):
+def _compute_input_extent(con, input_path, input_bbox_col, input_geom_col, source_crs=None):
     """Compute the input's (xmin, xmax, ymin, ymax) extent in one scan.
+
+    ``input_path`` is RAW; ``sql_path`` escapes it at each interpolation (#802).
 
     The extent does not change across admin levels, so callers compute it once
     and reuse it for every level's WHERE clause (issue #480) rather than
@@ -165,7 +169,7 @@ def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source
                 MAX({input_bbox_col}.xmax) as xmax,
                 MIN({input_bbox_col}.ymin) as ymin,
                 MAX({input_bbox_col}.ymax) as ymax
-            FROM '{input_url}'
+            FROM {sql_path(input_path)}
         """
     else:
         geom_ref = transform_geom_sql(quote_identifier(input_geom_col), source_crs)
@@ -175,7 +179,7 @@ def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source
                 MAX(ST_XMax({geom_ref})) as xmax,
                 MIN(ST_YMin({geom_ref})) as ymin,
                 MAX(ST_YMax({geom_ref})) as ymax
-            FROM '{input_url}'
+            FROM {sql_path(input_path)}
         """
     extent = con.execute(extent_query).fetchone()
     if extent and all(v is not None for v in extent):
@@ -235,13 +239,18 @@ def _setup_admin_dataset(dataset_name, verbose, levels):
 
 
 def _get_input_file_info(input_parquet, verbose):
-    """Get input file info (URL, geometry column, bbox column)."""
-    input_url = safe_file_url(input_parquet, verbose)
+    """Get input file info (RAW path, geometry column, bbox column).
+
+    The path is returned unescaped: it is chained through ``current_source``,
+    which alternately holds a temp-table name, so the escape belongs at the SQL
+    boundary (:func:`sql_path`) rather than in this return value (#802).
+    """
+    input_path = resolve_file_url(input_parquet, verbose)
     input_geom_col = find_primary_geometry_column(input_parquet, verbose)
     input_bbox_info = check_bbox_structure(input_parquet, verbose)
     input_bbox_col = input_bbox_info["bbox_column_name"]
 
-    return input_url, input_geom_col, input_bbox_col
+    return input_path, input_geom_col, input_bbox_col
 
 
 def _setup_admin_join_connection(dataset, get_duckdb_connection):
@@ -326,7 +335,7 @@ def _build_admin_table_reference(dataset, admin_source):
 def _perform_enrichment_join(
     con,
     enriched_table,
-    input_url,
+    input_path,
     admin_table_ref,
     admin_where_clause,
     admin_select_clause,
@@ -339,7 +348,7 @@ def _perform_enrichment_join(
 ):
     """Perform spatial join enrichment."""
     enrichment_query = _build_enrichment_query(
-        input_url,
+        input_path,
         admin_table_ref,
         admin_where_clause,
         admin_select_clause,
@@ -360,7 +369,7 @@ def _perform_per_level_enrichment_join(
     levels,
     boundary_columns,
     enriched_table,
-    input_url,
+    input_path,
     admin_geom_col,
     admin_bbox_col,
     input_geom_col,
@@ -383,18 +392,18 @@ def _perform_per_level_enrichment_join(
 
     Returns the list of output admin column names.
     """
-    current_source = input_url
+    current_source = input_path
     current_is_table_ref = False
     output_column_names = []
     intermediate_tables = []
 
     # The data extent does not change across levels, so compute it once and reuse
     # it for every level's WHERE clause rather than re-scanning per level (#480).
-    extent = _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source_crs)
+    extent = _compute_input_extent(con, input_path, input_bbox_col, input_geom_col, source_crs)
 
     for i, (level, col) in enumerate(zip(levels, boundary_columns, strict=True)):
         level_source = dataset.get_source_for_level(level)
-        admin_table_ref = _build_admin_table_reference(dataset, f"'{level_source}'")
+        admin_table_ref = _build_admin_table_reference(dataset, sql_path(level_source))
         select_clause, level_outputs = _build_admin_select_for_partitioning(
             [level], [col], dataset=dataset, vecorel=vecorel
         )
@@ -477,9 +486,9 @@ def _verify_enrichment_results(con, enriched_table, output_column_names):
     return total_count, with_admin_count
 
 
-def _get_original_columns(con, input_url):
-    """Get original column names from input file."""
-    original_columns_query = f"SELECT * FROM '{input_url}' LIMIT 0"
+def _get_original_columns(con, input_path):
+    """Get original column names from the (RAW) input file path."""
+    original_columns_query = f"SELECT * FROM {sql_path(input_path)} LIMIT 0"
     original_schema = con.execute(original_columns_query)
     return [desc[0] for desc in original_schema.description]
 
@@ -704,7 +713,7 @@ def partition_by_admin_hierarchical(
     try:
         # Setup dataset and get input file info
         dataset, boundary_columns = _setup_admin_dataset(dataset_name, verbose, levels)
-        input_url, input_geom_col, input_bbox_col = _get_input_file_info(actual_input, verbose)
+        input_path, input_geom_col, input_bbox_col = _get_input_file_info(actual_input, verbose)
 
         # Admin boundaries are OGC:CRS84; reproject a non-CRS84 input before the
         # join so ST_Intersects neither errors on a CRS mismatch nor silently
@@ -740,7 +749,7 @@ def partition_by_admin_hierarchical(
                     levels,
                     boundary_columns,
                     enriched_table,
-                    input_url,
+                    input_path,
                     admin_geom_col,
                     admin_bbox_col,
                     input_geom_col,
@@ -756,7 +765,7 @@ def partition_by_admin_hierarchical(
                 )
                 admin_table_ref = _build_admin_table_reference(dataset, admin_source)
                 extent = _compute_input_extent(
-                    con, input_url, input_bbox_col, input_geom_col, source_crs
+                    con, input_path, input_bbox_col, input_geom_col, source_crs
                 )
                 admin_where_clause = _build_admin_where_clause(
                     dataset, levels, admin_bbox_col, extent, verbose
@@ -764,7 +773,7 @@ def partition_by_admin_hierarchical(
                 _perform_enrichment_join(
                     con,
                     enriched_table,
-                    input_url,
+                    input_path,
                     admin_table_ref,
                     admin_where_clause,
                     admin_select_clause,
@@ -811,7 +820,7 @@ def partition_by_admin_hierarchical(
             os.makedirs(output_folder, exist_ok=True)
 
             # Get original columns (exclude temporary admin columns)
-            original_cols = _get_original_columns(con, input_url)
+            original_cols = _get_original_columns(con, input_path)
 
             # Create each partition
             partition_count = _create_all_partitions(

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -12,6 +12,7 @@ from geoparquet_io.core.crs_utils import extract_crs_from_parquet
 from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
+    sql_path,
     validate_where_clause,
     where_sql_fragment,
 )
@@ -50,10 +51,14 @@ def _get_admin_ref(dataset, con, level: str) -> str:
     For datasets with per-level caches (Overture), uses the pre-filtered
     level-specific cache file directly.  For others, falls back to the
     generic prepare_data_source + read_parquet options path.
+
+    ``get_source_for_level`` returns a RAW path -- the user's
+    ``--dataset-source`` or a cache file under the user's home directory -- so
+    :func:`sql_path` quotes and escapes it here (#802).
     """
     if dataset.supports_per_level_sources():
         path = dataset.get_source_for_level(level)
-        return f"read_parquet('{path}')"
+        return f"read_parquet({sql_path(path)})"
     admin_source = dataset.prepare_data_source(con)
     admin_ref: str = _build_admin_table_reference(dataset, admin_source)
     return admin_ref

--- a/scripts/sql_path_literals_baseline.txt
+++ b/scripts/sql_path_literals_baseline.txt
@@ -2,19 +2,11 @@
 # A ratchet, not a target: counts may fall, never rise. New code must use
 # sql_path() from geoparquet_io/core/duckdb_utils.py instead.
 # Regenerate with: uv run python scripts/check_sql_path_literals.py --update
-2 geoparquet_io/core/add/admin_divisions.py
-4 geoparquet_io/core/add/bbox_metadata.py
-10 geoparquet_io/core/add/country_codes.py
-1 geoparquet_io/core/add/geometry_metrics.py
-5 geoparquet_io/core/add/kdtree.py
-1 geoparquet_io/core/add/quadkey.py
-5 geoparquet_io/core/admin_datasets.py
 1 geoparquet_io/core/arcgis.py
 6 geoparquet_io/core/benchmark.py
 2 geoparquet_io/core/carto.py
 3 geoparquet_io/core/check_fixes.py
 3 geoparquet_io/core/check_spatial_order.py
-8 geoparquet_io/core/common.py
 5 geoparquet_io/core/convert.py
 2 geoparquet_io/core/crs_utils.py
 13 geoparquet_io/core/duckdb_metadata.py
@@ -27,7 +19,6 @@
 6 geoparquet_io/core/inspect_utils.py
 2 geoparquet_io/core/layers.py
 1 geoparquet_io/core/metadata_utils.py
-3 geoparquet_io/core/partition/admin_hierarchical.py
 4 geoparquet_io/core/partition/auto_resolution.py
 4 geoparquet_io/core/partition/common.py
 2 geoparquet_io/core/partition/reader.py

--- a/scripts/sql_path_literals_baseline.txt
+++ b/scripts/sql_path_literals_baseline.txt
@@ -23,7 +23,6 @@
 4 geoparquet_io/core/partition/common.py
 2 geoparquet_io/core/partition/reader.py
 2 geoparquet_io/core/partition/staging.py
-1 geoparquet_io/core/process/aggregate/by_admin.py
 1 geoparquet_io/core/process/aggregate/common.py
 2 geoparquet_io/core/process/aggregate/grid_common.py
 1 geoparquet_io/core/process/overview/detect.py

--- a/tests/test_admin_datasets.py
+++ b/tests/test_admin_datasets.py
@@ -21,6 +21,9 @@ from geoparquet_io.core.admin_datasets import (
     get_cached_path,
     get_or_cache_dataset,
 )
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+
+TEST_DATA_DIR = Path(__file__).parent / "data"
 
 
 class TestCurrentAdminDataset:
@@ -1089,3 +1092,88 @@ class TestCacheEdgeCases:
         # This is a placeholder for thread-safety testing
         # The implementation should use atomic file operations
         pass
+
+
+class TestDownloadToCache:
+    """Test AdminDataset._download_to_cache() -- the default DuckDB download path.
+
+    ``get_default_source`` is monkeypatched to a local test fixture, so this
+    exercises the read_parquet/COPY SQL (built via sql_path (#802)) without any
+    network access.
+    """
+
+    def test_download_to_cache_no_read_options(self, tmp_path):
+        """No per-dataset read_parquet options -> the plain read_parquet branch."""
+        dataset = GAULAdminDataset()
+        local_source = str(TEST_DATA_DIR / "buildings_test.parquet")
+        cache_path = tmp_path / "cache" / "gaul-test.parquet"
+
+        with patch.object(dataset, "get_default_source", return_value=local_source):
+            result = dataset._download_to_cache(cache_path)
+
+        assert result == cache_path
+        assert cache_path.exists()
+
+        con = get_duckdb_connection(load_spatial=True)
+        try:
+            count = con.execute(f"SELECT COUNT(*) FROM {sql_path(str(cache_path))}").fetchone()[0]
+        finally:
+            con.close()
+        assert count > 0
+
+    def test_download_to_cache_with_read_options(self, tmp_path):
+        """Non-empty read_parquet options (e.g. Overture's hive_partitioning) build the options branch."""
+        dataset = GAULAdminDataset()
+        local_source = str(TEST_DATA_DIR / "buildings_test.parquet")
+        cache_path = tmp_path / "cache2" / "gaul-test2.parquet"
+
+        with (
+            patch.object(dataset, "get_default_source", return_value=local_source),
+            patch.object(
+                dataset, "get_read_parquet_options", return_value={"hive_partitioning": 1}
+            ),
+        ):
+            result = dataset._download_to_cache(cache_path)
+
+        assert result == cache_path
+        assert cache_path.exists()
+
+
+class TestPrepareDataSource:
+    """Test AdminDataset.prepare_data_source() -- returns a SQL table reference (#802)."""
+
+    def test_remote_source_returns_sql_path_literal(self):
+        """A remote (s3://) source is quoted/escaped via sql_path, not verified on disk."""
+        dataset = GAULAdminDataset(verbose=True)
+        con = get_duckdb_connection()
+        try:
+            result = dataset.prepare_data_source(con)
+        finally:
+            con.close()
+
+        assert result == sql_path(dataset.get_default_source())
+
+    def test_local_source_returns_sql_path_literal(self, tmp_path):
+        """A local source is verified to exist, then also returned via sql_path."""
+        local_file = tmp_path / "local_admin.parquet"
+        local_file.write_bytes(b"not a real parquet file, just needs to exist")
+        dataset = GAULAdminDataset(source_path=str(local_file))
+        con = get_duckdb_connection()
+        try:
+            result = dataset.prepare_data_source(con)
+        finally:
+            con.close()
+
+        assert result == sql_path(str(local_file))
+
+    def test_local_source_missing_raises(self):
+        """A local source that does not exist raises FileNotFoundGeoParquetError."""
+        from geoparquet_io.core.exceptions import FileNotFoundGeoParquetError
+
+        dataset = GAULAdminDataset(source_path="/nonexistent/admin-source.parquet")
+        con = get_duckdb_connection()
+        try:
+            with pytest.raises(FileNotFoundGeoParquetError):
+                dataset.prepare_data_source(con)
+        finally:
+            con.close()

--- a/tests/test_admin_sql_injection.py
+++ b/tests/test_admin_sql_injection.py
@@ -87,7 +87,7 @@ def test_country_codes_join_query_quotes_identifiers():
     from geoparquet_io.core.add.country_codes import _build_spatial_join_query
 
     query = _build_spatial_join_query(
-        input_url="input.parquet",
+        input_path="input.parquet",
         countries_source="'countries.parquet'",
         select_clause="b.iso_a2 as country",
         input_geom_col=MALICIOUS_GEOM_NAME,

--- a/tests/test_admin_transform_qualification.py
+++ b/tests/test_admin_transform_qualification.py
@@ -53,7 +53,7 @@ def test_admin_divisions_handles_input_with_region_column():
         )
 
         query = _build_spatial_join_query(
-            input_url="_gpio_test_input",
+            input_source="_gpio_test_input",
             admin_subquery="(SELECT geometry, region FROM _admin)",
             admin_select_clause=select_clause,
             input_bbox_col=None,

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -6,7 +6,30 @@ import logging
 
 import pytest
 
-from geoparquet_io.core.common import get_dataset_bounds
+from geoparquet_io.core.common import calculate_file_bounds, get_dataset_bounds
+
+
+class TestCalculateFileBounds:
+    """Test suite for calculate_file_bounds -- ST_XMin/ST_YMin extent via spatial extension."""
+
+    def test_calculates_bounds_for_local_file(self, buildings_test_file):
+        """A RAW local path resolves through resolve_file_url and sql_path (#802)."""
+        bounds = calculate_file_bounds(buildings_test_file, verbose=False)
+
+        assert bounds is not None
+        xmin, ymin, xmax, ymax = bounds
+        assert xmin < xmax
+        assert ymin < ymax
+        # Buildings test file is in Germany, so roughly these coords.
+        assert 5 < xmin < 7
+        assert 49 < ymin < 51
+
+    def test_auto_detects_geometry_column(self, buildings_test_file):
+        """geom_column=None triggers find_primary_geometry_column."""
+        explicit = calculate_file_bounds(buildings_test_file, geom_column="geometry", verbose=False)
+        auto = calculate_file_bounds(buildings_test_file, geom_column=None, verbose=False)
+
+        assert auto == explicit
 
 
 class TestGetDatasetBounds:

--- a/tests/test_country_code.py
+++ b/tests/test_country_code.py
@@ -449,3 +449,74 @@ class TestCountryCodesLocalCountriesFile:
         assert "Could not summarize the output file" in caplog.text
         assert "HTTP 403 while reading the output" in caplog.text
         assert "Successfully wrote output to" in caplog.text
+
+
+class TestDryRunDefaultCountriesSqlPath:
+    """Dry-run SQL for the default (Overture) countries source uses sql_path (#802).
+
+    These call the module helpers directly with a patched Overture URL, so the
+    printed SQL is exercised with no network access.
+    """
+
+    def test_bounds_info_bbox_branch_escapes_path(self, caplog):
+        """With a bbox column, the printed bounds SQL quotes the RAW input path."""
+        from geoparquet_io.core.add.country_codes import _print_dry_run_bounds_info
+
+        with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+            _print_dry_run_bounds_info("bbox", "/tmp/it's_data.parquet", "geometry")
+
+        assert '"bbox".xmin' in caplog.text
+        # sql_path doubles the apostrophe so the echoed statement is runnable.
+        assert "'/tmp/it''s_data.parquet'" in caplog.text
+
+    def test_bounds_info_geometry_branch_escapes_path(self, caplog):
+        """Without a bbox column, the ST_XMin bounds SQL quotes the RAW input path."""
+        from geoparquet_io.core.add.country_codes import _print_dry_run_bounds_info
+
+        with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+            _print_dry_run_bounds_info(None, "/tmp/it's_data.parquet", "geometry")
+
+        assert 'ST_XMin("geometry")' in caplog.text
+        assert "'/tmp/it''s_data.parquet'" in caplog.text
+
+    def test_setup_countries_source_default_dry_run(self, buildings_test_file, caplog):
+        """using_default resolves the Overture URL and prints sql_path-quoted SQL.
+
+        The Overture URL lookup is patched (no network); bounds come from the
+        local input fixture; dry-run only prints the filter-table SQL.
+        """
+        from unittest.mock import patch
+
+        from geoparquet_io.core.add.country_codes import _setup_countries_source
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+
+        fake_url = "s3://overture-fake/release/theme=divisions/it's_a_url/*.parquet"
+        con = get_duckdb_connection()
+        try:
+            with (
+                caplog.at_level(logging.INFO, logger="geoparquet_io"),
+                patch(
+                    "geoparquet_io.core.overture.get_overture_divisions_url",
+                    return_value=fake_url,
+                ),
+            ):
+                result = _setup_countries_source(
+                    con,
+                    using_default=True,
+                    countries_path=None,
+                    input_parquet=buildings_test_file,
+                    input_path=buildings_test_file,
+                    input_geom_col="geometry",
+                    input_bbox_col=None,
+                    countries_bbox_col="bbox",
+                    dry_run=True,
+                    verbose=False,
+                )
+        finally:
+            con.close()
+
+        # The default source is staged into a filtered temp table (by name).
+        assert result == "filtered_countries"
+        assert "-- Step 2: Create filtered countries table" in caplog.text
+        # The remote URL lands in the printed SQL as one escaped literal.
+        assert sql_path(fake_url) in caplog.text

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -433,7 +433,7 @@ class TestAdminJoinIsCrsAware:
         con = _con_with_admin()
         try:
             kwargs = {
-                "input_url": fields_5070_file,
+                "input_source": fields_5070_file,
                 "admin_subquery": "(SELECT geom, region FROM _admin)",
                 "admin_select_clause": 'b."region" AS region',
                 "input_bbox_col": None,
@@ -460,7 +460,7 @@ class TestAdminJoinIsCrsAware:
         con = _con_with_admin()
         try:
             sql = _build_enrichment_query(
-                input_url=fields_5070_file,
+                input_source=fields_5070_file,
                 admin_table_ref="_admin",
                 admin_where_clause="",
                 admin_select_clause='b."region" AS region',
@@ -494,7 +494,7 @@ class TestAdminReprojectsAdminSideWithBbox:
         from geoparquet_io.core.add.admin_divisions import _build_spatial_join_query
 
         sql = _build_spatial_join_query(
-            input_url="x.parquet",
+            input_source="x.parquet",
             admin_subquery="(SELECT geom, bbox, region FROM admin)",
             admin_select_clause='b."region" AS region',
             input_bbox_col="bbox",
@@ -528,7 +528,7 @@ class TestAdminReprojectsAdminSideWithBbox:
         from geoparquet_io.core.partition.admin_hierarchical import _build_enrichment_query
 
         sql = _build_enrichment_query(
-            input_url="x.parquet",
+            input_source="x.parquet",
             admin_table_ref="admin",
             admin_where_clause="",
             admin_select_clause='b."region" AS region',
@@ -565,7 +565,7 @@ class TestAdminReprojectsAdminSideWithBbox:
                 f"FROM '{fields_5070_file}'"
             )
             sql = _build_enrichment_query(
-                input_url="_inp",
+                input_source="_inp",
                 admin_table_ref="_admin_b",
                 admin_where_clause="",
                 admin_select_clause='b."region" AS region',

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -205,3 +205,65 @@ class TestDryRunCommands:
         # The message must match the predicate that actually runs (bbox pre-filter).
         assert "Using bbox columns for optimized spatial join" in result.output
         assert "no bbox optimization" not in result.output
+
+
+class TestPerLevelJoinsDryRun:
+    """Dry-run of the per-level-source join path (Overture) with no network.
+
+    ``add admin-divisions`` only reaches ``_execute_per_level_joins`` for
+    datasets with per-level sources, which the CLI dry-run tests above never
+    exercise. Calling it directly with a dataset pinned to a local
+    ``source_path`` keeps ``get_source_for_level`` off the network, and
+    ``dry_run=True`` only prints the chained per-level SQL.
+    """
+
+    def test_dry_run_prints_chained_per_level_queries(self, buildings_test_file, caplog):
+        import logging
+
+        from geoparquet_io.core.add.admin_divisions import _execute_per_level_joins
+        from geoparquet_io.core.admin_datasets import OvertureAdminDataset
+        from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+
+        dataset = OvertureAdminDataset(source_path=buildings_test_file)
+        levels = ["country", "region"]
+        partition_columns = dataset.get_partition_columns(levels)
+
+        con = get_duckdb_connection()
+        try:
+            with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+                result = _execute_per_level_joins(
+                    con,
+                    dataset,
+                    levels,
+                    partition_columns,
+                    buildings_test_file,
+                    admin_geom_col="geometry",
+                    admin_bbox_col=None,
+                    input_geom_col="geometry",
+                    input_bbox_col=None,
+                    output_parquet="output.parquet",
+                    metadata=None,
+                    dry_run=True,
+                    verbose=False,
+                    compression="ZSTD",
+                    compression_level=None,
+                    row_group_size_mb=None,
+                    row_group_rows=None,
+                    profile=None,
+                    geoparquet_version=None,
+                    prefix=None,
+                    no_cache=False,
+                )
+        finally:
+            con.close()
+
+        # Dry-run returns the no-stats triple and writes nothing.
+        assert result == (None, None, None)
+        # One step per level, chained: step 2 reads the step-1 temp table.
+        assert "-- Step 1: Add" in caplog.text
+        assert "-- Step 2: Add" in caplog.text
+        assert "_gpio_admin_step_0" in caplog.text
+        # The per-level admin source is interpolated via sql_path with the
+        # dataset's read options (#802).
+        assert sql_path(buildings_test_file) in caplog.text
+        assert "hive_partitioning=1" in caplog.text

--- a/tests/test_sql_path_escaping.py
+++ b/tests/test_sql_path_escaping.py
@@ -179,6 +179,29 @@ class TestCliCommandsOnApostrophePath:
         assert result.exit_code == 0, result.output
         assert "bbox" in pq.read_schema(out).names
 
+    def test_add_kdtree_succeeds(self, apostrophe_file, tmp_path):
+        """Not just ``--dry-run``: the migrated SQL has to actually execute.
+
+        Both the input and the output path contain the apostrophe, so a missed
+        escape on either side fails here (#802).
+        """
+        out = str(tmp_path / "o'brien" / "kdtree.parquet")
+        runner = CliRunner()
+        result = runner.invoke(add, ["kdtree", apostrophe_file, out, "--partitions", "4"])
+
+        assert result.exit_code == 0, result.output
+        assert "kdtree_cell" in pq.read_schema(out).names
+        assert pq.read_metadata(out).num_rows == 10
+
+    def test_add_quadkey_succeeds(self, apostrophe_file, tmp_path):
+        out = str(tmp_path / "o'brien" / "quadkey.parquet")
+        runner = CliRunner()
+        result = runner.invoke(add, ["quadkey", apostrophe_file, out])
+
+        assert result.exit_code == 0, result.output
+        assert "quadkey" in pq.read_schema(out).names
+        assert pq.read_metadata(out).num_rows == 10
+
     @pytest.mark.parametrize("fmt", ["geojson", "csv"])
     def test_convert_succeeds(self, apostrophe_file, tmp_path, fmt):
         out = str(tmp_path / "o'brien" / f"out.{fmt}")
@@ -206,6 +229,16 @@ class TestSqlPath:
         finally:
             con.close()
         assert rows[0] == 10
+
+    def test_accepts_a_pathlib_path(self, apostrophe_file):
+        """Callers hold ``Path`` objects as often as strings.
+
+        ``_escape_sql_string`` calls ``str.replace``, which on a ``Path`` is the
+        completely unrelated *filesystem rename*, so a ``Path`` argument used to
+        raise ``TypeError`` (or, worse, move a file) instead of being escaped.
+        """
+        assert sql_path(Path(apostrophe_file)) == sql_path(apostrophe_file)
+        assert sql_path(Path("/tmp/it's_data.parquet")) == "'/tmp/it''s_data.parquet'"
 
     def test_takes_a_raw_path_not_a_safe_file_url_result(self, apostrophe_file):
         """The contract is RAW in.
@@ -611,8 +644,8 @@ def _make_countries_file(source_parquet, dest):
     con = get_duckdb_connection(load_spatial=True)
     try:
         con.execute(
-            f"COPY (SELECT geometry, 'US' AS country_code FROM {sql_path(str(source_parquet))}) "
-            f"TO {sql_path(str(dest))} (FORMAT PARQUET)"
+            f"COPY (SELECT geometry, 'US' AS country_code FROM {sql_path(source_parquet)}) "
+            f"TO {sql_path(dest)} (FORMAT PARQUET)"
         )
     finally:
         con.close()
@@ -706,6 +739,40 @@ class TestBboxMetadataNativeGeometryProbe:
             con.execute(f'COPY (SELECT 1 AS "it\'s_geom") TO {sql_path(path)} (FORMAT PARQUET)')
             # No ParserException, and an INTEGER column is not native geometry.
             assert _detect_native_geometry(con, path, "it's_geom") is False
+        finally:
+            con.close()
+
+
+class TestAggregateByAdminSource:
+    """``_get_admin_ref`` interpolates a per-level admin source path.
+
+    That path is either the user's ``--dataset-source`` or a cache file under
+    the user's home directory, so an apostrophe in *either* -- a home directory
+    called ``/Users/o'brien`` is enough -- crashed ``process aggregate admin``
+    with a ``ParserException``.
+    """
+
+    def test_per_level_source_is_escaped(self, apostrophe_file):
+        from geoparquet_io.core.admin_datasets import AdminDatasetFactory
+        from geoparquet_io.core.process.aggregate.by_admin import _get_admin_ref
+
+        dataset = AdminDatasetFactory.create("overture", source_path=apostrophe_file)
+        assert dataset.supports_per_level_sources()
+
+        ref = _get_admin_ref(dataset, None, "country")
+
+        assert ref == f"read_parquet({sql_path(apostrophe_file)})"
+
+    def test_per_level_source_ref_is_runnable_sql(self, apostrophe_file):
+        from geoparquet_io.core.admin_datasets import AdminDatasetFactory
+        from geoparquet_io.core.process.aggregate.by_admin import _get_admin_ref
+
+        dataset = AdminDatasetFactory.create("overture", source_path=apostrophe_file)
+        ref = _get_admin_ref(dataset, None, "country")
+
+        con = get_duckdb_connection(load_spatial=False)
+        try:
+            assert con.execute(f"SELECT count(*) FROM {ref}").fetchone()[0] == 10
         finally:
             con.close()
 

--- a/tests/test_sql_path_escaping.py
+++ b/tests/test_sql_path_escaping.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -238,7 +239,9 @@ class TestSqlPath:
         raise ``TypeError`` (or, worse, move a file) instead of being escaped.
         """
         assert sql_path(Path(apostrophe_file)) == sql_path(apostrophe_file)
-        assert sql_path(Path("/tmp/it's_data.parquet")) == "'/tmp/it''s_data.parquet'"
+        p = Path("/tmp") / "it's_data.parquet"
+        expected = "'" + os.fspath(p).replace("'", "''") + "'"
+        assert sql_path(p) == expected
 
     def test_takes_a_raw_path_not_a_safe_file_url_result(self, apostrophe_file):
         """The contract is RAW in.

--- a/tests/test_sql_path_escaping.py
+++ b/tests/test_sql_path_escaping.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 import subprocess
 import sys
 from pathlib import Path
@@ -498,6 +499,215 @@ class TestSqlPathLiteralRatchet:
         result = run()
         assert result.returncode != 0, result.stdout + result.stderr
         assert "geoparquet_io/reader.py" in result.stdout
+
+
+class TestDisplayedPathsAreNotEscaped:
+    """Issue #802 part 1: a message shows the path the user typed.
+
+    The escape belongs to the SQL string, not to the human reading the log. A
+    dry-run header that prints ``o''brien/data.parquet`` for a file called
+    ``o'brien/data.parquet`` is confusing to read and wrong to copy-paste.
+    """
+
+    @staticmethod
+    def _assert_shows_raw(text, path):
+        """No ``--`` prose line may carry an escaped path.
+
+        The SQL these runs echo is another matter: there ``o''brien`` is the
+        correct literal, and ``add/country_codes.py:_print_dry_run_bounds_info``
+        prints SQL on purpose.
+        """
+        prose = [line for line in text.splitlines() if line.strip().startswith("--")]
+        assert prose, text
+        for line in prose:
+            assert "o''brien" not in line, line
+        assert str(path) in text, text
+
+    def test_add_computed_column_dry_run_header(self, apostrophe_file, tmp_path, caplog):
+        """``common.add_computed_column`` sanitized the *escaped* URL (#802)."""
+        from geoparquet_io.core.common import add_computed_column
+
+        out = str(tmp_path / "o'brien" / "computed.parquet")
+        with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+            add_computed_column(
+                apostrophe_file,
+                out,
+                column_name="answer",
+                sql_expression="42",
+                dry_run=True,
+            )
+
+        assert f"-- Input file: {apostrophe_file}" in caplog.text
+        self._assert_shows_raw(caplog.text, apostrophe_file)
+        # The echoed COPY is SQL, so there the escape is correct -- and the
+        # printed statement has to be runnable.
+        assert f"TO {sql_path(out)}" in caplog.text
+
+    def test_add_kdtree_dry_run_header(self, apostrophe_file, tmp_path):
+        out = str(tmp_path / "kdtree.parquet")
+        runner = CliRunner()
+        result = runner.invoke(
+            add, ["kdtree", apostrophe_file, out, "--partitions", "4", "--dry-run"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert f"-- Input: {apostrophe_file}" in result.output
+        self._assert_shows_raw(result.output, apostrophe_file)
+
+    def test_add_quadkey_dry_run_header(self, apostrophe_file, tmp_path):
+        out = str(tmp_path / "quadkey.parquet")
+        runner = CliRunner()
+        result = runner.invoke(add, ["quadkey", apostrophe_file, out, "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert f"-- Input file: {apostrophe_file}" in result.output
+        self._assert_shows_raw(result.output, apostrophe_file)
+
+    def test_add_admin_divisions_dry_run_header(self, apostrophe_file, tmp_path):
+        out = str(tmp_path / "adm.parquet")
+        runner = CliRunner()
+        result = runner.invoke(
+            add,
+            [
+                "admin-divisions",
+                apostrophe_file,
+                out,
+                "--dataset",
+                "gaul",
+                "--levels",
+                "continent",
+                "--dry-run",
+                "--no-cache",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert f"-- Input file: {apostrophe_file}" in result.output
+        self._assert_shows_raw(result.output, apostrophe_file)
+
+    def test_add_country_codes_dry_run_header(self, apostrophe_file, tmp_path, caplog):
+        """Both the input and the ``--countries`` path are shown raw (#802)."""
+        from geoparquet_io.core.add.country_codes import add_country_codes
+
+        countries = _make_countries_file(apostrophe_file, tmp_path / "o'brien" / "c.parquet")
+        with caplog.at_level(logging.INFO, logger="geoparquet_io"):
+            add_country_codes(
+                input_parquet=apostrophe_file,
+                countries_parquet=countries,
+                output_parquet=str(tmp_path / "o'brien" / "cc_out.parquet"),
+                add_bbox_flag=False,
+                dry_run=True,
+                verbose=False,
+            )
+
+        assert f"-- Input file: {apostrophe_file}" in caplog.text
+        assert f"-- Countries file: {countries}" in caplog.text
+        self._assert_shows_raw(caplog.text, apostrophe_file)
+
+
+def _make_countries_file(source_parquet, dest):
+    """A countries file built from ``source_parquet``'s own geometries."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        con.execute(
+            f"COPY (SELECT geometry, 'US' AS country_code FROM {sql_path(str(source_parquet))}) "
+            f"TO {sql_path(str(dest))} (FORMAT PARQUET)"
+        )
+    finally:
+        con.close()
+    return str(dest)
+
+
+class TestEscapedValuesDoNotCrossFunctionBoundaries:
+    """Issue #802 part 2: a function hands back a RAW path.
+
+    None of these is a bug today -- every consumer happens to be SQL -- but the
+    escaped value outliving the function that escaped it is exactly the shape
+    that produced #718's crashes: the next consumer added has to know.
+    """
+
+    def test_get_countries_config_returns_a_raw_path(self, apostrophe_file, tmp_path):
+        from geoparquet_io.core.add.country_codes import _get_countries_config
+
+        countries = _make_countries_file(apostrophe_file, tmp_path / "o'brien" / "c.parquet")
+        countries_path, _, _ = _get_countries_config(countries, using_default=False, verbose=False)
+
+        assert countries_path == countries
+
+    def test_get_input_file_info_returns_a_raw_path(self, apostrophe_file):
+        from geoparquet_io.core.partition.admin_hierarchical import _get_input_file_info
+
+        input_path, _, _ = _get_input_file_info(apostrophe_file, verbose=False)
+
+        assert input_path == apostrophe_file
+
+    def test_admin_divisions_input_ref_escapes_a_raw_path(self, apostrophe_file):
+        """``current_source`` alternately holds a table name, so the RAW path
+        has to be the thing that reaches the SQL boundary."""
+        from geoparquet_io.core.add.admin_divisions import _format_input_ref
+
+        assert _format_input_ref(apostrophe_file) == sql_path(apostrophe_file)
+        assert _format_input_ref("_gpio_admin_step_0", is_table_ref=True) == "_gpio_admin_step_0"
+
+    def test_admin_hierarchical_enrichment_query_escapes_a_raw_path(self, apostrophe_file):
+        from geoparquet_io.core.partition.admin_hierarchical import _build_enrichment_query
+
+        query = _build_enrichment_query(
+            apostrophe_file,
+            "admin_tbl",
+            "",
+            "b.country AS admin_country",
+            "geometry",
+            None,
+            ["country"],
+            "geometry",
+            None,
+            "_enriched",
+        )
+
+        assert f"FROM {sql_path(apostrophe_file)} a" in query
+
+    def test_admin_hierarchical_enrichment_query_keeps_a_table_ref_bare(self, apostrophe_file):
+        from geoparquet_io.core.partition.admin_hierarchical import _build_enrichment_query
+
+        query = _build_enrichment_query(
+            "_admin_step_0",
+            "admin_tbl",
+            "",
+            "b.country AS admin_country",
+            "geometry",
+            None,
+            ["country"],
+            "geometry",
+            None,
+            "_enriched",
+            input_is_table_ref=True,
+        )
+
+        assert "FROM _admin_step_0 a" in query
+
+
+class TestBboxMetadataNativeGeometryProbe:
+    """``_detect_native_geometry`` interpolates the file's own column name.
+
+    The name comes from the file's ``geo`` metadata, so it is untrusted input
+    like any other: an apostrophe in it broke the probe's SQL, and the caller
+    reads the result as "this file is not GeoParquet 2.0".
+    """
+
+    def test_apostrophe_in_the_geometry_column_name(self, tmp_path):
+        from geoparquet_io.core.add.bbox_metadata import _detect_native_geometry
+
+        path = str(tmp_path / "o'brien" / "odd_col.parquet")
+        (tmp_path / "o'brien").mkdir()
+        con = get_duckdb_connection(load_spatial=False)
+        try:
+            con.execute(f'COPY (SELECT 1 AS "it\'s_geom") TO {sql_path(path)} (FORMAT PARQUET)')
+            # No ParserException, and an INTEGER column is not native geometry.
+            assert _detect_native_geometry(con, path, "it's_geom") is False
+        finally:
+            con.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

**Part 1 — the escaped path shown to the user (all sites fixed).** An
already-escaped path reached the dry-run headers, so a user with a file called
`o'brien/data.parquet` was told about `o''brien/data.parquet`: harmless to the
run, confusing to read, and wrong once copy-pasted. Fixed in
`core/common.py` (`add_computed_column`'s `-- Input file:`),
`core/add/kdtree.py`, `core/add/quadkey.py`, `core/add/admin_divisions.py` and
`core/add/country_codes.py` (both `input_url` and `countries_url`). The SQL those
same commands echo keeps its escape — that statement has to be runnable — and
`country_codes._print_dry_run_bounds_info`, which prints SQL on purpose, is
unchanged in behaviour.

**Part 2 — escaped values crossing a function boundary (all sites fixed).** Each
of these now returns a RAW path, with the escape moved to the point of SQL
interpolation (`sql_path`, from #803):

- `add/country_codes._get_countries_config` — its default-Overture branch already
  returned a raw URL, so the two branches now agree instead of disagreeing
  silently;
- `partition/admin_hierarchical._get_input_file_info`;
- the `current_source` chains in `add/admin_divisions._execute_per_level_joins`
  and `partition/admin_hierarchical._perform_per_level_enrichment_join`, which
  alternately hold a *table name* — the one place the value must not already be
  escaped. `_format_input_ref` / `_build_enrichment_query` now escape the path
  branch themselves.

Parameters that hold a raw path are renamed off `input_url` (to `input_path` /
`input_source` / `countries_path`) so the contract is visible at the call site;
that is most of the line count.

**Part 3 — migrating `FROM '{path}'` (partial, deliberately).** Ten files are
fully migrated: the six that Parts 1 and 2 touch, plus the rest of `core/add/`
(`bbox_metadata.py`, `geometry_metrics.py`), `core/admin_datasets.py` and
`core/process/aggregate/by_admin.py`. The ratchet baseline goes **160 → 120
sites, 45 → 35 files**. I stopped there on purpose: the remaining 35 files are
unrelated to this fix and migrating them here would bury the real changes above
in mechanical churn. The ratchet stays in place and the next batch can land the
same way.

Three latent escaping bugs turned up inside those files and are fixed as part of
the migration rather than left behind:

- `core/admin_datasets.py` interpolated a **completely unescaped** path in its
  cache `COPY ... TO`, its `read_parquet(...)` calls and `prepare_data_source` —
  an admin cache directory or `--dataset-source` containing an apostrophe would
  have died with a `ParserException`;
- `process/aggregate/by_admin._get_admin_ref` had the same shape: a hand-written
  `read_parquet('{path}')` over the per-level admin source, which is either the
  user's `--dataset-source` or a cache file under the user's home directory. A
  home directory called `/Users/o'brien` was enough to break
  `gpio process aggregate admin`;
- `add/bbox_metadata._detect_native_geometry` interpolated the geometry-column
  name, which comes from the file's own `geo` metadata, into a SQL literal
  unescaped. An apostrophe in it broke the probe, and the caller reads a broken
  probe as "this file is not GeoParquet 2.0". Now escaped via `_escape_sql_string`.

Each is covered by a test that fails without the fix.

**`sql_path` accepts a `PathLike`.** It crashed on one: `_escape_sql_string`
calls `str.replace`, which on a `Path` is the completely unrelated *filesystem
rename*, so a `Path` argument raised `TypeError` rather than being escaped. It
now coerces with `os.fspath`, and the three call sites that had worked around
this with a manual `str()` drop it.

## Why

Closes the follow-up half of #718. The display bug is user-visible today. The
boundary-crossing values are not bugs yet — every current consumer is SQL — but
they are the exact shape that produced #718's crashes: the escape outlives the
function that applied it, so the next consumer added has to know. Fixing the
contract, not the symptom, is what stops the next one.

## Verification

Tests were written first and watched fail. For the display sites, 9 failures
each showing `o''brien` where the raw path belongs, plus the two returning
functions handing back an escaped path. For `by_admin`, the exact user-visible
crash:

```
E   _duckdb.ParserException: Parser Error: syntax error at or near "brien"
E   LINE 1: ...test_per_level_source_ref_is_r0/o'brien/q.parquet')
```

and for `sql_path` on a `Path`:

```
E   TypeError: Path.replace() takes 2 positional arguments but 3 were given
```

The two new end-to-end tests (`add kdtree` / `add quadkey` run for real, not
`--dry-run`, with the apostrophe in **both** the input and the output path) were
checked against a mutation that strips `sql_path` back out of those two commands:
both then fail with a `ParserException`, so they are real guards rather than
tests that merely pass.

```
$ uv run pytest tests/test_sql_path_escaping.py -q
============================== 63 passed in 4.85s ==============================

$ uv run pytest tests -n auto -q -m "not slow and not network and not meta"
==== 5190 passed, 87 skipped, 2 xfailed, 105 warnings in 153.20s (0:02:33) =====

$ uv run python scripts/check_sql_path_literals.py
(exit 0)

$ uv run pre-commit run --files <changed>
... all hooks Passed

$ uv run pre-commit run --all-files --hook-stage pre-push
deptry / mypy / vulture / xenon / import-linter / menard-check / fast-tests ... Passed
```

The fast suite ran clean on the first attempt — no xdist cold-run flake this time.

New tests keep to what runs offline: `add country-codes` is exercised through the
core function with a locally built countries file (the pattern
`tests/test_country_code.py` already uses), and `add admin-divisions --dry-run
--no-cache` needs no download. There is deliberately **no** full-run
`country-codes` / `admin-divisions` CLI test on an apostrophe path: both download
an admin dataset, so a real run cannot go in the offline lane. `by_admin` is
covered at the function level instead, which needs no download.

## Scope of #802

Refs #802 — **not** closing it. Parts 1 and 2 are complete; Part 3 is partial:
**35 files / 120 hand-written `FROM '{path}'` sites remain** in
`scripts/sql_path_literals_baseline.txt`. The largest remainders are
`core/validate.py` (16), `core/duckdb_metadata.py` (13), `plugins/gpio-fiboa`
tests (9), `core/inspect_utils.py` (6) and `core/benchmark.py` (6). Suggest
keeping the issue open scoped to that remainder.

Rebased onto `main` now that #803 has merged, so CI here is meaningful and the
runs above are reproducible from this branch alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of local and remote file paths across data-processing workflows.
  * Prevented incorrect escaping of paths and metadata in generated queries.
  * Preserved readable paths in dry-run output while keeping queries executable.
  * Improved administrative dataset filtering, caching, and country-code handling.
  * Added warnings when administrative joins produce unexpected row counts.
  * Added support for path-like input values and improved geometry and dataset reference handling.

* **Tests**
  * Expanded coverage for path escaping, dry-run output, spatial joins, bounds calculation, and administrative dataset processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->