### PR TITLE
fix(streaming): read a geoarrow CRS object as PROJJSON instead of stringifying it

### DIFF
--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -527,6 +527,62 @@ def apply_geoarrow_extension_type(
         ) from e
 
 
+def _geoarrow_crs_to_projjson(crs: object) -> dict | str | None:
+    """Return an Arrow extension type's ``.crs`` as PROJJSON, or None.
+
+    ``geom_type.crs`` is whatever the extension type chose to hold. Once
+    ``geoarrow.pyarrow`` is imported, PyArrow resolves ``geoarrow.wkb`` fields
+    into real extension types and this is a ``geoarrow.types.crs.Crs`` object
+    (``ProjJsonCrs``, ``StringCrs``, or a ``pyproj.CRS``) — never a plain value.
+
+    Those objects must be read through their PROJJSON accessor. ``str()`` on one
+    returns its *repr* (``"ProjJsonCrs(OGC:CRS84)"``), which downstream code then
+    split on ``:`` into the fabricated identifier
+    ``{"id": {"authority": "PROJJSONCRS(OGC", "code": "CRS84)"}}`` — invalid
+    GeoParquet that gpio's own validator rejects (issue #816).
+
+    Unknown objects are rejected (None + a warning) rather than stringified: a
+    repr is never a CRS, and inventing one writes a file that lies about its
+    coordinates. Returning None lets the caller fall back to the ``geo``
+    metadata, which is where the truth usually is; raising would fail an
+    otherwise-fine read over a metadata detail this function documents as
+    optional.
+    """
+    from geoparquet_io.core.logging_config import warn
+
+    # Already a usable representation: PROJJSON dict, or a string identifier
+    # such as "EPSG:3857" that callers normalise themselves.
+    if isinstance(crs, dict):
+        return crs
+    if isinstance(crs, str):
+        return crs
+    if isinstance(crs, bytes | bytearray):
+        try:
+            return crs.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+
+    # The geoarrow ``Crs`` protocol (and pyproj.CRS) expose PROJJSON directly:
+    # ``to_json_dict()`` returns a Mapping, ``to_json()`` the same as a string.
+    for accessor, parse in (("to_json_dict", dict), ("to_json", json.loads)):
+        method = getattr(crs, accessor, None)
+        if not callable(method):
+            continue
+        try:
+            resolved = parse(method())
+        except Exception as exc:  # pyproj lookup failure, malformed PROJJSON, ...
+            warn(f"Could not read PROJJSON from CRS object {type(crs).__name__}: {exc}")
+            return None
+        # An empty PROJJSON object is not a CRS; let the caller fall back.
+        return resolved if isinstance(resolved, dict) and resolved else None
+
+    warn(
+        f"Ignoring geometry CRS of unsupported type {type(crs).__name__}: it exposes no "
+        "PROJJSON accessor, and its text form is not a coordinate reference system."
+    )
+    return None
+
+
 def extract_crs_from_table(
     table: pa.Table,
     geometry_column: str | None = None,
@@ -554,11 +610,11 @@ def extract_crs_from_table(
 
         # Check for geoarrow extension type with CRS
         if hasattr(geom_type, "crs") and geom_type.crs is not None:
-            crs = geom_type.crs
-            # Convert to string if it's a CRS object
-            if hasattr(crs, "__str__"):
-                return str(crs)
-            return crs
+            resolved = _geoarrow_crs_to_projjson(geom_type.crs)
+            if resolved is not None:
+                return resolved
+            # Unreadable CRS object: fall through to the geo metadata rather
+            # than returning a value that isn't a CRS (issue #816).
 
     # Fall back to geo metadata
     if table.schema.metadata and b"geo" in table.schema.metadata:

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -490,14 +490,8 @@ class TestAddKDTreePythonAPI:
         assert pa.types.is_binary(table.schema.field(primary).type)
         assert table.column(primary).null_count == 0
 
-        # Every validator check except one, which is excused by name and for a
-        # reason outside this branch: in a session that imported
-        # `geoarrow.pyarrow`, PyArrow resolves the geometry extension type and
-        # `Table.crs` (via `core/streaming.py::extract_crs_from_table`)
-        # stringifies the resolved CRS object to "ProjJsonCrs(OGC:CRS84)". The
-        # writer parses that back as authority "PROJJSONCRS(OGC" / code
-        # "CRS84)", so `crs_valid_geometry` fails. That is pre-existing on main
-        # in a module this branch does not touch, which is also why the failure
-        # depends on what else the test session had imported.
-        failed = [name for name in _failed_checks(temp_output_file) if name != "crs_valid_geometry"]
-        assert failed == []
+        # Every validator check, with nothing excused. `crs_valid_geometry` used
+        # to fail here in any session that had imported `geoarrow.pyarrow`,
+        # because `extract_crs_from_table` stringified the resolved geoarrow CRS
+        # object into "ProjJsonCrs(OGC:CRS84)" (issue #816, fixed).
+        assert _failed_checks(temp_output_file) == []

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -25,6 +25,7 @@ from geoparquet_io.core.streaming import (
     apply_geo_metadata,
     apply_geoarrow_extension_type,
     apply_metadata_to_table,
+    extract_crs_from_table,
     extract_geo_metadata,
     find_geometry_column_from_metadata,
     find_geometry_column_from_table,
@@ -955,3 +956,205 @@ class TestReadStdinToTempFile:
             assert pq.read_table(path).num_rows == 2
         finally:
             os.remove(path)
+
+
+OGC_CRS84_PROJJSON = {
+    "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+    "type": "GeographicCRS",
+    "name": "WGS 84 (CRS84)",
+    "datum": {
+        "type": "GeodeticReferenceFrame",
+        "name": "World Geodetic System 1984",
+        "ellipsoid": {
+            "name": "WGS 84",
+            "semi_major_axis": 6378137,
+            "inverse_flattening": 298.257223563,
+        },
+    },
+    "coordinate_system": {
+        "subtype": "ellipsoidal",
+        "axis": [
+            {
+                "name": "Geodetic longitude",
+                "abbreviation": "Lon",
+                "direction": "east",
+                "unit": "degree",
+            },
+            {
+                "name": "Geodetic latitude",
+                "abbreviation": "Lat",
+                "direction": "north",
+                "unit": "degree",
+            },
+        ],
+    },
+    "id": {"authority": "OGC", "code": "CRS84"},
+}
+
+
+class _OpaqueCrs:
+    """A CRS-ish object that is neither PROJJSON nor a geoarrow ``Crs``."""
+
+    def __repr__(self) -> str:
+        return "Opaque(EPSG:9999)"
+
+
+class _OpaqueCrsType(pa.ExtensionType):
+    """An extension type exposing ``.crs`` as an object gpio cannot interpret."""
+
+    def __init__(self):
+        super().__init__(pa.binary(), "gpio.test.opaque_crs")
+
+    def __arrow_ext_serialize__(self) -> bytes:
+        return b""
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, _storage_type, _serialized):
+        return cls()
+
+    @property
+    def crs(self):
+        return _OpaqueCrs()
+
+
+def _geoarrow_typed_table(crs, nrows: int = 1) -> pa.Table:
+    """A table whose geometry column carries a *resolved* geoarrow type.
+
+    Importing ``geoarrow.pyarrow`` registers the extension types, which is the
+    process state issue #816 depends on.
+    """
+    import geoarrow.pyarrow  # noqa: F401  -- registers the extension types
+
+    table = pa.table(
+        {
+            "id": list(range(nrows)),
+            "geometry": pa.array([_wkb_polygon(4)] * nrows, type=pa.large_binary()),
+        }
+    )
+    return apply_geoarrow_extension_type(table, "geometry", crs=crs)
+
+
+class TestExtractCrsFromGeoArrowType:
+    """`extract_crs_from_table` must read a geoarrow CRS object, not stringify it.
+
+    Regression guard for issue #816. Once ``geoarrow.pyarrow`` is imported
+    anywhere in the process, PyArrow resolves ``geoarrow.wkb`` fields into real
+    extension types whose ``.crs`` is a ``geoarrow.types.crs.Crs`` object. The
+    old ``if hasattr(crs, "__str__"): return str(crs)`` catch-all matched every
+    Python object, so the CRS came back as the repr ``"ProjJsonCrs(OGC:CRS84)"``
+    and the writer split it into authority ``PROJJSONCRS(OGC`` / code ``CRS84)``.
+    """
+
+    def test_projjson_crs_object_returns_projjson_dict(self):
+        """A ProjJsonCrs object comes back as PROJJSON, not as its repr."""
+        table = _geoarrow_typed_table(OGC_CRS84_PROJJSON)
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert not isinstance(crs, str), f"stringified the CRS object: {crs!r}"
+        assert isinstance(crs, dict)
+        assert crs["id"] == {"authority": "OGC", "code": "CRS84"}
+
+    def test_string_crs_object_resolves_to_projjson(self):
+        """A StringCrs object ("EPSG:3857") resolves through its PROJJSON accessor."""
+        table = _geoarrow_typed_table("EPSG:3857")
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert crs is not None
+        parsed = crs if isinstance(crs, dict) else json.loads(crs)
+        assert parsed["id"] == {"authority": "EPSG", "code": 3857}
+
+    def test_result_is_parseable_by_pyproj(self):
+        """Whatever comes back must be a CRS pyproj can round-trip."""
+        import pyproj
+
+        table = _geoarrow_typed_table(OGC_CRS84_PROJJSON)
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert pyproj.CRS(crs).to_authority() == ("OGC", "CRS84")
+
+    def test_unregistered_extension_shape_falls_back_to_geo_metadata(self):
+        """The other shape -- ``ARROW:extension:name`` in field metadata with no
+        resolved extension type -- must keep reading the CRS out of ``geo``.
+
+        This is what PyArrow produces for a geoarrow field when the extension
+        type is not registered, and it is the path most sessions take.
+        """
+        geo = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": [],
+                    "crs": OGC_CRS84_PROJJSON,
+                }
+            },
+        }
+        field = pa.field(
+            "geometry",
+            pa.binary(),
+            metadata={
+                b"ARROW:extension:name": b"geoarrow.wkb",
+                b"ARROW:extension:metadata": b'{"crs": {"id": {"authority": "OGC"}}}',
+            },
+        )
+        schema = pa.schema(
+            [pa.field("id", pa.int64()), field],
+            metadata={b"geo": json.dumps(geo).encode("utf-8")},
+        )
+        table = pa.table(
+            [pa.array([1]), pa.array([_wkb_polygon(4)], type=pa.binary())], schema=schema
+        )
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert crs == OGC_CRS84_PROJJSON
+
+    def test_unknown_crs_object_is_rejected_not_stringified(self):
+        """An unrecognised CRS object yields None, never its repr.
+
+        The old catch-all would have returned ``"Opaque(EPSG:9999)"``, which the
+        writer then split on ``:`` into a fabricated authority/code pair.
+        """
+        storage = pa.array([_wkb_polygon(4)], type=pa.binary())
+        geom = pa.ExtensionArray.from_storage(_OpaqueCrsType(), storage)
+        table = pa.table({"id": [1], "geometry": geom})
+
+        assert extract_crs_from_table(table, "geometry") is None
+
+
+class TestGeoArrowCrsSurvivesWrite:
+    """End-to-end: a geoarrow-typed table writes a CRS the validator accepts (#816)."""
+
+    def _write_and_validate(self, tmp_path, crs):
+        import pyarrow.parquet as pq
+
+        import geoparquet_io as gpio
+        from geoparquet_io.core.validate import validate_geoparquet
+
+        table = _geoarrow_typed_table(crs, nrows=2)
+        out = tmp_path / "out.parquet"
+        gpio.Table(table, geometry_column="geometry").write(str(out))
+
+        geo = json.loads(pq.read_schema(str(out)).metadata[b"geo"].decode("utf-8"))
+        written = geo["columns"][geo["primary_column"]].get("crs")
+        failed = sorted(
+            {c.name for c in validate_geoparquet(str(out)).checks if c.status.value == "failed"}
+        )
+        return written, failed
+
+    def test_crs84_geoarrow_table_passes_crs_valid_geometry(self, tmp_path):
+        written, failed = self._write_and_validate(tmp_path, OGC_CRS84_PROJJSON)
+
+        assert "crs_valid_geometry" not in failed
+        assert written is None or written["id"] == {"authority": "OGC", "code": "CRS84"}
+
+    def test_projected_geoarrow_table_keeps_its_authority_code(self, tmp_path):
+        written, failed = self._write_and_validate(tmp_path, "EPSG:3857")
+
+        assert "crs_valid_geometry" not in failed
+        assert written is not None
+        assert written["id"] == {"authority": "EPSG", "code": 3857}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import sys
 from unittest import mock
 
@@ -999,22 +1000,54 @@ class _OpaqueCrs:
         return "Opaque(EPSG:9999)"
 
 
-class _OpaqueCrsType(pa.ExtensionType):
-    """An extension type exposing ``.crs`` as an object gpio cannot interpret."""
+class _ExplodingCrs:
+    """A geoarrow-shaped ``Crs`` whose PROJJSON accessor fails.
 
-    def __init__(self):
-        super().__init__(pa.binary(), "gpio.test.opaque_crs")
+    Real ``StringCrs.to_json_dict()`` calls pyproj, which raises for an
+    identifier PROJ does not know.
+    """
+
+    def to_json_dict(self):
+        raise ValueError("crs not found: EPSG:999999")
+
+
+# PyArrow may rebuild an extension type from its serialized form while a table
+# is assembled, so the payload cannot live on the instance. Keyed by the token
+# the type serializes, it survives any number of round-trips.
+_CRS_PAYLOADS: dict[bytes, object] = {}
+
+
+class _CrsCarrierType(pa.ExtensionType):
+    """An Arrow extension type exposing an arbitrary value as ``.crs``.
+
+    Lets a test hand ``extract_crs_from_table`` exactly one CRS carrier shape
+    with no dependence on import order or on what geoarrow chooses to wrap the
+    value in -- the process state that made issue #816 intermittent.
+    """
+
+    def __init__(self, token: bytes):
+        self._token = token
+        super().__init__(pa.binary(), "gpio.test.crs_carrier")
 
     def __arrow_ext_serialize__(self) -> bytes:
-        return b""
+        return self._token
 
     @classmethod
-    def __arrow_ext_deserialize__(cls, _storage_type, _serialized):
-        return cls()
+    def __arrow_ext_deserialize__(cls, _storage_type, serialized):
+        return cls(serialized)
 
     @property
     def crs(self):
-        return _OpaqueCrs()
+        return _CRS_PAYLOADS[self._token]
+
+
+def _table_with_crs_carrier(crs) -> pa.Table:
+    """A one-row table whose geometry field's type reports ``crs``."""
+    token = f"crs-{len(_CRS_PAYLOADS)}".encode()
+    _CRS_PAYLOADS[token] = crs
+    storage = pa.array([_wkb_polygon(4)], type=pa.binary())
+    geom = pa.ExtensionArray.from_storage(_CrsCarrierType(token), storage)
+    return pa.table({"id": [1], "geometry": geom})
 
 
 def _geoarrow_typed_table(crs, nrows: int = 1) -> pa.Table:
@@ -1113,17 +1146,117 @@ class TestExtractCrsFromGeoArrowType:
 
         assert crs == OGC_CRS84_PROJJSON
 
-    def test_unknown_crs_object_is_rejected_not_stringified(self):
+    def test_unknown_crs_object_is_rejected_not_stringified(self, caplog):
         """An unrecognised CRS object yields None, never its repr.
 
         The old catch-all would have returned ``"Opaque(EPSG:9999)"``, which the
         writer then split on ``:`` into a fabricated authority/code pair.
         """
-        storage = pa.array([_wkb_polygon(4)], type=pa.binary())
-        geom = pa.ExtensionArray.from_storage(_OpaqueCrsType(), storage)
-        table = pa.table({"id": [1], "geometry": geom})
+        table = _table_with_crs_carrier(_OpaqueCrs())
+
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            crs = extract_crs_from_table(table, "geometry")
+
+        assert crs is None
+        assert "_OpaqueCrs" in caplog.text
+        assert "Opaque(EPSG:9999)" not in caplog.text
+
+
+class TestCrsCarrierShapes:
+    """Every shape ``geom_type.crs`` can take, driven directly (#816).
+
+    These call ``extract_crs_from_table`` with one carrier shape each, with no
+    dependence on whether ``geoarrow.pyarrow`` happened to be imported first --
+    so each branch is exercised deterministically on every run.
+    """
+
+    def test_real_projjson_crs_object(self):
+        """A ``geoarrow.types.crs.ProjJsonCrs`` resolves to its PROJJSON."""
+        from geoarrow.types.crs import ProjJsonCrs
+
+        table = _table_with_crs_carrier(ProjJsonCrs(OGC_CRS84_PROJJSON))
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert isinstance(crs, dict)
+        assert crs["id"] == {"authority": "OGC", "code": "CRS84"}
+
+    def test_real_string_crs_object(self):
+        """A ``geoarrow.types.crs.StringCrs`` resolves through pyproj to PROJJSON."""
+        from geoarrow.types.crs import StringCrs
+
+        table = _table_with_crs_carrier(StringCrs("EPSG:3857"))
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert isinstance(crs, dict)
+        assert crs["id"] == {"authority": "EPSG", "code": 3857}
+
+    def test_pyproj_crs_object(self):
+        """``pyproj.CRS`` satisfies the same protocol and must work too."""
+        import pyproj
+
+        table = _table_with_crs_carrier(pyproj.CRS("EPSG:4326"))
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert isinstance(crs, dict)
+        assert crs["id"] == {"authority": "EPSG", "code": 4326}
+
+    def test_plain_projjson_dict_passes_through(self):
+        """A type that already holds PROJJSON is returned unchanged."""
+        table = _table_with_crs_carrier(OGC_CRS84_PROJJSON)
+
+        assert extract_crs_from_table(table, "geometry") == OGC_CRS84_PROJJSON
+
+    def test_plain_string_identifier_passes_through(self):
+        """A bare identifier string stays a string for the caller to normalise."""
+        table = _table_with_crs_carrier("EPSG:3857")
+
+        assert extract_crs_from_table(table, "geometry") == "EPSG:3857"
+
+    def test_utf8_bytes_are_decoded(self):
+        """Bytes are decoded to text rather than stringified as ``b'...'``."""
+        table = _table_with_crs_carrier(b"EPSG:3857")
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert crs == "EPSG:3857"
+        assert not str(crs).startswith("b'")
+
+    def test_undecodable_bytes_are_rejected(self):
+        """Bytes that are not UTF-8 are not a CRS; return None, never a repr."""
+        table = _table_with_crs_carrier(b"\xff\xfe not utf-8")
 
         assert extract_crs_from_table(table, "geometry") is None
+
+    def test_failing_projjson_accessor_warns_and_returns_none(self, caplog):
+        """An accessor that raises is reported, and yields None -- not a repr."""
+        table = _table_with_crs_carrier(_ExplodingCrs())
+
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            crs = extract_crs_from_table(table, "geometry")
+
+        assert crs is None
+        assert "_ExplodingCrs" in caplog.text
+        assert "crs not found: EPSG:999999" in caplog.text
+
+    def test_carrier_failure_falls_back_to_geo_metadata(self, caplog):
+        """A rejected CRS object must not shadow the truth in the `geo` metadata."""
+        geo = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {"encoding": "WKB", "geometry_types": [], "crs": OGC_CRS84_PROJJSON}
+            },
+        }
+        table = _table_with_crs_carrier(_OpaqueCrs())
+        table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode("utf-8")})
+
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            crs = extract_crs_from_table(table, "geometry")
+
+        assert crs == OGC_CRS84_PROJJSON
 
 
 class TestGeoArrowCrsSurvivesWrite:


### PR DESCRIPTION
## What changed

`core/streaming.py::extract_crs_from_table` ended its geoarrow branch with

```python
if hasattr(crs, "__str__"):
    return str(crs)
```

which is true for **every** Python object. It is replaced with
`_geoarrow_crs_to_projjson()`, which:

- passes a `dict` (PROJJSON) or `str` (`"EPSG:3857"`) straight through, and decodes `bytes`;
- otherwise reads the object's PROJJSON accessor — `to_json_dict()`, falling back to
  `to_json()`. In the installed `geoarrow-pyarrow` 0.2.0 / `geoarrow-types` 0.3.0 this is
  the `geoarrow.types.crs.Crs` protocol (`ProjJsonCrs`, `StringCrs`), and `pyproj.CRS`
  satisfies the same protocol. `core/crs_utils.py::_crs_from_extension_type` and
  `core/duckdb_metadata.py` already read the CRS this way — this brings `streaming.py`
  in line with them;
- **rejects an object that exposes neither**: it warns and returns `None`, and the caller
  falls back to the `geo` file metadata.

Rejecting rather than raising is deliberate. A repr is never a CRS, and inventing one
writes a file that lies about its coordinates — but the truth is usually still in the
`geo` metadata one branch below, and this function's documented contract is already
"PROJJSON dict, string, **or None** if not found". Raising would turn an optional
metadata detail into a hard failure of an otherwise-fine read.

`tests/test_kdtree.py::test_add_kdtree_then_write` no longer excuses `crs_valid_geometry`
by name; it now asserts the validator reports **no** failures.

Grepped the rest of `core/` for the same shape. `core/streaming.py:293`,
`core/geojson_stream.py:75`, `core/inspect_utils.py`, `api/table.py:790` and
`core/crs_utils.py:743` all call `str()` on a value parsed out of the `geo` JSON
(so only ever `dict`/`str`/`None`) or format a value for display. Different shape, not
the same bug — left alone.

## Why

Whenever the process has imported `geoarrow.pyarrow` — which many gpio code paths and
tests do transitively — PyArrow resolves `geoarrow.wkb` fields into real extension types,
and `geom_type.crs` becomes a `Crs` **object** rather than a dict or string. The catch-all
stringified it to its repr, `"ProjJsonCrs(OGC:CRS84)"`. `Table.crs` returned that repr,
`api/table.py` handed it to `parse_crs_string_to_projjson`, and `_extract_crs_identifier`
split it on `:` into a fabricated identifier. gpio then failed its own validator on its
own output.

Because it depends only on what else the session had imported, the bug hid from most runs.

Closes #816. Refs #791, which is where this was found and which excused the resulting
`crs_valid_geometry` failure pending this fix.

## Verification

Reproduction on `main`, in a process that has imported `geoarrow.pyarrow`:

```
$ uv run python -c "... gpio.read('tests/data/buildings_test.parquet').add_kdtree(iterations=3) ..."
Table.crs      -> 'ProjJsonCrs(OGC:CRS84)'
written crs    -> {"id": {"authority": "PROJJSONCRS(OGC", "code": "CRS84)"}}
failed checks  -> ['crs_valid_geometry']
```

Same command on this branch:

```
Table.crs type   -> dict
Table.crs id     -> {'authority': 'OGC', 'code': 'CRS84'}
written crs id   -> None      # `crs` key omitted == OGC:CRS84, matching the source file
written crs name -> None
failed checks    -> []
```

The source file also omits `crs` (i.e. declares the OGC:CRS84 default), so the round-trip
is faithful — and the new `test_projected_geoarrow_table_keeps_its_authority_code` pins the
non-default case, where `EPSG:3857` must survive the write as
`{"authority": "EPSG", "code": 3857}`.

New tests (all written failing first — 6 of the 7 failed against the old code, the
`ARROW:extension:name`-in-field-metadata fallback test passed both before and after,
which is the point of pinning it):

```
tests/test_streaming.py::TestExtractCrsFromGeoArrowType
  test_projjson_crs_object_returns_projjson_dict
  test_string_crs_object_resolves_to_projjson
  test_result_is_parseable_by_pyproj
  test_unregistered_extension_shape_falls_back_to_geo_metadata
  test_unknown_crs_object_is_rejected_not_stringified
tests/test_streaming.py::TestGeoArrowCrsSurvivesWrite
  test_crs84_geoarrow_table_passes_crs_valid_geometry
  test_projected_geoarrow_table_keeps_its_authority_code
```

Before the fix:

```
FAILED tests/test_streaming.py::TestExtractCrsFromGeoArrowType::test_projjson_crs_object_returns_projjson_dict
FAILED tests/test_streaming.py::TestExtractCrsFromGeoArrowType::test_string_crs_object_resolves_to_projjson
FAILED tests/test_streaming.py::TestExtractCrsFromGeoArrowType::test_result_is_parseable_by_pyproj
FAILED tests/test_streaming.py::TestExtractCrsFromGeoArrowType::test_unknown_crs_object_is_rejected_not_stringified
FAILED tests/test_streaming.py::TestGeoArrowCrsSurvivesWrite::test_crs84_geoarrow_table_passes_crs_valid_geometry
FAILED tests/test_streaming.py::TestGeoArrowCrsSurvivesWrite::test_projected_geoarrow_table_keeps_its_authority_code
================== 6 failed, 1 passed, 69 deselected in 1.64s ==================
```

with, for example:

```
E   pyproj.exceptions.CRSError: Invalid projection: ProjJsonCrs(OGC:CRS84):
    (Internal Proj Error: proj_create: crs not found: ProjJsonCrs(OGC:CRS84))
```

After:

```
$ uv run pytest tests/test_streaming.py tests/test_kdtree.py tests/test_api.py -q
285 passed, 1 skipped in 23.38s

$ uv run pytest -q -m "not slow and not network and not meta" -k "crs or streaming or geoarrow"
1060 passed, 12 skipped, 5319 deselected, 87 warnings in 694.12s (0:11:34)

$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5405 passed, 65 skipped, 1 xfailed, 93 warnings in 198.42s (0:03:18)
```

The new tests were also run serially in a fresh process (the whole point is import state):
`tests/test_streaming.py` alone — 76 passed; `test_add_kdtree_then_write` alone — 1 passed.

Hooks:

```
$ uv run pre-commit run --all-files            # all Passed
$ uv run pre-commit run --all-files --hook-stage pre-push   # all Passed (deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordinate reference system (CRS) handling when reading geospatial tables.
  - CRS information is now preserved in the standard PROJJSON format where available.
  - Invalid or unreadable CRS information no longer produces misleading values; available metadata is used instead.
  - Improved compatibility with common CRS representations, including dictionaries, strings, and byte values.
  - Parquet files now pass CRS-related geometry validation more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->