### PR TITLE
fix(validate): recognize the authority:code CRS form in the Parquet GEOMETRY type

### DIFF
--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -284,6 +284,12 @@ Validates file structure and metadata against the GeoParquet specification:
   file passes. If the coordinates really are lon/lat WGS84, drop the null
   instead: `gpio convert reproject in.parquet out.parquet --assume-crs84`
   writes the default (see [convert](../cli/convert.md)).
+- **Every CRS form the Parquet geo type may use** — the `GEOMETRY`/`GEOGRAPHY`
+  logical type can name its CRS as inline PROJJSON, `srid:<id>`,
+  `projjson:<key>` or the compact `<authority>:<code>` (e.g. `EPSG:32633`), and
+  `v2_crs_consistency` compares the real CRS in each case. A type whose CRS gpio
+  cannot read would otherwise look like one that names no CRS, which the Parquet
+  spec defines as OGC:CRS84 — a claim the file never made.
 - **Datum-aware epoch validation** — a coordinate `epoch` on a datum ensemble
   (e.g. EPSG:4326, or the OGC:CRS84 default when `crs` is omitted) fails; on a
   specific static frame (e.g. GDA2020) it warns; on a dynamic frame (e.g. ITRF)

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -287,9 +287,12 @@ Validates file structure and metadata against the GeoParquet specification:
 - **Every CRS form the Parquet geo type may use** — the `GEOMETRY`/`GEOGRAPHY`
   logical type can name its CRS as inline PROJJSON, `srid:<id>`,
   `projjson:<key>` or the compact `<authority>:<code>` (e.g. `EPSG:32633`), and
-  `v2_crs_consistency` compares the real CRS in each case. A type whose CRS gpio
-  cannot read would otherwise look like one that names no CRS, which the Parquet
-  spec defines as OGC:CRS84 — a claim the file never made.
+  `v2_crs_consistency` compares the real CRS for the resolvable forms (inline
+  PROJJSON, `srid:<id>` as EPSG:<id>, and the compact form). A `projjson:<key>`
+  reference names a metadata key this check cannot look up, so it is compared
+  conservatively: it reports a mismatch rather than guessing. A type whose CRS
+  gpio cannot read would otherwise look like one that names no CRS, which the
+  Parquet spec defines as OGC:CRS84 — a claim the file never made.
 - **Datum-aware epoch validation** — a coordinate `epoch` on a datum ensemble
   (e.g. EPSG:4326, or the OGC:CRS84 default when `crs` is omitted) fails; on a
   specific static frame (e.g. GDA2020) it warns; on a dynamic frame (e.g. ITRF)

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -220,6 +220,7 @@ def _get_pyarrow_logical_type(field) -> str | None:
     Returns DuckDB-compatible logical type string like:
     - GeometryType(crs=projjson:key_name)
     - GeometryType(crs=srid:5070)
+    - GeometryType(crs=EPSG:32633)  (bare authority code)
     - GeometryType(crs={...})  (inline PROJJSON)
     - GeometryType()  (no CRS)
 
@@ -650,6 +651,108 @@ def get_num_row_groups(parquet_file: str, con=None) -> int:
     return metadata.get("num_row_groups", 0)
 
 
+#: The prefixed CRS forms, which have the same ``a:b`` shape as a bare
+#: ``<authority>:<code>`` and must therefore be matched *before* it. ``srid:`` is
+#: an SRID (``srid:0`` meaning "unknown"), not an authority named "srid", and
+#: ``projjson:`` names a file-metadata key, not a CRS code.
+_PREFIXED_CRS_FORMS = ("projjson:", "srid:")
+
+#: A bare ``<authority>:<code>`` CRS, e.g. ``EPSG:32633`` or ``OGC:CRS84``.
+#:
+#: The Parquet geospatial spec permits it alongside ``srid:``, ``projjson:`` and
+#: inline PROJJSON, and geoarrow-based writers emit it whenever their CRS is a
+#: plain authority code. Deliberately narrow: an authority is an identifier and
+#: a code is alphanumeric, so neither ``<null>`` nor an empty ``crs=`` (what
+#: DuckDB emits for a type that declares no CRS) can match.
+_AUTHORITY_CODE_CRS = re.compile(r"^[A-Za-z][A-Za-z0-9_.\-]*:[A-Za-z0-9_.\-]+$")
+
+
+def _authority_code_crs(crs_value: Any) -> tuple[str, str] | None:
+    """The ``(authority, code)`` a bare ``<authority>:<code>`` CRS names, else None.
+
+    Returns None for the prefixed forms (``srid:``, ``projjson:``), which share
+    the shape but not the meaning, and for every value that is not that form.
+    """
+    if not isinstance(crs_value, str):
+        return None
+    token = crs_value.strip()
+    if token.lower().startswith(_PREFIXED_CRS_FORMS):
+        return None
+    if not _AUTHORITY_CODE_CRS.match(token):
+        return None
+    authority, code = token.split(":", 1)
+    return authority, code
+
+
+def resolve_authority_code_crs(crs_value: Any) -> Any:
+    """Resolve a bare ``<authority>:<code>`` CRS to PROJJSON, via pyproj.
+
+    Anything else -- another CRS form, an unknown authority, a code the PROJ
+    database does not carry -- is returned unchanged, so callers can keep
+    treating the value as opaque.
+    """
+    pair = _authority_code_crs(crs_value)
+    if pair is None:
+        return crs_value
+
+    from geoparquet_io.core.crs_utils import _projjson_from_authority
+
+    projjson = _projjson_from_authority(*pair)
+    return crs_value if projjson is None else json.loads(projjson)
+
+
+def _parse_crs_property(params: str) -> Any:
+    """The ``crs=`` property of a geo logical type's parameters, or None if it has none.
+
+    The property has four shapes, and this returns each one as the value it
+    means:
+
+    - ``crs=`` / ``crs=<null>`` -- the type declares no CRS: None
+    - ``crs={...}`` -- inline PROJJSON: the parsed dict
+    - ``crs=srid:XXXX`` / ``crs=projjson:key`` -- a reference: the string, for
+      :func:`resolve_crs_reference` to look up
+    - ``crs=EPSG:32633`` -- a bare authority code: the string, likewise
+
+    Returning None for "declares no CRS" is what keeps the ``crs`` key out of
+    :func:`parse_geometry_logical_type`'s result; callers read that absence as
+    the Parquet spec's OGC:CRS84 default, so no *unrecognized* value may reach
+    it -- that would turn a CRS the file names into a CRS84 claim it never made
+    (#814).
+    """
+    crs_start = params.find("crs=")
+    if crs_start == -1:
+        return None
+    crs_value = params[crs_start + 4 :]
+
+    if crs_value.startswith("{"):
+        # Find the matching closing brace for inline PROJJSON.
+        brace_count = 0
+        end_pos = 0
+        for i, char in enumerate(crs_value):
+            if char == "{":
+                brace_count += 1
+            elif char == "}":
+                brace_count -= 1
+                if brace_count == 0:
+                    end_pos = i + 1
+                    break
+        if end_pos == 0:
+            return None
+        crs_json_str = crs_value[:end_pos]
+        try:
+            return json.loads(crs_json_str)
+        except json.JSONDecodeError:
+            return crs_json_str
+
+    # Every other form is a single token, ending at the next parameter.
+    token = crs_value.split(",", 1)[0].strip()
+    if token.lower().startswith(_PREFIXED_CRS_FORMS):
+        return token
+    if _authority_code_crs(token) is not None:
+        return token
+    return None
+
+
 def parse_geometry_logical_type(logical_type: str) -> dict | None:
     """
     Parse Geometry/Geography logical type string from DuckDB schema.
@@ -658,6 +761,7 @@ def parse_geometry_logical_type(logical_type: str) -> dict | None:
     - GeometryType(crs={"$schema": "...", "id": {"authority": "EPSG", "code": 4326}})
     - GeographyType(algorithm=spherical)
     - GeometryType(crs=<null>)
+    - GeometryType(crs=EPSG:32633)
 
     Returns dict with keys: geo_type, geometry_type, coordinate_dimension, crs, algorithm
     """
@@ -674,49 +778,11 @@ def parse_geometry_logical_type(logical_type: str) -> dict | None:
 
     result: dict[str, Any] = {"geo_type": geo_type}
 
-    # Parse CRS if present (handle nested JSON with brace counting)
-    # DuckDB returns:
-    # - crs=<null> for files without CRS
-    # - crs={...} for inline PROJJSON
-    # - crs=projjson:key_name for reference to metadata field
-    crs_start = params.find("crs=")
-    if crs_start != -1:
-        crs_start += 4  # Skip "crs="
-        crs_value = params[crs_start:]
-
-        # Check for <null> - DuckDB's way of indicating no CRS
-        if crs_value.startswith("<null>"):
-            pass  # No CRS specified, leave result without "crs" key
-        elif crs_value.startswith("projjson:") or crs_value.startswith("srid:"):
-            # Reference to metadata field: projjson:key_name
-            # Or SRID reference: srid:XXXX (interpreted as EPSG:XXXX)
-            # Extract the reference (up to next comma or end of string)
-            end_pos = crs_value.find(",")
-            if end_pos == -1:
-                end_pos = crs_value.find(")")
-            if end_pos == -1:
-                end_pos = len(crs_value)
-            # Store the full reference string for later resolution
-            result["crs"] = crs_value[:end_pos].strip()
-        elif crs_value.startswith("{"):
-            # Find matching closing brace for inline PROJJSON
-            brace_count = 0
-            end_pos = 0
-            for i, char in enumerate(crs_value):
-                if char == "{":
-                    brace_count += 1
-                elif char == "}":
-                    brace_count -= 1
-                    if brace_count == 0:
-                        end_pos = i + 1
-                        break
-
-            if end_pos > 0:
-                crs_json_str = crs_value[:end_pos]
-                try:
-                    result["crs"] = json.loads(crs_json_str)
-                except json.JSONDecodeError:
-                    result["crs"] = crs_json_str
+    # Parse CRS if present. A type that declares no CRS leaves no "crs" key at
+    # all, which callers read as the Parquet spec's OGC:CRS84 default.
+    crs = _parse_crs_property(params)
+    if crs is not None:
+        result["crs"] = crs
 
     # Parse algorithm for Geography
     algo_match = re.search(r"algorithm=(planar|spherical)", params)
@@ -784,6 +850,7 @@ def resolve_crs_reference(parquet_file: str, crs_value: Any) -> Any:
     - Inline PROJJSON (dict)
     - Reference to metadata field: "projjson:key_name"
     - SRID reference: "srid:XXXX" (interpreted as EPSG:XXXX)
+    - Bare authority code: "EPSG:32633"
 
     Args:
         parquet_file: Path to the parquet file
@@ -791,6 +858,7 @@ def resolve_crs_reference(parquet_file: str, crs_value: Any) -> Any:
             - A dict (already resolved PROJJSON)
             - A string like "projjson:key_name" (reference to metadata field)
             - A string like "srid:5070" (interpreted as EPSG:5070)
+            - A string like "EPSG:32633" (a bare authority code)
             - None
 
     Returns:
@@ -833,8 +901,9 @@ def resolve_crs_reference(parquet_file: str, crs_value: Any) -> Any:
             pass  # Fall through to return the original value
         return crs_value  # Return the srid string if resolution failed
 
-    # Return as-is for other string values
-    return crs_value
+    # Handle a bare <authority>:<code>, e.g. "EPSG:32633". Checked last: the
+    # prefixed forms above share its shape and mean something else.
+    return resolve_authority_code_crs(crs_value)
 
 
 def detect_geometry_columns(parquet_file: str, con=None) -> dict[str, str]:

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -871,8 +871,9 @@ def resolve_crs_reference(parquet_file: str, crs_value: Any) -> Any:
     if isinstance(crs_value, dict):
         return crs_value
 
-    # Handle projjson:key_name reference to file metadata
-    if isinstance(crs_value, str) and crs_value.startswith("projjson:"):
+    # Handle projjson:key_name reference to file metadata. The prefixes are
+    # matched case-insensitively, like the parser's guard that carried them here.
+    if isinstance(crs_value, str) and crs_value.lower().startswith("projjson:"):
         key_name = crs_value[9:]  # Skip "projjson:"
         try:
             import pyarrow.parquet as pq
@@ -890,7 +891,7 @@ def resolve_crs_reference(parquet_file: str, crs_value: Any) -> Any:
         return crs_value  # Return the reference string if resolution failed
 
     # Handle srid:XXXX format - convert to PROJJSON using pyproj
-    if isinstance(crs_value, str) and crs_value.startswith("srid:"):
+    if isinstance(crs_value, str) and crs_value.lower().startswith("srid:"):
         srid = crs_value[5:]  # Skip "srid:"
         try:
             from pyproj import CRS

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2500,14 +2500,14 @@ def _schema_crs_for_consistency(schema_info: list, geom_col: str) -> Any:
     as the geo metadata), ``None`` for ``srid:0`` (unknown, the pair for an
     explicit ``"crs": null``), else the parsed CRS value.
 
-    ``parse_geometry_logical_type`` leaves no ``crs`` key in two cases, not one:
-    when the type genuinely carries no CRS (``crs=<null>``), and when it carries
-    a bare ``<authority>:<code>`` — a form the spec permits but that parser does
-    not recognize (it handles only ``srid:``, ``projjson:`` and inline PROJJSON).
-    The second case therefore reads here as a positive CRS84 claim rather than as
-    the CRS it names, so a genuine mismatch can pass this check. Tracked in #814.
+    A bare ``<authority>:<code>`` (``crs=EPSG:32633``) is resolved to PROJJSON
+    here, because the geo-metadata side of the comparison is always PROJJSON and
+    a string would never compare equal to it (#814).
     """
-    from geoparquet_io.core.duckdb_metadata import parse_geometry_logical_type
+    from geoparquet_io.core.duckdb_metadata import (
+        parse_geometry_logical_type,
+        resolve_authority_code_crs,
+    )
 
     for col in schema_info:
         if col.get("name") != geom_col:
@@ -2518,7 +2518,7 @@ def _schema_crs_for_consistency(schema_info: list, geom_col: str) -> Any:
         crs = parsed["crs"]
         if isinstance(crs, str) and crs.strip().lower() == _PARQUET_UNKNOWN_CRS:
             return None
-        return _parse_crs_value(crs)
+        return _parse_crs_value(resolve_authority_code_crs(crs))
     return CRS_ABSENT
 
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2500,9 +2500,15 @@ def _schema_crs_for_consistency(schema_info: list, geom_col: str) -> Any:
     as the geo metadata), ``None`` for ``srid:0`` (unknown, the pair for an
     explicit ``"crs": null``), else the parsed CRS value.
 
-    A bare ``<authority>:<code>`` (``crs=EPSG:32633``) is resolved to PROJJSON
-    here, because the geo-metadata side of the comparison is always PROJJSON and
-    a string would never compare equal to it (#814).
+    A bare ``<authority>:<code>`` (``crs=EPSG:32633``) and an ``srid:<id>``
+    reference (which the Parquet spec defines as EPSG:<id>) are resolved to
+    PROJJSON here, because the geo-metadata side of the comparison is always
+    PROJJSON and a string would never compare equal to it (#814).
+
+    A ``projjson:<key>`` reference names a key in the file's own metadata, which
+    this function never sees, so it is deliberately left as the raw string: it
+    compares unequal and the check reports a mismatch rather than guessing.
+    Conservative, but never a silent false PASS.
     """
     from geoparquet_io.core.duckdb_metadata import (
         parse_geometry_logical_type,
@@ -2516,8 +2522,15 @@ def _schema_crs_for_consistency(schema_info: list, geom_col: str) -> Any:
         if not (parsed and "crs" in parsed):
             return CRS_ABSENT
         crs = parsed["crs"]
-        if isinstance(crs, str) and crs.strip().lower() == _PARQUET_UNKNOWN_CRS:
-            return None
+        if isinstance(crs, str):
+            token = crs.strip()
+            if token.lower() == _PARQUET_UNKNOWN_CRS:
+                return None
+            if token.lower().startswith("srid:"):
+                # srid:<id> is EPSG:<id> per the Parquet spec; keep the raw
+                # string (fail-closed) when the code doesn't resolve.
+                resolved = resolve_authority_code_crs(f"EPSG:{token[len('srid:') :]}")
+                return _parse_crs_value(resolved if isinstance(resolved, dict) else crs)
         return _parse_crs_value(resolve_authority_code_crs(crs))
     return CRS_ABSENT
 

--- a/tests/test_parquet_authority_code_crs.py
+++ b/tests/test_parquet_authority_code_crs.py
@@ -36,6 +36,7 @@ from geoparquet_io.core.validate import (
 )
 
 EPSG3857_PROJJSON = PyprojCRS.from_epsg(3857).to_json_dict()
+EPSG5070_PROJJSON = PyprojCRS.from_epsg(5070).to_json_dict()
 EPSG32633_PROJJSON = PyprojCRS.from_epsg(32633).to_json_dict()
 CRS84_ID = {
     "type": "GeographicCRS",
@@ -134,6 +135,12 @@ class TestResolveCompactForm:
         assert isinstance(result, dict)
         assert result.get("id", {}).get("code") == 5070
 
+    def test_uppercase_srid_still_takes_the_srid_path(self):
+        """The parser carries ``SRID:5070`` through, so the resolver must match it too."""
+        result = resolve_crs_reference("any_file.parquet", "SRID:5070")
+        assert isinstance(result, dict)
+        assert result.get("id", {}).get("code") == 5070
+
     @pytest.mark.parametrize("value", ["unknown:format", "EPSG:99999999", "not-a-crs"])
     def test_an_unresolvable_value_is_returned_unchanged(self, value):
         assert resolve_crs_reference("any_file.parquet", value) == value
@@ -182,6 +189,63 @@ class TestV2CrsConsistencyVerdicts:
             _geo_meta({"crs": None}), _schema("GeometryType(crs=srid:0)"), "geometry"
         )
         assert check.status is CheckStatus.PASSED
+
+
+class TestSridReferenceInConsistency:
+    """Per the Parquet spec, ``srid:<id>`` in the geo context is EPSG:<id>.
+
+    It must resolve like the compact form does, so a file whose metadata carries
+    the identical CRS as PROJJSON does not false-fail; ``projjson:<key>`` names
+    file metadata this check cannot read, so it stays a conservative mismatch.
+    """
+
+    def test_matching_srid_reference_passes(self):
+        """Was FAILED: the raw ``srid:5070`` string never equals its own PROJJSON."""
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": EPSG5070_PROJJSON}),
+            _schema("GeometryType(crs=srid:5070)"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.PASSED
+
+    def test_mismatching_srid_reference_fails(self):
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": PyprojCRS.from_epsg(4326).to_json_dict()}),
+            _schema("GeometryType(crs=srid:5070)"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.FAILED
+
+    def test_uppercase_srid_reference_behaves_like_lowercase(self):
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": EPSG5070_PROJJSON}),
+            _schema("GeometryType(crs=SRID:5070)"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.PASSED
+
+    def test_uppercase_srid_zero_still_means_unknown(self):
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": None}), _schema("GeometryType(crs=SRID:0)"), "geometry"
+        )
+        assert check.status is CheckStatus.PASSED
+
+    def test_unresolvable_srid_reference_still_fails_closed(self):
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": EPSG5070_PROJJSON}),
+            _schema("GeometryType(crs=srid:99999999)"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.FAILED
+
+    def test_projjson_reference_is_a_conservative_mismatch(self):
+        """The named key cannot be read here, so report a mismatch, never a guess."""
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": EPSG5070_PROJJSON}),
+            _schema("GeometryType(crs=projjson:my_crs)"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.FAILED
 
 
 # =============================================================================

--- a/tests/test_parquet_authority_code_crs.py
+++ b/tests/test_parquet_authority_code_crs.py
@@ -1,0 +1,277 @@
+"""#814: the Parquet geo type's bare ``<authority>:<code>`` CRS must be recognized.
+
+The Parquet geospatial spec lets the ``GEOMETRY``/``GEOGRAPHY`` logical type name
+its CRS in four shapes: nothing at all (which the spec defines as OGC:CRS84),
+``srid:<id>``, ``projjson:<key>``, and inline PROJJSON — plus the compact
+``<authority>:<code>`` form, e.g. ``EPSG:32633``. gpio's parser recognized only
+the first four, so a file using the compact form parsed to *no* ``crs`` key,
+which reads downstream as the positive claim "this type declares OGC:CRS84".
+
+That made ``_check_v2_crs_consistency`` wrong in both directions: a real mismatch
+(geo metadata OGC:CRS84 vs a Parquet type naming EPSG:32633) passed, and a real
+match (both naming EPSG:3857) failed. The two prefix forms have the same
+``a:b`` shape as the compact one, so the assertions below also pin that
+``srid:``/``projjson:`` keep winning over the new branch.
+"""
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from pyproj import CRS as PyprojCRS
+
+from geoparquet_io.core.crs_utils import extract_crs_from_parquet
+from geoparquet_io.core.duckdb_metadata import (
+    get_schema_info,
+    parse_geometry_logical_type,
+    resolve_crs_reference,
+)
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_native_crs_format,
+    _check_parquet_geo_only_crs,
+    _check_v2_crs_consistency,
+    validate_geoparquet,
+)
+
+EPSG3857_PROJJSON = PyprojCRS.from_epsg(3857).to_json_dict()
+EPSG32633_PROJJSON = PyprojCRS.from_epsg(32633).to_json_dict()
+CRS84_ID = {
+    "type": "GeographicCRS",
+    "name": "WGS 84 (CRS84)",
+    "id": {"authority": "OGC", "code": "CRS84"},
+}
+
+
+def _schema(logical_type: str) -> list[dict]:
+    return [{"name": "geometry", "logical_type": logical_type}]
+
+
+def _geo_meta(col_meta: dict) -> dict:
+    return {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": col_meta}}
+
+
+# =============================================================================
+# The parser: the compact form has to survive parse_geometry_logical_type
+# =============================================================================
+
+
+class TestParserRecognizesTheCompactForm:
+    def test_bare_authority_code_is_returned_as_the_crs(self):
+        result = parse_geometry_logical_type("GeometryType(crs=EPSG:32633)")
+        assert result is not None
+        assert result["crs"] == "EPSG:32633"
+
+    def test_compact_form_alongside_positional_params(self):
+        result = parse_geometry_logical_type("GeometryType(Point, XY, crs=EPSG:32633)")
+        assert result is not None
+        assert result["crs"] == "EPSG:32633"
+        assert result["geometry_type"] == "Point"
+        assert result["coordinate_dimension"] == "XY"
+
+    def test_compact_form_on_a_geography_type_keeps_the_algorithm(self):
+        result = parse_geometry_logical_type("GeographyType(crs=OGC:CRS84, algorithm=spherical)")
+        assert result is not None
+        assert result["crs"] == "OGC:CRS84"
+        assert result["algorithm"] == "spherical"
+
+    @pytest.mark.parametrize(
+        "logical_type,expected",
+        [
+            ("GeometryType(crs=srid:5070)", "srid:5070"),
+            ("GeometryType(crs=srid:0)", "srid:0"),
+            ("GeometryType(crs=projjson:projjson_epsg_5070)", "projjson:projjson_epsg_5070"),
+        ],
+    )
+    def test_prefixed_forms_still_win_over_the_new_branch(self, logical_type, expected):
+        """``srid:``/``projjson:`` have the same ``a:b`` shape and keep their meaning."""
+        result = parse_geometry_logical_type(logical_type)
+        assert result is not None
+        assert result["crs"] == expected
+
+    @pytest.mark.parametrize(
+        "logical_type",
+        [
+            "GeometryType(crs=<null>)",
+            "GeometryType(crs=)",  # what DuckDB actually emits for a CRS-less type
+            "GeographyType(crs=, algorithm=spherical)",
+            "GeographyType(algorithm=spherical)",
+        ],
+    )
+    def test_a_type_that_declares_no_crs_still_has_no_crs_key(self, logical_type):
+        result = parse_geometry_logical_type(logical_type)
+        assert result is not None
+        assert "crs" not in result
+
+    def test_inline_projjson_is_still_parsed_into_a_dict(self):
+        result = parse_geometry_logical_type(
+            'GeometryType(crs={"type": "ProjectedCRS", "id": {"authority": "EPSG", "code": 5070}})'
+        )
+        assert result is not None
+        assert result["crs"]["id"]["code"] == 5070
+
+
+# =============================================================================
+# The resolver: the compact form resolves through pyproj, like srid:
+# =============================================================================
+
+
+class TestResolveCompactForm:
+    def test_epsg_authority_code_resolves_to_projjson(self):
+        result = resolve_crs_reference("any_file.parquet", "EPSG:32633")
+        assert isinstance(result, dict)
+        assert result["id"] == {"authority": "EPSG", "code": 32633}
+
+    def test_ogc_crs84_resolves_to_projjson(self):
+        result = resolve_crs_reference("any_file.parquet", "OGC:CRS84")
+        assert isinstance(result, dict)
+        assert str(result.get("id", {}).get("code", "")).upper() == "CRS84"
+
+    def test_srid_still_takes_the_srid_path(self):
+        """``srid`` must not be read as an authority name."""
+        result = resolve_crs_reference("any_file.parquet", "srid:5070")
+        assert isinstance(result, dict)
+        assert result.get("id", {}).get("code") == 5070
+
+    @pytest.mark.parametrize("value", ["unknown:format", "EPSG:99999999", "not-a-crs"])
+    def test_an_unresolvable_value_is_returned_unchanged(self, value):
+        assert resolve_crs_reference("any_file.parquet", value) == value
+
+
+# =============================================================================
+# The verdicts #814 reports as wrong, in both directions
+# =============================================================================
+
+
+class TestV2CrsConsistencyVerdicts:
+    def test_metadata_crs84_against_a_compact_utm_type_is_a_mismatch(self):
+        """Was PASSED: the unrecognized form read as a positive CRS84 claim."""
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": CRS84_ID}), _schema("GeometryType(crs=EPSG:32633)"), "geometry"
+        )
+        assert check.status is CheckStatus.FAILED
+
+    def test_omitted_metadata_crs_against_a_compact_utm_type_is_a_mismatch(self):
+        """An omitted metadata crs means CRS84, which EPSG:32633 is not."""
+        check = _check_v2_crs_consistency(
+            _geo_meta({}), _schema("GeometryType(crs=EPSG:32633)"), "geometry"
+        )
+        assert check.status is CheckStatus.FAILED
+
+    def test_matching_crs_on_both_sides_passes(self):
+        """Was FAILED: the same CRS, rejected."""
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": EPSG3857_PROJJSON}),
+            _schema("GeometryType(crs=EPSG:3857)"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.PASSED
+
+    def test_compact_crs84_matches_explicit_epsg_4326_metadata(self):
+        """CRS84/EPSG:4326 equivalence still holds through the new branch."""
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": PyprojCRS.from_epsg(4326).to_json_dict()}),
+            _schema("GeometryType(crs=OGC:CRS84)"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.PASSED
+
+    def test_srid_zero_still_means_unknown_not_an_authority_code(self):
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": None}), _schema("GeometryType(crs=srid:0)"), "geometry"
+        )
+        assert check.status is CheckStatus.PASSED
+
+
+# =============================================================================
+# The parquet-geo-only checks, which now see a CRS where they saw none
+# =============================================================================
+
+
+class TestParquetGeoOnlyChecksSeeTheCompactCrs:
+    """A CRS-less type and a compactly-named CRS must no longer report the same."""
+
+    def test_native_crs_format_warns_like_the_other_reference_forms(self):
+        """Was PASSED "no CRS (defaults to OGC:CRS84)" — a CRS the file never named."""
+        check = _check_native_crs_format(_schema("GeometryType(crs=EPSG:32633)"), "geometry")
+        assert check.status is CheckStatus.WARNING
+        assert "EPSG:32633" in (check.details or "")
+
+    def test_parquet_geo_only_crs_reports_the_resolved_crs(self):
+        check = _check_parquet_geo_only_crs(
+            _schema("GeometryType(crs=EPSG:32633)"), "geometry", "any_file.parquet"
+        )
+        assert check.status is CheckStatus.PASSED
+        assert "no CRS" not in check.message
+
+    def test_a_crs_less_type_still_reports_the_default(self):
+        check = _check_native_crs_format(_schema("GeometryType(crs=)"), "geometry")
+        assert check.status is CheckStatus.PASSED
+        assert "defaults to OGC:CRS84" in check.message
+
+
+# =============================================================================
+# End to end on a real file that carries the compact form
+# =============================================================================
+
+
+def _write_compact_crs_file(tmp_path, name: str, parquet_crs: str, metadata_crs) -> str:
+    """Write a real file whose Parquet geo type names its CRS as ``authority:code``.
+
+    DuckDB expands an authority code into full PROJJSON when it writes, so the
+    compact form has to come from geoarrow-pyarrow, which writes the CRS string
+    onto the logical type verbatim.
+    """
+    import geoarrow.pyarrow as ga
+    import shapely
+
+    wkb = [bytes(w) for w in shapely.to_wkb(shapely.points([[500000.0, 5000000.0]]))]
+    array = ga.wkb().with_crs(parquet_crs).wrap_array(pa.array(wkb, type=pa.binary()))
+    geo = {
+        "version": "2.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {"encoding": "WKB", "geometry_types": ["Point"], "crs": metadata_crs}
+        },
+    }
+    table = pa.table({"geometry": array})
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode("utf-8")})
+    out = tmp_path / name
+    pq.write_table(table, out)
+
+    # Non-vacuity: the written file really carries the compact form, not PROJJSON.
+    logical = [c["logical_type"] for c in get_schema_info(str(out)) if c["name"] == "geometry"]
+    assert logical == [f"GeometryType(crs={parquet_crs})"]
+    return str(out)
+
+
+class TestCompactCrsFileValidatesEndToEnd:
+    def test_a_matching_compact_crs_file_passes_consistency(self, tmp_path):
+        path = _write_compact_crs_file(
+            tmp_path, "compact_match.parquet", "EPSG:32633", EPSG32633_PROJJSON
+        )
+        result = validate_geoparquet(path, validate_data=False)
+        check = next(c for c in result.checks if c.name == "v2_crs_consistency_geometry")
+        assert check.status is CheckStatus.PASSED
+
+    def test_a_mismatching_compact_crs_file_fails_consistency(self, tmp_path):
+        path = _write_compact_crs_file(tmp_path, "compact_mismatch.parquet", "EPSG:32633", CRS84_ID)
+        result = validate_geoparquet(path, validate_data=False)
+        check = next(c for c in result.checks if c.name == "v2_crs_consistency_geometry")
+        assert check.status is CheckStatus.FAILED
+        assert "32633" in (check.details or "") or "UTM" in (check.details or "")
+
+    def test_crs_detection_reads_the_compact_form_off_the_parquet_type(self, tmp_path):
+        """A file with no geo metadata still has a real CRS gpio can read."""
+        import geoarrow.pyarrow as ga
+        import shapely
+
+        wkb = [bytes(w) for w in shapely.to_wkb(shapely.points([[500000.0, 5000000.0]]))]
+        array = ga.wkb().with_crs("EPSG:32633").wrap_array(pa.array(wkb, type=pa.binary()))
+        out = tmp_path / "compact_no_geo.parquet"
+        pq.write_table(pa.table({"geometry": array}), out)
+
+        crs = extract_crs_from_parquet(str(out))
+        assert isinstance(crs, dict)
+        assert crs["id"] == {"authority": "EPSG", "code": 32633}


### PR DESCRIPTION
## What changed

`core/duckdb_metadata.py` now recognizes a bare `<authority>:<code>` CRS
(e.g. `EPSG:32633`) on the Parquet `GEOMETRY`/`GEOGRAPHY` logical type.

- The `crs=` parsing moves out of `parse_geometry_logical_type` into
  `_parse_crs_property`, which returns each shape as the value it means and
  `None` only for "this type declares no CRS". The compact form is matched
  **after** the `srid:` / `projjson:` prefixes — they have the same `a:b` shape
  and keep their own meanings (`srid:0` is still "unknown", not authority
  "srid").
- `resolve_crs_reference` resolves the compact form to PROJJSON through pyproj,
  the way `srid:` already is, reusing `crs_utils._projjson_from_authority`
  (lru-cached). An unknown authority or code is returned unchanged.
- `validate._schema_crs_for_consistency` resolves it before comparing — the
  geo-metadata side of that comparison is always PROJJSON, so a string would
  never compare equal — and its docstring drops the accepted-gap note #796
  left there.
- `docs/guide/check.md` gains a bullet listing every CRS form the Parquet geo
  type may use.

## Why

`parse_geometry_logical_type` handled four shapes (`<null>`, `srid:`,
`projjson:`, inline PROJJSON). The compact `<authority>:<code>` is
spec-permitted and is what geoarrow-based writers emit when their CRS is a
plain authority code, but it fell through all four branches, so the parser
returned **no `crs` key at all** — indistinguishable from a type that genuinely
declares no CRS. Every caller reads that absence as the Parquet spec's
OGC:CRS84 default, so an unreadable CRS became a *positive* CRS84 claim, and
`_check_v2_crs_consistency` was wrong in both directions.

#796 documented this as an accepted gap and pointed here; refs #796.

## Verification

The two verdicts from the issue, on the same inputs, before and after:

```
$ uv run python verdicts.py     # before (this branch's parent)
parse_geometry_logical_type('GeometryType(crs=EPSG:32633)'):
    {'geo_type': 'Geometry'}

geo metadata OGC:CRS84 + Parquet crs=EPSG:32633 -> PASSED
    CRS matches: both are OGC:CRS84 (explicit or default) | None
geo metadata EPSG:3857  + Parquet crs=EPSG:3857  -> FAILED
    CRS in geo metadata must match CRS in Parquet schema | Metadata: WGS 84 / Pseudo-Mercator (EPSG:3857), Schema: OGC:CRS84 (default)

$ uv run python verdicts.py     # after
parse_geometry_logical_type('GeometryType(crs=EPSG:32633)'):
    {'geo_type': 'Geometry', 'crs': 'EPSG:32633'}

geo metadata OGC:CRS84 + Parquet crs=EPSG:32633 -> FAILED
    CRS in geo metadata must match CRS in Parquet schema | Metadata: WGS 84 (CRS84) (OGC:CRS84), Schema: WGS 84 / UTM zone 33N (EPSG:32633)
geo metadata EPSG:3857  + Parquet crs=EPSG:3857  -> PASSED
    CRS in metadata matches CRS in Parquet schema | None
```

New tests (`tests/test_parquet_authority_code_crs.py`, 28 cases) written first
and watched fail — 11 failed on the unfixed tree, exactly the behaviours this
PR changes; the other 17 are the guards that must not move (`srid:`/`projjson:`
precedence, `crs=` / `crs=<null>` still leaving no `crs` key, inline PROJJSON,
CRS84 ⇄ EPSG:4326 equivalence, `srid:0` still meaning unknown):

```
$ uv run pytest tests/test_parquet_authority_code_crs.py -q   # before
FAILED ...TestParserRecognizesTheCompactForm::test_bare_authority_code_is_returned_as_the_crs
FAILED ...TestParserRecognizesTheCompactForm::test_compact_form_alongside_positional_params
FAILED ...TestParserRecognizesTheCompactForm::test_compact_form_on_a_geography_type_keeps_the_algorithm
FAILED ...TestResolveCompactForm::test_epsg_authority_code_resolves_to_projjson
FAILED ...TestResolveCompactForm::test_ogc_crs84_resolves_to_projjson
FAILED ...TestV2CrsConsistencyVerdicts::test_metadata_crs84_against_a_compact_utm_type_is_a_mismatch
FAILED ...TestV2CrsConsistencyVerdicts::test_omitted_metadata_crs_against_a_compact_utm_type_is_a_mismatch
FAILED ...TestV2CrsConsistencyVerdicts::test_matching_crs_on_both_sides_passes
FAILED ...TestCompactCrsFileValidatesEndToEnd::test_a_matching_compact_crs_file_passes_consistency
FAILED ...TestCompactCrsFileValidatesEndToEnd::test_a_mismatching_compact_crs_file_fails_consistency
FAILED ...TestCompactCrsFileValidatesEndToEnd::test_crs_detection_reads_the_compact_form_off_the_parquet_type
11 failed, 14 passed in 4.05s

$ uv run pytest tests/test_parquet_authority_code_crs.py -q   # after
28 passed in 2.55s
```

The end-to-end cases write a real file: DuckDB expands an authority code into
full PROJJSON when it writes, so the compact form comes from geoarrow-pyarrow,
which puts the string on the logical type verbatim (`GeometryType(crs=EPSG:32633)`,
asserted in the fixture so the test cannot go vacuous).

Blast radius:

```
$ uv run pytest -m corpus -q -n auto
229 passed, 8 xfailed in 22.52s          # no corpus verdict changed

$ uv run pytest tests/ -q -k "crs or validate or duckdb_metadata or logical_type"
1189 passed, 3 skipped, 3 xfailed, 1 xpassed in 755.75s

$ uv run pytest -n auto -m "not slow and not network and not meta" -q
4 failed, 5647 passed, 20 skipped, 10 xfailed in 442.53s
# the 4 are the known cold-run xdist flakes; serially:
$ uv run pytest tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe tests/test_pipe_integration.py -q
27 passed in 45.09s
```

No corpus fixture uses the compact form (the corpus's own CHANGELOG lists it as
a variant it does not yet cover), so the corpus lane is unchanged.

Two other checks now see a CRS where they previously saw none, both pinned in
the new tests: for a parquet-geo-only file with `crs=EPSG:32633`,
`native_crs_format` reports WARNING "CRS format may not be widely recognized"
(as it already does for `projjson:`) instead of PASSED "no CRS (defaults to
OGC:CRS84)", and `parquet_geo_only_crs` reports the resolved CRS.
`crs_utils.extract_crs_from_parquet` now returns EPSG:32633 for such a file
instead of `None`.

`uv run pre-commit run --all-files` and `--hook-stage pre-push` pass. (`vulture`
flags `tests/data/geoparquet-testing/scripts/gen_bad_data.py:222` — upstream
corpus-submodule code, unrelated to this diff and only visible because the
submodule is checked out locally.)

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV
