### PR TITLE
fix(extract): recompute geometry_types and bbox after geometry repair

### DIFF
--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -188,13 +188,18 @@ Filter features by a rectangular bounding box. The bbox is specified as `xmin,ym
       inputs, not just the first file whose footer was read. (Carrying the first
       file's `bbox` would under-cover the merge, and conformant readers skip
       data outside a declared bbox.)
+    - **A geometry repair** (`--repair-geometry`, on by default) that actually
+      fixed a row — `ST_MakeValid` can change a geometry's type, so a repaired
+      self-intersecting `Polygon` comes back a `MultiPolygon` and the input's
+      `geometry_types` would under-declare the output. A repair pass that found
+      nothing invalid changes no row and keeps the carried stats.
     - **`--exclude-cols`** — metadata that references a dropped column is
       pruned: excluding the `bbox` column drops the `covering` entry, and
       excluding the geometry column writes plain Parquet with no `geo` metadata
       at all.
 
-    An unfiltered, single-file column-only extract preserves the input's
-    `bbox`/`geometry_types` unchanged.
+    An unfiltered, unrepaired, single-file column-only extract preserves the
+    input's `bbox`/`geometry_types` unchanged.
 
     Recomputing costs one extra aggregate pass over the (already filtered)
     query — on the order of 30% of a plain copy for a few million rows. Use

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -39,7 +39,11 @@ from geoparquet_io.core.file_utils import (
     is_partition_path,
     safe_file_url,
 )
-from geoparquet_io.core.geo_metadata import prune_geo_metadata_to_columns, strip_derived_stats
+from geoparquet_io.core.geo_metadata import (
+    backfill_derived_stats,
+    prune_geo_metadata_to_columns,
+    strip_derived_stats,
+)
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
     find_primary_geometry_column,
@@ -786,17 +790,40 @@ def extract_table(
             )
 
         # Repair invalid geometry (issue #506) before materializing the result.
+        geometry_repaired = False
         if keeps_geometry:
-            query = repair_query_geometry(con, query, geom_col, repair=repair_geometry)
+            query, geometry_repaired = _repair_geometry_in_query(
+                con, query, geom_col, repair_geometry
+            )
 
         result = con.execute(query).arrow().read_all()
         if table.schema.metadata:
-            result = result.replace_schema_metadata(
-                _carry_metadata_to_columns(table.schema.metadata, result.column_names)
-            )
+            metadata = _carry_metadata_to_columns(table.schema.metadata, result.column_names)
+            if geometry_repaired:
+                # The repair rewrote rows, so the carried stats no longer
+                # describe them (#812): drop them and recompute from the result,
+                # which is what the file path asks the writer to do.
+                metadata = backfill_derived_stats(strip_derived_stats(metadata), result)
+            result = result.replace_schema_metadata(metadata)
         return result
     finally:
         con.close()
+
+
+def _repair_geometry_in_query(
+    con, query: str, geometry_column: str, repair: bool
+) -> tuple[str, bool]:
+    """Run the geometry repair pass, reporting whether it rewrote the query.
+
+    :func:`repair_query_geometry` returns ``query`` unchanged when repair is off,
+    when the column is not repairable in place, and when it counted zero invalid
+    rows; it returns a rewritten query only when at least one row will actually
+    be repaired. That distinction is what decides whether the input's derived
+    stats survive into the output: a pass that changed nothing keeps them, so a
+    file with no invalid geometry is never rescanned for nothing.
+    """
+    repaired_query = repair_query_geometry(con, query, geometry_column, repair=repair)
+    return repaired_query, repaired_query != query
 
 
 def _carry_metadata_to_columns(metadata: dict, columns: list[str]) -> dict | None:
@@ -818,22 +845,29 @@ def _output_stats_are_stale(
     spatial_filter: str | None,
     where: str | None,
     limit: int | None,
+    geometry_repaired: bool = False,
 ) -> bool:
     """True when the input's carried bbox/geometry_types cannot describe the output.
 
-    Two independent reasons:
+    Three independent reasons:
 
     * A row filter (``--bbox``/``--geometry``/``--where``/``--limit``) keeps only
       part of the input, so the carried stats over-cover the result.
     * A glob/directory input merges several files, but ``get_parquet_metadata``
       reads the footer of the FIRST file only — carrying its stats would
       UNDER-cover the merged output, which makes conformant readers skip data.
+    * The repair pass (``--repair-geometry``, on by default) rewrote at least one
+      row: ``ST_MakeValid`` can change a geometry's type (a bowtie ``Polygon``
+      comes back a ``MultiPolygon``) and its extent, so the carried
+      ``geometry_types`` UNDER-declares what the output holds and ``gpio check
+      spec`` fails the file gpio just wrote (#812). A repair pass that found
+      nothing to fix is not a reason: it left every row as it was.
 
-    A single-file, unfiltered column projection keeps its stats.
+    A single-file, unfiltered, unrepaired column projection keeps its stats.
     """
     if spatial_filter or where or limit is not None:
         return True
-    return is_partition_path(input_path)
+    return geometry_repaired or is_partition_path(input_path)
 
 
 def _extract_streaming(
@@ -895,12 +929,13 @@ def _extract_streaming(
         query = _build_query_for_source(source, selected_columns, spatial_filter, where, limit)
 
         # Repair invalid geometry (issue #506) before streaming the write.
-        query = repair_query_geometry(con, query, geom_col, repair=repair_geometry)
+        query, geometry_repaired = _repair_geometry_in_query(con, query, geom_col, repair_geometry)
 
         if verbose:
             debug(f"Streaming extraction query: {query}")
 
-        if _output_stats_are_stale(input_path, spatial_filter, where, limit):
+        # write_output backfills whatever is stripped here from the rows it writes.
+        if _output_stats_are_stale(input_path, spatial_filter, where, limit, geometry_repaired):
             metadata = strip_derived_stats(metadata)
 
         # Write output
@@ -1041,14 +1076,18 @@ def _execute_extraction(
             # silently drop all geo/kv metadata: warn so it is visible.
             warn(f"Could not read input metadata for preservation; skipping: {e}")
 
-        invalidate_derived_stats = _output_stats_are_stale(
-            input_parquet, spatial_filter, where, limit
-        )
-
         # Repair invalid geometry (issue #506). Auto-detects GEOMETRY vs WKB
         # encoding and rewrites the query to repair in place before the write.
+        # Runs before the staleness decision, which depends on its outcome.
+        geometry_repaired = False
         if geometry_col:
-            query = repair_query_geometry(con, query, geometry_col, repair=repair_geometry)
+            query, geometry_repaired = _repair_geometry_in_query(
+                con, query, geometry_col, repair_geometry
+            )
+
+        invalidate_derived_stats = _output_stats_are_stale(
+            input_parquet, spatial_filter, where, limit, geometry_repaired
+        )
 
         # Write output
         write_parquet_with_metadata(

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -43,6 +43,7 @@ from geoparquet_io.core.geo_metadata import (
     backfill_derived_stats,
     prune_geo_metadata_to_columns,
     strip_derived_stats,
+    strip_orientation,
 )
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
@@ -802,8 +803,11 @@ def extract_table(
             if geometry_repaired:
                 # The repair rewrote rows, so the carried stats no longer
                 # describe them (#812): drop them and recompute from the result,
-                # which is what the file path asks the writer to do.
+                # which is what the file path asks the writer to do. A carried
+                # orientation declaration is dropped outright — ST_MakeValid
+                # can rewind rings and gpio does not re-orient.
                 metadata = backfill_derived_stats(strip_derived_stats(metadata), result)
+                metadata = strip_orientation(metadata, geom_col)
             result = result.replace_schema_metadata(metadata)
         return result
     finally:
@@ -937,6 +941,10 @@ def _extract_streaming(
         # write_output backfills whatever is stripped here from the rows it writes.
         if _output_stats_are_stale(input_path, spatial_filter, where, limit, geometry_repaired):
             metadata = strip_derived_stats(metadata)
+        if geometry_repaired:
+            # ST_MakeValid can rewind rings, so a carried orientation
+            # declaration no longer holds; it is dropped, not recomputed.
+            metadata = strip_orientation(metadata, geom_col)
 
         # Write output
         write_output(
@@ -1088,6 +1096,10 @@ def _execute_extraction(
         invalidate_derived_stats = _output_stats_are_stale(
             input_parquet, spatial_filter, where, limit, geometry_repaired
         )
+        if geometry_repaired:
+            # ST_MakeValid can rewind rings, so a carried orientation
+            # declaration no longer holds; it is dropped, not recomputed.
+            metadata = strip_orientation(metadata, geometry_col)
 
         # Write output
         write_parquet_with_metadata(

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -356,6 +356,30 @@ def strip_derived_stats(metadata: dict | None) -> dict | None:
     return _rewrite_geo_metadata(metadata, _drop_derived_stats)
 
 
+def strip_orientation(metadata: dict | None, column: str) -> dict | None:
+    """Return a copy of KV ``metadata`` without ``column``'s ``orientation``.
+
+    A geometry repair (``ST_MakeValid``) can rewind rings — the repaired bowtie
+    of issue #812 comes back with clockwise exterior rings — so a carried
+    ``orientation: "counterclockwise"`` declaration no longer describes the
+    rows. Unlike :data:`DERIVED_STAT_KEYS`, which the write path recomputes,
+    ``orientation`` is only removed: gpio does not re-orient rings, and the key
+    is optional per spec, so absence is the honest value after a rewrite.
+
+    Only ``column``'s entry is touched — a repair runs on one geometry column,
+    and any other column's declaration still holds. Both ``"geo"`` and
+    ``b"geo"`` keys are handled; the input is never mutated.
+    """
+
+    def _drop(geo_dict: dict) -> dict:
+        col_meta = (geo_dict.get("columns") or {}).get(column)
+        if isinstance(col_meta, dict):
+            col_meta.pop("orientation", None)
+        return geo_dict
+
+    return _rewrite_geo_metadata(metadata, _drop)
+
+
 def backfill_derived_stats(
     metadata: dict | None,
     table: pa.Table,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2416,3 +2416,26 @@ class TestOpsPartition:
 
         with pytest.raises(InvalidParameterError, match="auto"):
             getattr(ops, function)(arrow_table, tmp_path / function, auto=True, **kwargs)
+
+
+class TestTableExtractRepairsStats:
+    """``Table.extract`` repairs geometry by default, so it must not carry stale stats."""
+
+    def test_repaired_geometry_types_reach_the_written_file(self, tmp_path):
+        """A repaired bowtie is a MultiPolygon all the way to the written file (#812)."""
+        import json
+
+        from tests.test_extract import _polygon_fixture_table
+
+        # A self-intersecting bowtie declared (correctly, for the input) as a Polygon.
+        source = _polygon_fixture_table("POLYGON ((0 0, 1 1, 1 0, 0 1, 0 0))")
+
+        result = Table(source).extract()
+
+        geo = json.loads(result.to_arrow().schema.metadata[b"geo"])
+        assert geo["columns"]["geometry"]["geometry_types"] == ["MultiPolygon"]
+
+        out = tmp_path / "out.parquet"
+        result.write(out)
+        written = json.loads(pq.read_schema(out).metadata[b"geo"])
+        assert written["columns"]["geometry"]["geometry_types"] == ["MultiPolygon"]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1298,3 +1298,150 @@ class TestExtractTableGeoMetadata:
         result = extract_table(table)
 
         assert _geo_of(result) == geo
+
+
+# A self-intersecting "bowtie" is invalid, and ST_MakeValid splits it into two
+# triangles: repairing it turns a Polygon into a MultiPolygon (issue #812).
+_BOWTIE_WKT = "POLYGON ((0 0, 1 1, 1 0, 0 1, 0 0))"
+_SQUARE_WKT = "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))"
+
+# Deliberately over-wide: the declared bbox of these fixtures does not describe
+# their row, so an output reporting it carried the input's stats over, and an
+# output reporting the tight [0, 0, 1, 1] recomputed them from the rows written.
+_WORLD_BBOX = [-180.0, -90.0, 180.0, 90.0]
+
+
+def _wkb_of(wkt: str) -> bytes:
+    """WKB for a WKT literal, via DuckDB's spatial extension."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial;")
+    try:
+        return con.execute("SELECT ST_AsWKB(ST_GeomFromText(?))", [wkt]).fetchone()[0]
+    finally:
+        con.close()
+
+
+def _polygon_fixture_table(wkt: str) -> pa.Table:
+    """One-row GeoParquet 1.1 table declaring Polygon and a world-wide bbox."""
+    return _table_with_geo(
+        {"id": [1], "geometry": [_wkb_of(wkt)]},
+        {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": ["Polygon"],
+                    "bbox": list(_WORLD_BBOX),
+                }
+            },
+        },
+    )
+
+
+def _write_polygon_fixture(path: Path, wkt: str) -> Path:
+    """Write the fixture table of :func:`_polygon_fixture_table` to ``path``."""
+    import pyarrow.parquet as pq
+
+    pq.write_table(_polygon_fixture_table(wkt), str(path))
+    return path
+
+
+def _geo_column_of_file(path: Path) -> dict:
+    """The primary geometry column's geo metadata entry of a written file."""
+    import pyarrow.parquet as pq
+
+    geo = json.loads(pq.read_schema(str(path)).metadata[b"geo"])
+    return geo["columns"][geo["primary_column"]]
+
+
+class TestRepairInvalidatesCarriedStats:
+    """A geometry repair rewrites rows, so carried stats must be recomputed (#812).
+
+    ``--repair-geometry`` is on by default and ``ST_MakeValid`` can change a
+    geometry's type, so an unfiltered extract that carried the input's
+    ``geometry_types``/``bbox`` verbatim shipped an output declaring ``Polygon``
+    while holding a ``MultiPolygon`` — which ``gpio check spec`` then failed.
+    """
+
+    @pytest.fixture
+    def bowtie_file(self, tmp_path):
+        return _write_polygon_fixture(tmp_path / "bowtie.parquet", _BOWTIE_WKT)
+
+    @pytest.fixture
+    def square_file(self, tmp_path):
+        return _write_polygon_fixture(tmp_path / "square.parquet", _SQUARE_WKT)
+
+    def test_repair_recomputes_geometry_types_and_bbox(self, bowtie_file, tmp_path):
+        from geoparquet_io.core.validate import validate_geoparquet
+
+        assert _geo_column_of_file(bowtie_file)["geometry_types"] == ["Polygon"]
+
+        out = tmp_path / "out.parquet"
+        extract(str(bowtie_file), str(out))
+
+        col = _geo_column_of_file(out)
+        assert col["geometry_types"] == ["MultiPolygon"]
+        assert col["bbox"] == [0.0, 0.0, 1.0, 1.0]
+        result = validate_geoparquet(str(out))
+        assert result.is_valid, [c.message for c in result.checks if not c.passed]
+
+    def test_no_repair_keeps_the_carried_stats(self, bowtie_file, tmp_path):
+        """Repair off leaves the rows alone, so the carried stats still describe them."""
+        out = tmp_path / "out.parquet"
+        extract(str(bowtie_file), str(out), repair_geometry=False)
+
+        col = _geo_column_of_file(out)
+        assert col["geometry_types"] == ["Polygon"]
+        assert col["bbox"] == _WORLD_BBOX
+
+    def test_nothing_to_repair_keeps_the_carried_stats(self, square_file, tmp_path):
+        """Repair on but nothing invalid: no rewrite happened, so no rescan either."""
+        out = tmp_path / "out.parquet"
+        extract(str(square_file), str(out))
+
+        col = _geo_column_of_file(out)
+        assert col["geometry_types"] == ["Polygon"]
+        assert col["bbox"] == _WORLD_BBOX
+
+    def test_streaming_output_recomputes_stats(self, bowtie_file, monkeypatch):
+        """The stdout path strips the stale stats and backfills them from the rows."""
+        import io
+        from unittest import mock
+
+        import pyarrow.ipc as ipc
+
+        buffer = io.BytesIO()
+        mock_stdout = mock.MagicMock()
+        mock_stdout.isatty.return_value = False
+        mock_stdout.buffer = buffer
+        monkeypatch.setattr("sys.stdout", mock_stdout)
+
+        extract(str(bowtie_file), "-")
+
+        buffer.seek(0)
+        col = _geo_of(ipc.open_stream(buffer).read_all())["columns"]["geometry"]
+        assert col["geometry_types"] == ["MultiPolygon"]
+        assert col["bbox"] == [0.0, 0.0, 1.0, 1.0]
+
+    def test_extract_table_repair_recomputes_stats(self):
+        """The in-memory (Python API) path carries the same metadata and must fix it too."""
+        result = extract_table(_polygon_fixture_table(_BOWTIE_WKT))
+
+        col = _geo_of(result)["columns"]["geometry"]
+        assert col["geometry_types"] == ["MultiPolygon"]
+        assert col["bbox"] == [0.0, 0.0, 1.0, 1.0]
+
+    def test_extract_table_no_repair_keeps_the_carried_stats(self):
+        result = extract_table(_polygon_fixture_table(_BOWTIE_WKT), repair_geometry=False)
+
+        col = _geo_of(result)["columns"]["geometry"]
+        assert col["geometry_types"] == ["Polygon"]
+        assert col["bbox"] == _WORLD_BBOX
+
+    def test_extract_table_nothing_to_repair_keeps_the_carried_stats(self):
+        result = extract_table(_polygon_fixture_table(_SQUARE_WKT))
+
+        col = _geo_of(result)["columns"]["geometry"]
+        assert col["geometry_types"] == ["Polygon"]
+        assert col["bbox"] == _WORLD_BBOX

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1321,29 +1321,30 @@ def _wkb_of(wkt: str) -> bytes:
         con.close()
 
 
-def _polygon_fixture_table(wkt: str) -> pa.Table:
+def _polygon_fixture_table(wkt: str, orientation: str | None = None) -> pa.Table:
     """One-row GeoParquet 1.1 table declaring Polygon and a world-wide bbox."""
+    column: dict = {
+        "encoding": "WKB",
+        "geometry_types": ["Polygon"],
+        "bbox": list(_WORLD_BBOX),
+    }
+    if orientation is not None:
+        column["orientation"] = orientation
     return _table_with_geo(
         {"id": [1], "geometry": [_wkb_of(wkt)]},
         {
             "version": "1.1.0",
             "primary_column": "geometry",
-            "columns": {
-                "geometry": {
-                    "encoding": "WKB",
-                    "geometry_types": ["Polygon"],
-                    "bbox": list(_WORLD_BBOX),
-                }
-            },
+            "columns": {"geometry": column},
         },
     )
 
 
-def _write_polygon_fixture(path: Path, wkt: str) -> Path:
+def _write_polygon_fixture(path: Path, wkt: str, orientation: str | None = None) -> Path:
     """Write the fixture table of :func:`_polygon_fixture_table` to ``path``."""
     import pyarrow.parquet as pq
 
-    pq.write_table(_polygon_fixture_table(wkt), str(path))
+    pq.write_table(_polygon_fixture_table(wkt, orientation), str(path))
     return path
 
 
@@ -1445,3 +1446,83 @@ class TestRepairInvalidatesCarriedStats:
         col = _geo_of(result)["columns"]["geometry"]
         assert col["geometry_types"] == ["Polygon"]
         assert col["bbox"] == _WORLD_BBOX
+
+
+class TestRepairDropsCarriedOrientation:
+    """A geometry repair can rewind rings, so a carried ``orientation`` must go.
+
+    ``ST_MakeValid`` gives the repaired bowtie clockwise exterior rings, so a
+    carried ``orientation: "counterclockwise"`` declaration would be factually
+    false in the output. Orientation is optional per spec and gpio does not
+    re-orient, so absence is the honest value — dropped only when the repair
+    actually rewrote a row, on the same condition that recomputes bbox and
+    geometry_types.
+    """
+
+    def test_repair_drops_the_carried_orientation(self, tmp_path):
+        src = _write_polygon_fixture(
+            tmp_path / "bowtie.parquet", _BOWTIE_WKT, orientation="counterclockwise"
+        )
+
+        out = tmp_path / "out.parquet"
+        extract(str(src), str(out))
+
+        assert "orientation" not in _geo_column_of_file(out)
+
+    def test_no_repair_keeps_the_carried_orientation(self, tmp_path):
+        """Repair off leaves the rows alone, so the declaration still holds."""
+        src = _write_polygon_fixture(
+            tmp_path / "bowtie.parquet", _BOWTIE_WKT, orientation="counterclockwise"
+        )
+
+        out = tmp_path / "out.parquet"
+        extract(str(src), str(out), repair_geometry=False)
+
+        assert _geo_column_of_file(out)["orientation"] == "counterclockwise"
+
+    def test_nothing_to_repair_keeps_the_carried_orientation(self, tmp_path):
+        """Repair on but nothing invalid: no ring was rewound."""
+        src = _write_polygon_fixture(
+            tmp_path / "square.parquet", _SQUARE_WKT, orientation="counterclockwise"
+        )
+
+        out = tmp_path / "out.parquet"
+        extract(str(src), str(out))
+
+        assert _geo_column_of_file(out)["orientation"] == "counterclockwise"
+
+    def test_streaming_repair_drops_the_carried_orientation(self, tmp_path, monkeypatch):
+        import io
+        from unittest import mock
+
+        import pyarrow.ipc as ipc
+
+        src = _write_polygon_fixture(
+            tmp_path / "bowtie.parquet", _BOWTIE_WKT, orientation="counterclockwise"
+        )
+
+        buffer = io.BytesIO()
+        mock_stdout = mock.MagicMock()
+        mock_stdout.isatty.return_value = False
+        mock_stdout.buffer = buffer
+        monkeypatch.setattr("sys.stdout", mock_stdout)
+
+        extract(str(src), "-")
+
+        buffer.seek(0)
+        col = _geo_of(ipc.open_stream(buffer).read_all())["columns"]["geometry"]
+        assert "orientation" not in col
+
+    def test_extract_table_repair_drops_the_carried_orientation(self):
+        result = extract_table(_polygon_fixture_table(_BOWTIE_WKT, orientation="counterclockwise"))
+
+        assert "orientation" not in _geo_of(result)["columns"]["geometry"]
+
+    def test_extract_table_no_repair_keeps_the_carried_orientation(self):
+        result = extract_table(
+            _polygon_fixture_table(_BOWTIE_WKT, orientation="counterclockwise"),
+            repair_geometry=False,
+        )
+
+        col = _geo_of(result)["columns"]["geometry"]
+        assert col["orientation"] == "counterclockwise"


### PR DESCRIPTION
## What changed

`gpio extract` now treats a geometry repair that actually rewrote rows as a
reason to invalidate the input's carried `bbox`/`geometry_types`.

- `_repair_geometry_in_query()` (`core/extract.py`) wraps `repair_query_geometry`
  and reports whether it rewrote the query. That helper returns the query
  unchanged when repair is off, when the column is not repairable in place, and
  when it counted **zero** invalid rows — so "query changed" is exactly "at
  least one row will be repaired".
- `_output_stats_are_stale()` gains that flag as a third independent reason,
  alongside a row filter and a glob/directory input.
- The file path and the streaming path use the existing mechanism: the stats are
  stripped and the writer recomputes them from the rows it writes.
- The in-memory `extract_table()` path (which `Table.extract()` delegates to)
  had the same bug and no writer to lean on, so it strips and backfills its own
  carried metadata with `backfill_derived_stats` from #801.

A repair pass that found nothing invalid changes no row and keeps the carried
stats, so a clean file is never rescanned for nothing.

Docs: the "Metadata `bbox` and `geometry_types` describe the output" note in
`docs/guide/extract.md` gains the repair case.

## Why

`--repair-geometry` is **on by default** and `ST_MakeValid` can change a
geometry's type: a self-intersecting bowtie `Polygon` comes back a
`MultiPolygon`. The repair pass was not one of the staleness reasons, so an
unfiltered extract looked like a straight copy and carried the input's
`geometry_types: ["Polygon"]` onto an output holding a `MultiPolygon` —
`gpio check spec` then failed the file gpio itself had just written. `bbox` was
exposed by the same path.

## Verification

The issue's repro fixture, built with `write_parquet_with_metadata` (declares
`geometry_types: ["Polygon"]`, correctly, for the input).

Before (on `main`):

```console
$ gpio extract bowtie.parquet out.parquet
Extracting rows...
Repaired 1 invalid geometry
Extracted 1 rows (out of 1 total) to out.parquet

$ python -c "import json,pyarrow.parquet as pq; print(json.loads(pq.read_schema('out.parquet').metadata[b'geo'])['columns'])"
{'geometry': {'encoding': 'WKB', 'bbox': [0.0, 0.0, 1.0, 1.0], 'geometry_types': ['Polygon']}}

$ gpio check spec out.parquet
...
  ✗ found undeclared geometry types: {'MultiPolygon'} (1 checked)
      Declared: {'Polygon'}, Found: {'MultiPolygon'}
Summary: 23 passed, 0 warnings, 1 failed
```

After (this branch):

```console
$ gpio extract bowtie.parquet out.parquet
Extracting rows...
Repaired 1 invalid geometry
Extracted 1 rows (out of 1 total) to out.parquet

$ python -c "import json,pyarrow.parquet as pq; print(json.loads(pq.read_schema('out.parquet').metadata[b'geo'])['columns'])"
{'geometry': {'encoding': 'WKB', 'bbox': [0.0, 0.0, 1.0, 1.0], 'geometry_types': ['MultiPolygon']}}

$ gpio check spec out.parquet
...
Data Validation:
  ✓ all geometry values match "WKB" encoding (1 checked)
  ✓ all geometry types match declared "geometry_types" (1 checked)
  ○ no orientation specified, skipping check
  ✓ all geometries fall within declared bbox (1 checked)
  ✓ coordinates within valid bounds for null (CRS unknown) (1 checked)
GeoParquet 1.1:
  ✓ column "geometry" has no covering (optional)
  ✓ file extension is ".parquet"

Summary: 24 passed, 0 warnings, 0 failed
```

### Tests

Eight new tests, written first and watched fail. They cover all three write
paths plus the `Table` front door, and — because the fixtures declare a
deliberately over-wide `bbox` of `[-180, -90, 180, 90]` — they distinguish
*carried* stats from *recomputed* ones for `bbox` as well as `geometry_types`.

Failing before the fix (the three repair paths):

```console
$ uv run pytest tests/test_extract.py -q -k RepairInvalidates
tests/test_extract.py F..FF..                                            [100%]
FAILED tests/test_extract.py::TestRepairInvalidatesCarriedStats::test_repair_recomputes_geometry_types_and_bbox
FAILED tests/test_extract.py::TestRepairInvalidatesCarriedStats::test_streaming_output_recomputes_stats
FAILED tests/test_extract.py::TestRepairInvalidatesCarriedStats::test_extract_table_repair_recomputes_stats
================= 3 failed, 4 passed, 103 deselected in 3.06s ==================

$ uv run pytest tests/test_api.py -q -k TableExtractRepairsStats
E   AssertionError: assert ['Polygon'] == ['MultiPolygon']
====================== 1 failed, 184 deselected in 0.65s =======================
```

The four passing ones are the "keeps the carried stats" cases (repair off,
nothing to repair) — they were green before and stay green, which is what pins
the fix to *actual* repairs.

Passing after:

```console
$ uv run pytest tests/test_extract.py -q -k RepairInvalidates
====================== 7 passed, 103 deselected in 1.20s =======================

$ uv run pytest tests/test_api.py -q -k TableExtractRepairsStats
====================== 1 passed, 184 deselected in 0.76s =======================

$ uv run pytest tests/test_extract.py -q
======================= 110 passed in 164.84s (0:02:44) ========================
```

Full fast lane:

```console
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
= 3 failed, 5402 passed, 65 skipped, 2 xfailed, 105 warnings in 479.31s (0:07:59) =
FAILED tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe
FAILED tests/test_pipe_integration.py::TestTwoStagePipelines::test_add_bbox_to_sort_hilbert
FAILED tests/test_pipe_integration.py::TestExtractIntoPartition::test_full_processing_pipeline_chain
```

All three are the known cold-run subprocess-timeout flakes; serially they pass:

```console
$ uv run pytest tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe tests/test_pipe_integration.py::TestTwoStagePipelines::test_add_bbox_to_sort_hilbert tests/test_pipe_integration.py::TestExtractIntoPartition::test_full_processing_pipeline_chain -q
============================== 3 passed in 18.99s ==============================
```

`uv run pre-commit run --all-files` and `--hook-stage pre-push` both clean
(deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests).

Closes #812. Reuses `backfill_derived_stats` from #801, which fixed the piped
stream dropping `geometry_types` entirely and deliberately left this behavior
change for its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Geometry repair now reports whether extracted geometries were changed.
  - When repairs modify rows, `geometry_types` and `bbox` metadata are recomputed, and affected orientation metadata is removed.
  - Unchanged geometry no longer invalidates existing metadata.

- **Documentation**
  - Updated extraction guidance to explain default geometry repair and metadata behavior.

- **Bug Fixes**
  - Corrected metadata for repaired invalid geometries, including cases where polygon repairs produce multipolygons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->