### PR TITLE
test: consolidate mechanical test duplication without losing coverage

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -277,105 +277,105 @@ class TestConvertCore:
         assert "not found" in str(exc_info.value).lower()
 
 
+@pytest.fixture(scope="module")
+def best_practices_file(tmp_path_factory):
+    """Convert the test shapefile once with default options for read-only checks.
+
+    Every test in TestConvertBestPractices previously re-ran this identical
+    default conversion just to assert one property of the output. The output is
+    only read in assertions, so a single module-scoped conversion is safe
+    (issue #666 item 2).
+    """
+    from tests.conftest import TEST_DATA_DIR
+
+    output = tmp_path_factory.mktemp("convert_best_practices") / "converted.parquet"
+    convert_to_geoparquet(str(TEST_DATA_DIR / "buildings_test.shp"), str(output))
+    return str(output)
+
+
 class TestConvertBestPractices:
-    """Test that convert applies all best practices."""
+    """Test that convert applies all best practices (one shared conversion)."""
 
-    def test_zstd_compression_applied(self, shapefile_input, temp_output_file):
+    def test_zstd_compression_applied(self, best_practices_file):
         """Verify ZSTD compression is applied by default."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
-        compression_info = get_compression_info(temp_output_file)
-        geom_col = find_primary_geometry_column(temp_output_file)
+        compression_info = get_compression_info(best_practices_file)
+        geom_col = find_primary_geometry_column(best_practices_file)
         geom_compression = compression_info.get(geom_col)
         assert geom_compression == "ZSTD", (
             f"Expected ZSTD compression on geometry column '{geom_col}'"
         )
 
-    def test_bbox_column_exists(self, shapefile_input, temp_output_file):
+    def test_bbox_column_exists(self, best_practices_file):
         """Verify bbox column is added."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
-        bbox_info = check_bbox_structure(temp_output_file, verbose=False)
+        bbox_info = check_bbox_structure(best_practices_file, verbose=False)
         assert bbox_info["has_bbox_column"], "Expected bbox column to exist"
         assert bbox_info["bbox_column_name"] == "bbox"
 
-    def test_bbox_metadata_present(self, shapefile_input, temp_output_file):
+    def test_bbox_metadata_present(self, best_practices_file):
         """Verify bbox covering metadata is added."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
-        bbox_info = check_bbox_structure(temp_output_file, verbose=False)
+        bbox_info = check_bbox_structure(best_practices_file, verbose=False)
         assert bbox_info["has_bbox_metadata"], "Expected bbox covering in metadata"
         assert bbox_info["status"] == "optimal"
 
-    def test_geoparquet_version(self, shapefile_input, temp_output_file):
+    def test_geoparquet_version(self, best_practices_file):
         """Verify GeoParquet 1.1.0+ metadata is created."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
-        metadata, _ = get_parquet_metadata(temp_output_file, verbose=False)
+        metadata, _ = get_parquet_metadata(best_practices_file, verbose=False)
         geo_meta = parse_geo_metadata(metadata, verbose=False)
 
         assert geo_meta is not None, "Expected GeoParquet metadata to exist"
         version = geo_meta.get("version")
         assert version >= "1.1.0", f"Expected version >= 1.1.0, got {version}"
 
-    def test_row_group_size(self, shapefile_input, temp_output_file):
+    def test_row_group_size(self, best_practices_file):
         """Verify row groups are properly sized."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
-        stats = get_row_group_stats(temp_output_file)
+        stats = get_row_group_stats(best_practices_file)
         # For small test files, we might only have 1 row group
         # The key is that row_group_rows parameter was set to 100k
         assert stats["num_groups"] >= 1
 
-    def test_hilbert_ordering_applied(self, shapefile_input, temp_output_file):
+    def test_hilbert_ordering_applied(self, best_practices_file):
         """Verify Hilbert ordering is applied by default."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
         # Check spatial order - should have good locality (low ratio)
         # Note: With small test files, this might not show perfect ordering
         # For now, just verify the file was created and has geometry
         # The spatial ordering check has its own encoding issues with converted files
-        assert os.path.exists(temp_output_file)
+        assert os.path.exists(best_practices_file)
 
         # Verify we can read the file
         con = duckdb.connect()
-        count = con.execute(f"SELECT COUNT(*) FROM read_parquet('{temp_output_file}')").fetchone()[
-            0
-        ]
+        count = con.execute(
+            f"SELECT COUNT(*) FROM read_parquet('{best_practices_file}')"
+        ).fetchone()[0]
         assert count > 0
         con.close()
 
-    def test_geometry_column_preserved(self, shapefile_input, temp_output_file):
+    def test_geometry_column_preserved(self, best_practices_file):
         """Verify geometry column is preserved."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
         # Use DuckDB to check schema
         con = duckdb.connect()
         con.execute("INSTALL spatial;")
         con.execute("LOAD spatial;")
 
         # Get actual geometry column name (DuckDB uses "geom" for shapefile conversion)
-        geom_col = find_primary_geometry_column(temp_output_file)
+        geom_col = find_primary_geometry_column(best_practices_file)
         result = con.execute(
-            f"SELECT ST_AsText(\"{geom_col}\") FROM '{temp_output_file}' LIMIT 1"
+            f"SELECT ST_AsText(\"{geom_col}\") FROM '{best_practices_file}' LIMIT 1"
         ).fetchone()
         assert result is not None
         con.close()
 
-    def test_attribute_columns_preserved(self, shapefile_input, temp_output_file):
+    def test_attribute_columns_preserved(self, best_practices_file):
         """Verify attribute columns are preserved from input."""
-        convert_to_geoparquet(shapefile_input, temp_output_file)
-
         # Use DuckDB to check schema
         con = duckdb.connect()
         con.execute("INSTALL spatial;")
         con.execute("LOAD spatial;")
 
-        result = con.execute(f"DESCRIBE SELECT * FROM '{temp_output_file}'").fetchall()
+        result = con.execute(f"DESCRIBE SELECT * FROM '{best_practices_file}'").fetchall()
         column_names = [row[0] for row in result]
 
         # Should have geometry (detected dynamically) and bbox at minimum
-        geom_col = find_primary_geometry_column(temp_output_file)
+        geom_col = find_primary_geometry_column(best_practices_file)
         assert geom_col in column_names, f"Expected geometry column '{geom_col}' in {column_names}"
         assert "bbox" in column_names
 
@@ -385,55 +385,18 @@ class TestConvertBestPractices:
 
 
 class TestConvertCLI:
-    """Test CLI interface for convert command."""
+    """CLI plumbing tests for convert (core conversion behavior is tested above).
 
-    def test_cli_basic_shapefile(self, shapefile_input, temp_output_file):
-        """Test CLI basic usage with shapefile."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["convert", shapefile_input, temp_output_file])
+    Consolidated from eight per-flag tests that each ran a full conversion
+    (issue #666 item 2). What the dropped tests asserted survives elsewhere:
+    GeoJSON and GeoPackage CLI/API conversions are exercised in the fast suite
+    by test_geoparquet_versions.py::TestVersionCLI (CLI convert on GeoJSON) and
+    test_convert_layer.py (GeoPackage), --skip-hilbert CLI plumbing by every
+    TestVersionCLI case, and the remaining flags by the single run below.
+    """
 
-        assert result.exit_code == 0, f"Command failed: {result.output}"
-        assert os.path.exists(temp_output_file)
-        assert "Converting" in result.output
-        assert "Done" in result.output
-
-    def test_cli_basic_geojson(self, geojson_input, temp_output_file):
-        """Test CLI with GeoJSON input."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["convert", geojson_input, temp_output_file])
-
-        assert result.exit_code == 0, f"Command failed: {result.output}"
-        assert os.path.exists(temp_output_file)
-
-    def test_cli_basic_geopackage(self, geopackage_input, temp_output_file):
-        """Test CLI with GeoPackage input."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["convert", geopackage_input, temp_output_file])
-
-        assert result.exit_code == 0, f"Command failed: {result.output}"
-        assert os.path.exists(temp_output_file)
-
-    def test_cli_verbose_output(self, shapefile_input, temp_output_file):
-        """Test verbose flag shows progress."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["convert", shapefile_input, temp_output_file, "--verbose"])
-
-        assert result.exit_code == 0
-        assert "Detecting geometry column" in result.output
-        assert "Dataset bounds" in result.output
-
-    def test_cli_skip_hilbert(self, shapefile_input, temp_output_file):
-        """Test --skip-hilbert flag."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["convert", shapefile_input, temp_output_file, "--skip-hilbert"]
-        )
-
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-
-    def test_cli_custom_compression(self, shapefile_input, temp_output_file):
-        """Test custom compression options."""
+    def test_cli_plumbing_full_options(self, shapefile_input, temp_output_file):
+        """One CLI run proving options reach core and expected messages print."""
         runner = CliRunner()
         result = runner.invoke(
             cli,
@@ -441,6 +404,7 @@ class TestConvertCLI:
                 "convert",
                 shapefile_input,
                 temp_output_file,
+                "--verbose",
                 "--compression",
                 "ZSTD",
                 "--compression-level",
@@ -448,10 +412,17 @@ class TestConvertCLI:
             ],
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"Command failed: {result.output}"
         assert os.path.exists(temp_output_file)
-
-        # Verify ZSTD compression was applied (use dynamic geometry column detection)
+        # --verbose plumbing
+        assert "Detecting geometry column" in result.output
+        assert "Dataset bounds" in result.output
+        # User-facing messages: converting, time, output file, validation
+        assert "Converting" in result.output
+        assert "Done in" in result.output
+        assert "Output:" in result.output
+        assert "validation" in result.output.lower()
+        # --compression/--compression-level plumbing
         compression_info = get_compression_info(temp_output_file)
         geom_col = find_primary_geometry_column(temp_output_file)
         assert compression_info.get(geom_col) == "ZSTD", f"Expected ZSTD for '{geom_col}'"
@@ -463,18 +434,6 @@ class TestConvertCLI:
 
         assert result.exit_code != 0
         assert "not found" in result.output.lower() or "does not exist" in result.output.lower()
-
-    def test_cli_output_messages(self, shapefile_input, temp_output_file):
-        """Test that CLI outputs expected messages."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["convert", shapefile_input, temp_output_file])
-
-        assert result.exit_code == 0
-        # Should show: converting, time, output file, size, validation
-        assert "Converting" in result.output
-        assert "Done in" in result.output
-        assert "Output:" in result.output
-        assert "validation" in result.output.lower()
 
 
 class TestConvertEdgeCases:

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -273,7 +273,10 @@ class TestVersionCLI:
         [
             # expected_version: metadata version string; None = no geo metadata
             # expected at all; "invalid" = the CLI must reject the invocation.
-            pytest.param([], "1.1.0", False, None, id="default-1.1"),
+            # "Done in" pins the non-verbose progress message: the dropped
+            # test_cli_output_messages asserted it in default mode, and line
+            # coverage alone cannot notice it moving behind --verbose.
+            pytest.param([], "1.1.0", False, "Done in", id="default-1.1"),
             pytest.param(["--geoparquet-version", "1.0"], "1.0.0", False, None, id="explicit-1.0"),
             pytest.param(["--geoparquet-version", "1.1"], "1.1.0", False, None, id="explicit-1.1"),
             pytest.param(["--geoparquet-version", "2.0"], "2.0.0", True, None, id="explicit-2.0"),

--- a/tests/test_geoparquet_versions.py
+++ b/tests/test_geoparquet_versions.py
@@ -261,126 +261,71 @@ class TestWriteParquetGeoOnly:
 
 
 class TestVersionCLI:
-    """Test CLI options for version control."""
+    """Test CLI options for version control.
 
-    def test_cli_default_version(self, geojson_input, temp_output_file):
-        """Test CLI default version is 1.1."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["convert", geojson_input, temp_output_file, "--skip-hilbert"])
+    One parametrized matrix over (flags, expected version, native types);
+    every cell has a distinct expected outcome, so every former test survives
+    as a param case (issue #666 item 10).
+    """
 
-        assert result.exit_code == 0
-        assert get_geoparquet_version(temp_output_file) == "1.1.0"
-
-    def test_cli_explicit_1_0(self, geojson_input, temp_output_file):
-        """Test CLI with explicit version 1.0."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "convert",
-                geojson_input,
-                temp_output_file,
-                "--skip-hilbert",
-                "--geoparquet-version",
-                "1.0",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert get_geoparquet_version(temp_output_file) == "1.0.0"
-
-    def test_cli_explicit_1_1(self, geojson_input, temp_output_file):
-        """Test CLI with explicit version 1.1."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "convert",
-                geojson_input,
-                temp_output_file,
-                "--skip-hilbert",
-                "--geoparquet-version",
-                "1.1",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert get_geoparquet_version(temp_output_file) == "1.1.0"
-
-    def test_cli_explicit_2_0(self, geojson_input, temp_output_file):
-        """Test CLI with explicit version 2.0."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "convert",
-                geojson_input,
-                temp_output_file,
-                "--skip-hilbert",
-                "--geoparquet-version",
+    @pytest.mark.parametrize(
+        ("extra_args", "expected_version", "expect_native_types", "output_contains"),
+        [
+            # expected_version: metadata version string; None = no geo metadata
+            # expected at all; "invalid" = the CLI must reject the invocation.
+            pytest.param([], "1.1.0", False, None, id="default-1.1"),
+            pytest.param(["--geoparquet-version", "1.0"], "1.0.0", False, None, id="explicit-1.0"),
+            pytest.param(["--geoparquet-version", "1.1"], "1.1.0", False, None, id="explicit-1.1"),
+            pytest.param(["--geoparquet-version", "2.0"], "2.0.0", True, None, id="explicit-2.0"),
+            pytest.param(
+                ["--geoparquet-version", "parquet-geo-only"],
+                None,
+                True,
+                None,
+                id="parquet-geo-only",
+            ),
+            pytest.param(
+                ["--geoparquet-version", "3.0"], "invalid", False, None, id="invalid-3.0-rejected"
+            ),
+            pytest.param(
+                ["--verbose", "--geoparquet-version", "2.0"],
+                "2.0.0",
+                True,
                 "2.0",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert get_geoparquet_version(temp_output_file) == "2.0.0"
-        assert has_native_geo_types(temp_output_file)
-
-    def test_cli_parquet_geo_only(self, geojson_input, temp_output_file):
-        """Test CLI with parquet-geo-only."""
+                id="verbose-shows-version",
+            ),
+        ],
+    )
+    def test_cli_version_matrix(
+        self,
+        geojson_input,
+        temp_output_file,
+        extra_args,
+        expected_version,
+        expect_native_types,
+        output_contains,
+    ):
+        """Each version flag produces its distinct expected output format."""
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            [
-                "convert",
-                geojson_input,
-                temp_output_file,
-                "--skip-hilbert",
-                "--geoparquet-version",
-                "parquet-geo-only",
-            ],
+            ["convert", geojson_input, temp_output_file, "--skip-hilbert", *extra_args],
         )
+
+        if expected_version == "invalid":
+            assert result.exit_code != 0
+            assert "Invalid value" in result.output or "invalid choice" in result.output.lower()
+            return
 
         assert result.exit_code == 0
-        assert not has_geoparquet_metadata(temp_output_file)
-        assert has_native_geo_types(temp_output_file)
-
-    def test_cli_invalid_version_rejected(self, geojson_input, temp_output_file):
-        """Test CLI rejects invalid version."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "convert",
-                geojson_input,
-                temp_output_file,
-                "--skip-hilbert",
-                "--geoparquet-version",
-                "3.0",
-            ],
-        )
-
-        assert result.exit_code != 0
-        assert "Invalid value" in result.output or "invalid choice" in result.output.lower()
-
-    def test_cli_verbose_shows_version(self, geojson_input, temp_output_file):
-        """Test verbose output shows version being used."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "convert",
-                geojson_input,
-                temp_output_file,
-                "--skip-hilbert",
-                "--verbose",
-                "--geoparquet-version",
-                "2.0",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert "2.0" in result.output
+        if expected_version is None:
+            assert not has_geoparquet_metadata(temp_output_file)
+        else:
+            assert get_geoparquet_version(temp_output_file) == expected_version
+        if expect_native_types:
+            assert has_native_geo_types(temp_output_file)
+        if output_contains is not None:
+            assert output_contains in result.output
 
 
 @pytest.mark.slow

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -294,14 +294,11 @@ def temp_dir():
 
 
 class TestHilbertSort:
-    """Test hilbert sort output format."""
+    """Test hilbert sort output format.
 
-    def test_default_format(self, sample_parquet, temp_output):
-        """Test default hilbert sort format."""
-        run_command_and_validate(
-            ["sort", "hilbert", sample_parquet, temp_output, "--geoparquet-version", "1.1"],
-            expect_bbox=False,
-        )
+    Default-format and custom-compression cases live in the parametrized
+    TestAllCommandsConsistency matrix (issue #666 item 9).
+    """
 
     def test_with_bbox(self, sample_parquet, temp_output):
         """Test hilbert sort with bbox."""
@@ -316,25 +313,6 @@ class TestHilbertSort:
                 "1.1",
             ],
             expect_bbox=True,
-        )
-
-    def test_custom_compression(self, sample_parquet, temp_output):
-        """Test hilbert sort with custom compression."""
-        run_command_and_validate(
-            [
-                "sort",
-                "hilbert",
-                sample_parquet,
-                temp_output,
-                "--compression",
-                "zstd",
-                "--compression-level",
-                "15",
-                "--geoparquet-version",
-                "1.1",
-            ],
-            expected_compression="ZSTD",
-            expect_bbox=False,
         )
 
     def test_row_groups(self, temp_dir, temp_output):
@@ -397,33 +375,11 @@ class TestHilbertSort:
 
 
 class TestAddBbox:
-    """Test add bbox output format."""
+    """Test add bbox output format.
 
-    def test_default_format(self, sample_parquet, temp_output):
-        """Test default add bbox format."""
-        run_command_and_validate(
-            ["add", "bbox", sample_parquet, temp_output, "--geoparquet-version", "1.1"],
-            expect_bbox=True,
-        )
-
-    def test_custom_compression(self, sample_parquet, temp_output):
-        """Test add bbox with custom compression."""
-        run_command_and_validate(
-            [
-                "add",
-                "bbox",
-                sample_parquet,
-                temp_output,
-                "--compression",
-                "zstd",
-                "--compression-level",
-                "15",
-                "--geoparquet-version",
-                "1.1",
-            ],
-            expected_compression="ZSTD",
-            expect_bbox=True,
-        )
+    Default-format and custom-compression cases live in the parametrized
+    TestAllCommandsConsistency matrix (issue #666 item 9).
+    """
 
     def test_custom_bbox_name(self, sample_parquet, temp_output):
         """Test add bbox with custom column name."""
@@ -540,14 +496,11 @@ class TestPartition:
 
 
 class TestExtractOutput:
-    """Test extract command output format compliance."""
+    """Test extract command output format compliance.
 
-    def test_default_format(self, sample_parquet, temp_output):
-        """Test default extract format."""
-        run_command_and_validate(
-            ["extract", sample_parquet, temp_output, "--geoparquet-version", "1.1"],
-            expect_bbox=None,  # Don't enforce bbox, just validate format
-        )
+    Default-format and custom-compression cases live in the parametrized
+    TestAllCommandsConsistency matrix (issue #666 item 9).
+    """
 
     def test_with_bbox_filter(self, sample_parquet, temp_output):
         """Test extract with bbox filter produces valid output."""
@@ -591,22 +544,6 @@ class TestExtractOutput:
                 "--geoparquet-version",
                 "1.1",
             ],
-            expect_bbox=None,
-        )
-
-    def test_custom_compression(self, sample_parquet, temp_output):
-        """Test extract with custom compression."""
-        run_command_and_validate(
-            [
-                "extract",
-                sample_parquet,
-                temp_output,
-                "--compression",
-                "gzip",
-                "--geoparquet-version",
-                "1.1",
-            ],
-            expected_compression="GZIP",
             expect_bbox=None,
         )
 
@@ -662,155 +599,133 @@ class TestConvertOutput:
         )
 
 
-class TestSortColumnOutput:
-    """Test sort column output format compliance."""
-
-    def test_default_format(self, sample_parquet, temp_output):
-        """Test default sort column format."""
-        # sort column takes: INPUT OUTPUT COLUMNS (positional arg)
-        run_command_and_validate(
-            [
-                "sort",
-                "column",
-                sample_parquet,
-                temp_output,
-                "id",
-                "--geoparquet-version",
-                "1.1",
-            ],
-            expect_bbox=None,  # Don't enforce bbox
-        )
-
-    def test_custom_compression(self, sample_parquet, temp_output):
-        """Test sort column with custom compression."""
-        run_command_and_validate(
-            [
-                "sort",
-                "column",
-                sample_parquet,
-                temp_output,
-                "id",
-                "--compression",
-                "gzip",
-                "--geoparquet-version",
-                "1.1",
-            ],
-            expected_compression="GZIP",
-            expect_bbox=None,
-        )
-
-
-class TestSortQuadkeyOutput:
-    """Test sort quadkey output format compliance."""
-
-    def test_default_format(self, sample_parquet, temp_output):
-        """Test default sort quadkey format."""
-        run_command_and_validate(
-            [
-                "sort",
-                "quadkey",
-                sample_parquet,
-                temp_output,
-                "--geoparquet-version",
-                "1.1",
-            ],
-            expect_bbox=None,  # Don't enforce bbox
-        )
-
-    def test_custom_compression(self, sample_parquet, temp_output):
-        """Test sort quadkey with custom compression."""
-        run_command_and_validate(
-            [
-                "sort",
-                "quadkey",
-                sample_parquet,
-                temp_output,
-                "--compression",
-                "gzip",
-                "--geoparquet-version",
-                "1.1",
-            ],
-            expected_compression="GZIP",
-            expect_bbox=None,
-        )
-
-
 class TestAllCommandsConsistency:
-    """Test consistency across all commands."""
+    """Parametrized output-format matrix across all writing commands.
 
-    def test_all_produce_correct_version(self, sample_parquet):
-        """Ensure all commands produce the configured GeoParquet version."""
-        # Commands where the pattern is: cmd INPUT OUTPUT [OPTIONS]
-        simple_commands = [
-            ["sort", "hilbert"],
-            ["sort", "quadkey"],
-            ["add", "bbox"],
-            ["extract"],
-        ]
+    One case per command with granular failure IDs. This matrix also carries
+    the per-command default-format and custom-compression cases that used to be
+    duplicated in per-command classes (issue #666 item 9); sort column and
+    sort quadkey have no other output-format cases, so their classes are gone.
+    """
 
-        for cmd_base in simple_commands:
-            with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
-                tmp_name = tmp.name
-            # Remove the file so tests don't trigger overwrite checks
-            os.unlink(tmp_name)
+    @pytest.mark.parametrize(
+        ("cmd_base", "positional_extra", "expect_bbox"),
+        [
+            # sort hilbert must NOT add a bbox by default; add bbox MUST produce one
+            pytest.param(["sort", "hilbert"], [], False, id="sort-hilbert"),
+            pytest.param(["sort", "quadkey"], [], None, id="sort-quadkey"),
+            pytest.param(["add", "bbox"], [], True, id="add-bbox"),
+            pytest.param(["extract"], [], None, id="extract"),
+            # sort column has special syntax: sort column INPUT OUTPUT COLUMNS
+            pytest.param(["sort", "column"], ["id"], None, id="sort-column"),
+        ],
+    )
+    def test_all_produce_correct_version(
+        self, sample_parquet, temp_output, cmd_base, positional_extra, expect_bbox
+    ):
+        """Ensure each command produces the configured GeoParquet version."""
+        run_command_and_validate(
+            cmd_base
+            + [sample_parquet, temp_output]
+            + positional_extra
+            + ["--geoparquet-version", "1.1"],
+            expect_bbox=expect_bbox,
+        )
 
-            try:
-                run_command_and_validate(
-                    cmd_base + [sample_parquet, tmp_name, "--geoparquet-version", "1.1"],
-                    expect_bbox=None,  # Don't check bbox, just version/compression
-                )
-            finally:
-                if os.path.exists(tmp_name):
-                    os.unlink(tmp_name)
-
-        # sort column has special syntax: sort column INPUT OUTPUT COLUMNS [OPTIONS]
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
-            tmp_name = tmp.name
-        # Remove the file so tests don't trigger overwrite checks
-        os.unlink(tmp_name)
-
-        try:
-            run_command_and_validate(
-                ["sort", "column", sample_parquet, tmp_name, "id", "--geoparquet-version", "1.1"],
-                expect_bbox=None,
-            )
-        finally:
-            if os.path.exists(tmp_name):
-                os.unlink(tmp_name)
-
-    def test_compression_options_work(self, sample_parquet):
-        """Test that all compression options work correctly."""
-        compressions = [
-            ("zstd", "ZSTD"),
-            ("gzip", "GZIP"),
-            ("brotli", "BROTLI"),
-            ("lz4", "LZ4"),
-            ("snappy", "SNAPPY"),
-        ]
-
-        for compression_arg, expected_compression in compressions:
-            with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
-                tmp_name = tmp.name
-            # Remove the file so tests don't trigger overwrite checks
-            os.unlink(tmp_name)
-
-            try:
-                run_command_and_validate(
-                    [
-                        "sort",
-                        "hilbert",
-                        sample_parquet,
-                        tmp_name,
-                        "--compression",
-                        compression_arg,
-                        "--geoparquet-version",
-                        "1.1",
-                    ],
-                    expected_compression=expected_compression,
-                )
-            finally:
-                if os.path.exists(tmp_name):
-                    os.unlink(tmp_name)
+    @pytest.mark.parametrize(
+        ("cmd_base", "positional_extra", "compression_args", "expected_compression", "expect_bbox"),
+        [
+            # Every supported codec, exercised through sort hilbert
+            pytest.param(
+                ["sort", "hilbert"],
+                [],
+                ["--compression", "zstd", "--compression-level", "15"],
+                "ZSTD",
+                False,
+                id="sort-hilbert-zstd-level",
+            ),
+            pytest.param(
+                ["sort", "hilbert"],
+                [],
+                ["--compression", "gzip"],
+                "GZIP",
+                None,
+                id="sort-hilbert-gzip",
+            ),
+            pytest.param(
+                ["sort", "hilbert"],
+                [],
+                ["--compression", "brotli"],
+                "BROTLI",
+                None,
+                id="sort-hilbert-brotli",
+            ),
+            pytest.param(
+                ["sort", "hilbert"],
+                [],
+                ["--compression", "lz4"],
+                "LZ4",
+                None,
+                id="sort-hilbert-lz4",
+            ),
+            pytest.param(
+                ["sort", "hilbert"],
+                [],
+                ["--compression", "snappy"],
+                "SNAPPY",
+                None,
+                id="sort-hilbert-snappy",
+            ),
+            # Per-command plumbing: --compression reaches each command's writer
+            pytest.param(
+                ["add", "bbox"],
+                [],
+                ["--compression", "zstd", "--compression-level", "15"],
+                "ZSTD",
+                True,
+                id="add-bbox-zstd-level",
+            ),
+            pytest.param(
+                ["extract"], [], ["--compression", "gzip"], "GZIP", None, id="extract-gzip"
+            ),
+            pytest.param(
+                ["sort", "column"],
+                ["id"],
+                ["--compression", "gzip"],
+                "GZIP",
+                None,
+                id="sort-column-gzip",
+            ),
+            pytest.param(
+                ["sort", "quadkey"],
+                [],
+                ["--compression", "gzip"],
+                "GZIP",
+                None,
+                id="sort-quadkey-gzip",
+            ),
+        ],
+    )
+    def test_compression_options_work(
+        self,
+        sample_parquet,
+        temp_output,
+        cmd_base,
+        positional_extra,
+        compression_args,
+        expected_compression,
+        expect_bbox,
+    ):
+        """Test that compression options work and reach every command."""
+        run_command_and_validate(
+            cmd_base
+            + [sample_parquet, temp_output]
+            + positional_extra
+            + compression_args
+            + ["--geoparquet-version", "1.1"],
+            expected_compression=expected_compression,
+            expect_bbox=expect_bbox,
+        )
 
 
 # ============================================================================

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -657,17 +657,24 @@ class TestErrorHandling:
 class TestWFSExceptionHierarchy:
     """Test typed WFS exception subclasses for downstream consumers."""
 
-    def test_empty_layer_error_is_wfs_error(self):
-        """EmptyLayerError should be catchable as WFSError (backward compatible)."""
-        assert issubclass(EmptyLayerError, WFSError)
-
-    def test_layer_not_found_error_is_wfs_error(self):
-        """LayerNotFoundError should be catchable as WFSError (backward compatible)."""
-        assert issubclass(LayerNotFoundError, WFSError)
-
-    def test_auth_error_is_wfs_error(self):
-        """WFSAuthenticationError should be catchable as WFSError (backward compatible)."""
-        assert issubclass(WFSAuthenticationError, WFSError)
+    @pytest.mark.parametrize(
+        ("exc_class", "args"),
+        [
+            pytest.param(EmptyLayerError, ("test:layer",), id="empty-layer"),
+            pytest.param(LayerNotFoundError, ("test:layer",), id="layer-not-found"),
+            pytest.param(
+                WFSAuthenticationError,
+                ("http://example.com/wfs", 401, "Auth required"),
+                id="authentication",
+            ),
+        ],
+    )
+    def test_subclass_catchable_as_wfs_error(self, exc_class, args):
+        """Each typed subclass is catchable as WFSError (backward compatible)."""
+        assert issubclass(exc_class, WFSError)
+        with pytest.raises(WFSError) as exc_info:
+            raise exc_class(*args)
+        assert isinstance(exc_info.value, exc_class)
 
     def test_empty_layer_error_has_typename(self):
         """EmptyLayerError should expose typename attribute."""
@@ -697,14 +704,6 @@ class TestWFSExceptionHierarchy:
         assert err.url == "http://example.com/wfs"
         assert err.status_code == 401
         assert "Auth required" in str(err)
-
-    def test_empty_layer_error_caught_as_wfs_error(self):
-        """Verify backward compatibility - catching as WFSError works."""
-        try:
-            raise EmptyLayerError("test:layer")
-        except WFSError as e:
-            assert isinstance(e, EmptyLayerError)
-            assert e.typename == "test:layer"
 
     @patch("owslib.wfs.WebFeatureService")
     def test_layer_not_found_raises_typed_error(self, mock_wfs_class):
@@ -1371,164 +1370,115 @@ class TestDuckDBNativeWFS:
         assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type)
 
 
+def _mock_wfs_http_response(body: bytes, content_type: str = "application/json"):
+    """Patch httpx.Client.stream to return a canned 200 response.
+
+    Shared factory for the content-type and properties-handling tests, which
+    previously each carried a near-identical inline mock class (issue #666
+    item 7). The response supports both ``read()`` (error-page validation path)
+    and ``iter_bytes()`` (streaming JSON path).
+    """
+    import httpx
+
+    def mock_stream(*args, **kwargs):
+        class MockResponse:
+            status_code = 200
+            headers = {"content-type": content_type}
+
+            def raise_for_status(self):
+                pass
+
+            def read(self):
+                return body
+
+            def iter_bytes(self, chunk_size=None):
+                yield body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        return MockResponse()
+
+    return patch.object(httpx.Client, "stream", mock_stream)
+
+
+_EMPTY_FEATURE_COLLECTION = b'{"type": "FeatureCollection", "features": []}'
+
+
 class TestContentTypeValidation:
     """Test content-type validation catches error pages returned with 200 OK."""
 
-    def test_rejects_html_content_type(self):
-        """HTML responses should be rejected with clear error."""
-        import httpx
-
+    @pytest.mark.parametrize(
+        ("content_type", "body", "error_match"),
+        [
+            pytest.param(
+                "text/html; charset=utf-8",
+                b"<html><body>Error: Service unavailable</body></html>",
+                "Expected JSON.*text/html",
+                id="rejects-html",
+            ),
+            pytest.param(
+                "application/xml",
+                b"<ows:ExceptionReport>Service error</ows:ExceptionReport>",
+                "Expected JSON.*application/xml",
+                id="rejects-xml",
+            ),
+            pytest.param(
+                "text/plain",
+                b"Error: Invalid request parameters",
+                "Expected JSON.*text/plain",
+                id="rejects-text-plain",
+            ),
+            pytest.param(
+                "application/json", _EMPTY_FEATURE_COLLECTION, None, id="accepts-application-json"
+            ),
+            pytest.param(
+                "text/javascript",
+                _EMPTY_FEATURE_COLLECTION,
+                None,
+                id="accepts-text-javascript",
+            ),
+        ],
+    )
+    def test_content_type_validation(self, content_type, body, error_match):
+        """Non-JSON content types raise WFSError; JSON-ish ones parse normally."""
         from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
 
-        html_response = b"<html><body>Error: Service unavailable</body></html>"
+        with _mock_wfs_http_response(body, content_type):
+            if error_match is not None:
+                with pytest.raises(WFSError, match=error_match):
+                    _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+            else:
+                # Should not raise, returns empty table
+                result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+                assert result.num_rows == 0
 
-        def mock_stream(*args, **kwargs):
-            class MockResponse:
-                status_code = 200
-                headers = {"content-type": "text/html; charset=utf-8"}
 
-                def raise_for_status(self):
-                    pass
+_OMIT_PROPERTIES = object()
+"""Sentinel: build a feature with no 'properties' key at all (malformed GeoJSON)."""
 
-                def read(self):
-                    return html_response
 
-                def __enter__(self):
-                    return self
+def _wfs_point_features(props_list, fids=None):
+    """Build GeoJSON point features with the given per-feature properties.
 
-                def __exit__(self, *args):
-                    pass
-
-            return MockResponse()
-
-        with patch.object(httpx.Client, "stream", mock_stream):
-            with pytest.raises(WFSError, match="Expected JSON.*text/html"):
-                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-
-    def test_rejects_xml_content_type(self):
-        """XML error responses should be rejected."""
-        import httpx
-
-        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
-
-        xml_response = b"<ows:ExceptionReport>Service error</ows:ExceptionReport>"
-
-        def mock_stream(*args, **kwargs):
-            class MockResponse:
-                status_code = 200
-                headers = {"content-type": "application/xml"}
-
-                def raise_for_status(self):
-                    pass
-
-                def read(self):
-                    return xml_response
-
-                def __enter__(self):
-                    return self
-
-                def __exit__(self, *args):
-                    pass
-
-            return MockResponse()
-
-        with patch.object(httpx.Client, "stream", mock_stream):
-            with pytest.raises(WFSError, match="Expected JSON.*application/xml"):
-                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-
-    def test_rejects_text_plain_content_type(self):
-        """text/plain error responses should be rejected."""
-        import httpx
-
-        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
-
-        text_response = b"Error: Invalid request parameters"
-
-        def mock_stream(*args, **kwargs):
-            class MockResponse:
-                status_code = 200
-                headers = {"content-type": "text/plain"}
-
-                def raise_for_status(self):
-                    pass
-
-                def read(self):
-                    return text_response
-
-                def __enter__(self):
-                    return self
-
-                def __exit__(self, *args):
-                    pass
-
-            return MockResponse()
-
-        with patch.object(httpx.Client, "stream", mock_stream):
-            with pytest.raises(WFSError, match="Expected JSON.*text/plain"):
-                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-
-    def test_accepts_application_json(self):
-        """application/json should be accepted."""
-        import httpx
-
-        from geoparquet_io.core.wfs import _fetch_wfs_page
-
-        json_response = b'{"type": "FeatureCollection", "features": []}'
-
-        def mock_stream(*args, **kwargs):
-            class MockResponse:
-                status_code = 200
-                headers = {"content-type": "application/json"}
-
-                def raise_for_status(self):
-                    pass
-
-                def iter_bytes(self, chunk_size=None):
-                    yield json_response
-
-                def __enter__(self):
-                    return self
-
-                def __exit__(self, *args):
-                    pass
-
-            return MockResponse()
-
-        with patch.object(httpx.Client, "stream", mock_stream):
-            # Should not raise, returns empty table
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-            assert result.num_rows == 0
-
-    def test_accepts_text_javascript(self):
-        """text/javascript (used by some servers) should be accepted."""
-        import httpx
-
-        from geoparquet_io.core.wfs import _fetch_wfs_page
-
-        json_response = b'{"type": "FeatureCollection", "features": []}'
-
-        def mock_stream(*args, **kwargs):
-            class MockResponse:
-                status_code = 200
-                headers = {"content-type": "text/javascript"}
-
-                def raise_for_status(self):
-                    pass
-
-                def iter_bytes(self, chunk_size=None):
-                    yield json_response
-
-                def __enter__(self):
-                    return self
-
-                def __exit__(self, *args):
-                    pass
-
-            return MockResponse()
-
-        with patch.object(httpx.Client, "stream", mock_stream):
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-            assert result.num_rows == 0
+    ``_OMIT_PROPERTIES`` omits the 'properties' member entirely (malformed per
+    RFC 7946); any other value (including ``None`` and ``{}``) is used as-is.
+    """
+    features = []
+    for i, props in enumerate(props_list):
+        feature = {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [i, i]},
+        }
+        if props is not _OMIT_PROPERTIES:
+            feature["properties"] = props
+        if fids is not None:
+            feature["id"] = fids[i]
+        features.append(feature)
+    return features
 
 
 class TestEmptyProperties:
@@ -1542,228 +1492,73 @@ class TestEmptyProperties:
     See: https://github.com/geoparquet/geoparquet-io/issues/441
     """
 
-    def _make_mock_stream(self, geojson_bytes: bytes):
-        """Create a mock httpx stream response."""
-        import httpx
-
-        def mock_stream(*args, **kwargs):
-            class MockResponse:
-                status_code = 200
-                headers = {"content-type": "application/json"}
-
-                def raise_for_status(self):
-                    pass
-
-                def iter_bytes(self, chunk_size=None):
-                    yield geojson_bytes
-
-                def __enter__(self):
-                    return self
-
-                def __exit__(self, *args):
-                    pass
-
-            return MockResponse()
-
-        return patch.object(httpx.Client, "stream", mock_stream)
-
-    def test_empty_properties_returns_geometry_only(self):
-        """Empty properties ({}) should return geometry-only table."""
+    @pytest.mark.parametrize(
+        ("features", "fetch_kwargs", "exact_columns", "required_columns"),
+        [
+            pytest.param(
+                _wfs_point_features([{}, {}]),
+                {},
+                ["geometry"],
+                [],
+                id="empty-properties-geometry-only",
+            ),
+            pytest.param(
+                _wfs_point_features([None, None]),
+                {},
+                ["geometry"],
+                [],
+                id="null-properties-geometry-only",
+            ),
+            pytest.param(
+                _wfs_point_features([{}, {}], fids=["line.1", "line.2"]),
+                {"extract_fid": True},
+                ["_wfs_fid", "geometry"],
+                [],
+                id="empty-properties-extract-fid",
+            ),
+            pytest.param(
+                _wfs_point_features(
+                    [{"name": "A", "population": 100}, {"name": "B", "population": 200}]
+                ),
+                {},
+                None,
+                ["geometry", "name", "population"],
+                id="normal-properties-unnested",
+            ),
+            pytest.param(
+                _wfs_point_features([{"value": 123}, {"value": "text"}]),
+                {},
+                None,
+                ["geometry", "value"],
+                id="heterogeneous-value-types",
+            ),
+            pytest.param(
+                _wfs_point_features([_OMIT_PROPERTIES, _OMIT_PROPERTIES]),
+                {},
+                ["geometry"],
+                [],
+                id="missing-properties-key-geometry-only",
+            ),
+        ],
+    )
+    def test_properties_handling(self, features, fetch_kwargs, exact_columns, required_columns):
+        """Each properties shape yields the expected columns (geometry-only fallback or unnest)."""
         import json
 
         import pyarrow as pa
 
         from geoparquet_io.core.wfs import _fetch_wfs_page
 
-        geojson = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [0, 0]},
-                    "properties": {},
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [1, 1]},
-                    "properties": {},
-                },
-            ],
-        }
-
-        with self._make_mock_stream(json.dumps(geojson).encode()):
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+        geojson = {"type": "FeatureCollection", "features": features}
+        with _mock_wfs_http_response(json.dumps(geojson).encode()):
+            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS", **fetch_kwargs)
 
         assert isinstance(result, pa.Table)
         assert result.num_rows == 2
-        assert "geometry" in result.column_names
-        # No property columns - only geometry
-        assert result.column_names == ["geometry"]
-
-    def test_null_properties_returns_geometry_only(self):
-        """Null properties should return geometry-only table."""
-        import json
-
-        import pyarrow as pa
-
-        from geoparquet_io.core.wfs import _fetch_wfs_page
-
-        geojson = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [0, 0]},
-                    "properties": None,
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [1, 1]},
-                    "properties": None,
-                },
-            ],
-        }
-
-        with self._make_mock_stream(json.dumps(geojson).encode()):
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 2
-        assert result.column_names == ["geometry"]
-
-    def test_empty_properties_with_extract_fid(self):
-        """Empty properties with extract_fid=True should include _wfs_fid."""
-        import json
-
-        import pyarrow as pa
-
-        from geoparquet_io.core.wfs import _fetch_wfs_page
-
-        geojson = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "id": "line.1",
-                    "geometry": {"type": "Point", "coordinates": [0, 0]},
-                    "properties": {},
-                },
-                {
-                    "type": "Feature",
-                    "id": "line.2",
-                    "geometry": {"type": "Point", "coordinates": [1, 1]},
-                    "properties": {},
-                },
-            ],
-        }
-
-        with self._make_mock_stream(json.dumps(geojson).encode()):
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS", extract_fid=True)
-
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 2
-        assert "_wfs_fid" in result.column_names
-        assert "geometry" in result.column_names
-        assert result.column_names == ["_wfs_fid", "geometry"]
-
-    def test_normal_properties_still_works(self):
-        """Normal properties should still be unnested into columns."""
-        import json
-
-        import pyarrow as pa
-
-        from geoparquet_io.core.wfs import _fetch_wfs_page
-
-        geojson = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [0, 0]},
-                    "properties": {"name": "A", "population": 100},
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [1, 1]},
-                    "properties": {"name": "B", "population": 200},
-                },
-            ],
-        }
-
-        with self._make_mock_stream(json.dumps(geojson).encode()):
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 2
-        assert "geometry" in result.column_names
-        assert "name" in result.column_names
-        assert "population" in result.column_names
-
-    def test_heterogeneous_value_types_still_works(self):
-        """Heterogeneous value types (promoted to JSON) should still work."""
-        import json
-
-        import pyarrow as pa
-
-        from geoparquet_io.core.wfs import _fetch_wfs_page
-
-        geojson = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [0, 0]},
-                    "properties": {"value": 123},
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [1, 1]},
-                    "properties": {"value": "text"},
-                },
-            ],
-        }
-
-        with self._make_mock_stream(json.dumps(geojson).encode()):
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 2
-        assert "geometry" in result.column_names
-        assert "value" in result.column_names
-
-    def test_missing_properties_key_returns_geometry_only(self):
-        """Missing properties key (malformed GeoJSON) should return geometry-only table.
-
-        Per RFC 7946, the 'properties' member is required, but we handle
-        malformed GeoJSON gracefully by returning geometry-only results.
-        """
-        import json
-
-        import pyarrow as pa
-
-        from geoparquet_io.core.wfs import _fetch_wfs_page
-
-        geojson = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [0, 0]},
-                    # No 'properties' key - malformed per RFC 7946
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [1, 1]},
-                },
-            ],
-        }
-
-        with self._make_mock_stream(json.dumps(geojson).encode()):
-            result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 2
-        assert result.column_names == ["geometry"]
+        if exact_columns is not None:
+            assert result.column_names == exact_columns
+        for column in required_columns:
+            assert column in result.column_names
 
 
 @pytest.mark.usefixtures("offline_wfs_probes")


### PR DESCRIPTION
Executes the mechanical-consolidation slice of #666: items 2, 7, 9 and 10 from the ranked table. Item 8 turned out to be already done on main (details below). Tests only — no `geoparquet_io/` code is touched, and none of the issue's Non-goals (version outcome matrix cells, injection vectors, Windows handle-closing patterns, `fields_5070`, corpus/bloom/overview tests) are modified.

## Before / after

Fast suite (`-n auto -m "not slow and not network and not meta" --cov=geoparquet_io`), same machine, back to back:

| Metric | origin/main (4a0cdc4) | this branch | delta |
|---|---|---|---|
| Collected (fast suite) | 5,309 (5,250 passed + 1 xdist flake* + 56 skipped + 2 xfailed) | 5,304 (5,246 passed + 56 skipped + 2 xfailed, no failures) | −5 test instances |
| Wall time | 202.2s (211s real) | 170.9s (172s real) | **−31s (−15%)** |
| Coverage | **19,472 / 23,824 lines = 81.73%** | **19,472 / 23,824 lines = 81.73%** | byte-identical |
| Touched-file LOC | 8,750 | 8,364 | **−386** |
| `diff-cover --compare-branch origin/main --fail-under 90` | — | "No lines with coverage information in this diff" (tests-only) | pass |
| `pytest -m meta` | — | 202 passed | pass |
| pre-commit | — | all hooks pass | pass |

\* baseline's one failure (`test_geojson_stream.py::test_streaming_handles_broken_pipe`) is a known xdist cold-run flake on untouched code; it passes serially and passed in the after-run.

Per-file LOC: `test_convert.py` 1,395→1,354 · `test_wfs.py` 4,488→4,283 · `test_output_format.py` 822→737 · `test_geoparquet_versions.py` 2,045→1,990.

## Per-item accounting

### Item 2 — `test_convert.py` (15 full conversions → 2)

- `TestConvertBestPractices`: all 8 tests ran the identical default shapefile conversion to assert one property each. Now a single module-scoped `best_practices_file` fixture converts once; all 8 tests keep their exact assertion bodies against it (output is read-only in every assertion, so scope promotion is safe).
- `TestConvertCLI`: 8 tests (7 conversions) → 2 tests (1 conversion). The merged plumbing run (`--verbose --compression ZSTD --compression-level 15`) asserts everything the dropped tests asserted: exit 0 + file exists, `Converting`/`Done in`/`Output:`/`validation` messages, verbose `Detecting geometry column`/`Dataset bounds`, and ZSTD on the geometry column. The error-path test is unchanged. Dropped-case coverage lives elsewhere in the fast suite:
  - GeoJSON via CLI convert: every `TestVersionCLI` case in `test_geoparquet_versions.py` (7 runs).
  - GeoPackage conversion: `tests/test_linearize.py::TestCliConvert::test_cli_convert_linearizes_by_default (bare-convert .gpkg dispatch) and test_convert_layer.py` (fast, multiple gpkg conversions).
  - `--skip-hilbert` CLI plumbing: every `TestVersionCLI` case passes it.

### Item 7 — `test_wfs.py` mock scaffolds (−205 LOC)

- `TestContentTypeValidation`: 5 tests × ~30-line inline mock class → 1 parametrized test over (content-type, body, error-match) with a shared `_mock_wfs_http_response` factory. All 3 reject vectors and both accept vectors survive as param ids with the same `pytest.raises(..., match=...)` / empty-table assertions.
- `TestEmptyProperties`: 6 tests → 1 parametrized test over (features, fetch kwargs, exact/required columns) using the same factory plus a `_wfs_point_features` builder; all six shapes (empty, null, empty+`extract_fid`, normal, heterogeneous, missing key) keep their exact expected column lists and `num_rows == 2`.
- `TestWFSExceptionHierarchy`: the 3 subclass checks + the raise/catch backward-compat test → 1 parametrized subclass-and-catchable test; the 5 attribute tests (distinct semantics) are untouched. The `typename == "test:layer"` assertion from the folded catch test is still made by `test_empty_layer_error_has_typename`.
- Retry-timing/backoff tests and the `offline_wfs_probes` fixture are untouched.

### Item 8 — `test_validate_claude_md.py`: already done, no change

Landed on main before this PR: the file already keeps exactly 2 subprocess spawns (`test_script_runs_successfully`, `test_catches_invalid_command`) and drives every other case through an in-process `main()` import, with a comment documenting that policy. Nothing left to do.

### Item 9 — `test_output_format.py` (27 CLI runs → 21, granular IDs)

`TestAllCommandsConsistency` looped all commands inside two monolithic tests while per-command classes duplicated the same default-format and custom-compression runs. Now:

- `test_all_produce_correct_version`: parametrized per command (5 cases) and strengthened to carry each command's bbox expectation (`sort hilbert` must not add bbox, `add bbox` must — previously only asserted in the duplicating per-command tests, `expect_bbox=None` in the old loop).
- `test_compression_options_work`: parametrized over 9 cases — all 5 codecs through `sort hilbert` (zstd keeping the `--compression-level 15` plumbing) plus per-command `--compression` plumbing for `add bbox` (zstd+level), `extract`, `sort column`, `sort quadkey` (gzip).
- Dropped: the per-command `test_default_format`/`test_custom_compression` in `TestHilbertSort`/`TestAddBbox`/`TestExtractOutput` and the whole `TestSortColumnOutput`/`TestSortQuadkeyOutput` classes — every one of their (command, options, expectation) tuples appears verbatim as a matrix case.
- Kept: hilbert `--add-bbox` and row-group tests, `add bbox --bbox-name`, extract's three filter tests, string partition, and the slow/network classes — all untouched.

### Item 10 — `test_geoparquet_versions.py::TestVersionCLI` (7 tests → 1×7 params)

One test parametrized over (flags, expected version, expect_native_types, output text). **Every instance survives as a param case; none dropped** — `default-1.1`, `explicit-1.0`, `explicit-1.1`, `explicit-2.0`, `parquet-geo-only`, `invalid-3.0-rejected`, `verbose-shows-version`. The verbose case gained the version/native-type assertions its flags imply (strictly stronger); all other cells assert exactly what they did before. Still 7 CLI runs — this item is LOC/maintenance only, per the issue.

## Zero-behavior-loss method

For every deleted or merged test, its assertions were enumerated and mapped to where the consolidated version (or another fast-suite test) makes the same assertion — see the per-item notes above. The two coverage runs bracket it: line coverage is byte-identical (19,472/23,824 both sides).

Refs #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated conversion, CLI, GeoParquet version, output-format, compression, and WFS test coverage.
  * Added parameterized coverage for supported compression methods, version combinations, command behaviors, and WFS error handling.
  * Reduced redundant test setup and repeated conversions while preserving validation of existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
