### PR TITLE
fix(api)!: return the same dict from partition_by_admin as the other partition methods

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -828,6 +828,8 @@ arrow_table = table.to_arrow()
 
 Each method below has an `ops.partition_by_*` twin taking a `pa.Table` plus the output directory, for callers who are not using the fluent wrapper -- `ops.partition_by_h3(table, 'output/', resolution=7)` does exactly what `Table.partition_by_h3('output/', resolution=7)` does. See [Pure Functions](#pure-functions-ops-module).
 
+Every partition method -- spatial, string and admin alike, through `Table` or `ops` -- returns the same dict: `{'output_dir': str, 'file_count': int, 'hive': bool}`, where `file_count` is the number of `.parquet` files written under `output_dir`.
+
 All spatial partitioning methods need to be told how finely to split. Give them an explicit resolution (or `level`), or pass `auto=True` to size one from the data -- the same choice `gpio partition` offers, and the same calculation behind it. A call that gives neither raises `InvalidParameterError` rather than picking a default for you. Under `auto=True`, `target_rows` (default 100,000) sets the rows you want per partition and `max_partitions` (default 10,000) caps how many are created; passing `auto=True` together with an explicit resolution is an error.
 
 !!! warning "Breaking change: the implicit resolutions are gone"
@@ -1519,7 +1521,8 @@ pq.write_table(table, 'output.parquet')
 
 Partitioning is the exception to the `table in -> table out` shape: like the CLI it
 writes a *directory*, so `ops.partition_by_*` takes the table plus an output
-directory and returns the run's statistics.
+directory and returns the run's statistics -- the same
+`{'output_dir': str, 'file_count': int, 'hive': bool}` dict from every scheme.
 
 ```python
 import pyarrow.parquet as pq
@@ -1531,9 +1534,9 @@ table = pq.read_table('input.parquet')
 stats = ops.partition_by_h3(table, 'output/', resolution=7)
 stats = ops.partition_by_a5(table, 'output/', auto=True, target_rows=50000)
 
-# Non-spatial schemes
-ops.partition_by_string(table, 'output/', column='region', hive=True)
-ops.partition_by_admin(table, 'output/', levels=['country'])
+# Non-spatial schemes return the same dict
+stats = ops.partition_by_string(table, 'output/', column='region', hive=True)
+stats = ops.partition_by_admin(table, 'output/', levels=['country'])
 
 print(f"Created {stats['file_count']} files")
 ```

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -856,6 +856,8 @@ schemes:
 | `gpio partition string` | `ops.partition_by_string(table, output_dir, column, chars=...)` |
 | `gpio partition admin` | `ops.partition_by_admin(table, output_dir, dataset=..., levels=...)` |
 
+Every one of them returns the same dict -- `{'output_dir': str, 'file_count': int, 'hive': bool}` -- as does the matching `Table.partition_by_*` method.
+
 <!-- doctest: skip="the 766-row sample is too small to partition meaningfully, has no 'region' column for partition_by_string, and partition_by_admin would download a boundaries dataset" -->
 ```python
 import pyarrow.parquet as pq
@@ -867,9 +869,9 @@ table = pq.read_table('input.parquet')
 stats = ops.partition_by_h3(table, 'output/', resolution=7)
 stats = ops.partition_by_a5(table, 'output/', auto=True, target_rows=50000)
 
-# Non-spatial schemes
-ops.partition_by_string(table, 'output/', column='region', hive=True)
-ops.partition_by_admin(table, 'output/', levels=['country'])
+# Non-spatial schemes return the same dict
+stats = ops.partition_by_string(table, 'output/', column='region', hive=True)
+stats = ops.partition_by_admin(table, 'output/', levels=['country'])
 
 print(f"Created {stats['file_count']} files")
 ```

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -799,7 +799,9 @@ def partition_by_h3(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        dict with output_dir, file_count and hive
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the same
+        dict every ``partition_by_*`` function returns, where ``file_count``
+        counts the ``.parquet`` files under ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -858,7 +860,9 @@ def partition_by_a5(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        dict with output_dir, file_count and hive
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the same
+        dict every ``partition_by_*`` function returns, where ``file_count``
+        counts the ``.parquet`` files under ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -920,7 +924,9 @@ def partition_by_s2(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        dict with output_dir, file_count and hive
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the same
+        dict every ``partition_by_*`` function returns, where ``file_count``
+        counts the ``.parquet`` files under ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -983,7 +989,9 @@ def partition_by_quadkey(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        dict with output_dir, file_count and hive
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the same
+        dict every ``partition_by_*`` function returns, where ``file_count``
+        counts the ``.parquet`` files under ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -1040,9 +1048,9 @@ def partition_by_kdtree(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        The core run's result, which for KD-tree is ``{'status': 'completed'}``.
-        Unlike the cell-index partitioners this one does not count the files it
-        wrote, so there is no ``file_count`` here -- read ``output_dir``.
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the same
+        dict every ``partition_by_*`` function returns, where ``file_count``
+        counts the ``.parquet`` files under ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -1092,10 +1100,9 @@ def partition_by_string(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        The core run's result, which for a string partition is
-        ``{'status': 'completed'}``. Unlike the cell-index partitioners this one
-        does not count the files it wrote, so there is no ``file_count`` here --
-        read ``output_dir``.
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the same
+        dict every ``partition_by_*`` function returns, where ``file_count``
+        counts the ``.parquet`` files under ``output_dir``.
 
     Example:
         >>> from geoparquet_io.api import ops
@@ -1150,11 +1157,12 @@ def partition_by_admin(
         geometry_column: Geometry column name (auto-detected if None)
 
     Returns:
-        The core run's result. The admin partitioner returns the number of
-        partitions it created, so a run that wrote at least one partition
-        returns that ``int``; a run that created none returns
-        ``{'status': 'completed'}``. There is no ``file_count`` here -- read
-        ``output_dir``.
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the same
+        dict every ``partition_by_*`` function returns, where ``file_count``
+        counts the ``.parquet`` files under ``output_dir``.
+        The ``int`` partition count that ``partition_by_admin_hierarchical``
+        reports is not passed through (#822); ``file_count`` is counted off
+        the output directory instead.
 
     Example:
         >>> from geoparquet_io.api import ops

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -98,12 +98,17 @@ def _run_partition_with_temp_file(
     core_kwargs: dict,
     compression: str = "ZSTD",
     compression_level: int | None = None,
-    collect_stats: bool = False,
 ) -> dict:
     """
     Run a partition operation using a temporary file.
 
     Handles temp file creation, writing, partition function call, and cleanup.
+
+    The core partition functions disagree on what they return -- an ``int``
+    partition count (admin), ``None`` (kdtree, string), nothing the cell-index
+    ones promise -- so the core result is not passed through. Every
+    ``Table.partition_by_*`` method gets the same dict from here, counted off
+    the output directory (#822).
 
     Args:
         table: The PyArrow table to partition
@@ -114,10 +119,11 @@ def _run_partition_with_temp_file(
         core_kwargs: Keyword arguments for the core function
         compression: Compression codec
         compression_level: Compression level (None lets the codec pick its own)
-        collect_stats: If True, return file count stats instead of core_fn result
 
     Returns:
-        dict with partition results or file stats if collect_stats=True
+        ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the output
+        directory, the number of ``.parquet`` files written under it, and
+        whether they are laid out Hive-style.
     """
     import tempfile
     import uuid
@@ -134,23 +140,20 @@ def _run_partition_with_temp_file(
             compression_level=compression_level,
         )
 
-        result = core_fn(
+        core_fn(
             input_parquet=str(temp_input),
             output_folder=str(output_dir),
             **core_kwargs,
             verbose=False,
         )
 
-        if collect_stats:
-            output_path = PathLib(output_dir)
-            parquet_files = list(output_path.rglob("*.parquet"))
-            return {
-                "output_dir": str(output_path),
-                "file_count": len(parquet_files),
-                "hive": core_kwargs.get("hive", False),
-            }
-
-        return result if result else {"status": "completed"}
+        output_path = PathLib(output_dir)
+        parquet_files = list(output_path.rglob("*.parquet"))
+        return {
+            "output_dir": str(output_path),
+            "file_count": len(parquet_files),
+            "hive": core_kwargs.get("hive", False),
+        }
     finally:
         _safe_unlink(temp_input)
 
@@ -1932,7 +1935,9 @@ class Table:
             overwrite: Overwrite existing output directory
 
         Returns:
-            dict with partition statistics (file_count, etc.)
+            ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the
+            same dict every ``partition_by_*`` method returns, where
+            ``file_count`` counts the ``.parquet`` files under ``output_dir``.
 
         Example:
             >>> table = gpio.read('data.parquet')
@@ -1968,7 +1973,6 @@ class Table:
                 "overwrite": overwrite,
             },
             compression=compression,
-            collect_stats=True,
         )
 
     def partition_by_h3(
@@ -2009,7 +2013,9 @@ class Table:
             overwrite: Overwrite existing output directory
 
         Returns:
-            dict with partition statistics (file_count, etc.)
+            ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the
+            same dict every ``partition_by_*`` method returns, where
+            ``file_count`` counts the ``.parquet`` files under ``output_dir``.
 
         Example:
             >>> table = gpio.read('data.parquet')
@@ -2042,7 +2048,6 @@ class Table:
                 "overwrite": overwrite,
             },
             compression=compression,
-            collect_stats=True,
         )
 
     def partition_by_s2(
@@ -2086,7 +2091,9 @@ class Table:
             overwrite: Overwrite existing output directory
 
         Returns:
-            dict with partition statistics (file_count, etc.)
+            ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the
+            same dict every ``partition_by_*`` method returns, where
+            ``file_count`` counts the ``.parquet`` files under ``output_dir``.
 
         Example:
             >>> table = gpio.read('data.parquet')
@@ -2119,7 +2126,6 @@ class Table:
                 "overwrite": overwrite,
             },
             compression=compression,
-            collect_stats=True,
         )
 
     def partition_by_a5(
@@ -2163,7 +2169,9 @@ class Table:
             overwrite: Overwrite existing output directory
 
         Returns:
-            dict with partition statistics (file_count, etc.)
+            ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the
+            same dict every ``partition_by_*`` method returns, where
+            ``file_count`` counts the ``.parquet`` files under ``output_dir``.
 
         Example:
             >>> table = gpio.read('data.parquet')
@@ -2196,7 +2204,6 @@ class Table:
                 "overwrite": overwrite,
             },
             compression=compression,
-            collect_stats=True,
         )
 
     def upload(
@@ -3059,7 +3066,9 @@ class Table:
                 codecs whose valid range excludes it (GZIP accepts 1-9).
 
         Returns:
-            dict with partition statistics
+            ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the
+            same dict every ``partition_by_*`` method returns, where
+            ``file_count`` counts the ``.parquet`` files under ``output_dir``.
 
         Example:
             >>> table = gpio.read('data.parquet')
@@ -3119,7 +3128,9 @@ class Table:
                 codecs whose valid range excludes it (GZIP accepts 1-9).
 
         Returns:
-            dict with partition statistics
+            ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the
+            same dict every ``partition_by_*`` method returns, where
+            ``file_count`` counts the ``.parquet`` files under ``output_dir``.
 
         Example:
             >>> table = gpio.read('data.parquet')
@@ -3178,7 +3189,9 @@ class Table:
                 codecs whose valid range excludes it (GZIP accepts 1-9).
 
         Returns:
-            dict with partition statistics
+            ``{'output_dir': str, 'file_count': int, 'hive': bool}`` -- the
+            same dict every ``partition_by_*`` method returns, where
+            ``file_count`` counts the ``.parquet`` files under ``output_dir``.
 
         Example:
             >>> table = gpio.read('data.parquet')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,7 +35,11 @@ from geoparquet_io.core.add import quadkey as core_quadkey
 from geoparquet_io.core.add import s2 as core_s2
 from geoparquet_io.core.process.aggregate import by_a5 as core_aggregate_a5
 from geoparquet_io.core.process.aggregate import by_h3 as core_aggregate_h3
-from tests.conftest import safe_unlink, skip_if_geography_available
+from tests.conftest import (
+    safe_unlink,
+    skip_if_geography_available,
+    skip_if_geography_unavailable,
+)
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 PLACES_PARQUET = TEST_DATA_DIR / "places_test.parquet"
@@ -2280,7 +2284,6 @@ class TestOpsPartition:
         assert self._partition_names(tmp_path / "out")
 
     def test_partition_by_kdtree(self, arrow_table, tmp_path):
-        """kdtree/string/admin return the core result, not the file-count stats."""
         result = ops.partition_by_kdtree(arrow_table, tmp_path / "out", iterations=2)
 
         assert isinstance(result, dict)
@@ -2361,6 +2364,115 @@ class TestOpsPartition:
         assert kwargs["dataset_name"] == "overture"
         assert kwargs["levels"] == ["country", "region"]
         assert kwargs["vecorel"] is True
+
+    # -- every partitioner returns the same stats dict (#822) ---------------
+
+    PARTITION_STATS_KEYS = frozenset({"output_dir", "file_count", "hive"})
+
+    @staticmethod
+    def _use_local_admin_dataset(monkeypatch, tmp_path):
+        """Point the admin join at one local CRS84 polygon covering the places sample.
+
+        The same shape as `local_admin_dataset` in test_crs_aware_operations:
+        a ``current``-style file with a ``country`` column, so the boundaries
+        dataset is never downloaded and the test needs no network.
+        """
+        import duckdb
+
+        from geoparquet_io.core.admin_datasets import CurrentAdminDataset
+        from geoparquet_io.core.common import add_bbox
+
+        admin = str(tmp_path / "admin.parquet")
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial")
+        con.execute(
+            f"""
+            COPY (
+                SELECT 'XX' AS country,
+                       ST_GeomFromText('POLYGON((-2 9, 2 9, 2 13, -2 13, -2 9))') AS geometry
+            ) TO '{admin}' (FORMAT PARQUET)
+            """
+        )
+        con.close()
+        add_bbox(admin, "bbox", False)
+
+        def fake_create(dataset_name, source_path=None, verbose=False):
+            return CurrentAdminDataset(source_path=admin, verbose=verbose)
+
+        monkeypatch.setattr(
+            "geoparquet_io.core.partition.admin_hierarchical.AdminDatasetFactory.create",
+            staticmethod(fake_create),
+        )
+
+    def test_partition_by_admin_returns_the_shared_stats_dict(
+        self, arrow_table, tmp_path, monkeypatch
+    ):
+        """Both front doors return the cell-index partitioners' dict, not the core int (#822).
+
+        `partition_by_admin_hierarchical` is annotated ``-> int`` and returns a
+        partition count. The API passed that straight through, so a run that
+        wrote partitions returned an ``int`` from two functions annotated
+        ``-> dict``.
+        """
+        self._use_local_admin_dataset(monkeypatch, tmp_path)
+
+        via_ops = ops.partition_by_admin(
+            arrow_table, tmp_path / "ops", dataset="current", levels=["country"]
+        )
+        via_table = Table(arrow_table).partition_by_admin(
+            tmp_path / "table", dataset="current", levels=["country"], hive=True
+        )
+
+        for result in (via_ops, via_table):
+            assert isinstance(result, dict), f"got {type(result).__name__}: {result!r}"
+            assert set(result) == self.PARTITION_STATS_KEYS
+        assert via_ops["file_count"] == len(self._partition_names(tmp_path / "ops")) == 1
+        assert via_ops["output_dir"] == str(tmp_path / "ops")
+        assert via_ops["hive"] is False
+        assert via_table["hive"] is True
+
+    @pytest.mark.parametrize(
+        ("method", "kwargs"),
+        [
+            ("partition_by_h3", {"resolution": 2}),
+            ("partition_by_a5", {"resolution": 4}),
+            ("partition_by_s2", {"level": 3}),
+            ("partition_by_quadkey", {"resolution": 13, "partition_resolution": 3}),
+            ("partition_by_kdtree", {"iterations": 2, "hive": True}),
+            ("partition_by_string", {"column": "region"}),
+            ("partition_by_admin", {"dataset": "current", "levels": ["country"]}),
+        ],
+    )
+    def test_every_partitioner_returns_the_same_stats_dict(
+        self, method, kwargs, arrow_table, tmp_path, monkeypatch
+    ):
+        """One return contract across all seven schemes, through `ops` and `Table` alike.
+
+        Pinned rather than left true by accident: the shape comes from
+        `_run_partition_with_temp_file`, and the core functions underneath it
+        return an ``int`` (admin), ``None`` (kdtree, string) or nothing the
+        caller can use.
+        """
+        if method == "partition_by_s2":
+            skip_if_geography_unavailable()
+        if method == "partition_by_admin":
+            self._use_local_admin_dataset(monkeypatch, tmp_path)
+
+        table = arrow_table
+        if method == "partition_by_string":
+            regions = pa.array(["north" if i % 2 else "south" for i in range(table.num_rows)])
+            table = table.append_column("region", regions)
+
+        via_ops = getattr(ops, method)(table, tmp_path / "ops", **kwargs)
+        via_table = getattr(Table(table), method)(tmp_path / "table", **kwargs)
+
+        for result in (via_ops, via_table):
+            assert isinstance(result, dict), f"{method} returned {result!r}"
+            assert set(result) == self.PARTITION_STATS_KEYS
+        assert via_ops["file_count"] == len(self._partition_names(tmp_path / "ops")) > 0
+        assert via_ops["file_count"] == via_table["file_count"]
+        assert via_ops["output_dir"] == str(tmp_path / "ops")
+        assert via_ops["hive"] is kwargs.get("hive", False)
 
     # -- the ops twin and the Table method are the same operation -----------
 


### PR DESCRIPTION
## What changed

`_run_partition_with_temp_file` (`api/table.py`) no longer passes the core partitioner's return value through. It discards it and always returns the dict the cell-index partitioners already produced:

```python
{'output_dir': str, 'file_count': int, 'hive': bool}
```

`file_count` is the number of `.parquet` files written under `output_dir`; `hive` is the flag the call was made with. Because that is now the only shape, the helper's `collect_stats` flag is gone along with its four call sites, and all seven `partition_by_*` schemes -- h3, a5, s2, quadkey, kdtree, string, admin -- share one contract through `Table` and through `ops` alike.

Docstrings in `api/table.py` and `api/ops.py`, plus `docs/api/python-api.md` and `docs/guide/partition.md`, now state that shape instead of the three different ones they described.

The core `partition_by_admin_hierarchical(...) -> int` contract is deliberately untouched: `geoparquet_io/benchmarks/operations.py` reports that count as `{"partitions": num_partitions}`, and `tests/test_crs_aware_operations.py` / `tests/test_partition_admin_vecorel.py` assert on it. The mismatch was at the API boundary, so that is where it is fixed.

## Why

`partition_by_admin_hierarchical` is annotated `-> int` and returns a partition count. The helper did:

```python
return result if result else {"status": "completed"}
```

so `Table.partition_by_admin` and `ops.partition_by_admin` returned an **`int`** on any run that wrote partitions, despite both being annotated `-> dict`. `partition_by_kdtree` and `partition_by_string` return `None`, so those two returned `{"status": "completed"}` -- a third shape, with no `file_count`. #808 corrected the docstrings to describe the real shapes; this makes the shapes worth describing in one line.

Closes #822. Refs #808.

## Verification

Failing test first, on `main`'s behaviour -- the bug reproduces exactly as reported:

```
$ uv run pytest tests/test_api.py -q -k "returns_the_shared_stats_dict"
tests/test_api.py F                                                      [100%]
=================================== FAILURES ===================================
____ TestOpsPartition.test_partition_by_admin_returns_the_shared_stats_dict ____
tests/test_api.py:2428: in test_partition_by_admin_returns_the_shared_stats_dict
    assert isinstance(result, dict), f"got {type(result).__name__}: {result!r}"
E   AssertionError: got int: 1
E   assert False
E    +  where False = isinstance(1, dict)
====================== 1 failed, 184 deselected in 33.23s ======================
```

Two tests were added to `TestOpsPartition`. The first pins the reported bug for both front doors; the second is parametrized over all seven schemes, through `ops` and `Table`, so the shared shape cannot drift back apart. Neither touches the network: the admin cases monkeypatch `AdminDatasetFactory.create` onto one local CRS84 polygon covering the places fixture, the same trick `tests/test_crs_aware_operations.py::local_admin_dataset` uses. S2 skips on the existing `skip_if_geography_unavailable()` reason (#737).

```
$ uv run pytest tests/test_api.py -q -k "every_partitioner" -v
tests/test_api.py::TestOpsPartition::test_every_partitioner_returns_the_same_stats_dict[partition_by_h3-kwargs0] PASSED [ 14%]
tests/test_api.py::TestOpsPartition::test_every_partitioner_returns_the_same_stats_dict[partition_by_a5-kwargs1] PASSED [ 28%]
tests/test_api.py::TestOpsPartition::test_every_partitioner_returns_the_same_stats_dict[partition_by_s2-kwargs2] PASSED [ 42%]
tests/test_api.py::TestOpsPartition::test_every_partitioner_returns_the_same_stats_dict[partition_by_quadkey-kwargs3] PASSED [ 57%]
tests/test_api.py::TestOpsPartition::test_every_partitioner_returns_the_same_stats_dict[partition_by_kdtree-kwargs4] PASSED [ 71%]
tests/test_api.py::TestOpsPartition::test_every_partitioner_returns_the_same_stats_dict[partition_by_string-kwargs5] PASSED [ 85%]
tests/test_api.py::TestOpsPartition::test_every_partitioner_returns_the_same_stats_dict[partition_by_admin-kwargs6] PASSED [100%]
====================== 7 passed, 185 deselected in 3.63s =======================
```

```
$ uv run pytest tests/test_api.py -q -k partition
================ 65 passed, 1 skipped, 126 deselected in 11.34s ================

$ uv run pytest -q -m "not slow and not network and not meta" -k "partition or parity"
============== 496 passed, 13 skipped, 5883 deselected in 45.39s ===============

$ uv run pytest -m meta -q
==================== 202 passed, 6190 deselected in 19.56s =====================
```

`pre-commit run --all-files` and `--hook-stage pre-push` are clean, mypy (which is what caught the wrong annotations being un-caught) included:

```
deptry...................................................................Passed
mypy.....................................................................Passed
vulture..................................................................Passed
xenon....................................................................Passed
import-linter............................................................Passed
menard-check.............................................................Passed
fast-tests...............................................................Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized partitioning results across all supported schemes and APIs.
  * Partition operations now return statistics including the output directory, Parquet file count, and Hive partitioning status.

* **Documentation**
  * Updated Python API and partitioning guides with the shared return format.
  * Clarified that file counts include Parquet files in the output directory.

* **Tests**
  * Added coverage verifying consistent results across all partitioning methods and interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Why the `!`:** `partition_by_kdtree`/`partition_by_string` returned a documented `{'status': 'completed'}` (#808); a caller reading `result["status"]` now gets `KeyError`. The old shape carried no information and nothing in-repo consumes it, but this repo marks Python-API behavior changes with `!` (#845, #855), so this one is too.
