### PR TITLE
fix(arcgis): correct polygon ring winding order

### DIFF
--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import struct
 import tempfile
 import uuid
 from collections.abc import Generator
@@ -960,10 +961,115 @@ def _build_schema_from_layer_info(layer_info: ArcGISLayerInfo) -> pa.Schema:
     return pa.schema(fields)
 
 
+def _ring_signed_area(raw: bytes, num_points: int, point_size: int, endian: str) -> float:
+    """Shoelace signed area of a WKB ring's raw point bytes (positive = CCW)."""
+    fmt = endian + "dd"
+    total = 0.0
+    prev_x, prev_y = struct.unpack_from(fmt, raw, 0)
+    for i in range(1, num_points):
+        x, y = struct.unpack_from(fmt, raw, i * point_size)
+        total += prev_x * y - x * prev_y
+        prev_x, prev_y = x, y
+    return total
+
+
+def _reverse_ring_points(raw: bytes, num_points: int, point_size: int) -> bytes:
+    """Reverse the point order of a WKB ring's raw bytes (flips its winding)."""
+    points = [raw[i * point_size : (i + 1) * point_size] for i in range(num_points)]
+    points.reverse()
+    return b"".join(points)
+
+
+def _process_polygon_wkb(buf: bytes, pos: int) -> tuple[bytes, int]:
+    """Reorient one WKB Polygon's rings in place: shell CCW, holes CW.
+
+    ``pos`` points at the polygon's own byte-order marker (a Polygon nested
+    inside a MultiPolygon has one of these per sub-geometry). Returns the
+    rewritten bytes for just this polygon and the position just past it.
+    """
+    start = pos
+    endian = "<" if buf[pos] == 1 else ">"
+    (type_code,) = struct.unpack_from(endian + "I", buf, pos + 1)
+    base = type_code % 1000
+    band = type_code // 1000
+    if base != 3:
+        raise ValueError(f"expected WKB Polygon (type 3), got type {type_code}")
+    has_z = band in (1, 3)
+    has_m = band in (2, 3)
+    point_size = 8 * (2 + has_z + has_m)
+
+    header_end = pos + 9  # byte order (1) + type (4) + numRings (4)
+    (num_rings,) = struct.unpack_from(endian + "I", buf, pos + 5)
+    out = bytearray(buf[start:header_end])
+    cursor = header_end
+    for ring_index in range(num_rings):
+        (num_points,) = struct.unpack_from(endian + "I", buf, cursor)
+        ring_header = buf[cursor : cursor + 4]
+        cursor += 4
+        ring_len = num_points * point_size
+        raw = buf[cursor : cursor + ring_len]
+        cursor += ring_len
+        if num_points >= 4:
+            wants_ccw = ring_index == 0
+            is_ccw = _ring_signed_area(raw, num_points, point_size, endian) > 0
+            if is_ccw != wants_ccw:
+                raw = _reverse_ring_points(raw, num_points, point_size)
+        out += ring_header
+        out += raw
+    return bytes(out), cursor
+
+
+def _normalize_polygon_winding(wkb: bytes | None) -> bytes | None:
+    """Force RFC 7946 / GeoParquet default polygon ring winding onto WKB.
+
+    ArcGIS's `f=geojson` output winds exterior rings clockwise and interior
+    rings (holes) counterclockwise — the reverse of what RFC 7946 section
+    3.1.6 requires and of the GeoParquet spec's default `orientation`
+    (counterclockwise exterior, clockwise interior). GDAL's GeoJSON/ESRIJSON
+    readers keep the ring order as delivered rather than correcting it, so
+    without normalization the winding-based (rather than nesting-based) hole
+    detection some GeoParquet/GeoJSON consumers use misreads which ring is
+    the shell and which is the hole (portolan-sdi/portolan-cli#809).
+
+    DuckDB's spatial extension has no force-orientation function —
+    ``ST_Normalize`` reorders points into a canonical *comparison* form, it
+    does not enforce winding direction — so this reorients each polygon ring
+    by hand: the first ring of every polygon is forced counterclockwise, and
+    every following ring (a hole) clockwise, per-ring, based on its own
+    shoelace signed area.
+
+    Only WKB Polygon/MultiPolygon (Z/M variants included) are rewritten;
+    other geometry types, empty/undersized rings, and anything that fails to
+    parse as plain (non-EWKB) WKB pass through unchanged.
+    """
+    if not wkb:
+        return wkb
+    try:
+        endian = "<" if wkb[0] == 1 else ">"
+        (type_code,) = struct.unpack_from(endian + "I", wkb, 1)
+        base = type_code % 1000
+        if base == 3:
+            new_bytes, _ = _process_polygon_wkb(wkb, 0)
+            return new_bytes
+        if base == 6:
+            (num_polys,) = struct.unpack_from(endian + "I", wkb, 5)
+            out = bytearray(wkb[:9])
+            pos = 9
+            for _ in range(num_polys):
+                poly_bytes, pos = _process_polygon_wkb(wkb, pos)
+                out += poly_bytes
+            return bytes(out)
+    except (struct.error, IndexError, ValueError):
+        return wkb
+    return wkb
+
+
 def _json_doc_to_table(doc: dict, exclude: str, suffix: str, con=None) -> pa.Table:
     """Write a JSON document to a temp file and convert it via DuckDB ST_Read.
 
-    Shared mechanics for the GeoJSON and EsriJSON page converters.
+    Shared mechanics for the GeoJSON and EsriJSON page converters. Polygon
+    ring winding is normalized afterwards to the RFC 7946 / GeoParquet
+    default (see `_normalize_polygon_winding`).
 
     Args:
         doc: JSON-serializable document (GeoJSON FeatureCollection or raw
@@ -995,7 +1101,14 @@ def _json_doc_to_table(doc: dict, exclude: str, suffix: str, con=None) -> pa.Tab
         # Allow arbitrarily large/complex single features through GDAL's parser
         # (issue #517) — must be in effect while ST_Read reads the temp file.
         with _gdal_geojson_size_limit_lifted():
-            return con.execute(query).arrow().read_all()
+            table = con.execute(query).arrow().read_all()
+
+        geometry_index = table.schema.get_field_index("geometry")
+        fixed_geometry = pa.array(
+            [_normalize_polygon_winding(v.as_py()) for v in table.column(geometry_index)],
+            type=pa.binary(),
+        )
+        return table.set_column(geometry_index, "geometry", fixed_geometry)
 
     finally:
         if owns_con:

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -1069,6 +1069,26 @@ def _normalize_polygon_winding(wkb: bytes | None) -> bytes | None:
     return wkb
 
 
+def _normalize_table_polygon_winding(table: pa.Table, geometry_column: str) -> pa.Table:
+    """Force RFC 7946 / GeoParquet default polygon ring winding onto a whole table.
+
+    This must run *after* any geometry repair (e.g. `ST_MakeValid` via
+    `repair_arrow_table_geometry`), since `ST_MakeValid` can re-wind rings
+    clockwise and undo the per-page normalization done in
+    `_json_doc_to_table` — see `_normalize_polygon_winding` for the ArcGIS
+    winding convention being corrected. Non-polygon geometries and rows with
+    no geometry pass through unchanged. Preserves schema metadata.
+    """
+    if geometry_column not in table.column_names:
+        return table
+    geometry_index = table.schema.get_field_index(geometry_column)
+    fixed_geometry = pa.array(
+        [_normalize_polygon_winding(v.as_py()) for v in table.column(geometry_index)],
+        type=pa.binary(),
+    )
+    return table.set_column(geometry_index, geometry_column, fixed_geometry)
+
+
 def _json_doc_to_table(doc: dict, exclude: str, suffix: str, con=None) -> pa.Table:
     """Write a JSON document to a temp file and convert it via DuckDB ST_Read.
 
@@ -1484,19 +1504,23 @@ def arcgis_to_table(
                     f"(coordinates were not reprojected)."
                 )
             crs = _extract_crs_from_spatial_reference(detected_sr or {"wkid": output_wkid})
+        is_polygon_layer = layer_info.geometry_type == "esriGeometryPolygon"
         if crs:
+            geometry_column_metadata = {
+                "encoding": "WKB",
+                "crs": crs,
+                "geometry_types": [ARCGIS_GEOM_TYPES.get(layer_info.geometry_type, "Geometry")],
+            }
+            # Declare the winding direction the normalization below guarantees.
+            # Per the GeoParquet spec, absence of this key is not an assertion,
+            # so consumers can't rely on the ring-winding fix without it (only
+            # meaningful for Polygon/MultiPolygon geometries).
+            if is_polygon_layer:
+                geometry_column_metadata["orientation"] = "counterclockwise"
             geo_metadata = {
                 "version": "1.1.0",
                 "primary_column": "geometry",
-                "columns": {
-                    "geometry": {
-                        "encoding": "WKB",
-                        "crs": crs,
-                        "geometry_types": [
-                            ARCGIS_GEOM_TYPES.get(layer_info.geometry_type, "Geometry")
-                        ],
-                    }
-                },
+                "columns": {"geometry": geometry_column_metadata},
             }
 
             # Update table schema with geo metadata
@@ -1507,6 +1531,12 @@ def arcgis_to_table(
         # Repair invalid geometry (issue #506). Helper preserves schema metadata.
         if table.num_rows > 0:
             table, _ = repair_arrow_table_geometry(table, "geometry", repair=repair_geometry)
+            # ST_MakeValid (run above) can re-wind rings clockwise, undoing the
+            # per-page normalization done in _json_doc_to_table. Re-normalize the
+            # whole assembled table so the orientation declared above (and RFC
+            # 7946 / GeoParquet's default winding) holds after repair too.
+            if is_polygon_layer:
+                table = _normalize_table_polygon_winding(table, "geometry")
 
         success(f"Converted {table.num_rows} features")
         return table

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -975,9 +975,14 @@ def _ring_signed_area(raw: bytes, num_points: int, point_size: int, endian: str)
 
 def _reverse_ring_points(raw: bytes, num_points: int, point_size: int) -> bytes:
     """Reverse the point order of a WKB ring's raw bytes (flips its winding)."""
-    points = [raw[i * point_size : (i + 1) * point_size] for i in range(num_points)]
-    points.reverse()
-    return b"".join(points)
+    reversed_raw = bytearray(len(raw))
+    for source_index in range(num_points):
+        source_start = source_index * point_size
+        destination_start = (num_points - source_index - 1) * point_size
+        reversed_raw[destination_start : destination_start + point_size] = raw[
+            source_start : source_start + point_size
+        ]
+    return bytes(reversed_raw)
 
 
 def _process_polygon_wkb(buf: bytes, pos: int) -> tuple[bytes, int]:

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -82,6 +82,43 @@ MOCK_ESRI_FEATURES_PAGE = {
 }
 
 
+def _wkb_polygon_rings(wkb: bytes) -> list[list[tuple[float, float]]]:
+    """Decode a WKB Polygon's rings without a shapely/geopandas dependency.
+
+    Only handles the plain (non-EWKB, no SRID) Polygon encoding DuckDB's
+    ``ST_AsWKB`` produces, which is all this test suite needs.
+    """
+    import struct
+
+    endian = "<" if wkb[0] == 1 else ">"
+    (geom_type,) = struct.unpack_from(endian + "I", wkb, 1)
+    assert geom_type == 3, f"expected WKB Polygon (type 3), got type {geom_type}"
+
+    offset = 5
+    (num_rings,) = struct.unpack_from(endian + "I", wkb, offset)
+    offset += 4
+
+    rings = []
+    for _ in range(num_rings):
+        (num_points,) = struct.unpack_from(endian + "I", wkb, offset)
+        offset += 4
+        points = []
+        for _ in range(num_points):
+            x, y = struct.unpack_from(endian + "dd", wkb, offset)
+            offset += 16
+            points.append((x, y))
+        rings.append(points)
+    return rings
+
+
+def _signed_ring_area(ring: list[tuple[float, float]]) -> float:
+    """Shoelace signed area: positive means counterclockwise winding."""
+    total = 0.0
+    for (x1, y1), (x2, y2) in zip(ring, ring[1:]):
+        total += x1 * y2 - x2 * y1
+    return total / 2
+
+
 class TestResolveToken:
     """Tests for token resolution."""
 
@@ -1349,6 +1386,47 @@ class TestStreamingConversion:
 
         result = _geojson_page_to_table([])
         assert result is None
+
+    def test_geojson_page_to_table_normalizes_arcgis_ring_winding(self):
+        """A mask polygon wound the ArcGIS way (CW shell / CCW hole) comes out
+        RFC 7946 / GeoParquet conformant (CCW shell / CW hole).
+        See portolan-sdi/portolan-cli#809.
+
+        ArcGIS's `f=geojson` output does not follow RFC 7946 section 3.1.6:
+        it winds exterior rings clockwise and interior rings (holes)
+        counterclockwise, the opposite of the spec (and of the GeoParquet
+        `orientation` default). Consumers that rely on winding rather than
+        ring nesting to tell shell from hole misread such geometry.
+
+        Decodes the resulting WKB by hand (only ``struct``, no shapely/
+        geopandas) since those live in the optional ``benchmark`` extra, not
+        the default ``dev`` dependency set this test runs under.
+        """
+        from geoparquet_io.core.arcgis import _geojson_page_to_table
+
+        # Shell: outer square, clockwise (ArcGIS convention). Hole: inner
+        # square, counterclockwise (also ArcGIS convention) — both reversed
+        # from what RFC 7946 requires.
+        arcgis_wound_feature = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]],  # shell, CW
+                    [[2, 2], [2, 8], [8, 8], [8, 2], [2, 2]],  # hole, CCW
+                ],
+            },
+            "properties": {},
+        }
+
+        table = _geojson_page_to_table([arcgis_wound_feature])
+
+        assert table is not None
+        rings = _wkb_polygon_rings(table.column("geometry")[0].as_py())
+        assert len(rings) == 2
+        shell, hole = rings
+        assert _signed_ring_area(shell) > 0, "exterior ring must be counterclockwise per RFC 7946"
+        assert _signed_ring_area(hole) < 0, "interior ring (hole) must be clockwise per RFC 7946"
 
     def test_gdal_size_limit_lifted_inside_scope_and_unset_after(self, monkeypatch):
         """The limit is lifted inside the scope and removed again on exit (#517)."""

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1413,7 +1413,7 @@ class TestStreamingConversion:
                 "type": "Polygon",
                 "coordinates": [
                     [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]],  # shell, CW
-                    [[2, 2], [2, 8], [8, 8], [8, 2], [2, 2]],  # hole, CCW
+                    [[2, 2], [8, 2], [8, 8], [2, 8], [2, 2]],  # hole, CCW
                 ],
             },
             "properties": {},

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -114,7 +114,7 @@ def _wkb_polygon_rings(wkb: bytes) -> list[list[tuple[float, float]]]:
 def _signed_ring_area(ring: list[tuple[float, float]]) -> float:
     """Shoelace signed area: positive means counterclockwise winding."""
     total = 0.0
-    for (x1, y1), (x2, y2) in zip(ring, ring[1:]):
+    for (x1, y1), (x2, y2) in zip(ring, ring[1:], strict=False):
         total += x1 * y2 - x2 * y1
     return total / 2
 

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1428,6 +1428,72 @@ class TestStreamingConversion:
         assert _signed_ring_area(shell) > 0, "exterior ring must be counterclockwise per RFC 7946"
         assert _signed_ring_area(hole) < 0, "interior ring (hole) must be clockwise per RFC 7946"
 
+    def test_geojson_page_to_table_normalizes_multipolygon_ring_winding(self):
+        """MultiPolygon shells/holes are normalized per-sub-polygon, same as Polygon."""
+        from geoparquet_io.core.arcgis import _geojson_page_to_table
+
+        arcgis_wound_feature = {
+            "type": "Feature",
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]],  # shell, CW
+                        [[2, 2], [8, 2], [8, 8], [2, 8], [2, 2]],  # hole, CCW
+                    ],
+                    [[[20, 20], [20, 30], [30, 30], [30, 20], [20, 20]]],  # shell, CW
+                ],
+            },
+            "properties": {},
+        }
+
+        table = _geojson_page_to_table([arcgis_wound_feature])
+
+        assert table is not None
+        wkb = table.column("geometry")[0].as_py()
+        # WKB MultiPolygon: byte order (1) + type (4) + numPolygons (4), then each
+        # polygon is itself a full WKB Polygon (with its own byte-order/type marker).
+        import struct
+
+        endian = "<" if wkb[0] == 1 else ">"
+        (geom_type,) = struct.unpack_from(endian + "I", wkb, 1)
+        assert geom_type == 6, f"expected WKB MultiPolygon (type 6), got type {geom_type}"
+        (num_polys,) = struct.unpack_from(endian + "I", wkb, 5)
+        assert num_polys == 2
+
+        pos = 9
+        first_poly_rings = _wkb_polygon_rings(wkb[pos:])
+        assert len(first_poly_rings) == 2
+        shell, hole = first_poly_rings
+        assert _signed_ring_area(shell) > 0
+        assert _signed_ring_area(hole) < 0
+
+    def test_normalize_polygon_winding_passthrough_on_malformed_wkb(self):
+        """Truncated/unparseable WKB is returned unchanged rather than raising."""
+        from geoparquet_io.core.arcgis import _normalize_polygon_winding
+
+        assert _normalize_polygon_winding(None) is None
+        assert _normalize_polygon_winding(b"") == b""
+
+        import struct
+
+        # Valid Polygon header claiming a 4-point ring, but the buffer is cut
+        # off well before that many bytes exist: unpacking the ring's points
+        # raises struct.error, which must be swallowed and the input returned
+        # unchanged.
+        truncated = struct.pack("<BII", 1, 3, 1) + struct.pack("<I", 4) + struct.pack("<dd", 0.0, 0.0)
+        assert _normalize_polygon_winding(truncated) == truncated
+
+    def test_process_polygon_wkb_rejects_non_polygon_type(self):
+        """`_process_polygon_wkb` refuses to run on a non-Polygon WKB type code."""
+        import struct
+
+        from geoparquet_io.core.arcgis import _process_polygon_wkb
+
+        point_wkb = struct.pack("<BI", 1, 1) + struct.pack("<dd", 0.0, 0.0)  # WKB Point (type 1)
+        with pytest.raises(ValueError, match="expected WKB Polygon"):
+            _process_polygon_wkb(point_wkb, 0)
+
     def test_gdal_size_limit_lifted_inside_scope_and_unset_after(self, monkeypatch):
         """The limit is lifted inside the scope and removed again on exit (#517)."""
         import os

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1469,7 +1469,7 @@ class TestStreamingConversion:
         assert _signed_ring_area(hole) < 0
 
     def test_normalize_polygon_winding_passthrough_on_malformed_wkb(self):
-        """Truncated/unparseable WKB is returned unchanged rather than raising."""
+        """Truncated/unparsable WKB is returned unchanged rather than raising."""
         from geoparquet_io.core.arcgis import _normalize_polygon_winding
 
         assert _normalize_polygon_winding(None) is None

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1481,7 +1481,9 @@ class TestStreamingConversion:
         # off well before that many bytes exist: unpacking the ring's points
         # raises struct.error, which must be swallowed and the input returned
         # unchanged.
-        truncated = struct.pack("<BII", 1, 3, 1) + struct.pack("<I", 4) + struct.pack("<dd", 0.0, 0.0)
+        truncated = (
+            struct.pack("<BII", 1, 3, 1) + struct.pack("<I", 4) + struct.pack("<dd", 0.0, 0.0)
+        )
         assert _normalize_polygon_winding(truncated) == truncated
 
     def test_process_polygon_wkb_rejects_non_polygon_type(self):

--- a/tests/test_arcgis.py
+++ b/tests/test_arcgis.py
@@ -1699,6 +1699,140 @@ class TestStreamingConversion:
         assert temp_files_before == temp_files_after
         assert result.num_rows == 3
 
+    def test_normalize_table_polygon_winding_rewinds_whole_column(self):
+        """`_normalize_table_polygon_winding` fixes every row's ring winding,
+        and leaves non-polygon geometry (and missing columns) untouched."""
+        # Build a CW-wound (already normalized-away-from-ArcGIS) shell by
+        # constructing raw WKB directly, bypassing the per-page normalizer.
+        import struct
+
+        from geoparquet_io.core.arcgis import (
+            _geojson_page_to_table,
+            _normalize_table_polygon_winding,
+        )
+
+        cw_square = [(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]  # CW, area < 0
+        wkb = bytearray()
+        wkb += struct.pack("<B", 1)
+        wkb += struct.pack("<I", 3)  # Polygon
+        wkb += struct.pack("<I", 1)  # 1 ring
+        wkb += struct.pack("<I", len(cw_square))
+        for x, y in cw_square:
+            wkb += struct.pack("<dd", x, y)
+
+        table = pa.table({"geometry": [bytes(wkb)], "name": ["a"]})
+        fixed = _normalize_table_polygon_winding(table, "geometry")
+
+        rings = _wkb_polygon_rings(fixed.column("geometry")[0].as_py())
+        assert len(rings) == 1
+        assert _signed_ring_area(rings[0]) > 0, "shell must be forced counterclockwise"
+
+        # Passes through unchanged when the geometry column is absent.
+        no_geom_table = pa.table({"name": ["a"]})
+        assert _normalize_table_polygon_winding(no_geom_table, "geometry") is no_geom_table
+
+        # Sanity: still works when fed a table built the normal way.
+        real_table = _geojson_page_to_table(
+            [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]],
+                    },
+                    "properties": {},
+                }
+            ]
+        )
+        result = _normalize_table_polygon_winding(real_table, "geometry")
+        assert result.num_rows == 1
+
+    @patch("geoparquet_io.core.arcgis._stream_features_to_parquet")
+    @patch("geoparquet_io.core.arcgis.get_layer_info")
+    @patch("geoparquet_io.core.arcgis.validate_arcgis_url")
+    def test_arcgis_to_table_reorients_after_repair(
+        self, mock_validate, mock_layer_info, mock_stream
+    ):
+        """Regression test for PR #821 review: `ST_MakeValid` (run by the
+        default `repair_geometry=True`) re-winds rings, so an invalid,
+        ArcGIS-wound polygon must be re-normalized *after* repair, not just
+        during the per-page conversion. Also asserts the `orientation` key is
+        now declared in the output's `geo` metadata.
+        """
+        import struct
+
+        from geoparquet_io.core.arcgis import (
+            ArcGISLayerInfo,
+            _geojson_page_to_table,
+            arcgis_to_table,
+        )
+
+        mock_validate.return_value = ("https://example.com/FeatureServer/0", 0)
+        mock_layer_info.return_value = ArcGISLayerInfo(
+            name="Test",
+            geometry_type="esriGeometryPolygon",
+            spatial_reference={"wkid": 4326},
+            fields=[],
+            max_record_count=1000,
+            total_count=1,
+        )
+
+        # A self-intersecting "bowtie" polygon: invalid, so ST_MakeValid splits
+        # it into a MultiPolygon of two triangles. Build it the same way the
+        # real page pipeline would (per-page normalization applied first).
+        bowtie_feature = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [10, 10], [10, 0], [0, 10], [0, 0]]],
+            },
+            "properties": {},
+        }
+        page_table = _geojson_page_to_table([bowtie_feature])
+        wkb = page_table.column("geometry")[0].as_py()
+
+        def mock_stream_impl(service_url, layer_info, output_path, **kwargs):
+            table = pa.table({"geometry": [wkb]})
+            pq.write_table(table, output_path)
+            return 1, None
+
+        mock_stream.side_effect = mock_stream_impl
+
+        result = arcgis_to_table("https://example.com/FeatureServer/0")
+
+        assert result.num_rows == 1
+        result_wkb = result.column("geometry")[0].as_py()
+        endian = "<" if result_wkb[0] == 1 else ">"
+        (geom_type,) = struct.unpack_from(endian + "I", result_wkb, 1)
+        assert geom_type % 1000 == 6, "invalid polygon must be repaired into a MultiPolygon"
+
+        # Every shell produced by the repair must have been re-normalized to
+        # counterclockwise, not left clockwise by ST_MakeValid.
+        (num_polys,) = struct.unpack_from(endian + "I", result_wkb, 5)
+        assert num_polys >= 1
+        pos = 9
+        for _ in range(num_polys):
+            sub_endian = "<" if result_wkb[pos] == 1 else ">"
+            (num_rings,) = struct.unpack_from(sub_endian + "I", result_wkb, pos + 5)
+            ring_pos = pos + 9
+            for ring_index in range(num_rings):
+                (num_points,) = struct.unpack_from(sub_endian + "I", result_wkb, ring_pos)
+                ring_pos += 4
+                points = []
+                for _pt in range(num_points):
+                    x, y = struct.unpack_from(sub_endian + "dd", result_wkb, ring_pos)
+                    ring_pos += 16
+                    points.append((x, y))
+                area = _signed_ring_area(points)
+                if ring_index == 0:
+                    assert area > 0, "exterior ring must be counterclockwise after repair"
+                else:
+                    assert area < 0, "hole ring must be clockwise after repair"
+            pos = ring_pos
+
+        geo_metadata = json.loads(result.schema.metadata[b"geo"])
+        assert geo_metadata["columns"]["geometry"]["orientation"] == "counterclockwise"
+
 
 class TestStreamOutputCrs:
     @patch("geoparquet_io.core.arcgis.fetch_all_features")


### PR DESCRIPTION
## Summary

ArcGIS's `f=geojson` output winds exterior (shell) rings **clockwise** and interior (hole) rings **counterclockwise** — the reverse of what [RFC 7946 §3.1.6](https://www.rfc-editor.org/rfc/rfc7946#section-3.1.6) and the GeoParquet spec's default `orientation` (counterclockwise exterior, clockwise interior) require. GDAL's GeoJSON/ESRIJSON readers pass ring order through unchanged, so consumers that infer shell/hole from winding direction rather than ring nesting misread these polygons — e.g. a masked area rendering as a hole and vice versa.

Reported in portolan-sdi/portolan-cli#809.

## Fix

`geoparquet_io/core/arcgis.py`'s `_json_doc_to_table` (shared by the GeoJSON and EsriJSON page converters) now reorients every polygon ring after `ST_AsWKB`: the first ring of each polygon is forced counterclockwise, every following ring (a hole) clockwise, based on each ring's own shoelace signed area.

DuckDB's spatial extension has no force-orientation function — `ST_Normalize` only reorders points into a canonical *comparison* form, it doesn't fix winding direction, so it can't be used here. The fix instead reorients rings directly on the WKB bytes with the standard library only (`struct`), no shapely/geopandas dependency, following the same per-ring signed-area approach as opengeos/GeoLibre#2069 (`orientRing`/`signedRingArea`), adapted from TypeScript/GeoJSON coordinates to Python/WKB bytes.

Handles Polygon and MultiPolygon, including Z/M variants; other geometry types and anything that doesn't parse as plain (non-EWKB) WKB pass through unchanged.

## Testing

- New unit test: `tests/test_arcgis.py::TestStreamingConversion::test_geojson_page_to_table_normalizes_arcgis_ring_winding` — feeds a mask polygon wound the ArcGIS way and asserts the resulting WKB is RFC 7946 / GeoParquet conformant.
- `uv run pytest tests/test_arcgis.py` — 121 passed.
- Manual end-to-end check against a real, previously-affected service:

``` 
uv run gpio extract arcgis https://services.arcgis.com/OnnVX2wGkBfflKqu/ArcGIS/rest/services/Mask_HHSK/FeatureServer/0 mask_hhsk.parquet
```

Output verified with  

```
gpio inspect meta mask_hhsk.parquet
```
 :  Geometry Types: MultiPolygon ,  Orientation: Not present - counterclockwise (default value) , correct bbox.

Closes portolan-sdi/portolan-cli#809.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Polygon geometries loaded from ArcGIS GeoJSON now use standardized ring orientation: exterior boundaries are counterclockwise and interior holes are clockwise.
  - MultiPolygon geometries now apply the same orientation correction consistently to each polygon.
  - Non-polygon, empty, undersized, or malformed geometries continue to pass through safely without disrupting page conversion.
  - Geometry conversion now better aligns ArcGIS-loaded data with GeoJSON and GeoParquet orientation standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->