### PR TITLE
fix(sort): accept a directory of GeoParquet files as input

### DIFF
--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -231,6 +231,40 @@ Column sorting:
 - Preserves all original columns and metadata
 - Useful for time-series data or alphabetical ordering
 
+## Multi-File Input
+
+`sort column` and `sort quadkey` read a whole dataset — a directory of GeoParquet
+files, or a quoted glob — and write one sorted file:
+
+=== "CLI"
+
+    <!-- doctest: skip="needs a directory of parquet files the sample data does not have" -->
+    ```bash
+    # Every .parquet file in the directory
+    gpio sort column parts/ sorted.parquet name
+
+    # Or a glob. Quote it, or the shell expands it before gpio sees it
+    gpio sort quadkey 'parts/*.parquet' sorted.parquet
+    ```
+
+=== "Python"
+
+    <!-- doctest: skip="needs a directory of parquet files the sample data does not have" -->
+    ```python
+    import geoparquet_io as gpio
+
+    gpio.read_partition('parts/') \
+        .sort_column('name') \
+        .write('sorted.parquet', row_group_rows=50000)
+    ```
+
+The output's `bbox` and `geometry_types` are recomputed over everything written,
+rather than carried from the first file — a merged extent that under-covered the
+result would make conformant readers skip data.
+
+`sort hilbert` and `sort str` take a single file only; they stop with a message
+pointing at `gpio extract` to consolidate first.
+
 ## Output Format
 
 The output file:

--- a/geoparquet_io/core/partition/reader.py
+++ b/geoparquet_io/core/partition/reader.py
@@ -19,6 +19,46 @@ from geoparquet_io.core.logging_config import debug
 from geoparquet_io.core.remote import is_remote_url
 
 
+def resolve_read_path(
+    path: str,
+    hive_input: bool | None = None,
+    verbose: bool = False,
+) -> tuple[str, dict]:
+    """Return a RAW path DuckDB can actually read, plus the options it implies.
+
+    A bare directory is not something DuckDB's reader can open -- it has to
+    become the glob over the parquet files it holds, or the read dies with a
+    ``Catalog Error`` naming the directory (#817). Single files and globs pass
+    straight through.
+
+    The pass-through is guarded by :func:`is_partition_path` rather than applied
+    unconditionally, because ``resolve_partition_path`` also turns on hive
+    partitioning for any path with a ``key=value`` directory in it: a single
+    file at ``data/country=US/x.parquet`` must keep reading as itself, without
+    the partition keys appearing as extra columns.
+
+    The result is RAW, so the caller still owes it exactly one escape --
+    :func:`safe_file_url` or ``sql_path``, never both.
+
+    Args:
+        path: File path, directory, or glob pattern (local or remote)
+        hive_input: Explicitly enable/disable hive partitioning. None = auto-detect.
+        verbose: Print debug messages
+
+    Returns:
+        tuple: (raw path for DuckDB, read_parquet options dict)
+    """
+    if not is_partition_path(path):
+        return path, {}
+
+    resolved_path, auto_options = resolve_partition_path(path, hive_input)
+    if verbose:
+        debug(f"Resolved partition path: {resolved_path}")
+        if auto_options:
+            debug(f"Auto-detected options: {auto_options}")
+    return resolved_path, auto_options
+
+
 def build_read_parquet_expr(
     path: str,
     allow_schema_diff: bool = False,
@@ -45,18 +85,8 @@ def build_read_parquet_expr(
         str: DuckDB read_parquet() expression like
              "read_parquet('path/*.parquet', hive_partitioning=true)"
     """
-    # Check if this is a partition path and resolve it
-    if is_partition_path(path):
-        resolved_path, auto_options = resolve_partition_path(path, hive_input)
-        safe_path = safe_file_url(resolved_path, verbose=False)
-
-        if verbose:
-            debug(f"Resolved partition path: {resolved_path}")
-            if auto_options:
-                debug(f"Auto-detected options: {auto_options}")
-    else:
-        safe_path = safe_file_url(path, verbose=False)
-        auto_options = {}
+    resolved_path, auto_options = resolve_read_path(path, hive_input, verbose=verbose)
+    safe_path = safe_file_url(resolved_path, verbose=False)
 
     # Build options list
     options = []

--- a/geoparquet_io/core/partition/reader.py
+++ b/geoparquet_io/core/partition/reader.py
@@ -197,6 +197,42 @@ def require_single_file(path: str, command_name: str) -> None:
         )
 
 
+def raise_for_schema_mismatch(exc: BaseException, path: str) -> None:
+    """Re-raise DuckDB's multi-file schema-mismatch as a user-facing error.
+
+    A directory whose parquet files disagree on their columns dies in DuckDB
+    with an ``InvalidInputException`` ("schema mismatch in glob ... try
+    setting union_by_name=True"). Reading with ``union_by_name`` implicitly
+    would NULL-fill the union -- for a renamed geometry column that fabricates
+    empty geometries -- so gpio points at the explicit reconciliation instead.
+
+    A no-op for single-file inputs and for unrelated errors, so callers can
+    invoke it first and fall through to their own handling.
+
+    Args:
+        exc: The DuckDB exception that interrupted the read
+        path: The RAW input path the user gave (directory or glob)
+
+    Raises:
+        GeoParquetError: When ``path`` is multi-file and ``exc`` is DuckDB's
+            schema-mismatch complaint.
+    """
+    from geoparquet_io.core.exceptions import GeoParquetError
+
+    if not is_partition_path(path):
+        return
+    text = str(exc)
+    if "schema mismatch" not in text.lower() and "union_by_name" not in text:
+        return
+    raise GeoParquetError(
+        f"The parquet files matched by '{path}' do not share one schema, so "
+        "they cannot be read together.\n\n"
+        "Reconcile them into a single file first:\n\n"
+        f'    gpio extract "{path}" merged.parquet --allow-schema-diff\n\n'
+        f"then run this command on the merged file.\n\nOriginal error: {exc}"
+    ) from exc
+
+
 def get_files_to_check(
     path: str,
     check_all: bool = False,

--- a/geoparquet_io/core/sort_by_column.py
+++ b/geoparquet_io/core/sort_by_column.py
@@ -12,7 +12,7 @@ from geoparquet_io.core.exceptions import InvalidParameterError, RemoteAccessErr
 from geoparquet_io.core.file_utils import handle_output_overwrite, is_partition_path
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.parquet_writer import resolve_sort_row_group_rows
-from geoparquet_io.core.partition.reader import build_read_parquet_expr
+from geoparquet_io.core.partition.reader import build_read_parquet_expr, raise_for_schema_mismatch
 from geoparquet_io.core.remote import (
     get_remote_error_hint,
     is_remote_url,
@@ -237,6 +237,11 @@ def sort_by_column(
         if is_remote_url(input_parquet):
             hints = get_remote_error_hint(str(e), input_parquet)
             raise RemoteAccessError(input_parquet, f"{hints}\n\nOriginal error: {str(e)}") from e
+        raise
+    except duckdb.InvalidInputException as e:
+        # A multi-file input whose files disagree on their columns only
+        # surfaces here, when the read actually runs (#817's new surface).
+        raise_for_schema_mismatch(e, input_parquet)
         raise
     finally:
         con.close()

--- a/geoparquet_io/core/sort_by_column.py
+++ b/geoparquet_io/core/sort_by_column.py
@@ -9,9 +9,10 @@ from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_m
 from geoparquet_io.core.duckdb_metadata import get_usable_columns
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import InvalidParameterError, RemoteAccessError
-from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.file_utils import handle_output_overwrite, is_partition_path
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.parquet_writer import resolve_sort_row_group_rows
+from geoparquet_io.core.partition.reader import build_read_parquet_expr
 from geoparquet_io.core.remote import (
     get_remote_error_hint,
     is_remote_url,
@@ -166,7 +167,9 @@ def sort_by_column(
     # Show remote read message
     show_remote_read_message(input_parquet, verbose)
 
-    safe_url = safe_file_url(input_parquet, verbose)
+    # A directory or glob reads as every parquet file under it, the way
+    # `extract` reads one (#817). The helper owns the single escape.
+    read_expr = build_read_parquet_expr(input_parquet, verbose=verbose)
 
     # Get metadata from original file
     metadata, schema = get_parquet_metadata(input_parquet, verbose)
@@ -196,7 +199,7 @@ def sort_by_column(
     # Build SELECT query
     order_query = f"""
         SELECT *
-        FROM '{safe_url}'
+        FROM {read_expr}
         ORDER BY {order_clause}
     """
 
@@ -221,6 +224,11 @@ def sort_by_column(
             geoparquet_version=geoparquet_version,
             input_file=input_parquet,
             memory_limit=memory_limit,
+            # `metadata` is the FIRST file's footer. Over a merged multi-file
+            # input its bbox/geometry_types under-cover the output, and a
+            # conformant reader would skip the rows they leave out, so the
+            # write recomputes them instead of carrying them (#793).
+            invalidate_derived_stats=is_partition_path(input_parquet),
         )
 
         success(f"Sorted by {', '.join(column_list)} to: {output_parquet}")

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -14,9 +14,14 @@ from geoparquet_io.core.constants import DEFAULT_QUADKEY_COLUMN_NAME, DEFAULT_QU
 from geoparquet_io.core.duckdb_metadata import get_column_names, get_usable_columns
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
-from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.file_utils import (
+    handle_output_overwrite,
+    is_partition_path,
+    safe_file_url,
+)
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.parquet_writer import resolve_sort_row_group_rows
+from geoparquet_io.core.partition.reader import build_read_parquet_expr, resolve_read_path
 from geoparquet_io.core.remote import (
     needs_httpfs,
     setup_aws_profile_if_needed,
@@ -171,7 +176,10 @@ def sort_by_quadkey(
 
     # Track if we created a temporary file with quadkey
     temp_file = None
-    actual_input = input_parquet
+    # A directory has to become the glob over its files before anything reads
+    # it (#817). `input_parquet` itself stays raw: it is what messages quote and
+    # what the multi-file stats guard below is asked about.
+    actual_input = resolve_read_path(input_parquet, verbose=verbose)[0]
 
     if not column_exists:
         if not using_default_name:
@@ -189,15 +197,16 @@ def sort_by_quadkey(
                 f"Auto-adding at resolution {resolution}..."
             )
 
-        # Create temporary file for quadkey-enriched data
+        # Create temporary file for quadkey-enriched data. The input's basename
+        # is deliberately not part of the name: a directory input has none (or
+        # a trailing separator), and a glob's `*` is not a legal filename
+        # character on Windows.
         temp_dir = tempfile.gettempdir()
-        temp_file = os.path.join(
-            temp_dir, f"quadkey_enriched_{uuid.uuid4().hex}_{os.path.basename(input_parquet)}"
-        )
+        temp_file = os.path.join(temp_dir, f"quadkey_enriched_{uuid.uuid4().hex}.parquet")
 
         try:
             add_quadkey_column(
-                input_parquet=input_parquet,
+                input_parquet=actual_input,
                 output_parquet=temp_file,
                 quadkey_column_name=quadkey_column_name,
                 resolution=resolution,
@@ -222,7 +231,7 @@ def sort_by_quadkey(
         debug(f"Using existing quadkey column '{quadkey_column_name}'")
 
     # Get metadata from input file (use actual_input in case we added quadkey)
-    actual_safe_url = safe_file_url(actual_input, verbose)
+    read_expr = build_read_parquet_expr(actual_input, verbose=verbose)
     metadata, _ = get_parquet_metadata(actual_input, verbose)
 
     # Get usable columns for building SELECT clause
@@ -247,7 +256,7 @@ def sort_by_quadkey(
         # Build sort query
         query = f"""
             SELECT {select_clause}
-            FROM '{actual_safe_url}'
+            FROM {read_expr}
             ORDER BY {quote_identifier(quadkey_column_name)}
         """
 
@@ -269,6 +278,11 @@ def sort_by_quadkey(
             geoparquet_version=geoparquet_version,
             input_file=input_parquet,
             memory_limit=memory_limit,
+            # `metadata` describes only the first file of a multi-file input
+            # (and the auto-add step carried that footer forward), so its
+            # bbox/geometry_types under-cover the merged output. Recompute
+            # rather than carry (#793).
+            invalidate_derived_stats=is_partition_path(input_parquet),
         )
 
         if remove_quadkey_column:

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import uuid
 
+import duckdb
 import pyarrow as pa
 
 from geoparquet_io.core.add.quadkey import add_quadkey_column, add_quadkey_table
@@ -21,7 +22,11 @@ from geoparquet_io.core.file_utils import (
 )
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.parquet_writer import resolve_sort_row_group_rows
-from geoparquet_io.core.partition.reader import build_read_parquet_expr, resolve_read_path
+from geoparquet_io.core.partition.reader import (
+    build_read_parquet_expr,
+    raise_for_schema_mismatch,
+    resolve_read_path,
+)
 from geoparquet_io.core.remote import (
     needs_httpfs,
     setup_aws_profile_if_needed,
@@ -225,6 +230,10 @@ def sort_by_quadkey(
         except Exception as e:
             if temp_file and os.path.exists(temp_file):
                 os.remove(temp_file)
+            # A multi-file input whose files disagree on their columns dies
+            # here, in the first read over the glob. Report the mismatch,
+            # not a failed quadkey add (#817's new surface).
+            raise_for_schema_mismatch(e, input_parquet)
             raise GeoParquetError(f"Failed to add quadkey column: {str(e)}") from e
 
     elif verbose:
@@ -290,6 +299,11 @@ def sort_by_quadkey(
         else:
             success(f"Sorted by quadkey to: {output_parquet}")
 
+    except duckdb.InvalidInputException as e:
+        # When the quadkey column already exists there is no auto-add step,
+        # so a schema mismatch across the glob first strikes the sort itself.
+        raise_for_schema_mismatch(e, input_parquet)
+        raise
     finally:
         con.close()
         # Clean up temp file if we created one

--- a/scripts/sql_path_literals_baseline.txt
+++ b/scripts/sql_path_literals_baseline.txt
@@ -28,8 +28,7 @@
 1 geoparquet_io/core/process/overview/detect.py
 1 geoparquet_io/core/process/overview/rollup.py
 5 geoparquet_io/core/reproject.py
-1 geoparquet_io/core/sort_by_column.py
-2 geoparquet_io/core/sort_quadkey.py
+1 geoparquet_io/core/sort_quadkey.py
 1 geoparquet_io/core/stream_io.py
 16 geoparquet_io/core/validate.py
 4 geoparquet_io/core/wfs.py

--- a/tests/test_partition_input.py
+++ b/tests/test_partition_input.py
@@ -18,6 +18,7 @@ from geoparquet_io.core.partition.reader import (
     build_read_parquet_expr,
     get_files_to_check,
     get_partition_info,
+    resolve_read_path,
 )
 
 
@@ -100,6 +101,39 @@ class TestGetFilesToCheck:
         assert len(files) == 1
         assert files[0] == buildings_test_file
         assert notice == ""
+
+
+class TestResolveReadPath:
+    """Tests for resolve_read_path, the raw-path half of the read helper."""
+
+    def test_directory_becomes_a_glob(self, country_partition_dir):
+        resolved, _options = resolve_read_path(country_partition_dir)
+        assert resolved != country_partition_dir
+        assert resolved.endswith(".parquet")
+        assert "*" in resolved
+
+    def test_single_file_passes_through_untouched(self, buildings_test_file):
+        assert resolve_read_path(buildings_test_file) == (buildings_test_file, {})
+
+    def test_a_single_file_under_a_hive_directory_is_not_read_as_a_partition(self, tmp_path):
+        """A ``key=value`` ancestor must not switch hive partitioning on.
+
+        ``resolve_partition_path`` infers hive mode from the directory names
+        alone, so calling it unguarded would make a plain single-file read
+        sprout the partition keys as extra columns.
+        """
+        hive_dir = tmp_path / "country=US"
+        hive_dir.mkdir()
+        one_file = hive_dir / "part.parquet"
+        one_file.touch()
+        assert resolve_read_path(str(one_file)) == (str(one_file), {})
+
+    def test_hive_directory_still_reports_hive_partitioning(self, tmp_path):
+        root = tmp_path / "hive_root"
+        (root / "country=US").mkdir(parents=True)
+        (root / "country=US" / "part.parquet").touch()
+        _resolved, options = resolve_read_path(str(root))
+        assert options.get("hive_partitioning") is True
 
 
 class TestBuildReadParquetExpr:

--- a/tests/test_partition_input.py
+++ b/tests/test_partition_input.py
@@ -11,13 +11,16 @@ These tests verify that gpio commands properly handle partition input:
 import os
 
 import pyarrow.parquet as pq
+import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.cli.main import check, extract, inspect
+from geoparquet_io.core.exceptions import GeoParquetError
 from geoparquet_io.core.partition.reader import (
     build_read_parquet_expr,
     get_files_to_check,
     get_partition_info,
+    raise_for_schema_mismatch,
     resolve_read_path,
 )
 
@@ -134,6 +137,36 @@ class TestResolveReadPath:
         (root / "country=US" / "part.parquet").touch()
         _resolved, options = resolve_read_path(str(root))
         assert options.get("hive_partitioning") is True
+
+    def test_verbose_reports_auto_detected_options(self, tmp_path):
+        """The verbose branch narrates the resolved path AND the options."""
+        root = tmp_path / "hive_root"
+        (root / "country=US").mkdir(parents=True)
+        (root / "country=US" / "part.parquet").touch()
+        _resolved, options = resolve_read_path(str(root), verbose=True)
+        assert options.get("hive_partitioning") is True
+
+
+class TestRaiseForSchemaMismatch:
+    """Direct tests for the helper's pass-through and raising branches."""
+
+    MISMATCH = (
+        'schema mismatch in glob: column "geometry" was read from the original '
+        "file ... If you are trying to read files with different schemas, try "
+        "setting union_by_name=True"
+    )
+
+    def test_single_file_input_is_a_no_op(self, buildings_test_file):
+        """A single file cannot disagree with itself; the caller re-raises."""
+        raise_for_schema_mismatch(Exception(self.MISMATCH), buildings_test_file)
+
+    def test_unrelated_error_on_a_partition_is_a_no_op(self, country_partition_dir):
+        """Other InvalidInputExceptions are not this helper's to rewrap."""
+        raise_for_schema_mismatch(Exception("out of memory"), country_partition_dir)
+
+    def test_mismatch_on_a_partition_raises_the_reconciliation_hint(self, country_partition_dir):
+        with pytest.raises(GeoParquetError, match="allow-schema-diff"):
+            raise_for_schema_mismatch(Exception(self.MISMATCH), country_partition_dir)
 
 
 class TestBuildReadParquetExpr:

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -20,6 +20,7 @@ import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.cli.main import sort
+from geoparquet_io.core import sort_by_column as sort_by_column_module
 from geoparquet_io.core import sort_quadkey as sort_quadkey_module
 from geoparquet_io.core.exceptions import GeoParquetError
 from geoparquet_io.core.sort_by_column import sort_by_column, sort_by_column_table
@@ -597,3 +598,27 @@ class TestSortPartitionSchemaMismatch:
         with pytest.raises(GeoParquetError, match="allow-schema-diff"):
             sort_by_quadkey(str(mismatched_schema_dir), temp_output_file)
         assert not os.path.exists(temp_output_file)
+
+    def test_sort_column_unrelated_invalid_input_propagates(
+        self, places_parts_dir, temp_output_file
+    ):
+        """Only the schema-mismatch complaint is rewrapped; anything else
+        DuckDB calls invalid input must keep its original type and text."""
+        parts_dir, _ = places_parts_dir
+        boom = duckdb.InvalidInputException("something else entirely")
+        with mock.patch.object(
+            sort_by_column_module, "write_parquet_with_metadata", side_effect=boom
+        ):
+            with pytest.raises(duckdb.InvalidInputException, match="something else entirely"):
+                sort_by_column(str(parts_dir), temp_output_file, "name")
+
+    def test_sort_quadkey_unrelated_invalid_input_propagates(
+        self, places_parts_dir, temp_output_file
+    ):
+        parts_dir, _ = places_parts_dir
+        boom = duckdb.InvalidInputException("something else entirely")
+        with mock.patch.object(
+            sort_quadkey_module, "write_parquet_with_metadata", side_effect=boom
+        ):
+            with pytest.raises(duckdb.InvalidInputException, match="something else entirely"):
+                sort_by_quadkey(str(parts_dir), temp_output_file)

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -3,6 +3,7 @@ Tests for sort commands.
 """
 
 import io
+import json
 import os
 import sys
 import tempfile
@@ -11,12 +12,14 @@ from pathlib import Path
 from unittest import mock
 
 import duckdb
+import pyarrow.compute as pc
 import pyarrow.ipc as ipc
 import pyarrow.parquet as pq
 import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.cli.main import sort
+from geoparquet_io.core import sort_quadkey as sort_quadkey_module
 from geoparquet_io.core.sort_by_column import sort_by_column, sort_by_column_table
 from tests.conftest import safe_unlink
 
@@ -379,3 +382,132 @@ class TestSortByColumnStreaming:
         reader = ipc.RecordBatchStreamReader(output_buffer)
         result = reader.read_all()
         assert result.num_rows > 0
+
+
+def _geo_bbox(parquet_path) -> list[float] | None:
+    """The primary column's declared ``bbox`` from a file's geo metadata."""
+    geo = json.loads(pq.ParquetFile(parquet_path).metadata.metadata[b"geo"])
+    return geo["columns"][geo["primary_column"]].get("bbox")
+
+
+@pytest.fixture
+def places_parts_dir(places_test_file, tmp_path):
+    """A directory of three GeoParquet files split out of places.parquet.
+
+    Each part declares its OWN extent in geo metadata, so a first-file ``bbox``
+    carried onto the merged output is distinguishable from one recomputed over
+    everything written. Returns ``(directory, union_bbox)``.
+    """
+    table = pq.read_table(places_test_file)
+    table = table.take(pc.sort_indices(pc.struct_field(table["bbox"], "xmin")))
+
+    def extent(bbox_col):
+        return [pc.min(pc.struct_field(bbox_col, k)).as_py() for k in ("xmin", "ymin")] + [
+            pc.max(pc.struct_field(bbox_col, k)).as_py() for k in ("xmax", "ymax")
+        ]
+
+    parts_dir = tmp_path / "places_parts"
+    parts_dir.mkdir()
+    n = table.num_rows
+    slices = [table.slice(0, n // 3), table.slice(n // 3, n // 3), table.slice(2 * (n // 3))]
+    for i, part in enumerate(slices):
+        meta = dict(part.schema.metadata)
+        geo = json.loads(meta[b"geo"])
+        geo["columns"]["geometry"]["bbox"] = extent(part["bbox"])
+        meta[b"geo"] = json.dumps(geo).encode()
+        pq.write_table(part.replace_schema_metadata(meta), parts_dir / f"part_{i}.parquet")
+
+    union = extent(table["bbox"])
+    # Fixture sanity: the first file's declared extent must NOT be the union,
+    # or the carry assertions below could not tell the two apart.
+    assert _geo_bbox(parts_dir / "part_0.parquet") != pytest.approx(union)
+    return parts_dir, union
+
+
+class TestSortPartitionInput:
+    """``sort column`` and ``sort quadkey`` accept a directory of files (#817).
+
+    Both already read a quoted glob, but a bare directory reached DuckDB as
+    ``FROM '<dir>'`` and died with a Catalog Error. ``sort hilbert`` and
+    ``sort str`` reject every multi-file input with a consolidation hint, and
+    keep doing so.
+    """
+
+    @pytest.mark.parametrize("version_args", [[], ["--geoparquet-version=2.0"]])
+    def test_sort_column_accepts_bare_directory(
+        self, places_parts_dir, temp_output_file, version_args
+    ):
+        parts_dir, union_bbox = places_parts_dir
+        runner = CliRunner()
+        result = runner.invoke(
+            sort, ["column", f"{parts_dir}{os.sep}", temp_output_file, "name", *version_args]
+        )
+        assert result.exit_code == 0, result.output
+
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == 766
+        names = out.column("name").to_pylist()
+        assert names == sorted(names)
+        # The merged output's extent, not the first part's (#793's carry guard).
+        assert _geo_bbox(temp_output_file) == pytest.approx(union_bbox)
+
+    @pytest.mark.parametrize("version_args", [[], ["--geoparquet-version=2.0"]])
+    def test_sort_column_glob_describes_the_merged_output(
+        self, places_parts_dir, temp_output_file, version_args
+    ):
+        parts_dir, union_bbox = places_parts_dir
+        runner = CliRunner()
+        result = runner.invoke(
+            sort,
+            ["column", str(parts_dir / "*.parquet"), temp_output_file, "name", *version_args],
+        )
+        assert result.exit_code == 0, result.output
+        assert pq.read_metadata(temp_output_file).num_rows == 766
+        assert _geo_bbox(temp_output_file) == pytest.approx(union_bbox)
+
+    def test_sort_quadkey_accepts_bare_directory(self, places_parts_dir, temp_output_file):
+        parts_dir, union_bbox = places_parts_dir
+        runner = CliRunner()
+        result = runner.invoke(sort, ["quadkey", str(parts_dir), temp_output_file])
+        assert result.exit_code == 0, result.output
+
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == 766
+        quadkeys = out.column("quadkey").to_pylist()
+        assert quadkeys == sorted(quadkeys)
+        assert _geo_bbox(temp_output_file) == pytest.approx(union_bbox)
+
+    def test_sort_quadkey_directory_temp_name_has_no_glob_character(
+        self, places_parts_dir, temp_output_file
+    ):
+        """The auto-add scratch file must be a name every OS can create.
+
+        It used to end in ``os.path.basename(input_parquet)``; for a glob
+        input that is a literal ``*.parquet``, and ``*`` is not a legal
+        filename character on Windows.
+        """
+        parts_dir, _ = places_parts_dir
+        seen = []
+        real_add = sort_quadkey_module.add_quadkey_column
+
+        def spy(**kwargs):
+            seen.append(kwargs["output_parquet"])
+            return real_add(**kwargs)
+
+        with mock.patch.object(sort_quadkey_module, "add_quadkey_column", spy):
+            result = CliRunner().invoke(
+                sort, ["quadkey", str(parts_dir / "*.parquet"), temp_output_file]
+            )
+        assert result.exit_code == 0, result.output
+        assert seen, "expected the quadkey column to be auto-added"
+        assert not any(c in os.path.basename(seen[0]) for c in '*?"<>|'), seen[0]
+
+    @pytest.mark.parametrize("subcommand", ["hilbert", "str"])
+    def test_spatial_sorts_still_reject_a_directory_with_guidance(
+        self, subcommand, places_parts_dir, temp_output_file
+    ):
+        parts_dir, _ = places_parts_dir
+        result = CliRunner().invoke(sort, [subcommand, str(parts_dir), temp_output_file])
+        assert result.exit_code != 0
+        assert "requires a single parquet file" in result.output
+        assert "gpio extract" in result.output

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 import duckdb
+import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.ipc as ipc
 import pyarrow.parquet as pq
@@ -20,7 +21,9 @@ from click.testing import CliRunner
 
 from geoparquet_io.cli.main import sort
 from geoparquet_io.core import sort_quadkey as sort_quadkey_module
+from geoparquet_io.core.exceptions import GeoParquetError
 from geoparquet_io.core.sort_by_column import sort_by_column, sort_by_column_table
+from geoparquet_io.core.sort_quadkey import sort_by_quadkey
 from tests.conftest import safe_unlink
 
 
@@ -511,3 +514,86 @@ class TestSortPartitionInput:
         assert result.exit_code != 0
         assert "requires a single parquet file" in result.output
         assert "gpio extract" in result.output
+
+
+@pytest.fixture
+def mismatched_schema_dir(places_test_file, tmp_path):
+    """A directory of two files whose geometry columns are named differently.
+
+    ``a.parquet`` keeps the column as ``geometry``; ``b.parquet`` renames it to
+    ``geom`` (in the schema and in its geo metadata). DuckDB refuses to read
+    the pair as one glob, and the sort commands must turn that refusal into a
+    user-facing error, not a raw ``InvalidInputException`` traceback.
+    """
+    table = pq.read_table(places_test_file)
+    half = table.num_rows // 2
+    parts_dir = tmp_path / "mismatched_parts"
+    parts_dir.mkdir()
+    pq.write_table(table.slice(0, half), parts_dir / "a.parquet")
+
+    part = table.slice(half)
+    meta = dict(part.schema.metadata)
+    geo = json.loads(meta[b"geo"])
+    geo["columns"]["geom"] = geo["columns"].pop("geometry")
+    geo["primary_column"] = "geom"
+    meta[b"geo"] = json.dumps(geo).encode()
+    renamed = part.rename_columns(
+        ["geom" if name == "geometry" else name for name in part.column_names]
+    ).replace_schema_metadata(meta)
+    pq.write_table(renamed, parts_dir / "b.parquet")
+    return parts_dir
+
+
+class TestSortPartitionSchemaMismatch:
+    """Mismatched schemas across a directory's files fail cleanly (#817 follow-up).
+
+    Reachable only through the multi-file input this branch added: a single
+    file can never disagree with itself. The message points at the explicit
+    reconciliation (``gpio extract ... --allow-schema-diff``) instead of
+    quietly union-by-naming, which would NULL-fill a renamed geometry column.
+    """
+
+    def test_sort_column_cli_reports_mismatch_cleanly(
+        self, mismatched_schema_dir, temp_output_file
+    ):
+        result = CliRunner().invoke(
+            sort, ["column", str(mismatched_schema_dir), temp_output_file, "name"]
+        )
+        assert result.exit_code == 1
+        assert "do not share one schema" in result.output
+        assert "--allow-schema-diff" in result.output
+        assert "InvalidInputException" not in result.output
+        assert "Traceback" not in result.output
+        assert not os.path.exists(temp_output_file)
+
+    def test_sort_column_core_raises_geoparquet_error(
+        self, mismatched_schema_dir, temp_output_file
+    ):
+        with pytest.raises(GeoParquetError, match="allow-schema-diff"):
+            sort_by_column(str(mismatched_schema_dir), temp_output_file, "name")
+        assert not os.path.exists(temp_output_file)
+
+    def test_sort_quadkey_cli_reports_mismatch_cleanly(
+        self, mismatched_schema_dir, temp_output_file
+    ):
+        """The auto-add step reads the whole glob, so it hits the mismatch."""
+        result = CliRunner().invoke(sort, ["quadkey", str(mismatched_schema_dir), temp_output_file])
+        assert result.exit_code == 1
+        assert "do not share one schema" in result.output
+        assert "--allow-schema-diff" in result.output
+        assert "InvalidInputException" not in result.output
+        assert not os.path.exists(temp_output_file)
+
+    def test_sort_quadkey_existing_column_raises_geoparquet_error(
+        self, mismatched_schema_dir, temp_output_file
+    ):
+        """With quadkey already present the sort itself reads the glob."""
+        for name in ("a.parquet", "b.parquet"):
+            path = mismatched_schema_dir / name
+            part = pq.read_table(path)
+            part = part.append_column("quadkey", pa.array(["0"] * part.num_rows))
+            pq.write_table(part, path)
+
+        with pytest.raises(GeoParquetError, match="allow-schema-diff"):
+            sort_by_quadkey(str(mismatched_schema_dir), temp_output_file)
+        assert not os.path.exists(temp_output_file)


### PR DESCRIPTION
## What changed

`gpio sort column` and `gpio sort quadkey` now accept a bare directory of
GeoParquet files, alongside the quoted glob they already took.

- Both read through `build_read_parquet_expr`, the same helper `extract` uses,
  so a directory resolves to the glob over the parquet files it holds. The path
  is escaped exactly once, inside the helper.
- `resolve_read_path` is factored out of `build_read_parquet_expr` for the
  callers that need the raw resolved path rather than the SQL expression
  (`sort quadkey` hands it to its auto-add step). Guarded by
  `is_partition_path`, so a single file under a `country=US/` directory keeps
  reading as itself rather than sprouting the partition keys as columns.
- Both writes now set `invalidate_derived_stats` when the input is a partition,
  routing through #793's multi-file carry guard.
- The `sort quadkey` scratch file no longer takes its name from the input's
  basename.
- `docs/guide/sort.md` gains a "Multi-File Input" section (CLI + Python tabs).

`sort hilbert` and `sort str` were already correct: they reject every
multi-file input via `require_single_file` with a hint pointing at
`gpio extract`. A test now locks that behaviour in.

## Why

`sort_by_column` interpolated the input straight into `FROM '<path>'`, so a
directory reached DuckDB as a table name and died with a Catalog Error
(#817). `sort quadkey` failed the same way one step earlier, inside its
auto-add of the quadkey column.

Resolving rather than rejecting is the direction the two commands were already
pointing: both accept a glob today, and `build_read_parquet_expr` is the
established convention for partition-aware reads. Rejecting would have meant
taking away the glob form that works.

Accepting a directory exposed a second, pre-existing bug the fix has to carry:
`get_parquet_metadata` reads the **first** file's footer only, so the merged
output was declaring one part's `bbox` as the whole set's. That under-covers
the result, and a conformant reader would skip the rows it leaves out. Both
commands now mark those stats stale for partition input, exactly as `extract`
does, and the write recomputes them. The glob form was silently wrong about
this before this PR; the two `..._glob_describes_the_merged_output` tests fail
on `main`.

The Python API has no equivalent entry point: `ops.sort_column` /
`ops.sort_quadkey` and the `Table` methods sort an already-materialised
`pa.Table`, and the path-reading front door is `gpio.read_partition()`, which
has always gone through `build_read_parquet_expr`. Verified directly:
`gpio.read_partition('parts/').sort_column('name')` returns all 766 rows in
sorted order.

## Verification

All four subcommands against a directory of three files split out of
`tests/data/canonical/places.parquet` (766 rows total):

```
########## gpio sort column .../parts/ ##########
Sorting by name...
Sorted by name to: .../v817/column.parquet
   -> exit 0
########## gpio sort quadkey .../parts/ ##########
Adding quadkey column 'quadkey' (zoom level 13)...
Successfully added quadkey column 'quadkey' (zoom level 13) to: /var/folders/.../quadkey_enriched_76045c3efec241c89fa218e655506f52.parquet
Sorting by 'quadkey'
Sorted by quadkey to: .../v817/quadkey.parquet
   -> exit 0
########## gpio sort hilbert .../parts/ ##########
Error: Partitioned input detected: .../parts/

The 'sort hilbert' command requires a single parquet file as input.
To work with partitioned data, first consolidate using:

    gpio extract ".../parts/" consolidated.parquet

Then run this command on the consolidated file.
   -> exit 1
########## gpio sort str .../parts/ ##########
Error: Partitioned input detected: .../parts/

The 'sort str' command requires a single parquet file as input.
[... same hint ...]
   -> exit 1
########## glob form, sort column ##########
Sorted by name to: .../v817/glob.parquet
   -> exit 0
```

Row counts and the declared extent of each output — 766 rows and the union of
all three parts, not part 0's `[-0.989, 9.799, -0.842, 12.051]`:

```
.../v817/column.parquet rows= 766
    "bbox": [-0.9891021251678467, 9.798559188842773, 1.4808248281478882, 12.391399]
.../v817/quadkey.parquet rows= 766
    "bbox": [-0.9891021251678467, 9.798559188842773, 1.4808248281478882, 12.391399]
.../v817/glob.parquet rows= 766
    "bbox": [-0.9891021251678467, 9.798559188842773, 1.4808248281478882, 12.391399]
```

The same eight cases before the fix — six failed, and the two that passed are
the `hilbert`/`str` rejection locks:

```
FAILED TestSortPartitionInput::test_sort_column_accepts_bare_directory[version_args0]
FAILED TestSortPartitionInput::test_sort_column_accepts_bare_directory[version_args1]
FAILED TestSortPartitionInput::test_sort_column_glob_describes_the_merged_output[version_args0]
FAILED TestSortPartitionInput::test_sort_column_glob_describes_the_merged_output[version_args1]
FAILED TestSortPartitionInput::test_sort_quadkey_accepts_bare_directory
FAILED TestSortPartitionInput::test_sort_quadkey_directory_temp_name_has_no_glob_character
6 failed, 2 passed, 23 deselected in 1.64s
```

Test lanes:

```
$ uv run pytest -q -n auto -m "not slow and not network and not meta" -k "sort or partition_path or directory or read_path"
214 passed, 7 skipped, 1 warning in 23.74s

$ uv run pytest -q -n auto -m "not slow and not network and not meta"
3 failed, 5406 passed, 67 skipped, 2 xfailed, 105 warnings in 205.16s

$ uv run pytest -q -p no:randomly \
    tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe \
    tests/e2e/test_journeys.py::test_journey_01_geojson_to_geoparquet_and_back \
    tests/test_pipe_integration.py::TestZeroRowStreams::test_extract_zero_rows_to_stdout
3 passed in 5.91s
```

The three parallel failures are the known cold-run flakes and pass serially.

`uv run pre-commit run --all-files` and `--hook-stage pre-push` both clean
(pre-push includes xenon, import-linter, deptry, vulture, mypy, menard-check
and the fast-test hook). `scripts/check_sql_path_literals.py` baseline drops
from 3 hand-written interpolations across the two sort modules to 1.

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `sort column` and `sort quadkey` now accept directories and quoted globs containing multiple GeoParquet files.
  - Combined outputs recalculate bounding boxes and geometry type metadata across all input files.
  - Schema mismatch errors now provide clear guidance for reconciling input files.

- **Bug Fixes**
  - Improved handling of partitioned and Hive-style input paths.
  - Spatial sorting continues to clearly require a single input file.

- **Documentation**
  - Added multi-file sorting guidance and CLI/Python examples to the sort guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->