### PR TITLE
feat(api): expose directory sub-partitioning (min_size, in_place, preview)

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1538,6 +1538,51 @@ ops.partition_by_admin(table, 'output/', levels=['country'])
 print(f"Created {stats['file_count']} files")
 ```
 
+### Sub-partitioning a directory
+
+`gpio partition <index> <dir>/ --min-size` is the other half of the partition
+commands: it walks a *directory*, splits every file over a size threshold into a
+sibling `<file>_<index>/` directory, and with `--in-place` removes each original
+once its sub-partitions hold every row it had. That is the step you reach for
+when partitioning by country or by a string column has left a few oversized
+files.
+
+Its unit of work is a directory on disk, not an in-memory table, so it is not a
+`Table` method. It is an `ops` function over a path — one per index, named after
+the command it mirrors:
+
+```python
+from geoparquet_io.api import ops
+
+# Split every file over 100MB into H3 sub-partitions, removing the originals
+result = ops.sub_partition_by_h3(
+    'by_country/', min_size='100MB', resolution=7, in_place=True
+)
+print(f"{result['processed']} file(s) sub-partitioned")
+
+# Or see what would happen, writing and deleting nothing
+plan = ops.sub_partition_by_a5('by_country/', min_size='100MB', auto=True, preview=True)
+for candidate in plan['candidates']:
+    print(f"{candidate['path']} -> {candidate['output_dir']}/")
+```
+
+The return value is a dict with `processed`, `skipped`, `errors`, `candidates`
+(the files the threshold selected, with sizes and destinations) and `preview`.
+
+- `min_size` takes the CLI's `'100MB'` spelling or a plain byte count.
+- A file whose sub-partitions do not hold all of its rows keeps its original —
+  rows with a NULL or empty geometry get a NULL index cell and are dropped by
+  partitioning — and is reported in `errors`.
+- Any per-file failure raises `PartitionError` once the run finishes, so a
+  partial run is never read as a complete one. `exc.result` carries the run dict,
+  including the files that succeeded.
+- `column_name=` and `output_dir=` are refused: in directory mode each file gets
+  its own sibling directory and the default index column name. Partition a single
+  file with `ops.partition_by_<index>` if you need to control those.
+- `ops.sub_partition_by_s2` is wired but **unavailable in this release** — it
+  raises `ExtensionUnavailableError` before touching a file, like every other S2
+  entry point. Use `ops.sub_partition_by_a5`.
+
 ### Available Functions
 
 | Function | Description |
@@ -1575,6 +1620,10 @@ print(f"Created {stats['file_count']} files")
 | `ops.partition_by_kdtree(table, output_dir, iterations=9, hive=False, keep_kdtree_column=None, overwrite=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by KD-tree cell |
 | `ops.partition_by_string(table, output_dir, column, chars=None, hive=False, overwrite=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by string column value |
 | `ops.partition_by_admin(table, output_dir, dataset='gaul', levels=None, hive=False, overwrite=False, vecorel=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by administrative boundaries |
+| `ops.sub_partition_by_h3(directory, min_size, resolution=None, auto=False, in_place=False, preview=False, hive=False, overwrite=False, force=False, skip_analysis=False, compression='ZSTD', compression_level=None, ...)` | Split every file in a directory over `min_size` into H3 sub-partitions |
+| `ops.sub_partition_by_a5(directory, min_size, resolution=None, auto=False, in_place=False, preview=False, ...)` | Split every file in a directory over `min_size` into A5 sub-partitions |
+| `ops.sub_partition_by_quadkey(directory, min_size, resolution=None, auto=False, in_place=False, preview=False, ...)` | Split every file in a directory over `min_size` into quadkey sub-partitions (use `auto=True`) |
+| `ops.sub_partition_by_s2(directory, min_size, level=None, auto=False, in_place=False, preview=False, ...)` | Split every file in a directory over `min_size` into S2 sub-partitions — **unavailable in this release**, use `ops.sub_partition_by_a5` |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |
 | `ops.explain_analyze(file_path, query=None)` | DuckDB EXPLAIN ANALYZE query plan |

--- a/docs/guide/sub-partitioning.md
+++ b/docs/guide/sub-partitioning.md
@@ -1,16 +1,41 @@
 # Sub-Partitioning Large Files
 
-After partitioning by administrative boundaries or string columns, some partitions may still be too large for efficient querying. Use `--min-size` to automatically sub-partition oversized files.
+After partitioning by administrative boundaries or string columns, some partitions may still be too large for efficient querying. Use `--min-size` — or `ops.sub_partition_by_<index>()` from Python — to automatically sub-partition oversized files.
 
 ## Quick Start
 
-```bash
-# First, partition by country
-gpio partition admin input.parquet by_country/ --dataset gaul --levels country
+First, partition by country — the boundaries dataset is downloaded on first use,
+so this step needs the network ([Partitioning Files](partition.md) covers it in
+full):
 
-# Then sub-partition large files (>100MB) with H3
-gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place
+<!-- doctest: network -->
+```bash
+gpio partition admin input.parquet by_country/ --dataset gaul --levels country
 ```
+
+Then sub-partition whatever came out too large:
+
+=== "CLI"
+
+    <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
+    ```bash
+    gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place
+    ```
+
+=== "Python"
+
+    <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
+    ```python
+    from geoparquet_io.api import ops
+
+    result = ops.sub_partition_by_h3(
+        'by_country/',
+        min_size='100MB',
+        resolution=7,
+        in_place=True,
+    )
+    print(f"sub-partitioned {result['processed']} file(s)")
+    ```
 
 This finds all parquet files over 100MB in `by_country/` and partitions them by H3 cells, replacing the original files with sub-partition directories.
 
@@ -43,18 +68,20 @@ by_country/
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `--min-size` | Size threshold (e.g., '100MB', '1GB'). Required for directory input. |
-| `--in-place` | Delete original files after successful sub-partitioning |
-| `--preview` | List the files that would be processed, then stop |
-| `--resolution` / `--level` | Spatial index resolution (or use `--auto`) |
-| `--auto` | Auto-calculate optimal resolution |
+| Option | Python argument | Description |
+|--------|-----------------|-------------|
+| `--min-size` | `min_size=` | Size threshold (e.g., '100MB', '1GB', or a byte count from Python). Required for directory input. |
+| `--in-place` | `in_place=` | Delete original files after successful sub-partitioning |
+| `--preview` | `preview=` | List the files that would be processed, then stop |
+| `--resolution` / `--level` | `resolution=` / `level=` | Spatial index resolution (or use `--auto`) |
+| `--auto` | `auto=` | Auto-calculate optimal resolution |
 
 `OUTPUT_FOLDER` and the index column name options (`--h3-name`, `--a5-name`,
 `--s2-name`, `--quadkey-column`) apply to single-file runs only: in directory
 mode each file gets its own sibling `<file>_<index>/` directory and the default
-column name, so passing them is an error rather than a silent no-op.
+column name, so passing them is an error rather than a silent no-op. The Python
+twins refuse their `output_dir=` and `column_name=` arguments for the same
+reason, with the same explanation.
 
 Sub-partitioning is accepted by `gpio partition h3`, `gpio partition a5`,
 `gpio partition quadkey` and `gpio partition s2`. Three of them run today: S2
@@ -78,6 +105,13 @@ reach for **H3**, **A5** or **Quadkey**.
     gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place
     ```
 
+    <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
+    ```python
+    from geoparquet_io.api import ops
+
+    ops.sub_partition_by_h3('by_country/', min_size='100MB', resolution=7, in_place=True)
+    ```
+
 === "A5"
 
     A tiny threshold is used here so the example actually splits the small sample
@@ -88,34 +122,116 @@ reach for **H3**, **A5** or **Quadkey**.
     gpio partition a5 by_country/ --min-size 1B --resolution 4 --in-place
     ```
 
+    <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
+    ```python
+    from geoparquet_io.api import ops
+
+    result = ops.sub_partition_by_a5(
+        'by_country/',
+        min_size='1B',
+        resolution=4,
+        in_place=True,
+    )
+    print(f"{result['processed']} file(s) sub-partitioned, {len(result['errors'])} failed")
+    ```
+
 === "S2"
 
     Unavailable in this release (see the warning above). Kept for reference — this
-    is the shape the command takes once the `geography` extension is republished.
+    is the shape the command and its Python twin take once the `geography`
+    extension is republished.
 
     <!-- doctest: skip="gpio partition s2 needs the 'geography' extension, unpublished past DuckDB 1.5.1 (#737); fenced as inert because no sample partition exceeds the threshold, so the harness would score this as passing without ever invoking S2" -->
     ```text
     gpio partition s2 by_country/ --min-size 100MB --level 10 --in-place
+
+    ops.sub_partition_by_s2('by_country/', min_size='100MB', level=10, in_place=True)
     ```
 
 === "Quadkey"
+
+    Quadkey needs `--auto` / `auto=True` here: the partitioner takes both a column
+    resolution and a partition resolution, and directory mode forwards only one.
 
     <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
     ```bash
     gpio partition quadkey by_country/ --min-size 100MB --auto --in-place
     ```
 
-## Preview Mode
+    <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
+    ```python
+    from geoparquet_io.api import ops
 
-`--preview` lists the files that exceed the threshold and the directory each one
-would be written to, then stops. Nothing is partitioned and nothing is deleted,
-even when `--in-place` is also passed.
+    ops.sub_partition_by_quadkey('by_country/', min_size='100MB', auto=True, in_place=True)
+    ```
+
+## From Python
+
+Sub-partitioning walks a directory of files on disk, so it is not a `Table`
+method — a `Table` is one table already in memory. It is a function over a path,
+one per index: `ops.sub_partition_by_h3`, `ops.sub_partition_by_a5`,
+`ops.sub_partition_by_quadkey` and `ops.sub_partition_by_s2`, each mirroring the
+`gpio partition <index> <dir>/ --min-size` command of the same name.
+
+Each returns a dict describing the run: `processed`, `skipped`, `errors`, the
+`candidates` the threshold selected, and `preview`.
 
 <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
-```bash
-# See which files would be sub-partitioned, without touching them
-gpio partition h3 by_country/ --min-size 1B --resolution 7 --preview
+```python
+from geoparquet_io.api import ops
+from geoparquet_io.core.exceptions import PartitionError
+
+try:
+    result = ops.sub_partition_by_a5(
+        'by_country/',
+        min_size='1B',       # a byte count works too: min_size=1
+        resolution=4,
+        in_place=True,
+    )
+except PartitionError as exc:
+    # Raised when any file failed; exc.result holds the whole run, including
+    # the files that succeeded.
+    result = exc.result
+    print(f"{len(result['errors'])} file(s) kept their original")
+
+for candidate in result['candidates']:
+    print(f"{candidate['path']} -> {candidate['output_dir']}/")
 ```
+
+An `InvalidParameterError` is raised before anything is written for a path that
+is not a directory, an unparsable `min_size`, a missing resolution, or an
+argument directory mode cannot honour.
+
+## Preview Mode
+
+`--preview` (`preview=True`) lists the files that exceed the threshold and the
+directory each one would be written to, then stops. Nothing is partitioned and
+nothing is deleted, even when `--in-place` is also passed.
+
+=== "CLI"
+
+    <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
+    ```bash
+    # See which files would be sub-partitioned, without touching them
+    gpio partition h3 by_country/ --min-size 1B --resolution 7 --preview
+    ```
+
+=== "Python"
+
+    <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
+    ```python
+    from geoparquet_io.api import ops
+
+    plan = ops.sub_partition_by_h3(
+        'by_country/',
+        min_size='1B',
+        resolution=7,
+        preview=True,
+    )
+    for candidate in plan['candidates']:
+        size_mb = candidate['size_bytes'] / (1024 * 1024)
+        print(f"{candidate['path']} ({size_mb:.1f}MB) -> {candidate['output_dir']}/")
+    ```
 
 Without `--preview` the files are partitioned for real; the originals are kept
 unless you pass `--in-place`.

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1270,6 +1270,19 @@ def _sub_partition(
 
     min_size_bytes = _parse_min_size(min_size)
 
+    if preview:
+        # The CLI's --preview branch plans and stops before any resolution is
+        # needed, so a preview without resolution/auto must succeed here too.
+        return {
+            "preview": True,
+            "candidates": core_sub_partition.plan_sub_partition(
+                str(directory), partition_type, min_size_bytes
+            ),
+            "processed": 0,
+            "skipped": 0,
+            "errors": [],
+        }
+
     argument = _SUB_PARTITION_RESOLUTION_ARG.get(partition_type, "resolution")
     if not auto and (resolution if resolution is not None else level) is None:
         raise InvalidParameterError(
@@ -1281,14 +1294,6 @@ def _sub_partition(
     candidates = core_sub_partition.plan_sub_partition(
         str(directory), partition_type, min_size_bytes
     )
-    if preview:
-        return {
-            "preview": True,
-            "candidates": candidates,
-            "processed": 0,
-            "skipped": 0,
-            "errors": [],
-        }
 
     result = core_sub_partition.sub_partition_directory(
         directory=str(directory),

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1175,6 +1175,512 @@ def partition_by_admin(
     )
 
 
+# --------------------------------------------------------------------------
+# Sub-partitioning a directory
+#
+# `gpio partition <index>` is two operations behind one command: partition a
+# file, or walk a *directory* and split every file over --min-size into a
+# sibling `<file>_<index>/`. The second is what you reach for after partitioning
+# by country or by a string column has left a handful of oversized files.
+#
+# It had no Python front door at all (#811). It cannot be a `Table` method --
+# the unit of work is a directory of files on disk, not an in-memory table --
+# and it does not fit `ops.partition_by_*` either, which take one table. So it
+# is its own family of `ops` functions over a path, one per index, named after
+# the CLI command each mirrors.
+# --------------------------------------------------------------------------
+
+_SUB_PARTITION_RESOLUTION_ARG = {"s2": "level"}
+
+
+def _parse_min_size(min_size: str | int) -> int:
+    """Bytes from either the CLI's '100MB' spelling or a plain byte count."""
+    from geoparquet_io.core.common import parse_size_string
+    from geoparquet_io.core.exceptions import InvalidParameterError
+
+    if isinstance(min_size, bool) or not isinstance(min_size, (str, int)):
+        raise InvalidParameterError(
+            "min_size", f"expected a size string or byte count, got {min_size!r}"
+        )
+    if isinstance(min_size, int):
+        if min_size < 0:
+            raise InvalidParameterError("min_size", f"byte count cannot be negative: {min_size}")
+        return min_size
+    try:
+        return parse_size_string(min_size)
+    except ValueError as exc:
+        raise InvalidParameterError("min_size", str(exc)) from None
+
+
+def _sub_partition(
+    directory: str | Path,
+    partition_type: str,
+    *,
+    min_size: str | int,
+    resolution: int | None = None,
+    level: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    in_place: bool = False,
+    preview: bool = False,
+    hive: bool = False,
+    overwrite: bool = False,
+    force: bool = False,
+    skip_analysis: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    verbose: bool = False,
+    column_name: str | None = None,
+    output_dir: str | Path | None = None,
+) -> dict:
+    """Shared body of the four `sub_partition_by_*` functions.
+
+    Validates what the CLI validates -- and refuses what it refuses -- then hands
+    the run to `core.sub_partition.sub_partition_directory`, which is the same
+    function `gpio partition <index> <dir> --min-size` reaches.
+    """
+    # `Path` is a TYPE_CHECKING-only import in this module, so the runtime one is
+    # aliased rather than shadowing the annotation name.
+    from pathlib import Path as _Path
+
+    from geoparquet_io.core import sub_partition as core_sub_partition
+    from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
+
+    if not _Path(directory).is_dir():
+        raise InvalidParameterError(
+            "directory",
+            f"not a directory: {directory}. Sub-partitioning walks a directory of "
+            f"parquet files; use ops.partition_by_{partition_type}() to partition "
+            "a single table.",
+        )
+
+    offending = core_sub_partition.offending_single_file_only_options(
+        partition_type,
+        column_name,
+        output_dir,
+        column_label="column_name",
+        output_label="output_dir",
+    )
+    if offending:
+        raise InvalidParameterError(
+            offending[0],
+            core_sub_partition.single_file_only_option_message(partition_type, offending),
+        )
+
+    min_size_bytes = _parse_min_size(min_size)
+
+    argument = _SUB_PARTITION_RESOLUTION_ARG.get(partition_type, "resolution")
+    if not auto and (resolution if resolution is not None else level) is None:
+        raise InvalidParameterError(
+            argument,
+            f"pass {argument}=<int> or auto=True -- gpio does not guess a "
+            f"{partition_type} {argument}",
+        )
+
+    candidates = core_sub_partition.plan_sub_partition(
+        str(directory), partition_type, min_size_bytes
+    )
+    if preview:
+        return {
+            "preview": True,
+            "candidates": candidates,
+            "processed": 0,
+            "skipped": 0,
+            "errors": [],
+        }
+
+    result = core_sub_partition.sub_partition_directory(
+        directory=str(directory),
+        partition_type=partition_type,
+        min_size_bytes=min_size_bytes,
+        resolution=resolution,
+        level=level,
+        in_place=in_place,
+        hive=hive,
+        overwrite=overwrite,
+        verbose=verbose,
+        force=force,
+        skip_analysis=skip_analysis,
+        compression=compression.upper(),
+        compression_level=compression_level or 15,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+    )
+
+    run = {"preview": False, "candidates": candidates, **result}
+    if run["errors"]:
+        # Per-file failures are collected rather than raised, so without this a
+        # caller who never inspected `errors` would read a partial run as a
+        # complete one -- the API's version of the exit-0 bug in #778.
+        failed = len(run["errors"])
+        detail = "\n".join(f"  {err['file']}: {err['error']}" for err in run["errors"])
+        raise PartitionError(
+            f"{failed} of {failed + run['processed']} file(s) failed to sub-partition "
+            f"by {partition_type}:\n{detail}",
+            result=run,
+        )
+    return run
+
+
+def sub_partition_by_h3(
+    directory: str | Path,
+    *,
+    min_size: str | int,
+    resolution: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    in_place: bool = False,
+    preview: bool = False,
+    hive: bool = False,
+    overwrite: bool = False,
+    force: bool = False,
+    skip_analysis: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    verbose: bool = False,
+    column_name: str | None = None,
+    output_dir: str | Path | None = None,
+) -> dict:
+    """
+    Split every file in a directory over ``min_size`` into H3 sub-partitions.
+
+    Function form of `gpio partition h3 <dir>/ --min-size ...`. Each file over
+    the threshold is partitioned into a sibling ``<file>_h3/`` directory; files
+    under it are left alone. Pass a ``resolution``, or ``auto=True``.
+
+    Args:
+        directory: Directory of parquet files, searched recursively
+        min_size: Size threshold -- ``'100MB'`` or a byte count
+        resolution: H3 resolution level 0-15. Required unless ``auto=True``
+        auto: Size the resolution from each file (default: False)
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        in_place: Delete each original once its sub-partitions hold every row it
+            had (default: False)
+        preview: List the candidate files and stop, writing and deleting nothing
+        hive: Use Hive-style ``h3_cell=value/`` directories (default: False)
+        overwrite: Overwrite existing output directories
+        force: Partition even when the analysis warns
+        skip_analysis: Skip the partition strategy analysis
+        compression: Compression codec (default: ZSTD)
+        compression_level: Compression level. None uses the ZSTD default of 15
+        verbose: Log each file as it is processed
+        column_name: Rejected unless it is the default ``h3_cell``: directory
+            mode writes one sibling directory per file with the default column
+            name. Partition a single file to control it
+        output_dir: Rejected for the same reason -- output directories are
+            derived per file, not shared
+
+    Returns:
+        dict with ``processed``, ``skipped``, ``errors``, the ``candidates`` the
+        threshold selected, and ``preview``
+
+    Raises:
+        InvalidParameterError: For a path that is not a directory, an
+            unparsable ``min_size``, a missing resolution, or an argument
+            directory mode cannot honour
+        PartitionError: If any file failed to sub-partition. Its ``result``
+            attribute carries the run dict, including the files that succeeded
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> ops.sub_partition_by_h3('by_country/', min_size='100MB', resolution=7,
+        ...                         in_place=True)
+    """
+    return _sub_partition(
+        directory,
+        "h3",
+        min_size=min_size,
+        resolution=resolution,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        in_place=in_place,
+        preview=preview,
+        hive=hive,
+        overwrite=overwrite,
+        force=force,
+        skip_analysis=skip_analysis,
+        compression=compression,
+        compression_level=compression_level,
+        verbose=verbose,
+        column_name=column_name,
+        output_dir=output_dir,
+    )
+
+
+def sub_partition_by_a5(
+    directory: str | Path,
+    *,
+    min_size: str | int,
+    resolution: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    in_place: bool = False,
+    preview: bool = False,
+    hive: bool = False,
+    overwrite: bool = False,
+    force: bool = False,
+    skip_analysis: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    verbose: bool = False,
+    column_name: str | None = None,
+    output_dir: str | Path | None = None,
+) -> dict:
+    """
+    Split every file in a directory over ``min_size`` into A5 sub-partitions.
+
+    Function form of `gpio partition a5 <dir>/ --min-size ...`. Each file over
+    the threshold is partitioned into a sibling ``<file>_a5/`` directory; files
+    under it are left alone. Pass a ``resolution``, or ``auto=True``.
+
+    Args:
+        directory: Directory of parquet files, searched recursively
+        min_size: Size threshold -- ``'100MB'`` or a byte count
+        resolution: A5 resolution level 0-30. Required unless ``auto=True``
+        auto: Size the resolution from each file (default: False)
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        in_place: Delete each original once its sub-partitions hold every row it
+            had (default: False)
+        preview: List the candidate files and stop, writing and deleting nothing
+        hive: Use Hive-style ``a5_cell=value/`` directories (default: False)
+        overwrite: Overwrite existing output directories
+        force: Partition even when the analysis warns
+        skip_analysis: Skip the partition strategy analysis
+        compression: Compression codec (default: ZSTD)
+        compression_level: Compression level. None uses the ZSTD default of 15
+        verbose: Log each file as it is processed
+        column_name: Rejected unless it is the default ``a5_cell`` (see
+            `sub_partition_by_h3`)
+        output_dir: Rejected -- output directories are derived per file
+
+    Returns:
+        dict with ``processed``, ``skipped``, ``errors``, ``candidates`` and
+        ``preview``
+
+    Raises:
+        InvalidParameterError: For a path that is not a directory, an
+            unparsable ``min_size``, a missing resolution, or an argument
+            directory mode cannot honour
+        PartitionError: If any file failed to sub-partition; ``result`` carries
+            the run dict
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> ops.sub_partition_by_a5('by_country/', min_size='100MB', resolution=10,
+        ...                         in_place=True)
+    """
+    return _sub_partition(
+        directory,
+        "a5",
+        min_size=min_size,
+        resolution=resolution,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        in_place=in_place,
+        preview=preview,
+        hive=hive,
+        overwrite=overwrite,
+        force=force,
+        skip_analysis=skip_analysis,
+        compression=compression,
+        compression_level=compression_level,
+        verbose=verbose,
+        column_name=column_name,
+        output_dir=output_dir,
+    )
+
+
+def sub_partition_by_quadkey(
+    directory: str | Path,
+    *,
+    min_size: str | int,
+    resolution: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    in_place: bool = False,
+    preview: bool = False,
+    hive: bool = False,
+    overwrite: bool = False,
+    force: bool = False,
+    skip_analysis: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    verbose: bool = False,
+    column_name: str | None = None,
+    output_dir: str | Path | None = None,
+) -> dict:
+    """
+    Split every file in a directory over ``min_size`` into quadkey sub-partitions.
+
+    Function form of `gpio partition quadkey <dir>/ --min-size ...`. Each file
+    over the threshold is partitioned into a sibling ``<file>_quadkey/``
+    directory; files under it are left alone.
+
+    **Use ``auto=True``.** The quadkey partitioner needs a column resolution
+    *and* a partition resolution, and directory mode -- on the CLI as here --
+    forwards only one, so a lone ``resolution`` is reported as a per-file
+    failure. ``auto=True`` sizes both from the data. ``resolution`` is accepted
+    for symmetry with the other three indexes and forwarded unchanged rather
+    than papered over.
+
+    Args:
+        directory: Directory of parquet files, searched recursively
+        min_size: Size threshold -- ``'100MB'`` or a byte count
+        resolution: Quadkey resolution 0-23. See above: directory mode wants
+            ``auto=True``
+        auto: Size the resolution from each file (default: False)
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        in_place: Delete each original once its sub-partitions hold every row it
+            had (default: False)
+        preview: List the candidate files and stop, writing and deleting nothing
+        hive: Use Hive-style ``quadkey=value/`` directories (default: False)
+        overwrite: Overwrite existing output directories
+        force: Partition even when the analysis warns
+        skip_analysis: Skip the partition strategy analysis
+        compression: Compression codec (default: ZSTD)
+        compression_level: Compression level. None uses the ZSTD default of 15
+        verbose: Log each file as it is processed
+        column_name: Rejected unless it is the default ``quadkey`` (see
+            `sub_partition_by_h3`)
+        output_dir: Rejected -- output directories are derived per file
+
+    Returns:
+        dict with ``processed``, ``skipped``, ``errors``, ``candidates`` and
+        ``preview``
+
+    Raises:
+        InvalidParameterError: For a path that is not a directory, an
+            unparsable ``min_size``, a missing resolution, or an argument
+            directory mode cannot honour
+        PartitionError: If any file failed to sub-partition; ``result`` carries
+            the run dict
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> ops.sub_partition_by_quadkey('by_country/', min_size='100MB', auto=True,
+        ...                              in_place=True)
+    """
+    return _sub_partition(
+        directory,
+        "quadkey",
+        min_size=min_size,
+        resolution=resolution,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        in_place=in_place,
+        preview=preview,
+        hive=hive,
+        overwrite=overwrite,
+        force=force,
+        skip_analysis=skip_analysis,
+        compression=compression,
+        compression_level=compression_level,
+        verbose=verbose,
+        column_name=column_name,
+        output_dir=output_dir,
+    )
+
+
+def sub_partition_by_s2(
+    directory: str | Path,
+    *,
+    min_size: str | int,
+    level: int | None = None,
+    auto: bool = False,
+    target_rows: int = 100000,
+    max_partitions: int = 10000,
+    in_place: bool = False,
+    preview: bool = False,
+    hive: bool = False,
+    overwrite: bool = False,
+    force: bool = False,
+    skip_analysis: bool = False,
+    compression: str = "ZSTD",
+    compression_level: int | None = None,
+    verbose: bool = False,
+    column_name: str | None = None,
+    output_dir: str | Path | None = None,
+) -> dict:
+    """
+    Split every file in a directory over ``min_size`` into S2 sub-partitions.
+
+    Function form of `gpio partition s2 <dir>/ --min-size ...`.
+
+    **Unavailable in this release**: S2 needs the ``geography`` DuckDB community
+    extension, which is not published for the DuckDB version gpio requires
+    (#737). The call raises `ExtensionUnavailableError` once, before any file is
+    touched. Use `sub_partition_by_a5` instead.
+
+    Args:
+        directory: Directory of parquet files, searched recursively
+        min_size: Size threshold -- ``'100MB'`` or a byte count
+        level: S2 level 0-30. Required unless ``auto=True``
+        auto: Size the level from each file (default: False)
+        target_rows: Target rows per partition when ``auto=True`` (default: 100000)
+        max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
+        in_place: Delete each original once its sub-partitions hold every row it
+            had (default: False)
+        preview: List the candidate files and stop, writing and deleting nothing
+        hive: Use Hive-style ``s2_cell=value/`` directories (default: False)
+        overwrite: Overwrite existing output directories
+        force: Partition even when the analysis warns
+        skip_analysis: Skip the partition strategy analysis
+        compression: Compression codec (default: ZSTD)
+        compression_level: Compression level. None uses the ZSTD default of 15
+        verbose: Log each file as it is processed
+        column_name: Rejected unless it is the default ``s2_cell`` (see
+            `sub_partition_by_h3`)
+        output_dir: Rejected -- output directories are derived per file
+
+    Returns:
+        dict with ``processed``, ``skipped``, ``errors``, ``candidates`` and
+        ``preview``
+
+    Raises:
+        ExtensionUnavailableError: Always, in this release -- see above
+        InvalidParameterError: For a path that is not a directory, an
+            unparsable ``min_size``, a missing level, or an argument directory
+            mode cannot honour
+        PartitionError: If any file failed to sub-partition; ``result`` carries
+            the run dict
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> ops.sub_partition_by_s2('by_country/', min_size='100MB', level=10)
+    """
+    return _sub_partition(
+        directory,
+        "s2",
+        min_size=min_size,
+        level=level,
+        auto=auto,
+        target_rows=target_rows,
+        max_partitions=max_partitions,
+        in_place=in_place,
+        preview=preview,
+        hive=hive,
+        overwrite=overwrite,
+        force=force,
+        skip_analysis=skip_analysis,
+        compression=compression,
+        compression_level=compression_level,
+        verbose=verbose,
+        column_name=column_name,
+        output_dir=output_dir,
+    )
+
+
 def read_bigquery(
     table_id: str,
     *,

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -701,42 +701,27 @@ class SingleFileCommand(GlobAwareCommand):
     supports_glob = False
 
 
-# Options that only make sense for a single-file partition run. In directory
-# --min-size mode each file gets its own sibling output directory and the index
-# column is created with its default name, so accepting these silently dropped
-# them (#790).
-_SUB_PARTITION_COLUMN_OPTIONS: dict[str, tuple[str, str]] = {
-    "h3": ("--h3-name", "h3_cell"),
-    "s2": ("--s2-name", "s2_cell"),
-    "a5": ("--a5-name", "a5_cell"),
-    "quadkey": ("--quadkey-column", "quadkey"),
-}
-
-
 def _reject_single_file_only_options(
     partition_type: str,
     column_name: str | None,
     output_folder: str | None,
 ) -> None:
-    """Fail loudly on options a directory --min-size run cannot honour."""
-    ignored = []
+    """Fail loudly on options a directory --min-size run cannot honour (#790).
 
-    option, default = _SUB_PARTITION_COLUMN_OPTIONS.get(partition_type, (None, None))
-    if option and column_name is not None and column_name != default:
-        ignored.append(option)
-    if output_folder:
-        ignored.append("OUTPUT_FOLDER")
+    The rule and its wording live in core, so `ops.sub_partition_by_*` refuses
+    the same arguments for the same stated reason (#811); only the spelling of
+    the argument names differs between the two front doors.
+    """
+    from geoparquet_io.core.sub_partition import (
+        offending_single_file_only_options,
+        single_file_only_option_message,
+    )
 
+    ignored = offending_single_file_only_options(partition_type, column_name, output_folder)
     if not ignored:
         return
 
-    verb = "does" if len(ignored) == 1 else "do"
-    raise click.UsageError(
-        f"{' and '.join(ignored)} {verb} not apply to directory input with --min-size.\n\n"
-        f"Each file over the threshold is partitioned into a sibling <file>_{partition_type}/\n"
-        "directory, using the default index column name. Run the command on a single\n"
-        "file if you need to control those."
-    )
+    raise click.UsageError(single_file_only_option_message(partition_type, ignored))
 
 
 def handle_directory_sub_partition(
@@ -809,7 +794,7 @@ def handle_directory_sub_partition(
 
     from geoparquet_io.core.common import parse_size_string
     from geoparquet_io.core.logging_config import info, progress, warn
-    from geoparquet_io.core.sub_partition import find_large_files, sub_partition_directory
+    from geoparquet_io.core.sub_partition import plan_sub_partition, sub_partition_directory
 
     try:
         min_size_bytes = parse_size_string(min_size)
@@ -819,17 +804,15 @@ def handle_directory_sub_partition(
     if preview:
         # --preview used to be accepted, ignored, and the originals deleted
         # anyway under --in-place (#790). Show the plan and change nothing.
-        candidates = find_large_files(input_parquet, min_size_bytes)
+        candidates = plan_sub_partition(input_parquet, partition_type, min_size_bytes)
         if not candidates:
             info(f"No files found exceeding {min_size} in {input_parquet}")
             return True
 
         progress(f"Would sub-partition {len(candidates)} file(s) by {partition_type}:")
         for candidate in candidates:
-            size_mb = os.path.getsize(candidate) / (1024 * 1024)
-            stem = os.path.splitext(os.path.basename(candidate))[0]
-            destination = os.path.join(os.path.dirname(candidate), f"{stem}_{partition_type}")
-            info(f"  {candidate} ({size_mb:.1f}MB) -> {destination}/")
+            size_mb = candidate["size_bytes"] / (1024 * 1024)
+            info(f"  {candidate['path']} ({size_mb:.1f}MB) -> {candidate['output_dir']}/")
         info("Preview only: no files were partitioned or removed.")
         return True
 

--- a/geoparquet_io/core/exceptions.py
+++ b/geoparquet_io/core/exceptions.py
@@ -103,9 +103,19 @@ class GeometryError(GeoParquetError):
 
 
 class PartitionError(GeoParquetError):
-    """Raised when partitioning operations fail."""
+    """Raised when partitioning operations fail.
 
-    pass
+    Attributes:
+        result: The run this failure came out of, when there is one. A directory
+            sub-partition run (`ops.sub_partition_by_*`) processes many files and
+            raises only at the end, so the caller needs what succeeded as well as
+            what failed (#811). ``None`` for a single-file partition failure,
+            which has no partial run to report.
+    """
+
+    def __init__(self, message: str, result: dict | None = None) -> None:
+        super().__init__(message)
+        self.result = result
 
 
 class ValidationError(GeoParquetError):

--- a/geoparquet_io/core/sub_partition.py
+++ b/geoparquet_io/core/sub_partition.py
@@ -13,6 +13,96 @@ _REQUIRED_EXTENSIONS: dict[str, tuple[tuple[str, str], ...]] = {
     "s2": (("geography", "gpio partition s2"),),
 }
 
+# The index column each partition type creates when nobody names one, keyed by
+# type, with the CLI option that would have named it. Directory mode uses the
+# default and writes one sibling directory per file, so a custom name is
+# refused rather than silently dropped (#790) -- through either front door.
+SUB_PARTITION_COLUMN_OPTIONS: dict[str, tuple[str, str]] = {
+    "h3": ("--h3-name", "h3_cell"),
+    "s2": ("--s2-name", "s2_cell"),
+    "a5": ("--a5-name", "a5_cell"),
+    "quadkey": ("--quadkey-column", "quadkey"),
+}
+
+
+def offending_single_file_only_options(
+    partition_type: str,
+    column_name: str | None = None,
+    output_folder: str | None = None,
+    *,
+    column_label: str | None = None,
+    output_label: str = "OUTPUT_FOLDER",
+) -> list[str]:
+    """Name the arguments a directory sub-partition run cannot honour.
+
+    Args:
+        partition_type: Type of partition ("a5", "h3", "s2", "quadkey")
+        column_name: Index column name the caller asked for, if any
+        output_folder: Single output directory the caller asked for, if any
+        column_label: How to spell the column argument back at the caller
+            (defaults to the CLI option name for ``partition_type``)
+        output_label: How to spell the output argument back at the caller
+
+    Returns:
+        The labels that were supplied and cannot be honoured, in the order they
+        should be reported. Empty when there is nothing to refuse.
+    """
+    option, default = SUB_PARTITION_COLUMN_OPTIONS.get(partition_type, (None, None))
+    label = column_label or option
+
+    offending = []
+    if label and column_name is not None and column_name != default:
+        offending.append(label)
+    if output_folder:
+        offending.append(output_label)
+    return offending
+
+
+def single_file_only_option_message(partition_type: str, offending: list[str]) -> str:
+    """Explain why ``offending`` cannot be honoured in directory mode."""
+    verb = "does" if len(offending) == 1 else "do"
+    return (
+        f"{' and '.join(offending)} {verb} not apply to directory input with a size "
+        f"threshold.\n\n"
+        f"Each file over the threshold is partitioned into a sibling <file>_{partition_type}/\n"
+        "directory, using the default index column name. Run on a single file if you\n"
+        "need to control those."
+    )
+
+
+def plan_sub_partition(
+    directory: str,
+    partition_type: str,
+    min_size_bytes: int,
+    recursive: bool = True,
+) -> list[dict]:
+    """List the files a sub-partition run would process, and where each would go.
+
+    The read-only half of :func:`sub_partition_directory`, backing ``--preview``
+    and its API twin: nothing is partitioned and nothing is removed.
+
+    Args:
+        directory: Directory containing parquet files
+        partition_type: Type of partition ("a5", "h3", "s2", "quadkey")
+        min_size_bytes: Minimum file size to process
+        recursive: Search subdirectories (default: True)
+
+    Returns:
+        One dict per candidate -- ``path``, ``size_bytes`` and the ``output_dir``
+        it would be partitioned into -- largest file first.
+    """
+    candidates = []
+    for file_path in find_large_files(directory, min_size_bytes, recursive=recursive):
+        path = Path(file_path)
+        candidates.append(
+            {
+                "path": file_path,
+                "size_bytes": path.stat().st_size,
+                "output_dir": str(path.parent / f"{path.stem}_{partition_type}"),
+            }
+        )
+    return candidates
+
 
 def _assert_no_rows_lost(source_file: str, output_dir: str) -> None:
     """Refuse to delete an original whose rows did not all reach the output.

--- a/tests/test_cli_api_default_parity.py
+++ b/tests/test_cli_api_default_parity.py
@@ -71,6 +71,14 @@ NAME_OVERRIDES: dict[tuple[str, ...], list[str]] = {
     ("check", "optimization"): ["check_optimization"],
     ("inspect", "summary"): ["info"],
     ("convert", "geoparquet"): ["write"],
+    # `gpio partition <index>` is two operations behind one command: a single
+    # file, and a *directory* walked with --min-size. The second has its own
+    # `ops` twin (#811), so name it here -- otherwise its defaults would drift
+    # from the flags they mirror with nothing watching.
+    ("partition", "a5"): ["partition_by_a5", "sub_partition_by_a5"],
+    ("partition", "h3"): ["partition_by_h3", "sub_partition_by_h3"],
+    ("partition", "s2"): ["partition_by_s2", "sub_partition_by_s2"],
+    ("partition", "quadkey"): ["partition_by_quadkey", "sub_partition_by_quadkey"],
 }
 
 # CLI-only plumbing (I/O paths, output formatting) with no API analogue.

--- a/tests/test_core_exceptions.py
+++ b/tests/test_core_exceptions.py
@@ -216,6 +216,23 @@ class TestCoreExceptions:
         with pytest.raises(PartitionError):
             raise PartitionError("Invalid partition scheme")
 
+    def test_partition_error_carries_no_result_by_default(self):
+        """Most partition failures are about one file and have nothing to report."""
+        assert PartitionError("Invalid partition scheme").result is None
+
+    def test_partition_error_can_carry_the_run_that_failed(self):
+        """A directory sub-partition run fails *partly*: the survivors still matter.
+
+        `ops.sub_partition_by_*` raises once the run finishes, so the caller needs
+        what succeeded as well as what did not (#811).
+        """
+        run = {"processed": 2, "skipped": 0, "errors": [{"file": "a.parquet", "error": "boom"}]}
+
+        exc = PartitionError("1 of 3 file(s) failed to sub-partition", result=run)
+
+        assert exc.result == run
+        assert str(exc) == "1 of 3 file(s) failed to sub-partition"
+
     def test_validation_error(self):
         with pytest.raises(ValidationError):
             raise ValidationError("File does not conform to GeoParquet spec")

--- a/tests/test_sub_partition.py
+++ b/tests/test_sub_partition.py
@@ -992,6 +992,30 @@ class TestApiDirectorySubPartition:
         assert "output_dir" in str(exc.value)
         assert os.path.exists(large)
 
+    def test_preview_needs_no_resolution_exactly_like_the_cli(self, temp_partition_dir):
+        """`gpio partition h3 <dir> --min-size ... --preview` plans without a
+        resolution -- the CLI's preview branch never reaches the resolution
+        check -- so the API's preview must plan too, and return the same shape
+        it would with one. A real run without a resolution still refuses.
+        """
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        large, _small = self._seed(temp_partition_dir)
+        threshold = os.path.getsize(large) - 100
+
+        planned = ops.sub_partition_by_h3(temp_partition_dir, min_size=threshold, preview=True)
+
+        assert planned["preview"] is True
+        assert planned["processed"] == 0
+        assert [c["path"] for c in planned["candidates"]] == [large]
+        assert planned == ops.sub_partition_by_h3(
+            temp_partition_dir, min_size=threshold, resolution=4, preview=True
+        )
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            ops.sub_partition_by_h3(temp_partition_dir, min_size=threshold)
+
     def test_a_missing_resolution_is_refused_rather_than_guessed(self, temp_partition_dir):
         from geoparquet_io.api import ops
         from geoparquet_io.core.exceptions import InvalidParameterError

--- a/tests/test_sub_partition.py
+++ b/tests/test_sub_partition.py
@@ -775,3 +775,342 @@ class TestH3ExtensionPreflight:
 
         assert result.exit_code != 0, f"unavailable extension exited 0: {result.output}"
         assert calls == ["h3"], f"preflight ran {len(calls)} times for 3 files"
+
+
+class TestApiDirectorySubPartition:
+    """Directory sub-partitioning was reachable only from the CLI (#811).
+
+    ``ops.partition_by_*`` takes a single table, so ``--min-size`` /
+    ``--in-place`` -- the mode that turns oversized admin or string partitions
+    into spatially indexed subdirectories -- had no Python front door at all.
+    ``ops.sub_partition_by_<index>`` is that door: a function over a *directory*,
+    one per index, mirroring the CLI command it is spelled after.
+    """
+
+    @staticmethod
+    def _seed(directory) -> tuple[str, str]:
+        """One file over the threshold and one under it."""
+        from pathlib import Path
+
+        buildings = Path(__file__).parent / "data" / "buildings_test.parquet"
+        large = os.path.join(directory, "large.parquet")
+        shutil.copy(buildings, large)
+        small = os.path.join(directory, "small.parquet")
+        pq.write_table(pa.table({"id": [1]}), small)
+        return large, small
+
+    def test_large_files_are_split_and_small_ones_are_left_alone(self, temp_partition_dir):
+        from geoparquet_io.api import ops
+
+        large, small = self._seed(temp_partition_dir)
+
+        result = ops.sub_partition_by_a5(
+            temp_partition_dir,
+            min_size=f"{os.path.getsize(large) - 100}B",
+            resolution=A5_SPLITTING_RESOLUTION,
+            in_place=True,
+            force=True,
+        )
+
+        assert result["errors"] == []
+        assert result["processed"] == 1
+        assert not os.path.exists(large), "the sub-partitioned original survived in_place=True"
+        assert os.path.exists(small), "a file under the threshold was touched"
+
+        subdir = os.path.join(temp_partition_dir, "large_a5")
+        assert len(_partition_files(subdir)) > 1
+        assert _total_rows(subdir) == BUILDINGS_ROWS
+
+    def test_min_size_accepts_a_byte_count(self, temp_partition_dir):
+        """A Python caller has a number to hand, not the CLI's '100MB' string."""
+        from geoparquet_io.api import ops
+
+        large, _small = self._seed(temp_partition_dir)
+
+        result = ops.sub_partition_by_a5(
+            temp_partition_dir,
+            min_size=os.path.getsize(large) - 100,
+            resolution=A5_SPLITTING_RESOLUTION,
+            force=True,
+        )
+
+        assert result["processed"] == 1
+        assert os.path.exists(large), "originals are kept without in_place=True"
+        assert _total_rows(os.path.join(temp_partition_dir, "large_a5")) == BUILDINGS_ROWS
+
+    def test_quadkey_partitions_by_its_own_index(self, temp_partition_dir):
+        """auto=True is what a quadkey directory run takes, exactly as on the CLI.
+
+        The quadkey partitioner needs both a column resolution and a partition
+        resolution, and directory mode forwards only one -- so a lone
+        ``resolution`` fails there through either front door (see
+        ``test_a_lone_quadkey_resolution_fails_the_same_way_as_the_cli``).
+        """
+        from geoparquet_io.api import ops
+
+        large, _small = self._seed(temp_partition_dir)
+
+        result = ops.sub_partition_by_quadkey(
+            temp_partition_dir,
+            min_size=os.path.getsize(large) - 100,
+            auto=True,
+            in_place=True,
+            force=True,
+        )
+
+        assert result["errors"] == []
+        assert result["processed"] == 1
+        assert _total_rows(os.path.join(temp_partition_dir, "large_quadkey")) == BUILDINGS_ROWS
+
+    def test_a_lone_quadkey_resolution_fails_the_same_way_as_the_cli(
+        self, cli_runner, temp_partition_dir
+    ):
+        """Pin the CLI's own limitation rather than quietly diverging from it.
+
+        `gpio partition quadkey <dir> --min-size ... --resolution 6` reports a
+        per-file failure and exits non-zero; the API must not paper over that by
+        inventing a partition resolution of its own.
+        """
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import PartitionError
+
+        large, _small = self._seed(temp_partition_dir)
+        threshold = f"{os.path.getsize(large) - 100}B"
+
+        cli = cli_runner.invoke(
+            partition,
+            [
+                "quadkey",
+                temp_partition_dir,
+                "--min-size",
+                threshold,
+                "--resolution",
+                "6",
+                "--force",
+            ],
+        )
+        assert cli.exit_code != 0
+        assert "partition-resolution" in cli.output
+
+        with pytest.raises(PartitionError) as exc:
+            ops.sub_partition_by_quadkey(
+                temp_partition_dir, min_size=threshold, resolution=6, force=True
+            )
+
+        assert "partition-resolution" in str(exc.value)
+
+    def test_preview_lists_candidates_and_writes_nothing(self, temp_partition_dir):
+        """The CLI's --preview: say what would happen, change nothing (#790)."""
+        from geoparquet_io.api import ops
+
+        large, small = self._seed(temp_partition_dir)
+
+        result = ops.sub_partition_by_a5(
+            temp_partition_dir,
+            min_size=os.path.getsize(large) - 100,
+            resolution=A5_SPLITTING_RESOLUTION,
+            preview=True,
+            in_place=True,
+            force=True,
+        )
+
+        assert result["preview"] is True
+        assert result["processed"] == 0
+        assert [c["path"] for c in result["candidates"]] == [large]
+        assert result["candidates"][0]["size_bytes"] == os.path.getsize(large)
+        assert result["candidates"][0]["output_dir"] == os.path.join(temp_partition_dir, "large_a5")
+
+        assert os.path.exists(large), "preview deleted the original"
+        assert os.path.exists(small)
+        assert not os.path.exists(os.path.join(temp_partition_dir, "large_a5"))
+
+    def test_preview_reports_no_candidates_without_failing(self, temp_partition_dir):
+        from geoparquet_io.api import ops
+
+        self._seed(temp_partition_dir)
+
+        result = ops.sub_partition_by_a5(
+            temp_partition_dir,
+            min_size="100MB",
+            resolution=A5_SPLITTING_RESOLUTION,
+            preview=True,
+        )
+
+        assert result["candidates"] == []
+        assert result["processed"] == 0
+
+    def test_a_custom_index_column_name_is_rejected(self, temp_partition_dir):
+        """Directory mode writes the default column name; asking for another is an error."""
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        large, _small = self._seed(temp_partition_dir)
+
+        with pytest.raises(InvalidParameterError) as exc:
+            ops.sub_partition_by_a5(
+                temp_partition_dir,
+                min_size=os.path.getsize(large) - 100,
+                resolution=A5_SPLITTING_RESOLUTION,
+                column_name="my_cell",
+            )
+
+        assert "column_name" in str(exc.value)
+        assert os.path.exists(large), "a rejected call still partitioned something"
+        assert not os.path.exists(os.path.join(temp_partition_dir, "large_a5"))
+
+    def test_the_default_index_column_name_is_accepted(self, temp_partition_dir):
+        """Passing the name it would have used anyway is not an error."""
+        from geoparquet_io.api import ops
+
+        large, _small = self._seed(temp_partition_dir)
+
+        result = ops.sub_partition_by_a5(
+            temp_partition_dir,
+            min_size=os.path.getsize(large) - 100,
+            resolution=A5_SPLITTING_RESOLUTION,
+            column_name="a5_cell",
+            preview=True,
+        )
+
+        assert [c["path"] for c in result["candidates"]] == [large]
+
+    def test_an_output_directory_is_rejected(self, temp_partition_dir):
+        """Each file gets a sibling <file>_<index>/; one shared output is not a thing."""
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        large, _small = self._seed(temp_partition_dir)
+
+        with pytest.raises(InvalidParameterError) as exc:
+            ops.sub_partition_by_h3(
+                temp_partition_dir,
+                min_size=os.path.getsize(large) - 100,
+                resolution=4,
+                output_dir=os.path.join(temp_partition_dir, "out"),
+            )
+
+        assert "output_dir" in str(exc.value)
+        assert os.path.exists(large)
+
+    def test_a_missing_resolution_is_refused_rather_than_guessed(self, temp_partition_dir):
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        large, _small = self._seed(temp_partition_dir)
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            ops.sub_partition_by_a5(temp_partition_dir, min_size=os.path.getsize(large) - 100)
+
+    def test_a_non_directory_input_is_refused(self, temp_partition_dir):
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        large, _small = self._seed(temp_partition_dir)
+
+        with pytest.raises(InvalidParameterError, match="directory"):
+            ops.sub_partition_by_a5(large, min_size="1B", resolution=A5_SPLITTING_RESOLUTION)
+
+    def test_an_unparseable_min_size_is_refused(self, temp_partition_dir):
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        self._seed(temp_partition_dir)
+
+        with pytest.raises(InvalidParameterError, match="min_size"):
+            ops.sub_partition_by_a5(
+                temp_partition_dir, min_size="one hundred megabytes", resolution=4
+            )
+
+    def test_in_place_keeps_the_original_when_rows_are_lost(self, temp_partition_dir):
+        """The row-count guard is the API's too, and a lost row is not a silent success."""
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import PartitionError
+
+        large = _seed_with_a_null_geometry_row(temp_partition_dir)
+
+        with pytest.raises(PartitionError) as exc:
+            ops.sub_partition_by_a5(
+                temp_partition_dir,
+                min_size=os.path.getsize(large) - 100,
+                resolution=A5_SPLITTING_RESOLUTION,
+                in_place=True,
+                force=True,
+            )
+
+        assert "keeping original" in str(exc.value)
+        assert os.path.exists(large), "original deleted despite losing rows"
+        assert exc.value.result["processed"] == 0
+        assert len(exc.value.result["errors"]) == 1
+
+    def test_s2_refuses_without_the_geography_extension(self, temp_partition_dir):
+        """S2 cannot run in this release (#737): wired, and refusing for that reason."""
+        from geoparquet_io.api import ops
+        from geoparquet_io.core.exceptions import ExtensionUnavailableError
+        from tests.conftest import skip_if_geography_available
+
+        skip_if_geography_available()
+
+        large, _small = self._seed(temp_partition_dir)
+
+        with pytest.raises(ExtensionUnavailableError) as exc:
+            ops.sub_partition_by_s2(
+                temp_partition_dir, min_size=os.path.getsize(large) - 100, level=10
+            )
+
+        assert exc.value.name == "geography"
+        assert os.path.exists(large)
+
+
+class TestSubPartitionFrontDoorParity:
+    """`gpio partition <index> <dir> --min-size` and its `ops` twin are one operation.
+
+    Both front doors reach `core.sub_partition.sub_partition_directory`; patch it
+    and compare the calls, so a knob wired into one door and not the other fails
+    here rather than in a user's script (#811).
+    """
+
+    CASES = [
+        ("a5", "sub_partition_by_a5", ["--resolution", "12"], {"resolution": 12}),
+        ("h3", "sub_partition_by_h3", ["--resolution", "4"], {"resolution": 4}),
+        ("s2", "sub_partition_by_s2", ["--level", "10"], {"level": 10}),
+        ("quadkey", "sub_partition_by_quadkey", ["--resolution", "6"], {"resolution": 6}),
+    ]
+
+    @pytest.mark.parametrize(
+        ("index", "function", "cli_args", "api_kwargs"),
+        CASES,
+        ids=[case[0] for case in CASES],
+    )
+    def test_both_front_doors_hand_core_the_same_call(
+        self, cli_runner, temp_partition_dir, index, function, cli_args, api_kwargs
+    ):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from geoparquet_io.api import ops
+        from geoparquet_io.core import sub_partition as core_sub_partition
+
+        buildings = Path(__file__).parent / "data" / "buildings_test.parquet"
+        test_file = os.path.join(temp_partition_dir, "test.parquet")
+        shutil.copy(buildings, test_file)
+        threshold = f"{os.path.getsize(test_file) - 100}B"
+
+        clean = {"processed": 1, "skipped": 0, "errors": []}
+
+        with patch.object(
+            core_sub_partition, "sub_partition_directory", return_value=clean
+        ) as fake:
+            result = cli_runner.invoke(
+                partition,
+                [index, temp_partition_dir, "--min-size", threshold, *cli_args],
+            )
+            assert result.exit_code == 0, f"CLI failed: {result.output}"
+            cli_call = fake.call_args.kwargs
+
+        with patch.object(
+            core_sub_partition, "sub_partition_directory", return_value=clean
+        ) as fake:
+            getattr(ops, function)(temp_partition_dir, min_size=threshold, **api_kwargs)
+            api_call = fake.call_args.kwargs
+
+        assert api_call == cli_call


### PR DESCRIPTION
## What changed

`gpio partition <index> <dir>/ --min-size` walks a directory and splits every file over a threshold into a sibling `<file>_<index>/`. That mode had no Python front door at all — `ops.partition_by_*` / `Table.partition_by_*` take a single table — uniformly across a5, h3, quadkey and s2.

- **New: `ops.sub_partition_by_h3`, `ops.sub_partition_by_a5`, `ops.sub_partition_by_quadkey`, `ops.sub_partition_by_s2`** — functions over a directory path, taking `min_size` (`'100MB'` or a byte count), `resolution`/`level` or `auto`, `in_place`, `preview`, plus the hive/overwrite/force/skip-analysis/compression knobs the flags carry.
- **Shared validation moved into core** (`core/sub_partition.py`), since core cannot import Click: `offending_single_file_only_options()` / `single_file_only_option_message()` (the #790 refusal of a custom index column name or `OUTPUT_FOLDER`) and `plan_sub_partition()` (the candidate list behind `--preview`). `cli/decorators.py` now calls both instead of keeping its own copies, so the two doors cannot drift.
- **Row-count guard preserved**: it lives in `sub_partition_directory`, which both doors call, so an original whose sub-partitions lost rows is kept and reported through the API too.
- **Per-file failures raise** `PartitionError` once the run finishes — the API's version of the exit-0 bug fixed in #778 — carrying the whole run on a new optional `PartitionError.result` attribute, so the files that succeeded are not lost with the ones that did not.
- **Parity is enforced, not allowlisted**: the four partition commands gain a `NAME_OVERRIDES` entry in `tests/test_cli_api_default_parity.py`, so each new function is diffed against the flags it mirrors (12 shared defaults per index) with **no** `KNOWN_DIVERGENCES` entry. A new call-parity test patches `core.sub_partition.sub_partition_directory` and asserts the CLI and the API hand it identical kwargs, for all four indexes.
- Docs: `docs/api/python-api.md` (new "Sub-partitioning a directory" section + four rows in the function table) and `docs/guide/sub-partitioning.md` (CLI/Python tabs throughout, a "From Python" section; the Python fences run as tests).

Two things found on the way, both pinned by tests rather than quietly changed:

- `gpio partition quadkey <dir>/ --min-size --resolution N` has always failed per file ("must specify either `--auto` or both `--resolution` and `--partition-resolution`") because directory mode forwards one resolution. The API mirrors that exactly instead of inventing a partition resolution; `test_a_lone_quadkey_resolution_fails_the_same_way_as_the_cli` pins both doors, and the docs say to use `auto=True`.
- The guide's Quick Start fence ran `gpio partition admin … --dataset gaul` with no directive, so it was in the **fast** docs lane and timed out on the boundaries download. It is now marked `<!-- doctest: network -->`, the convention `docs/guide/partition.md` already uses for that command, and split from the sub-partition step so that half runs locally.

## Why

**Shape decision — four `ops.sub_partition_by_<index>` functions over a path, not one function with an `index=` parameter, and not a `Table` method.**

- Not `Table`: a `Table` is one table already in memory; the unit of work here is a directory of files on disk, which a `Table` receiver cannot express.
- One function per index rather than `sub_partition_directory(dir, index='a5')`: `ops` mirrors the CLI command-for-command everywhere else (`partition_by_h3`, `partition_by_a5`, …), and nothing in `ops` dispatches on a stringly-typed scheme name. Per-index functions also let s2 take `level` where the others take `resolution` — the same split the CLI and `ops.partition_by_*` already have — and let each docstring say what is true of that index (s2's unavailability, quadkey's `auto=True`).
- The decisive argument is the parity suite: it resolves an API twin *per CLI command path*, so four functions can be registered against the four commands and have their defaults diffed against the real flags. A single generic function would have been compared against all four commands at once and could not express `level` vs `resolution` — it would have needed allowlist entries, which is exactly the outcome the issue asked to avoid.

## Verification

```
$ uv run pytest tests/test_sub_partition.py tests/test_api.py tests/test_cli_api_default_parity.py tests/test_core_exceptions.py -q
292 passed, 2 skipped in 13.07s

$ uv run pytest -q -m "not slow and not network and not meta" -k "partition or parity"
507 passed, 14 skipped, 5890 deselected in 36.00s

$ uv run pytest -m meta -q
202 passed, 6209 deselected in 12.52s

$ uv run pytest -m "docs_example and not network" -q -k sub-partitioning
docs/guide/sub-partitioning.md ...........
11 passed, 6400 deselected in 10.12s

$ uv run pre-commit run --all-files
(all hooks Passed — includes check-api-for-cli, no-click-echo, doc-sync, codespell)

$ uv run pre-commit run --all-files --hook-stage pre-push
deptry / mypy / vulture / xenon / import-linter / menard-check / fast-tests .... Passed
```

The parity suite really does cover the new surface (not silently skipping it):

```
('partition', 'a5') ['ops.partition_by_a5', 'Table.partition_by_a5', 'ops.sub_partition_by_a5']
   shared params checked: ['auto', 'compression', 'compression_level', 'force', 'hive',
                           'in_place', 'max_partitions', 'overwrite', 'preview',
                           'resolution', 'skip_analysis', 'target_rows']
('partition', 's2') ['ops.partition_by_s2', 'Table.partition_by_s2', 'ops.sub_partition_by_s2']
   shared params checked: ['auto', 'compression', 'compression_level', 'force', 'hive',
                           'in_place', 'level', 'max_partitions', 'overwrite', 'preview',
                           'skip_analysis', 'target_rows']
```

`-m docs_example -k sub-partitioning` (i.e. including the network lane) still fails on the one `network`-marked GAUL fence: `timed out after 120s` downloading the boundaries dataset. That block is pre-existing and untouched apart from gaining the directive that moves it out of the fast lane; every local block on the page passes.

New tests: 15 in `TestApiDirectorySubPartition` (split large / leave small, byte-count `min_size`, quadkey via `auto`, preview writes nothing, preview with no candidates, custom column name rejected, default column name accepted, `output_dir` rejected, missing resolution refused, non-directory refused, unparsable `min_size` refused, row-count guard, s2 refusal), 4 parametrized front-door call-parity cases, and 2 for `PartitionError.result`.

Closes #811
Refs #790, #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV
