### PR TITLE
fix(sort): say that an explicit default CRS is normalized, not preserved

### DIFF
--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -236,9 +236,17 @@ Column sorting:
 The output file:
 
 - Defaults to GeoParquet 1.1 spec (use `--geoparquet-version 2.0` for native spatial stats)
-- Preserves CRS information
+- Carries a non-default CRS through unchanged
 - Includes bbox covering metadata
 - Uses optimal row group sizes
+
+!!! note "An explicit default CRS is normalized, not preserved"
+    GeoParquet writes its default CRS (OGC:CRS84, equivalently EPSG:4326) by
+    *omitting* the `crs` key. An input that spells that default out therefore
+    comes back without the key: the coordinates and their meaning are unchanged,
+    but a byte-for-byte diff of the `geo` metadata will show the key gone. Every
+    gpio write path does this, not just `sort`. Run with `--verbose` to see a
+    note when it happens, and use `gpio inspect meta` to confirm the result.
 
 !!! note "Version options"
     Use `--geoparquet-version` to control the output format: `1.1` (default), `2.0` (recommended for spatial filter pushdown), or `parquet-geo-only` (Parquet native geo types without GeoParquet metadata).

--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -245,7 +245,9 @@ The output file:
     *omitting* the `crs` key. An input that spells that default out therefore
     comes back without the key: the coordinates and their meaning are unchanged,
     but a byte-for-byte diff of the `geo` metadata will show the key gone. Every
-    gpio write path does this, not just `sort`. Run with `--verbose` to see a
+    gpio write path that rebuilds the `geo` block does this, not just `sort`
+    (a metadata-only rewrite like `add bbox-metadata` carries the block as-is).
+    Run with `--verbose` to see a
     note when it happens, and use `gpio inspect meta` to confirm the result.
 
 !!! note "Version options"

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -3683,7 +3683,10 @@ def hilbert_order(
     by their position along a Hilbert space-filling curve.
 
     Applies optimal formatting (configurable compression, optimized row groups,
-    bbox metadata) while preserving the CRS.
+    bbox metadata). A non-default CRS is carried through unchanged; a CRS that
+    spells out the GeoParquet default (OGC:CRS84 / EPSG:4326) is normalized to
+    how the spec writes it, an omitted crs key. Use --verbose to see when that
+    happens.
 
     Supports both local and remote (S3, GCS, Azure) inputs and outputs.
     """

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -237,14 +237,30 @@ def apply_output_crs(col_meta: dict, input_crs) -> None:
     - ``input_crs`` is ``None`` (CRS unchanged) -> preserve a real ``crs`` but
       still strip a stray default/null one the source or DuckDB may have attached.
 
+    Dropping a ``crs`` the input *spelled out* as the default is invisible in the
+    output — the file is correct GeoParquet, but a caller diffing ``geo`` blocks
+    sees a key they wrote go missing (#815). Note it once at ``--verbose``. An
+    explicit ``crs: null`` is excluded: that means *unknown*, and it has its own
+    warning (:data:`NULL_CRS_HINT`).
+
     Mutates ``col_meta`` in place.
     """
+    declared = col_meta.get("crs")
+    # Only a value that actually names the default counts: ``None`` is the
+    # unknown-CRS case and an empty value names nothing at all.
+    declared_the_default = bool(declared) and is_default_crs(declared)
+
     if input_crs and not is_default_crs(input_crs):
         col_meta["crs"] = input_crs
-    elif input_crs:
+        return
+    if input_crs or is_default_crs(col_meta.get("crs")):
         col_meta.pop("crs", None)
-    elif is_default_crs(col_meta.get("crs")):
-        col_meta.pop("crs", None)
+        if declared_the_default:
+            debug(
+                "Normalized an explicit default CRS: dropped the geometry column's "
+                "`crs` key, which is how GeoParquet spells the OGC:CRS84 / EPSG:4326 "
+                "default (the coordinates are unchanged)."
+            )
 
 
 #: Shared guidance appended to null-CRS warnings and the validate message.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,9 @@ def _write_with_crs_state(source_file, dest_file, crs_state):
     """Write a copy of source_file with the geometry column's crs key adjusted.
 
     crs_state: "null" sets crs to None (explicit unknown CRS); "absent" removes
-    the crs key entirely (defaults to OGC:CRS84 per the GeoParquet spec).
+    the crs key entirely (defaults to OGC:CRS84 per the GeoParquet spec);
+    "default" writes an explicit EPSG:4326, the redundant spelling of that same
+    default that gpio normalizes away on write.
     """
     table = pq.read_table(source_file)
     metadata = dict(table.schema.metadata or {})
@@ -197,6 +199,8 @@ def _write_with_crs_state(source_file, dest_file, crs_state):
         col_meta["crs"] = None
     elif crs_state == "absent":
         col_meta.pop("crs", None)
+    elif crs_state == "default":
+        col_meta["crs"] = {"id": {"authority": "EPSG", "code": 4326}}
     metadata[b"geo"] = json.dumps(geo).encode("utf-8")
     table = table.replace_schema_metadata(metadata)
     pq.write_table(table, dest_file)
@@ -216,6 +220,14 @@ def absent_crs_parquet(tmp_path):
     """A GeoParquet file with the crs key omitted (defaults to OGC:CRS84)."""
     return _write_with_crs_state(
         str(BUILDINGS_TEST_FILE), str(tmp_path / "absent_crs.parquet"), "absent"
+    )
+
+
+@pytest.fixture
+def default_crs_parquet(tmp_path):
+    """A GeoParquet file declaring an explicit EPSG:4326 (the default, spelled out)."""
+    return _write_with_crs_state(
+        str(BUILDINGS_TEST_FILE), str(tmp_path / "default_crs.parquet"), "default"
     )
 
 

--- a/tests/test_crs_null_vs_default.py
+++ b/tests/test_crs_null_vs_default.py
@@ -301,3 +301,138 @@ def test_warn_on_two_distinct_null_files(null_crs_parquet, buildings_test_file, 
         extract_crs_from_parquet(null_crs_parquet)
         extract_crs_from_parquet(second_path)
     assert len(_null_crs_warnings(caplog.records)) == 2
+
+
+# --------------------------------------------------------------------------- #
+# verbose note when an explicit default crs is normalized away (#815)
+# --------------------------------------------------------------------------- #
+
+EPSG_4326 = {"id": {"authority": "EPSG", "code": 4326}}
+OGC_CRS84 = {"id": {"authority": "OGC", "code": "CRS84"}}
+EPSG_3857 = {"id": {"authority": "EPSG", "code": 3857}}
+
+
+def _normalization_notes(records):
+    return [r for r in records if "explicit default CRS" in r.message]
+
+
+def _apply_and_capture(caplog, col_meta, input_crs=None):
+    """Run ``apply_output_crs`` at DEBUG and return its normalization notes."""
+    import logging
+
+    from geoparquet_io.core.crs_utils import apply_output_crs
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+        apply_output_crs(col_meta, input_crs)
+    return _normalization_notes(caplog.records)
+
+
+@pytest.mark.parametrize("declared", [EPSG_4326, OGC_CRS84])
+def test_note_when_explicit_default_crs_is_dropped(caplog, declared):
+    """Every spelling of the default gets one note when its key is dropped."""
+    col_meta = {"crs": declared}
+    notes = _apply_and_capture(caplog, col_meta)
+    assert "crs" not in col_meta
+    assert len(notes) == 1
+
+
+def test_note_mentions_the_omitted_crs_key(caplog):
+    notes = _apply_and_capture(caplog, {"crs": EPSG_4326})
+    assert "crs" in notes[0].message
+    assert "OGC:CRS84" in notes[0].message
+
+
+def test_no_note_when_there_is_no_crs_key(caplog):
+    col_meta = {"encoding": "WKB"}
+    assert _apply_and_capture(caplog, col_meta) == []
+    assert "crs" not in col_meta
+
+
+def test_no_note_when_a_non_default_crs_is_carried(caplog):
+    col_meta = {"crs": EPSG_3857}
+    assert _apply_and_capture(caplog, col_meta) == []
+    assert col_meta["crs"] == EPSG_3857
+
+
+def test_no_note_for_an_explicit_null_crs(caplog):
+    """``crs: null`` means *unknown*; it has its own warning, not this note."""
+    col_meta = {"crs": None}
+    assert _apply_and_capture(caplog, col_meta) == []
+
+
+def test_no_note_when_a_stale_non_default_crs_is_replaced(caplog):
+    """Reprojecting 3857 -> the default drops a key that never said 4326."""
+    col_meta = {"crs": EPSG_3857}
+    assert _apply_and_capture(caplog, col_meta, input_crs=EPSG_4326) == []
+    assert "crs" not in col_meta
+
+
+def test_note_when_output_crs_is_the_default_and_input_said_so(caplog):
+    col_meta = {"crs": EPSG_4326}
+    assert len(_apply_and_capture(caplog, col_meta, input_crs=OGC_CRS84)) == 1
+
+
+def test_no_note_when_a_non_default_crs_is_written(caplog):
+    col_meta = {"crs": EPSG_4326}
+    assert _apply_and_capture(caplog, col_meta, input_crs=EPSG_3857) == []
+    assert col_meta["crs"] == EPSG_3857
+
+
+def test_sort_hilbert_verbose_notes_the_normalization(default_crs_parquet, temp_output_file):
+    """The CLI surfaces the drop at --verbose, and the key really is gone."""
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import sort
+
+    result = CliRunner().invoke(
+        sort, ["hilbert", default_crs_parquet, temp_output_file, "--verbose"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "explicit default CRS" in result.output
+    assert _col_crs(temp_output_file) == (False, None)
+
+
+def test_sort_hilbert_is_quiet_about_it_without_verbose(default_crs_parquet, temp_output_file):
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import sort
+
+    result = CliRunner().invoke(sort, ["hilbert", default_crs_parquet, temp_output_file])
+    assert result.exit_code == 0, result.output
+    assert "explicit default CRS" not in result.output
+
+
+def test_sort_hilbert_verbose_is_silent_for_an_absent_crs(absent_crs_parquet, temp_output_file):
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import sort
+
+    result = CliRunner().invoke(
+        sort, ["hilbert", absent_crs_parquet, temp_output_file, "--verbose"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "explicit default CRS" not in result.output
+
+
+def test_sort_hilbert_verbose_is_silent_for_a_non_default_crs(buildings_test_file, tmp_path):
+    """A projected input keeps its CRS, so there is nothing to note."""
+    import json
+
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import sort
+
+    table = pq.read_table(buildings_test_file)
+    meta = dict(table.schema.metadata)
+    geo = json.loads(meta[b"geo"].decode("utf-8"))
+    geo["columns"][geo.get("primary_column", "geometry")]["crs"] = EPSG_3857
+    meta[b"geo"] = json.dumps(geo).encode("utf-8")
+    src = str(tmp_path / "epsg3857.parquet")
+    pq.write_table(table.replace_schema_metadata(meta), src)
+
+    out = str(tmp_path / "sorted_3857.parquet")
+    result = CliRunner().invoke(sort, ["hilbert", src, out, "--verbose"])
+    assert result.exit_code == 0, result.output
+    assert "explicit default CRS" not in result.output
+    assert _col_crs(out)[0] is True


### PR DESCRIPTION
## What changed

- `gpio sort hilbert --help` no longer claims it formats a file "while preserving the CRS". It now says what the write paths actually do: a non-default CRS is carried through unchanged, and a CRS that spells out the GeoParquet default (OGC:CRS84 / EPSG:4326) is normalized to how the spec writes it — an omitted `crs` key.
- `apply_output_crs` — the single source of truth for the null-vs-default rule — logs one `debug` line when it drops a `crs` that really named the default, so the normalization is visible at `--verbose` from every write path that carries a `geo` block. It stays quiet for an explicit `crs: null` (that means *unknown* and already has its own warning), for a non-default CRS that is carried through, and for a stale non-default key replaced by a reprojection to the default.
- `docs/guide/sort.md`: the "Output Format" bullet `Preserves CRS information` becomes `Carries a non-default CRS through unchanged`, plus a note explaining the normalization and that it applies to every gpio write path.
- Tests: `tests/conftest.py` grows a `default_crs_parquet` fixture (a file declaring an explicit EPSG:4326) and `tests/test_crs_null_vs_default.py` grows twelve cases — unit coverage of every `apply_output_crs` branch and end-to-end `sort hilbert` runs asserting the note appears at `--verbose`, is absent without it, and is absent for an absent or non-default CRS.

Those were the only sites making the claim. `grep -rn "preserving the CRS\|preserve.*CRS\|CRS.*preserv" geoparquet_io/cli/ geoparquet_io/api/ docs/` leaves only genuinely different statements: `convert geojson --keep-crs` (about reprojection to WGS84), `extract arcgis --output-crs`, `Table._table_to_temp_parquet`'s internal note, and the `pq.write_table` caveat in the Python API guide. No sibling `sort` subcommand mentions the CRS at all.

## Why

Reported in #815 against gpio 1.3.0 over 53 published files: 24 declared `EPSG:4326` and all 24 came back without the key, with the CLI reporting success each time. #796 settled the semantics — OGC:CRS84 ≡ EPSG:4326, so dropping the key is a normalization to the default rather than a downgrade to "unknown", and the outputs are correct GeoParquet. What was left is what this PR fixes: the help overstated the guarantee, and the drop had no diagnostic, so a caller diffing `geo` blocks saw a key they wrote go missing with nothing to explain it.

No behaviour changes for the data or the metadata: the same key is dropped in the same cases as before.

## Verification

The reported behaviour, reproduced on `main` — a GeoParquet 2.0 input declaring an explicit `EPSG:4326`, and a control declaring `EPSG:3857`:

```
$ gpio sort hilbert in_4326.parquet out_4326.parquet
$ gpio sort hilbert in_3857.parquet out_3857.parquet
in_4326.parquet          v=2.0.0    'crs' key present=True   value={"id": {"authority": "EPSG", "code": 4326}}
out_4326.parquet         v=2.0.0    'crs' key present=False  value=
in_3857.parquet          v=2.0.0    'crs' key present=True   value={"id": {"authority": "EPSG", "code": 3857}}
out_3857.parquet         v=2.0.0    'crs' key present=True   value={"id": {"authority": "EPSG", "code": 3857}}
```

Help text before:

```
  Applies optimal formatting (configurable compression, optimized row groups,
  bbox metadata) while preserving the CRS.
```

Help text after:

```
  Applies optimal formatting (configurable compression, optimized row groups,
  bbox metadata). A non-default CRS is carried through unchanged; a CRS that
  spells out the GeoParquet default (OGC:CRS84 / EPSG:4326) is normalized to
  how the spec writes it, an omitted crs key. Use --verbose to see when that
  happens.
```

The verbose note, on the same two files (`| grep -i crs`):

```
$ gpio sort hilbert in_4326.parquet out_4326.parquet --overwrite --verbose
Normalized an explicit default CRS: dropped the geometry column's `crs` key, which is how GeoParquet spells the OGC:CRS84 / EPSG:4326 default (the coordinates are unchanged).

$ gpio sort hilbert in_3857.parquet out_3857.parquet --overwrite --verbose
(no output)
```

Exactly one line, on `--geoparquet-version 2.0` as well as the 1.1 default.

Test runs:

```
$ uv run pytest tests/ -q -k "sort or crs or help or surface"
1053 passed, 12 skipped, 4861 deselected, 1 xpassed, 3 warnings in 1186.41s (0:19:46)

$ uv run pytest -q -m "not slow and not network and not meta" -k "sort or crs" -n auto
822 passed, 16 skipped, 3 warnings in 61.83s (0:01:01)

$ uv run pytest -m docs_example -q -k sort
9 passed, 5 skipped, 6383 deselected in 78.88s (0:01:18)

$ uv run pre-commit run --all-files
(all hooks passed)

$ uv run pre-commit run --all-files --hook-stage pre-push
deptry / mypy / vulture / xenon / import-linter / menard-check / fast-tests ... Passed
```

`tests/data/cli_surface.json` needs no regeneration: that snapshot freezes the command tree's structure — groups, commands, parameters, types, defaults, flags — and records no help prose (`grep -c "preserving the CRS" tests/data/cli_surface.json` → 0). The snapshot comparison and the per-command `--help` render cases pass unchanged.

Closes #815. Refs #699, #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified CRS handling for sorting and other GeoParquet write operations.
  - Non-default CRS values are preserved unchanged.
  - Explicit default CRS values (`OGC:CRS84`/`EPSG:4326`) are normalized by omitting the `crs` key while preserving coordinate meaning.
  - Updated guidance explains how to view normalization messages with `--verbose` and verify metadata with `gpio inspect meta`.

- **Bug Fixes**
  - Added clearer verbose notifications when default CRS metadata is normalized.
  - Improved handling of explicit, omitted, and null CRS metadata during output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->