### PR TITLE
fix(write): give disk-rewrite 2.0 output a native GEOMETRY logical type

### DIFF
--- a/geoparquet_io/core/geoarrow_encoding.py
+++ b/geoparquet_io/core/geoarrow_encoding.py
@@ -70,6 +70,29 @@ def is_geoarrow_extension_field(field: pa.Field) -> bool:
     return name is not None and name.startswith("geoarrow.")
 
 
+def native_wkb_type(crs: dict | None):
+    """The ``geoarrow.wkb`` type a 2.0 / parquet-geo-only geometry column is written as.
+
+    PyArrow writes this extension type as a native Parquet GEOMETRY logical
+    type, which 2.0 requires for every column in ``geo["columns"]`` and which is
+    a parquet-geo-only column's *only* geometry identity (#706, #764).
+
+    The CRS belongs in the type at these versions, and is taken from what the
+    ``geo`` block declares for that column, so the two can never disagree
+    (``v2_crs_consistency``). A default CRS is signalled by carrying none, the
+    same way the metadata signals it by omitting the key.
+
+    One definition, shared by every strategy that builds the type: the streaming
+    writer's output schema and the disk-rewrite writer's.
+    """
+    import geoarrow.pyarrow as ga
+
+    geoarrow_type = ga.wkb()
+    if crs and not is_default_crs(crs):
+        geoarrow_type = geoarrow_type.with_crs(crs)
+    return geoarrow_type
+
+
 def is_wkb_extension_field(field: pa.Field) -> bool:
     """True when a field declares a WKB extension type, in either carrier shape.
 

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -19,7 +19,11 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.duckdb_utils import quote_identifier
-from geoparquet_io.core.geoarrow_encoding import WKB_EXTENSION_NAMES, arrow_extension_name
+from geoparquet_io.core.geoarrow_encoding import (
+    WKB_EXTENSION_NAMES,
+    arrow_extension_name,
+    native_wkb_type,
+)
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.write_strategies.base import BaseWriteStrategy
 
@@ -93,6 +97,30 @@ def _to_plain_wkb_array(array: pa.Array | pa.ChunkedArray) -> pa.Array | pa.Chun
             f"(Arrow's 2 GB limit for 32-bit binary offsets): {e}. "
             "Write smaller row groups (--row-group-rows) or simplify very large geometries."
         ) from e
+
+
+def to_geoarrow_column(column: pa.Array, target_type) -> pa.Array:
+    """Encode one WKB column as the given geoarrow extension type.
+
+    Module level, and shared with the disk-rewrite strategy, which converts the
+    same columns one row group at a time (#764).
+
+    Note that ``WkbType.__eq__`` ignores the CRS, so the equality shortcut can
+    return an array whose type carries a different CRS than ``target_type``.
+    Both callers build their output batch/table against an explicit schema, so
+    the schema's field type -- and its CRS -- is what gets written.
+    """
+    import geoarrow.pyarrow as ga
+
+    geoarrow_arr = ga.as_wkb(column)
+    if geoarrow_arr.type == target_type:
+        return geoarrow_arr
+    # from_buffers cannot carry a slice offset, so rebuild from the storage
+    # array — ga.as_wkb returns a fresh, offset-free array, but a sliced input
+    # (see the >2 GB split path) must not silently take the parent's rows.
+    return pa.ExtensionArray.from_storage(
+        target_type, _wkb_storage(geoarrow_arr).cast(target_type.storage_type)
+    )
 
 
 def _coerce_column(array: pa.Array, target_type: pa.DataType) -> pa.Array:
@@ -781,8 +809,6 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geometry_columns: set[str] | None = None,
     ) -> pa.Schema:
         """Build the output schema for streaming write."""
-        from geoparquet_io.core.crs_utils import is_default_crs
-
         schema_metadata = dict(schema.metadata or {})
 
         geo_columns = set(geometry_columns or ())
@@ -790,16 +816,6 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geo_columns.update((geo_meta or {}).get("columns", {}))
 
         if use_native_geometry:
-            import geoarrow.pyarrow as ga
-
-            def native_type(crs):
-                geoarrow_type = ga.wkb()
-                if crs and not is_default_crs(crs):
-                    geoarrow_type = geoarrow_type.with_crs(crs)
-                    if verbose:
-                        debug("Built geoarrow type with CRS")
-                return geoarrow_type
-
             # EVERY geometry column becomes native, not just the primary: 2.0
             # validation requires a native Parquet GEOMETRY type for each column in
             # geo["columns"], and under parquet-geo-only (which writes no geo
@@ -812,8 +828,11 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 for name in geo_columns
             }
             column_crs[geometry_column] = input_crs
+            if verbose:
+                with_crs = sorted(name for name, crs in column_crs.items() if crs)
+                debug(f"Native Parquet GEOMETRY type for {sorted(geo_columns)}, CRS on {with_crs}")
             new_fields = [
-                pa.field(field.name, native_type(column_crs[field.name]))
+                pa.field(field.name, native_wkb_type(column_crs[field.name]))
                 if field.name in geo_columns
                 else field
                 for field in schema
@@ -868,27 +887,13 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         fails validation deterministically (#688 review).
         """
         new_columns = [
-            self._to_geoarrow_column(batch.column(i), field.type)
+            to_geoarrow_column(batch.column(i), field.type)
             if isinstance(field.type, pa.ExtensionType)
             else _coerce_column(batch.column(i), field.type)
             for i, field in enumerate(schema_with_geoarrow)
         ]
 
         return pa.RecordBatch.from_arrays(new_columns, schema=schema_with_geoarrow)
-
-    def _to_geoarrow_column(self, column: pa.Array, target_type) -> pa.Array:
-        """Encode one WKB column as the given geoarrow extension type."""
-        import geoarrow.pyarrow as ga
-
-        geoarrow_arr = ga.as_wkb(column)
-        if geoarrow_arr.type == target_type:
-            return geoarrow_arr
-        # from_buffers cannot carry a slice offset, so rebuild from the storage
-        # array — ga.as_wkb returns a fresh, offset-free array, but a sliced input
-        # (see the >2 GB split path) must not silently take the parent's rows.
-        return pa.ExtensionArray.from_storage(
-            target_type, _wkb_storage(geoarrow_arr).cast(target_type.storage_type)
-        )
 
     def _convert_batch_to_native_geoarrow(
         self,

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -87,19 +87,18 @@ def _native_geometry_schema(schema: pa.Schema, native_crs: dict[str, dict | None
     return pa.schema(fields, metadata=schema.metadata)
 
 
-def _to_native_geometry(column, target_type):
+def _to_native_geometry(column: pa.ChunkedArray, target_type) -> pa.ChunkedArray:
     """Encode one WKB column as ``target_type``, chunk by chunk.
 
     ``to_geoarrow_column`` (shared with the streaming strategy) takes a single
     array; a row group read back through PyArrow -- and anything the row-group
-    coarsening concatenates -- arrives as a ChunkedArray.
+    coarsening concatenates -- arrives as a ChunkedArray. Passing ``target_type``
+    on is what keeps a zero-chunk column (an empty row group) typed, and what
+    restores the CRS on chunks whose own type dropped it.
     """
-    if not isinstance(column, pa.ChunkedArray):
-        return to_geoarrow_column(column, target_type)
-    chunks = [to_geoarrow_column(chunk, target_type) for chunk in column.chunks]
-    if not chunks:
-        return pa.chunked_array([], type=target_type)
-    return pa.chunked_array(chunks, type=chunks[0].type)
+    return pa.chunked_array(
+        [to_geoarrow_column(chunk, target_type) for chunk in column.chunks], type=target_type
+    )
 
 
 def _conform_row_group(table: pa.Table, schema: pa.Schema, native_crs: dict[str, dict | None]):

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -228,10 +228,15 @@ class DiskRewriteStrategy(BaseWriteStrategy):
             con.execute(copy_query)
 
             if verbose:
-                pf = pq.ParquetFile(temp_path)
-                debug(
-                    f"DuckDB wrote {pf.metadata.num_rows:,} rows, {pf.metadata.num_row_groups} row groups"
-                )
+                # Closed before leaving the block: this file is `os.unlink`ed a
+                # few lines below, and Windows refuses to delete a file with an
+                # open handle -- `--verbose` disk-rewrite writes died there with
+                # `PermissionError: [WinError 32]` while POSIX cleaned up fine.
+                with pq.ParquetFile(temp_path) as pf:
+                    debug(
+                        f"DuckDB wrote {pf.metadata.num_rows:,} rows, "
+                        f"{pf.metadata.num_row_groups} row groups"
+                    )
 
             geo_meta = build_geo_metadata(
                 geometry_column=geometry_column,
@@ -460,8 +465,8 @@ class DiskRewriteStrategy(BaseWriteStrategy):
                 upload_if_remote(local_path, output_path, is_directory=False, verbose=verbose)
 
             if verbose:
-                pf = pq.ParquetFile(local_path)
-                success(f"Wrote {pf.metadata.num_rows:,} rows to {output_path}")
+                with pq.ParquetFile(local_path) as pf:
+                    success(f"Wrote {pf.metadata.num_rows:,} rows to {output_path}")
         finally:
             if work_dir and os.path.exists(work_dir):
                 import shutil
@@ -508,11 +513,41 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         every over-full batch into a full group plus a runt, which is how a
         request of 25 against 10-row sources produced ``[25, 5, 25, 5, ...]``.
         """
-        from geoparquet_io.core.common import _CARRIED_SCHEMA_METADATA_KEYS_BYTES
-
         native_crs = native_geometry_crs or {}
 
         pf = pq.ParquetFile(input_path)
+        try:
+            self._write_rewritten_row_groups(
+                pf,
+                output_path,
+                geo_meta,
+                compression,
+                compression_level,
+                verbose,
+                extra_kv_metadata,
+                row_group_rows,
+                native_crs,
+            )
+        finally:
+            # The caller unlinks `input_path` as soon as this returns, and
+            # Windows refuses to delete a file this process still has open.
+            pf.close()
+
+    def _write_rewritten_row_groups(
+        self,
+        pf: pq.ParquetFile,
+        output_path: str,
+        geo_meta: dict | None,
+        compression: str,
+        compression_level: int | None,
+        verbose: bool,
+        extra_kv_metadata: dict[str, str] | None,
+        row_group_rows: int | None,
+        native_crs: dict[str, dict | None],
+    ) -> None:
+        """Write the already-open source file out again, one row group at a time."""
+        from geoparquet_io.core.common import _CARRIED_SCHEMA_METADATA_KEYS_BYTES
+
         schema = _native_geometry_schema(pf.schema_arrow, native_crs)
 
         new_meta = dict(schema.metadata or {})
@@ -580,5 +615,5 @@ class DiskRewriteStrategy(BaseWriteStrategy):
                     writer.write_table(pa.concat_tables(pending), row_group_size=row_group_rows)
 
         if verbose:
-            result_pf = pq.ParquetFile(output_path)
-            success(f"Wrote {result_pf.metadata.num_rows:,} rows to {output_path}")
+            with pq.ParquetFile(output_path) as result_pf:
+                success(f"Wrote {result_pf.metadata.num_rows:,} rows to {output_path}")

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -24,11 +24,13 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     quote_identifier,
 )
-from geoparquet_io.core.geoarrow_encoding import arrow_extension_name
+from geoparquet_io.core.geoarrow_encoding import arrow_extension_name, native_wkb_type
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
+from geoparquet_io.core.write_strategies.arrow_streaming import to_geoarrow_column
 from geoparquet_io.core.write_strategies.base import (
     BaseWriteStrategy,
     build_geo_metadata,
+    resolve_geometry_columns,
 )
 from geoparquet_io.core.write_strategies.row_group_sizing import (
     _resolve_row_group_rows,
@@ -37,6 +39,82 @@ from geoparquet_io.core.write_strategies.row_group_sizing import (
 
 if TYPE_CHECKING:
     import duckdb
+
+
+def _native_geometry_crs(
+    geoparquet_version: str,
+    geo_meta: dict,
+    geometry_column: str,
+    geometry_info: dict | None,
+) -> dict[str, dict | None]:
+    """Geometry columns needing a native Parquet GEOMETRY type, each with its CRS.
+
+    Empty below 2.0, where geometry is plain BYTE_ARRAY WKB and the CRS lives in
+    the ``geo`` block alone.
+
+    EVERY declared geometry column, not just the primary: 2.0 validation applies
+    the same requirement to each column in ``geo["columns"]``, and under
+    parquet-geo-only -- which writes no ``geo`` block at all -- the logical type
+    is a column's only geometry identity (#706).
+
+    Each CRS is read back out of the metadata just built for the file, so the
+    type and the block cannot disagree (``v2_crs_consistency``). A column the
+    block gives no ``crs`` is the spec default, and carries none in its type.
+    """
+    if geoparquet_version not in ("2.0", "parquet-geo-only"):
+        return {}
+
+    column_metadata = geo_meta.get("columns") or {}
+    return {
+        column: (column_metadata.get(column) or {}).get("crs")
+        for column in resolve_geometry_columns(geometry_column, geometry_info, geo_meta)
+    }
+
+
+def _native_geometry_schema(schema: pa.Schema, native_crs: dict[str, dict | None]) -> pa.Schema:
+    """Retype the given geometry columns as ``geoarrow.wkb``, leaving the rest alone.
+
+    ``pa.schema`` starts with no metadata, so the source's is reattached: the
+    caller reads the carried KV keys straight off the returned schema, and
+    dropping them here would make the metadata a function of the target version.
+    """
+    fields = [
+        pa.field(field.name, native_wkb_type(native_crs[field.name]), nullable=field.nullable)
+        if field.name in native_crs
+        else field
+        for field in schema
+    ]
+    return pa.schema(fields, metadata=schema.metadata)
+
+
+def _to_native_geometry(column, target_type):
+    """Encode one WKB column as ``target_type``, chunk by chunk.
+
+    ``to_geoarrow_column`` (shared with the streaming strategy) takes a single
+    array; a row group read back through PyArrow -- and anything the row-group
+    coarsening concatenates -- arrives as a ChunkedArray.
+    """
+    if not isinstance(column, pa.ChunkedArray):
+        return to_geoarrow_column(column, target_type)
+    chunks = [to_geoarrow_column(chunk, target_type) for chunk in column.chunks]
+    if not chunks:
+        return pa.chunked_array([], type=target_type)
+    return pa.chunked_array(chunks, type=chunks[0].type)
+
+
+def _conform_row_group(table: pa.Table, schema: pa.Schema, native_crs: dict[str, dict | None]):
+    """Give one row group the output schema, converting its native geometry columns."""
+    if not native_crs:
+        return table.replace_schema_metadata(schema.metadata)
+    columns = [
+        _to_native_geometry(table.column(index), field.type)
+        if field.name in native_crs
+        else table.column(index)
+        for index, field in enumerate(schema)
+    ]
+    # Built against the output schema, so the field's type -- and the CRS that
+    # `WkbType.__eq__` ignores -- is what reaches the writer.
+    return pa.Table.from_arrays(columns, schema=schema)
 
 
 class DiskRewriteStrategy(BaseWriteStrategy):
@@ -167,15 +245,29 @@ class DiskRewriteStrategy(BaseWriteStrategy):
                 geometry_info=geometry_info,
             )
 
+            # 2.0 and parquet-geo-only require a native Parquet GEOMETRY logical
+            # type; 1.0/1.1 require plain BYTE_ARRAY WKB and forbid it. Every
+            # other strategy branches on the version here -- this one did not, so
+            # its 2.0 output declared a version whose own spec its bytes violated
+            # (#764). parquet-geo-only additionally writes no `geo` block: the
+            # one built above is still what the native types are keyed off, but
+            # it names a null version, which DuckDB refuses to open.
+            native_crs = _native_geometry_crs(
+                geoparquet_version, geo_meta, geometry_column, geometry_info
+            )
+            if verbose and native_crs:
+                debug(f"Writing native Parquet GEOMETRY types for {sorted(native_crs)}")
+
             self._rewrite_with_metadata(
                 input_path=temp_path,
                 output_path=final_path,
-                geo_meta=geo_meta,
+                geo_meta=None if geoparquet_version == "parquet-geo-only" else geo_meta,
                 compression=validated_compression,
                 compression_level=validated_level,
                 verbose=verbose,
                 extra_kv_metadata=extra_kv_metadata,
                 row_group_rows=resolved_row_group_rows,
+                native_geometry_crs=native_crs,
             )
 
             os.unlink(temp_path)
@@ -381,14 +473,25 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         self,
         input_path: str,
         output_path: str,
-        geo_meta: dict,
+        geo_meta: dict | None,
         compression: str,
         compression_level: int | None,
         verbose: bool,
         extra_kv_metadata: dict[str, str] | None = None,
         row_group_rows: int | None = None,
+        native_geometry_crs: dict[str, dict | None] | None = None,
     ) -> None:
         """Rewrite file with proper geo metadata, row group by row group.
+
+        ``geo_meta`` is ``None`` for parquet-geo-only output, which carries its
+        geometry typing in the Parquet schema and must declare no GeoParquet
+        version at all -- writing the block built for it put ``"version": null``
+        in the file, which DuckDB's reader rejects outright (#764).
+
+        ``native_geometry_crs`` names the geometry columns that must reach the
+        writer as a native Parquet GEOMETRY logical type (2.0 and
+        parquet-geo-only), each with the CRS its ``geo`` entry declares. Empty at
+        1.0/1.1, where the same columns stay plain BYTE_ARRAY WKB.
 
         ``row_group_rows`` is the already-resolved rows-per-group request. The
         DuckDB COPY that produced ``input_path`` was given the same value, but it
@@ -406,11 +509,25 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         every over-full batch into a full group plus a runt, which is how a
         request of 25 against 10-row sources produced ``[25, 5, 25, 5, ...]``.
         """
+        from geoparquet_io.core.common import _CARRIED_SCHEMA_METADATA_KEYS_BYTES
+
+        native_crs = native_geometry_crs or {}
+
         pf = pq.ParquetFile(input_path)
-        schema = pf.schema_arrow
+        schema = _native_geometry_schema(pf.schema_arrow, native_crs)
 
         new_meta = dict(schema.metadata or {})
-        new_meta[b"geo"] = json.dumps(geo_meta).encode("utf-8")
+        if geo_meta is not None:
+            new_meta[b"geo"] = json.dumps(geo_meta).encode("utf-8")
+        else:
+            # parquet-geo-only: no `geo` key, and no serialized descriptor of the
+            # input's schema either -- the same exclusion set the other write
+            # paths use (`_strip_geo_metadata_key`).
+            new_meta = {
+                key: value
+                for key, value in new_meta.items()
+                if key not in _CARRIED_SCHEMA_METADATA_KEYS_BYTES
+            }
         if extra_kv_metadata:
             for key, value in extra_kv_metadata.items():
                 bkey = key.encode("utf-8") if isinstance(key, str) else key
@@ -434,7 +551,9 @@ class DiskRewriteStrategy(BaseWriteStrategy):
             # No sizing request: keep the source's row-group shape, one for one.
             if not row_group_rows:
                 for i in range(num_source_groups):
-                    writer.write_table(pf.read_row_group(i).replace_schema_metadata(new_meta))
+                    writer.write_table(
+                        _conform_row_group(pf.read_row_group(i), new_schema, native_crs)
+                    )
                     if verbose and (i + 1) % 10 == 0:
                         debug(f"Rewrote {i + 1}/{num_source_groups} row groups...")
             else:
@@ -443,7 +562,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
                 pending: list[pa.Table] = []
                 pending_rows = 0
                 for i in range(num_source_groups):
-                    table = pf.read_row_group(i).replace_schema_metadata(new_meta)
+                    table = _conform_row_group(pf.read_row_group(i), new_schema, native_crs)
                     pending.append(table)
                     pending_rows += table.num_rows
                     while pending_rows >= row_group_rows:

--- a/tests/test_secondary_geometry_carriers.py
+++ b/tests/test_secondary_geometry_carriers.py
@@ -39,12 +39,6 @@ from geoparquet_io.core.write_strategies.base import resolve_geometry_columns
 
 STRATEGIES = ["duckdb-kv", "in-memory", "streaming", "disk-rewrite"]
 
-# disk-rewrite never emits a native Parquet GEOMETRY type at 2.0 -- for the
-# PRIMARY column as well, on an ordinary single-geometry file. That is a
-# strategy-wide gap, not a secondary-column one, so it is tracked in #764 and
-# excluded here rather than silently expected.
-NATIVE_CAPABLE_STRATEGIES = ["duckdb-kv", "in-memory", "streaming"]
-
 
 def _wkb_point(x: float, y: float) -> bytes:
     return struct.pack("<BI2d", 1, 1, x, y)
@@ -175,7 +169,7 @@ class TestSecondaryCarrierMatchesTheTargetVersion:
 
         assert _failed_checks(out) == []
 
-    @pytest.mark.parametrize("strategy", NATIVE_CAPABLE_STRATEGIES)
+    @pytest.mark.parametrize("strategy", STRATEGIES)
     def test_v20_writes_native_for_both_columns(self, strategy, two_geometry_source, tmp_path):
         """2.0 requires a native Parquet GEOMETRY type for every declared column."""
         out = str(tmp_path / f"{strategy}_20.parquet")
@@ -466,9 +460,6 @@ def test_secondary_carrier_is_independent_of_geoarrow_import(
     Runs in subprocesses because geoarrow's extension registration is
     process-global and cannot be undone once done.
     """
-    if strategy == "disk-rewrite" and version == "2.0":
-        pytest.skip("disk-rewrite never emits native types at 2.0 (#764)")
-
     outputs = {}
     for label in ("clean", "import"):
         out = tmp_path / f"{strategy}_{version}_{label}.parquet"

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -10,6 +10,7 @@ Tests the Strategy Pattern for GeoParquet writes including:
 import json
 import logging
 import struct
+import sys
 import tempfile
 import uuid
 from pathlib import Path
@@ -19,6 +20,9 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
+from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+from geoparquet_io.core.validate import validate_geoparquet
 from geoparquet_io.core.write_strategies import (
     WriteStrategy,
     WriteStrategyFactory,
@@ -1305,3 +1309,232 @@ class TestDuckDBArrowExtensionTypeMapping:
     def test_unmarked_binary_registers_as_blob(self):
         """No marker means no promotion -- the baseline the wrapper is written for."""
         assert self._duckdb_type_for(None, pa.binary(), [self.WKB_POINT]) == "BLOB"
+
+
+# ---------------------------------------------------------------------------
+# Native Parquet GEOMETRY logical types (#764)
+# ---------------------------------------------------------------------------
+
+ALL_STRATEGIES = ["duckdb-kv", "in-memory", "streaming", "disk-rewrite"]
+NATIVE_VERSIONS = ["2.0", "parquet-geo-only"]
+
+
+def _geometry_carriers(path: str) -> dict[str, str]:
+    """Physical carrier per geometry column: "native" or the Parquet physical type.
+
+    Read without the spatial extension so the answer is the file's own schema,
+    not something DuckDB reconstructed.
+    """
+    con = get_duckdb_connection(load_spatial=False)
+    try:
+        rows = con.execute(
+            f"SELECT name, type, logical_type FROM parquet_schema({sql_path(path)})"
+        ).fetchall()
+    finally:
+        con.close()
+    return {
+        name: "native" if (logical and "Geometry" in str(logical)) else str(typ).lower()
+        for name, typ, logical in rows
+        if name in ("geometry", "geom2")
+    }
+
+
+def _failed_checks(path: str) -> list[str]:
+    """Validator failures, minus the one Windows fails for a platform reason.
+
+    On win32 ``native_geo_stats_contains_data_*`` reports every geometry as
+    outside its own column's geospatial statistics, for any native GEOMETRY
+    column written by any code path (#721, #748). Excused by name and only on
+    win32, exactly as ``tests/test_secondary_geometry_carriers.py`` does it, so
+    every other check stays enforced everywhere.
+    """
+    failed = sorted(
+        {c.name for c in validate_geoparquet(path).checks if c.status.value == "failed"}
+    )
+    if sys.platform == "win32":
+        failed = [f for f in failed if not f.startswith("native_geo_stats_contains_data")]
+    return failed
+
+
+def _write_via_query(source: str, out: str, version: str, strategy: str, **kwargs) -> None:
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        metadata, _ = get_parquet_metadata(source)
+        write_parquet_with_metadata(
+            con,
+            f"SELECT * FROM read_parquet({sql_path(source)})",
+            out,
+            original_metadata=metadata,
+            geoparquet_version=version,
+            write_strategy=strategy,
+            input_file=source,
+            **kwargs,
+        )
+    finally:
+        con.close()
+
+
+class TestNativeGeometryTypeAcrossStrategies:
+    """Every strategy gives a 2.0 / parquet-geo-only geometry column a native type.
+
+    Regression suite for #764. Three strategies branch on the target version and
+    build a native Parquet GEOMETRY logical type; ``disk-rewrite`` did not, so
+    its 2.0 output declared a version whose spec requires that type and carried
+    plain BYTE_ARRAY WKB -- two failures from gpio's own ``check spec``. Under
+    parquet-geo-only it was worse: the logical type is a column's only geometry
+    identity there, and the ``geo`` block the strategy wrote anyway carried
+    ``"version": null``, which DuckDB refuses to open at all.
+    """
+
+    @pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+    @pytest.mark.parametrize("version", NATIVE_VERSIONS)
+    def test_primary_column_is_native_and_valid(self, strategy, version, tmp_path):
+        """The issue's reproducer: one geometry column, one ordinary file."""
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / f"{strategy}_{version}.parquet")
+
+        _write_via_query(source, out, version, strategy)
+
+        carriers = _geometry_carriers(out)
+        assert carriers == {"geometry": "native"}, (
+            f"{strategy} wrote a {carriers['geometry']} primary column in a {version} file"
+        )
+        assert _failed_checks(out) == []
+
+    @pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+    def test_secondary_column_is_native_under_parquet_geo_only(self, strategy, tmp_path):
+        """parquet-geo-only writes no ``geo`` block, so every column needs the type (#706).
+
+        The 2.0 half of this lives in ``tests/test_secondary_geometry_carriers.py``;
+        parquet-geo-only has nothing to name the secondary by afterwards, which is
+        why the names must reach the write as ``geometry_info``.
+        """
+        source = str(tmp_path / "two_geom.parquet")
+        wkb = [struct.pack("<BI2d", 1, 1, float(i), float(i)) for i in range(4)]
+        geo = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {"encoding": "WKB", "geometry_types": ["Point"]},
+                "geom2": {"encoding": "WKB", "geometry_types": ["Point"]},
+            },
+        }
+        table = pa.table({"id": [1, 2], "geometry": wkb[:2], "geom2": wkb[2:]})
+        pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), source)
+        out = str(tmp_path / f"{strategy}_geo_only.parquet")
+
+        _write_via_query(
+            source,
+            out,
+            "parquet-geo-only",
+            strategy,
+            geometry_info={
+                "primary": "geometry",
+                "secondary": ["geom2"],
+                "metadata": {"geom2": geo["columns"]["geom2"]},
+            },
+        )
+
+        assert _geometry_carriers(out) == {"geometry": "native", "geom2": "native"}
+        assert _failed_checks(out) == []
+
+    @pytest.mark.parametrize("version", NATIVE_VERSIONS)
+    def test_disk_rewrite_table_entry_point_is_native(self, version, tmp_path):
+        """``write_from_table`` (the ``Table.write()`` path) takes the same branch."""
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / f"table_{version}.parquet")
+
+        WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE).write_from_table(
+            table=pq.read_table(source),
+            output_path=out,
+            geometry_column="geometry",
+            geoparquet_version=version,
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=None,
+            verbose=False,
+        )
+
+        assert _geometry_carriers(out) == {"geometry": "native"}
+        assert _failed_checks(out) == []
+
+    def test_disk_rewrite_parquet_geo_only_writes_no_geo_key(self, tmp_path):
+        """parquet-geo-only means no ``geo`` block, not one with ``"version": null``."""
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / "geo_only.parquet")
+
+        _write_via_query(source, out, "parquet-geo-only", "disk-rewrite")
+
+        assert b"geo" not in (pq.read_schema(out).metadata or {})
+        # DuckDB's own reader refused the file this used to write, with
+        # "Geoparquet metadata does not have a version".
+        con = duckdb.connect()
+        try:
+            count = con.execute(f"SELECT count(*) FROM read_parquet({sql_path(out)})").fetchone()
+        finally:
+            con.close()
+        assert count[0] == 3
+
+    @pytest.mark.parametrize("version", ["1.0", "1.1"])
+    def test_disk_rewrite_v1x_output_is_unchanged(self, version, tmp_path):
+        """The version branch must not leak the native type into 1.x output."""
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / f"v{version}.parquet")
+
+        _write_via_query(source, out, version, "disk-rewrite")
+
+        assert _geometry_carriers(out) == {"geometry": "byte_array"}
+        assert _failed_checks(out) == []
+        assert json.loads(pq.read_schema(out).metadata[b"geo"])["version"] == f"{version}.0"
+
+    def test_disk_rewrite_native_type_carries_the_declared_crs(self, tmp_path):
+        """A projected CRS reaches the logical type, which is where 2.0 keeps it.
+
+        Asserted on the file's own logical type rather than on the Arrow field:
+        ``WkbType.__eq__`` ignores the CRS, so comparing PyArrow types cannot
+        tell a CRS84 column from an EPSG:3857 one. ``v2_crs_consistency`` is the
+        check that notices, and it is in ``_failed_checks`` below.
+        """
+        import pyproj
+
+        crs = pyproj.CRS.from_authority("EPSG", "3857").to_json_dict()
+        geo_meta = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"], "crs": crs}},
+        }
+        points = [struct.pack("<BI2d", 1, 1, float(i) * 1000, float(i) * 1000) for i in range(3)]
+        table = pa.table({"id": [0, 1, 2], "geometry": points})
+        source = str(tmp_path / "src_3857.parquet")
+        pq.write_table(
+            table.replace_schema_metadata({b"geo": json.dumps(geo_meta).encode()}), source
+        )
+        out = str(tmp_path / "disk_rewrite_crs.parquet")
+
+        _write_via_query(source, out, "2.0", "disk-rewrite")
+
+        con = get_duckdb_connection(load_spatial=False)
+        try:
+            logical = con.execute(
+                f"SELECT logical_type FROM parquet_schema({sql_path(out)}) WHERE name = 'geometry'"
+            ).fetchone()[0]
+        finally:
+            con.close()
+        assert "Pseudo-Mercator" in str(logical)
+        assert json.loads(pq.read_schema(out).metadata[b"geo"])["columns"]["geometry"]["crs"] == crs
+        assert _failed_checks(out) == []
+
+    def test_disk_rewrite_native_type_survives_row_group_coarsening(self, tmp_path):
+        """The rewrite is per row group, so a resized write must stay native throughout."""
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 25)
+        out = str(tmp_path / "coarsened.parquet")
+
+        _write_via_query(source, out, "2.0", "disk-rewrite", row_group_rows=10)
+
+        pf = pq.ParquetFile(out)
+        shape = [pf.metadata.row_group(i).num_rows for i in range(pf.metadata.num_row_groups)]
+        assert shape == [10, 10, 5]
+        assert _geometry_carriers(out) == {"geometry": "native"}
+        assert pq.read_table(out).column("id").to_pylist() == list(range(25))
+        assert _failed_checks(out) == []

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -1525,6 +1525,24 @@ class TestNativeGeometryTypeAcrossStrategies:
         assert json.loads(pq.read_schema(out).metadata[b"geo"])["columns"]["geometry"]["crs"] == crs
         assert _failed_checks(out) == []
 
+    @pytest.mark.parametrize("strategy", ["disk-rewrite", "streaming"])
+    def test_verbose_write_names_the_native_columns(self, strategy, tmp_path, caplog):
+        """The verbose branch of the native path is code too, and says which columns.
+
+        Both strategies build the native type from the same helper, and both log
+        what they are about to write; an f-string that only runs under
+        ``--verbose`` is exactly the kind of line that ships broken otherwise.
+        """
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / f"verbose_{strategy}.parquet")
+
+        with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+            _write_via_query(source, out, "2.0", strategy, verbose=True)
+
+        assert "native parquet geometry type" in caplog.text.lower()
+        assert "'geometry'" in caplog.text
+        assert _geometry_carriers(out) == {"geometry": "native"}
+
     def test_disk_rewrite_native_type_survives_row_group_coarsening(self, tmp_path):
         """The rewrite is per row group, so a resized write must stay native throughout."""
         source = _write_points_geoparquet(tmp_path / "src.parquet", 25)
@@ -1538,3 +1556,49 @@ class TestNativeGeometryTypeAcrossStrategies:
         assert _geometry_carriers(out) == {"geometry": "native"}
         assert pq.read_table(out).column("id").to_pylist() == list(range(25))
         assert _failed_checks(out) == []
+
+
+class TestNativeWkbTypeHelpers:
+    """The two pieces every native-type write path shares."""
+
+    WKB_POINT = struct.pack("<BI2d", 1, 1, 1.0, 2.0)
+
+    def test_native_wkb_type_omits_a_default_crs(self):
+        """A default CRS is carried by omission, the way the geo block omits the key."""
+        import geoarrow.pyarrow as ga
+
+        from geoparquet_io.core.geoarrow_encoding import native_wkb_type
+
+        assert native_wkb_type(None).crs == ga.wkb().crs
+        assert native_wkb_type({"id": {"authority": "OGC", "code": "CRS84"}}).crs == ga.wkb().crs
+
+    def test_native_wkb_type_carries_a_projected_crs(self):
+        """The CRS the geo block declares is what the logical type must carry."""
+        from geoparquet_io.core.geoarrow_encoding import native_wkb_type
+
+        crs = {"id": {"authority": "EPSG", "code": 3857}}
+
+        assert json.loads(native_wkb_type(crs).crs.to_json())["id"]["code"] == 3857
+
+    def test_to_geoarrow_column_keeps_an_already_matching_array(self):
+        """The common path: plain WKB binary already matches ``geoarrow.wkb``."""
+        from geoparquet_io.core.geoarrow_encoding import native_wkb_type
+        from geoparquet_io.core.write_strategies.arrow_streaming import to_geoarrow_column
+
+        converted = to_geoarrow_column(
+            pa.array([self.WKB_POINT], type=pa.binary()), native_wkb_type(None)
+        )
+
+        assert converted.type.extension_name == "geoarrow.wkb"
+        assert converted.storage.to_pylist() == [self.WKB_POINT]
+
+    def test_to_geoarrow_column_retypes_when_the_storage_differs(self):
+        """A target whose storage differs takes the rebuild path, bytes intact."""
+        import geoarrow.pyarrow as ga
+
+        from geoparquet_io.core.write_strategies.arrow_streaming import to_geoarrow_column
+
+        converted = to_geoarrow_column(pa.array([self.WKB_POINT], type=pa.binary()), ga.large_wkb())
+
+        assert converted.type.storage_type == pa.large_binary()
+        assert converted.storage.to_pylist() == [self.WKB_POINT]

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -625,6 +625,36 @@ class TestWriteStrategiesNoGeometry:
 
         self._assert_valid_plain_parquet(output_file)
 
+    def test_disk_rewrite_query_no_geometry_verbose(
+        self, duckdb_connection, non_geo_query, output_file, caplog
+    ):
+        """The verbose row count on the plain-Parquet path opens the file it just wrote.
+
+        Same shape as the geo path's temp-file peek: the handle has to be closed
+        before the work directory is torn down, which on Windows is the
+        difference between a cleaned-up temp dir and a leaked one.
+        """
+        strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DISK_REWRITE)
+
+        with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+            strategy.write_from_query(
+                con=duckdb_connection,
+                query=non_geo_query,
+                output_path=output_file,
+                geometry_column=None,
+                original_metadata=None,
+                geoparquet_version="1.1",
+                compression="ZSTD",
+                compression_level=15,
+                row_group_size_mb=None,
+                row_group_rows=None,
+                input_crs=None,
+                verbose=True,
+            )
+
+        assert "Wrote 3 rows" in caplog.text
+        self._assert_valid_plain_parquet(output_file)
+
     def test_compression_options_honored_no_geometry(self, non_geo_table, output_file):
         """Compression options are honored when writing non-geo data."""
         strategy = WriteStrategyFactory.get_strategy(WriteStrategy.DUCKDB_KV)
@@ -1542,6 +1572,41 @@ class TestNativeGeometryTypeAcrossStrategies:
         assert "native parquet geometry type" in caplog.text.lower()
         assert "'geometry'" in caplog.text
         assert _geometry_carriers(out) == {"geometry": "native"}
+
+    def test_verbose_write_leaves_no_open_parquet_handle(self, tmp_path, monkeypatch):
+        """disk-rewrite deletes its temp file, so nothing may still hold it open.
+
+        The verbose row-count peek at the DuckDB temp file kept a
+        ``pq.ParquetFile`` alive in the enclosing frame until ``write_from_query``
+        returned -- past the ``os.unlink`` of that very file. POSIX unlinks an
+        open file happily; Windows raises ``PermissionError: [WinError 32]``, so
+        every ``--verbose`` disk-rewrite write died there.
+
+        Asserted as the invariant rather than as the platform error, so this
+        fails on every OS: when the write returns, every ParquetFile it opened
+        is closed.
+        """
+        opened = []
+        real_parquet_file = pq.ParquetFile
+
+        def tracking_parquet_file(source, *args, **kwargs):
+            handle = real_parquet_file(source, *args, **kwargs)
+            # Only the strategy's own scratch directory: those are the files it
+            # deletes, and the only ones whose handles have to be closed by the
+            # time it returns.
+            if "gpio_disk_rewrite_" in str(source):
+                opened.append(handle)
+            return handle
+
+        monkeypatch.setattr(pq, "ParquetFile", tracking_parquet_file)
+
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / "handles.parquet")
+
+        _write_via_query(source, out, "2.0", "disk-rewrite", verbose=True)
+
+        assert opened, "no temp-file ParquetFile opened -- test no longer exercises the path"
+        assert [h.closed for h in opened] == [True] * len(opened)
 
     def test_disk_rewrite_native_type_survives_row_group_coarsening(self, tmp_path):
         """The rewrite is per row group, so a resized write must stay native throughout."""


### PR DESCRIPTION
## What changed

`DiskRewriteStrategy` now branches on the target GeoParquet version, the way the
other three strategies already did.

- For **2.0** and **parquet-geo-only**, the PyArrow rewrite retypes every
  declared geometry column — primary *and* secondary, per #706 — as
  `geoarrow.wkb`, which PyArrow writes as a native Parquet GEOMETRY logical
  type. Each column's CRS comes from the `geo` entry just built for it, so the
  logical type and the metadata cannot disagree (`v2_crs_consistency`).
- For **parquet-geo-only**, no `geo` key is written at all (and the carried
  `ARROW:schema`/`pandas` descriptors are dropped, matching
  `_strip_geo_metadata_key` on the other paths).
- **1.0/1.1 output is untouched**: plain BYTE_ARRAY WKB, same `geo` block.

Two definitions are now shared rather than duplicated: `native_wkb_type()` in
`core/geoarrow_encoding.py` (the `geoarrow.wkb`-with-CRS type both the streaming
and disk-rewrite writers build) and `to_geoarrow_column()` in
`arrow_streaming.py` (the WKB→extension column encoder, promoted from a method
to a module-level function). `arrow_extension_name()` /
`is_geoarrow_extension_field()` from #791/#807 are used as-is.

The `#764` exclusions come out of `tests/test_secondary_geometry_carriers.py`:
disk-rewrite now runs in the 2.0 native-carrier matrix and in the
import-state-determinism check, and passes both.

## Why

`write_from_query` wrapped every query with `_wrap_query_with_wkb_conversion`
and `_rewrite_with_metadata` copied the schema through unchanged, so this
strategy never built a native GEOMETRY logical type at any version. Its 2.0
output declared a version whose own spec requires that type while carrying plain
BYTE_ARRAY WKB, and `gpio check spec` rejected it.

parquet-geo-only was worse: with no `geo` block to fall back on the logical type
is the column's only geometry identity — and the block this strategy wrote
anyway carried `"version": null`, which DuckDB refuses outright
(`Invalid Input Error: Geoparquet metadata does not have a version`), so that
output was unreadable rather than merely non-conforming. Both are fixed here;
the root cause is the one the issue names.

Closes #764. Refs #706 (the multi-column carrier decision this reuses), #689
(the other disk-rewrite gap in the same family).

## Verification

`gpio extract geoparquet in.parquet out.parquet --geoparquet-version 2.0
--write-strategy disk-rewrite`, 100 WKB points, then `gpio check spec`:

**Before** (this branch with `geoparquet_io/` restored to `main`):

```
Parquet Native Geo Types:
  ✗ column "geometry" does not have GEOMETRY/GEOGRAPHY logical type
  ⚠ geometry column "geometry" missing geospatial statistics
...
GeoParquet 2.0 Requirements:
  ✗ GeoParquet 2.0 requires native Parquet GEOMETRY/GEOGRAPHY type
      Column "geometry" does not use native geo type

Summary: 27 passed, 1 warnings, 2 failed
```

**After**:

```
Parquet Native Geo Types:
  ✓ column "geometry" uses Parquet GEOMETRY logical type
  ✓ column "geometry" has no CRS (defaults to OGC:CRS84)
  ✓ geometry column has geospatial statistics: [0.00, 0.00, 9.90, 9.90]
  ✓ geo_types [Point] matches data (1000 sampled)
  ✓ all geometries fall within geospatial statistics (100 checked)
...
GeoParquet 2.0 Requirements:
  ✓ column "geometry" uses required Parquet native geo type
  ✓ using default CRS (OGC:CRS84), no inline CRS required
  ✓ CRS matches: both are OGC:CRS84 (explicit or default)

Summary: 32 passed, 0 warnings, 0 failed
```

Full four-strategy × four-version matrix after the fix (carrier, written
version, row count, `validate_geoparquet` failures) — 1.x is unchanged and
`parquet-geo-only` is now readable at all:

```
1.0               duckdb-kv     geometry=byte_array  geo.version=1.0.0        rows=3 failed=[]
1.0               in-memory     geometry=byte_array  geo.version=1.0.0        rows=3 failed=[]
1.0               streaming     geometry=byte_array  geo.version=1.0.0        rows=3 failed=[]
1.0               disk-rewrite  geometry=byte_array  geo.version=1.0.0        rows=3 failed=[]
1.1               duckdb-kv     geometry=byte_array  geo.version=1.1.0        rows=3 failed=[]
1.1               in-memory     geometry=byte_array  geo.version=1.1.0        rows=3 failed=[]
1.1               streaming     geometry=byte_array  geo.version=1.1.0        rows=3 failed=[]
1.1               disk-rewrite  geometry=byte_array  geo.version=1.1.0        rows=3 failed=[]
2.0               duckdb-kv     geometry=native      geo.version=2.0.0        rows=3 failed=[]
2.0               in-memory     geometry=native      geo.version=2.0.0        rows=3 failed=[]
2.0               streaming     geometry=native      geo.version=2.0.0        rows=3 failed=[]
2.0               disk-rewrite  geometry=native      geo.version=2.0.0        rows=3 failed=[]
parquet-geo-only  duckdb-kv     geometry=native      geo.version=<no geo key> rows=3 failed=[]
parquet-geo-only  in-memory     geometry=native      geo.version=<no geo key> rows=3 failed=[]
parquet-geo-only  streaming     geometry=native      geo.version=<no geo key> rows=3 failed=[]
parquet-geo-only  disk-rewrite  geometry=native      geo.version=<no geo key> rows=3 failed=[]
```

The same matrix on `main` (the state the issue reports):

```
2.0               disk-rewrite  geometry=byte_array  failed=['native_geo_type_present_geometry',
                                                            'v2_native_types_geometry']
parquet-geo-only  disk-rewrite  <unreadable: geo block with "version": null>
```

Tests (macOS, Python 3.11):

- `uv run pytest tests/test_write_strategies.py tests/test_secondary_geometry_carriers.py -q`
  → **173 passed**. Before the fix, the new `TestNativeGeometryTypeAcrossStrategies`
  class failed 8 of 19, all disk-rewrite.
- `uv run pytest -q -m "not slow and not network and not meta" -k "write or strategy or disk"`
  → **573 passed, 14 skipped, 2 xfailed**.
- Full fast lane `-n auto` → **5414 passed, 64 skipped, 2 xfailed**, plus the four
  known cold-run parallel flakes (`test_streaming_handles_broken_pipe`, two in
  `test_pipe_integration.py`, `test_journey_07_csv_roundtrip`), which all pass
  re-run serially.
- `uv run pre-commit run --all-files` and `--hook-stage pre-push` → all hooks pass.
- Diff-coverage gate (the ubuntu/3.11 leg), reproduced locally — fast lane with
  `--cov=geoparquet_io --cov-report=xml`, then
  `uv run diff-cover coverage.xml --compare-branch origin/main --fail-under=90`:

```
Diff Coverage
Diff: origin/main...HEAD, staged and unstaged changes
-------------
geoparquet_io/core/geoarrow_encoding.py (100%)
geoparquet_io/core/write_strategies/arrow_streaming.py (100%)
geoparquet_io/core/write_strategies/disk_rewrite.py (100%)
-------------
Total:   44 lines
Missing: 0 lines
Coverage: 100%
```

  The first push landed at 87% (6 uncovered changed lines). `_to_native_geometry`
  lost two unreachable branches, and the remaining gaps — both verbose-only log
  lines and the `to_geoarrow_column` rebuild path — now have tests.

### Also fixed here: `--verbose` disk-rewrite was broken on Windows

Adding a test for the new verbose log line turned the three Windows legs red on
a defect that predates this PR. `write_from_query`'s verbose row-count peek bound
`pq.ParquetFile(temp_path)` to a local in the enclosing frame, so the handle was
still open at the `os.unlink(temp_path)` a few lines later:

```
geoparquet_io\core\write_strategies\disk_rewrite.py:272: in write_from_query
    os.unlink(temp_path)
E   PermissionError: [WinError 32] The process cannot access the file because it
    is being used by another process:
    'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\gpio_disk_rewrite_ov1d8fkg\\temp_duckdb.parquet'
```

POSIX unlinks an open file happily, which is why no existing test saw it — none
of them ran disk-rewrite with `verbose=True`. Every Parquet handle the strategy
opens on a file it later deletes is now closed first: that peek, the
plain-Parquet path's verbose row count, the rewrite's own source reader (held
across the whole write, unlinked by the caller the moment it returns), and the
verbose count on the output, which a remote write uploads and then deletes. The
regression test asserts the invariant rather than the platform error — after a
verbose write, every ParquetFile opened on the strategy's scratch directory is
closed — so it fails on every OS. Verified red before the fix
(`assert [False, ...] == [True, ...]`) and green after.

### One thing found on the way, not fixed here

With no `input_crs` threaded through, `in-memory` and `streaming` write a 2.0
file whose logical type carries **no** CRS while its `geo` block declares
EPSG:3857 — `v2_crs_consistency_geometry` and `v2_crs_in_parquet_type_geometry`
both fail. They fall back to the CRS the reader attached rather than to the CRS
the block declares. `disk-rewrite` (this PR) and `duckdb-kv` get it right. That
is a separate defect in two other strategies, so it is left for its own issue and
PR rather than widened into this one; the regression test here asserts the
correct behaviour on disk-rewrite rather than parity with `in-memory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for writing native Parquet `GEOMETRY` columns in GeoParquet 2.0 and `parquet-geo-only` outputs.
  - Preserves coordinate reference system (CRS) information for geometry columns when applicable.
  - Supports native geometry output across all write strategies, including disk-based rewrites and secondary geometry columns.
  - `parquet-geo-only` output omits the GeoParquet metadata block as expected.

- **Compatibility**
  - GeoParquet 1.0 and 1.1 outputs continue using the existing WKB representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
