### PR TITLE
test: dedupe cross-layer assertions and the ops mirror suite

### DIFF
--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -487,9 +487,10 @@ class TestAddH3CLI:
     """`gpio add h3` plumbing, asserted off two shared runs (#666, item 5).
 
     H3 *semantics* -- what the column holds, which resolutions are legal, what
-    the metadata survives -- are asserted once against the core functions in
-    ``tests/test_add_h3.py`` (``TestAddH3Table`` for ``add_h3_table``,
-    ``TestAddH3File`` for ``add_h3_column``). What only the CLI layer can get
+    the metadata survives -- are asserted once against the core functions
+    ``add_h3_table`` and ``add_h3_column`` in the per-index family suite:
+    ``tests/test_add_h3.py`` today, ``tests/test_spatial_index_family.py`` once
+    #830 folds the per-index files into it. What only the CLI layer can get
     wrong is whether each option reaches core at all, so this class runs the
     command twice -- once on defaults, once with every option set -- and asserts
     both outputs many times over, instead of paying a DuckDB + h3-extension run
@@ -564,21 +565,39 @@ class TestAddH3CLI:
         assert "Loading DuckDB extension: h3" in result.output
 
     @pytest.mark.parametrize(
-        ("input_file", "extra_args"),
+        ("input_file", "extra_args", "message"),
         [
-            pytest.param("nonexistent.parquet", [], id="missing-input"),
-            pytest.param(str(BUILDINGS_TEST_FILE), ["--resolution", "-1"], id="resolution-below-0"),
             pytest.param(
-                str(BUILDINGS_TEST_FILE), ["--resolution", "16"], id="resolution-above-15"
+                "nonexistent.parquet",
+                [],
+                "Cannot read file: nonexistent.parquet",
+                id="missing-input",
+            ),
+            pytest.param(
+                str(BUILDINGS_TEST_FILE),
+                ["--resolution", "-1"],
+                "-1 is not in the range 0<=x<=15",
+                id="resolution-below-0",
+            ),
+            pytest.param(
+                str(BUILDINGS_TEST_FILE),
+                ["--resolution", "16"],
+                "16 is not in the range 0<=x<=15",
+                id="resolution-above-15",
             ),
         ],
     )
-    def test_refuses_bad_input(self, input_file, extra_args, tmp_path):
-        """Each of these must fail loudly rather than write a file (#666, item 5)."""
+    def test_refuses_bad_input(self, input_file, extra_args, message, tmp_path):
+        """Each of these must fail loudly rather than write a file (#666, item 5).
+
+        The message is asserted too: a non-zero exit says only that *something*
+        went wrong, which an unrelated failure would satisfy just as well.
+        """
         output = tmp_path / "out.parquet"
         result = CliRunner().invoke(add, ["h3", input_file, str(output), *extra_args])
 
         assert result.exit_code != 0, result.output
+        assert message in result.output
         assert not output.exists()
 
     def test_core_function_rejects_an_out_of_range_resolution(

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -9,6 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.cli.main import add
+from tests.conftest import BUILDINGS_TEST_FILE
 
 
 def _read_geo_metadata(parquet_file):
@@ -24,29 +25,6 @@ def _read_geo_metadata(parquet_file):
 
 class TestAddCommands:
     """Test suite for add commands."""
-
-    def test_add_bbox_to_buildings(self, buildings_test_file, temp_output_file):
-        """Test adding bbox column to buildings file (which doesn't have bbox)."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["bbox", buildings_test_file, temp_output_file])
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-
-        # Verify bbox column was added
-        conn = duckdb.connect()
-        columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
-        column_names = [col[0] for col in columns]
-        assert "bbox" in column_names
-
-        # Verify row count matches
-        input_count = conn.execute(f'SELECT COUNT(*) FROM "{buildings_test_file}"').fetchone()[0]
-        output_count = conn.execute(f'SELECT COUNT(*) FROM "{temp_output_file}"').fetchone()[0]
-        assert input_count == output_count
-
-        # Verify bbox structure
-        bbox_col = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
-        bbox_info = [col for col in bbox_col if col[0] == "bbox"][0]
-        assert "STRUCT" in bbox_info[1]
 
     def test_add_bbox_to_places_copies_existing(self, places_with_covering_file, temp_output_file):
         """Existing bbox column: copy the input to OUTPUT_FILE and say so (#728).
@@ -352,77 +330,12 @@ class TestAddCommands:
         assert "bbox" in column_names  # Original kept
         assert "bounds" in column_names  # New one added
 
-    def test_add_bbox_with_custom_name(self, buildings_test_file, temp_output_file):
-        """Test adding bbox column with custom name."""
-        runner = CliRunner()
-        result = runner.invoke(
-            add, ["bbox", buildings_test_file, temp_output_file, "--bbox-name", "bounds"]
-        )
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-
-        # Verify custom bbox column name was used
-        conn = duckdb.connect()
-        columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
-        column_names = [col[0] for col in columns]
-        assert "bounds" in column_names
-
-    def test_add_bbox_with_verbose(self, buildings_test_file, temp_output_file):
-        """Test adding bbox column with verbose flag."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["bbox", buildings_test_file, temp_output_file, "--verbose"])
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-
-    def test_add_bbox_preserves_columns(self, buildings_test_file, temp_output_file):
-        """Test that add bbox preserves all original columns."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["bbox", buildings_test_file, temp_output_file])
-        assert result.exit_code == 0
-
-        # Verify columns are preserved
-        conn = duckdb.connect()
-        input_columns = conn.execute(f'DESCRIBE SELECT * FROM "{buildings_test_file}"').fetchall()
-        output_columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
-
-        input_col_names = {col[0] for col in input_columns}
-        output_col_names = {col[0] for col in output_columns}
-
-        # All input columns should be in output
-        assert input_col_names.issubset(output_col_names)
-        # Output should have bbox column added
-        assert "bbox" in output_col_names
-
     def test_add_bbox_nonexistent_file(self, temp_output_file):
         """Test add bbox on nonexistent file."""
         runner = CliRunner()
         result = runner.invoke(add, ["bbox", "nonexistent.parquet", temp_output_file])
         # Should fail with non-zero exit code
         assert result.exit_code != 0
-
-    def test_add_bbox_with_metadata_always_added(self, buildings_test_file, temp_output_file):
-        """Test that bbox metadata is automatically added."""
-        import json
-
-        import pyarrow.parquet as pq
-
-        runner = CliRunner()
-        result = runner.invoke(add, ["bbox", buildings_test_file, temp_output_file])
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-
-        # Verify bbox metadata was added automatically
-        pf = pq.ParquetFile(temp_output_file)
-        metadata = pf.schema_arrow.metadata
-        assert b"geo" in metadata
-
-        geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-
-        # Verify bbox covering metadata exists
-        assert "columns" in geo_meta
-        assert "geometry" in geo_meta["columns"]
-        assert "covering" in geo_meta["columns"]["geometry"]
-        assert "bbox" in geo_meta["columns"]["geometry"]["covering"]
 
     def test_add_bbox_metadata_on_v10_file_with_bbox_errors(self, temp_output_dir):
         """add bbox-metadata refuses a 1.0 file, whose version cannot carry covering.
@@ -461,205 +374,234 @@ class TestAddCommands:
         assert result.exit_code != 0
         assert "No valid bbox column found" in result.output
 
-    # H3 tests
-    def test_add_h3_to_buildings(self, buildings_test_file, temp_output_file):
-        """Test adding H3 column to buildings file."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["h3", buildings_test_file, temp_output_file])
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-
-        # Verify h3_cell column was added
-        conn = duckdb.connect()
-        conn.execute("INSTALL spatial; LOAD spatial;")
-        conn.execute("INSTALL h3 FROM community; LOAD h3;")
-
-        columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
-        column_names = [col[0] for col in columns]
-        assert "h3_cell" in column_names
-
-        # Verify row count is preserved
-        input_count = conn.execute(f'SELECT COUNT(*) FROM "{buildings_test_file}"').fetchone()[0]
-        output_count = conn.execute(f'SELECT COUNT(*) FROM "{temp_output_file}"').fetchone()[0]
-        assert input_count == output_count
-
-        # Verify H3 column is VARCHAR
-        h3_col = [col for col in columns if col[0] == "h3_cell"][0]
-        assert "VARCHAR" in h3_col[1]
-
-        # Verify H3 cells are valid
-        valid_count = conn.execute(
-            f'SELECT COUNT(*) FROM "{temp_output_file}" '
-            f"WHERE h3_is_valid_cell(h3_string_to_h3(h3_cell))"
-        ).fetchone()[0]
-        assert valid_count == output_count
-
-    def test_add_h3_default_resolution(self, buildings_test_file, temp_output_file):
-        """Test that H3 uses resolution 9 by default."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["h3", buildings_test_file, temp_output_file])
-        assert result.exit_code == 0
-
-        # Verify all cells are resolution 9
-        conn = duckdb.connect()
-        conn.execute("INSTALL spatial; LOAD spatial;")
-        conn.execute("INSTALL h3 FROM community; LOAD h3;")
-
-        resolutions = conn.execute(
-            f'SELECT DISTINCT h3_get_resolution(h3_string_to_h3(h3_cell)) FROM "{temp_output_file}"'
-        ).fetchall()
-        assert len(resolutions) == 1
-        assert resolutions[0][0] == 9
-
-    def test_add_h3_custom_resolution(self, buildings_test_file, temp_output_file):
-        """Test adding H3 column with custom resolution."""
-        runner = CliRunner()
-        result = runner.invoke(
-            add, ["h3", buildings_test_file, temp_output_file, "--resolution", "13"]
-        )
-        assert result.exit_code == 0
-
-        # Verify all cells are resolution 13
-        conn = duckdb.connect()
-        conn.execute("INSTALL spatial; LOAD spatial;")
-        conn.execute("INSTALL h3 FROM community; LOAD h3;")
-
-        resolutions = conn.execute(
-            f'SELECT DISTINCT h3_get_resolution(h3_string_to_h3(h3_cell)) FROM "{temp_output_file}"'
-        ).fetchall()
-        assert len(resolutions) == 1
-        assert resolutions[0][0] == 13
-
-    def test_add_h3_with_custom_name(self, buildings_test_file, temp_output_file):
-        """Test adding H3 column with custom name."""
-        runner = CliRunner()
-        result = runner.invoke(
-            add, ["h3", buildings_test_file, temp_output_file, "--h3-name", "h3_building"]
-        )
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-
-        # Verify custom H3 column name was used
-        conn = duckdb.connect()
-        columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
-        column_names = [col[0] for col in columns]
-        assert "h3_building" in column_names
-
-    def test_add_h3_with_verbose(self, buildings_test_file, temp_output_file):
-        """Test adding H3 column with verbose flag."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["h3", buildings_test_file, temp_output_file, "--verbose"])
-        assert result.exit_code == 0
-        assert os.path.exists(temp_output_file)
-        assert "Loading DuckDB extension: h3" in result.output
-
-    def test_add_h3_preserves_columns(self, buildings_test_file, temp_output_file):
-        """Test that add H3 preserves all original columns."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["h3", buildings_test_file, temp_output_file])
-        assert result.exit_code == 0
-
-        # Verify columns are preserved
-        conn = duckdb.connect()
-        input_columns = conn.execute(f'DESCRIBE SELECT * FROM "{buildings_test_file}"').fetchall()
-        output_columns = conn.execute(f'DESCRIBE SELECT * FROM "{temp_output_file}"').fetchall()
-
-        input_col_names = {col[0] for col in input_columns}
-        output_col_names = {col[0] for col in output_columns}
-
-        # All input columns should be in output
-        assert input_col_names.issubset(output_col_names)
-        # Output should have h3_cell column added
-        assert "h3_cell" in output_col_names
-
-    def test_add_h3_nonexistent_file(self, temp_output_file):
-        """Test add H3 on nonexistent file."""
-        runner = CliRunner()
-        result = runner.invoke(add, ["h3", "nonexistent.parquet", temp_output_file])
-        # Should fail with non-zero exit code
-        assert result.exit_code != 0
-
-    def test_add_h3_metadata(self, buildings_test_file, temp_output_file):
-        """Test that H3 metadata is added to GeoParquet file."""
-        import json
-
-        import pyarrow.parquet as pq
-
-        runner = CliRunner()
-        result = runner.invoke(
-            add, ["h3", buildings_test_file, temp_output_file, "--resolution", "13"]
-        )
-        assert result.exit_code == 0
-
-        # Read metadata
-        pf = pq.ParquetFile(temp_output_file)
-        metadata = pf.schema_arrow.metadata
-        assert b"geo" in metadata
-
-        geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-
-        # Verify H3 covering metadata exists
-        assert "columns" in geo_meta
-        assert "geometry" in geo_meta["columns"]
-        assert "covering" in geo_meta["columns"]["geometry"]
-        assert "h3" in geo_meta["columns"]["geometry"]["covering"]
-
-        # Verify H3 metadata content
-        h3_meta = geo_meta["columns"]["geometry"]["covering"]["h3"]
-        assert h3_meta["column"] == "h3_cell"
-        assert h3_meta["resolution"] == 13
-
-    def test_add_h3_invalid_resolution_too_low(self, buildings_test_file, temp_output_file):
-        """Test adding H3 with invalid resolution (too low)."""
-        runner = CliRunner()
-        result = runner.invoke(
-            add, ["h3", buildings_test_file, temp_output_file, "--resolution", "-1"]
-        )
-        # Should fail with error about invalid resolution
-        assert result.exit_code != 0
-
-    def test_add_h3_invalid_resolution_too_high(self, buildings_test_file, temp_output_file):
-        """Test adding H3 with invalid resolution (too high)."""
-        runner = CliRunner()
-        result = runner.invoke(
-            add, ["h3", buildings_test_file, temp_output_file, "--resolution", "16"]
-        )
-        # Should fail with error about invalid resolution
-        assert result.exit_code != 0
-
-    def test_add_h3_core_function_invalid_resolution(self, buildings_test_file, temp_output_file):
-        """Test core add_h3_column function with invalid resolution (covers line 51)."""
-        from geoparquet_io.core.add.h3 import add_h3_column
-        from geoparquet_io.core.exceptions import InvalidParameterError
-
-        # Test resolution too high (bypassing CLI validation)
-        with pytest.raises(InvalidParameterError) as exc_info:
-            add_h3_column(
-                input_parquet=buildings_test_file,
-                output_parquet=temp_output_file,
-                h3_resolution=16,
-                h3_column_name="h3_cell",
-                verbose=False,
-            )
-        assert "must be between 0 and 15" in str(exc_info.value)
-
-        # Test resolution too low
-        with pytest.raises(InvalidParameterError) as exc_info:
-            add_h3_column(
-                input_parquet=buildings_test_file,
-                output_parquet=temp_output_file,
-                h3_resolution=-1,
-                h3_column_name="h3_cell",
-                verbose=False,
-            )
-        assert "must be between 0 and 15" in str(exc_info.value)
-
     # Note: add admin-divisions tests are skipped because they require a countries file
     # and network access. These should be tested separately with appropriate test data.
     @pytest.mark.skip(reason="Requires countries file and network access")
     def test_add_admin_divisions(self, places_test_file, temp_output_file):
         """Test adding admin divisions (skipped - requires countries file)."""
         pass
+
+
+@pytest.fixture(scope="module")
+def bbox_default_run(tmp_path_factory):
+    """One `gpio add bbox IN OUT` run with no options, shared by every assertion."""
+    output = tmp_path_factory.mktemp("add_bbox_default") / "output.parquet"
+    result = CliRunner().invoke(add, ["bbox", str(BUILDINGS_TEST_FILE), str(output)])
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    return output
+
+
+@pytest.fixture(scope="module")
+def bbox_optioned_run(tmp_path_factory):
+    """The same command with ``--bbox-name`` and ``--verbose`` set."""
+    output = tmp_path_factory.mktemp("add_bbox_options") / "output.parquet"
+    result = CliRunner().invoke(
+        add,
+        ["bbox", str(BUILDINGS_TEST_FILE), str(output), "--bbox-name", "bounds", "--verbose"],
+    )
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    return output
+
+
+@pytest.fixture(scope="module")
+def h3_default_run(tmp_path_factory):
+    """One `gpio add h3 IN OUT` run with no options, shared by every assertion."""
+    output = tmp_path_factory.mktemp("add_h3_default") / "output.parquet"
+    result = CliRunner().invoke(add, ["h3", str(BUILDINGS_TEST_FILE), str(output)])
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    return output
+
+
+@pytest.fixture(scope="module")
+def h3_optioned_run(tmp_path_factory):
+    """The same command with every option this subcommand has set at once.
+
+    One run rather than one per option: each option is read back off the output
+    separately below, so a dropped option still fails on its own assertion.
+    """
+    output = tmp_path_factory.mktemp("add_h3_options") / "output.parquet"
+    result = CliRunner().invoke(
+        add,
+        [
+            "h3",
+            str(BUILDINGS_TEST_FILE),
+            str(output),
+            "--resolution",
+            "13",
+            "--h3-name",
+            "h3_building",
+            "--verbose",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    return output, result
+
+
+class TestAddBboxCLI:
+    """`gpio add bbox` on an input with no bbox column, asserted off two shared runs.
+
+    The interesting `add bbox` behaviour -- the #728 copy path, ``--force``,
+    the streaming forms, ``--dry-run`` -- stays in ``TestAddCommands``, where
+    each case is a genuinely different outcome. What lived here instead was six
+    runs of the *same* plain invocation, one per property being read back
+    (#666, item 5).
+    """
+
+    def test_adds_a_bbox_struct_keeping_every_row_and_column(self, bbox_default_run):
+        conn = duckdb.connect()
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{bbox_default_run}"').fetchall()
+        column_names = {col[0] for col in columns}
+        assert "bbox" in column_names
+
+        bbox_info = next(col for col in columns if col[0] == "bbox")
+        assert "STRUCT" in bbox_info[1]
+
+        input_columns = conn.execute(f'DESCRIBE SELECT * FROM "{BUILDINGS_TEST_FILE}"').fetchall()
+        assert {col[0] for col in input_columns}.issubset(column_names)
+
+        input_count = conn.execute(f'SELECT COUNT(*) FROM "{BUILDINGS_TEST_FILE}"').fetchone()[0]
+        output_count = conn.execute(f'SELECT COUNT(*) FROM "{bbox_default_run}"').fetchone()[0]
+        assert input_count == output_count
+
+    def test_covering_metadata_is_written_without_being_asked_for(self, bbox_default_run):
+        covering = _read_geo_metadata(bbox_default_run)["columns"]["geometry"]["covering"]
+        assert covering["bbox"]["xmin"][0] == "bbox"
+
+    def test_bbox_name_option_reaches_core(self, bbox_optioned_run):
+        conn = duckdb.connect()
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{bbox_optioned_run}"').fetchall()
+        column_names = {col[0] for col in columns}
+        assert "bounds" in column_names
+        assert "bbox" not in column_names
+
+        # The covering must point at the column that was actually written.
+        covering = _read_geo_metadata(bbox_optioned_run)["columns"]["geometry"]["covering"]
+        assert covering["bbox"]["xmin"][0] == "bounds"
+
+
+class TestAddH3CLI:
+    """`gpio add h3` plumbing, asserted off two shared runs (#666, item 5).
+
+    H3 *semantics* -- what the column holds, which resolutions are legal, what
+    the metadata survives -- are asserted once against the core functions in
+    ``tests/test_add_h3.py`` (``TestAddH3Table`` for ``add_h3_table``,
+    ``TestAddH3File`` for ``add_h3_column``). What only the CLI layer can get
+    wrong is whether each option reaches core at all, so this class runs the
+    command twice -- once on defaults, once with every option set -- and asserts
+    both outputs many times over, instead of paying a DuckDB + h3-extension run
+    per assertion.
+    """
+
+    @staticmethod
+    def _h3_connection():
+        conn = duckdb.connect()
+        conn.execute("INSTALL spatial; LOAD spatial;")
+        conn.execute("INSTALL h3 FROM community; LOAD h3;")
+        return conn
+
+    def test_writes_valid_cells_and_keeps_every_row_and_column(self, h3_default_run):
+        """The default run produces real H3, not just a column of the right name."""
+        conn = self._h3_connection()
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{h3_default_run}"').fetchall()
+        column_names = {col[0] for col in columns}
+        assert "h3_cell" in column_names
+
+        # The generated column is a VARCHAR of valid cells...
+        h3_col = next(col for col in columns if col[0] == "h3_cell")
+        assert "VARCHAR" in h3_col[1]
+
+        output_count = conn.execute(f'SELECT COUNT(*) FROM "{h3_default_run}"').fetchone()[0]
+        valid_count = conn.execute(
+            f'SELECT COUNT(*) FROM "{h3_default_run}" '
+            f"WHERE h3_is_valid_cell(h3_string_to_h3(h3_cell))"
+        ).fetchone()[0]
+        assert valid_count == output_count
+
+        # ...added to, not in place of, the input's rows and columns.
+        input_columns = conn.execute(f'DESCRIBE SELECT * FROM "{BUILDINGS_TEST_FILE}"').fetchall()
+        assert {col[0] for col in input_columns}.issubset(column_names)
+        input_count = conn.execute(f'SELECT COUNT(*) FROM "{BUILDINGS_TEST_FILE}"').fetchone()[0]
+        assert input_count == output_count
+
+    def test_default_resolution_is_9(self, h3_default_run):
+        conn = self._h3_connection()
+        resolutions = conn.execute(
+            f'SELECT DISTINCT h3_get_resolution(h3_string_to_h3(h3_cell)) FROM "{h3_default_run}"'
+        ).fetchall()
+        assert resolutions == [(9,)]
+
+    def test_default_run_records_covering_metadata(self, h3_default_run):
+        covering = _read_geo_metadata(h3_default_run)["columns"]["geometry"]["covering"]
+        assert covering["h3"] == {"column": "h3_cell", "resolution": 9}
+
+    def test_resolution_option_reaches_core(self, h3_optioned_run):
+        output, _ = h3_optioned_run
+        conn = self._h3_connection()
+        resolutions = conn.execute(
+            f'SELECT DISTINCT h3_get_resolution(h3_string_to_h3(h3_building)) FROM "{output}"'
+        ).fetchall()
+        assert resolutions == [(13,)]
+
+    def test_column_name_option_reaches_core(self, h3_optioned_run):
+        output, _ = h3_optioned_run
+        conn = duckdb.connect()
+        columns = conn.execute(f'DESCRIBE SELECT * FROM "{output}"').fetchall()
+        column_names = {col[0] for col in columns}
+        assert "h3_building" in column_names
+        assert "h3_cell" not in column_names
+
+        # The covering must name the column that was actually written, at the
+        # resolution that was actually asked for.
+        covering = _read_geo_metadata(output)["columns"]["geometry"]["covering"]
+        assert covering["h3"] == {"column": "h3_building", "resolution": 13}
+
+    def test_verbose_option_reaches_the_extension_loader(self, h3_optioned_run):
+        _, result = h3_optioned_run
+        assert "Loading DuckDB extension: h3" in result.output
+
+    @pytest.mark.parametrize(
+        ("input_file", "extra_args"),
+        [
+            pytest.param("nonexistent.parquet", [], id="missing-input"),
+            pytest.param(str(BUILDINGS_TEST_FILE), ["--resolution", "-1"], id="resolution-below-0"),
+            pytest.param(
+                str(BUILDINGS_TEST_FILE), ["--resolution", "16"], id="resolution-above-15"
+            ),
+        ],
+    )
+    def test_refuses_bad_input(self, input_file, extra_args, tmp_path):
+        """Each of these must fail loudly rather than write a file (#666, item 5)."""
+        output = tmp_path / "out.parquet"
+        result = CliRunner().invoke(add, ["h3", input_file, str(output), *extra_args])
+
+        assert result.exit_code != 0, result.output
+        assert not output.exists()
+
+    def test_core_function_rejects_an_out_of_range_resolution(
+        self, buildings_test_file, temp_output_file
+    ):
+        """``add_h3_column`` validates for itself, not only behind Click.
+
+        The file-centric core function is reachable from the Python API, so its
+        own guard has to hold when the CLI's ``IntRange`` is not in the way.
+        """
+        from geoparquet_io.core.add.h3 import add_h3_column
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        for resolution in (16, -1):
+            with pytest.raises(InvalidParameterError) as exc_info:
+                add_h3_column(
+                    input_parquet=buildings_test_file,
+                    output_parquet=temp_output_file,
+                    h3_resolution=resolution,
+                    h3_column_name="h3_cell",
+                    verbose=False,
+                )
+            assert "must be between 0 and 15" in str(exc_info.value)
 
 
 class TestRemoteWriteSupport:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,10 +4,14 @@ Tests for the Python API (fluent Table class and ops module).
 
 from __future__ import annotations
 
+import inspect
 import struct
 import tempfile
 import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pyarrow as pa
@@ -15,6 +19,19 @@ import pyarrow.parquet as pq
 import pytest
 
 from geoparquet_io.api import Table, convert, ops, pipe, read
+from geoparquet_io.core import extract as core_extract
+from geoparquet_io.core import format_writers as core_format_writers
+from geoparquet_io.core import hilbert_order as core_hilbert
+from geoparquet_io.core import reproject as core_reproject
+from geoparquet_io.core import sort_by_column as core_sort_column
+from geoparquet_io.core import sort_quadkey as core_sort_quadkey
+from geoparquet_io.core import str_order as core_str_order
+from geoparquet_io.core.add import a5 as core_a5
+from geoparquet_io.core.add import bbox as core_bbox
+from geoparquet_io.core.add import h3 as core_h3
+from geoparquet_io.core.add import kdtree as core_kdtree
+from geoparquet_io.core.add import quadkey as core_quadkey
+from geoparquet_io.core.add import s2 as core_s2
 from tests.conftest import safe_unlink, skip_if_geography_available
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
@@ -95,11 +112,6 @@ class TestTable:
         assert isinstance(result, Table)
         assert "bbox" in result.column_names
         assert result.num_rows == 766
-
-    def test_add_bbox_custom_name(self, sample_table):
-        """Test add_bbox() with custom column name."""
-        result = sample_table.add_bbox(column_name="bounds")
-        assert "bounds" in result.column_names
 
     def test_add_quadkey(self, sample_table):
         """Test add_quadkey() method."""
@@ -211,35 +223,11 @@ class TestTable:
         assert "h3_cell" in result.column_names
         assert result.num_rows == 766
 
-    def test_add_h3_custom_resolution(self, sample_table):
-        """Test add_h3() with custom resolution."""
-        result = sample_table.add_h3(resolution=5)
-        assert "h3_cell" in result.column_names
-        assert result.num_rows == 766
-
-    def test_add_h3_custom_column_name(self, sample_table):
-        """Test add_h3() with custom column name."""
-        result = sample_table.add_h3(column_name="my_h3")
-        assert "my_h3" in result.column_names
-        assert result.num_rows == 766
-
     def test_add_s2(self, sample_table):
         """Test add_s2() method."""
         result = sample_table.add_s2()
         assert isinstance(result, Table)
         assert "s2_cell" in result.column_names
-        assert result.num_rows == 766
-
-    def test_add_s2_custom_level(self, sample_table):
-        """Test add_s2() with custom level."""
-        result = sample_table.add_s2(level=10)
-        assert "s2_cell" in result.column_names
-        assert result.num_rows == 766
-
-    def test_add_s2_custom_column_name(self, sample_table):
-        """Test add_s2() with custom column name."""
-        result = sample_table.add_s2(column_name="my_s2")
-        assert "my_s2" in result.column_names
         assert result.num_rows == 766
 
     def test_add_kdtree(self, sample_table):
@@ -249,21 +237,9 @@ class TestTable:
         assert "kdtree_cell" in result.column_names
         assert result.num_rows == 766
 
-    def test_add_kdtree_custom_params(self, sample_table):
-        """Test add_kdtree() with custom parameters."""
-        result = sample_table.add_kdtree(iterations=5, sample_size=1000)
-        assert "kdtree_cell" in result.column_names
-        assert result.num_rows == 766
-
     def test_sort_column(self, sample_table):
         """Test sort_column() method."""
         result = sample_table.sort_column("name")
-        assert isinstance(result, Table)
-        assert result.num_rows == 766
-
-    def test_sort_column_descending(self, sample_table):
-        """Test sort_column() in descending order."""
-        result = sample_table.sort_column("name", descending=True)
         assert isinstance(result, Table)
         assert result.num_rows == 766
 
@@ -291,42 +267,322 @@ class TestTable:
         assert result.num_rows == 766
 
 
-class TestOps:
-    """Tests for the ops module (pure functions)."""
+# ---------------------------------------------------------------------------
+# Front-door delegation
+#
+# `Table.add_h3(resolution=5)` and `ops.add_h3(table, resolution=5)` are two
+# doors onto one core function, `add_h3_table`. Neither door has behaviour of
+# its own: all either can get wrong is *which arguments it hands down*. Running
+# the real operation once per door per option costs a DuckDB round trip and
+# still only proves the option was not dropped, so the plumbing is asserted here
+# on the call itself and the operation once per family by `TestOpsEndToEnd`.
+#
+# Division of labour with the two existing parity harnesses:
+# `test_cli_api_default_parity.py` diffs *declared signature defaults* by
+# introspection; `test_cli_api_call_parity_scaffold.py` invokes all three front
+# ends **with nothing but defaults** and diffs what core receives. This table
+# drives that comparison with **every option set to a non-default value** --
+# the half neither of the others can see, since a door that ignores its
+# `resolution` argument entirely still passes a defaults-only comparison.
+# ---------------------------------------------------------------------------
+
+
+class _CallRecorder:
+    """Stand-in for a core ``*_table`` function that records what it was handed.
+
+    Calls are normalized through ``reference``'s signature with
+    ``apply_defaults()``, so what is compared is the *effective* value core sees:
+    a value passed positionally by one door and by keyword (or left to core's
+    default) by the other still compares equal.
+
+    Returns its first positional argument -- the real core functions return a
+    table that both doors immediately re-wrap, so returning ``None`` would blow
+    up before anything could be inspected.
+    """
+
+    def __init__(self, reference: Callable):
+        self._signature = inspect.signature(reference)
+        self.delivered: dict[str, Any] | None = None
+
+    def __call__(self, *args, **kwargs):
+        bound = self._signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        self.delivered = {k: v for k, v in bound.arguments.items() if k != "table"}
+        return args[0]
+
+
+@dataclass(frozen=True)
+class FrontDoorCase:
+    """One operation reachable through both `ops` and `Table`.
+
+    ``core_name`` is the attribute name of the core function on *both* `ops`
+    (which binds it at module import time) and ``core_module`` (which is where
+    the `Table` method imports it from inside the method body). Patching one
+    leaves the other alone, so each door is recorded independently.
+
+    ``expected`` names the knobs under core's own parameter spelling. It is
+    asserted as a subset, and the two doors' full calls are asserted equal to
+    each other, so a knob one door quietly renames or drops is caught either way.
+    """
+
+    id: str
+    core_module: Any
+    core_name: str
+    ops_call: Callable[[pa.Table], Any]
+    table_call: Callable[[Table], Any]
+    expected: dict[str, Any]
+
+    @property
+    def reference(self) -> Callable:
+        return getattr(self.core_module, self.core_name)
+
+
+#: Every table-in/table-out operation that both front doors expose.
+#:
+#: Where a call passes ``geometry_column`` on the `ops` side it is because the
+#: `Table` method forwards the column it detected at ``read()`` time; where it
+#: does not, the method does not forward one either. The comparison is of the
+#: values the two doors deliver, so the calls are written to be the same request.
+FRONT_DOOR_CASES: list[FrontDoorCase] = [
+    FrontDoorCase(
+        id="add_bbox",
+        core_module=core_bbox,
+        core_name="add_bbox_table",
+        ops_call=lambda t: ops.add_bbox(t, column_name="bounds", geometry_column="geometry"),
+        table_call=lambda t: t.add_bbox(column_name="bounds"),
+        expected={"bbox_column_name": "bounds", "geometry_column": "geometry"},
+    ),
+    FrontDoorCase(
+        id="add_quadkey",
+        core_module=core_quadkey,
+        core_name="add_quadkey_table",
+        ops_call=lambda t: ops.add_quadkey(
+            t, column_name="qk", resolution=11, use_centroid=True, geometry_column="geometry"
+        ),
+        table_call=lambda t: t.add_quadkey(column_name="qk", resolution=11, use_centroid=True),
+        expected={
+            "quadkey_column_name": "qk",
+            "resolution": 11,
+            "use_centroid": True,
+            "geometry_column": "geometry",
+        },
+    ),
+    FrontDoorCase(
+        id="add_h3",
+        core_module=core_h3,
+        core_name="add_h3_table",
+        ops_call=lambda t: ops.add_h3(t, column_name="my_h3", resolution=5),
+        table_call=lambda t: t.add_h3(column_name="my_h3", resolution=5),
+        expected={"h3_column_name": "my_h3", "resolution": 5},
+    ),
+    FrontDoorCase(
+        id="add_a5",
+        core_module=core_a5,
+        core_name="add_a5_table",
+        ops_call=lambda t: ops.add_a5(t, column_name="my_a5", resolution=7),
+        table_call=lambda t: t.add_a5(column_name="my_a5", resolution=7),
+        expected={"a5_column_name": "my_a5", "resolution": 7},
+    ),
+    FrontDoorCase(
+        id="add_s2",
+        core_module=core_s2,
+        core_name="add_s2_table",
+        ops_call=lambda t: ops.add_s2(t, column_name="my_s2", level=10),
+        table_call=lambda t: t.add_s2(column_name="my_s2", level=10),
+        expected={"s2_column_name": "my_s2", "level": 10},
+    ),
+    FrontDoorCase(
+        id="add_kdtree",
+        core_module=core_kdtree,
+        core_name="add_kdtree_table",
+        ops_call=lambda t: ops.add_kdtree(t, column_name="my_kd", iterations=5, sample_size=1000),
+        table_call=lambda t: t.add_kdtree(column_name="my_kd", iterations=5, sample_size=1000),
+        expected={"kdtree_column_name": "my_kd", "iterations": 5, "sample_size": 1000},
+    ),
+    FrontDoorCase(
+        id="sort_hilbert",
+        core_module=core_hilbert,
+        core_name="hilbert_order_table",
+        ops_call=lambda t: ops.sort_hilbert(t, geometry_column="geometry"),
+        table_call=lambda t: t.sort_hilbert(),
+        expected={"geometry_column": "geometry"},
+    ),
+    FrontDoorCase(
+        id="sort_str",
+        core_module=core_str_order,
+        core_name="str_order_table",
+        ops_call=lambda t: ops.sort_str(t, tile_size=100, geometry_column="geometry"),
+        table_call=lambda t: t.sort_str(tile_size=100),
+        expected={"tile_size": 100, "geometry_column": "geometry"},
+    ),
+    FrontDoorCase(
+        id="sort_column",
+        core_module=core_sort_column,
+        core_name="sort_by_column_table",
+        # The one knob the two doors spell differently: `ops.sort_column(column=)`
+        # against `Table.sort_column(column_name=)`. Both must still land on
+        # core's `columns`.
+        ops_call=lambda t: ops.sort_column(t, column="name", descending=True),
+        table_call=lambda t: t.sort_column(column_name="name", descending=True),
+        expected={"columns": "name", "descending": True},
+    ),
+    FrontDoorCase(
+        id="sort_quadkey",
+        core_module=core_sort_quadkey,
+        core_name="sort_by_quadkey_table",
+        ops_call=lambda t: ops.sort_quadkey(
+            t, column_name="qk", resolution=10, use_centroid=True, remove_column=True
+        ),
+        table_call=lambda t: t.sort_quadkey(
+            column_name="qk", resolution=10, use_centroid=True, remove_column=True
+        ),
+        expected={
+            "quadkey_column_name": "qk",
+            "resolution": 10,
+            "use_centroid": True,
+            "remove_quadkey_column": True,
+        },
+    ),
+    FrontDoorCase(
+        id="extract",
+        core_module=core_extract,
+        core_name="extract_table",
+        ops_call=lambda t: ops.extract(
+            t,
+            columns=["name"],
+            exclude_columns=["address"],
+            bbox=(0.0, 0.0, 1.0, 1.0),
+            where="name IS NOT NULL",
+            limit=10,
+            geometry_column="geometry",
+            repair_geometry=False,
+        ),
+        table_call=lambda t: t.extract(
+            columns=["name"],
+            exclude_columns=["address"],
+            bbox=(0.0, 0.0, 1.0, 1.0),
+            where="name IS NOT NULL",
+            limit=10,
+            repair_geometry=False,
+        ),
+        expected={
+            "columns": ["name"],
+            "exclude_columns": ["address"],
+            "bbox": (0.0, 0.0, 1.0, 1.0),
+            "where": "name IS NOT NULL",
+            "limit": 10,
+            "geometry_column": "geometry",
+            "repair_geometry": False,
+        },
+    ),
+    FrontDoorCase(
+        id="reproject",
+        core_module=core_reproject,
+        core_name="reproject_table",
+        ops_call=lambda t: ops.reproject(
+            t,
+            target_crs="EPSG:3857",
+            source_crs="EPSG:4326",
+            geometry_column="geometry",
+            assume_crs84=True,
+        ),
+        table_call=lambda t: t.reproject(
+            target_crs="EPSG:3857", source_crs="EPSG:4326", assume_crs84=True
+        ),
+        expected={
+            "target_crs": "EPSG:3857",
+            "source_crs": "EPSG:4326",
+            "geometry_column": "geometry",
+            "assume_crs84": True,
+        },
+    ),
+]
+
+FRONT_DOOR_IDS = [case.id for case in FRONT_DOOR_CASES]
+
+
+class TestFrontDoorDelegation:
+    """`ops.<op>` and `Table.<op>` must hand core the same call (#666, item 6).
+
+    Replaces the per-function `TestOps` mirrors of `TestTable`, which asserted
+    the same delegation by running the real operation a second time.
+    """
 
     @pytest.fixture
     def arrow_table(self):
-        """Get an Arrow table from test data."""
         if not PLACES_PARQUET.exists():
             pytest.skip("Test data not available")
         return pq.read_table(PLACES_PARQUET)
 
-    def test_add_bbox(self, arrow_table):
-        """Test ops.add_bbox()."""
+    @pytest.fixture
+    def gpio_table(self):
+        if not PLACES_PARQUET.exists():
+            pytest.skip("Test data not available")
+        return read(PLACES_PARQUET)
+
+    @pytest.mark.parametrize("case", FRONT_DOOR_CASES, ids=FRONT_DOOR_IDS)
+    def test_both_front_doors_hand_core_the_same_call(self, case, arrow_table, gpio_table):
+        via_ops = _CallRecorder(case.reference)
+        with patch.object(ops, case.core_name, via_ops):
+            case.ops_call(arrow_table)
+
+        via_table = _CallRecorder(case.reference)
+        with patch.object(case.core_module, case.core_name, via_table):
+            case.table_call(gpio_table)
+
+        assert via_ops.delivered is not None, f"ops.{case.id} never called core"
+        assert via_table.delivered is not None, f"Table.{case.id} never called core"
+
+        # Every named knob arrives, under core's own spelling...
+        for name, value in case.expected.items():
+            assert via_ops.delivered[name] == value, f"ops.{case.id} dropped {name}"
+            assert via_table.delivered[name] == value, f"Table.{case.id} dropped {name}"
+
+        # ...and neither door slips something past the other.
+        assert via_ops.delivered == via_table.delivered
+
+    def test_every_shared_operation_has_a_case(self):
+        """A new `ops`/`Table` twin must be added here, not left uncompared."""
+        for case in FRONT_DOOR_CASES:
+            assert hasattr(ops, case.core_name), (
+                f"{case.id}: ops no longer binds {case.core_name}; the patch site moved"
+            )
+            assert hasattr(case.core_module, case.core_name), (
+                f"{case.id}: {case.core_module.__name__} no longer defines {case.core_name}"
+            )
+            assert hasattr(Table, case.id), f"{case.id}: Table has no such method"
+            assert hasattr(ops, case.id), f"{case.id}: ops has no such function"
+
+        assert len(FRONT_DOOR_IDS) == len(set(FRONT_DOOR_IDS)), "duplicate case id"
+
+
+class TestOpsEndToEnd:
+    """One real run per `ops` family, so the wrappers are covered unmocked.
+
+    `TestFrontDoorDelegation` patches core away, which proves the plumbing but
+    would leave a wrapper that raises before it delegates -- or mangles what
+    core returns -- undetected. Partitioning's end-to-end runs live in
+    `TestOpsPartition`; conversion's in `TestOpsConversionFunctions`.
+    """
+
+    @pytest.fixture
+    def arrow_table(self):
+        if not PLACES_PARQUET.exists():
+            pytest.skip("Test data not available")
+        return pq.read_table(PLACES_PARQUET)
+
+    def test_add_family(self, arrow_table):
         result = ops.add_bbox(arrow_table)
         assert isinstance(result, pa.Table)
         assert "bbox" in result.column_names
+        assert result.num_rows == 766
 
-    def test_add_quadkey(self, arrow_table):
-        """Test ops.add_quadkey()."""
-        result = ops.add_quadkey(arrow_table, resolution=10)
-        assert isinstance(result, pa.Table)
-        assert "quadkey" in result.column_names
-
-    def test_sort_hilbert(self, arrow_table):
-        """Test ops.sort_hilbert()."""
+    def test_sort_family(self, arrow_table):
         result = ops.sort_hilbert(arrow_table)
         assert isinstance(result, pa.Table)
         assert result.num_rows == 766
 
-    def test_sort_str(self, arrow_table):
-        """Test ops.sort_str()."""
-        result = ops.sort_str(arrow_table, tile_size=100)
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 766
-
-    def test_extract(self, arrow_table):
-        """Test ops.extract()."""
+    def test_extract_family(self, arrow_table):
         result = ops.extract(arrow_table, limit=10)
         assert isinstance(result, pa.Table)
         assert result.num_rows == 10
@@ -606,53 +862,6 @@ class TestWriteReturnsPath:
         assert isinstance(result, Path)
         assert result.exists()
         assert str(result) == output_file
-
-
-class TestOpsNewFunctions:
-    """Tests for the new ops module functions."""
-
-    @pytest.fixture
-    def arrow_table(self):
-        """Get an Arrow table from test data."""
-        if not PLACES_PARQUET.exists():
-            pytest.skip("Test data not available")
-        return pq.read_table(PLACES_PARQUET)
-
-    def test_add_h3(self, arrow_table):
-        """Test ops.add_h3()."""
-        result = ops.add_h3(arrow_table, resolution=7)
-        assert isinstance(result, pa.Table)
-        assert "h3_cell" in result.column_names
-
-    def test_add_s2(self, arrow_table):
-        """Test ops.add_s2()."""
-        result = ops.add_s2(arrow_table, level=13)
-        assert isinstance(result, pa.Table)
-        assert "s2_cell" in result.column_names
-
-    def test_add_kdtree(self, arrow_table):
-        """Test ops.add_kdtree()."""
-        result = ops.add_kdtree(arrow_table, iterations=5)
-        assert isinstance(result, pa.Table)
-        assert "kdtree_cell" in result.column_names
-
-    def test_sort_column(self, arrow_table):
-        """Test ops.sort_column()."""
-        result = ops.sort_column(arrow_table, column="name")
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 766
-
-    def test_sort_quadkey(self, arrow_table):
-        """Test ops.sort_quadkey()."""
-        result = ops.sort_quadkey(arrow_table, resolution=10)
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 766
-
-    def test_reproject(self, arrow_table):
-        """Test ops.reproject()."""
-        result = ops.reproject(arrow_table, target_crs="EPSG:3857")
-        assert isinstance(result, pa.Table)
-        assert result.num_rows == 766
 
 
 class TestTablePartitionByA5:
@@ -1700,8 +1909,50 @@ class TestTableWriteFormats:
             safe_unlink(output_path)
 
 
+#: ``ops.convert_to_<format>`` against the ``core.format_writers`` function it
+#: must reach, and the format-specific options that must survive the trip.
+#: The writers themselves are exercised for real by `TestTableWriteFormats`
+#: (the `Table.write` door) and by `TestOpsConversionFunctions` below, which
+#: keeps one unmocked run.
+CONVERSION_CASES = [
+    (
+        "geopackage",
+        "write_geopackage",
+        ".gpkg",
+        lambda t, p: ops.convert_to_geopackage(t, p, overwrite=True, layer_name="test_layer"),
+        {"overwrite": True, "layer_name": "test_layer"},
+    ),
+    (
+        "flatgeobuf",
+        "write_flatgeobuf",
+        ".fgb",
+        lambda t, p: ops.convert_to_flatgeobuf(t, p),
+        {},
+    ),
+    (
+        "csv",
+        "write_csv",
+        ".csv",
+        lambda t, p: ops.convert_to_csv(t, p, include_wkt=False, include_bbox=False),
+        {"include_wkt": False, "include_bbox": False},
+    ),
+    (
+        "shapefile",
+        "write_shapefile",
+        ".shp",
+        lambda t, p: ops.convert_to_shapefile(t, p, overwrite=True, encoding="LATIN1"),
+        {"overwrite": True, "encoding": "LATIN1"},
+    ),
+]
+
+
 class TestOpsConversionFunctions:
-    """Tests for ops.convert_to_*() functions."""
+    """`ops.convert_to_*()` writes a temp parquet and hands it to a format writer.
+
+    The four functions differ only in which writer they name and which options
+    they forward, so the options are asserted on the call (#666, item 6) and one
+    format is run unmocked to prove the temp-file round trip itself works.
+    """
 
     @pytest.fixture
     def sample_table(self):
@@ -1710,60 +1961,42 @@ class TestOpsConversionFunctions:
             pytest.skip("Test data not available")
         return pq.read_table(str(PLACES_PARQUET))
 
-    def test_convert_to_geopackage(self, sample_table):
-        """Test ops.convert_to_geopackage()."""
+    @pytest.mark.parametrize(
+        ("writer_name", "suffix", "call", "expected"),
+        [case[1:] for case in CONVERSION_CASES],
+        ids=[case[0] for case in CONVERSION_CASES],
+    )
+    def test_options_reach_the_format_writer(
+        self, sample_table, writer_name, suffix, call, expected, tmp_path
+    ):
+        output_path = str(tmp_path / f"out{suffix}")
+
+        with patch.object(core_format_writers, writer_name) as writer:
+            result = call(sample_table, output_path)
+
+        assert result == output_path
+        kwargs = writer.call_args.kwargs
+        assert kwargs["output_path"] == output_path
+        # The input is a temp parquet the caller never sees, but it must be one.
+        assert kwargs["input_path"].endswith(".parquet")
+        for name, value in expected.items():
+            assert kwargs[name] == value, f"convert_to_{writer_name} dropped {name}"
+
+    def test_conversion_runs_end_to_end(self, sample_table):
+        """One unmocked run: the temp parquet is written, used, and cleaned up."""
         output_path = Path(tempfile.gettempdir()) / f"test_{uuid.uuid4()}.gpkg"
         try:
             result = ops.convert_to_geopackage(sample_table, str(output_path))
             assert result == str(output_path)
             assert output_path.exists()
+            assert output_path.stat().st_size > 0
         finally:
             safe_unlink(output_path)
 
-    def test_convert_to_flatgeobuf(self, sample_table):
-        """Test ops.convert_to_flatgeobuf()."""
-        output_path = Path(tempfile.gettempdir()) / f"test_{uuid.uuid4()}.fgb"
-        try:
-            result = ops.convert_to_flatgeobuf(sample_table, str(output_path))
-            assert result == str(output_path)
-            assert output_path.exists()
-        finally:
-            safe_unlink(output_path)
-
-    def test_convert_to_csv(self, sample_table):
-        """Test ops.convert_to_csv()."""
-        output_path = Path(tempfile.gettempdir()) / f"test_{uuid.uuid4()}.csv"
-        try:
-            result = ops.convert_to_csv(sample_table, str(output_path))
-            assert result == str(output_path)
-            assert output_path.exists()
-        finally:
-            safe_unlink(output_path)
-
-    def test_convert_to_shapefile(self, sample_table):
-        """Test ops.convert_to_shapefile()."""
-        output_path = Path(tempfile.gettempdir()) / f"test_{uuid.uuid4()}.shp"
-        try:
-            result = ops.convert_to_shapefile(sample_table, str(output_path))
-            assert result == str(output_path)
-            assert output_path.exists()
-        finally:
-            for ext in [".shp", ".shx", ".dbf", ".prj", ".cpg"]:
-                safe_unlink(output_path.with_suffix(ext))
-
-    def test_convert_with_options(self, sample_table):
-        """Test ops conversion functions with format-specific options."""
-        output_path = Path(tempfile.gettempdir()) / f"test_{uuid.uuid4()}.gpkg"
-        try:
-            ops.convert_to_geopackage(
-                sample_table,
-                str(output_path),
-                layer_name="test_layer",
-                overwrite=True,
-            )
-            assert output_path.exists()
-        finally:
-            safe_unlink(output_path)
+    def test_a_non_arrow_table_is_refused(self, tmp_path):
+        """The shared helper's type guard, which no real conversion reaches."""
+        with pytest.raises(TypeError, match="Expected pa.Table"):
+            ops.convert_to_csv("not a table", str(tmp_path / "out.csv"))
 
 
 class TestReadPartitionS3:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ import struct
 import tempfile
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -28,10 +28,13 @@ from geoparquet_io.core import sort_quadkey as core_sort_quadkey
 from geoparquet_io.core import str_order as core_str_order
 from geoparquet_io.core.add import a5 as core_a5
 from geoparquet_io.core.add import bbox as core_bbox
+from geoparquet_io.core.add import bbox_metadata as core_bbox_metadata
 from geoparquet_io.core.add import h3 as core_h3
 from geoparquet_io.core.add import kdtree as core_kdtree
 from geoparquet_io.core.add import quadkey as core_quadkey
 from geoparquet_io.core.add import s2 as core_s2
+from geoparquet_io.core.process.aggregate import by_a5 as core_aggregate_a5
+from geoparquet_io.core.process.aggregate import by_h3 as core_aggregate_h3
 from tests.conftest import safe_unlink, skip_if_geography_available
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
@@ -315,14 +318,23 @@ class _CallRecorder:
 class FrontDoorCase:
     """One operation reachable through both `ops` and `Table`.
 
-    ``core_name`` is the attribute name of the core function on *both* `ops`
-    (which binds it at module import time) and ``core_module`` (which is where
-    the `Table` method imports it from inside the method body). Patching one
-    leaves the other alone, so each door is recorded independently.
+    ``core_name`` is the attribute name of the core function on ``core_module``
+    (where the `Table` method imports it from inside the method body) and on
+    ``ops_patch_module`` -- `ops` itself for the operations it binds at module
+    import time, or ``core_module`` again for the ones it imports inside the
+    function body. The two doors are recorded one at a time, under separate
+    patches, so a shared patch site still records each independently.
 
     ``expected`` names the knobs under core's own parameter spelling. It is
     asserted as a subset, and the two doors' full calls are asserted equal to
     each other, so a knob one door quietly renames or drops is caught either way.
+
+    ``ops_only_expected`` names knobs the `ops` function exposes and the `Table`
+    method has no way to set (``geometry_column`` on the index adders, which the
+    method leaves to core's auto-detection). They are asserted against the `ops`
+    door alone and then dropped from both sides before the doors are compared --
+    without them, an `ops` wrapper that forgets to forward its own argument looks
+    identical to the `Table` method that never had one.
     """
 
     id: str
@@ -331,18 +343,27 @@ class FrontDoorCase:
     ops_call: Callable[[pa.Table], Any]
     table_call: Callable[[Table], Any]
     expected: dict[str, Any]
+    ops_only_expected: dict[str, Any] = field(default_factory=dict)
+    #: Where the `ops` door's core call is patched, when it is not `ops` itself.
+    ops_module: Any = None
 
     @property
     def reference(self) -> Callable:
         return getattr(self.core_module, self.core_name)
 
+    @property
+    def ops_patch_module(self) -> Any:
+        return ops if self.ops_module is None else self.ops_module
+
 
 #: Every table-in/table-out operation that both front doors expose.
 #:
-#: Where a call passes ``geometry_column`` on the `ops` side it is because the
-#: `Table` method forwards the column it detected at ``read()`` time; where it
-#: does not, the method does not forward one either. The comparison is of the
-#: values the two doors deliver, so the calls are written to be the same request.
+#: Where a call passes ``geometry_column`` on the `ops` side and the `Table`
+#: method forwards the column it detected at ``read()`` time, the knob goes in
+#: ``expected`` and is compared across both doors. Where only `ops` exposes it,
+#: it goes in ``ops_only_expected`` instead: still asserted, but on the `ops`
+#: door alone. Otherwise the comparison is of the values the two doors deliver,
+#: so the calls are written to be the same request.
 FRONT_DOOR_CASES: list[FrontDoorCase] = [
     FrontDoorCase(
         id="add_bbox",
@@ -351,6 +372,16 @@ FRONT_DOOR_CASES: list[FrontDoorCase] = [
         ops_call=lambda t: ops.add_bbox(t, column_name="bounds", geometry_column="geometry"),
         table_call=lambda t: t.add_bbox(column_name="bounds"),
         expected={"bbox_column_name": "bounds", "geometry_column": "geometry"},
+    ),
+    FrontDoorCase(
+        id="add_bbox_metadata",
+        core_module=core_bbox_metadata,
+        core_name="add_bbox_metadata_table",
+        ops_call=lambda t: ops.add_bbox_metadata(
+            t, bbox_column="bounds", geometry_column="geometry"
+        ),
+        table_call=lambda t: t.add_bbox_metadata(bbox_column="bounds"),
+        expected={"bbox_column": "bounds", "geometry_column": "geometry"},
     ),
     FrontDoorCase(
         id="add_quadkey",
@@ -371,33 +402,131 @@ FRONT_DOOR_CASES: list[FrontDoorCase] = [
         id="add_h3",
         core_module=core_h3,
         core_name="add_h3_table",
-        ops_call=lambda t: ops.add_h3(t, column_name="my_h3", resolution=5),
+        ops_call=lambda t: ops.add_h3(
+            t, column_name="my_h3", resolution=5, geometry_column="geometry"
+        ),
         table_call=lambda t: t.add_h3(column_name="my_h3", resolution=5),
         expected={"h3_column_name": "my_h3", "resolution": 5},
+        ops_only_expected={"geometry_column": "geometry"},
     ),
     FrontDoorCase(
         id="add_a5",
         core_module=core_a5,
         core_name="add_a5_table",
-        ops_call=lambda t: ops.add_a5(t, column_name="my_a5", resolution=7),
+        ops_call=lambda t: ops.add_a5(
+            t, column_name="my_a5", resolution=7, geometry_column="geometry"
+        ),
         table_call=lambda t: t.add_a5(column_name="my_a5", resolution=7),
         expected={"a5_column_name": "my_a5", "resolution": 7},
+        ops_only_expected={"geometry_column": "geometry"},
     ),
     FrontDoorCase(
         id="add_s2",
         core_module=core_s2,
         core_name="add_s2_table",
-        ops_call=lambda t: ops.add_s2(t, column_name="my_s2", level=10),
+        ops_call=lambda t: ops.add_s2(t, column_name="my_s2", level=10, geometry_column="geometry"),
         table_call=lambda t: t.add_s2(column_name="my_s2", level=10),
         expected={"s2_column_name": "my_s2", "level": 10},
+        ops_only_expected={"geometry_column": "geometry"},
     ),
     FrontDoorCase(
         id="add_kdtree",
         core_module=core_kdtree,
         core_name="add_kdtree_table",
-        ops_call=lambda t: ops.add_kdtree(t, column_name="my_kd", iterations=5, sample_size=1000),
+        ops_call=lambda t: ops.add_kdtree(
+            t, column_name="my_kd", iterations=5, sample_size=1000, geometry_column="geometry"
+        ),
         table_call=lambda t: t.add_kdtree(column_name="my_kd", iterations=5, sample_size=1000),
         expected={"kdtree_column_name": "my_kd", "iterations": 5, "sample_size": 1000},
+        ops_only_expected={"geometry_column": "geometry"},
+    ),
+    # The two aggregators whose doors both import core inside the function body,
+    # so `ops` has no module-level binding to patch and both are recorded at the
+    # core module instead (`aggregate_admin` is not here: `Table` delegates to
+    # `ops`, so there is only one door -- see NOT_TABLE_IN_TABLE_OUT).
+    FrontDoorCase(
+        id="aggregate_h3",
+        core_module=core_aggregate_h3,
+        core_name="aggregate_h3_table",
+        ops_module=core_aggregate_h3,
+        ops_call=lambda t: ops.aggregate_h3(
+            t,
+            resolution=6,
+            metric="sum:population",
+            breakdown="category",
+            breakdown_limit=5,
+            out_geometry="centroid",
+            geometry_column="geometry",
+            where="population > 0",
+            metric_nodata="-999",
+            bucket_point="bbox",
+            bbox_column="bounds",
+        ),
+        table_call=lambda t: t.aggregate_h3(
+            resolution=6,
+            metric="sum:population",
+            breakdown="category",
+            breakdown_limit=5,
+            out_geometry="centroid",
+            where="population > 0",
+            metric_nodata="-999",
+            bucket_point="bbox",
+            bbox_column="bounds",
+        ),
+        expected={
+            "resolution": 6,
+            "metric": "sum:population",
+            "breakdown": "category",
+            "breakdown_limit": 5,
+            "out_geometry": "centroid",
+            "geometry_column": "geometry",
+            "where": "population > 0",
+            "metric_nodata": "-999",
+            "bucket_point": "bbox",
+            "bbox_column": "bounds",
+        },
+    ),
+    FrontDoorCase(
+        id="aggregate_a5",
+        core_module=core_aggregate_a5,
+        core_name="aggregate_a5_table",
+        ops_module=core_aggregate_a5,
+        ops_call=lambda t: ops.aggregate_a5(
+            t,
+            resolution=8,
+            metric="mean:population",
+            breakdown="category",
+            breakdown_limit=5,
+            out_geometry="centroid",
+            geometry_column="geometry",
+            where="population > 0",
+            metric_nodata="-999",
+            bucket_point="bbox",
+            bbox_column="bounds",
+        ),
+        table_call=lambda t: t.aggregate_a5(
+            resolution=8,
+            metric="mean:population",
+            breakdown="category",
+            breakdown_limit=5,
+            out_geometry="centroid",
+            where="population > 0",
+            metric_nodata="-999",
+            bucket_point="bbox",
+            bbox_column="bounds",
+        ),
+        expected={
+            "resolution": 8,
+            "metric": "mean:population",
+            "breakdown": "category",
+            "breakdown_limit": 5,
+            "out_geometry": "centroid",
+            "geometry_column": "geometry",
+            "where": "population > 0",
+            "metric_nodata": "-999",
+            "bucket_point": "bbox",
+            "bbox_column": "bounds",
+        },
     ),
     FrontDoorCase(
         id="sort_hilbert",
@@ -500,6 +629,43 @@ FRONT_DOOR_CASES: list[FrontDoorCase] = [
 
 FRONT_DOOR_IDS = [case.id for case in FRONT_DOOR_CASES]
 
+#: The rest of the `ops`/`Table` surface, and why each entry is not a case above.
+#: `FRONT_DOOR_CASES` compares one *table-in/table-out* core call per operation;
+#: these have no such call to compare, so each names where it is covered instead.
+#: `test_every_shared_operation_has_a_case` asserts this list plus the case ids
+#: is exactly the shared surface, so a new twin lands in one place or the other.
+NOT_TABLE_IN_TABLE_OUT: dict[str, str] = {
+    # Core is file-in/file-out: both doors write the table to a temp parquet and
+    # read the result back, so there is no in-memory core call to record.
+    "add_admin_divisions": "file round trip onto add_admin_divisions_multi",
+    "add_geometry_metrics": "file round trip onto add_geometry_metrics",
+    "aggregate_admin": "Table.aggregate_admin calls ops.aggregate_admin -- one door, "
+    "and that one round-trips through a file",
+    # Not a transform of a table at all.
+    "explain_analyze": "file path in, dict out; Table's is a classmethod, not an operation",
+    "from_wfs": "constructor: fetches a service over the network, no input table",
+    # Table in, partition tree out. Both doors are run for real, and asserted to
+    # write the same tree, by TestOpsPartition.
+    "partition_by_a5": "writes a partition tree; covered by TestOpsPartition",
+    "partition_by_admin": "writes a partition tree; covered by TestOpsPartition",
+    "partition_by_h3": "writes a partition tree; covered by TestOpsPartition",
+    "partition_by_kdtree": "writes a partition tree; covered by TestOpsPartition",
+    "partition_by_quadkey": "writes a partition tree; covered by TestOpsPartition",
+    "partition_by_s2": "writes a partition tree; covered by TestOpsPartition",
+    "partition_by_string": "writes a partition tree; covered by TestOpsPartition",
+}
+
+
+def _shared_front_door_surface() -> set[str]:
+    """Every public callable `ops` and `Table` both expose under the same name."""
+    ops_names = {name for name in dir(ops) if not name.startswith("_")}
+    table_names = {name for name in dir(Table) if not name.startswith("_")}
+    return {
+        name
+        for name in ops_names & table_names
+        if callable(getattr(ops, name)) and callable(getattr(Table, name))
+    }
+
 
 class TestFrontDoorDelegation:
     """`ops.<op>` and `Table.<op>` must hand core the same call (#666, item 6).
@@ -523,7 +689,7 @@ class TestFrontDoorDelegation:
     @pytest.mark.parametrize("case", FRONT_DOOR_CASES, ids=FRONT_DOOR_IDS)
     def test_both_front_doors_hand_core_the_same_call(self, case, arrow_table, gpio_table):
         via_ops = _CallRecorder(case.reference)
-        with patch.object(ops, case.core_name, via_ops):
+        with patch.object(case.ops_patch_module, case.core_name, via_ops):
             case.ops_call(arrow_table)
 
         via_table = _CallRecorder(case.reference)
@@ -538,14 +704,30 @@ class TestFrontDoorDelegation:
             assert via_ops.delivered[name] == value, f"ops.{case.id} dropped {name}"
             assert via_table.delivered[name] == value, f"Table.{case.id} dropped {name}"
 
+        # Knobs only the `ops` door exposes: asserted there, then dropped from
+        # both sides, since the `Table` method has no way to set them.
+        for name, value in case.ops_only_expected.items():
+            assert via_ops.delivered[name] == value, f"ops.{case.id} dropped {name}"
+
         # ...and neither door slips something past the other.
-        assert via_ops.delivered == via_table.delivered
+        compared = set(case.ops_only_expected)
+        assert {k: v for k, v in via_ops.delivered.items() if k not in compared} == {
+            k: v for k, v in via_table.delivered.items() if k not in compared
+        }
 
     def test_every_shared_operation_has_a_case(self):
-        """A new `ops`/`Table` twin must be added here, not left uncompared."""
+        """A new `ops`/`Table` twin must be added here, not left uncompared.
+
+        The shared surface is enumerated, not assumed: every public callable both
+        `ops` and `Table` expose under the same name must be either a case above
+        or an entry in `NOT_TABLE_IN_TABLE_OUT` saying where it is covered
+        instead. Iterating the cases alone would let a new twin be added with no
+        comparison at all and still leave this green.
+        """
         for case in FRONT_DOOR_CASES:
-            assert hasattr(ops, case.core_name), (
-                f"{case.id}: ops no longer binds {case.core_name}; the patch site moved"
+            assert hasattr(case.ops_patch_module, case.core_name), (
+                f"{case.id}: {case.ops_patch_module.__name__} no longer binds "
+                f"{case.core_name}; the ops patch site moved"
             )
             assert hasattr(case.core_module, case.core_name), (
                 f"{case.id}: {case.core_module.__name__} no longer defines {case.core_name}"
@@ -555,14 +737,24 @@ class TestFrontDoorDelegation:
 
         assert len(FRONT_DOOR_IDS) == len(set(FRONT_DOOR_IDS)), "duplicate case id"
 
+        accounted_for = set(FRONT_DOOR_IDS) | set(NOT_TABLE_IN_TABLE_OUT)
+        shared = _shared_front_door_surface()
+        assert shared == accounted_for, (
+            "the ops/Table surface and this file have drifted apart.\n"
+            f"  uncompared twins (add a FrontDoorCase, or a NOT_TABLE_IN_TABLE_OUT "
+            f"entry with the reason): {sorted(shared - accounted_for)}\n"
+            f"  listed here but no longer a twin: {sorted(accounted_for - shared)}"
+        )
+
 
 class TestOpsEndToEnd:
     """One real run per `ops` family, so the wrappers are covered unmocked.
 
     `TestFrontDoorDelegation` patches core away, which proves the plumbing but
     would leave a wrapper that raises before it delegates -- or mangles what
-    core returns -- undetected. Partitioning's end-to-end runs live in
-    `TestOpsPartition`; conversion's in `TestOpsConversionFunctions`.
+    core returns -- undetected. One run per family: add, sort, extract and
+    reproject. Partitioning's end-to-end runs live in `TestOpsPartition`;
+    conversion's in `TestOpsConversionFunctions`.
     """
 
     @pytest.fixture
@@ -586,6 +778,11 @@ class TestOpsEndToEnd:
         result = ops.extract(arrow_table, limit=10)
         assert isinstance(result, pa.Table)
         assert result.num_rows == 10
+
+    def test_reproject_family(self, arrow_table):
+        result = ops.reproject(arrow_table, target_crs="EPSG:3857")
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 766
 
 
 class TestPipe:
@@ -1962,12 +2159,12 @@ class TestOpsConversionFunctions:
         return pq.read_table(str(PLACES_PARQUET))
 
     @pytest.mark.parametrize(
-        ("writer_name", "suffix", "call", "expected"),
-        [case[1:] for case in CONVERSION_CASES],
+        ("fmt", "writer_name", "suffix", "call", "expected"),
+        CONVERSION_CASES,
         ids=[case[0] for case in CONVERSION_CASES],
     )
     def test_options_reach_the_format_writer(
-        self, sample_table, writer_name, suffix, call, expected, tmp_path
+        self, sample_table, fmt, writer_name, suffix, call, expected, tmp_path
     ):
         output_path = str(tmp_path / f"out{suffix}")
 
@@ -1980,7 +2177,7 @@ class TestOpsConversionFunctions:
         # The input is a temp parquet the caller never sees, but it must be one.
         assert kwargs["input_path"].endswith(".parquet")
         for name, value in expected.items():
-            assert kwargs[name] == value, f"convert_to_{writer_name} dropped {name}"
+            assert kwargs[name] == value, f"convert_to_{fmt} dropped {name}"
 
     def test_conversion_runs_end_to_end(self, sample_table):
         """One unmocked run: the temp parquet is written, used, and cleaned up."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,7 +300,9 @@ class _CallRecorder:
 
     Returns its first positional argument -- the real core functions return a
     table that both doors immediately re-wrap, so returning ``None`` would blow
-    up before anything could be inspected.
+    up before anything could be inspected. That return doubles as a sentinel:
+    the delegation test asserts each door hands it back, so a wrapper that
+    calls core but drops the result cannot pass.
     """
 
     def __init__(self, reference: Callable):
@@ -690,14 +692,24 @@ class TestFrontDoorDelegation:
     def test_both_front_doors_hand_core_the_same_call(self, case, arrow_table, gpio_table):
         via_ops = _CallRecorder(case.reference)
         with patch.object(case.ops_patch_module, case.core_name, via_ops):
-            case.ops_call(arrow_table)
+            ops_result = case.ops_call(arrow_table)
 
         via_table = _CallRecorder(case.reference)
         with patch.object(case.core_module, case.core_name, via_table):
-            case.table_call(gpio_table)
+            table_result = case.table_call(gpio_table)
 
         assert via_ops.delivered is not None, f"ops.{case.id} never called core"
         assert via_table.delivered is not None, f"Table.{case.id} never called core"
+
+        # Each door must also *return* core's result, not just make the call.
+        # The recorder hands back its input table as a sentinel: the `ops`
+        # wrapper returns core's table as-is, and the `Table` method wraps it
+        # in a new Table -- so a wrapper that computes but drops the result
+        # (the classic missing-`return` refactor bug) fails here.
+        assert ops_result is arrow_table, f"ops.{case.id} did not return core's result"
+        assert isinstance(table_result, Table), f"Table.{case.id} did not return a Table"
+        assert table_result is not gpio_table, f"Table.{case.id} returned self, not a new Table"
+        assert table_result.table is gpio_table.table, f"Table.{case.id} did not wrap core's result"
 
         # Every named knob arrives, under core's own spelling...
         for name, value in case.expected.items():


### PR DESCRIPTION
Issue #666 items 5 (cross-layer dedup) and 6 (the `TestOps` mirror suite), scoped
to the three files this branch owns: `tests/test_api.py`, `tests/test_add.py`,
`tests/test_streaming.py`.

## What changed

**Item 6 — the ops mirror suite.** `TestOps` and `TestOpsNewFunctions` mirrored
`TestTable` method for method. Every mirror re-ran the real DuckDB operation to
assert only that a column of the right name had appeared — which is not what an
`ops` wrapper can get wrong. All either front door can get wrong is *which
arguments it hands down*, so that is now what is asserted, by a spec table:

```python
FrontDoorCase(
    id="add_h3",
    core_module=core_h3, core_name="add_h3_table",
    ops_call=lambda t: ops.add_h3(
        t, column_name="my_h3", resolution=5, geometry_column="geometry"
    ),
    table_call=lambda t: t.add_h3(column_name="my_h3", resolution=5),
    expected={"h3_column_name": "my_h3", "resolution": 5},
    # Knobs only `ops` exposes: asserted on that door, then dropped from both
    # sides before the doors are compared.
    ops_only_expected={"geometry_column": "geometry"},
)
```

Both doors are invoked **with every option set to a non-default value**, core is
recorded rather than run (calls normalized through core's own signature with
`apply_defaults()`), each named knob is asserted to arrive under core's spelling,
and the two doors' full calls are asserted equal to each other.

This is strictly stronger than the mirrors it replaces, and it is the half the
two existing harnesses cannot see:

| harness | compares |
|---|---|
| `test_cli_api_default_parity.py` | declared signature defaults, by introspection |
| `test_cli_api_call_parity_scaffold.py` | CLI/ops/Table invoked with **defaults only** |
| `TestFrontDoorDelegation` (new) | ops/Table invoked with **every option non-default** |

**Item 5 — cross-layer duplication in `test_add.py`.** `gpio add bbox` ran five
times and `gpio add h3` ten times on the same input, once per property being read
back, while H3 option *semantics* are already asserted at core level in
`tests/test_add_h3.py` (`TestAddH3Table`, `TestAddH3File`). Each collapses to two
module-scoped runs — one all-defaults, one with every option at once — with the
assertions unchanged and read off the shared outputs.

**`test_streaming.py` — no change, deliberately.** It references neither the CLI
nor the Python API (`grep -n "CliRunner\|cli.main\|from geoparquet_io.api"` is
empty): it is already the core-level home for the `core/streaming.py` and
`core/stream_io.py` primitives, not a third copy of `add` behaviour.

## Old → new mapping

Nothing was dropped. Every assertion below has a named destination.

### `tests/test_api.py`

| removed | where its assertion now lives |
|---|---|
| `TestOps::test_add_bbox` | `TestOpsEndToEnd::test_add_family` (real run) + `FRONT_DOOR_CASES["add_bbox"]` |
| `TestOps::test_add_quadkey` | `FRONT_DOOR_CASES["add_quadkey"]`; real quadkey run kept in `TestTable::test_add_quadkey` |
| `TestOps::test_sort_hilbert` | `TestOpsEndToEnd::test_sort_family` (real run) + `FRONT_DOOR_CASES["sort_hilbert"]` |
| `TestOps::test_sort_str` | `FRONT_DOOR_CASES["sort_str"]`; real run kept in `TestTable::test_sort_str` |
| `TestOps::test_extract` | `TestOpsEndToEnd::test_extract_family` (real run) |
| `TestOpsNewFunctions::test_add_h3` | `FRONT_DOOR_CASES["add_h3"]`; real run in `TestTable::test_add_h3` |
| `TestOpsNewFunctions::test_add_s2` | `FRONT_DOOR_CASES["add_s2"]`; real run in `TestTable::test_add_s2` |
| `TestOpsNewFunctions::test_add_kdtree` | `FRONT_DOOR_CASES["add_kdtree"]`; real run in `TestTable::test_add_kdtree` |
| `TestOpsNewFunctions::test_sort_column` | `FRONT_DOOR_CASES["sort_column"]`; real run in `TestTable::test_sort_column` |
| `TestOpsNewFunctions::test_sort_quadkey` | `FRONT_DOOR_CASES["sort_quadkey"]`; real run in `TestTable::test_sort_quadkey` |
| `TestOpsNewFunctions::test_reproject` | `FRONT_DOOR_CASES["reproject"]`; real run in `TestTable::test_reproject` |
| `TestTable::test_add_bbox_custom_name` | `FRONT_DOOR_CASES["add_bbox"]` (`column_name="bounds"`) |
| `TestTable::test_add_h3_custom_resolution` / `_custom_column_name` | `FRONT_DOOR_CASES["add_h3"]` |
| `TestTable::test_add_s2_custom_level` / `_custom_column_name` | `FRONT_DOOR_CASES["add_s2"]` |
| `TestTable::test_add_kdtree_custom_params` | `FRONT_DOOR_CASES["add_kdtree"]` |
| `TestTable::test_sort_column_descending` | `FRONT_DOOR_CASES["sort_column"]` (`descending=True`) |
| `TestOpsConversionFunctions::test_convert_to_geopackage` | `test_conversion_runs_end_to_end` (real, unmocked) |
| `..._flatgeobuf` / `..._csv` / `..._shapefile` | `test_options_reach_the_format_writer[flatgeobuf\|csv\|shapefile]`; the writers themselves stay covered for real by `TestTableWriteFormats` |
| `TestOpsConversionFunctions::test_convert_with_options` | `test_options_reach_the_format_writer[geopackage]` (`overwrite`, `layer_name`) |

New coverage that had none before: `ops.add_bbox`'s `geometry_column`
forwarding, `use_centroid`, `include_wkt`/`include_bbox`,
`encoding`, `repair_geometry`, `where`/`bbox`/`exclude_columns`, `assume_crs84`,
`source_crs`, and the `_table_to_temp_parquet_and_convert` type guard
(`test_a_non_arrow_table_is_refused`).

### `tests/test_add.py`

| removed | where its assertion now lives |
|---|---|
| `test_add_bbox_to_buildings` | `TestAddBboxCLI::test_adds_a_bbox_struct_keeping_every_row_and_column` |
| `test_add_bbox_preserves_columns` | same test (input columns ⊆ output) |
| `test_add_bbox_with_metadata_always_added` | `TestAddBboxCLI::test_covering_metadata_is_written_without_being_asked_for` |
| `test_add_bbox_with_custom_name` | `TestAddBboxCLI::test_bbox_name_option_reaches_core` |
| `test_add_bbox_with_verbose` | folded into the `bbox_optioned_run` fixture (`--verbose` still exercised, exit code still asserted) |
| `test_add_h3_to_buildings` | `TestAddH3CLI::test_writes_valid_cells_and_keeps_every_row_and_column` |
| `test_add_h3_preserves_columns` | same test |
| `test_add_h3_default_resolution` | `TestAddH3CLI::test_default_resolution_is_9` |
| `test_add_h3_metadata` | `TestAddH3CLI::test_default_run_records_covering_metadata` **and** `test_column_name_option_reaches_core` (both the default and the custom column/resolution now asserted, where only the latter was before) |
| `test_add_h3_custom_resolution` | `TestAddH3CLI::test_resolution_option_reaches_core` |
| `test_add_h3_with_custom_name` | `TestAddH3CLI::test_column_name_option_reaches_core` |
| `test_add_h3_with_verbose` | `TestAddH3CLI::test_verbose_option_reaches_the_extension_loader` |
| `test_add_h3_nonexistent_file` | `test_refuses_bad_input[missing-input]` |
| `test_add_h3_invalid_resolution_too_low` / `_too_high` | `test_refuses_bad_input[resolution-below-0\|resolution-above-15]` |
| `test_add_h3_core_function_invalid_resolution` | `test_core_function_rejects_an_out_of_range_resolution` (kept, both bounds) |

`test_refuses_bad_input` also asserts no output file is left behind, which the
three exit-code-only tests it replaces did not.

## Mirrors deliberately kept

- **`TestOpsPartition` (all of it).** Added by #808 as the `ops` twins' own
  enforcement suite. Its `partition_by_kdtree`/`_string`/`_admin` cases assert a
  **genuinely different return shape** from the cell-index partitioners — the
  int-vs-dict divergence tracked in #822 — and `test_partition_by_s2_fails_like_the_table_method`,
  `test_ops_and_table_write_the_same_partitions` and the `_forwards_to_core`
  cases assert things no other harness does. None of it re-runs work a `Table`
  test already ran on the same index.
- **`TestTable::test_sort_quadkey_remove_column`.** Reads an *outcome* (the
  column is gone from the result), not just that the flag arrived. The
  delegation harness only proves the flag reached core.
- **One real run per `TestTable` add/sort method.** The delegation harness patches
  core away; these keep the unmocked path covered for diff-cover.
- **`TestTableWriteFormats` (all six).** The `Table.write` door, not an `ops`
  mirror — `_write_format` is a separate implementation from
  `ops.convert_to_*`, and each format is a distinct branch of it.
- **Every `add bbox` test asserting a distinct outcome**: the #728 copy path,
  `--force`, the streaming forms, `--dry-run`, `--geoparquet-version` beating the
  copy, the v1.0 covering gate.

## Deferred (files this branch does not own)

Listed for whoever picks up the rest of #666 item 5:

- `tests/test_add_h3.py::TestAddH3CLI` — `test_add_h3_cli_basic` now overlaps
  `test_add.py::TestAddH3CLI`'s default run, and `test_add_h3_cli_help` is one of
  the ~40 help smoke tests item 3 subsumes.
- `tests/test_output_format.py` — `TestAddBbox` re-asserts `add bbox` output
  shape (item 9 of the same issue already targets the file). It has no `add h3`
  class, so nothing there overlaps this branch's H3 consolidation.
- `tests/test_add_a5.py`, `test_add_quadkey.py`, `test_add_s2.py` — the same
  per-index CLI/core/API triplication, which item 1's parametrized spatial-index
  module is the right place to fix, not this branch.
- `tests/test_api.py::TestTableWriteFormats::test_write_format_options` and
  `test_write_explicit_format` are pure option plumbing that the delegation
  harness pattern would suit, but they belong to the `Table.write` facade rather
  than to items 5/6.

## Verification

**Zero coverage loss — byte-identical.** `pytest tests/test_api.py tests/test_add.py
tests/test_streaming.py --cov=geoparquet_io`:

| | statements | missed | covered |
|---|---|---|---|
| before | 23822 | 16107 | 7715 |
| after | 23822 | 16107 | 7715 |

**Counts.** Test definitions 280 → 260 (−20; `test_api.py` 158 → 143,
`test_add.py` 53 → 48). Collected instances 303 → 299. Heavyweight
DuckDB/GDAL/CLI runs in the touched areas ~38 → ~8. Warm wall clock for the three
files 19.8s → 16.5s. LOC is up (4226 → 4401): the spec tables and their
justifications are longer than the copy-pasted tests they replace, and the win
here is the assertions' strength and the run count, not lines.

**Suites.** `pytest -n auto -m "not slow and not network and not meta"` →
5373 passed, 65 skipped, 2 xfailed. `pytest -m meta` → 202 passed.
`pre-commit run --files ...` → clean.

**Sabotage-verified twice**, both against the consolidated suite:

1. *Break an ops kwarg forward* — `ops.add_h3` pinned to `resolution=9` instead of
   forwarding its argument:
   ```
   FAILED tests/test_api.py::TestFrontDoorDelegation::
     test_both_front_doors_hand_core_the_same_call[add_h3]
   E   AssertionError: ops.add_h3 dropped resolution
   E   assert 9 == 5
   ```
   The deleted `TestOpsNewFunctions::test_add_h3` would **not** have caught this:
   it only asserted `"h3_cell" in result.column_names`.

2. *Break a CLI option's plumbing* — `gpio add h3` passing a literal
   `h3_column_name="h3_cell"` instead of `h3_name`:
   ```
   FAILED tests/test_add.py::TestAddH3CLI::test_column_name_option_reaches_core
   E   AssertionError: assert 'h3_building' in {'geometry', 'h3_cell', 'id'}
   FAILED tests/test_add.py::TestAddH3CLI::test_resolution_option_reaches_core
   ```

Both sabotages were reverted with `git checkout` before committing; the diff
touches tests only.

## Review fixes (round 2)

- **The guard test now enumerates the surface.**
  `test_every_shared_operation_has_a_case` only iterated the cases it already
  had, so a new `ops`/`Table` twin could be added with no comparison at all and
  leave it green — eight were sitting uncompared. It now computes
  `dir(ops) ∩ dir(Table)` (public callables) and asserts that set is exactly the
  case ids plus `NOT_TABLE_IN_TABLE_OUT`, a commented allowlist carrying a reason
  per entry (file round trips, the partitioners covered end-to-end by
  `TestOpsPartition`, `explain_analyze`/`from_wfs` which take no input table).
  Three of the eight were real table-in/table-out twins and became cases instead
  of allowlist entries: `add_bbox_metadata`, `aggregate_h3`, `aggregate_a5`.
  Sabotage: deleting the `from_wfs` allowlist line fails the test with
  `uncompared twins ...: ['from_wfs']`.
- **`geometry_column` forwarding is now asserted on the index adders.**
  `ops.add_h3`/`add_a5`/`add_s2`/`add_kdtree` never passed it, so dropping the
  forward in those wrappers was invisible — the `Table` twin has no such knob, so
  both doors delivered `None` and compared equal. A new `ops_only_expected` field
  asserts such knobs against the `ops` door and drops them from both sides before
  the doors are compared. Sabotage: `ops.add_h3` not forwarding `geometry_column`
  now fails with `ops.add_h3 dropped geometry_column / assert None == 'geometry'`.
  (The earlier body claimed `ops.add_a5`'s `geometry_column` forwarding was
  already covered; it was not, and that sentence is corrected above.)
- **`ops.reproject` gets an unmocked run.** `TestOpsEndToEnd::test_reproject_family`,
  the fourth family alongside add/sort/extract; the class docstring says so.
- **`test_refuses_bad_input` asserts the message,** not just a non-zero exit —
  `Cannot read file: ...` and `N is not in the range 0<=x<=15` per case.
- **Pointer kept valid across #830.** `TestAddH3CLI`'s docstring named
  `tests/test_add_h3.py` as the home of H3 semantics, which #830 deletes into
  `tests/test_spatial_index_family.py`; it now names both, so neither merge order
  leaves it stale.
- **Failure message uses the case id**, not the writer name
  (`convert_to_geopackage dropped ...`, not `convert_to_write_csv dropped ...`).
- Corrected the deferred-work entry for `tests/test_output_format.py`: it has a
  `TestAddBbox` class but no `add h3` one.

Refs #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for command-line and API operations, including bounding-box and H3 workflows.
  * Added validation for invalid and nonexistent inputs.
  * Added checks confirming options are passed through consistently across interfaces.
  * Added end-to-end coverage and type-safety checks for conversion operations.
  * Consolidated test scenarios to reduce duplicate execution while preserving coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->