### PR TITLE
fix(wfs): keep existing query params (e.g. apikey) when building WFS GetFeature URLs

### DIFF
--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -319,6 +319,48 @@ def _clean_service_url(url: str) -> str:
     )
 
 
+def _merge_query_params(url: str, params: dict) -> str:
+    """
+    Merge additional query params into a URL that may already have a query string.
+
+    Building the final URL by naive string concatenation (``f"{url}?{...}"``)
+    corrupts any pre-existing query string (e.g. ``?apikey=mykey``) by adding
+    a second ``?``, which has no delimiter meaning in a query string — the
+    server sees a single, garbled query and everything after the first ``?``
+    (including the real ``apikey`` value) is misparsed (Issue #828).
+
+    New params take precedence over any same-named param already present in
+    ``url`` (WFS control params like ``service``/``request``/``version``
+    should always reflect the request being built, not a stale value carried
+    over from the caller's URL).
+
+    Args:
+        url: Base URL, with or without an existing query string.
+        params: Additional query params to merge in.
+
+    Returns:
+        URL with a single, correctly merged query string.
+    """
+    parsed = urlparse(url)
+    existing_params = parse_qs(parsed.query, keep_blank_values=True)
+    # dict values from parse_qs are lists; flatten before merging with new
+    # scalar values so urlencode doesn't emit e.g. "apikey=['mykey']".
+    merged = {k: v[0] if len(v) == 1 else v for k, v in existing_params.items()}
+    merged.update(params)
+
+    new_query = urlencode(merged, doseq=True)
+    return urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            parsed.params,
+            new_query,
+            "",
+        )
+    )
+
+
 def get_wfs_capabilities(service_url: str, version: str = "1.1.0"):
     """
     Get WFS capabilities using OWSLib.
@@ -2367,8 +2409,6 @@ def _build_wfs_url(
     replies in its own default — the only thing that works on a service which
     advertises no format gpio recognizes (issue #818).
     """
-    from urllib.parse import urlencode
-
     clean_url = _clean_service_url(service_url)
 
     params = {
@@ -2404,7 +2444,7 @@ def _build_wfs_url(
     if sort_by and version != "1.0.0":
         params["sortBy"] = sort_by
 
-    return f"{clean_url}?{urlencode(params)}"
+    return _merge_query_params(clean_url, params)
 
 
 def _single_fetch_mode(

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -305,6 +305,48 @@ def _clean_service_url(url: str) -> str:
     )
 
 
+def _merge_query_params(url: str, params: dict) -> str:
+    """
+    Merge additional query params into a URL that may already have a query string.
+
+    Building the final URL by naive string concatenation (``f"{url}?{...}"``)
+    corrupts any pre-existing query string (e.g. ``?apikey=mykey``) by adding
+    a second ``?``, which has no delimiter meaning in a query string — the
+    server sees a single, garbled query and everything after the first ``?``
+    (including the real ``apikey`` value) is misparsed (Issue #828).
+
+    New params take precedence over any same-named param already present in
+    ``url`` (WFS control params like ``service``/``request``/``version``
+    should always reflect the request being built, not a stale value carried
+    over from the caller's URL).
+
+    Args:
+        url: Base URL, with or without an existing query string.
+        params: Additional query params to merge in.
+
+    Returns:
+        URL with a single, correctly merged query string.
+    """
+    parsed = urlparse(url)
+    existing_params = parse_qs(parsed.query, keep_blank_values=True)
+    # dict values from parse_qs are lists; flatten before merging with new
+    # scalar values so urlencode doesn't emit e.g. "apikey=['mykey']".
+    merged = {k: v[0] if len(v) == 1 else v for k, v in existing_params.items()}
+    merged.update(params)
+
+    new_query = urlencode(merged, doseq=True)
+    return urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            parsed.params,
+            new_query,
+            "",
+        )
+    )
+
+
 def get_wfs_capabilities(service_url: str, version: str = "1.1.0"):
     """
     Get WFS capabilities using OWSLib.
@@ -1959,8 +2001,6 @@ def _build_wfs_url(
     sort_by: str | None = None,
 ) -> str:
     """Build a WFS GetFeature URL with pagination support."""
-    from urllib.parse import urlencode
-
     clean_url = _clean_service_url(service_url)
 
     params = {
@@ -1994,7 +2034,7 @@ def _build_wfs_url(
     if sort_by and version != "1.0.0":
         params["sortBy"] = sort_by
 
-    return f"{clean_url}?{urlencode(params)}"
+    return _merge_query_params(clean_url, params)
 
 
 def _single_fetch_mode(

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -300,10 +300,26 @@ def _clean_service_url(url: str) -> str:
     parsed = urlparse(url)
     params = parse_qs(parsed.query, keep_blank_values=True)
 
-    # Remove WFS-specific params that shouldn't persist
-    for key in ["service", "request", "version", "typename", "typenames"]:
-        params.pop(key, None)
-        params.pop(key.upper(), None)
+    # Remove WFS request-control params that shouldn't persist, in any casing:
+    # WFS KVP keys are case-insensitive per the OGC spec, so ``typeName``
+    # (the canonical 1.1 casing users copy from a browser URL) must be
+    # stripped just like ``typename``, or it survives next to the
+    # ``typeNames`` gpio sets and the server picks a layer from conflicting
+    # duplicate keys. Everything else (apikeys, tokens, vendor params) stays.
+    wfs_control_keys = {
+        "service",
+        "request",
+        "version",
+        "typename",
+        "typenames",
+        "outputformat",
+        "srsname",
+        "count",
+        "maxfeatures",
+        "startindex",
+        "resulttype",
+    }
+    params = {k: v for k, v in params.items() if k.lower() not in wfs_control_keys}
 
     # Rebuild URL
     new_query = urlencode(params, doseq=True) if params else ""
@@ -1366,8 +1382,15 @@ def _get_feature_count(
     if bbox and crs:
         params["bbox"] = _build_bbox_param(bbox, crs, version, axis_order)
 
+    # Merge the WFS params into the URL instead of passing params= to the
+    # HTTP layer: httpx *replaces* a URL's existing query when params= is
+    # given, which would drop e.g. an apikey the service URL carries — the
+    # probe then 403s, the failure degrades to count=None, and pagination /
+    # auto-tiling silently disengage (issues #828, #678).
+    url = _merge_query_params(clean_url, params)
+
     try:
-        content = _make_request(clean_url, params=params)
+        content = _make_request(url)
     except (WFSError, httpx.HTTPError, OSError) as e:
         # Expected failure modes: the service is down, unreachable, rejecting us,
         # or timing out. Degrade to "count unknown" rather than aborting the

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -3063,6 +3063,59 @@ class TestBuildWfsUrlQueryParamMerging:
         assert params["request"] == ["GetFeature"]
         assert params["apikey"] == ["mykey"]
 
+    def test_build_wfs_url_strips_mixed_case_wfs_params(self):
+        """WFS KVP keys are case-insensitive per the OGC spec, so the strip
+        must be too: ``typeName`` (canonical WFS 1.1 casing users copy from a
+        browser URL) surviving next to the ``typeNames`` we set would leave the
+        server to pick a layer from conflicting duplicate keys."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs"
+            "?Version=1.0.0&typeName=roads&Request=GetCapabilities&apikey=mykey",
+            "buildings",
+            version="2.0.0",
+        )
+
+        assert url.count("?") == 1
+        params = parse_qs(urlparse(url).query)
+        # The apikey survives; every mixed-case control param is replaced by
+        # exactly one authoritative value.
+        assert params["apikey"] == ["mykey"]
+        assert params["typeNames"] == ["buildings"]
+        assert params["version"] == ["2.0.0"]
+        assert params["request"] == ["GetFeature"]
+        lowered = [k.lower() for k in params]
+        assert "typename" not in lowered  # typeName=roads must not survive
+        assert lowered.count("version") == 1
+        assert lowered.count("request") == 1
+
+    def test_build_wfs_url_strips_stale_control_params_case_insensitively(self):
+        """A GetFeature URL copied from a browser carries request-control keys
+        (outputFormat, count, startIndex, resultType, srsName) that must not
+        leak into the request gpio builds — a stale ``resultType=hits`` would
+        turn every data request into a count response."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs"
+            "?resultType=hits&outputFormat=text/xml&startIndex=100"
+            "&maxFeatures=5&Count=5&srsName=EPSG:3857&apikey=mykey",
+            "buildings",
+            version="2.0.0",
+        )
+
+        params = parse_qs(urlparse(url).query)
+        assert params["apikey"] == ["mykey"]
+        lowered = [k.lower() for k in params]
+        for stale in ("resulttype", "outputformat", "startindex", "maxfeatures", "srsname"):
+            assert stale not in lowered
+        assert "count" not in lowered  # no max_features requested → no count param
+
 
 # =============================================================================
 # CRS Validation Tests (Issue #398)
@@ -4412,6 +4465,22 @@ class TestRefineTilesAdaptive:
         assert len(result) == 1
 
 
+def _hits_probe_query(mock_req) -> dict:
+    """Return the query params of the URL a mocked _make_request received.
+
+    The hits probe must pre-merge its WFS params into the URL rather than
+    passing ``params=`` to httpx: httpx 0.28 *replaces* a URL's existing
+    query when ``params=`` is given, which drops e.g. an apikey (issue #828).
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    assert mock_req.call_args.kwargs.get("params") is None, (
+        "hits probe must not pass params= (httpx replaces the URL query, dropping apikeys)"
+    )
+    requested_url = mock_req.call_args[0][0]
+    return parse_qs(urlparse(requested_url).query)
+
+
 class TestGetFeatureCountWithBbox:
     """Test _get_feature_count extended with bbox parameter."""
 
@@ -4430,8 +4499,7 @@ class TestGetFeatureCountWithBbox:
             )
 
         assert result == 42
-        call_params = mock_req.call_args[1]["params"]
-        assert "bbox" in call_params
+        assert "bbox" in _hits_probe_query(mock_req)
 
     def test_no_bbox_backward_compatible(self):
         """Without bbox, request should not include bbox param."""
@@ -4442,8 +4510,34 @@ class TestGetFeatureCountWithBbox:
             result = _get_feature_count("http://mock/wfs", "layer", "1.1.0")
 
         assert result == 100
-        call_params = mock_req.call_args[1]["params"]
-        assert "bbox" not in call_params
+        assert "bbox" not in _hits_probe_query(mock_req)
+
+
+class TestGetFeatureCountPreservesQueryParams:
+    """The resultType=hits probe must keep the service URL's own query params.
+
+    On the issue #828 scenario a server that 403s without its apikey made the
+    probe fail, the failure was swallowed into count=None, and pagination /
+    auto-tiling silently disengaged — the #678 truncation failure mode.
+    """
+
+    def test_hits_probe_url_carries_apikey_and_resulttype(self):
+        """The probe request URL carries BOTH the apikey and resultType=hits."""
+        from geoparquet_io.core.wfs import _get_feature_count
+
+        with patch("geoparquet_io.core.wfs._make_request") as mock_req:
+            mock_req.return_value = b'numberMatched="7"'
+            result = _get_feature_count(
+                "https://example.com/geo/wfs?apikey=mykey", "layer", "2.0.0"
+            )
+
+        assert result == 7
+        params = _hits_probe_query(mock_req)
+        assert params["apikey"] == ["mykey"]
+        assert params["resultType"] == ["hits"]
+        assert params["service"] == ["WFS"]
+        assert params["request"] == ["GetFeature"]
+        assert params["typeNames"] == ["layer"]
 
 
 class TestGetFeatureCountErrorVisibility:
@@ -4532,8 +4626,12 @@ class TestGetFeatureCountErrorVisibility:
         seen = []
 
         def fake_request(url, params=None, **kwargs):
-            # Root tile is over the limit; every quadrant is under it.
-            seen.append(params.get("bbox", ""))
+            from urllib.parse import parse_qs, urlparse
+
+            # Root tile is over the limit; every quadrant is under it. The
+            # probe pre-merges its params into the URL (issue #828).
+            query = parse_qs(urlparse(url).query)
+            seen.append(query.get("bbox", [""])[0])
             n = 500 if len(seen) == 1 else 10
             return f'numberOfFeatures="{n}"'.encode()
 
@@ -4618,7 +4716,11 @@ class TestSpeculativeCountProbeIsQuiet:
         """2.0.0 rejected, negotiated 1.1.0 answers: no probe warning at all."""
 
         def fake_request(url, params=None, **kwargs):
-            if params.get("version") == "2.0.0":
+            from urllib.parse import parse_qs, urlparse
+
+            # The probe pre-merges its params into the URL (issue #828).
+            query = parse_qs(urlparse(url).query)
+            if query.get("version") == ["2.0.0"]:
                 raise WFSError("HTTP error 400: version 2.0.0 not supported")
             return b'numberOfFeatures="42"'
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -2974,6 +2974,97 @@ class TestVersionNegotiation:
 
 
 # =============================================================================
+# Query Param Merging Tests (Issue #828)
+# =============================================================================
+
+
+class TestBuildWfsUrlQueryParamMerging:
+    """A service_url with an existing query param (e.g. an apikey) must not
+    be corrupted by a second "?" when WFS GetFeature params are appended."""
+
+    def test_build_wfs_url_preserves_existing_query_param(self):
+        """The issue's exact reproduction: an apikey query param must survive
+        intact, joined with '&' rather than a second '?'."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/geo/wfs?apikey=mykey",
+            "layer",
+            "2.0.0",
+        )
+
+        # Exactly one '?' delimiter in the whole URL.
+        assert url.count("?") == 1
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert params["apikey"] == ["mykey"]
+        assert params["service"] == ["WFS"]
+        assert params["version"] == ["2.0.0"]
+        assert params["request"] == ["GetFeature"]
+        assert params["typeNames"] == ["layer"]
+
+    def test_build_wfs_url_no_existing_query_param(self):
+        """Non-regression: a service_url with no query string still produces
+        a single '?' and no stray leading '&'."""
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs",
+            "test:layer",
+            version="2.0.0",
+        )
+
+        assert url.count("?") == 1
+        assert "?&" not in url
+        assert url.startswith("https://example.com/wfs?")
+
+    def test_build_wfs_url_merges_multiple_existing_query_params(self):
+        """Multiple pre-existing query params must all be preserved and
+        merged with the WFS params."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs?apikey=mykey&format=json",
+            "test:layer",
+            version="1.1.0",
+        )
+
+        assert url.count("?") == 1
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert params["apikey"] == ["mykey"]
+        assert params["format"] == ["json"]
+        assert params["service"] == ["WFS"]
+        assert params["typeName"] == ["test:layer"]
+
+    def test_build_wfs_url_strips_wfs_specific_params_before_merging(self):
+        """A service_url that already carries GetCapabilities-style WFS
+        params (service/request/version) must not end up with duplicate or
+        conflicting keys after merging."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs?service=WFS&request=GetCapabilities&apikey=mykey",
+            "test:layer",
+            version="2.0.0",
+        )
+
+        assert url.count("?") == 1
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        # Stale GetCapabilities value must not survive; GetFeature is authoritative.
+        assert params["request"] == ["GetFeature"]
+        assert params["apikey"] == ["mykey"]
+
+
+# =============================================================================
 # CRS Validation Tests (Issue #398)
 # =============================================================================
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -2078,6 +2078,97 @@ class TestVersionNegotiation:
 
 
 # =============================================================================
+# Query Param Merging Tests (Issue #828)
+# =============================================================================
+
+
+class TestBuildWfsUrlQueryParamMerging:
+    """A service_url with an existing query param (e.g. an apikey) must not
+    be corrupted by a second "?" when WFS GetFeature params are appended."""
+
+    def test_build_wfs_url_preserves_existing_query_param(self):
+        """The issue's exact reproduction: an apikey query param must survive
+        intact, joined with '&' rather than a second '?'."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/geo/wfs?apikey=mykey",
+            "layer",
+            "2.0.0",
+        )
+
+        # Exactly one '?' delimiter in the whole URL.
+        assert url.count("?") == 1
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert params["apikey"] == ["mykey"]
+        assert params["service"] == ["WFS"]
+        assert params["version"] == ["2.0.0"]
+        assert params["request"] == ["GetFeature"]
+        assert params["typeNames"] == ["layer"]
+
+    def test_build_wfs_url_no_existing_query_param(self):
+        """Non-regression: a service_url with no query string still produces
+        a single '?' and no stray leading '&'."""
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs",
+            "test:layer",
+            version="2.0.0",
+        )
+
+        assert url.count("?") == 1
+        assert "?&" not in url
+        assert url.startswith("https://example.com/wfs?")
+
+    def test_build_wfs_url_merges_multiple_existing_query_params(self):
+        """Multiple pre-existing query params must all be preserved and
+        merged with the WFS params."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs?apikey=mykey&format=json",
+            "test:layer",
+            version="1.1.0",
+        )
+
+        assert url.count("?") == 1
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert params["apikey"] == ["mykey"]
+        assert params["format"] == ["json"]
+        assert params["service"] == ["WFS"]
+        assert params["typeName"] == ["test:layer"]
+
+    def test_build_wfs_url_strips_wfs_specific_params_before_merging(self):
+        """A service_url that already carries GetCapabilities-style WFS
+        params (service/request/version) must not end up with duplicate or
+        conflicting keys after merging."""
+        from urllib.parse import parse_qs, urlparse
+
+        from geoparquet_io.core.wfs import _build_wfs_url
+
+        url = _build_wfs_url(
+            "https://example.com/wfs?service=WFS&request=GetCapabilities&apikey=mykey",
+            "test:layer",
+            version="2.0.0",
+        )
+
+        assert url.count("?") == 1
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        # Stale GetCapabilities value must not survive; GetFeature is authoritative.
+        assert params["request"] == ["GetFeature"]
+        assert params["apikey"] == ["mykey"]
+
+
+# =============================================================================
 # CRS Validation Tests (Issue #398)
 # =============================================================================
 


### PR DESCRIPTION
Fixes #828

## Problem

When `service_url` already contains a query parameter (e.g. an API key),
`_build_wfs_url` built the final request URL with:

```python
clean_url = _clean_service_url(service_url)
return f"{clean_url}?{urlencode(params)}"
```

`_clean_service_url` only strips WFS-specific keys (`service`, `request`,
`version`, `typename(s)`); it does not remove an existing query string. So a
`service_url` like `https://example.com/geo/wfs?apikey=mykey` produced:

```
https://example.com/geo/wfs?apikey=mykey?service=WFS&version=2.0.0&...
```

A second `?` has no delimiter meaning in a query string, so everything after
the first `?` is parsed as one query -- the `apikey` value became
`mykey?service=WFS&version=2.0.0&...`, and servers that validate the key
returned HTTP 403. This affected the single-fetch path and both pagination
modes, since they all build URLs through `_build_wfs_url`.

## Fix

Added `_merge_query_params(url, params)`, which parses the existing query
string, merges in the new WFS params (new params win on key collision), and
rebuilds a single, correctly `&`-joined query string. `_build_wfs_url` now
uses this helper instead of raw string concatenation.

`_get_feature_count` / `_make_request` were not affected -- they pass `params`
separately to httpx's `client.get()`, which already merges correctly with an
existing URL query.

## Tests

Added `TestBuildWfsUrlQueryParamMerging` in `tests/test_wfs.py`:
- Exact reproduction from the issue (`apikey` preserved, single `?`)
- No-existing-query-param case (non-regression)
- Multiple pre-existing query params merged correctly
- WFS control params (`service`/`request`/`version`) in `service_url` are
  still stripped before merging, so `request=GetFeature` isn't overridden by
  a stale `GetCapabilities` value

## Validation

- `uv run pytest tests/test_wfs.py -n auto -m "not slow and not network and not meta"` -- 218 passed, 2 skipped
- `uv run pytest -n auto -m "not slow and not network and not meta"` -- 5327 passed (remaining failures pre-exist on `main`, unrelated to this change)
- `uv run pre-commit run --files geoparquet_io/core/wfs.py tests/test_wfs.py` -- ruff, duckdb-antipatterns, no-click-echo, doc-sync all pass
- No CLI/API surface change (private core helper); no `docs/guide/` or `api/` updates needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed WFS request URL construction when the base URL already contains query parameters.
  - Existing parameters, such as API keys, are now preserved while WFS parameters are added or updated.
  - Improved handling of multiple query parameters and separators.

- **Tests**
  - Added regression coverage for query-parameter merging and replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->