### PR TITLE
fix(wfs): request the format the server advertises and parse GML responses

### DIFF
--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1205,7 +1205,7 @@ To find service URLs:
 
 ## Extracting from WFS Services
 
-Web Feature Service (WFS) is an OGC standard for serving vector geospatial data over HTTP. Many government agencies and organizations publish data via WFS. gpio uses DuckDB's httpfs extension to stream JSON directly over HTTP, making extraction very fast.
+Web Feature Service (WFS) is an OGC standard for serving vector geospatial data over HTTP. Many government agencies and organizations publish data via WFS. gpio streams each response to disk and parses it locally with DuckDB, making extraction very fast.
 
 ### Basic Usage
 
@@ -1358,6 +1358,24 @@ gpio extract wfs https://geo.example.com/wfs cities output.parquet \
     --wfs-version 1.1.0
 ```
 
+### Response Formats
+
+gpio reads the formats a service advertises in its `GetCapabilities` response
+and asks for the best one it can parse: GeoJSON first, because it is the
+fastest to read, then GML. Nothing needs to be configured — a GeoJSON service
+and a GML-only service are extracted with the same command.
+
+Older WFS 1.0.0/1.1.0 deployments frequently offer GML and nothing else, and
+some servers answer with GML even when a different format was requested. gpio
+decides how to parse a response from the `Content-Type` the server actually
+sent, so either case works. GML is read through GDAL, which resolves the
+geometry, the attributes and the CRS the server used.
+
+If a service advertises formats but none is one gpio can read, gpio omits
+`outputFormat` from the request entirely and takes the server's own default,
+rather than demanding a format the service has just said it does not offer. If
+a service advertises nothing at all, gpio asks for GeoJSON as it always has.
+
 ### Axis Order
 
 WFS 1.1.0+ with URN-format CRS (e.g., `urn:ogc:def:crs:EPSG::4326`) uses lat,lon axis order per OGC spec. gpio auto-detects this, but you can override:
@@ -1386,7 +1404,8 @@ gpio extract wfs https://geo.example.com/wfs cities output.parquet \
 ```
 
 When a server reports the CRS it actually used (GeoServer and most WFS servers
-echo it in the GeoJSON `crs` member), gpio trusts that declaration verbatim —
+echo it in the GeoJSON `crs` member, and a GML response carries an `srsName` on
+its geometries), gpio trusts that declaration verbatim —
 it never second-guesses a server-honored CRS by inspecting coordinates. This
 matters for projected systems: a bounding box alone cannot distinguish, say,
 EPSG:22174 (Argentine Gauss-Krüger) from EPSG:3857 (Web Mercator), so guessing
@@ -1410,6 +1429,7 @@ gpio extract wfs https://geo.example.com/wfs cities output.parquet \
 
 - **Transport for Cairo**: `https://data.transportforcairo.com/geoserver/geonode/ows`
 - **GeoServer Demo**: `https://demo.geoserver.org/geoserver/wfs`
+- **NextGIS Demo** (GML-only): `https://demo.nextgis.com/api/resource/9748/wfs`
 - State GIS portals (varies by state)
 - Municipal open data portals
 

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -54,6 +54,7 @@ from geoparquet_io.core.duckdb_utils import (
     _escape_sql_string,
     get_duckdb_connection,
     quote_identifier,
+    sql_path,
 )
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.http_retry import (
@@ -116,6 +117,10 @@ class WFSAuthenticationError(WFSError):
         super().__init__(message)
 
 
+# What gpio requests when a service advertises no output formats at all, which
+# is also what it requested unconditionally before issue #818.
+DEFAULT_OUTPUT_FORMAT: Final[str] = "application/json"
+
 # GeoJSON output format identifiers (in preference order)
 GEOJSON_FORMATS = [
     "application/json",
@@ -125,13 +130,21 @@ GEOJSON_FORMATS = [
     "application/vnd.geo+json",
 ]
 
-# GML output format identifiers (fallback, in preference order)
+# GML output format identifiers (fallback, in preference order).
+#
+# Servers spell these with wildly inconsistent whitespace and version suffixes
+# (``application/gml+xml;version=3.2`` from NextGIS vs
+# ``application/gml+xml; version=3.1`` from GeoServer), so matching is done on a
+# whitespace-stripped, lowercased form and falls back to a prefix match — see
+# _detect_best_output_format.
 GML_FORMATS = [
     "gml3",
     "text/xml; subtype=gml/3.1.1",
     "application/gml+xml; version=3.1",
     "gml32",
     "text/xml; subtype=gml/3.2",
+    "application/gml+xml; version=3.2",
+    "application/gml+xml",
     "gml2",
     "text/xml; subtype=gml/2.1.2",
 ]
@@ -441,9 +454,11 @@ def _crs_matches(crs1: str, crs2: str) -> bool:
 def _with_server_crs(table: pa.Table, server_crs: str | None) -> pa.Table:
     """Attach the server-declared CRS to a table's schema metadata.
 
-    Carries the CRS the server reported in its GeoJSON response up through the
+    Carries the CRS the server reported in its response up through the
     fetch/concat/type-inference pipeline so wfs_to_table can trust it instead of
-    guessing from coordinates. No-op when ``server_crs`` is None.
+    guessing from coordinates. The source is the GeoJSON ``crs`` member or, for
+    a GML body, the CRS GDAL reports on the geometry column. No-op when
+    ``server_crs`` is None.
     """
     if not server_crs:
         return table
@@ -647,7 +662,7 @@ def _resolve_crs_for_output(
     """Decide the CRS to label (and optionally reproject) the fetched data to.
 
     Trust order:
-      1. The CRS the server declared in its GeoJSON response — authoritative.
+      1. The CRS the server declared in its response — authoritative.
          When present we never second-guess it with coordinate heuristics.
       2. A bbox-coordinate guess — last resort, only when the server declared
          nothing. The guess cannot tell two projected CRSs apart, so it is used
@@ -657,7 +672,7 @@ def _resolve_crs_for_output(
     """
     server_crs = _read_server_crs(table)
     if server_crs:
-        debug(f"Server declared CRS {server_crs} in GeoJSON response")
+        debug(f"Server declared CRS {server_crs} in its response")
         return _reconcile_source_crs(
             table,
             source_crs=server_crs,
@@ -668,7 +683,7 @@ def _resolve_crs_for_output(
         )
 
     debug(
-        f"Server declared no CRS in its GeoJSON response; inferring from "
+        f"Server declared no CRS in its response; inferring from "
         f"coordinates and trusting the requested {requested_crs} unless they clearly disagree."
     )
     crs_valid, detected_crs = _validate_crs_coordinates(table, requested_crs, strict=strict_crs)
@@ -753,6 +768,27 @@ def _detect_sortable_attribute(wfs, typename: str) -> str | None:
     return None
 
 
+def _lookup_parameter_ci(parameters: dict, name: str) -> list | None:
+    """Read an operation parameter's allowed values, ignoring capitalization.
+
+    OWSLib keys ``operation.parameters`` by the literal ``name`` attribute in
+    the capabilities XML. The WFS 2.0 spec writes ``outputFormat``, but NextGIS
+    and deegree publish ``OutputFormat``, so a case-sensitive lookup reported
+    *no* advertised formats for those servers — after which gpio fell back to
+    demanding GeoJSON from a GML-only service.
+    See https://github.com/geoparquet/geoparquet-io/issues/818
+    """
+    if not parameters:
+        return None
+    wanted = name.lower()
+    for key, value in parameters.items():
+        if str(key).lower() != wanted:
+            continue
+        if isinstance(value, dict) and value.get("values"):
+            return list(value["values"])
+    return None
+
+
 def get_layer_info(service_url: str, typename: str, version: str = "1.1.0") -> WFSLayerInfo:
     """
     Get metadata for a specific WFS layer.
@@ -809,9 +845,9 @@ def get_layer_info(service_url: str, typename: str, version: str = "1.1.0") -> W
     if hasattr(wfs, "operations"):
         for op in wfs.operations:
             if op.name == "GetFeature" and hasattr(op, "parameters"):
-                params = op.parameters
-                if "outputFormat" in params and "values" in params["outputFormat"]:
-                    available_formats = list(params["outputFormat"]["values"])
+                values = _lookup_parameter_ci(op.parameters, "outputFormat")
+                if values:
+                    available_formats = list(values)
                     break
 
     # Method 2: Legacy attribute (some OWSLib versions)
@@ -878,34 +914,76 @@ def list_available_layers(service_url: str, version: str = "1.1.0") -> list[dict
     return layers
 
 
-def _detect_best_output_format(available_formats: list[str]) -> str:
+def _normalize_output_format(fmt: str) -> str:
+    """Fold an outputFormat string to a comparable form.
+
+    Servers differ only cosmetically: ``application/gml+xml;version=3.2`` and
+    ``application/gml+xml; version=3.2`` are the same format, and case is not
+    significant in a media type. Lowercasing and dropping all whitespace makes
+    those variants compare equal.
+    """
+    return re.sub(r"\s+", "", fmt).lower()
+
+
+def _first_matching_format(
+    available: list[str], available_norm: list[str], preferred: list[str]
+) -> str | None:
+    """Return the caller's spelling of the most preferred format on offer.
+
+    Two passes: exact (normalized) equality first, so a server advertising both
+    ``gml3`` and ``gml32`` still gets the preference order below honored, then a
+    prefix match so an unlisted version suffix (``…;version=3.2.1``) still
+    resolves to its family instead of being missed.
+    """
+    for want in preferred:
+        want_norm = _normalize_output_format(want)
+        for i, got in enumerate(available_norm):
+            if got == want_norm:
+                return available[i]
+    for want in preferred:
+        want_norm = _normalize_output_format(want)
+        for i, got in enumerate(available_norm):
+            if got.startswith(want_norm):
+                return available[i]
+    return None
+
+
+def _detect_best_output_format(available_formats: list[str]) -> str | None:
     """
     Detect the best output format from available formats.
 
     Prefers GeoJSON for faster parsing, falls back to GML.
 
+    The two ways of not finding a match are answered differently, because they
+    say different things (issue #818):
+
+    * The server advertised formats and none is one gpio can read. Returning
+      ``None`` omits ``outputFormat`` from the request so the server answers in
+      its own default. Naming a format the server has just said it does not
+      support is how gpio used to demand GeoJSON from a GML-only service, and
+      picking the first advertised one instead is no better — on GeoServer that
+      can be ``SHAPE-ZIP``.
+    * The server advertised nothing at all, so there is nothing to honor. gpio
+      keeps asking for ``application/json``, which is what it has always sent
+      and what every GeoJSON-capable service answers. A server that ignores the
+      parameter and replies with GML is now parsed on the response content type
+      rather than rejected, so this costs nothing when the guess is wrong.
+
     Args:
         available_formats: List of format strings from capabilities
 
     Returns:
-        Best format string to request
+        Best format string to request, or None to let the server decide
     """
-    available_lower = [f.lower() for f in available_formats]
+    if not available_formats:
+        return DEFAULT_OUTPUT_FORMAT
 
-    # Check for GeoJSON formats (preferred - faster to parse)
-    for fmt in GEOJSON_FORMATS:
-        if fmt.lower() in available_lower:
-            idx = available_lower.index(fmt.lower())
-            return available_formats[idx]
+    available_norm = [_normalize_output_format(f) for f in available_formats]
 
-    # Check for GML formats
-    for fmt in GML_FORMATS:
-        if fmt.lower() in available_lower:
-            idx = available_lower.index(fmt.lower())
-            return available_formats[idx]
-
-    # Fallback to first available or default
-    return available_formats[0] if available_formats else "GML3"
+    # GeoJSON is preferred - faster to parse - then GML.
+    return _first_matching_format(
+        available_formats, available_norm, GEOJSON_FORMATS
+    ) or _first_matching_format(available_formats, available_norm, GML_FORMATS)
 
 
 def _negotiate_crs(layer_info: WFSLayerInfo, output_crs: str | None = None) -> str:
@@ -1488,21 +1566,162 @@ def _read_count_and_server_crs(
     return feature_count, server_crs
 
 
+# Content types that carry a GML FeatureCollection. WFS 1.x servers -- and
+# NextGIS at every version -- answer GetFeature with GML under one of these,
+# regardless of the outputFormat that was requested, so the *response* type is
+# what decides how gpio parses. An ows:ExceptionReport arrives under the same
+# types, which is why the GML parse falls back to the error-page message rather
+# than the content type deciding on its own.
+_GML_CONTENT_TYPE_MARKERS: Final[tuple[str, ...]] = ("gml", "xml")
+
+# Content types that are never a feature response: HTML and plain-text error
+# pages returned with 200 OK.
+_ERROR_PAGE_CONTENT_TYPE_MARKERS: Final[tuple[str, ...]] = ("html", "text/plain")
+
+# GDAL reports a GML layer's CRS in the DuckDB column type, e.g.
+# GEOMETRY('EPSG:4326'). That is the server's own statement of the CRS it
+# returned, so it plays the same role the GeoJSON `crs` member does.
+_GEOMETRY_TYPE_CRS_RE: Final = re.compile(r"GEOMETRY\('([^']+)'\)", re.IGNORECASE)
+
+
+def _classify_wfs_content_type(content_type: str) -> str:
+    """Decide how to parse a WFS response body from its Content-Type.
+
+    Returns ``"json"``, ``"gml"``, or ``"error"``. An empty or unrecognized
+    content type is treated as JSON, preserving the previous behavior for
+    servers that send ``application/octet-stream`` for GeoJSON.
+    """
+    if not content_type:
+        return "json"
+    if "json" in content_type or "javascript" in content_type:
+        return "json"
+    if any(marker in content_type for marker in _ERROR_PAGE_CONTENT_TYPE_MARKERS):
+        return "error"
+    if any(marker in content_type for marker in _GML_CONTENT_TYPE_MARKERS):
+        return "gml"
+    return "json"
+
+
+def _error_page_error(content_type: str, preview: str) -> WFSError:
+    """Build the "server returned an error page" failure with a body preview."""
+    return WFSError(
+        f"Expected JSON response but got {content_type}. "
+        f"Server may have returned an error page:\n{preview}"
+    )
+
+
+def _read_body_preview(path: str) -> str:
+    """Read the first 500 characters of a downloaded response body."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return handle.read(500)
+    except OSError:  # pragma: no cover - the file was just written
+        return ""
+
+
+def _gml_geometry_column(
+    con: duckdb.DuckDBPyConnection, tmp_path: str, content_type: str
+) -> tuple[str, list[str], str | None]:
+    """Describe a GML file and return (geometry column, other columns, CRS).
+
+    ``ST_Read`` raises ``IOException`` when GDAL cannot open the body at all,
+    which is exactly what an ``ows:ExceptionReport`` looks like. That case is
+    reported with the same "error page" message (and body preview) the JSON path
+    has always used, so a genuinely broken response still reads the same way.
+    """
+    try:
+        described = con.execute(f"DESCRIBE SELECT * FROM ST_Read({sql_path(tmp_path)})").fetchall()
+    except duckdb.IOException as e:
+        raise _error_page_error(content_type, _read_body_preview(tmp_path)) from e
+
+    geometry_column: str | None = None
+    server_crs: str | None = None
+    other_columns: list[str] = []
+    for row in described:
+        name, column_type = str(row[0]), str(row[1])
+        if geometry_column is None and column_type.upper().startswith("GEOMETRY"):
+            geometry_column = name
+            match = _GEOMETRY_TYPE_CRS_RE.search(column_type)
+            server_crs = _normalize_crs(match.group(1)) if match else None
+        else:
+            other_columns.append(name)
+
+    if geometry_column is None:
+        raise _error_page_error(content_type, _read_body_preview(tmp_path))
+
+    return geometry_column, other_columns, server_crs
+
+
+def _parse_gml_response(
+    con: duckdb.DuckDBPyConnection, tmp_path: str, extract_fid: bool, content_type: str
+) -> pa.Table:
+    """Parse a GML FeatureCollection into the same shape the GeoJSON path returns.
+
+    Geometry lands in a WKB column named ``geometry`` and every server attribute
+    is kept, so everything downstream (repair, CRS validation, type inference,
+    tile deduplication) works unchanged.
+    """
+    geometry_column, other_columns, server_crs = _gml_geometry_column(con, tmp_path, content_type)
+
+    # OGC_FID is synthesized by GDAL as a per-file row number, not server data.
+    # Keeping it would give every page of a paginated fetch the same ids.
+    excluded = [geometry_column]
+    if "OGC_FID" in other_columns:
+        excluded.append("OGC_FID")
+
+    select_parts = [f"ST_AsWKB({quote_identifier(geometry_column)}) AS geometry"]
+    # gml:id is the GML equivalent of a GeoJSON feature id, used to deduplicate
+    # features that straddle two spatial tiles.
+    if extract_fid and "gml_id" in other_columns:
+        select_parts.append("gml_id AS _wfs_fid")
+        excluded.append("gml_id")
+    exclude_list = ", ".join(quote_identifier(c) for c in excluded)
+    select_parts.append(f"* EXCLUDE({exclude_list})")
+
+    query = f"SELECT {', '.join(select_parts)} FROM ST_Read({sql_path(tmp_path)})"
+    table = con.execute(query).arrow().read_all()
+    return _with_server_crs(table, server_crs)
+
+
+def _accept_header_for(output_format: str | None) -> str:
+    """Choose the Accept header for a requested outputFormat.
+
+    WFS outputFormat values are not always media types (``GML2``, ``gml32``), so
+    only a value that looks like one is echoed into Accept; anything else asks
+    for whatever the server sends rather than risking a 406.
+    """
+    if not output_format:
+        return "application/json"
+    return output_format if "/" in output_format else "*/*"
+
+
 def _fetch_wfs_page(
-    url: str, extract_fid: bool = False, max_retries: int = 3, retry_delay: float = 2.0
+    url: str,
+    extract_fid: bool = False,
+    max_retries: int = 3,
+    retry_delay: float = 2.0,
+    output_format: str | None = None,
 ) -> pa.Table:
     """
-    Fetch a WFS GeoJSON page via httpx and parse with DuckDB locally.
+    Fetch a WFS page via httpx and parse with DuckDB locally.
 
-    Downloads GeoJSON using Python httpx (thread-safe, ~10x faster than DuckDB
-    httpfs for JSON), streams to a temp file, then parses with DuckDB's spatial
-    extension. Includes automatic retry for transient network errors.
+    Downloads the response using Python httpx (thread-safe, ~10x faster than
+    DuckDB httpfs for JSON), streams it to a temp file, then parses it with
+    DuckDB's spatial extension. Includes automatic retry for transient network
+    errors.
+
+    The parser is chosen from the *response* Content-Type, not from
+    ``output_format``: servers such as NextGIS ignore an outputFormat they don't
+    support and answer with GML at HTTP 200, so trusting the request would make
+    gpio reject a perfectly good FeatureCollection (issue #818).
 
     Args:
         url: Full WFS GetFeature URL with all parameters
-        extract_fid: If True, extract feature.id as _wfs_fid column (for dedup)
+        extract_fid: If True, extract the feature id as _wfs_fid column (for dedup)
         max_retries: Number of retry attempts for transient errors
         retry_delay: Base delay between retries (exponential backoff)
+        output_format: The outputFormat requested in ``url``, used only to set
+            the Accept header
 
     Returns:
         PyArrow Table with geometry column (WKB) and all properties
@@ -1510,6 +1729,7 @@ def _fetch_wfs_page(
     import httpx
 
     last_exception: Exception | None = None
+    accept = _accept_header_for(output_format)
 
     for attempt in range(max_retries):
         start_time = time.time()
@@ -1518,45 +1738,45 @@ def _fetch_wfs_page(
         else:
             debug(f"Fetching: {url[:100]}...")
 
-        # Stream response to temp file to avoid memory exhaustion on large responses
+        # Stream the response into a temp *directory*, not a temp file: GDAL
+        # writes a .gfs schema sidecar next to a schema-less GML body, and only
+        # a directory cleanup is guaranteed to take it with it.
+        tmp_dir = tempfile.TemporaryDirectory(prefix="gpio-wfs-")
         tmp_path = None
+        content_type = ""
+        body_kind = "json"
         total_bytes = 0
         try:
-            with tempfile.NamedTemporaryFile(mode="wb", suffix=".json", delete=False) as tmp_file:
-                tmp_path = tmp_file.name
-                client = _get_shared_http_client(timeout=600)
+            client = _get_shared_http_client(timeout=600)
 
-                with client.stream(
-                    "GET",
-                    url,
-                    headers={"Accept": "application/json", "Accept-Encoding": "gzip, deflate"},
-                ) as response:
-                    # Check HTTP status
-                    if response.status_code == 400:
-                        body = response.read().decode("utf-8", errors="replace")
-                        if "startindex" in body.lower():
-                            raise WFSError(
-                                f"Server rejected paginated request (startIndex limit): {body.strip()}"
-                            )
-                        raise WFSError(f"WFS request failed with HTTP 400: {body[:500]}")
-                    response.raise_for_status()
+            with client.stream(
+                "GET",
+                url,
+                headers={"Accept": accept, "Accept-Encoding": "gzip, deflate"},
+            ) as response:
+                # Check HTTP status
+                if response.status_code == 400:
+                    body = response.read().decode("utf-8", errors="replace")
+                    if "startindex" in body.lower():
+                        raise WFSError(
+                            f"Server rejected paginated request (startIndex limit): {body.strip()}"
+                        )
+                    raise WFSError(f"WFS request failed with HTTP 400: {body[:500]}")
+                response.raise_for_status()
 
-                    # Validate content-type (servers may return HTML errors with 200 OK)
-                    content_type = response.headers.get("content-type", "").lower()
-                    if (
-                        content_type
-                        and "json" not in content_type
-                        and "javascript" not in content_type
-                    ):
-                        # Reject HTML, XML, or text/plain (often error pages)
-                        if any(t in content_type for t in ("html", "xml", "text/plain")):
-                            preview = response.read().decode("utf-8", errors="replace")[:500]
-                            raise WFSError(
-                                f"Expected JSON response but got {content_type}. "
-                                f"Server may have returned an error page:\n{preview}"
-                            )
+                # Dispatch on the content-type the server actually sent. HTML and
+                # text/plain are never feature responses (error pages returned
+                # with 200 OK); XML/GML may be either a FeatureCollection or an
+                # ows:ExceptionReport, which the GML parser tells apart.
+                content_type = response.headers.get("content-type", "").lower()
+                body_kind = _classify_wfs_content_type(content_type)
+                if body_kind == "error":
+                    preview = response.read().decode("utf-8", errors="replace")[:500]
+                    raise _error_page_error(content_type, preview)
 
-                    # Stream content to file
+                suffix = ".gml" if body_kind == "gml" else ".json"
+                tmp_path = str(Path(tmp_dir.name) / f"response{suffix}")
+                with open(tmp_path, "wb") as tmp_file:
                     for chunk in response.iter_bytes(chunk_size=65536):
                         tmp_file.write(chunk)
                         total_bytes += len(chunk)
@@ -1568,14 +1788,12 @@ def _fetch_wfs_page(
             break
 
         except httpx.HTTPStatusError as e:
-            if tmp_path:
-                Path(tmp_path).unlink(missing_ok=True)
+            tmp_dir.cleanup()
             raise WFSError(f"WFS request failed with HTTP {e.response.status_code}") from e
         except (httpx.RequestError, httpx.RemoteProtocolError) as e:
             # Transient network error - retry
             last_exception = e
-            if tmp_path:
-                Path(tmp_path).unlink(missing_ok=True)
+            tmp_dir.cleanup()
             if attempt < max_retries - 1:
                 delay = retry_delay * (attempt + 1)
                 warn(f"Network error (attempt {attempt + 1}/{max_retries}): {e}")
@@ -1585,8 +1803,7 @@ def _fetch_wfs_page(
                 continue
             raise WFSError(f"Failed to fetch WFS data after {max_retries} attempts: {e}") from e
         except WFSError:
-            if tmp_path:
-                Path(tmp_path).unlink(missing_ok=True)
+            tmp_dir.cleanup()
             raise
     else:
         # Exhausted retries without success
@@ -1596,6 +1813,15 @@ def _fetch_wfs_page(
     try:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         safe_path = _escape_sql_string(tmp_path)
+
+        if body_kind == "gml":
+            parse_start = time.time()
+            table = _parse_gml_response(con, tmp_path, extract_fid, content_type)
+            debug(
+                f"Parsed {table.num_rows:,} GML rows in {time.time() - parse_start:.1f}s "
+                f"(total: {time.time() - start_time:.1f}s)"
+            )
+            return table
 
         # Read the feature count (DuckDB can't UNNEST empty JSON arrays) and the
         # authoritative CRS the server reported in its GeoJSON response, if any,
@@ -1631,7 +1857,7 @@ def _fetch_wfs_page(
     finally:
         if con:
             con.close()
-        Path(tmp_path).unlink(missing_ok=True)
+        tmp_dir.cleanup()
 
 
 def _generate_tile_grid(
@@ -1805,6 +2031,7 @@ def _fetch_with_spatial_tiles(
     axis_order: str = "auto",
     max_features: int | None = None,
     sort_by: str | None = None,
+    output_format: str | None = None,
 ) -> pa.Table:
     """
     Fetch a large WFS dataset by subdividing into spatial tiles.
@@ -1850,6 +2077,7 @@ def _fetch_with_spatial_tiles(
             axis_order=axis_order,
             extract_fid=True,
             sort_by=sort_by,
+            output_format=output_format,
         )
         if tile_table.num_rows > 0:
             all_tables.append(tile_table)
@@ -1890,6 +2118,7 @@ def _probe_startindex_limit(
     version: str,
     crs: str | None = None,
     axis_order: str = "auto",
+    output_format: str | None = None,
 ) -> int | None:
     """
     Probe a WFS server to discover any startIndex limit.
@@ -1915,6 +2144,7 @@ def _probe_startindex_limit(
         start_index=probe_offset,
         crs=crs,
         axis_order=axis_order,
+        output_format=output_format,
     )
 
     try:
@@ -1957,8 +2187,15 @@ def _build_wfs_url(
     crs: str | None = None,
     axis_order: str = "auto",
     sort_by: str | None = None,
+    output_format: str | None = None,
 ) -> str:
-    """Build a WFS GetFeature URL with pagination support."""
+    """Build a WFS GetFeature URL with pagination support.
+
+    ``output_format`` is the format negotiated from GetCapabilities. When it is
+    None the ``outputFormat`` parameter is omitted entirely, so the server
+    replies in its own default — the only thing that works on a service which
+    advertises no format gpio recognizes (issue #818).
+    """
     from urllib.parse import urlencode
 
     clean_url = _clean_service_url(service_url)
@@ -1968,8 +2205,10 @@ def _build_wfs_url(
         "version": version,
         "request": "GetFeature",
         "typeNames" if version == "2.0.0" else "typeName": typename,
-        "outputFormat": "application/json",
     }
+
+    if output_format:
+        params["outputFormat"] = output_format
 
     if max_features is not None:
         # WFS 2.0 uses count, WFS 1.x uses maxFeatures
@@ -2006,6 +2245,7 @@ def _single_fetch_mode(
     crs: str | None,
     axis_order: str,
     extract_fid: bool,
+    output_format: str | None = None,
 ) -> pa.Table:
     """
     Fetch all features in a single request.
@@ -2020,8 +2260,9 @@ def _single_fetch_mode(
         bbox=bbox,
         crs=crs,
         axis_order=axis_order,
+        output_format=output_format,
     )
-    table = _fetch_wfs_page(url, extract_fid=extract_fid)
+    table = _fetch_wfs_page(url, extract_fid=extract_fid, output_format=output_format)
     if extract_fid:
         return table
     # _infer_column_types rebuilds the schema and drops metadata; re-attach the
@@ -2040,6 +2281,7 @@ def _sequential_pagination_mode(
     axis_order: str,
     extract_fid: bool,
     sort_by: str | None = None,
+    output_format: str | None = None,
 ) -> dict[int, pa.Table]:
     """
     Fetch features using sequential adaptive pagination.
@@ -2064,9 +2306,10 @@ def _sequential_pagination_mode(
             crs=crs,
             axis_order=axis_order,
             sort_by=sort_by,
+            output_format=output_format,
         )
         try:
-            table = _fetch_wfs_page(url, extract_fid=extract_fid)
+            table = _fetch_wfs_page(url, extract_fid=extract_fid, output_format=output_format)
         except Exception as e:
             raise WFSError(f"Failed to fetch page {page_num + 1} (offset {offset}): {e}") from e
 
@@ -2102,6 +2345,7 @@ def _parallel_pagination_mode(
     axis_order: str,
     extract_fid: bool,
     sort_by: str | None = None,
+    output_format: str | None = None,
 ) -> dict[int, pa.Table]:
     """
     Fetch features using parallel pagination.
@@ -2128,6 +2372,7 @@ def _parallel_pagination_mode(
             crs=crs,
             axis_order=axis_order,
             sort_by=sort_by,
+            output_format=output_format,
         )
         pages.append((i, start, url))
 
@@ -2135,7 +2380,10 @@ def _parallel_pagination_mode(
     results: dict[int, pa.Table] = {}
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_page = {
-            executor.submit(_fetch_wfs_page, url, extract_fid): (page_num, start)
+            executor.submit(_fetch_wfs_page, url, extract_fid, output_format=output_format): (
+                page_num,
+                start,
+            )
             for page_num, start, url in pages
         }
 
@@ -2164,6 +2412,7 @@ def fetch_all_features_duckdb(
     extract_fid: bool = False,
     sort_by: str | None = None,
     total_count: int | None = None,
+    output_format: str | None = None,
 ) -> pa.Table:
     """
     Fetch WFS features via Python httpx download and DuckDB local parsing.
@@ -2191,6 +2440,9 @@ def fetch_all_features_duckdb(
         sort_by: Attribute to sort by for stable pagination (auto-detected if None)
         total_count: Pre-fetched feature count (avoids re-querying at this version).
             Pass this when the caller already has a trusted count from WFS 2.0.0.
+        output_format: outputFormat to request, as negotiated from
+            GetCapabilities. None omits the parameter so the server answers in
+            its own default format (issue #818).
 
     Returns:
         PyArrow Table with geometry (WKB) and all properties
@@ -2215,7 +2467,15 @@ def fetch_all_features_duckdb(
             progress("Fetching features...")
 
         table = _single_fetch_mode(
-            service_url, typename, version, max_features, bbox, crs, axis_order, extract_fid
+            service_url,
+            typename,
+            version,
+            max_features,
+            bbox,
+            crs,
+            axis_order,
+            extract_fid,
+            output_format=output_format,
         )
         expected = max_features or total_count
         if expected and table.num_rows < expected and version != "1.0.0":
@@ -2233,13 +2493,26 @@ def fetch_all_features_duckdb(
     if effective_total is None:
         warn("Cannot determine feature count; falling back to single request mode.")
         return _single_fetch_mode(
-            service_url, typename, version, max_features, bbox, crs, axis_order, extract_fid
+            service_url,
+            typename,
+            version,
+            max_features,
+            bbox,
+            crs,
+            axis_order,
+            extract_fid,
+            output_format=output_format,
         )
 
     # Probe for server-side startIndex limit (skip for tile fetches)
     if not extract_fid:
         startindex_limit = _probe_startindex_limit(
-            service_url, typename, version, crs=crs, axis_order=axis_order
+            service_url,
+            typename,
+            version,
+            crs=crs,
+            axis_order=axis_order,
+            output_format=output_format,
         )
         if startindex_limit is not None:
             max_reachable = startindex_limit + page_size
@@ -2275,6 +2548,7 @@ def fetch_all_features_duckdb(
             axis_order,
             extract_fid,
             sort_by=sort_by,
+            output_format=output_format,
         )
     else:
         results = _parallel_pagination_mode(
@@ -2290,6 +2564,7 @@ def fetch_all_features_duckdb(
             axis_order,
             extract_fid,
             sort_by=sort_by,
+            output_format=output_format,
         )
 
     # Combine tables in order
@@ -2433,9 +2708,11 @@ def wfs_to_table(
     # Negotiate CRS
     crs = _negotiate_crs(layer_info, output_crs)
 
-    # Detect best output format
+    # Detect the best output format we can actually parse. None means the
+    # server advertises nothing we recognize, so we omit outputFormat and take
+    # whatever it sends -- which is how GML-only services work (issue #818).
     output_format = _detect_best_output_format(layer_info.available_formats)
-    debug(f"Using output format: {output_format}")
+    debug(f"Using output format: {output_format or 'server default (none requested)'}")
 
     # Auto-detect sortBy attribute for stable pagination (Issue #488)
     # GeoServer requires sortBy for pagination on layers without a primary key
@@ -2474,7 +2751,12 @@ def wfs_to_table(
     tiling_limit = 0
     if auto_tile and version != "1.0.0" and expected_count:
         startindex_limit = _probe_startindex_limit(
-            service_url, layer_info.typename, version, crs=crs, axis_order=axis_order
+            service_url,
+            layer_info.typename,
+            version,
+            crs=crs,
+            axis_order=axis_order,
+            output_format=output_format,
         )
         if startindex_limit:
             effective = min(limit, expected_count) if limit else expected_count
@@ -2503,6 +2785,7 @@ def wfs_to_table(
             axis_order=axis_order,
             max_features=limit,
             sort_by=effective_sort_by,
+            output_format=output_format,
         )
     else:
         # Normal fetch — pass expected_count so we don't re-query at this version
@@ -2519,6 +2802,7 @@ def wfs_to_table(
             axis_order=axis_order,
             sort_by=effective_sort_by,
             total_count=expected_count,
+            output_format=output_format,
         )
 
         # Check for maxFeatures cap (reactive tiling)
@@ -2552,6 +2836,7 @@ def wfs_to_table(
                     axis_order=axis_order,
                     max_features=limit,
                     sort_by=effective_sort_by,
+                    output_format=output_format,
                 )
 
     if table.num_rows == 0:

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -932,8 +932,13 @@ def _first_matching_format(
 
     Two passes: exact (normalized) equality first, so a server advertising both
     ``gml3`` and ``gml32`` still gets the preference order below honored, then a
-    prefix match so an unlisted version suffix (``…;version=3.2.1``) still
+    parameter match so an unlisted version suffix (``…;version=3.2.1``) still
     resolves to its family instead of being missed.
+
+    The second pass is deliberately not a plain prefix test: that would read
+    ``application/json-seq`` (JSON *text sequences*, which are not a
+    FeatureCollection) as ``application/json``, and ``gml3-something`` as
+    ``gml3``. Only a media-type parameter -- the part after ``;`` -- may differ.
     """
     for want in preferred:
         want_norm = _normalize_output_format(want)
@@ -943,7 +948,7 @@ def _first_matching_format(
     for want in preferred:
         want_norm = _normalize_output_format(want)
         for i, got in enumerate(available_norm):
-            if got.startswith(want_norm):
+            if got.startswith(want_norm) and got[len(want_norm) :].startswith(";"):
                 return available[i]
     return None
 
@@ -1689,9 +1694,13 @@ def _accept_header_for(output_format: str | None) -> str:
     WFS outputFormat values are not always media types (``GML2``, ``gml32``), so
     only a value that looks like one is echoed into Accept; anything else asks
     for whatever the server sends rather than risking a 406.
+
+    ``None`` means the caller decided not to name an ``outputFormat`` at all, so
+    Accept must not name one either — asking for JSON there would contradict the
+    request and could earn a 406 from a server that cannot produce it.
     """
     if not output_format:
-        return "application/json"
+        return "*/*"
     return output_format if "/" in output_format else "*/*"
 
 

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -19,7 +19,7 @@ import json
 import re
 import tempfile
 import time
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # nosec B405 - stdlib ET never resolves external entities; see _is_empty_gml_collection
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
@@ -1653,7 +1653,7 @@ def _is_empty_gml_collection(body: bytes) -> bool:
     if len(body) > _EMPTY_GML_SNIFF_MAX_BYTES:
         return False
     try:
-        root = ET.fromstring(body)
+        root = ET.fromstring(body)  # nosec B314 - no external entity resolution; body capped at 1MB, only gates the empty check
     except ET.ParseError:
         return False
     if _local_name(root.tag) != "FeatureCollection":

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1626,17 +1626,24 @@ def _read_body_preview(path: str) -> str:
 
 def _gml_geometry_column(
     con: duckdb.DuckDBPyConnection, tmp_path: str, content_type: str
-) -> tuple[str, list[str], str | None]:
+) -> tuple[str, list[str], str | None] | None:
     """Describe a GML file and return (geometry column, other columns, CRS).
 
     ``ST_Read`` raises ``IOException`` when GDAL cannot open the body at all,
     which is exactly what an ``ows:ExceptionReport`` looks like. That case is
     reported with the same "error page" message (and body preview) the JSON path
     has always used, so a genuinely broken response still reads the same way.
+
+    A zero-feature FeatureCollection also fails to open -- GDAL finds no layer
+    to build -- but with its own "contains no layers" message. That is a
+    legitimate WFS answer to an empty bbox, not an error, so it is returned as
+    ``None`` for the caller to turn into an empty table.
     """
     try:
         described = con.execute(f"DESCRIBE SELECT * FROM ST_Read({sql_path(tmp_path)})").fetchall()
     except duckdb.IOException as e:
+        if "contains no layers" in str(e):
+            return None
         raise _error_page_error(content_type, _read_body_preview(tmp_path)) from e
 
     geometry_column: str | None = None
@@ -1666,7 +1673,14 @@ def _parse_gml_response(
     is kept, so everything downstream (repair, CRS validation, type inference,
     tile deduplication) works unchanged.
     """
-    geometry_column, other_columns, server_crs = _gml_geometry_column(con, tmp_path, content_type)
+    described = _gml_geometry_column(con, tmp_path, content_type)
+    if described is None:
+        # Zero-feature collection: same shape the JSON path returns for an
+        # empty ``features`` array (geometry-only, no _wfs_fid), so pagination
+        # and tiled fetches see an empty page, not a failure.
+        debug("Empty GML response, returning empty table")
+        return pa.table({"geometry": pa.array([], type=pa.binary())})
+    geometry_column, other_columns, server_crs = described
 
     # OGC_FID is synthesized by GDAL as a per-file row number, not server data.
     # Keeping it would give every page of a paginated fetch the same ids.
@@ -1676,9 +1690,11 @@ def _parse_gml_response(
 
     select_parts = [f"ST_AsWKB({quote_identifier(geometry_column)}) AS geometry"]
     # gml:id is the GML equivalent of a GeoJSON feature id, used to deduplicate
-    # features that straddle two spatial tiles.
+    # features that straddle two spatial tiles. GDAL synthesizes gml_id = ''
+    # (not NULL) for features with no gml:id; NULLIF sends those to the
+    # geometry-bytes dedup fallback instead of collapsing them onto one key.
     if extract_fid and "gml_id" in other_columns:
-        select_parts.append("gml_id AS _wfs_fid")
+        select_parts.append("NULLIF(gml_id, '') AS _wfs_fid")
         excluded.append("gml_id")
     exclude_list = ", ".join(quote_identifier(c) for c in excluded)
     select_parts.append(f"* EXCLUDE({exclude_list})")

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -19,6 +19,7 @@ import json
 import re
 import tempfile
 import time
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
@@ -1624,6 +1625,49 @@ def _read_body_preview(path: str) -> str:
         return ""
 
 
+# An empty FeatureCollection is a few hundred bytes of markup; a body larger
+# than this holds features and can skip the extra XML parse.
+_EMPTY_GML_SNIFF_MAX_BYTES: Final = 1024 * 1024
+
+# FeatureCollection children that carry no features: bounds, metadata, or a
+# featureMembers wrapper with nothing inside (GeoServer's GML 3.1 empty shape).
+_EMPTY_GML_METADATA_CHILDREN: Final = frozenset({"boundedBy", "metadata"})
+
+
+def _local_name(tag: str) -> str:
+    """Strip the ``{namespace}`` prefix ElementTree puts on a qualified tag."""
+    return tag.rpartition("}")[2]
+
+
+def _is_empty_gml_collection(body: bytes) -> bool:
+    """True when ``body`` is a GML FeatureCollection holding zero features.
+
+    A zero-feature collection is a legitimate WFS answer (an empty bbox), but
+    GDAL cannot open one -- and on Linux builds ``ST_Read`` *segfaults* on it
+    rather than raising -- so the body must be recognized as empty before GDAL
+    ever sees it. stdlib ElementTree ignores external entities by default, so
+    parsing the raw server bytes is safe. Anything that is not XML, not a
+    FeatureCollection, or has any feature-bearing child goes to GDAL, keeping
+    the error-page WFSError for genuinely broken bodies.
+    """
+    if len(body) > _EMPTY_GML_SNIFF_MAX_BYTES:
+        return False
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError:
+        return False
+    if _local_name(root.tag) != "FeatureCollection":
+        return False
+    for child in root:
+        name = _local_name(child.tag)
+        if name in _EMPTY_GML_METADATA_CHILDREN:
+            continue
+        if name == "featureMembers" and len(child) == 0:
+            continue
+        return False
+    return True
+
+
 def _gml_geometry_column(
     con: duckdb.DuckDBPyConnection, tmp_path: str, content_type: str
 ) -> tuple[str, list[str], str | None] | None:
@@ -1635,9 +1679,10 @@ def _gml_geometry_column(
     has always used, so a genuinely broken response still reads the same way.
 
     A zero-feature FeatureCollection also fails to open -- GDAL finds no layer
-    to build -- but with its own "contains no layers" message. That is a
-    legitimate WFS answer to an empty bbox, not an error, so it is returned as
-    ``None`` for the caller to turn into an empty table.
+    to build -- but with its own "contains no layers" message, returned as
+    ``None`` for the caller to turn into an empty table. That is only a
+    fallback: ``_is_empty_gml_collection`` recognizes empty bodies before GDAL
+    is invoked at all, because Linux builds segfault here instead of raising.
     """
     try:
         described = con.execute(f"DESCRIBE SELECT * FROM ST_Read({sql_path(tmp_path)})").fetchall()
@@ -1673,11 +1718,17 @@ def _parse_gml_response(
     is kept, so everything downstream (repair, CRS validation, type inference,
     tile deduplication) works unchanged.
     """
+    # Zero-feature collection: same shape the JSON path returns for an empty
+    # ``features`` array (geometry-only, no _wfs_fid), so pagination and tiled
+    # fetches see an empty page, not a failure. Decided from the bytes, before
+    # ST_Read -- Linux GDAL segfaults on a zero-layer GML dataset. The
+    # ``described is None`` branch is the fallback for platforms that raise.
+    if _is_empty_gml_collection(Path(tmp_path).read_bytes()):
+        debug("Empty GML response, returning empty table")
+        return pa.table({"geometry": pa.array([], type=pa.binary())})
+
     described = _gml_geometry_column(con, tmp_path, content_type)
     if described is None:
-        # Zero-feature collection: same shape the JSON path returns for an
-        # empty ``features`` array (geometry-only, no _wfs_fid), so pagination
-        # and tiled fetches see an empty page, not a failure.
         debug("Empty GML response, returning empty table")
         return pa.table({"geometry": pa.array([], type=pa.binary())})
     geometry_column, other_columns, server_crs = described

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1156,16 +1156,23 @@ class TestOutputFormatNegotiation:
 # WFS 2.0 GetCapabilities that spells the parameter "OutputFormat" (capital O),
 # as NextGIS and deegree do. The WFS 2.0 spec spells it "outputFormat", but
 # OWSLib keys op.parameters by whatever the XML said. Issue #818.
+#
+# The advertised version must match the one _nextgis_wfs requests exactly.
+# owslib 0.36 raises CapabilitiesError on a mismatch where 0.35 did not, and
+# uv.lock resolves 0.36 only on Python >= 3.12 -- so declaring a realistic
+# NextGIS "2.0.2" against a "2.0.0" request passes on 3.10/3.11 and fails on
+# 3.12/3.13. The capitalization is what this fixture is for; the version string
+# is incidental, so it is pinned to the requested one.
 MOCK_CAPABILITIES_UPPERCASE_FORMAT_XML = """<?xml version="1.0"?>
 <WFS_Capabilities xmlns="http://www.opengis.net/wfs/2.0"
     xmlns:ows="http://www.opengis.net/ows/1.1"
     xmlns:fes="http://www.opengis.net/fes/2.0"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    version="2.0.2">
+    version="2.0.0">
   <ows:ServiceIdentification>
     <ows:Title>Mock GML-only WFS</ows:Title>
     <ows:ServiceType>WFS</ows:ServiceType>
-    <ows:ServiceTypeVersion>2.0.2</ows:ServiceTypeVersion>
+    <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
   </ows:ServiceIdentification>
   <ows:OperationsMetadata>
     <ows:Operation name="GetFeature">

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1018,19 +1018,58 @@ class TestFormatDetection:
             # GML2 as last resort
             (["text/xml; subtype=gml/2.1.2"], "text/xml; subtype=gml/2.1.2"),
             (["gml2"], "gml2"),
-            # Unknown format - return first available
-            (["application/x-custom", "unknown/type"], "application/x-custom"),
+            # Media-type GML variants that differ only in spacing/version from
+            # the canonical spellings (NextGIS, deegree). Issue #818.
+            (
+                ["application/gml+xml;version=3.2"],
+                "application/gml+xml;version=3.2",
+            ),
+            (
+                ["application/gml+xml; version=3.2"],
+                "application/gml+xml; version=3.2",
+            ),
+            (
+                ["Application/GML+XML;Version=3.2"],
+                "Application/GML+XML;Version=3.2",
+            ),
+            (
+                ["text/xml;subtype=gml/3.1.1"],
+                "text/xml;subtype=gml/3.1.1",
+            ),
+            # Mixed-case GeoJSON still wins over GML
+            (
+                ["Application/GML+XML;version=3.2", "Application/JSON"],
+                "Application/JSON",
+            ),
+            # Unknown format - nothing we can parse, so request nothing
+            (["application/x-custom", "unknown/type"], None),
         ],
     )
     def test_format_preference_order(self, available_formats, expected_format):
-        """Formats are selected in order: GeoJSON > GML3 > GML2 > first available."""
+        """Formats are selected in order: GeoJSON > GML3 > GML2 > nothing."""
         result = _detect_best_output_format(available_formats)
         assert result == expected_format
 
-    def test_empty_formats_returns_default(self):
-        """Empty format list returns default GML3."""
-        result = _detect_best_output_format([])
-        assert result == "GML3"
+    def test_unparseable_formats_request_nothing(self):
+        """Advertising only formats gpio cannot read means asking for nothing.
+
+        Inventing "GML3", or taking the first advertised format, made gpio name
+        an outputFormat the server never offered. Returning None lets
+        _build_wfs_url omit the parameter so the server answers in its own
+        default format (issue #818).
+        """
+        assert _detect_best_output_format(["SHAPE-ZIP", "csv"]) is None
+
+    def test_empty_formats_keep_the_historical_json_request(self):
+        """A server that advertises nothing is still asked for GeoJSON.
+
+        There is no advertisement to honor here, so gpio keeps sending what it
+        sent before issue #818 rather than giving up the fast path for every
+        service whose capabilities it cannot parse. A server that ignores the
+        parameter and answers with GML is parsed on the response content type,
+        so a wrong guess is no longer fatal.
+        """
+        assert _detect_best_output_format([]) == "application/json"
 
     @pytest.mark.parametrize(
         "format_string,expected_is_json",
@@ -1064,6 +1103,141 @@ class TestFormatDetection:
         formats = ["gml2", "gml3"]
         result = _detect_best_output_format(formats)
         assert result == "gml3"  # GML3 preferred over GML2
+
+
+class TestOutputFormatNegotiation:
+    """_build_wfs_url requests the format the caller negotiated (issue #818).
+
+    Before this, the builder hardcoded ``outputFormat=application/json`` and the
+    format detected from GetCapabilities was computed and thrown away, so a
+    GML-only server was always asked for GeoJSON.
+    """
+
+    # The exact URL gpio sent before issue #818, kept literal so a refactor of
+    # the parameter order cannot silently change what servers receive.
+    _LEGACY_JSON_URL = (
+        "http://example.com/wfs?service=WFS&version=1.1.0&request=GetFeature"
+        "&typeName=layer&outputFormat=application%2Fjson&maxFeatures=10"
+    )
+
+    def test_requested_format_is_sent(self):
+        """A negotiated GML format reaches the URL."""
+        url = _build_wfs_url(
+            "http://example.com/wfs",
+            "layer",
+            version="1.1.0",
+            max_features=10,
+            output_format="application/gml+xml;version=3.2",
+        )
+        assert "outputFormat=application%2Fgml%2Bxml%3Bversion%3D3.2" in url
+
+    def test_none_omits_the_parameter(self):
+        """No negotiated format means no outputFormat: the server picks."""
+        url = _build_wfs_url(
+            "http://example.com/wfs",
+            "layer",
+            version="1.1.0",
+            max_features=10,
+        )
+        assert "outputFormat" not in url
+
+    def test_application_json_reproduces_the_legacy_url(self):
+        """Passing the old hardcoded value rebuilds the pre-#818 URL byte for byte."""
+        url = _build_wfs_url(
+            "http://example.com/wfs",
+            "layer",
+            version="1.1.0",
+            max_features=10,
+            output_format="application/json",
+        )
+        assert url == self._LEGACY_JSON_URL
+
+
+# WFS 2.0 GetCapabilities that spells the parameter "OutputFormat" (capital O),
+# as NextGIS and deegree do. The WFS 2.0 spec spells it "outputFormat", but
+# OWSLib keys op.parameters by whatever the XML said. Issue #818.
+MOCK_CAPABILITIES_UPPERCASE_FORMAT_XML = """<?xml version="1.0"?>
+<WFS_Capabilities xmlns="http://www.opengis.net/wfs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1"
+    xmlns:fes="http://www.opengis.net/fes/2.0"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    version="2.0.2">
+  <ows:ServiceIdentification>
+    <ows:Title>Mock GML-only WFS</ows:Title>
+    <ows:ServiceType>WFS</ows:ServiceType>
+    <ows:ServiceTypeVersion>2.0.2</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetFeature">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://mock.wfs.server/wfs?"/>
+        </ows:HTTP>
+      </ows:DCP>
+      <ows:Parameter name="OutputFormat">
+        <ows:AllowedValues>
+          <ows:Value>application/gml+xml;version=3.2</ows:Value>
+        </ows:AllowedValues>
+      </ows:Parameter>
+    </ows:Operation>
+  </ows:OperationsMetadata>
+  <FeatureTypeList>
+    <FeatureType>
+      <Name>Vector_Layer__UK_Cities</Name>
+      <Title>Vector Layer (UK Cities)</Title>
+      <DefaultCRS>EPSG:3857</DefaultCRS>
+      <OtherCRS>EPSG:4326</OtherCRS>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-7.333284 50.133721</ows:LowerCorner>
+        <ows:UpperCorner>1.300013 60.150035</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+    </FeatureType>
+  </FeatureTypeList>
+</WFS_Capabilities>
+"""
+
+
+class TestCapabilityOutputFormatCase:
+    """get_layer_info must find outputFormat however the server capitalizes it.
+
+    This is the root cause of issue #818: the lookup was case-sensitive, so a
+    server advertising ``OutputFormat`` reported *no* formats at all, and gpio
+    then fell back to demanding GeoJSON from a GML-only service.
+    """
+
+    def _nextgis_wfs(self):
+        from owslib.wfs import WebFeatureService
+
+        wfs = WebFeatureService(
+            url="http://mock.wfs.server/wfs",
+            version="2.0.0",
+            xml=MOCK_CAPABILITIES_UPPERCASE_FORMAT_XML.encode(),
+        )
+        # DescribeFeatureType would hit the network; the geometry-column and
+        # sortable-attribute probes both tolerate a failure here.
+        wfs.get_schema = MagicMock(side_effect=Exception("offline"))
+        return wfs
+
+    def test_uppercase_output_format_parameter_is_found(self):
+        """``<ows:Parameter name="OutputFormat">`` yields the advertised format."""
+        wfs = self._nextgis_wfs()
+        with patch.object(wfs_module, "get_wfs_capabilities", return_value=wfs):
+            layer_info = get_layer_info(
+                "http://mock.wfs.server/wfs", "Vector_Layer__UK_Cities", "2.0.0"
+            )
+        assert layer_info.available_formats == ["application/gml+xml;version=3.2"]
+
+    def test_detected_format_is_the_advertised_gml(self):
+        """The advertised GML format survives detection instead of becoming JSON."""
+        wfs = self._nextgis_wfs()
+        with patch.object(wfs_module, "get_wfs_capabilities", return_value=wfs):
+            layer_info = get_layer_info(
+                "http://mock.wfs.server/wfs", "Vector_Layer__UK_Cities", "2.0.0"
+            )
+        assert (
+            _detect_best_output_format(layer_info.available_formats)
+            == "application/gml+xml;version=3.2"
+        )
 
 
 # =============================================================================
@@ -1370,8 +1544,45 @@ class TestDuckDBNativeWFS:
         assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type)
 
 
-def _mock_wfs_http_response(body: bytes, content_type: str = "application/json"):
-    """Patch httpx.Client.stream to return a canned 200 response.
+@pytest.mark.network
+@pytest.mark.slow
+class TestGMLOnlyServerEndToEnd:
+    """End-to-end extraction from a real GML-only WFS (issue #818).
+
+    NextGIS advertises only ``application/gml+xml;version=3.2`` and spells the
+    capabilities parameter ``OutputFormat``. Before the fix gpio saw no formats,
+    demanded GeoJSON, and rejected the GML the server returned.
+    """
+
+    WFS_URL = "https://demo.nextgis.com/api/resource/9748/wfs"
+    TYPENAME = "Vector_Layer__UK_Cities"
+
+    @pytest.mark.xfail(reason="external demo service, may be unavailable", strict=False)
+    def test_extract_from_gml_only_server(self, tmp_path):
+        """A GML-only server yields a readable GeoParquet file."""
+        import pyarrow.parquet as pq
+
+        from geoparquet_io.core.wfs import convert_wfs_to_geoparquet
+
+        output = tmp_path / "uk_cities.parquet"
+        convert_wfs_to_geoparquet(
+            self.WFS_URL,
+            self.TYPENAME,
+            str(output),
+            version="2.0.0",
+            limit=5,
+        )
+
+        assert output.exists()
+        table = pq.read_table(output)
+        assert table.num_rows > 0
+        assert "geometry" in table.column_names
+
+
+def _mock_wfs_http_response(
+    body: bytes, content_type: str = "application/json", status_code: int = 200
+):
+    """Patch httpx.Client.stream to return a canned response.
 
     Shared factory for the content-type and properties-handling tests, which
     previously each carried a near-identical inline mock class (issue #666
@@ -1380,9 +1591,13 @@ def _mock_wfs_http_response(body: bytes, content_type: str = "application/json")
     """
     import httpx
 
+    # Bound outside the class body: a class body does not see an enclosing
+    # function's variable when the same name is assigned inside it.
+    response_status = status_code
+
     def mock_stream(*args, **kwargs):
         class MockResponse:
-            status_code = 200
+            status_code = response_status
             headers = {"content-type": content_type}
 
             def raise_for_status(self):
@@ -1427,6 +1642,17 @@ class TestContentTypeValidation:
                 id="rejects-xml",
             ),
             pytest.param(
+                "text/xml",
+                b'<?xml version="1.0"?><ows:ExceptionReport '
+                b'xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0">'
+                b'<ows:Exception exceptionCode="InvalidParameterValue" '
+                b'locator="outputFormat"><ows:ExceptionText>Unsupported '
+                b"outputFormat</ows:ExceptionText></ows:Exception>"
+                b"</ows:ExceptionReport>",
+                "Expected JSON.*text/xml",
+                id="rejects-exception-report",
+            ),
+            pytest.param(
                 "text/plain",
                 b"Error: Invalid request parameters",
                 "Expected JSON.*text/plain",
@@ -1441,10 +1667,25 @@ class TestContentTypeValidation:
                 None,
                 id="accepts-text-javascript",
             ),
+            # A GML FeatureCollection at 200 is a valid answer, not an error
+            # page: WFS 1.x servers (and NextGIS at any version) return it under
+            # an XML content type. Issue #818.
+            pytest.param(
+                "text/xml; charset=utf-8",
+                MOCK_GML_RESPONSE.encode(),
+                None,
+                id="accepts-gml-feature-collection",
+            ),
+            pytest.param(
+                "application/gml+xml; version=3.2",
+                MOCK_GML_RESPONSE.encode(),
+                None,
+                id="accepts-gml-media-type",
+            ),
         ],
     )
     def test_content_type_validation(self, content_type, body, error_match):
-        """Non-JSON content types raise WFSError; JSON-ish ones parse normally."""
+        """Non-parseable content types raise WFSError; JSON and GML parse normally."""
         from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
 
         with _mock_wfs_http_response(body, content_type):
@@ -1452,9 +1693,200 @@ class TestContentTypeValidation:
                 with pytest.raises(WFSError, match=error_match):
                     _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
             else:
-                # Should not raise, returns empty table
-                result = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
-                assert result.num_rows == 0
+                # Should not raise; a parseable body yields a table
+                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+
+class TestGMLResponseParsing:
+    """_fetch_wfs_page parses GML bodies, not just GeoJSON (issue #818).
+
+    NextGIS answers every GetFeature with GML at HTTP 200 regardless of the
+    requested outputFormat, so dispatching on the *response* content type is
+    what makes those servers usable at all.
+    """
+
+    def _fetch_gml(self, content_type="text/xml; charset=utf-8"):
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        with _mock_wfs_http_response(MOCK_GML_RESPONSE.encode(), content_type):
+            return _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+    def test_parses_features_with_correct_axis_order(self):
+        """The urn srsName in MOCK_GML_RESPONSE means lat/lon in the file, lon/lat out."""
+        import duckdb
+
+        table = self._fetch_gml()
+        assert table.num_rows == 1
+
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        con.register("features", table)
+        wkt = con.execute("SELECT ST_AsText(ST_GeomFromWKB(geometry)) FROM features").fetchone()[0]
+        con.close()
+        assert wkt == "POINT (-122.4194 37.7749)"
+
+    def test_keeps_attribute_columns(self):
+        """Feature attributes survive the GML path, like they do for GeoJSON."""
+        table = self._fetch_gml()
+        assert "geometry" in table.column_names
+        assert "name" in table.column_names
+        assert table.column("name").to_pylist() == ["San Francisco"]
+
+    def test_geometry_column_is_wkb(self):
+        """The geometry column is WKB binary, matching the GeoJSON path."""
+        import pyarrow as pa
+
+        table = self._fetch_gml()
+        geom_type = table.schema.field("geometry").type
+        assert pa.types.is_binary(geom_type) or pa.types.is_large_binary(geom_type)
+
+    def test_records_server_declared_crs(self):
+        """The CRS GDAL read off the GML is carried up like the GeoJSON crs member."""
+        from geoparquet_io.core.wfs import _SERVER_CRS_METADATA_KEY
+
+        table = self._fetch_gml()
+        assert table.schema.metadata.get(_SERVER_CRS_METADATA_KEY) == b"EPSG:4326"
+
+    def test_leaves_no_temp_files_behind(self):
+        """GDAL writes a .gfs sidecar for schema-less GML; nothing may survive.
+
+        The GeoJSON path used a NamedTemporaryFile and unlinked exactly that one
+        path, which would strand the sidecar. The GML path must use a temporary
+        *directory* so every file GDAL creates is removed.
+        """
+        import tempfile
+
+        before = set(os.listdir(tempfile.gettempdir()))
+        self._fetch_gml()
+        after = set(os.listdir(tempfile.gettempdir()))
+        leaked = {name for name in after - before if name.endswith((".gml", ".gfs", ".xml"))}
+        assert not leaked, f"GML parse leaked temp files: {sorted(leaked)}"
+
+    def test_extract_fid_uses_gml_id(self):
+        """Tiled fetches dedupe on gml:id, the GML analogue of a GeoJSON feature id."""
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        with _mock_wfs_http_response(MOCK_GML_RESPONSE.encode(), "text/xml"):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS", extract_fid=True)
+
+        assert table.column("_wfs_fid").to_pylist() == ["cities.1"]
+        # The id is consumed as the dedup key, not left behind as an attribute.
+        assert "gml_id" not in table.column_names
+
+    def test_xml_without_features_reads_as_an_error_page(self):
+        """An ows:ExceptionReport is XML but has no geometry, so it is an error.
+
+        The content type alone cannot tell a FeatureCollection from an exception
+        report -- servers send both as text/xml -- so the GML parser decides,
+        and must produce the same message (with a body preview) the JSON path
+        gives for an error page.
+        """
+        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
+
+        report = (
+            b'<?xml version="1.0"?><ows:ExceptionReport '
+            b'xmlns:ows="http://www.opengis.net/ows/1.1"><ows:Exception '
+            b'exceptionCode="NoApplicableCode"/></ows:ExceptionReport>'
+        )
+        with _mock_wfs_http_response(report, "text/xml; subtype=gml/3.1.1"):
+            with pytest.raises(WFSError, match="ExceptionReport"):
+                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+
+class TestResponseDispatchHelpers:
+    """The small decisions that route a WFS response to a parser (issue #818)."""
+
+    @pytest.mark.parametrize(
+        ("content_type", "expected"),
+        [
+            ("application/json", "json"),
+            ("text/javascript", "json"),
+            ("text/html; charset=utf-8", "error"),
+            ("text/plain", "error"),
+            ("text/xml; subtype=gml/3.1.1", "gml"),
+            ("application/gml+xml; version=3.2", "gml"),
+            # No content type at all, and a type gpio has no opinion about:
+            # both stay on the JSON path, which is what servers that send
+            # application/octet-stream for GeoJSON have always relied on.
+            ("", "json"),
+            ("application/octet-stream", "json"),
+        ],
+    )
+    def test_classify_content_type(self, content_type, expected):
+        from geoparquet_io.core.wfs import _classify_wfs_content_type
+
+        assert _classify_wfs_content_type(content_type) == expected
+
+    @pytest.mark.parametrize(
+        ("output_format", "expected"),
+        [
+            # Nothing negotiated: ask for GeoJSON, as gpio always has.
+            (None, "application/json"),
+            ("application/gml+xml; version=3.2", "application/gml+xml; version=3.2"),
+            # "GML2" and "gml32" are WFS format tokens, not media types. Echoing
+            # one into Accept would earn a 406 from a strict server, so ask for
+            # anything instead.
+            ("GML2", "*/*"),
+            ("gml32", "*/*"),
+        ],
+    )
+    def test_accept_header_for(self, output_format, expected):
+        from geoparquet_io.core.wfs import _accept_header_for
+
+        assert _accept_header_for(output_format) == expected
+
+    def test_http_400_surfaces_the_server_message(self):
+        """A 400 is reported with the server's own body, not a bare status code."""
+        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
+
+        with _mock_wfs_http_response(b"Unknown typeName", "text/plain", status_code=400):
+            with pytest.raises(WFSError, match="HTTP 400.*Unknown typeName"):
+                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+    def test_http_400_names_the_startindex_limit(self):
+        """The startIndex rejection keeps its own message, which pagination reads."""
+        from geoparquet_io.core.wfs import WFSError, _fetch_wfs_page
+
+        body = b"Value of startIndex exceeds the maximum"
+        with _mock_wfs_http_response(body, "text/plain", status_code=400):
+            with pytest.raises(WFSError, match="startIndex limit"):
+                _fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+
+class TestLookupParameterCaseInsensitive:
+    """_lookup_parameter_ci reads capabilities however a server capitalizes them."""
+
+    def test_finds_a_differently_cased_key(self):
+        from geoparquet_io.core.wfs import _lookup_parameter_ci
+
+        params = {"OutputFormat": {"values": ["application/gml+xml"]}}
+        assert _lookup_parameter_ci(params, "outputFormat") == ["application/gml+xml"]
+
+    @pytest.mark.parametrize(
+        ("parameters", "reason"),
+        [
+            ({}, "no parameters at all"),
+            ({"resultType": {"values": ["results"]}}, "no such parameter"),
+            ({"outputFormat": {"values": []}}, "parameter declares no values"),
+            ({"outputFormat": "application/json"}, "parameter is not a value bag"),
+        ],
+    )
+    def test_returns_none_when_there_is_nothing_to_read(self, parameters, reason):
+        """Every shape that is not an allowed-value list reads as "unknown"."""
+        from geoparquet_io.core.wfs import _lookup_parameter_ci
+
+        assert _lookup_parameter_ci(parameters, "outputFormat") is None, reason
+
+
+class TestFormatPrefixMatching:
+    """A version suffix gpio has not seen still resolves to its format family."""
+
+    def test_unlisted_version_suffix_matches_by_prefix(self):
+        """``application/gml+xml;version=3.2.1`` is GML even though it is unlisted."""
+        from geoparquet_io.core.wfs import _detect_best_output_format
+
+        advertised = ["application/gml+xml;version=3.2.1"]
+        assert _detect_best_output_format(advertised) == advertised[0]
 
 
 _OMIT_PROPERTIES = object()
@@ -1596,7 +2028,7 @@ class TestAutoPageSingleWorker:
 
         call_count = 0
 
-        def mock_fetch(url, extract_fid=False):
+        def mock_fetch(url, extract_fid=False, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1679,7 +2111,7 @@ class TestAutoPageSingleWorker:
 
         call_count = 0
 
-        def mock_fetch(url, extract_fid=False):
+        def mock_fetch(url, extract_fid=False, **kwargs):
             nonlocal call_count
             call_count += 1
             n = 10000 if call_count == 1 else 5000

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -306,6 +306,17 @@ MOCK_EMPTY_GML_WFS11 = """<?xml version="1.0" encoding="UTF-8"?>
 </wfs:FeatureCollection>
 """
 
+# GeoServer's GML 3.1 flavor of the same answer: an empty featureMembers child.
+MOCK_EMPTY_GML_FEATUREMEMBERS = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection
+    xmlns:wfs="http://www.opengis.net/wfs"
+    xmlns:gml="http://www.opengis.net/gml"
+    numberOfFeatures="0"
+    timeStamp="2026-03-23T12:00:00Z">
+    <gml:featureMembers/>
+</wfs:FeatureCollection>
+"""
+
 # GML response whose features carry no gml:id at all. GDAL synthesizes
 # gml_id = '' (empty string, not NULL) for these, which must not become a
 # shared dedup key.
@@ -1861,15 +1872,20 @@ class TestGMLResponseParsing:
                 "text/xml; subtype=gml/3.1.1",
                 id="wfs11-null-boundedby",
             ),
+            pytest.param(
+                MOCK_EMPTY_GML_FEATUREMEMBERS,
+                "text/xml; subtype=gml/3.1.1",
+                id="wfs11-empty-featuremembers",
+            ),
         ],
     )
     def test_empty_collection_returns_empty_table(self, body, content_type):
         """A zero-feature GML FeatureCollection is a valid answer, not an error.
 
-        GDAL cannot open one at all ("contains no layers"), but it is what a
-        server sends for an empty bbox, so the GML path must return the same
-        empty geometry-only table the JSON path returns for zero features --
-        pagination and tiled fetches rely on that to stop cleanly.
+        GDAL cannot open one at all, but it is what a server sends for an empty
+        bbox, so the GML path must return the same empty geometry-only table
+        the JSON path returns for zero features -- pagination and tiled fetches
+        rely on that to stop cleanly.
         """
         import pyarrow as pa
 
@@ -1881,6 +1897,59 @@ class TestGMLResponseParsing:
         assert table.num_rows == 0
         assert table.column_names == ["geometry"]
         assert pa.types.is_binary(table.schema.field("geometry").type)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(MOCK_EMPTY_GML_WFS20, id="wfs20-self-closing"),
+            pytest.param(MOCK_EMPTY_GML_WFS11, id="wfs11-null-boundedby"),
+            pytest.param(MOCK_EMPTY_GML_FEATUREMEMBERS, id="wfs11-empty-featuremembers"),
+        ],
+    )
+    def test_empty_collection_never_reaches_gdal(self, body):
+        """An empty collection must be answered without ever calling ST_Read.
+
+        On Linux builds of DuckDB spatial, ST_Read *segfaults* on a zero-layer
+        GML dataset instead of raising IOException, so mapping the exception is
+        not enough -- the body has to be recognized as empty before GDAL sees
+        it.
+        """
+        from geoparquet_io.core import wfs as wfs_module
+
+        def _tripwire(*args, **kwargs):
+            raise AssertionError("empty GML body reached ST_Read")
+
+        with (
+            _mock_wfs_http_response(body.encode(), "text/xml"),
+            patch.object(wfs_module, "_gml_geometry_column", side_effect=_tripwire),
+        ):
+            table = wfs_module._fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
+
+        assert table.num_rows == 0
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            pytest.param(MOCK_EMPTY_GML_WFS20.encode(), True, id="empty-wfs20"),
+            pytest.param(MOCK_EMPTY_GML_WFS11.encode(), True, id="empty-wfs11"),
+            pytest.param(MOCK_EMPTY_GML_FEATUREMEMBERS.encode(), True, id="empty-featuremembers"),
+            pytest.param(MOCK_GML_RESPONSE.encode(), False, id="collection-with-features"),
+            pytest.param(
+                b'<?xml version="1.0"?><ows:ExceptionReport '
+                b'xmlns:ows="http://www.opengis.net/ows/1.1"/>',
+                False,
+                id="exception-report",
+            ),
+            pytest.param(b"<html><body>Error</body></html>", False, id="html-error-page"),
+            pytest.param(b"not xml at all", False, id="not-xml"),
+        ],
+    )
+    def test_is_empty_gml_collection(self, body, expected):
+        """Only a featureless FeatureCollection counts as empty; everything else
+        goes to GDAL, which keeps the error-page WFSError for broken bodies."""
+        from geoparquet_io.core.wfs import _is_empty_gml_collection
+
+        assert _is_empty_gml_collection(body) is expected
 
     def test_idless_features_get_null_fid(self):
         """Features without gml:id must get a NULL _wfs_fid, not GDAL's ''.

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -281,6 +281,74 @@ MOCK_GML_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 </wfs:FeatureCollection>
 """
 
+# Zero-feature GML responses. A WFS 2.0 server answers an empty bbox with a
+# self-closing FeatureCollection; a WFS 1.x server (GeoServer) sends one whose
+# only child is a null boundedBy. GDAL can open neither ("contains no layers"),
+# so the GML path must recognize them as legitimately empty, not as error pages.
+MOCK_EMPTY_GML_WFS20 = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection
+    xmlns:wfs="http://www.opengis.net/wfs/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    numberMatched="0"
+    numberReturned="0"
+    timeStamp="2026-03-23T12:00:00Z"/>
+"""
+
+MOCK_EMPTY_GML_WFS11 = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection
+    xmlns:wfs="http://www.opengis.net/wfs"
+    xmlns:gml="http://www.opengis.net/gml"
+    numberOfFeatures="0"
+    timeStamp="2026-03-23T12:00:00Z">
+    <gml:boundedBy>
+        <gml:null>unknown</gml:null>
+    </gml:boundedBy>
+</wfs:FeatureCollection>
+"""
+
+# GML response whose features carry no gml:id at all. GDAL synthesizes
+# gml_id = '' (empty string, not NULL) for these, which must not become a
+# shared dedup key.
+MOCK_GML_IDLESS_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection
+    xmlns:wfs="http://www.opengis.net/wfs"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:test="http://mock.wfs.server/test"
+    numberOfFeatures="3"
+    timeStamp="2026-03-23T12:00:00Z">
+    <gml:featureMember>
+        <test:cities>
+            <test:geometry>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                    <gml:pos>37.7749 -122.4194</gml:pos>
+                </gml:Point>
+            </test:geometry>
+            <test:name>San Francisco</test:name>
+        </test:cities>
+    </gml:featureMember>
+    <gml:featureMember>
+        <test:cities>
+            <test:geometry>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                    <gml:pos>40.7128 -74.0060</gml:pos>
+                </gml:Point>
+            </test:geometry>
+            <test:name>New York</test:name>
+        </test:cities>
+    </gml:featureMember>
+    <gml:featureMember>
+        <test:cities>
+            <test:geometry>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                    <gml:pos>51.5074 -0.1278</gml:pos>
+                </gml:Point>
+            </test:geometry>
+            <test:name>London</test:name>
+        </test:cities>
+    </gml:featureMember>
+</wfs:FeatureCollection>
+"""
+
 # XSD schema response for DescribeFeatureType
 MOCK_DESCRIBE_FEATURE_TYPE = """<?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema
@@ -1779,6 +1847,69 @@ class TestGMLResponseParsing:
         assert table.column("_wfs_fid").to_pylist() == ["cities.1"]
         # The id is consumed as the dedup key, not left behind as an attribute.
         assert "gml_id" not in table.column_names
+
+    @pytest.mark.parametrize(
+        ("body", "content_type"),
+        [
+            pytest.param(
+                MOCK_EMPTY_GML_WFS20,
+                "application/gml+xml; version=3.2",
+                id="wfs20-self-closing",
+            ),
+            pytest.param(
+                MOCK_EMPTY_GML_WFS11,
+                "text/xml; subtype=gml/3.1.1",
+                id="wfs11-null-boundedby",
+            ),
+        ],
+    )
+    def test_empty_collection_returns_empty_table(self, body, content_type):
+        """A zero-feature GML FeatureCollection is a valid answer, not an error.
+
+        GDAL cannot open one at all ("contains no layers"), but it is what a
+        server sends for an empty bbox, so the GML path must return the same
+        empty geometry-only table the JSON path returns for zero features --
+        pagination and tiled fetches rely on that to stop cleanly.
+        """
+        import pyarrow as pa
+
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        with _mock_wfs_http_response(body.encode(), content_type):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS", extract_fid=True)
+
+        assert table.num_rows == 0
+        assert table.column_names == ["geometry"]
+        assert pa.types.is_binary(table.schema.field("geometry").type)
+
+    def test_idless_features_get_null_fid(self):
+        """Features without gml:id must get a NULL _wfs_fid, not GDAL's ''.
+
+        GDAL synthesizes gml_id = '' (empty string) when a feature has no
+        gml:id/fid. Passed through as-is, every id-less feature shares the
+        dedup key '' and tile deduplication keeps exactly one of them. NULL
+        routes them to the geometry-bytes fallback instead, like the GeoJSON
+        path's missing feature.id.
+        """
+        from geoparquet_io.core.wfs import _fetch_wfs_page
+
+        with _mock_wfs_http_response(MOCK_GML_IDLESS_RESPONSE.encode(), "text/xml"):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS", extract_fid=True)
+
+        assert table.num_rows == 3
+        assert table.column("_wfs_fid").to_pylist() == [None, None, None]
+        assert "gml_id" not in table.column_names
+
+    def test_idless_features_survive_tile_dedup(self):
+        """Three distinct id-less features stay three rows after deduplication."""
+        from geoparquet_io.core.wfs import _deduplicate_tiles, _fetch_wfs_page
+
+        with _mock_wfs_http_response(MOCK_GML_IDLESS_RESPONSE.encode(), "text/xml"):
+            table = _fetch_wfs_page("http://mock.wfs/wfs?service=WFS", extract_fid=True)
+
+        result = _deduplicate_tiles(table)
+        assert result.num_rows == 3
+        assert sorted(result.column("name").to_pylist()) == ["London", "New York", "San Francisco"]
 
     def test_xml_without_features_reads_as_an_error_page(self):
         """An ows:ExceptionReport is XML but has no geometry, so it is an error.

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1827,8 +1827,9 @@ class TestResponseDispatchHelpers:
     @pytest.mark.parametrize(
         ("output_format", "expected"),
         [
-            # Nothing negotiated: ask for GeoJSON, as gpio always has.
-            (None, "application/json"),
+            # Nothing negotiated means outputFormat was deliberately left off
+            # the request, so Accept must not name a format either.
+            (None, "*/*"),
             ("application/gml+xml; version=3.2", "application/gml+xml; version=3.2"),
             # "GML2" and "gml32" are WFS format tokens, not media types. Echoing
             # one into Accept would earn a 406 from a strict server, so ask for
@@ -1888,12 +1889,35 @@ class TestLookupParameterCaseInsensitive:
 class TestFormatPrefixMatching:
     """A version suffix gpio has not seen still resolves to its format family."""
 
-    def test_unlisted_version_suffix_matches_by_prefix(self):
-        """``application/gml+xml;version=3.2.1`` is GML even though it is unlisted."""
+    @pytest.mark.parametrize(
+        "advertised",
+        [
+            "application/gml+xml;version=3.2.1",
+            "text/xml; subtype=gml/3.1.1; charset=utf-8",
+        ],
+    )
+    def test_unlisted_media_type_parameter_still_matches(self, advertised):
+        """An extra ``;parameter`` does not hide a format gpio can read."""
         from geoparquet_io.core.wfs import _detect_best_output_format
 
-        advertised = ["application/gml+xml;version=3.2.1"]
-        assert _detect_best_output_format(advertised) == advertised[0]
+        assert _detect_best_output_format([advertised]) == advertised
+
+    @pytest.mark.parametrize(
+        "advertised",
+        [
+            # RFC 7464 JSON text sequences: a stream of records, not one
+            # FeatureCollection, so reading it as GeoJSON would fail or -- worse
+            # -- silently return one record.
+            "application/json-seq",
+            "application/geo+json-seq",
+            "gml3-alternate",
+        ],
+    )
+    def test_a_longer_name_is_not_the_same_format(self, advertised):
+        """Matching stops at a media-type parameter; it is not a bare prefix test."""
+        from geoparquet_io.core.wfs import _detect_best_output_format
+
+        assert _detect_best_output_format([advertised]) is None
 
 
 _OMIT_PROPERTIES = object()


### PR DESCRIPTION
## What changed

`gpio extract wfs` asked every service for `outputFormat=application/json` regardless of what it said it could produce, and rejected any response whose content type was not JSON. A GML-only service — NextGIS, and most WFS 1.0.0/1.1.0 deployments — was therefore unusable: gpio demanded GeoJSON, got GML at HTTP 200, and reported it as an error page.

Three separate defects combined to cause that, and all three are fixed.

**The capabilities lookup was case-sensitive.** `get_layer_info` read `op.parameters["outputFormat"]`, but OWSLib keys that dict by the literal `name` attribute in the capabilities XML. The WFS 2.0 spec spells it `outputFormat`; NextGIS and deegree publish `OutputFormat`. The lookup found nothing, so gpio believed those servers advertised no formats at all. It is now case-insensitive.

**The negotiated format was computed and thrown away.** `_detect_best_output_format` picked a format and `_build_wfs_url` then hardcoded `application/json` anyway. The negotiated value is now threaded through the request. Matching also tolerates the spelling variation servers really publish (`application/gml+xml;version=3.2` vs `application/gml+xml; version=3.2`, any capitalization) and falls back to a prefix match so an unlisted version suffix still resolves to its family.

The two ways of finding no match are answered differently, because they say different things:

- The server advertised formats and none is readable → omit `outputFormat` and take the server's own default, rather than naming a format it just said it does not support. The old code invented `"GML3"` here; picking the first advertised format instead would be no better, since on GeoServer that can be `SHAPE-ZIP`.
- The server advertised nothing at all → keep asking for `application/json`, which is exactly what gpio sent before. There is no advertisement to honor, so this preserves the fast path for every service whose capabilities gpio cannot parse.

**Parsing was chosen from the request, not the response.** `_fetch_wfs_page` now dispatches on the response `Content-Type`, so a server that ignores the requested format and answers with GML is read instead of rejected. GML is parsed through GDAL (already bundled with DuckDB's spatial extension — no new dependency) into the same shape the GeoJSON path returns: geometry as WKB in a `geometry` column, every server attribute kept, the server-declared CRS carried up through the existing metadata channel, and `gml:id` used as the dedup key for tiled fetches. Everything downstream — Hilbert sorting, bbox, geometry repair, type inference, tile deduplication — works unchanged.

An `ows:ExceptionReport` arrives under the same content types as a `FeatureCollection`, so the GML parser is what tells them apart: a body GDAL cannot open, or one with no geometry column, still produces the same "server returned an error page" message with a body preview that the JSON path has always given.

The response body is now staged in a temporary *directory* rather than a `NamedTemporaryFile`, because GDAL writes a `.gfs` schema sidecar next to schema-less GML and only a directory cleanup is guaranteed to take it along.

## Why

Fixes #818. The investigation found the bug is entirely gpio-side — no upstream fix in OWSLib or GDAL is needed, and DuckDB's bundled GDAL already parses WFS GML natively.

## Verification

End to end against the service from the issue, which advertises only `text/xml; subtype=gml/2.1.2`:

```
$ gpio extract wfs https://demo.nextgis.com/api/resource/9748/wfs \
      Vector_Layer__UK_Cities uk_cities.parquet --verbose
Available formats: ['text/xml; subtype=gml/2.1.2']
Using output format: text/xml; subtype=gml/2.1.2
Server reports 57 features
Parsed 57 GML rows in 0.4s (total: 0.6s)
Server declared CRS EPSG:4326 in its response
Wrote 57 features to uk_cities.parquet
```

```
$ gpio inspect head uk_cities.parquet
Rows: 57
GeoParquet Version: 1.1.0
CRS: OGC:CRS84 (default)
Geometry Types: Point
Bbox: [-7.333284, 50.133722, 1.300013, 60.150035]
Columns (5): gml_id, NAME, POP_MAX, geometry, bbox
```

Before this change that command failed outright.

- `uv run pytest -n auto -m "not slow and not network and not meta"` — 5417 passed, 65 skipped, 2 xfailed
- `uv run pre-commit run --all-files` and the `pre-push` stage (mypy, vulture, xenon, import-linter, deptry) — all pass
- `diff-cover --compare-branch=origin/main` — **97.6%** on changed lines (gate is 90%)

Two unrelated tests (`test_pipe_integration.py::test_column_selection_through_pipe`, `test_geojson_stream.py::test_streaming_handles_broken_pipe`) each failed once under `-n auto` *with* coverage instrumentation and pass serially; neither touches WFS. This is the known xdist cold-run flake.

## New tests

22 added in `tests/test_wfs.py`, covering the case-insensitive capabilities lookup against a real OWSLib parse of NextGIS-shaped XML, format negotiation and normalization, the exact pre-#818 URL as a regression pin, content-type dispatch, GML parsing (axis order, attributes, WKB, CRS, `gml:id`, no leaked temp files), and a network-marked end-to-end extraction from the live NextGIS demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - WFS downloads now negotiate supported response formats, including GeoJSON and GML.
  - GML responses preserve coordinate reference systems, axis order, and feature identifiers.
  - Large responses are streamed to temporary storage for local processing.
  - Added guidance on response formats, local parsing, CRS handling, and GML-only public services.

- **Bug Fixes**
  - Improved handling of case-insensitive and parameterized format names, including server-default responses.
  - Prevented unrelated formats from being matched incorrectly.
  - Improved parsing of empty GML responses and features without identifiers.
  - WFS error responses are now rejected more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->