### PR TITLE
fix(remote)!: take an http(s) URL as already percent-encoded instead of re-encoding it

### DIFF
--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -417,7 +417,7 @@ gpio convert s3://bucket/input.parquet local-optimized.parquet
 gpio convert s3://bucket/data.parquet local.gpkg
 ```
 
-See [Remote Files Guide](remote-files.md) for authentication setup.
+A URL is used exactly as you paste it — gpio takes it as already percent-encoded and never re-encodes it. See [Remote Files Guide](remote-files.md) for authentication setup.
 
 ## Options
 

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -171,7 +171,7 @@ Filter features by a rectangular bounding box. The bbox is specified as `xmin,ym
     ```
 
 !!! note "Remote file support"
-    S3, GCS, Azure, and HTTPS URLs are supported via DuckDB's httpfs extension. See the [Remote Files guide](remote-files.md) for credential configuration.
+    S3, GCS, Azure, and HTTPS URLs are supported via DuckDB's httpfs extension. A URL is used exactly as you paste it — gpio takes it as already percent-encoded and never re-encodes it. See the [Remote Files guide](remote-files.md) for credential configuration.
 
 **CRS Awareness**: The tool detects coordinate system mismatches. If your bbox looks like lat/long coordinates but the data uses a projected CRS, you'll get a helpful warning showing the data's actual bounds.
 

--- a/docs/guide/remote-files.md
+++ b/docs/guide/remote-files.md
@@ -12,6 +12,10 @@ gpio uses different libraries for reads and writes:
 
 The `--aws-profile` global flag is available on all commands for AWS authentication. See also `--s3-endpoint`, `--s3-region`, and `--s3-no-ssl` for S3-compatible storage.
 
+### URLs are taken as-is
+
+A URL you pass to gpio is used exactly as you typed it: gpio assumes it is already percent-encoded, as a URL is by definition, and never re-encodes it. Paste the URL that works in your browser or in `curl` — `gpio inspect meta 'https://example.com/my%20file.parquet'` requests `my%20file.parquet`, not `my%2520file.parquet`. A URL containing a raw space, bracket or other character that has to be escaped is yours to encode before passing it in.
+
 ### gpio publish upload
 
 For more control over uploads, use `gpio publish upload` which provides:
@@ -220,6 +224,7 @@ See [Command Piping](piping.md) for more streaming patterns.
 ## Notes
 
 - Remote writes use temporary local storage (~2× output file size required)
+- URLs are passed through unchanged; encode them yourself if they contain spaces or other reserved characters
 - HTTPS wildcards (`*.parquet`) not supported
 - For very large files (>10 GB), consider processing locally for better performance
 - S3-compatible endpoints work with all commands via `--s3-endpoint`

--- a/geoparquet_io/core/file_utils.py
+++ b/geoparquet_io/core/file_utils.py
@@ -4,7 +4,6 @@ File path utilities for GeoParquet files.
 
 import glob as glob_module
 import os
-import urllib.parse
 from pathlib import Path
 
 from geoparquet_io.core.duckdb_utils import _escape_sql_string
@@ -219,10 +218,19 @@ def resolve_file_url(file_path, verbose=False):
     """
     Validate a path and resolve it to the URL readers should open.
 
-    Percent-encodes HTTP(S) URLs and checks that a local path exists, but does
-    **not** escape it for SQL -- use this for anything that opens the file
-    directly (fsspec, pyarrow, metadata helpers). :func:`safe_file_url` is the
-    SQL-facing variant, and it is the single point at which a path is escaped.
+    A remote URL is passed through **verbatim**: per RFC 3986 a URL already *is*
+    the percent-encoded form, so gpio takes the one the user pasted as-is rather
+    than encoding it again. Encoding here used to turn a browser-copied
+    ``my%20file.parquet`` into ``my%2520file.parquet`` and 404 (#825); ``%20``
+    (an encoded space) and ``%2520`` (a name containing ``%20``) cannot be told
+    apart from the string, so -- as with SQL escaping (#718) -- the value is
+    transformed exactly once, at the boundary where its state is known. A URL
+    with a raw space or bracket in it is now the caller's to encode.
+
+    Local paths are checked for existence. Nothing here escapes the result for
+    SQL -- use this for anything that opens the file directly (fsspec, pyarrow,
+    metadata helpers). :func:`safe_file_url` is the SQL-facing variant, and it
+    is the single point at which a path is escaped.
 
     Args:
         file_path: Local path or remote URL
@@ -234,18 +242,10 @@ def resolve_file_url(file_path, verbose=False):
     from geoparquet_io.core.remote import is_remote_url
 
     if is_remote_url(file_path):
-        if file_path.startswith(("http://", "https://")):
-            parsed = urllib.parse.urlparse(file_path)
-            duckdb_safe_chars = "/*?[]=,"
-            encoded_path = urllib.parse.quote(parsed.path, safe=duckdb_safe_chars)
-            resolved = parsed._replace(path=encoded_path).geturl()
-        else:
-            resolved = file_path
-
         if verbose:
             protocol = file_path.split("://")[0].upper() if "://" in file_path else "HTTP"
-            debug(f"Reading from {protocol}: {resolved}")
-        return resolved
+            debug(f"Reading from {protocol}: {file_path}")
+        return file_path
 
     if not has_glob_pattern(file_path) and not os.path.exists(file_path):
         raise FileNotFoundGeoParquetError(file_path)
@@ -256,8 +256,10 @@ def safe_file_url(file_path, verbose=False):
     """
     Prepare a file path for safe use in SQL queries.
 
-    Handles URL encoding for HTTP(S) URLs and escapes single quotes
-    to prevent SQL injection when paths are interpolated into queries.
+    Resolves the path with :func:`resolve_file_url` -- which takes a remote URL
+    as already percent-encoded (#825) -- and escapes single quotes to prevent
+    SQL injection when paths are interpolated into queries. That escape is the
+    only transform applied to the value.
 
     Escaping is **not** idempotent: the result is only ever interpolated into
     SQL, never re-escaped and never handed back to a filesystem API. Pass the

--- a/geoparquet_io/core/file_utils.py
+++ b/geoparquet_io/core/file_utils.py
@@ -224,8 +224,10 @@ def resolve_file_url(file_path, verbose=False):
     ``my%20file.parquet`` into ``my%2520file.parquet`` and 404 (#825); ``%20``
     (an encoded space) and ``%2520`` (a name containing ``%20``) cannot be told
     apart from the string, so -- as with SQL escaping (#718) -- the value is
-    transformed exactly once, at the boundary where its state is known. A URL
-    with a raw space or bracket in it is now the caller's to encode.
+    transformed exactly once, at the boundary where its state is known. What an
+    un-encoded URL (raw space, bracket) does is no longer defined by gpio but
+    by the underlying reader -- today's HTTP stacks happen to encode a raw
+    space themselves -- so encode it yourself rather than rely on that.
 
     Local paths are checked for existence. Nothing here escapes the result for
     SQL -- use this for anything that opens the file directly (fsspec, pyarrow,

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -708,13 +708,19 @@ class TestValidateParquetExtension:
 class TestSafeFileUrl:
     """Tests for safe_file_url function."""
 
-    def test_http_url_encoding(self):
-        """Test that HTTP URLs with special characters are encoded properly."""
+    def test_http_url_is_taken_as_already_encoded(self):
+        """An http(s) URL is passed through verbatim, encoded or not (#825).
 
-        # URL with spaces and special chars
-        result = safe_file_url("https://example.com/path with spaces/file.parquet")
-        assert "path%20with%20spaces" in result
-        assert "example.com" in result
+        gpio used to percent-encode the path, which double-encoded a URL the
+        user had copied from a browser. It now encodes nothing -- including
+        the raw space below, which is the caller's to encode.
+        """
+
+        already_encoded = "https://example.com/path%20with%20spaces/file.parquet"
+        assert safe_file_url(already_encoded) == already_encoded
+
+        raw_space = "https://example.com/path with spaces/file.parquet"
+        assert safe_file_url(raw_space) == raw_space
 
     def test_http_preserves_duckdb_safe_chars(self):
         """Test that DuckDB-safe chars like * ? [ ] are preserved."""

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -482,11 +482,10 @@ class TestSafeFileUrl:
         with pytest.raises(FileNotFoundGeoParquetError):
             safe_file_url(str(tmp_path / "nonexistent.parquet"))
 
-    def test_remote_url_encoding(self):
-        """Remote URLs are properly encoded."""
+    def test_remote_url_passes_through(self):
+        """Remote URLs are resolved without being altered."""
         url = "https://example.com/path/to/file.parquet"
-        result = safe_file_url(url)
-        assert "example.com" in result
+        assert safe_file_url(url) == url
 
     def test_s3_url_passes_through(self):
         """S3 URLs pass through unchanged (except quote escaping)."""
@@ -494,12 +493,17 @@ class TestSafeFileUrl:
         result = safe_file_url(url)
         assert result == url
 
-    def test_http_url_with_special_chars(self):
-        """HTTP URLs with special characters are encoded."""
-        url = "https://example.com/path with spaces/file.parquet"
-        result = safe_file_url(url)
-        # Spaces should be encoded
-        assert "%20" in result or " " not in result.split("://")[1]
+    def test_http_url_with_special_chars_is_taken_as_given(self):
+        """HTTP URLs are taken as already percent-encoded (#825).
+
+        Both a valid encoded URL and one with a raw space reach the reader
+        unchanged; see tests/test_remote_url_encoding.py for the contract.
+        """
+        encoded = "https://example.com/path%20with%20spaces/file.parquet"
+        assert safe_file_url(encoded) == encoded
+
+        raw = "https://example.com/path with spaces/file.parquet"
+        assert safe_file_url(raw) == raw
 
     def test_sql_injection_prevention(self, tmp_path):
         """SQL injection via single quotes is prevented."""

--- a/tests/test_remote_files.py
+++ b/tests/test_remote_files.py
@@ -75,11 +75,15 @@ class TestSafeFileURL:
         url = "https://example.com/path/file.parquet"
         assert safe_file_url(url) == url
 
-    def test_safe_file_url_https_with_spaces(self):
-        """Test HTTPS URL with spaces gets encoded."""
+    def test_safe_file_url_https_percent_encoded(self):
+        """An already-encoded HTTPS URL is not encoded a second time (#825)."""
+        url = "https://example.com/path%20with%20spaces/file.parquet"
+        assert safe_file_url(url) == url
+
+    def test_safe_file_url_https_with_raw_spaces_is_not_encoded(self):
+        """BREAKING (#825): a raw space is passed through, not encoded."""
         url = "https://example.com/path with spaces/file.parquet"
-        result = safe_file_url(url)
-        assert "path%20with%20spaces" in result
+        assert safe_file_url(url) == url
 
     def test_safe_file_url_s3(self):
         """Test S3 URL handling."""

--- a/tests/test_remote_url_encoding.py
+++ b/tests/test_remote_url_encoding.py
@@ -79,6 +79,11 @@ class TestHttpUrlIsTakenAsEncoded:
         url = "https://example.com/my<file>.parquet"
         assert resolve_file_url(url) == url
 
+    def test_verbose_logs_and_returns_the_url_unchanged(self):
+        """The verbose debug line reports the URL as given, not a re-encoding."""
+        url = "https://example.com/my%20file.parquet"
+        assert resolve_file_url(url, verbose=True) == url
+
     def test_non_http_remote_schemes_unchanged(self):
         """S3/GCS/Azure URLs were never encoded and still are not."""
         for url in (

--- a/tests/test_remote_url_encoding.py
+++ b/tests/test_remote_url_encoding.py
@@ -1,0 +1,188 @@
+"""
+An http(s) URL is taken as already percent-encoded (#825).
+
+``resolve_file_url()`` used to percent-encode the path component of every
+HTTP(S) URL, with ``%`` absent from its ``safe`` set. A URL the user pasted
+from a browser -- ``https://example.com/my%20file.parquet`` -- was therefore
+encoded a second time into ``my%2520file.parquet``, and the server answered
+404 for a file it holds.
+
+There is no way to tell ``my%20file.parquet`` (an encoded space) from
+``my%2520file.parquet`` (a file whose name really contains ``%20``) by looking
+at the string, which is the same shape as the SQL-escaping problem #718/#803
+solved: transform exactly once, at a boundary where the input's state is known.
+Per RFC 3986 a URL *is* the encoded form, so the boundary is the caller: gpio
+passes an http(s) URL through verbatim and encodes nothing.
+
+The deliberate cost is the breaking side, pinned below: a URL containing a raw
+space or bracket is no longer encoded for the user either.
+"""
+
+import functools
+import http.server
+import shutil
+import threading
+from pathlib import Path
+
+import pytest
+
+from geoparquet_io.core.file_utils import resolve_file_url, safe_file_url
+
+# =============================================================================
+# resolve_file_url() / safe_file_url(): an http(s) URL is passed through
+# =============================================================================
+
+
+class TestHttpUrlIsTakenAsEncoded:
+    """A user-supplied http(s) URL reaches the reader byte-for-byte."""
+
+    def test_percent_encoded_space_is_not_re_encoded(self):
+        """The regression in #825: ``%20`` must not become ``%2520``."""
+        url = "https://example.com/my%20file.parquet"
+        assert resolve_file_url(url) == url
+
+    def test_literal_percent_20_in_a_filename_survives(self):
+        """A file genuinely named ``my%20file.parquet`` is requested as written.
+
+        Its URL spells the ``%`` as ``%25``; encoding again would ask for
+        ``my%252520file.parquet``.
+        """
+        url = "https://example.com/my%2520file.parquet"
+        assert resolve_file_url(url) == url
+
+    def test_plain_url_unchanged(self):
+        url = "https://example.com/path/to/file.parquet"
+        assert resolve_file_url(url) == url
+
+    def test_glob_and_query_string_unchanged(self):
+        """Globs, hive ``=`` and a query string (presigned URLs) survive."""
+        url = "https://example.com/data/state=CA/*.parquet?X-Amz-Signature=abc%2Fdef"
+        assert resolve_file_url(url) == url
+
+    def test_http_scheme_too(self):
+        url = "http://example.com/my%20file.parquet"
+        assert resolve_file_url(url) == url
+
+    def test_raw_space_is_now_passed_through_unencoded_breaking_change(self):
+        """BREAKING (#825): gpio no longer encodes a raw space for the user.
+
+        A URL with a literal space is not a valid URL per RFC 3986. gpio used
+        to paper over that; it now hands the string to the reader as given, so
+        this is the case that changes behaviour for existing callers. Encode
+        the URL before passing it in.
+        """
+        url = "https://example.com/my file.parquet"
+        assert resolve_file_url(url) == url
+
+    def test_raw_bracket_is_now_passed_through_unencoded_breaking_change(self):
+        """BREAKING (#825): the same for any other character gpio used to encode."""
+        url = "https://example.com/my<file>.parquet"
+        assert resolve_file_url(url) == url
+
+    def test_non_http_remote_schemes_unchanged(self):
+        """S3/GCS/Azure URLs were never encoded and still are not."""
+        for url in (
+            "s3://bucket/my%20file.parquet",
+            "gs://bucket/my%20file.parquet",
+            "az://container/my%20file.parquet",
+        ):
+            assert resolve_file_url(url) == url
+
+
+class TestSafeFileUrlTransformsOnce:
+    """``safe_file_url`` adds SQL escaping and nothing else."""
+
+    def test_percent_encoded_url_is_neither_re_encoded_nor_escaped(self):
+        url = "https://example.com/my%20file.parquet"
+        assert safe_file_url(url) == url
+
+    def test_literal_percent_20_in_a_filename_survives(self):
+        url = "https://example.com/my%2520file.parquet"
+        assert safe_file_url(url) == url
+
+    def test_raw_space_is_now_passed_through_unencoded_breaking_change(self):
+        """BREAKING (#825): the SQL-facing wrapper does not encode either."""
+        url = "https://example.com/my file.parquet"
+        assert safe_file_url(url) == url
+
+    def test_only_the_sql_quote_is_transformed(self):
+        """The one transform ``safe_file_url`` still applies is SQL escaping."""
+        url = "https://example.com/o'brien%20data.parquet"
+        assert safe_file_url(url) == "https://example.com/o''brien%20data.parquet"
+
+
+# =============================================================================
+# End to end: the server sees the path the user typed
+# =============================================================================
+
+
+class _RecordingHandler(http.server.SimpleHTTPRequestHandler):
+    """Static file handler that records every raw request path it is given."""
+
+    seen: list[str] = []
+
+    def do_GET(self):  # noqa: N802 - http.server API
+        type(self).seen.append(self.path)
+        super().do_GET()
+
+    def do_HEAD(self):  # noqa: N802 - http.server API
+        type(self).seen.append(self.path)
+        super().do_HEAD()
+
+    def log_message(self, *args):  # pragma: no cover - silence stderr noise
+        pass
+
+
+@pytest.fixture
+def recording_http_server(tmp_path):
+    """Serve a directory over loopback HTTP, recording the raw paths requested.
+
+    Yields ``(base_url, served_dir, seen_paths)``. No outside network is
+    touched, so this is not a ``network`` test.
+    """
+
+    served = tmp_path / "served"
+    served.mkdir()
+
+    handler_cls = type("_Handler", (_RecordingHandler,), {"seen": []})
+    httpd = http.server.ThreadingHTTPServer(
+        ("127.0.0.1", 0), functools.partial(handler_cls, directory=str(served))
+    )
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{httpd.server_address[1]}", served, handler_cls.seen
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.integration
+class TestRemoteReadRequestsTheUrlVerbatim:
+    """Prove the fix on a real read, not just on the helper's return value."""
+
+    def test_inspect_meta_requests_the_encoded_path_as_given(
+        self, recording_http_server, buildings_test_file
+    ):
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        base_url, served, seen = recording_http_server
+        shutil.copyfile(buildings_test_file, served / "my file.parquet")
+
+        result = CliRunner().invoke(cli, ["inspect", "meta", f"{base_url}/my%20file.parquet"])
+
+        assert seen, "the server was never contacted"
+        # Before the fix the server saw /my%2520file.parquet and answered 404.
+        assert all(path.startswith("/my%20file.parquet") for path in seen), seen
+        assert result.exit_code == 0, result.output
+
+
+def test_no_module_percent_encodes_a_read_path():
+    """Guard the deletion: ``file_utils`` no longer encodes anything (#825)."""
+    source = (Path(__file__).parents[1] / "geoparquet_io" / "core" / "file_utils.py").read_text(
+        encoding="utf-8"
+    )
+    assert "quote(" not in source, "file_utils must not percent-encode a path; see #825"


### PR DESCRIPTION
## What changed

`resolve_file_url()` no longer percent-encodes anything. An `http(s)` URL is now passed through to the reader byte-for-byte, exactly as the user typed it; `s3://`, `gs://` and `az://` URLs were never encoded and still are not. `safe_file_url()` keeps its one remaining transform, the SQL escape, so a path is still transformed exactly once.

- `geoparquet_io/core/file_utils.py`: the `urllib.parse.quote(parsed.path, safe="/*?[]=,")` branch is deleted, along with the now-unused `urllib.parse` import. Both docstrings are rewritten to describe what the functions actually do.
- `tests/test_remote_url_encoding.py` (new): the pass-through contract for `resolve_file_url` / `safe_file_url`, including a literal `%` in a filename, and an end-to-end read against a loopback `http.server` that records the raw request path.
- Three existing tests that pinned the old encoding (`test_file_utils.py`, `test_remote_files.py`, `test_common_utils.py`) are rewritten to the new contract.
- `docs/guide/remote-files.md` gains a short "URLs are taken as-is" section and a Notes bullet; `extract.md` and `convert.md` get one line each at their existing remote-file notes.

## Why

`%` was not in the `safe` set, and nothing checked whether the input was already encoded, so a URL copied out of a browser was encoded a second time:

```
https://example.com/my%20file.parquet  ->  https://example.com/my%2520file.parquet
```

The server was then asked for a file literally named `my%20file.parquet` and answered 404 — on a URL that works in a browser and in `curl`, so the failure was unattributable from the user's side. Every remote-reading command (`inspect`, `check`, `convert`, `add`, `sort`, `extract`) goes through this helper.

`my%20file.parquet` (an encoded space) and `my%2520file.parquet` (a file whose name really contains `%20`) cannot be told apart by looking at the string — the same shape as the SQL-escaping problem #718/#803 solved, and the same answer: transform exactly once, at a boundary where the input's state is known. Per RFC 3986 a URL already *is* the percent-encoded form, so that boundary is the caller and the fix is a deletion.

**The breaking side, stated plainly:** a URL containing a raw space, bracket or other reserved character is no longer encoded on the user's behalf. `gpio inspect meta 'https://example.com/my file.parquet'` used to be papered over into `my%20file.parquet`; what happens to it is now defined by the underlying reader, not by gpio (review probing showed today's HTTP stacks — yarl/aiohttp and DuckDB httpfs — encode a raw space themselves, so that particular case still works; a raw `%` in a filename is where behavior actually changes). Anyone relying on gpio encoding for them should encode the URL before passing it in. This is why the title carries `!` — the input contract for a user-supplied argument changes, even though the code change is a deletion. Tests pin the new behaviour explicitly (`test_raw_space_is_now_passed_through_unencoded_breaking_change`), and the guides say it.

The audit for other transforms on the read path found none to fix: `core/carto.py` encodes a SQL string into a query parameter it builds itself, `core/layers.py` encodes a *local* path into a `file:` SQLite URI, `core/wfs.py` builds its own query strings, and `core/partition/staging.py` *decodes* hive values DuckDB wrote. None of them touches a user-supplied file URL, and each is a single transform at a known boundary.

## Verification

Before (on `main`), with a loopback server recording the raw request path and a file named `my file.parquet` on disk:

```
URL: http://127.0.0.1:60288/my%20file.parquet
resolve_file_url -> http://127.0.0.1:60288/my%2520file.parquet
exit code: 1
output: Error: Cannot read file: http://127.0.0.1:60288/my%20file.parquet
HTTP Error: HTTP GET error on 'http://127.0.0.1:60288/my%2520file.parquet' (HTTP 404 Not Found)

SERVER SAW: ['/my%2520file.parquet']
```

After, same probe:

```
URL: http://127.0.0.1:51013/my%20file.parquet
resolve_file_url -> http://127.0.0.1:51013/my%20file.parquet
exit code: 0
SERVER SAW: ['/my%20file.parquet', '/my%20file.parquet', ... ]   # 22 range requests, all verbatim
```

That probe is now a test (`TestRemoteReadRequestsTheUrlVerbatim`), asserting the server saw `/my%20file.parquet` and the command exited 0. It uses `http.server` on `127.0.0.1` — no outside network, so it is not in the `network` lane.

The new tests failed first, on the unfixed tree:

```
$ uv run pytest tests/test_remote_url_encoding.py -q
...
FAILED tests/test_remote_url_encoding.py::TestHttpUrlIsTakenAsEncoded::test_percent_encoded_space_is_not_re_encoded
FAILED tests/test_remote_url_encoding.py::TestHttpUrlIsTakenAsEncoded::test_literal_percent_20_in_a_filename_survives
FAILED tests/test_remote_url_encoding.py::TestSafeFileUrlTransformsOnce::test_percent_encoded_url_is_neither_re_encoded_nor_escaped
FAILED tests/test_remote_url_encoding.py::TestRemoteReadRequestsTheUrlVerbatim::test_inspect_meta_requests_the_encoded_path_as_given
  AssertionError: ['/my%2520file.parquet']
FAILED tests/test_remote_url_encoding.py::test_no_module_percent_encodes_a_read_path
11 failed, 3 passed in 1.06s
```

and pass after:

```
$ uv run pytest tests/test_remote_url_encoding.py -q
14 passed in 0.92s

$ uv run pytest tests/test_file_utils.py tests/test_sql_path_escaping.py tests/test_remote_files.py \
    tests/test_remote_url_encoding.py tests/test_common_utils.py -q -m "not network"
317 passed, 8 deselected, 1 warning in 20.54s

$ uv run pytest -q -m "not slow and not network and not meta" -k "url or remote or resolve or escap"
330 passed, 6069 deselected in 14.44s
```

Full fast lane:

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
4 failed, 5408 passed, 65 skipped, 2 xfailed, 99 warnings in 403.26s
```

The four are the known cold-run flakes in `test_pipe_integration.py` / `test_geojson_stream.py`: they shell out to two `gpio` processes under a 60s timeout, and pass on re-run (`3 passed in 17.79s`, then `1 passed in 49.07s` for the last one — 49s against a 60s ceiling on a loaded machine). None of them reads a remote URL.

Hooks:

```
$ uv run pre-commit run --all-files            # 20 hooks, all Passed
$ uv run pre-commit run --all-files --hook-stage pre-push
deptry / mypy / vulture / xenon / import-linter / menard-check / fast-tests ... Passed
$ uv run pytest docs/guide/remote-files.md -q  # 2 passed, 9 skipped
```

Closes #825
Refs #718, #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV

