### PR TITLE
fix(admin): attribute Overture dependency territories instead of dropping them to ZZ

### DIFF
--- a/docs/_includes/admin-datasets.md
+++ b/docs/_includes/admin-datasets.md
@@ -3,7 +3,7 @@ Two remote admin boundary datasets are supported:
 | Dataset | Standard | Columns Added | Description |
 |---------|----------|---------------|-------------|
 | `gaul` (default) | GAUL naming + ISO 3166-1 alpha-3 | `admin:continent`, `admin:country`, `admin:department` | FAO Global Administrative Unit Layers (GAUL) L2 - worldwide coverage with standardized naming |
-| `overture` | **Vecorel compliant** (ISO 3166-1/2) | `admin:country_code`, `admin:subdivision_code` | Overture Maps Divisions with ISO 3166 codes (219 countries, 3,544 regions) - [docs](https://docs.overturemaps.org/guides/divisions/) |
+| `overture` | **Vecorel compliant** (ISO 3166-1/2) | `admin:country_code`, `admin:subdivision_code` | Overture Maps Divisions with ISO 3166 codes (219 countries + 53 dependent territories, 3,544 regions) - [docs](https://docs.overturemaps.org/guides/divisions/) |
 
 ### Vecorel Compliance (Overture Dataset Only)
 

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -551,6 +551,13 @@ The `--vecorel` flag:
     boundaries are downloaded and cached as separate files rather than one
     combined file.
 
+    The country level covers **dependent territories** as well as sovereign
+    states, each attributed to its own ISO 3166-1 alpha-2 code — `GF` for
+    French Guiana, `PR` for Puerto Rico, `RE` for Réunion, `GL`, `HK`, `NC`
+    and the rest, plus `BQ` and `SJ` for the Caribbean and Arctic islands
+    Overture files under placeholder codes. They are not folded into their
+    sovereign's code.
+
     Overture boundaries are simplified with `ST_SimplifyPreserveTopology` at a
     tolerance of `0.0001` degrees (roughly 11 m near the equator, ~7 m at
     50°N). Country and region layers are simplified **independently**, so

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -338,6 +338,36 @@ def _get_result_stats(con, output_parquet, dataset, levels, verbose, prefix=None
     return total_features, features_with_admin, unique_counts
 
 
+def _warn_if_row_count_changed(input_rows, output_rows):
+    """Warn when the per-level admin join did not preserve the row count.
+
+    The per-level caches are built to be non-overlapping precisely so a plain
+    LEFT JOIN is row-preserving (see ``_build_level_cache_query``). When that
+    breaks — a maritime polygon slipping back in, overlapping territories, a
+    custom ``--admin-source`` — nothing errors: the output just silently gains
+    duplicate features. Naming both counts turns the whole class of bug into a
+    visible one, at the cost of a metadata-only ``COUNT(*)``.
+    """
+    if input_rows is None or output_rows is None or input_rows == output_rows:
+        return
+    verb = "duplicated" if output_rows > input_rows else "dropped"
+    warn(
+        f"Admin join {verb} rows: {input_rows} input features, {output_rows} in the "
+        "output. Overlapping admin polygons emit one row per match; check the "
+        "admin dataset for overlapping boundaries."
+    )
+
+
+def _count_rows(con, source, is_table_ref=False):
+    """Row count for a file/URL or a temp table, or None if it cannot be read."""
+    try:
+        return con.execute(
+            f"SELECT COUNT(*) FROM {_format_input_ref(source, is_table_ref)}"
+        ).fetchone()[0]
+    except Exception:
+        return None
+
+
 def _setup_dataset_and_columns(
     input_parquet, dataset_name, dataset_source, levels, verbose, no_cache=False
 ):
@@ -437,10 +467,14 @@ def _build_admin_where_clauses_list(
     dry_run,
     is_table_ref=False,
     source_crs=None,
+    admin_source=None,
 ):
     """Build WHERE clauses for admin boundaries."""
     admin_where_clauses = []
-    subtype_filter = dataset.get_subtype_filter(levels)
+    # The admin source decides how much filtering the clause has to do: a
+    # pre-filtered cache needs only the subtype clause, a raw release needs the
+    # level's whole predicate (#819).
+    subtype_filter = dataset.get_subtype_filter(levels, source=admin_source)
     if subtype_filter:
         admin_where_clauses.append(subtype_filter)
         if verbose and not dry_run:
@@ -529,6 +563,7 @@ def _build_query_components(
         dry_run,
         is_table_ref=is_table_ref,
         source_crs=source_crs,
+        admin_source=admin_source,
     )
 
     admin_select_clause = _build_admin_select_clause(
@@ -662,6 +697,8 @@ def _execute_per_level_joins(
     normally preserves the row count.
     """
     current_source = input_url
+    # Cheap (metadata-only) baseline for the row-preservation check below.
+    input_rows = None if dry_run else _count_rows(con, input_url)
 
     for i, (level, col) in enumerate(zip(levels, partition_columns, strict=True)):
         level_admin_source = dataset.get_source_for_level(level, no_cache=no_cache)
@@ -727,6 +764,7 @@ def _execute_per_level_joins(
     total_features, features_with_admin, unique_counts = _get_result_stats(
         con, output_parquet, dataset, levels, verbose, prefix=prefix
     )
+    _warn_if_row_count_changed(input_rows, total_features)
     return total_features, features_with_admin, unique_counts
 
 

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import duckdb
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
     InvalidParameterError,
@@ -37,6 +37,39 @@ CACHE_AGE_THRESHOLD_SECONDS = 6 * 30 * 24 * 60 * 60  # ~180 days
 # independently, so shared borders are not perfectly coincident (see todo 016).
 _OVERTURE_SIMPLIFY_TOLERANCE_DEG = 0.0001
 
+# Land-only filter shared by every Overture level. ``IS NOT FALSE`` (not
+# ``= true``) drops only explicitly-maritime polygons and keeps land polygons
+# whose flag is NULL, so genuine territory with an unset flag is not silently
+# lost to SQL three-valued logic. See _build_level_cache_query for why maritime
+# (EEZ) polygons have to go.
+_OVERTURE_LAND_FILTER = "is_land IS NOT FALSE"
+
+# Overture files three ISO-coded islands under placeholder X* codes: Saba (XS)
+# and Sint Eustatius (XE) are both part of Bonaire, Sint Eustatius and Saba
+# (ISO 3166-1 BQ), and Jan Mayen (XJ) is part of Svalbard and Jan Mayen (SJ).
+# They are not disputed, so the X* filter below would drop real territory
+# (NULL -> 'ZZ' under --vecorel). Every other X* code (XK for Kosovo, ...) is a
+# genuine placeholder for a territory with no ISO code and stays excluded —
+# that policy predates #819.
+_OVERTURE_PLACEHOLDER_CODE_REMAP = {"XE": "BQ", "XS": "BQ", "XJ": "SJ"}
+
+
+def _overture_country_code_sql(col: str = "country") -> str:
+    """The country code for ``col``, with Overture's placeholder codes remapped.
+
+    Used both by the cache producer (so the remapped rows survive the X*
+    filter, which is applied to this expression rather than to the raw column)
+    and by the join-time column transform (so a ``--no-cache`` run, which reads
+    the raw release, emits the same codes the cache stores). Re-applying it to
+    an already-remapped value is a no-op, so the cached path is unaffected.
+    """
+    whens = " ".join(
+        f"WHEN {col} = '{_escape_sql_string(raw)}' THEN '{_escape_sql_string(iso)}'"
+        for raw, iso in _OVERTURE_PLACEHOLDER_CODE_REMAP.items()
+    )
+    return f"CASE {whens} ELSE {col} END"
+
+
 # Per-level cache schema for Overture. Declares, in one place, the Overture
 # subtypes each level draws from, the columns its cache projects, and any
 # level-specific row filters, so the cache producer (_build_level_cache_query)
@@ -44,25 +77,33 @@ _OVERTURE_SIMPLIFY_TOLERANCE_DEG = 0.0001
 # level fails loudly instead of being silently treated as a region.
 _OVERTURE_LEVEL_CACHE_CONFIG: dict[str, dict[str, list[str]]] = {
     "country": {
-        # Overture splits sovereign states ("country", 219 land rows) from
-        # dependent territories ("dependency", 53: French Guiana, Puerto Rico,
-        # Reunion, Guadeloupe, Mayotte, New Caledonia, Greenland, Hong Kong,
-        # Macao, Guam, the Channel Islands, ...) — 197 and 50 respectively once
-        # the X*/AQ filters below apply. Both classes carry an ISO 3166-1
-        # alpha-2 `country` code, so the country level takes both; filtering to
-        # 'country' alone left every dependency unattributed (NULL -> 'ZZ'
-        # under --vecorel). See #819.
+        # Overture splits its two country-shaped classes: "country" (219 land
+        # rows — sovereign states plus a few that are not, such as MF, SX, TW
+        # and XK) from dependent territories ("dependency", 53: French Guiana,
+        # Puerto Rico, Reunion, Guadeloupe, Mayotte, New Caledonia, Greenland,
+        # Hong Kong, Macao, Guam, the Channel Islands, ...) — 197 and 53
+        # respectively once the X*/AQ filters below apply, the three
+        # placeholder-coded dependencies being remapped rather than dropped.
+        # Both classes carry an ISO 3166-1 alpha-2 `country` code, so the
+        # country level takes both; filtering to 'country' alone left every
+        # dependency unattributed (NULL -> 'ZZ' under --vecorel). See #819.
         #
-        # This keeps the level non-overlapping, which the memory-safe plain
-        # LEFT JOIN relies on: a dependency is not contained in its sovereign's
-        # polygon (Overture's FR is metropolitan France only). Verified against
-        # release 2026-08-19.0 — the only country/dependency intersections are
-        # six shared borders (GF-BR, GF-SR, GL-CA, GI-ES, HK-CN, MO-CN), all of
-        # zero area, and no dependency intersects another dependency.
+        # This keeps the level effectively non-overlapping, which the
+        # memory-safe plain LEFT JOIN relies on: a dependency is not contained
+        # in its sovereign's polygon (Overture's FR is metropolitan France
+        # only). Measured on the simplified geometry this cache actually stores
+        # (release 2026-07-22.0), the only country/dependency intersections are
+        # six shared borders — SR/GF, HK/CN, BR/GF, MO/CN, ES/GI, CA/GL — and
+        # they are sub-hectare slivers (3.6e-07 deg² at worst, ~0 for CA/GL)
+        # left by simplifying each polygon independently. That is six orders of
+        # magnitude below the country-country overlaps the join already lives
+        # with (CL-AR alone is 0.192 deg²), so the invariant is approximate, not
+        # exact: a feature sitting inside such a sliver is emitted twice.
         "subtypes": ["country", "dependency"],
         "cols": ["bbox", "country", "subtype"],
-        # Exclude disputed (X*) territories and Antarctica.
-        "extra_filters": ["country NOT LIKE 'X%'", "country != 'AQ'"],
+        # Exclude Antarctica and the disputed/uncoded X* territories — applied
+        # to the remapped code so BQ/SJ survive.
+        "extra_filters": [f"{_overture_country_code_sql()} NOT LIKE 'X%'", "country != 'AQ'"],
     },
     "region": {
         # Only the country level widens: a dependency polygon is country-shaped,
@@ -72,6 +113,11 @@ _OVERTURE_LEVEL_CACHE_CONFIG: dict[str, dict[str, list[str]]] = {
         "extra_filters": [],
     },
 }
+
+
+def _overture_subtype_sql(subtypes: list[str]) -> str:
+    """Render an ``IN`` predicate over the given subtypes."""
+    return "subtype IN ({})".format(", ".join(f"'{_escape_sql_string(s)}'" for s in subtypes))
 
 
 def _overture_subtypes_for_levels(levels: list[str]) -> list[str]:
@@ -84,9 +130,69 @@ def _overture_subtypes_for_levels(levels: list[str]) -> list[str]:
     return subtypes
 
 
-def _overture_subtype_sql(subtypes: list[str]) -> str:
-    """Render an ``IN`` predicate over the given subtypes."""
-    return "subtype IN ({})".format(", ".join(f"'{s}'" for s in subtypes))
+def _level_cache_config(level: str) -> dict[str, list[str]]:
+    """The cache config for ``level``, or raise for an unconfigured level."""
+    try:
+        return _OVERTURE_LEVEL_CACHE_CONFIG[level]
+    except KeyError:
+        raise ValueError(f"No per-level cache config for admin level: {level!r}") from None
+
+
+def _remove_stale_level_caches(cache_dir: Path, version: str, level: str, cache_path: Path) -> None:
+    """Delete this level's superseded cache files for ``version``.
+
+    The cache key encodes the filters baked into the file, so it changes
+    whenever those filters change: the "-land" rename (todo 031) orphaned the
+    unsuffixed file, and the "-dependency" segment (#819) orphaned the ~40MB
+    ``-country-land.parquet`` one. Anything matching this level and version
+    that is not the file we are about to use is dead weight.
+    """
+    for stale in cache_dir.glob(f"overture-{version}-{level}*.parquet"):
+        if stale == cache_path:
+            continue
+        try:
+            stale.unlink()
+        except OSError:
+            pass  # A cache we cannot delete is not worth failing the run over.
+
+
+def _overture_level_predicate(level: str) -> str | None:
+    """The full row predicate for one Overture admin level.
+
+    Subtypes, the land-only filter and the level's own extra filters, ANDed —
+    exactly the ``WHERE`` the level's cache is built with. ``None`` for a level
+    with no cache config.
+    """
+    config = _OVERTURE_LEVEL_CACHE_CONFIG.get(level)
+    if not config:
+        return None
+    return " AND ".join(
+        [
+            _overture_subtype_sql(config["subtypes"]),
+            _OVERTURE_LAND_FILTER,
+            *config["extra_filters"],
+        ]
+    )
+
+
+def _overture_levels_predicate(levels: list[str]) -> str | None:
+    """The row predicate admitting every configured level in ``levels``.
+
+    Levels are OR'd, not AND'd, and each keeps its own filters: the country
+    level's placeholder/Antarctica filters must not leak onto the region level.
+    A repeated level contributes once. The result is parenthesised when it
+    contains an ``OR``, because callers AND it with an extent filter.
+    """
+    seen: list[str] = []
+    for level in levels:
+        if level not in seen:
+            seen.append(level)
+    predicates = [p for p in (_overture_level_predicate(level) for level in seen) if p]
+    if not predicates:
+        return None
+    if len(predicates) == 1:
+        return predicates[0]
+    return "({})".format(" OR ".join(f"({p})" for p in predicates))
 
 
 def get_cache_dir() -> Path:
@@ -458,12 +564,15 @@ class AdminDataset(ABC):
         """
         return {}
 
-    def get_subtype_filter(self, levels: list[str]) -> str | None:
+    def get_subtype_filter(self, levels: list[str], source: str | None = None) -> str | None:
         """
         Get SQL WHERE clause to filter by subtype (for datasets that use subtype).
 
         Args:
             levels: List of level names to include
+            source: The resolved source the clause will run against. Datasets
+                whose filters depend on which source is being read (a raw
+                release vs. a pre-filtered cache) use it; others ignore it.
 
         Returns:
             SQL WHERE clause string or None if not applicable
@@ -690,7 +799,8 @@ class OvertureAdminDataset(AdminDataset):
     Provides hierarchical administrative boundaries at two levels, compliant with
     the Vecorel administrative division extension specification:
     - country: Country level → admin:country_code. Covers both of Overture's
-      sovereign classes, ``subtype`` ``country`` (219 sovereign states) and
+      two country-shaped classes, ``subtype`` ``country`` (219 rows: sovereign
+      states plus a few that are not, such as MF, SX, TW and XK) and
       ``dependency`` (53 dependent territories such as French Guiana, Puerto
       Rico and Greenland), since both carry ISO 3166-1 alpha-2 codes.
     - region: First-level subdivisions (3,544 unique regions) → admin:subdivision_code
@@ -754,21 +864,51 @@ class OvertureAdminDataset(AdminDataset):
         """Overture uses Hive partitioning."""
         return {"hive_partitioning": 1}
 
-    def get_subtype_filter(self, levels: list[str]) -> str | None:
-        """Filter by subtype to only load relevant admin levels.
+    def _is_prefiltered_source(self, source: str | None) -> bool:
+        """Whether ``source`` already holds exactly the rows a level selects.
 
-        Shares :data:`_OVERTURE_LEVEL_CACHE_CONFIG` with the cache producer so
-        the ``--no-cache`` path and the cached path admit the same rows — the
-        country level therefore covers dependent territories here too (#819).
+        True for the per-level caches this class produces —
+        :meth:`_build_level_cache_query` bakes every filter in, and the cache
+        projects only ``bbox``/``country``/``subtype`` (no ``is_land``), so the
+        full predicate could not even bind against it — and for a user-supplied
+        ``--admin-source``, whose schema gpio does not control.
         """
-        subtypes = _overture_subtypes_for_levels(levels)
-        if subtypes:
-            return _overture_subtype_sql(subtypes)
-        return None
+        if self.source_path is not None:
+            return True
+        if source is None:
+            return False
+        return Path(source).parent == get_cache_dir()
+
+    def get_subtype_filter(self, levels: list[str], source: str | None = None) -> str | None:
+        """The row filter that selects the requested admin levels.
+
+        Against Overture's raw release — the ``--no-cache`` path — this is the
+        whole per-level predicate: subtypes, the land-only filter and the
+        level's own extra filters, exactly the ``WHERE`` its cache is built
+        with, so both paths admit the same rows (#819). Emitting the subtype
+        clause alone let a feature match both a territory's land polygon and
+        its maritime (EEZ) polygon, and the plain LEFT JOIN then emitted it
+        twice — for every sovereign, and for the 53 dependencies this level now
+        attributes.
+
+        Against a pre-filtered source (see :meth:`_is_prefiltered_source`) only
+        the subtype clause is emitted: the rest is already baked in, and
+        ``is_land`` is not there to filter on.
+        """
+        if self._is_prefiltered_source(source):
+            subtypes = _overture_subtypes_for_levels(levels)
+            return _overture_subtype_sql(subtypes) if subtypes else None
+        return _overture_levels_predicate(levels)
 
     def get_column_transform(self, level_name: str) -> str | None:
         """
         Get SQL expression to transform a column value for Vecorel compliance.
+
+        For country codes, remaps Overture's placeholder X* codes for the three
+        ISO-coded islands that carry them (XS/XE -> BQ, XJ -> SJ). The cache
+        already stores the remapped code, so this only bites on the
+        ``--no-cache`` path, where it reads the raw release; re-applying it to a
+        cached BQ/SJ is a no-op.
 
         For region codes, strips the country prefix from ISO 3166-2 codes.
         Example: 'US-CA' becomes 'CA', 'AR-U' becomes 'U'
@@ -779,6 +919,11 @@ class OvertureAdminDataset(AdminDataset):
         Returns:
             SQL transformation expression or None if no transform needed
         """
+        if level_name == "country":
+            # Qualified with the admin alias `b.` (and quoted) for the same
+            # reason as the region transform below: the input may carry its own
+            # `country` column, which `a.*` forwards through the join.
+            return _overture_country_code_sql('b."country"')
         if level_name == "region":
             # Strip country prefix for Vecorel compliance. Qualify with the admin
             # alias `b.` (and quote) so the ref is unambiguous when the input
@@ -809,8 +954,10 @@ class OvertureAdminDataset(AdminDataset):
         # subtypes a level draws on beyond its own name are appended, so the
         # dependency-aware country cache (#819) gets a fresh key while the
         # unchanged region cache keeps its own and is not re-downloaded.
-        config = _OVERTURE_LEVEL_CACHE_CONFIG.get(level, {})
-        extra = [s for s in config.get("subtypes", [level]) if s != level]
+        # An unknown level raises here rather than naming a file that
+        # _build_level_cache_query would then refuse to fill.
+        config = _level_cache_config(level)
+        extra = [s for s in config["subtypes"] if s != level]
         suffix = f"-{'-'.join(extra)}" if extra else ""
         return cache_dir / f"overture-{version}-{level}{suffix}-land.parquet"
 
@@ -830,21 +977,20 @@ class OvertureAdminDataset(AdminDataset):
         NULL, so genuine territory with an unset flag is not silently lost to
         SQL three-valued logic. Columns and level-specific filters come from
         :data:`_OVERTURE_LEVEL_CACHE_CONFIG` so an unknown level raises rather
-        than being mis-projected.
+        than being mis-projected, and the ``WHERE`` is the same predicate
+        :meth:`get_subtype_filter` hands the ``--no-cache`` path.
+
+        The projected ``country`` column carries the placeholder-code remap
+        (see :func:`_overture_country_code_sql`), so the cache stores BQ/SJ
+        rather than Overture's XS/XE/XJ.
         """
-        try:
-            config = _OVERTURE_LEVEL_CACHE_CONFIG[level]
-        except KeyError:
-            raise ValueError(f"No per-level cache config for admin level: {level!r}") from None
+        config = _level_cache_config(level)
         tol = _OVERTURE_SIMPLIFY_TOLERANCE_DEG
-        cols = ", ".join(config["cols"])
-        where = " AND ".join(
-            [
-                _overture_subtype_sql(config["subtypes"]),
-                "is_land IS NOT FALSE",
-                *config["extra_filters"],
-            ]
+        cols = ", ".join(
+            _overture_country_code_sql() + " AS country" if col == "country" else col
+            for col in config["cols"]
         )
+        where = _overture_level_predicate(level)
         return (
             f"SELECT ST_SimplifyPreserveTopology(geometry, {tol}) as geometry, "
             f"{cols} "
@@ -900,12 +1046,9 @@ class OvertureAdminDataset(AdminDataset):
             try:
                 for level in self.get_available_levels():
                     cache_path = self.get_cached_path_for_level(level)
-                    # Remove the pre-fix (maritime-contaminated) unsuffixed cache
-                    # for this level/version so it doesn't linger after the
-                    # "-land" rename (todo 031).
-                    legacy_cache = cache_dir / f"overture-{version}-{level}.parquet"
-                    if legacy_cache.exists():
-                        legacy_cache.unlink()
+                    # Drop every superseded cache for this level/version so
+                    # renamed keys don't strand ~40MB files in the cache dir.
+                    _remove_stale_level_caches(cache_dir, version, level, cache_path)
 
                     if cache_path.exists() and cache_path.stat().st_size > 0:
                         continue

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -37,21 +37,56 @@ CACHE_AGE_THRESHOLD_SECONDS = 6 * 30 * 24 * 60 * 60  # ~180 days
 # independently, so shared borders are not perfectly coincident (see todo 016).
 _OVERTURE_SIMPLIFY_TOLERANCE_DEG = 0.0001
 
-# Per-level cache schema for Overture. Declares, in one place, the columns each
-# level's cache projects and any level-specific row filters, so the cache
-# producer (_build_level_cache_query) has a single source of truth and an
-# unknown level fails loudly instead of being silently treated as a region.
+# Per-level cache schema for Overture. Declares, in one place, the Overture
+# subtypes each level draws from, the columns its cache projects, and any
+# level-specific row filters, so the cache producer (_build_level_cache_query)
+# and the no-cache subtype filter share a single source of truth and an unknown
+# level fails loudly instead of being silently treated as a region.
 _OVERTURE_LEVEL_CACHE_CONFIG: dict[str, dict[str, list[str]]] = {
     "country": {
+        # Overture splits sovereign states ("country", 219 land rows) from
+        # dependent territories ("dependency", 53: French Guiana, Puerto Rico,
+        # Reunion, Guadeloupe, Mayotte, New Caledonia, Greenland, Hong Kong,
+        # Macao, Guam, the Channel Islands, ...) — 197 and 50 respectively once
+        # the X*/AQ filters below apply. Both classes carry an ISO 3166-1
+        # alpha-2 `country` code, so the country level takes both; filtering to
+        # 'country' alone left every dependency unattributed (NULL -> 'ZZ'
+        # under --vecorel). See #819.
+        #
+        # This keeps the level non-overlapping, which the memory-safe plain
+        # LEFT JOIN relies on: a dependency is not contained in its sovereign's
+        # polygon (Overture's FR is metropolitan France only). Verified against
+        # release 2026-08-19.0 — the only country/dependency intersections are
+        # six shared borders (GF-BR, GF-SR, GL-CA, GI-ES, HK-CN, MO-CN), all of
+        # zero area, and no dependency intersects another dependency.
+        "subtypes": ["country", "dependency"],
         "cols": ["bbox", "country", "subtype"],
         # Exclude disputed (X*) territories and Antarctica.
         "extra_filters": ["country NOT LIKE 'X%'", "country != 'AQ'"],
     },
     "region": {
+        # Only the country level widens: a dependency polygon is country-shaped,
+        # so admitting it here would shadow the regions nested inside it.
+        "subtypes": ["region"],
         "cols": ["bbox", "country", "region", "subtype"],
         "extra_filters": [],
     },
 }
+
+
+def _overture_subtypes_for_levels(levels: list[str]) -> list[str]:
+    """Overture subtypes backing the given levels, in order, without repeats."""
+    subtypes: list[str] = []
+    for level in levels:
+        for subtype in _OVERTURE_LEVEL_CACHE_CONFIG.get(level, {}).get("subtypes", []):
+            if subtype not in subtypes:
+                subtypes.append(subtype)
+    return subtypes
+
+
+def _overture_subtype_sql(subtypes: list[str]) -> str:
+    """Render an ``IN`` predicate over the given subtypes."""
+    return "subtype IN ({})".format(", ".join(f"'{s}'" for s in subtypes))
 
 
 def get_cache_dir() -> Path:
@@ -654,7 +689,10 @@ class OvertureAdminDataset(AdminDataset):
 
     Provides hierarchical administrative boundaries at two levels, compliant with
     the Vecorel administrative division extension specification:
-    - country: Country level (219 unique countries) → admin:country_code
+    - country: Country level → admin:country_code. Covers both of Overture's
+      sovereign classes, ``subtype`` ``country`` (219 sovereign states) and
+      ``dependency`` (53 dependent territories such as French Guiana, Puerto
+      Rico and Greenland), since both carry ISO 3166-1 alpha-2 codes.
     - region: First-level subdivisions (3,544 unique regions) → admin:subdivision_code
 
     Vecorel Compliance:
@@ -717,16 +755,15 @@ class OvertureAdminDataset(AdminDataset):
         return {"hive_partitioning": 1}
 
     def get_subtype_filter(self, levels: list[str]) -> str | None:
-        """Filter by subtype to only load relevant admin levels."""
-        # Map level names to Overture subtype values
-        level_to_subtype = {
-            "country": "country",
-            "region": "region",
-        }
-        subtypes = [level_to_subtype[level] for level in levels if level in level_to_subtype]
+        """Filter by subtype to only load relevant admin levels.
+
+        Shares :data:`_OVERTURE_LEVEL_CACHE_CONFIG` with the cache producer so
+        the ``--no-cache`` path and the cached path admit the same rows — the
+        country level therefore covers dependent territories here too (#819).
+        """
+        subtypes = _overture_subtypes_for_levels(levels)
         if subtypes:
-            subtype_list = ", ".join([f"'{s}'" for s in subtypes])
-            return f"subtype IN ({subtype_list})"
+            return _overture_subtype_sql(subtypes)
         return None
 
     def get_column_transform(self, level_name: str) -> str | None:
@@ -766,9 +803,16 @@ class OvertureAdminDataset(AdminDataset):
     def get_cached_path_for_level(self, level: str) -> Path:
         cache_dir = get_cache_dir()
         version = self.get_version()
-        # "-land" suffix invalidates pre-fix caches that mixed in maritime (EEZ)
-        # polygons; see _build_level_cache_query for the rationale.
-        return cache_dir / f"overture-{version}-{level}-land.parquet"
+        # The filename encodes the filters baked into the file so a stale cache
+        # is never silently reused. "-land" invalidates pre-fix caches that
+        # mixed in maritime (EEZ) polygons (see _build_level_cache_query); the
+        # subtypes a level draws on beyond its own name are appended, so the
+        # dependency-aware country cache (#819) gets a fresh key while the
+        # unchanged region cache keeps its own and is not re-downloaded.
+        config = _OVERTURE_LEVEL_CACHE_CONFIG.get(level, {})
+        extra = [s for s in config.get("subtypes", [level]) if s != level]
+        suffix = f"-{'-'.join(extra)}" if extra else ""
+        return cache_dir / f"overture-{version}-{level}{suffix}-land.parquet"
 
     def _build_level_cache_query(self, level: str, source: str) -> str:
         """Build the SELECT that produces a non-overlapping per-level cache.
@@ -795,7 +839,11 @@ class OvertureAdminDataset(AdminDataset):
         tol = _OVERTURE_SIMPLIFY_TOLERANCE_DEG
         cols = ", ".join(config["cols"])
         where = " AND ".join(
-            [f"subtype = '{level}'", "is_land IS NOT FALSE", *config["extra_filters"]]
+            [
+                _overture_subtype_sql(config["subtypes"]),
+                "is_land IS NOT FALSE",
+                *config["extra_filters"],
+            ]
         )
         return (
             f"SELECT ST_SimplifyPreserveTopology(geometry, {tol}) as geometry, "

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -183,16 +183,19 @@ def _compute_input_extent(con, input_url, input_bbox_col, input_geom_col, source
     return None
 
 
-def _build_admin_where_clause(dataset, levels, admin_bbox_col, extent, verbose):
+def _build_admin_where_clause(dataset, levels, admin_bbox_col, extent, verbose, admin_source=None):
     """Build WHERE clause for admin boundaries with filters.
 
     ``extent`` is the precomputed input extent (from ``_compute_input_extent``)
     or None; it is reused across levels instead of being recomputed each call.
+    ``admin_source`` is the resolved source for these levels: how much
+    filtering the subtype clause has to carry depends on whether it is a
+    pre-filtered cache or a raw release (#819).
     """
     admin_where_clauses = []
 
     # Add subtype filter if applicable
-    subtype_filter = dataset.get_subtype_filter(levels)
+    subtype_filter = dataset.get_subtype_filter(levels, source=admin_source)
     if subtype_filter:
         admin_where_clauses.append(subtype_filter)
         if verbose:
@@ -401,7 +404,7 @@ def _perform_per_level_enrichment_join(
         output_column_names.extend(level_outputs)
 
         admin_where_clause = _build_admin_where_clause(
-            dataset, [level], admin_bbox_col, extent, verbose
+            dataset, [level], admin_bbox_col, extent, verbose, admin_source=level_source
         )
 
         is_last = i == len(levels) - 1
@@ -759,7 +762,12 @@ def partition_by_admin_hierarchical(
                     con, input_url, input_bbox_col, input_geom_col, source_crs
                 )
                 admin_where_clause = _build_admin_where_clause(
-                    dataset, levels, admin_bbox_col, extent, verbose
+                    dataset,
+                    levels,
+                    admin_bbox_col,
+                    extent,
+                    verbose,
+                    admin_source=dataset.get_source(),
                 )
                 _perform_enrichment_join(
                     con,

--- a/tests/test_admin_datasets.py
+++ b/tests/test_admin_datasets.py
@@ -23,6 +23,35 @@ from geoparquet_io.core.admin_datasets import (
 )
 
 
+def _spatial_connection(duckdb):
+    """An in-memory DuckDB with spatial loaded, configured as gpio configures it."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    con.execute("SET geometry_always_xy=true;")
+    return con
+
+
+def _write_divisions_fixture(con, tmp_path, rows, name="division_area.parquet"):
+    """Write an Overture-divisions-shaped fixture and return its path.
+
+    ``rows`` are ``(wkt, (xmin, xmax, ymin, ymax), country, subtype, is_land)``.
+    The geometry column is written as a real ``GEOMETRY`` (as Overture's own
+    files read back), so the emitted queries — ``ST_SimplifyPreserveTopology``
+    included — can be run verbatim instead of being rewritten by the test.
+    """
+    src = tmp_path / name
+    selects = []
+    for wkt, (xmin, xmax, ymin, ymax), country, subtype, is_land in rows:
+        land = "NULL" if is_land is None else str(is_land).lower()
+        selects.append(
+            f"SELECT ST_GeomFromText('{wkt}') AS geometry, "
+            f"{{'xmin':{xmin},'xmax':{xmax},'ymin':{ymin},'ymax':{ymax}}} AS bbox, "
+            f"'{country}' AS country, '{subtype}' AS subtype, {land}::BOOLEAN AS is_land"
+        )
+    con.execute(f"COPY ({' UNION ALL '.join(selects)}) TO '{src}' (FORMAT PARQUET)")
+    return src
+
+
 class TestCurrentAdminDataset:
     """Test CurrentAdminDataset implementation."""
 
@@ -184,7 +213,7 @@ class TestOvertureAdminDataset:
         # The country level spans both of Overture's sovereign classes, so
         # dependent territories are attributed rather than left NULL (#819).
         filter_country = dataset.get_subtype_filter(["country"])
-        assert filter_country == "subtype IN ('country', 'dependency')"
+        assert "subtype IN ('country', 'dependency')" in filter_country
 
         # Test with both levels
         filter_both = dataset.get_subtype_filter(["country", "region"])
@@ -193,11 +222,153 @@ class TestOvertureAdminDataset:
         assert "region" in filter_both
         assert "subtype IN" in filter_both
 
-    def test_get_subtype_filter_does_not_duplicate_subtypes(self):
-        """Overlapping level requests must not emit a subtype twice."""
+    def test_get_subtype_filter_carries_the_whole_level_predicate(self):
+        """``--no-cache`` must admit exactly the rows the cache holds (#819).
+
+        The cache bakes ``is_land IS NOT FALSE`` and the country level's
+        placeholder/Antarctica filters into the file. A ``--no-cache`` run reads
+        the raw Overture release instead, so the same filters have to travel in
+        the subtype predicate or a feature matches both a territory's land
+        polygon and its maritime (EEZ) polygon and the LEFT JOIN emits it twice.
+        """
+        dataset = OvertureAdminDataset()
+        filter_country = dataset.get_subtype_filter(["country"])
+        assert "is_land IS NOT FALSE" in filter_country
+        assert "NOT LIKE 'X%'" in filter_country
+        assert "'AQ'" in filter_country
+
+        # The region level has no extra filters but still needs the land filter.
+        filter_region = dataset.get_subtype_filter(["region"])
+        assert "is_land IS NOT FALSE" in filter_region
+        assert "NOT LIKE 'X%'" not in filter_region
+
+    def test_get_subtype_filter_drops_the_extras_for_a_prefiltered_source(self):
+        """A per-level cache already holds exactly those rows — and does not
+        project ``is_land`` at all — so only the subtype clause is emitted.
+
+        Same for a user-supplied ``--admin-source``: gpio does not control its
+        schema, so it keeps the pre-#819 clause.
+        """
+        dataset = OvertureAdminDataset()
+        cached = dataset.get_subtype_filter(
+            ["country"], source=str(get_cache_dir() / "overture-x-country-dependency-land.parquet")
+        )
+        assert cached == "subtype IN ('country', 'dependency')"
+
+        custom = OvertureAdminDataset(source_path="/data/my-divisions.parquet")
+        assert custom.get_subtype_filter(["country"], source="/data/my-divisions.parquet") == (
+            "subtype IN ('country', 'dependency')"
+        )
+
+    def test_get_subtype_filter_ors_levels_with_different_filters(self):
+        """A multi-level request keeps each level's own filters.
+
+        The country level's placeholder/Antarctica filters must not leak onto
+        the region level, so the levels are OR'd rather than AND'd, and the
+        whole predicate is parenthesised because callers AND it with an extent
+        filter.
+        """
         dataset = OvertureAdminDataset()
         filter_both = dataset.get_subtype_filter(["country", "region"])
-        assert filter_both == "subtype IN ('country', 'dependency', 'region')"
+        assert filter_both.startswith("(") and filter_both.endswith(")")
+        assert ") OR (" in filter_both
+
+    def test_get_subtype_filter_does_not_duplicate_levels(self):
+        """A repeated level must not emit its predicate twice."""
+        dataset = OvertureAdminDataset()
+        assert dataset.get_subtype_filter(["country", "country"]) == dataset.get_subtype_filter(
+            ["country"]
+        )
+
+    def test_get_subtype_filter_no_cache_matches_each_feature_once(self, tmp_path):
+        """Behavioral (#819): a dependency's feature matches ONE polygon on the
+        ``--no-cache`` path.
+
+        Overture stores a land polygon and a maritime (EEZ) polygon per
+        territory; the EEZ polygon covers the landmass too. Filtering on
+        ``subtype`` alone matched both, so the plain LEFT JOIN duplicated every
+        row in French Guiana (and in the 50+ other dependencies this level now
+        attributes).
+        """
+        duckdb = pytest.importorskip("duckdb")
+        con = _spatial_connection(duckdb)
+        src = _write_divisions_fixture(
+            con,
+            tmp_path,
+            [
+                ("POLYGON((0 0,0 2,2 2,2 0,0 0))", (0.0, 2.0, 0.0, 2.0), "GF", "dependency", True),
+                # French Guiana's maritime polygon spans the landmass as well.
+                (
+                    "POLYGON((-5 -5,-5 5,5 5,5 -5,-5 -5))",
+                    (-5.0, 5.0, -5.0, 5.0),
+                    "GF",
+                    "dependency",
+                    False,
+                ),
+                ("POLYGON((2 0,2 2,4 2,4 0,2 0))", (2.0, 4.0, 0.0, 2.0), "BR", "country", True),
+            ],
+        )
+
+        predicate = OvertureAdminDataset().get_subtype_filter(["country"])
+        matches = con.execute(
+            f"""
+            SELECT country FROM read_parquet('{src}', hive_partitioning=1)
+            WHERE {predicate}
+              AND ST_Intersects(geometry, ST_GeomFromText('POINT(1 1)'))
+            """
+        ).fetchall()
+        assert matches == [("GF",)], "no-cache predicate must match each feature exactly once"
+
+    def test_placeholder_country_codes_map_to_their_iso_codes(self, tmp_path):
+        """Saba, Sint Eustatius and Jan Mayen carry Overture placeholder X*
+        codes but are not disputed: their ISO 3166-1 codes are BQ, BQ and SJ.
+
+        Without the remap the disputed-territory filter dropped them to NULL ->
+        'ZZ' under ``--vecorel``. Genuinely disputed X* codes (XK) stay out.
+        """
+        duckdb = pytest.importorskip("duckdb")
+        con = _spatial_connection(duckdb)
+        src = _write_divisions_fixture(
+            con,
+            tmp_path,
+            [
+                ("POLYGON((0 0,0 1,1 1,1 0,0 0))", (0.0, 1.0, 0.0, 1.0), "XS", "dependency", True),
+                ("POLYGON((2 0,2 1,3 1,3 0,2 0))", (2.0, 3.0, 0.0, 1.0), "XE", "dependency", True),
+                ("POLYGON((4 0,4 1,5 1,5 0,4 0))", (4.0, 5.0, 0.0, 1.0), "XJ", "dependency", True),
+                ("POLYGON((6 0,6 1,7 1,7 0,6 0))", (6.0, 7.0, 0.0, 1.0), "XK", "country", True),
+                ("POLYGON((8 0,8 1,9 1,9 0,8 0))", (8.0, 9.0, 0.0, 1.0), "AQ", "country", True),
+            ],
+        )
+
+        dataset = OvertureAdminDataset()
+        cached = con.execute(
+            f"SELECT country FROM ({dataset._build_level_cache_query('country', str(src))}) "
+            "ORDER BY country"
+        ).fetchall()
+        assert [r[0] for r in cached] == ["BQ", "BQ", "SJ"]
+
+        # The --no-cache path reads the raw release, so the same codes have to
+        # survive its predicate and be remapped by the join's column transform.
+        no_cache = con.execute(
+            f"""
+            SELECT {dataset.get_column_transform("country")} AS code
+            FROM read_parquet('{src}', hive_partitioning=1) b
+            WHERE {dataset.get_subtype_filter(["country"])}
+            ORDER BY code
+            """
+        ).fetchall()
+        assert [r[0] for r in no_cache] == ["BQ", "BQ", "SJ"]
+
+    def test_country_transform_leaves_real_codes_alone(self):
+        """The remap is a no-op on already-correct codes, so re-applying it to a
+        cache that already stores BQ/SJ cannot corrupt them."""
+        duckdb = pytest.importorskip("duckdb")
+        con = _spatial_connection(duckdb)
+        expr = OvertureAdminDataset().get_column_transform("country").replace('b."country"', "c")
+        rows = con.execute(
+            f"SELECT {expr} FROM (VALUES ('US'), ('BQ'), ('SJ'), (NULL)) t(c)"
+        ).fetchall()
+        assert [r[0] for r in rows] == ["US", "BQ", "SJ", None]
 
     def test_get_column_transform_region(self):
         """Test that region level returns SQL transformation for Vecorel compliance."""
@@ -213,12 +384,22 @@ class TestOvertureAdminDataset:
         assert 'ELSE b."region" END' in transform
 
     def test_get_column_transform_country(self):
-        """Test that country level returns None (no transformation needed)."""
+        """The country level remaps Overture's placeholder X* codes to the ISO
+        codes those territories actually hold (XS/XE -> BQ, XJ -> SJ).
+
+        Column refs are qualified with the admin alias ``b.`` (and quoted) so
+        the transform stays unambiguous when the input carries its own
+        ``country`` column.
+        """
         dataset = OvertureAdminDataset()
         transform = dataset.get_column_transform("country")
 
-        # Country doesn't need transformation
-        assert transform is None
+        assert transform is not None
+        assert "'XS' THEN 'BQ'" in transform
+        assert "'XE' THEN 'BQ'" in transform
+        assert "'XJ' THEN 'SJ'" in transform
+        assert 'ELSE b."country" END' in transform
+        assert "country" not in transform.replace('b."country"', "").replace("'BQ'", "")
 
     def test_get_column_transform_unknown_level(self):
         """Test that unknown levels return None."""
@@ -326,32 +507,28 @@ class TestOvertureAdminDataset:
         point matched nothing (-> NULL -> 'ZZ'); after, it matches GF only.
         Matching *once* is the invariant the memory-safe plain LEFT JOIN
         depends on, so the border-sharing BR polygon is here on purpose.
-        """
-        from geoparquet_io.core.admin_datasets import _OVERTURE_SIMPLIFY_TOLERANCE_DEG
 
+        The probe sits a hair inside GF *at the shared border* (x=2), where a
+        double match would actually show up, and the cache query is run exactly
+        as emitted — simplification included. Simplification is why the
+        invariant is approximate rather than exact: two independently simplified
+        borders leave sub-hectare slivers, so an interior probe is the honest
+        assertion and the sliver caveat is documented on
+        ``_OVERTURE_LEVEL_CACHE_CONFIG``.
+        """
         duckdb = pytest.importorskip("duckdb")
-        con = duckdb.connect()
-        con.execute("INSTALL spatial; LOAD spatial;")
-        con.execute("SET geometry_always_xy=true;")
-        src = tmp_path / "division_area.parquet"
-        con.execute(
-            f"""
-            COPY (
-              SELECT ST_AsWKB(ST_GeomFromText('POLYGON((0 0,0 2,2 2,2 0,0 0))')) AS geometry,
-                     {{'xmin':0.0,'xmax':2.0,'ymin':0.0,'ymax':2.0}} AS bbox,
-                     'GF' AS country, 'dependency' AS subtype, true AS is_land
-              UNION ALL SELECT ST_AsWKB(ST_GeomFromText('POLYGON((2 0,2 2,4 2,4 0,2 0))')),
-                     {{'xmin':2.0,'xmax':4.0,'ymin':0.0,'ymax':2.0}}, 'BR', 'country', true
-            ) TO '{src}' (FORMAT PARQUET)
-            """
+        con = _spatial_connection(duckdb)
+        src = _write_divisions_fixture(
+            con,
+            tmp_path,
+            [
+                ("POLYGON((0 0,0 2,2 2,2 0,0 0))", (0.0, 2.0, 0.0, 2.0), "GF", "dependency", True),
+                ("POLYGON((2 0,2 2,4 2,4 0,2 0))", (2.0, 4.0, 0.0, 2.0), "BR", "country", True),
+            ],
         )
 
         query = OvertureAdminDataset()._build_level_cache_query("country", str(src))
-        runnable = query.replace(
-            f"ST_SimplifyPreserveTopology(geometry, {_OVERTURE_SIMPLIFY_TOLERANCE_DEG})",
-            "geometry",
-        )
-        con.execute(f"CREATE TABLE land AS SELECT * FROM ({runnable})")
+        con.execute(f"CREATE TABLE land AS SELECT * FROM ({query})")
 
         assert [
             r[0] for r in con.execute("SELECT country FROM land ORDER BY country").fetchall()
@@ -360,11 +537,48 @@ class TestOvertureAdminDataset:
             "GF",
         ]
 
-        pt = "ST_GeomFromText('POINT(1 1)')"
+        # Just inside GF, right on the GF/BR border — where a duplicate match
+        # would surface if the two polygons overlapped.
+        pt = "ST_GeomFromText('POINT(1.999999 1)')"
         matches = con.execute(
-            f"SELECT country FROM land WHERE ST_Intersects(ST_GeomFromWKB(geometry), {pt})"
+            f"SELECT country FROM land WHERE ST_Intersects(geometry, {pt})"
         ).fetchall()
         assert matches == [("GF",)], "dependency feature must match its own code, exactly once"
+
+    def test_cached_path_rejects_unknown_level(self):
+        """An unconfigured level must fail the same way the cache producer does,
+        instead of inventing a plausible-looking filename for a cache that
+        ``_build_level_cache_query`` will refuse to build."""
+        dataset = OvertureAdminDataset()
+        with pytest.raises(ValueError, match="cache config"):
+            dataset.get_cached_path_for_level("locality")
+
+    def test_stale_level_caches_are_removed(self, tmp_path):
+        """Every superseded cache for this level/version is unlinked, not just
+        the legacy unsuffixed one.
+
+        The country cache key gained a "-dependency" segment in #819, so the
+        ~40MB ``-country-land.parquet`` file it supersedes would otherwise sit
+        in the cache dir forever.
+        """
+        from geoparquet_io.core.admin_datasets import _remove_stale_level_caches
+
+        version = "2026-07-22.0"
+        current = tmp_path / f"overture-{version}-country-dependency-land.parquet"
+        superseded = tmp_path / f"overture-{version}-country-land.parquet"
+        legacy = tmp_path / f"overture-{version}-country.parquet"
+        other_level = tmp_path / f"overture-{version}-region-land.parquet"
+        other_version = tmp_path / "overture-2026-01-01.0-country-land.parquet"
+        for path in (current, superseded, legacy, other_level, other_version):
+            path.write_bytes(b"stub")
+
+        _remove_stale_level_caches(tmp_path, version, "country", current)
+
+        assert current.exists(), "the current cache must survive"
+        assert other_level.exists(), "another level's cache must survive"
+        assert other_version.exists(), "another version's cache must survive"
+        assert not superseded.exists()
+        assert not legacy.exists()
 
     def test_cached_path_distinguishes_land_only_caches(self):
         """Cache filename encodes the land-only filter so stale (maritime-
@@ -384,40 +598,36 @@ class TestOvertureAdminDataset:
         polygon per level instead of two (land + maritime EEZ) — the root cause
         of the ~2.6x row multiplication (PR #474).
 
-        Runs the real ``_build_level_cache_query`` output, only substituting the
-        ``ST_SimplifyPreserveTopology`` wrapper (not implemented in the test
-        DuckDB build; the multiplication is in the join/filter, not the
-        simplification).
+        Runs the ``_build_level_cache_query`` output verbatim.
         """
-        from geoparquet_io.core.admin_datasets import _OVERTURE_SIMPLIFY_TOLERANCE_DEG
-
         duckdb = pytest.importorskip("duckdb")
-        con = duckdb.connect()
-        con.execute("INSTALL spatial; LOAD spatial;")
-        con.execute("SET geometry_always_xy=true;")
-        src = tmp_path / "division_area.parquet"
+        con = _spatial_connection(duckdb)
         # US: a land polygon AND a maritime (EEZ) polygon spanning the whole
         # territory (incl. the landmass). CA: a land polygon with NULL is_land.
-        con.execute(
-            f"""
-            COPY (
-              SELECT ST_AsWKB(ST_GeomFromText('POLYGON((0 0,0 1,1 1,1 0,0 0))')) AS geometry,
-                     {{'xmin':0.0,'xmax':1.0,'ymin':0.0,'ymax':1.0}} AS bbox,
-                     'US' AS country, 'country' AS subtype, true AS is_land
-              UNION ALL SELECT ST_AsWKB(ST_GeomFromText('POLYGON((-5 -5,-5 5,5 5,5 -5,-5 -5))')),
-                     {{'xmin':-5.0,'xmax':5.0,'ymin':-5.0,'ymax':5.0}}, 'US', 'country', false
-              UNION ALL SELECT ST_AsWKB(ST_GeomFromText('POLYGON((10 10,10 11,11 11,11 10,10 10))')),
-                     {{'xmin':10.0,'xmax':11.0,'ymin':10.0,'ymax':11.0}}, 'CA', 'country', NULL
-            ) TO '{src}' (FORMAT PARQUET)
-            """
+        src = _write_divisions_fixture(
+            con,
+            tmp_path,
+            [
+                ("POLYGON((0 0,0 1,1 1,1 0,0 0))", (0.0, 1.0, 0.0, 1.0), "US", "country", True),
+                (
+                    "POLYGON((-5 -5,-5 5,5 5,5 -5,-5 -5))",
+                    (-5.0, 5.0, -5.0, 5.0),
+                    "US",
+                    "country",
+                    False,
+                ),
+                (
+                    "POLYGON((10 10,10 11,11 11,11 10,10 10))",
+                    (10.0, 11.0, 10.0, 11.0),
+                    "CA",
+                    "country",
+                    None,
+                ),
+            ],
         )
 
         query = OvertureAdminDataset()._build_level_cache_query("country", str(src))
-        runnable = query.replace(
-            f"ST_SimplifyPreserveTopology(geometry, {_OVERTURE_SIMPLIFY_TOLERANCE_DEG})",
-            "geometry",
-        )
-        con.execute(f"CREATE TABLE land AS SELECT * FROM ({runnable})")
+        con.execute(f"CREATE TABLE land AS SELECT * FROM ({query})")
 
         # Maritime US polygon dropped; NULL-is_land CA land polygon kept.
         countries = [
@@ -427,7 +637,7 @@ class TestOvertureAdminDataset:
 
         pt = "ST_GeomFromText('POINT(0.5 0.5)')"
         n_land = con.execute(
-            f"SELECT count(*) FROM land WHERE ST_Intersects(ST_GeomFromWKB(geometry), {pt})"
+            f"SELECT count(*) FROM land WHERE ST_Intersects(geometry, {pt})"
         ).fetchone()[0]
         assert n_land == 1, "land-only cache must match each feature exactly once"
 
@@ -435,7 +645,7 @@ class TestOvertureAdminDataset:
         n_all = con.execute(
             f"""
             SELECT count(*) FROM read_parquet('{src}')
-            WHERE subtype='country' AND ST_Intersects(ST_GeomFromWKB(geometry), {pt})
+            WHERE subtype='country' AND ST_Intersects(geometry, {pt})
             """
         ).fetchone()[0]
         assert n_all == 2
@@ -1189,3 +1399,37 @@ class TestCacheEdgeCases:
         # This is a placeholder for thread-safety testing
         # The implementation should use atomic file operations
         pass
+
+
+class TestPerLevelJoinRowCountGuard:
+    """Runtime guard for the join-multiplication class of bugs.
+
+    The per-level caches are built to be non-overlapping so a plain LEFT JOIN
+    preserves the row count (see ``_build_level_cache_query``). When that
+    invariant breaks — a maritime polygon slipping back in, an overlapping
+    dependency, a custom ``--admin-source`` — the failure is silent duplication.
+    A cheap count comparison after the join names it instead.
+    """
+
+    def test_warns_when_the_join_changed_the_row_count(self, monkeypatch):
+        from geoparquet_io.core.add import admin_divisions
+
+        messages = []
+        monkeypatch.setattr(admin_divisions, "warn", messages.append)
+
+        admin_divisions._warn_if_row_count_changed(1000, 2600)
+
+        assert len(messages) == 1
+        assert "1000" in messages[0] and "2600" in messages[0]
+
+    def test_silent_when_the_row_count_is_preserved(self, monkeypatch):
+        from geoparquet_io.core.add import admin_divisions
+
+        messages = []
+        monkeypatch.setattr(admin_divisions, "warn", messages.append)
+
+        admin_divisions._warn_if_row_count_changed(1000, 1000)
+        admin_divisions._warn_if_row_count_changed(None, 1000)
+        admin_divisions._warn_if_row_count_changed(1000, None)
+
+        assert messages == []

--- a/tests/test_admin_datasets.py
+++ b/tests/test_admin_datasets.py
@@ -1433,3 +1433,245 @@ class TestPerLevelJoinRowCountGuard:
         admin_divisions._warn_if_row_count_changed(1000, None)
 
         assert messages == []
+
+    def test_count_rows_returns_the_count_for_a_readable_source(self, tmp_path):
+        """The happy path: a metadata-only ``COUNT(*)`` against a real file."""
+        duckdb = pytest.importorskip("duckdb")
+        from geoparquet_io.core.add.admin_divisions import _count_rows
+
+        con = duckdb.connect()
+        src = tmp_path / "rows.parquet"
+        con.execute(f"COPY (SELECT * FROM range(7) AS t(i)) TO '{src}' (FORMAT PARQUET)")
+
+        assert _count_rows(con, str(src)) == 7
+
+    def test_count_rows_returns_the_count_for_a_table_ref(self, tmp_path):
+        """``is_table_ref=True`` emits the source bare, not single-quoted, so a
+        chained per-level temp table (not a file path) can be counted too."""
+        duckdb = pytest.importorskip("duckdb")
+        from geoparquet_io.core.add.admin_divisions import _count_rows
+
+        con = duckdb.connect()
+        con.execute("CREATE TEMP TABLE _gpio_admin_step_0 AS SELECT * FROM range(3) AS t(i)")
+
+        assert _count_rows(con, "_gpio_admin_step_0", is_table_ref=True) == 3
+
+    def test_count_rows_returns_none_when_the_source_cannot_be_read(self, tmp_path):
+        """A missing/unreadable source must not raise — the row-count guard is
+        a best-effort diagnostic, not something that should break the join."""
+        duckdb = pytest.importorskip("duckdb")
+        from geoparquet_io.core.add.admin_divisions import _count_rows
+
+        con = duckdb.connect()
+
+        assert _count_rows(con, str(tmp_path / "does-not-exist.parquet")) is None
+
+
+def _write_country_admin_fixture(con, tmp_path, polygons, name="admin.parquet"):
+    """A minimal Overture-country-shaped admin fixture: subtype/country/bbox.
+
+    ``polygons`` are ``(wkt, country_code)`` pairs.
+    """
+    selects = [
+        f"SELECT 'country' AS subtype, '{country}' AS country, ST_GeomFromText('{wkt}') AS geometry"
+        for wkt, country in polygons
+    ]
+    src = tmp_path / name
+    con.execute(
+        f"""
+        COPY (
+            SELECT subtype, country, geometry,
+                {{'xmin': ST_XMin(geometry), 'xmax': ST_XMax(geometry),
+                  'ymin': ST_YMin(geometry), 'ymax': ST_YMax(geometry)}} AS bbox
+            FROM ({" UNION ALL ".join(selects)})
+        ) TO '{src}' (FORMAT PARQUET)
+        """
+    )
+    return src
+
+
+def _write_points_fixture(con, tmp_path, points, name="input.parquet"):
+    """A plain points input fixture: one ``geometry`` column, no bbox/metadata."""
+    selects = [f"SELECT ST_GeomFromText('POINT({x} {y})') AS geometry" for x, y in points]
+    src = tmp_path / name
+    con.execute(f"COPY ({' UNION ALL '.join(selects)}) TO '{src}' (FORMAT PARQUET)")
+    return src
+
+
+class TestPerLevelJoinRowCountGuardEndToEnd:
+    """``add admin-divisions`` runs the row-count guard on the real per-level
+    join path (``_execute_per_level_joins``), not just the standalone helper.
+
+    Uses a local, offline ``--admin-source`` (Overture-shaped, per #819) so no
+    network access or real cache is involved.
+    """
+
+    def test_row_count_preserved_stays_silent(self, tmp_path, monkeypatch):
+        import duckdb
+
+        from geoparquet_io.core.add import admin_divisions
+        from geoparquet_io.core.add.admin_divisions import add_admin_divisions_multi
+
+        messages = []
+        monkeypatch.setattr(admin_divisions, "warn", messages.append)
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        admin_file = _write_country_admin_fixture(
+            con,
+            tmp_path,
+            [
+                ("POLYGON((0 0,0 1,1 1,1 0,0 0))", "AA"),
+                ("POLYGON((10 10,10 11,11 11,11 10,10 10))", "BB"),
+            ],
+        )
+        input_file = _write_points_fixture(con, tmp_path, [(0.5, 0.5), (10.5, 10.5)])
+        con.close()
+
+        out = str(tmp_path / "out.parquet")
+        add_admin_divisions_multi(
+            input_parquet=str(input_file),
+            output_parquet=out,
+            dataset_name="overture",
+            levels=["country"],
+            dataset_source=str(admin_file),
+            verbose=False,
+        )
+
+        con = duckdb.connect()
+        assert con.execute(f"SELECT COUNT(*) FROM '{out}'").fetchone()[0] == 2
+        # Other warnings (e.g. bbox-optimization advice) may fire; the row-count
+        # guard itself must stay silent.
+        assert [m for m in messages if "Admin join" in m] == []
+
+    def test_overlapping_admin_polygons_duplicate_rows_and_warn(self, tmp_path, monkeypatch):
+        """Two overlapping country polygons make one input point match twice —
+        exactly the join-multiplication bug the guard exists to name.
+        """
+        import duckdb
+
+        from geoparquet_io.core.add import admin_divisions
+        from geoparquet_io.core.add.admin_divisions import add_admin_divisions_multi
+
+        messages = []
+        monkeypatch.setattr(admin_divisions, "warn", messages.append)
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        admin_file = _write_country_admin_fixture(
+            con,
+            tmp_path,
+            [
+                # Both polygons cover (0.5, 0.5) - an overlapping-territory bug.
+                ("POLYGON((0 0,0 2,2 2,2 0,0 0))", "AA"),
+                ("POLYGON((0 0,0 2,2 2,2 0,0 0))", "BB"),
+                ("POLYGON((10 10,10 11,11 11,11 10,10 10))", "CC"),
+            ],
+        )
+        input_file = _write_points_fixture(con, tmp_path, [(0.5, 0.5), (10.5, 10.5)])
+        con.close()
+
+        out = str(tmp_path / "out.parquet")
+        add_admin_divisions_multi(
+            input_parquet=str(input_file),
+            output_parquet=out,
+            dataset_name="overture",
+            levels=["country"],
+            dataset_source=str(admin_file),
+            verbose=False,
+        )
+
+        con = duckdb.connect()
+        # Duplicated: 1 input point matched 2 polygons, the other matched 1.
+        assert con.execute(f"SELECT COUNT(*) FROM '{out}'").fetchone()[0] == 3
+        guard_messages = [m for m in messages if "Admin join" in m]
+        assert len(guard_messages) == 1
+        assert "duplicated" in guard_messages[0]
+        assert "2 input features" in guard_messages[0]
+        assert "3 in the" in guard_messages[0]
+
+
+class TestOvertureLevelPredicates:
+    """The predicate helpers' "unconfigured level" branches return None, so the
+    ``--no-cache`` SQL builders fall back cleanly instead of emitting a bogus
+    ``WHERE``."""
+
+    def test_level_predicate_is_none_for_an_unconfigured_level(self):
+        from geoparquet_io.core.admin_datasets import _overture_level_predicate
+
+        assert _overture_level_predicate("locality") is None
+
+    def test_levels_predicate_is_none_when_no_level_is_configured(self):
+        from geoparquet_io.core.admin_datasets import _overture_levels_predicate
+
+        assert _overture_levels_predicate(["locality"]) is None
+        assert _overture_levels_predicate([]) is None
+
+
+class TestStaleCacheCleanupResilience:
+    """Cache pruning is best-effort housekeeping: a file we cannot delete (say,
+    held open on Windows) must not fail the run."""
+
+    def test_unlink_oserror_is_swallowed(self, tmp_path, monkeypatch):
+        from geoparquet_io.core.admin_datasets import _remove_stale_level_caches
+
+        version = "2026-07-22.0"
+        current = tmp_path / f"overture-{version}-country-dependency-land.parquet"
+        stubborn = tmp_path / f"overture-{version}-country-land.parquet"
+        current.write_bytes(b"stub")
+        stubborn.write_bytes(b"stub")
+
+        original_unlink = Path.unlink
+
+        def failing_unlink(self, *args, **kwargs):
+            if self == stubborn:
+                raise OSError("file is locked")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+        # Must not raise.
+        _remove_stale_level_caches(tmp_path, version, "country", current)
+
+        assert current.exists()
+        assert stubborn.exists(), "the undeletable file is simply left behind"
+
+
+class TestDownloadPerLevelCachesHousekeeping:
+    """``_download_per_level_caches`` prunes superseded caches for every level
+    before checking freshness, and skips the download when each level's cache
+    is already present — fully offline via a mocked connection."""
+
+    def test_prunes_stale_caches_and_skips_fresh_levels(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from geoparquet_io.core import admin_datasets
+        from geoparquet_io.core.admin_datasets import OvertureAdminDataset
+
+        version = "2026-07-22.0"
+        monkeypatch.setattr(admin_datasets, "get_cache_dir", lambda: tmp_path)
+        mock_con = MagicMock()
+        monkeypatch.setattr(admin_datasets, "get_duckdb_connection", lambda **kwargs: mock_con)
+
+        dataset = OvertureAdminDataset()
+        # Keep version/source resolution offline and deterministic.
+        monkeypatch.setattr(dataset, "get_version", lambda: version)
+        monkeypatch.setattr(dataset, "get_default_source", lambda: "s3://stub/divisions")
+
+        fresh = {
+            level: dataset.get_cached_path_for_level(level)
+            for level in dataset.get_available_levels()
+        }
+        for path in fresh.values():
+            path.write_bytes(b"stub")
+        # Superseded by the "-dependency" cache key (#819); must be pruned.
+        stale = tmp_path / f"overture-{version}-country-land.parquet"
+        stale.write_bytes(b"stale")
+
+        dataset._download_per_level_caches()
+
+        assert not stale.exists()
+        for path in fresh.values():
+            assert path.exists()
+        mock_con.execute.assert_not_called()
+        mock_con.close.assert_called_once()

--- a/tests/test_admin_datasets.py
+++ b/tests/test_admin_datasets.py
@@ -181,15 +181,23 @@ class TestOvertureAdminDataset:
 
     def test_get_subtype_filter(self):
         dataset = OvertureAdminDataset()
-        # Test with country level
+        # The country level spans both of Overture's sovereign classes, so
+        # dependent territories are attributed rather than left NULL (#819).
         filter_country = dataset.get_subtype_filter(["country"])
-        assert filter_country == "subtype IN ('country')"
+        assert filter_country == "subtype IN ('country', 'dependency')"
 
         # Test with both levels
         filter_both = dataset.get_subtype_filter(["country", "region"])
         assert "country" in filter_both
+        assert "dependency" in filter_both
         assert "region" in filter_both
         assert "subtype IN" in filter_both
+
+    def test_get_subtype_filter_does_not_duplicate_subtypes(self):
+        """Overlapping level requests must not emit a subtype twice."""
+        dataset = OvertureAdminDataset()
+        filter_both = dataset.get_subtype_filter(["country", "region"])
+        assert filter_both == "subtype IN ('country', 'dependency', 'region')"
 
     def test_get_column_transform_region(self):
         """Test that region level returns SQL transformation for Vecorel compliance."""
@@ -256,7 +264,7 @@ class TestOvertureAdminDataset:
             query = dataset._build_level_cache_query(level, "s3://example/*")
             assert "is_land IS NOT FALSE" in query, f"{level} cache must filter to land"
             assert "is_land = true" not in query, f"{level} must not drop NULL is_land"
-            assert f"subtype = '{level}'" in query
+            assert f"'{level}'" in query and "subtype IN (" in query
 
     def test_per_level_cache_query_excludes_disputed_countries(self):
         """Country cache still excludes disputed (X*) territories and Antarctica."""
@@ -272,12 +280,104 @@ class TestOvertureAdminDataset:
         with pytest.raises(ValueError, match="cache config"):
             dataset._build_level_cache_query("locality", "s3://example/*")
 
+    def test_country_cache_query_includes_dependencies(self):
+        """Overture files dependent territories (French Guiana, Puerto Rico,
+        Reunion, Greenland, Hong Kong, ...) under ``subtype = 'dependency'``,
+        not ``'country'``. They carry ISO 3166-1 alpha-2 codes, so the country
+        level must take both classes or those territories get NULL -> 'ZZ'
+        (#819).
+        """
+        dataset = OvertureAdminDataset()
+        query = dataset._build_level_cache_query("country", "s3://example/*")
+        assert "'dependency'" in query
+        assert "'country'" in query
+        assert "subtype IN (" in query
+
+    def test_region_cache_query_excludes_dependencies(self):
+        """Only the country level widens: a dependency is not a region, and
+        pulling it in would put a country-shaped polygon in the region cache.
+        """
+        dataset = OvertureAdminDataset()
+        query = dataset._build_level_cache_query("region", "s3://example/*")
+        assert "'dependency'" not in query
+        assert "'region'" in query
+
+    def test_cached_path_distinguishes_dependency_aware_country_cache(self):
+        """A country cache built before #819 holds no dependency polygons, so
+        the cache key must change or the fix is invisible to existing users.
+        The region cache is unaffected and must keep its key (no needless
+        ~1GB re-download).
+        """
+        dataset = OvertureAdminDataset()
+        country = dataset.get_cached_path_for_level("country")
+        region = dataset.get_cached_path_for_level("region")
+        assert "dependency" in country.name
+        assert country.name.endswith("-land.parquet")
+        assert "dependency" not in region.name
+        assert region.name.endswith("-region-land.parquet")
+
+    def test_dependency_territory_gets_its_own_country_code(self, tmp_path):
+        """Behavioral: a feature inside a dependency polygon is attributed to
+        that dependency's ISO code, exactly once.
+
+        The fixture mirrors the real Overture shape around French Guiana: a
+        ``dependency`` polygon coded GF, and the neighbouring ``country``
+        polygon for Brazil that shares a border with it. Before #819 the GF
+        point matched nothing (-> NULL -> 'ZZ'); after, it matches GF only.
+        Matching *once* is the invariant the memory-safe plain LEFT JOIN
+        depends on, so the border-sharing BR polygon is here on purpose.
+        """
+        from geoparquet_io.core.admin_datasets import _OVERTURE_SIMPLIFY_TOLERANCE_DEG
+
+        duckdb = pytest.importorskip("duckdb")
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.execute("SET geometry_always_xy=true;")
+        src = tmp_path / "division_area.parquet"
+        con.execute(
+            f"""
+            COPY (
+              SELECT ST_AsWKB(ST_GeomFromText('POLYGON((0 0,0 2,2 2,2 0,0 0))')) AS geometry,
+                     {{'xmin':0.0,'xmax':2.0,'ymin':0.0,'ymax':2.0}} AS bbox,
+                     'GF' AS country, 'dependency' AS subtype, true AS is_land
+              UNION ALL SELECT ST_AsWKB(ST_GeomFromText('POLYGON((2 0,2 2,4 2,4 0,2 0))')),
+                     {{'xmin':2.0,'xmax':4.0,'ymin':0.0,'ymax':2.0}}, 'BR', 'country', true
+            ) TO '{src}' (FORMAT PARQUET)
+            """
+        )
+
+        query = OvertureAdminDataset()._build_level_cache_query("country", str(src))
+        runnable = query.replace(
+            f"ST_SimplifyPreserveTopology(geometry, {_OVERTURE_SIMPLIFY_TOLERANCE_DEG})",
+            "geometry",
+        )
+        con.execute(f"CREATE TABLE land AS SELECT * FROM ({runnable})")
+
+        assert [
+            r[0] for r in con.execute("SELECT country FROM land ORDER BY country").fetchall()
+        ] == [
+            "BR",
+            "GF",
+        ]
+
+        pt = "ST_GeomFromText('POINT(1 1)')"
+        matches = con.execute(
+            f"SELECT country FROM land WHERE ST_Intersects(ST_GeomFromWKB(geometry), {pt})"
+        ).fetchall()
+        assert matches == [("GF",)], "dependency feature must match its own code, exactly once"
+
     def test_cached_path_distinguishes_land_only_caches(self):
         """Cache filename encodes the land-only filter so stale (maritime-
-        contaminated) caches are not silently reused after the fix."""
+        contaminated) caches are not silently reused after the fix.
+
+        The segment between the level and the "-land" marker records the extra
+        subtypes the level draws on (#819), so this pins the level and the
+        marker rather than their adjacency.
+        """
         dataset = OvertureAdminDataset()
         path = dataset.get_cached_path_for_level("country")
-        assert path.name.endswith("-country-land.parquet")
+        assert "-country" in path.name
+        assert path.name.endswith("-land.parquet")
 
     def test_land_filter_removes_maritime_double_match(self, tmp_path):
         """Behavioral: the land-only filter makes a feature match exactly one


### PR DESCRIPTION
## Description

`gpio add admin-divisions` (Overture) left every dependent territory unattributed. The country level filtered on `subtype = 'country'`, which matches only Overture's 219 country-shaped rows; the 53 dependent territories — French Guiana, Puerto Rico, Réunion, Guadeloupe, Mayotte, New Caledonia, Greenland, Hong Kong, Macao, Guam, the Channel Islands and the rest — are filed under `subtype = 'dependency'`. Features there matched no polygon at all, so `admin:country_code` came out NULL, which `--vecorel` coalesces to `'ZZ'`.

They all carry a perfectly good ISO 3166-1 alpha-2 code, so the country level now draws on both subtypes.

## Technical Details

- `_OVERTURE_LEVEL_CACHE_CONFIG` gains a `subtypes` key per level: `["country", "dependency"]` for country, `["region"]` for region. Only the country level widens — a dependency polygon is country-shaped, so admitting it into the region cache would shadow the regions nested inside it.
- `_build_level_cache_query` emits `subtype IN (…)` from that config instead of a hardcoded `subtype = '<level>'`.
- `get_cached_path_for_level()` appends the subtypes a level draws on beyond its own name, so the country cache key becomes `overture-<release>-country-dependency-land.parquet`. A pre-fix cache holds no dependency polygons, so without a key change the fix would be invisible to anyone with a warm cache. The region key is untouched — no needless ~1 GB re-download. An unconfigured level now raises the same `ValueError` `_build_level_cache_query` raises, instead of naming a file nothing will fill.
- `_remove_stale_level_caches()` unlinks **every** superseded cache for a level/version, not just the legacy unsuffixed one. The `-dependency` key change would otherwise strand the ~40 MB `…-country-land.parquet` file it supersedes, exactly as the `-land` rename stranded its predecessor.

**Placeholder country codes.** Overture files three ISO-coded islands under placeholder `X*` codes: Saba (`XS`) and Sint Eustatius (`XE`) are both part of Bonaire, Sint Eustatius and Saba (`BQ`), and Jan Mayen (`XJ`) is part of Svalbard and Jan Mayen (`SJ`). The pre-existing "exclude disputed `X*`" filter dropped all three to `ZZ` even though they are not disputed. `_overture_country_code_sql()` remaps them in one place — used both by the cache producer (the `X*` filter is applied to the remapped expression, so the three survive it) and by the join-time column transform (so a `--no-cache` run, which reads the raw release, emits the same codes the cache stores). Every other `X*` code — `XK` and friends, genuine placeholders for territories with no ISO code — stays excluded, as before. This is why the attributed-dependency count is **53, not 50**.

**`--no-cache` row duplication.** `get_subtype_filter()` used to emit only the subtype predicate, while `is_land IS NOT FALSE` and the country level's `X*`/`AQ` filters lived solely in `_build_level_cache_query`. Overture stores a maritime (EEZ) polygon per territory whose geometry spans the landmass, so on `--no-cache` a feature matched **both** its land and its maritime polygon and the plain `LEFT JOIN` emitted it twice — pre-existing for sovereigns, and this PR would have extended it to all 53 dependencies. `get_subtype_filter()` now composes the level's whole predicate from `_OVERTURE_LEVEL_CACHE_CONFIG`, so the two paths admit the same rows. Multiple levels are OR'd, each keeping its own filters, so the country level's `X*`/`AQ` filters cannot leak onto the region level. It takes the resolved source, because a per-level cache has those filters already baked in and does not project `is_land` at all; the full predicate is emitted only against a raw release.

**The non-overlap invariant.** `_build_level_cache_query` keeps each level's polygons non-overlapping so the memory-safe plain `LEFT JOIN` preserves row count; adding a whole new class of polygon is exactly the kind of change that could break it. Measured on the **simplified** geometry the cache actually stores (release `2026-07-22.0`), all land polygons after the `X*`/`AQ` filters:

| pair | intersection area (deg²) |
|---|---|
| SR–GF | 3.58e-07 |
| HK–CN | 2.99e-07 |
| BR–GF | 1.02e-07 |
| MO–CN | 8.48e-08 |
| ES–GI | 8.43e-10 |
| CA–GL | 0.0 |

Six shared borders, and no dependency intersects another dependency. The slivers are real — they are what simplifying each polygon independently leaves behind — but sub-hectare, and roughly six orders of magnitude below the country–country overlaps the join already lives with (CL–AR alone is 0.192 deg²). So the invariant is approximate rather than exact, and the comment on `_OVERTURE_LEVEL_CACHE_CONFIG` now says so. Overture's sovereign polygons genuinely exclude their dependencies — `FR` is metropolitan France only, which is also why these features were not silently attributed to France before.

`_execute_per_level_joins` now compares the input and output row counts after the per-level joins and warns, naming both, when they differ — a cheap (metadata-only `COUNT(*)`) runtime guard for this whole class of bug, which otherwise fails silently.

Note the region level does not compensate for any of this: French Guiana's regions (Cayenne, Saint-Georges, Saint-Laurent-du-Maroni) exist but carry `region = NULL`, so `admin:subdivision_code` stays null for those territories either way.

## Tests

`tests/test_admin_datasets.py`: 117 passing, 15 of them new.

- `test_get_subtype_filter_no_cache_matches_each_feature_once` — behavioral: a GF land polygon, GF's maritime polygon spanning it, and neighbouring BR. Against the old subtype-only predicate the probe returned `[('GF',), ('GF',)]`; it now returns one row.
- `test_get_subtype_filter_carries_the_whole_level_predicate`, `…_ors_levels_with_different_filters`, `…_drops_the_extras_for_a_prefiltered_source`, `…_does_not_duplicate_levels` — the predicate's shape, per level and per source kind. The dedup guard now uses a genuinely overlapping input (`["country", "country"]`); the old one compared disjoint sets and could not fail.
- `test_placeholder_country_codes_map_to_their_iso_codes` — behavioral, both paths: XS/XE/XJ come out BQ/BQ/SJ through the cache query *and* through the `--no-cache` predicate + column transform, while XK and AQ stay dropped. Plus `test_country_transform_leaves_real_codes_alone` (the remap is a no-op on US/BQ/SJ/NULL, so re-applying it to a cached value cannot corrupt it).
- `test_stale_level_caches_are_removed` — the superseded and legacy files go, the current one and other levels/versions stay.
- `test_cached_path_rejects_unknown_level`.
- `TestPerLevelJoinRowCountGuard` — the row-count warning fires on a mismatch and stays quiet otherwise.
- `test_dependency_territory_gets_its_own_country_code` — reworked: it now probes *at* the shared GF/BR edge (the old probe sat a full degree inside GF, where nothing could double-match) and runs the emitted cache query **verbatim**, `ST_SimplifyPreserveTopology` included. The fixtures write a real `GEOMETRY` column, as Overture's own files read back, so no rewriting is needed; `test_land_filter_removes_maritime_double_match` gets the same treatment.

Verified on real data: this is the cause of a large share of the 46.4M-polygon `ZZ` bucket in the [Fields of the World global field boundaries](https://source.coop/repositories/tge-labs/ftw-global-data) release, including 63,424 polygons in French Guiana that users could not find under `GF`.

`uv run pytest tests -m "not slow and not network and not meta"` passes.

## Breaking Changes

**Does this PR introduce breaking changes?** No.

Output changes for the better — features in the 53 dependent territories now get their real ISO code instead of `'ZZ'` — but no API or CLI surface changes. `AdminDataset.get_subtype_filter()` gains an optional `source` argument; overrides that ignore it keep working. Anyone with a warm country cache gets it rebuilt automatically on the next run via the new cache key, and the file it supersedes is deleted; no `--clear-cache` needed.

## Related Issue(s)

Closes #819

## Checklist
- [x] Tests added/updated, run against real data where feasible
- [x] Integration tests for changes that cross module/format/service boundaries
- [x] All tests pass (`uv run pytest`)
- [x] At least one adversarial review (AI counts, rubber stamps don't)
- [ ] CodeRabbit comments fixed or answered
- [x] Documentation updated (README, guides, CLI reference)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Overture country coverage now includes dependent territories with their own ISO codes.
  - Cache generation and no-cache processing apply more accurate, source-aware administrative filters.
  - Cache filenames now reflect included subtypes and land-only coverage.

- **Bug Fixes**
  - Corrected placeholder territory codes and prevented stale superseded caches.
  - Added warnings when administrative joins duplicate or drop rows.

- **Documentation**
  - Updated Overture coverage details to include dependent territories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->