### PR TITLE
fix(partition,check): handle a zero-row input cleanly instead of crashing

### DIFF
--- a/geoparquet_io/core/check_optimization.py
+++ b/geoparquet_io/core/check_optimization.py
@@ -135,11 +135,18 @@ def _check_compression(parquet_file, verbose=False):
     Returns:
         dict with 'passed' (bool) and 'detail' (str)
     """
-    from geoparquet_io.core.check_parquet_structure import check_compression
+    from geoparquet_io.core.check_parquet_structure import (
+        _NO_COMPRESSION_INFO,
+        check_compression,
+    )
 
     result = check_compression(parquet_file, verbose=False, return_results=True, quiet=True)
     if result is None:
         return {"passed": False, "detail": "No geometry column found"}
+
+    if result.get("geometry_column") and result.get("current_compression") is None:
+        # No row groups, so no codec to report -- don't claim ZSTD (#823).
+        return {"passed": True, "detail": _NO_COMPRESSION_INFO}
 
     if result.get("passed"):
         return {

--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -8,6 +8,10 @@ from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import error, info, progress, success, warn
 from geoparquet_io.core.metadata_utils import has_parquet_geo_row_group_stats
 
+#: What a file with no row groups can be told about its compression: nothing.
+#: Shared with ``check_optimization`` so both checks word it the same way (#823).
+_NO_COMPRESSION_INFO = "No compression information available (file has no row groups)"
+
 
 class CheckProfile(str, Enum):
     """
@@ -587,7 +591,26 @@ def check_compression(parquet_file, verbose=False, return_results=False, quiet=F
             }
         return
 
-    compression = get_compression_info(parquet_file, primary_col)[primary_col]
+    compression = get_compression_info(parquet_file, primary_col).get(primary_col)
+    if compression is None:
+        # A file with no row groups -- a zero-row result of a spatial filter, say --
+        # has no column chunks, so parquet_metadata() reports no codec for any
+        # column. Say so instead of indexing blind (#823). Nothing is wrong with
+        # the file and there is nothing to re-compress, so this passes.
+        if not quiet:
+            progress("\nCompression Analysis:")
+            info(f"ℹ️  {_NO_COMPRESSION_INFO}")
+        if return_results:
+            return {
+                "passed": True,
+                "current_compression": None,
+                "geometry_column": primary_col,
+                "issues": [],
+                "recommendations": [],
+                "fix_available": False,
+            }
+        return
+
     passed = compression == "ZSTD"
 
     issues = []

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -30,7 +30,7 @@ from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, progress, success, warn
-from geoparquet_io.core.partition.common import sanitize_filename
+from geoparquet_io.core.partition.common import raise_if_no_rows, sanitize_filename
 from geoparquet_io.core.partition.staging import (
     PartitionWriteOptions,
     check_output_collision,
@@ -714,6 +714,10 @@ def partition_by_admin_hierarchical(
         actual_input = stdin_temp_file
 
     try:
+        # Nothing to partition: stop before fetching remote admin
+        # boundaries and spatially joining against nothing (#823).
+        raise_if_no_rows(actual_input)
+
         # Setup dataset and get input file info
         dataset, boundary_columns = _setup_admin_dataset(dataset_name, verbose, levels)
         input_path, input_geom_col, input_bbox_col = _get_input_file_info(actual_input, verbose)

--- a/geoparquet_io/core/partition/by_a5.py
+++ b/geoparquet_io/core/partition/by_a5.py
@@ -22,6 +22,7 @@ from geoparquet_io.core.partition.common import (
     calculate_partition_stats,
     partition_by_column,
     preview_partition,
+    raise_if_no_rows,
 )
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
@@ -206,6 +207,10 @@ def partition_by_a5(
         keep_a5_column = hive
 
     try:
+        # Nothing to partition: stop before rewriting the whole input just
+        # to add an index column to it (#823).
+        raise_if_no_rows(actual_input)
+
         working_parquet, column_existed, temp_file = _ensure_a5_column(
             actual_input, a5_column_name, resolution, verbose
         )

--- a/geoparquet_io/core/partition/by_h3.py
+++ b/geoparquet_io/core/partition/by_h3.py
@@ -22,6 +22,7 @@ from geoparquet_io.core.partition.common import (
     calculate_partition_stats,
     partition_by_column,
     preview_partition,
+    raise_if_no_rows,
 )
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
@@ -206,6 +207,10 @@ def partition_by_h3(
         keep_h3_column = hive
 
     try:
+        # Nothing to partition: stop before rewriting the whole input just
+        # to add an index column to it (#823).
+        raise_if_no_rows(actual_input)
+
         working_parquet, column_existed, temp_file = _ensure_h3_column(
             actual_input, h3_column_name, resolution, verbose
         )

--- a/geoparquet_io/core/partition/by_kdtree.py
+++ b/geoparquet_io/core/partition/by_kdtree.py
@@ -16,7 +16,11 @@ from geoparquet_io.core.logging_config import (
     success,
     warn,
 )
-from geoparquet_io.core.partition.common import partition_by_column, preview_partition
+from geoparquet_io.core.partition.common import (
+    partition_by_column,
+    preview_partition,
+    raise_if_no_rows,
+)
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
 
@@ -185,6 +189,10 @@ def partition_by_kdtree(
         actual_input = stdin_temp_file
 
     try:
+        # Nothing to partition: stop before rewriting the whole input just
+        # to add an index column to it (#823).
+        raise_if_no_rows(actual_input)
+
         # Check if KD-tree column exists and get row count for dataset size validation
         from geoparquet_io.core.duckdb_metadata import get_column_names, get_row_count
 

--- a/geoparquet_io/core/partition/by_quadkey.py
+++ b/geoparquet_io/core/partition/by_quadkey.py
@@ -24,6 +24,7 @@ from geoparquet_io.core.partition.common import (
     calculate_partition_stats,
     partition_by_column,
     preview_partition,
+    raise_if_no_rows,
 )
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
@@ -223,6 +224,10 @@ def partition_by_quadkey(
         keep_quadkey_column = hive
 
     try:
+        # Nothing to partition: stop before rewriting the whole input just
+        # to add an index column to it (#823).
+        raise_if_no_rows(actual_input)
+
         working_parquet, temp_file = _ensure_quadkey_column(
             actual_input, quadkey_column_name, resolution, use_centroid, verbose, profile
         )

--- a/geoparquet_io/core/partition/by_s2.py
+++ b/geoparquet_io/core/partition/by_s2.py
@@ -33,6 +33,7 @@ from geoparquet_io.core.partition.common import (
     calculate_partition_stats,
     partition_by_column,
     preview_partition,
+    raise_if_no_rows,
 )
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
@@ -245,6 +246,10 @@ def partition_by_s2(
 
     # Wrap all operations in try/finally to ensure stdin temp file cleanup
     try:
+        # Nothing to partition: stop before rewriting the whole input just
+        # to add an index column to it (#823).
+        raise_if_no_rows(actual_input)
+
         # Calculate auto level if requested
         if auto:
             level = calculate_auto_resolution(

--- a/geoparquet_io/core/partition/by_string.py
+++ b/geoparquet_io/core/partition/by_string.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success, warn
-from geoparquet_io.core.partition.common import partition_by_column, preview_partition
+from geoparquet_io.core.partition.common import (
+    partition_by_column,
+    preview_partition,
+    raise_if_no_rows,
+)
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file
 
 
@@ -104,6 +108,9 @@ def partition_by_string(
         if verbose:
             debug(f"Validating column '{column}'...")
         validate_column_exists(input_parquet, column, verbose)
+
+        # Nothing to partition: stop before analysis or any write (#823).
+        raise_if_no_rows(input_parquet)
 
         # Validate chars parameter if provided
         if chars is not None and chars < 1:

--- a/geoparquet_io/core/partition/common.py
+++ b/geoparquet_io/core/partition/common.py
@@ -126,18 +126,57 @@ def calculate_partition_stats(output_folder: str, num_partitions: int) -> tuple[
     return total_size_mb, avg_size_mb
 
 
+def raise_if_no_rows(input_parquet: str) -> None:
+    """Stop cleanly when the input has no rows at all (issue #823).
+
+    A zero-row GeoParquet is an ordinary outcome of a spatial filter, and it has
+    no row groups and no partition values, so DuckDB's aggregates over it come
+    back all-NULL. That used to reach :func:`_calculate_size_estimates` as
+    ``total_rows=None`` and raise a bare ``TypeError``.
+
+    Called twice over, deliberately. Each ``partition_by_*`` entry point calls it
+    on the input it was handed, so nothing is rewritten to add an index column
+    and no admin boundaries are fetched before the command gives up; and
+    :func:`analyze_partition_strategy`, :func:`preview_partition` and
+    :func:`partition_by_column` call it again, which covers direct Python API
+    callers and the ``--skip-analysis`` / ``--force`` paths that bypass the
+    pre-flight analysis.
+
+    Fails open: if the row count cannot be read (a glob, a directory of
+    partitions, an unreadable remote), let the normal code path report whatever
+    it would have reported. The ``None`` guard in
+    :func:`_calculate_size_estimates` is the backstop.
+    """
+    from geoparquet_io.core.duckdb_metadata import get_row_count
+
+    try:
+        row_count = get_row_count(input_parquet)
+    except Exception:
+        return
+
+    if row_count == 0:
+        # No path in the message: with a piped input it would name the spooled
+        # temp file, not anything the caller would recognise.
+        raise PartitionError("Input has no rows to partition")
+
+
 def _calculate_size_estimates(file_size_bytes, total_rows, min_rows, max_rows, avg_rows):
-    """Calculate partition size estimates based on file size and row distribution."""
-    if file_size_bytes > 0 and total_rows > 0:
+    """Calculate partition size estimates based on file size and row distribution.
+
+    ``total_rows`` and the row-distribution aggregates are ``None`` when the
+    grouped pre-scan matched nothing (a zero-row input, or a partition column
+    that is entirely NULL), so every operand is coerced before use (#823).
+    """
+    if file_size_bytes and total_rows:
         bytes_per_row = file_size_bytes / total_rows
         return (
-            int(min_rows * bytes_per_row),
-            int(max_rows * bytes_per_row),
-            int(avg_rows * bytes_per_row),
+            int((min_rows or 0) * bytes_per_row),
+            int((max_rows or 0) * bytes_per_row),
+            int((avg_rows or 0) * bytes_per_row),
         )
     else:
         # Fallback if we can't get file size - assume 1KB per row
-        return min_rows * 1000, max_rows * 1000, avg_rows * 1000
+        return (min_rows or 0) * 1000, (max_rows or 0) * 1000, (avg_rows or 0) * 1000
 
 
 def _check_partition_errors(
@@ -269,6 +308,8 @@ def analyze_partition_strategy(
     Raises:
         PartitionAnalysisError: If blocking issues are detected
     """
+    raise_if_no_rows(input_parquet)
+
     # Show remote read message
     show_remote_read_message(input_parquet, verbose)
 
@@ -322,6 +363,12 @@ def analyze_partition_strategy(
 
     # Unpack results
     partition_count, total_rows, min_rows, max_rows, avg_rows, median_rows = result
+
+    # No groups: the column is entirely NULL (a zero-row input already stopped
+    # in raise_if_no_rows above). Every aggregate below is NULL, so report it
+    # the way preview_partition does instead of dividing by None (#823).
+    if not partition_count:
+        raise PartitionError(f"No non-NULL values found in column '{column_name}'")
 
     # Estimate size based on file size and row distribution
     min_size_bytes, max_size_bytes, avg_size_bytes = _calculate_size_estimates(
@@ -555,6 +602,8 @@ def preview_partition(
     Returns:
         Dictionary with partition statistics
     """
+    raise_if_no_rows(input_parquet)
+
     # Show remote read message
     show_remote_read_message(input_parquet, verbose)
 
@@ -764,6 +813,10 @@ def partition_by_column(
         Distinct partition values that sanitize to the same filename raise a
         ``PartitionError`` rather than silently dropping rows.
     """
+    # Stop before touching the output: nothing to partition means nothing to
+    # write, and --skip-analysis/--force must not get past this either (#823).
+    raise_if_no_rows(input_parquet)
+
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, input_parquet, output_folder)
 

--- a/tests/test_zero_row_inputs.py
+++ b/tests/test_zero_row_inputs.py
@@ -1,0 +1,240 @@
+"""Zero-row inputs must stop with a clean message, not a traceback (issue #823).
+
+A zero-row GeoParquet is an ordinary outcome of a spatial filter
+(``gpio extract --bbox ...`` over an area with nothing in it), so every consumer
+downstream has to cope with a valid file that has no rows and no row groups.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import check, extract, partition
+from geoparquet_io.core.check_parquet_structure import check_all, check_compression
+from geoparquet_io.core.exceptions import PartitionError
+from geoparquet_io.core.partition.common import (
+    _calculate_size_estimates,
+    analyze_partition_strategy,
+    partition_by_column,
+    preview_partition,
+    raise_if_no_rows,
+)
+
+# A bbox in the Southern Ocean: matches nothing in places_test.parquet.
+EMPTY_BBOX = "170,-80,171,-79"
+
+
+@pytest.fixture
+def empty_geoparquet(tmp_path, places_test_file):
+    """A valid zero-row GeoParquet, built exactly as in the issue repro."""
+    out = tmp_path / "empty.parquet"
+    result = CliRunner().invoke(extract, [f"--bbox={EMPTY_BBOX}", places_test_file, str(out)])
+    assert result.exit_code == 0, result.output
+    meta = pq.ParquetFile(out).metadata
+    assert meta.num_rows == 0
+    assert meta.num_row_groups == 0
+    return str(out)
+
+
+def _assert_clean_stop(result, message):
+    assert result.exit_code == 1, result.output
+    assert message in result.output
+    assert "Traceback" not in result.output
+    assert "TypeError" not in result.output
+
+
+class TestPartitionZeroRows:
+    """``gpio partition *`` on a zero-row file stops before computing a strategy."""
+
+    def test_string_stops_cleanly(self, empty_geoparquet, tmp_path):
+        out = tmp_path / "out"
+        result = CliRunner().invoke(
+            partition, ["string", empty_geoparquet, str(out), "--column", "name"]
+        )
+        _assert_clean_stop(result, "no rows to partition")
+        assert not out.exists(), "nothing should be written for an empty input"
+
+    def test_string_preview_stops_cleanly(self, empty_geoparquet, tmp_path):
+        result = CliRunner().invoke(
+            partition,
+            ["string", empty_geoparquet, str(tmp_path / "out"), "--column", "name", "--preview"],
+        )
+        _assert_clean_stop(result, "no rows to partition")
+
+    def test_string_skip_analysis_stops_cleanly(self, empty_geoparquet, tmp_path):
+        """``--skip-analysis`` skips the pre-flight, so the guard cannot live only there."""
+        out = tmp_path / "out"
+        result = CliRunner().invoke(
+            partition,
+            ["string", empty_geoparquet, str(out), "--column", "name", "--skip-analysis"],
+        )
+        _assert_clean_stop(result, "no rows to partition")
+        assert not out.exists()
+
+    def test_string_force_stops_cleanly(self, empty_geoparquet, tmp_path):
+        """``--force`` overrides analysis findings, but there is still nothing to write."""
+        out = tmp_path / "out"
+        result = CliRunner().invoke(
+            partition,
+            ["string", empty_geoparquet, str(out), "--column", "name", "--force"],
+        )
+        _assert_clean_stop(result, "no rows to partition")
+        assert not out.exists()
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["h3", "--resolution", "2"],
+            ["a5", "--resolution", "2"],
+            ["quadkey", "--resolution", "2", "--partition-resolution", "2"],
+            ["kdtree"],
+            ["s2", "--level", "2"],
+        ],
+        ids=["h3", "a5", "quadkey", "kdtree", "s2"],
+    )
+    def test_spatial_index_partitions_stop_cleanly(self, empty_geoparquet, tmp_path, args):
+        out = tmp_path / "out"
+        result = CliRunner().invoke(partition, [args[0], empty_geoparquet, str(out), *args[1:]])
+        assert result.exit_code == 1, result.output
+        assert "Traceback" not in result.output
+        assert "TypeError" not in result.output
+        assert "no rows to partition" in result.output
+        # Stopped before the index column was added, so no file was rewritten.
+        assert "Successfully added" not in result.output
+        assert "Added KD-tree column" not in result.output
+        assert not out.exists()
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["h3", "--auto"],
+            ["a5", "--auto"],
+            ["quadkey", "--auto"],
+            ["s2", "--auto"],
+            ["kdtree", "--auto", "1000"],
+        ],
+        ids=["h3", "a5", "quadkey", "s2", "kdtree"],
+    )
+    def test_auto_resolution_stops_cleanly(self, empty_geoparquet, tmp_path, args):
+        """``--auto`` sizes the index off the row count, so it meets the empty input first.
+
+        h3/a5/quadkey stop in ``calculate_auto_resolution`` with its own wording;
+        s2/kdtree reach the shared guard. Either way: exit 1, no traceback.
+        """
+        out = tmp_path / "out"
+        result = CliRunner().invoke(partition, [args[0], empty_geoparquet, str(out), *args[1:]])
+        assert result.exit_code == 1, result.output
+        assert "Traceback" not in result.output
+        assert "TypeError" not in result.output
+        assert "no rows" in result.output
+        assert not out.exists()
+
+    def test_admin_stops_before_fetching_boundaries(self, empty_geoparquet, tmp_path):
+        """``partition admin`` used to reach the network before finding nothing."""
+        result = CliRunner().invoke(
+            partition,
+            [
+                "admin",
+                empty_geoparquet,
+                str(tmp_path / "out"),
+                "--dataset",
+                "gaul",
+                "--levels",
+                "continent",
+            ],
+        )
+        _assert_clean_stop(result, "no rows to partition")
+        assert "spatial join" not in result.output
+
+
+class TestPartitionCoreZeroRows:
+    def test_size_estimates_guard_none_and_zero_rows(self):
+        # DuckDB returns NULL aggregates over an empty group set; never compare None to int.
+        assert _calculate_size_estimates(1000, None, 0, 0, 0) == (0, 0, 0)
+        assert _calculate_size_estimates(1000, 0, 0, 0, 0) == (0, 0, 0)
+        assert _calculate_size_estimates(1000, None, None, None, None) == (0, 0, 0)
+
+    def test_guard_fails_open_when_row_count_is_unreadable(self, tmp_path):
+        """An unreadable input is the normal code path's problem to report, not the guard's."""
+        raise_if_no_rows(str(tmp_path / "does_not_exist.parquet"))
+
+    def test_guard_passes_a_file_with_rows(self, places_test_file):
+        raise_if_no_rows(places_test_file)
+
+    def test_analyze_raises_partition_error(self, empty_geoparquet):
+        with pytest.raises(PartitionError, match="no rows to partition"):
+            analyze_partition_strategy(empty_geoparquet, "name")
+
+    def test_preview_raises_partition_error(self, empty_geoparquet):
+        with pytest.raises(PartitionError, match="no rows to partition"):
+            preview_partition(empty_geoparquet, "name")
+
+    def test_partition_by_column_raises_before_writing(self, empty_geoparquet, tmp_path):
+        out = tmp_path / "out"
+        with pytest.raises(PartitionError, match="no rows to partition"):
+            partition_by_column(empty_geoparquet, str(out), "name", skip_analysis=True)
+        assert not out.exists()
+
+    def test_analyze_all_null_column_reports_no_values(self, places_test_file, tmp_path):
+        """Rows exist but the partition column is entirely NULL.
+
+        The same aggregate comes back all-NULL, so this must be reported the way
+        ``preview_partition`` already reports it, not crash on ``None > 0``.
+        """
+        table = pq.read_table(places_test_file).slice(0, 50)
+        table = table.append_column("all_null", pa.nulls(table.num_rows, pa.string()))
+        path = tmp_path / "all_null.parquet"
+        pq.write_table(table, path)
+        with pytest.raises(PartitionError, match="No non-NULL values found in column 'all_null'"):
+            analyze_partition_strategy(str(path), "all_null")
+
+
+class TestCheckZeroRows:
+    """``gpio check *`` on a zero-row file reports what it can instead of raising."""
+
+    def test_check_compression_core_reports_no_information(self, empty_geoparquet):
+        result = check_compression(empty_geoparquet, return_results=True, quiet=True)
+        assert result["passed"] is True
+        assert result["current_compression"] is None
+        assert result["geometry_column"] == "geometry"
+        assert result["fix_available"] is False
+        assert result["issues"] == []
+
+    def test_check_all_core_does_not_raise(self, empty_geoparquet):
+        results = check_all(empty_geoparquet, return_results=True, quiet=True)
+        assert results["compression"]["current_compression"] is None
+
+    @pytest.mark.parametrize("subcommand", ["all", "compression", "optimization"])
+    def test_check_cli_exits_cleanly(self, empty_geoparquet, subcommand):
+        result = CliRunner().invoke(check, [subcommand, empty_geoparquet])
+        assert result.exit_code == 0, result.output
+        assert "KeyError" not in result.output
+        assert "Traceback" not in result.output
+        assert "No compression information" in result.output
+
+    @pytest.mark.parametrize("subcommand", ["bbox", "row-group", "spatial", "spec"])
+    def test_other_check_subcommands_still_pass(self, empty_geoparquet, subcommand):
+        result = CliRunner().invoke(check, [subcommand, empty_geoparquet])
+        assert result.exit_code == 0, result.output
+        assert "Traceback" not in result.output
+
+
+@pytest.mark.integration
+def test_piped_empty_extract_into_partition_stops_cleanly(places_test_file, tmp_path):
+    """The #804 pipeline: an empty producer result reaches a consumer that exits cleanly."""
+    out = tmp_path / "out"
+    pipeline = (
+        f"gpio extract --bbox={EMPTY_BBOX} {places_test_file} - | "
+        f"gpio partition string - {out} --column=name"
+    )
+    result = subprocess.run(pipeline, shell=True, capture_output=True, text=True, timeout=300)
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1, combined
+    assert "no rows to partition" in combined
+    assert "Traceback" not in combined
+    assert "TypeError" not in combined


### PR DESCRIPTION
## What changed

**`gpio partition *` stops with "Input has no rows to partition" (exit 1).**
A new `raise_if_no_rows()` in `core/partition/common.py` is called twice over,
deliberately:

- once at the top of each `partition_by_*` entry point, on the input the command
  was handed — so `h3`/`a5`/`s2`/`quadkey`/`kdtree` no longer rewrite the file to
  add an index column first, and `admin` no longer fetches remote boundaries to
  spatially join against nothing;
- once inside `analyze_partition_strategy`, `preview_partition` and
  `partition_by_column` — which covers direct Python API callers and the
  `--skip-analysis` / `--force` paths that bypass the pre-flight analysis.

It fails open: if the row count can't be read (a glob, a directory of partitions,
an unreadable remote) the normal code path reports whatever it would have
reported. `_calculate_size_estimates` coerces its NULL operands as the backstop.

The message carries no path on purpose — with a piped input it would name the
spooled temp file, not anything the caller would recognise.

Two related NULL-aggregate bugs fell out of the same fix:

- an **all-NULL partition column** (rows present, no groups) hit the same
  `None > 0` comparison; `analyze_partition_strategy` now reports
  `No non-NULL values found in column '<name>'`, the wording `preview_partition`
  already used;
- `--force` could previously have carried an unusable strategy forward; the
  guard in `partition_by_column` sits ahead of `_run_partition_analysis`, so
  there is nothing to force.

**`gpio check all|compression|optimization` report the missing information.**
`check_compression` uses `.get(primary_col)` and, when there is no entry, returns
`passed=True`, `current_compression=None`, `fix_available=False` and prints
`No compression information available (file has no row groups)`.
`check_optimization` learned the same case, so it no longer claims ZSTD for a
file whose codec it could not read. The wording is a shared constant.

## Why

Closes #823. A zero-row GeoParquet is an ordinary outcome of a spatial filter —
`gpio extract --bbox=170,-80,171,-79 tests/data/places_test.parquet empty.parquet`
produces a perfectly valid one — and both commands met it with a raw traceback.
Both are pre-existing on `main` and independent of streaming: a zero-row file on
disk is enough. #806 fixed the producing side (a zero-row result now streams as a
valid empty Arrow IPC stream); these are the consuming side, and they were the
remaining gap in what #804 expected — that an empty result flows through a
pipeline and the next stage exits cleanly.

Refs #804, #806.

## Verification

### Before

```
$ gpio partition string empty.parquet out --column name
  File ".../geoparquet_io/core/partition/common.py", line 327, in analyze_partition_strategy
    min_size_bytes, max_size_bytes, avg_size_bytes = _calculate_size_estimates(
  File ".../geoparquet_io/core/partition/common.py", line 131, in _calculate_size_estimates
    if file_size_bytes > 0 and total_rows > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'

$ gpio check all empty.parquet
  File ".../geoparquet_io/core/check_parquet_structure.py", line 590, in check_compression
    compression = get_compression_info(parquet_file, primary_col)[primary_col]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'geometry'
```

### After — every `gpio partition` subcommand on the zero-row file

| Command | Before | After |
|---|---|---|
| `partition string ... --column=name` | exit 1, `TypeError` traceback | exit 1, `Error: Input has no rows to partition` |
| `partition string ... --preview` | exit 1, `TypeError` traceback | exit 1, same message (once, no "Analysis error:" noise) |
| `partition string ... --skip-analysis` | exit 1, `TypeError` traceback | exit 1, same message |
| `partition string ... --force` | exit 1, `TypeError` traceback | exit 1, same message |
| `partition h3 --resolution=2` | exit 1, `TypeError` traceback (after adding the H3 column) | exit 1, same message, no rewrite |
| `partition a5 --resolution=2` | exit 1, `TypeError` traceback (after adding the A5 column) | exit 1, same message, no rewrite |
| `partition s2 --level=2` | exit 1, `TypeError` traceback (after adding the S2 column) | exit 1, same message, no rewrite |
| `partition quadkey --resolution=2 --partition-resolution=2` | exit 1, `TypeError` traceback (after adding the quadkey column) | exit 1, same message, no rewrite |
| `partition kdtree` | exit 1, `TypeError` traceback (after adding the KD-tree column) | exit 1, same message, no rewrite |
| `partition admin --dataset=gaul --levels=continent` | exit 1, `No features matched to admin boundaries` **after a network fetch and join** | exit 1, same message, no network access |

No output directory is left behind in any row.

`--auto` (which sizes the index off the row count, so it meets the empty input
before anything else) was already clean and stays clean — all five exit 1 with
no traceback and write nothing:

| Command | After |
|---|---|
| `partition h3 --auto` | `Error: Auto-resolution calculation failed: Input file has no rows` (pre-existing guard) |
| `partition a5 --auto` | same |
| `partition quadkey --auto` | same |
| `partition s2 --auto` | `Error: Input has no rows to partition` (new guard) |
| `partition kdtree --auto 1000` | `Error: Input has no rows to partition` (new guard) |

All ten `--auto` and non-`--auto` variants are pinned in
`TestPartitionZeroRows`.


```
===== partition string =====
exit=1
Error: Input has no rows to partition
===== partition string --preview =====
exit=1
Error: Input has no rows to partition
===== partition string --skip-analysis =====
exit=1
Error: Input has no rows to partition
===== partition string --force =====
exit=1
Error: Input has no rows to partition
===== partition h3 =====
exit=1
Error: Input has no rows to partition
===== partition a5 =====
exit=1
Error: Input has no rows to partition
===== partition s2 --level 2 =====
exit=1
Error: Input has no rows to partition
===== partition quadkey =====
exit=1
Error: Input has no rows to partition
===== partition kdtree =====
exit=1
Error: Input has no rows to partition
===== partition admin (network) =====
exit=1
Error: Input has no rows to partition
===== leftover output dir? =====
ls: .../out: No such file or directory
```

Note: `partition s2` reached the partition step in this environment rather than
stopping on the missing `geography` extension, so it is a real row in the matrix
above, not a skip.

### After — every `gpio check` subcommand on the zero-row file

| Subcommand | Before | After |
|---|---|---|
| `check all` | exit 1, `KeyError: 'geometry'` | exit 0, no traceback |
| `check compression` | exit 1, `KeyError: 'geometry'` | exit 0, no traceback |
| `check optimization` | exit 1, `KeyError: 'geometry'` | exit 0, no traceback |
| `check bbox` | exit 0 | exit 0 (unchanged) |
| `check row-group` | exit 0 | exit 0 (unchanged) |
| `check spatial` | exit 0 | exit 0 (unchanged) |
| `check spec` | exit 0, `26 passed, 0 warnings, 0 failed` | unchanged — confirmed already passing |
| `check stac` | exit 1, `'utf-8' codec can't decode byte 0xbc in position 7` | unchanged — **pre-existing and unrelated**: it fails identically on `tests/data/places_test.parquet`, so it is not a zero-row bug. Not fixed here. |

```
$ gpio check compression empty.parquet
Compression Analysis:
ℹ️  No compression information available (file has no row groups)

$ gpio check optimization empty.parquet | grep -i compress
  [pass] Compression: No compression information available (file has no row groups)
```

### The #804 pipeline

```
$ gpio extract --bbox=170,-80,171,-79 tests/data/places_test.parquet - \
    | gpio partition string - out --column=name
Error: Input has no rows to partition
pipestatus=0/1
```

Producer exits 0 having streamed a valid empty result, consumer exits 1 with a
clean message and writes nothing.

### Tests

`tests/test_zero_row_inputs.py`, 32 tests, written failing first (the first cut
ran 20 failed / 4 passed against `main`; the 4 that passed are the `check`
subcommands that were already clean, and the `--auto` cases added afterwards
pin behaviour this PR must not break).

```
$ uv run pytest -q -n auto -m "not slow and not network and not meta" \
    -k "zero or empty or partition or check_"
778 passed, 3 skipped, 24 warnings in 48.93s
```

Full fast lane: `5423 passed, 65 skipped, 2 xfailed` with one unrelated
`-n auto` flake (`tests/test_pipe_integration.py::TestExtractIntoPartition::test_spatial_filter_and_partition_chain`
timed out at 60s under parallel load); it passes serially —
`tests/test_pipe_integration.py: 26 passed in 29.32s`.

`uv run pre-commit run --all-files` and `--hook-stage pre-push` both pass
(deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV

