### PR TITLE
feat(api)!: accept auto mode on the kdtree methods instead of pinning iterations=9

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -858,6 +858,11 @@ All spatial partitioning methods need to be told how finely to split. Give them 
     `max_partitions`, matching `gpio add kdtree --auto N` and
     `gpio partition kdtree --auto N`.
 
+    One workflow is exempt: `partition_by_kdtree` on a table that already
+    carries the `kdtree_cell` column (say from `add_kdtree()`) needs no sizing
+    parameter, and never fell back to `iterations=9` — the existing cells drive
+    the partition, before and after this change.
+
 #### `partition_by_quadkey(output_dir, resolution=None, partition_resolution=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_quadkey_column=None, overwrite=False)`
 
 Partition the table into a directory by quadkey. Pass `hive=True` for Hive-style `key=value/` subdirectories (matches CLI `--hive`).
@@ -958,7 +963,9 @@ keep it (mirrors the CLI's `--keep-kdtree-column`).
 
 Name an `iterations` count, or pass `auto=True` to size the tree from the row
 count the way `gpio partition kdtree` does. A call that gives neither -- or both
--- raises `InvalidParameterError`.
+-- raises `InvalidParameterError`, unless the table already carries the
+`kdtree_cell` column (say from `add_kdtree()`): then no sizing parameter is
+needed and the existing cells drive the partition.
 
 ```python
 # Auto: sized from the row count, targeting ~120k rows per partition

--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -622,15 +622,22 @@ table = gpio.read('input.parquet').add_admin_divisions(vecorel=True)
   dataset's own name, so columns are `gaul_country` under the default dataset and
   `overture_country` under Overture. Pass `prefix='overture'` to keep the pre-1.4 names
 
-#### `add_kdtree(column_name='kdtree_cell', iterations=9, sample_size=100000)`
+#### `add_kdtree(column_name='kdtree_cell', iterations=None, sample_size=100000, *, auto=False, target_rows=120000)`
 
 Add a KD-tree cell column for data-adaptive spatial partitioning.
 
-```python
-# Default settings (512 partitions = 2^9)
-table = gpio.read('input.parquet').add_kdtree()
+Name an `iterations` count, or pass `auto=True` to size the tree from the row
+count the way `gpio add kdtree` does. A call that gives neither -- or both --
+raises `InvalidParameterError`.
 
-# Fewer partitions
+```python
+# Auto: sized from the row count, targeting ~120k rows per cell
+table = gpio.read('input.parquet').add_kdtree(auto=True)
+
+# Auto with a different target
+table = gpio.read('input.parquet').add_kdtree(auto=True, target_rows=50000)
+
+# An explicit count
 table = gpio.read('input.parquet').add_kdtree(iterations=6)  # 64 partitions
 
 # More partitions with larger sample
@@ -843,8 +850,13 @@ All spatial partitioning methods need to be told how finely to split. Give them 
     | `partition_by_quadkey` | `resolution=13, partition_resolution=6` |
     | `partition_by_s2` | `level=13` |
     | `partition_by_a5` | `resolution=15` |
+    | `partition_by_kdtree` | `iterations=9` |
+    | `add_kdtree` | `iterations=9` |
 
-    To get what the CLI gives you instead, pass `auto=True`.
+    To get what the CLI gives you instead, pass `auto=True`. Under `auto=True`
+    the KD-tree methods take `target_rows` (default 120,000) and no
+    `max_partitions`, matching `gpio add kdtree --auto N` and
+    `gpio partition kdtree --auto N`.
 
 #### `partition_by_quadkey(output_dir, resolution=None, partition_resolution=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_quadkey_column=None, overwrite=False)`
 
@@ -936,7 +948,7 @@ stats = table.partition_by_string('output/', column='category')
 stats = table.partition_by_string('output/', column='mgrs_code', chars=2)
 ```
 
-#### `partition_by_kdtree(output_dir, iterations=9, hive=False, keep_kdtree_column=None, overwrite=False)`
+#### `partition_by_kdtree(output_dir, iterations=None, auto=False, target_rows=120000, hive=False, keep_kdtree_column=None, overwrite=False)`
 
 Partition by KD-tree spatial cells.
 
@@ -944,9 +956,13 @@ With `hive=False` the partition value lives only in the file name, so the genera
 `kdtree_cell` column is dropped from the output. Pass `keep_kdtree_column=True` to
 keep it (mirrors the CLI's `--keep-kdtree-column`).
 
+Name an `iterations` count, or pass `auto=True` to size the tree from the row
+count the way `gpio partition kdtree` does. A call that gives neither -- or both
+-- raises `InvalidParameterError`.
+
 ```python
-# Default (512 partitions = 2^9)
-stats = table.partition_by_kdtree('output/')
+# Auto: sized from the row count, targeting ~120k rows per partition
+stats = table.partition_by_kdtree('output/', auto=True)
 
 # 64 partitions (2^6)
 stats = table.partition_by_kdtree('output/', iterations=6)
@@ -1550,7 +1566,7 @@ print(f"Created {stats['file_count']} files")
 | `ops.add_s2(table, column_name='s2_cell', level=13, geometry_column=None)` | Add S2 cell column — **unavailable in this release**, use `ops.add_a5` |
 | `ops.add_geometry_metrics(table, vecorel=True)` | Add geodesic area and perimeter columns |
 | `ops.add_admin_divisions(table, dataset='gaul', levels=None, vecorel=False)` | Add admin division columns via spatial join |
-| `ops.add_kdtree(table, column_name='kdtree_cell', iterations=9, sample_size=100000, geometry_column=None)` | Add KD-tree cell column |
+| `ops.add_kdtree(table, column_name='kdtree_cell', iterations=None, sample_size=100000, geometry_column=None, auto=False, target_rows=120000)` | Add KD-tree cell column |
 | `ops.sort_hilbert(table, geometry_column=None)` | Reorder by Hilbert curve |
 | `ops.sort_str(table, geometry_column=None, tile_size=50000)` | Reorder with Sort-Tile-Recursive ordering (`tile_size` picks the strip count) |
 | `ops.sort_column(table, column, descending=False)` | Sort by column(s) |
@@ -1572,7 +1588,7 @@ print(f"Created {stats['file_count']} files")
 | `ops.partition_by_a5(table, output_dir, resolution=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_a5_column=None, overwrite=False, geometry_column=None)` | Partition into a directory by A5 cell |
 | `ops.partition_by_s2(table, output_dir, level=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_s2_column=None, overwrite=False, geometry_column=None)` | Partition into a directory by S2 cell — **unavailable in this release**, use `ops.partition_by_a5` |
 | `ops.partition_by_quadkey(table, output_dir, resolution=None, partition_resolution=None, auto=False, target_rows=100000, max_partitions=10000, compression='ZSTD', hive=False, keep_quadkey_column=None, overwrite=False, geometry_column=None)` | Partition into a directory by quadkey |
-| `ops.partition_by_kdtree(table, output_dir, iterations=9, hive=False, keep_kdtree_column=None, overwrite=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by KD-tree cell |
+| `ops.partition_by_kdtree(table, output_dir, iterations=None, auto=False, target_rows=120000, hive=False, keep_kdtree_column=None, overwrite=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by KD-tree cell |
 | `ops.partition_by_string(table, output_dir, column, chars=None, hive=False, overwrite=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by string column value |
 | `ops.partition_by_admin(table, output_dir, dataset='gaul', levels=None, hive=False, overwrite=False, vecorel=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by administrative boundaries |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |

--- a/docs/concepts/spatial-indices.md
+++ b/docs/concepts/spatial-indices.md
@@ -216,7 +216,7 @@ Data-adaptive partitioning that divides space based on data distribution.
 gpio add kdtree input.parquet output.parquet
 
 # Python
-gpio.read('input.parquet').add_kdtree().write('output.parquet')
+gpio.read('input.parquet').add_kdtree(auto=True).write('output.parquet')
 ```
 
 ### Summary: Cell Columns

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -332,15 +332,27 @@ Add balanced spatial partition IDs using KD-tree:
     ```python
     import geoparquet_io as gpio
 
-    # Add kdtree column with default settings (9 iterations = 512 partitions)
-    gpio.read('input.parquet').add_kdtree().write('output.parquet')
+    # Auto mode: size the tree from the row count, like the bare CLI call
+    gpio.read('input.parquet').add_kdtree(auto=True).write('output.parquet')
 
-    # Custom column name and iterations
+    # A different target, still auto
+    gpio.read('input.parquet').add_kdtree(
+        auto=True, target_rows=50000
+    ).write('output.parquet')
+
+    # Custom column name and an explicit iteration count
     gpio.read('input.parquet').add_kdtree(
         column_name='partition_id',
         iterations=5  # 2^5 = 32 partitions
     ).write('output.parquet')
     ```
+
+!!! warning "Breaking change for the Python API: the implicit `iterations=9` is gone"
+    `Table.add_kdtree()` and `ops.add_kdtree()` used to fall back to
+    `iterations=9` — 512 partitions whatever the input — where the bare CLI call
+    sizes the tree from the row count. Such a call now raises
+    `InvalidParameterError`. Pass `auto=True` to get what the CLI gives you, or
+    pass `iterations=9` to keep the output you had.
 
 **Auto mode** (default):
 - Targets ~120k rows per partition

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -22,6 +22,11 @@ Neither front end guesses for you: pass a resolution, or ask for `auto`. A call 
     `partition_by_kdtree(iterations=9)`. The same applies to `add_kdtree()`,
     which pinned `iterations=9` too.
 
+    One workflow is exempt: `partition_by_kdtree()` on a table that already
+    carries the `kdtree_cell` column (say from `add_kdtree()`) needs no sizing
+    parameter — the existing cells drive the partition, exactly as they did
+    before this change.
+
 ### How It Works
 
 Auto-resolution analyzes your dataset and calculates the optimal spatial index resolution to achieve your target partition size:
@@ -608,10 +613,16 @@ Partition by balanced spatial partitions:
 
 !!! warning "Breaking change for the Python API: the implicit `iterations=9` is gone"
     `Table.partition_by_kdtree()` and `ops.partition_by_kdtree()` used to fall
-    back to `iterations=9` — 512 partitions whatever the input — where the bare
-    CLI call sizes the tree from the row count. Such a call now raises
-    `InvalidParameterError`. Pass `auto=True` to get what the CLI gives you, or
-    pass `iterations=9` to keep the output you had.
+    back to `iterations=9` when they had to build the tree themselves — 512
+    partitions whatever the input — where the bare CLI call sizes the tree from
+    the row count. Such a call now raises `InvalidParameterError`. Pass
+    `auto=True` to get what the CLI gives you, or pass `iterations=9` to keep
+    the output you had.
+
+    A table that already carries the `kdtree_cell` column (say from
+    `add_kdtree()`) is unaffected: it needs no sizing parameter, and never fell
+    back to 512 partitions — the existing cells drive the partition, before and
+    after this change.
 
 **Column behavior:**
 - Similar to H3: excluded by default, included for Hive

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -18,7 +18,9 @@ Neither front end guesses for you: pass a resolution, or ask for `auto`. A call 
     pass the old value explicitly to keep the output you had:
     `partition_by_h3(resolution=9)`,
     `partition_by_quadkey(resolution=13, partition_resolution=6)`,
-    `partition_by_s2(level=13)`, `partition_by_a5(resolution=15)`.
+    `partition_by_s2(level=13)`, `partition_by_a5(resolution=15)`,
+    `partition_by_kdtree(iterations=9)`. The same applies to `add_kdtree()`,
+    which pinned `iterations=9` too.
 
 ### How It Works
 
@@ -573,8 +575,13 @@ Partition by balanced spatial partitions:
     ```python
     import geoparquet_io as gpio
 
-    # Partition using KD-tree (creates 2^iterations partitions)
-    gpio.read('input.parquet').partition_by_kdtree('output/')
+    # Auto mode: size the tree from the row count, like the bare CLI call
+    gpio.read('input.parquet').partition_by_kdtree('output/', auto=True)
+
+    # A different target, still auto
+    gpio.read('input.parquet').partition_by_kdtree(
+        'output/', auto=True, target_rows=50000
+    )
 
     # 64 partitions (2^6)
     gpio.read('input.parquet').partition_by_kdtree('output/', iterations=6)
@@ -594,6 +601,17 @@ Partition by balanced spatial partitions:
 
         - Python `iterations=6` → 64 partitions (2^6)
         - CLI `--partitions 64` → 64 partitions
+
+        Auto mode is spelled `auto=True` with `target_rows=` on the Python side
+        and `--auto N` on the CLI; both mean "size the tree so partitions hold
+        about N rows", and both default to 120,000.
+
+!!! warning "Breaking change for the Python API: the implicit `iterations=9` is gone"
+    `Table.partition_by_kdtree()` and `ops.partition_by_kdtree()` used to fall
+    back to `iterations=9` — 512 partitions whatever the input — where the bare
+    CLI call sizes the tree from the row count. Such a call now raises
+    `InvalidParameterError`. Pass `auto=True` to get what the CLI gives you, or
+    pass `iterations=9` to keep the output you had.
 
 **Column behavior:**
 - Similar to H3: excluded by default, included for Hive
@@ -852,7 +870,7 @@ schemes:
 | `gpio partition a5` | `ops.partition_by_a5(table, output_dir, resolution=..., auto=...)` |
 | `gpio partition s2` | `ops.partition_by_s2(table, output_dir, level=..., auto=...)` |
 | `gpio partition quadkey` | `ops.partition_by_quadkey(table, output_dir, resolution=..., partition_resolution=..., auto=...)` |
-| `gpio partition kdtree` | `ops.partition_by_kdtree(table, output_dir, iterations=...)` |
+| `gpio partition kdtree` | `ops.partition_by_kdtree(table, output_dir, iterations=..., auto=...)` |
 | `gpio partition string` | `ops.partition_by_string(table, output_dir, column, chars=...)` |
 | `gpio partition admin` | `ops.partition_by_admin(table, output_dir, dataset=..., levels=...)` |
 

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -25,7 +25,7 @@ from geoparquet_io.core.add.a5 import add_a5_table
 from geoparquet_io.core.add.bbox import add_bbox_table
 from geoparquet_io.core.add.bbox_metadata import add_bbox_metadata_table
 from geoparquet_io.core.add.h3 import add_h3_table
-from geoparquet_io.core.add.kdtree import add_kdtree_table
+from geoparquet_io.core.add.kdtree import DEFAULT_KDTREE_TARGET_ROWS, add_kdtree_table
 from geoparquet_io.core.add.quadkey import add_quadkey_table
 from geoparquet_io.core.add.s2 import add_s2_table
 from geoparquet_io.core.extract import extract_table
@@ -582,22 +582,42 @@ def create_overviews(
 def add_kdtree(
     table: pa.Table,
     column_name: str = "kdtree_cell",
-    iterations: int = 9,
+    iterations: int | None = None,
     sample_size: int = 100000,
     geometry_column: str | None = None,
+    *,
+    auto: bool = False,
+    target_rows: int = DEFAULT_KDTREE_TARGET_ROWS,
 ) -> pa.Table:
     """
     Add a KD-tree cell column based on geometry location.
 
+    Function form of `Table.add_kdtree`, mirroring `gpio add kdtree`. Like both
+    of them it refuses to guess: pass ``iterations``, or pass ``auto=True`` to
+    size the tree from the row count.
+
     Args:
         table: Input PyArrow Table
         column_name: Name for the KD-tree column (default: 'kdtree_cell')
-        iterations: Number of recursive splits 1-20 (default: 9)
+        iterations: Number of recursive splits 1-20, giving ``2 ** iterations``
+            cells. Required unless ``auto=True``
         sample_size: Number of points to sample for boundaries (default: 100000)
         geometry_column: Geometry column name (auto-detected if None)
+        auto: Size the tree from the row count (default: False); mutually
+            exclusive with ``iterations``
+        target_rows: Target rows per cell when ``auto=True`` (default: 120000)
 
     Returns:
         New table with KD-tree column added
+
+    Raises:
+        InvalidParameterError: If both ``iterations`` and ``auto`` were given, or
+            neither was
+
+    Example:
+        >>> from geoparquet_io.api import ops
+        >>> sized = ops.add_kdtree(table, iterations=6)
+        >>> auto = ops.add_kdtree(table, auto=True)
     """
     return add_kdtree_table(
         table,
@@ -605,6 +625,7 @@ def add_kdtree(
         iterations=iterations,
         sample_size=sample_size,
         geometry_column=geometry_column,
+        auto_target_rows=("rows", target_rows) if auto else None,
     )
 
 
@@ -1012,7 +1033,9 @@ def partition_by_kdtree(
     table: pa.Table,
     output_dir: str | Path,
     *,
-    iterations: int = 9,
+    iterations: int | None = None,
+    auto: bool = False,
+    target_rows: int = DEFAULT_KDTREE_TARGET_ROWS,
     hive: bool = False,
     keep_kdtree_column: bool | None = None,
     overwrite: bool = False,
@@ -1025,12 +1048,17 @@ def partition_by_kdtree(
 
     Function form of `Table.partition_by_kdtree`, mirroring
     `gpio partition kdtree`. Recursively splits the data spatially, producing
-    ``2 ** iterations`` balanced partitions.
+    ``2 ** iterations`` balanced partitions. Like both of them it refuses to
+    guess: pass ``iterations``, or pass ``auto=True`` to size the tree from the
+    row count.
 
     Args:
         table: Input PyArrow Table with a geometry column
         output_dir: Output directory path
-        iterations: Number of KD-tree splits (default: 9)
+        iterations: Number of KD-tree splits. Required unless ``auto=True``
+        auto: Size the tree from the row count (default: False); mutually
+            exclusive with ``iterations``
+        target_rows: Target rows per partition when ``auto=True`` (default: 120000)
         hive: Use Hive-style ``kdtree_cell=value/`` directories (default: False)
         keep_kdtree_column: Keep the generated ``kdtree_cell`` column. None
             (default) follows ``hive``
@@ -1044,9 +1072,14 @@ def partition_by_kdtree(
         Unlike the cell-index partitioners this one does not count the files it
         wrote, so there is no ``file_count`` here -- read ``output_dir``.
 
+    Raises:
+        InvalidParameterError: If both ``iterations`` and ``auto`` were given, or
+            neither was
+
     Example:
         >>> from geoparquet_io.api import ops
         >>> stats = ops.partition_by_kdtree(table, 'output/', iterations=6)
+        >>> auto = ops.partition_by_kdtree(table, 'output/', auto=True)
     """
     return _partition(
         table,
@@ -1054,6 +1087,8 @@ def partition_by_kdtree(
         "partition_by_kdtree",
         geometry_column,
         iterations=iterations,
+        auto=auto,
+        target_rows=target_rows,
         hive=hive,
         keep_kdtree_column=keep_kdtree_column,
         overwrite=overwrite,

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1050,7 +1050,8 @@ def partition_by_kdtree(
     `gpio partition kdtree`. Recursively splits the data spatially, producing
     ``2 ** iterations`` balanced partitions. Like both of them it refuses to
     guess: pass ``iterations``, or pass ``auto=True`` to size the tree from the
-    row count.
+    row count. A table already carrying a ``kdtree_cell`` column needs neither
+    -- the existing cells drive the partition and no tree is built.
 
     Args:
         table: Input PyArrow Table with a geometry column
@@ -1074,7 +1075,7 @@ def partition_by_kdtree(
 
     Raises:
         InvalidParameterError: If both ``iterations`` and ``auto`` were given, or
-            neither was
+            neither was and the table does not already carry the column
 
     Example:
         >>> from geoparquet_io.api import ops

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -17,6 +17,11 @@ from typing import TYPE_CHECKING
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from geoparquet_io.core.add.kdtree import (
+    DEFAULT_KDTREE_TARGET_ROWS,
+    ITERATIONS_CONFLICT,
+    ITERATIONS_MISSING,
+)
 from geoparquet_io.core.check_parquet_structure import CheckProfile
 from geoparquet_io.core.common import write_geoparquet_table
 from geoparquet_io.core.duckdb_utils import quote_identifier
@@ -1779,19 +1784,40 @@ class Table:
     def add_kdtree(
         self,
         column_name: str = "kdtree_cell",
-        iterations: int = 9,
+        iterations: int | None = None,
         sample_size: int = 100000,
+        *,
+        auto: bool = False,
+        target_rows: int = DEFAULT_KDTREE_TARGET_ROWS,
     ) -> Table:
         """
         Add a KD-tree cell column based on geometry location.
 
+        Like ``gpio add kdtree``, this refuses to guess: pass ``iterations``, or
+        pass ``auto=True`` to size the tree from the row count.
+
         Args:
             column_name: Name for the KD-tree column (default: 'kdtree_cell')
-            iterations: Number of recursive splits 1-20 (default: 9)
+            iterations: Number of recursive splits 1-20, giving ``2 ** iterations``
+                cells. Required unless ``auto=True``. Mirrors ``--partitions``,
+                which the CLI spells as the partition count itself.
             sample_size: Number of points to sample for boundaries (default: 100000)
+            auto: Size the tree from the row count (default: False). Mirrors the
+                CLI's default auto mode; mutually exclusive with ``iterations``.
+            target_rows: Target rows per cell when ``auto=True`` (default: 120000).
+                Mirrors ``--auto N``.
 
         Returns:
             New Table with KD-tree column added
+
+        Raises:
+            InvalidParameterError: If both ``iterations`` and ``auto`` were given,
+                or neither was
+
+        Example:
+            >>> table = gpio.read('data.parquet')
+            >>> sized = table.add_kdtree(iterations=6)  # 64 cells
+            >>> auto = table.add_kdtree(auto=True)  # sized from the row count
         """
         from geoparquet_io.core.add.kdtree import add_kdtree_table
 
@@ -1800,6 +1826,7 @@ class Table:
             kdtree_column_name=column_name,
             iterations=iterations,
             sample_size=sample_size,
+            auto_target_rows=("rows", target_rows) if auto else None,
         )
         return self._wrap(result, self._geometry_column)
 
@@ -3091,7 +3118,9 @@ class Table:
         self,
         output_dir: str | Path,
         *,
-        iterations: int = 9,
+        iterations: int | None = None,
+        auto: bool = False,
+        target_rows: int = DEFAULT_KDTREE_TARGET_ROWS,
         hive: bool = False,
         keep_kdtree_column: bool | None = None,
         overwrite: bool = False,
@@ -3104,9 +3133,18 @@ class Table:
         Recursively splits the data spatially using KD-tree algorithm,
         creating balanced partitions based on geometry distribution.
 
+        Like ``gpio partition kdtree``, this refuses to guess: pass
+        ``iterations``, or pass ``auto=True`` to size the tree from the row count.
+
         Args:
             output_dir: Output directory for partition files
-            iterations: Number of KD-tree splits (creates 2^iterations partitions)
+            iterations: Number of KD-tree splits (creates 2^iterations partitions).
+                Required unless ``auto=True``. Mirrors ``--partitions``, which the
+                CLI spells as the partition count itself.
+            auto: Size the tree from the row count (default: False). Mirrors the
+                CLI's default auto mode; mutually exclusive with ``iterations``.
+            target_rows: Target rows per partition when ``auto=True``
+                (default: 120000). Mirrors ``--auto N``.
             hive: Use Hive-style partitioning (default: False, matches CLI --hive)
             keep_kdtree_column: Keep the generated ``kdtree_cell`` column in the output
                 files. None (default) follows ``hive``: kept for Hive-style
@@ -3121,11 +3159,23 @@ class Table:
         Returns:
             dict with partition statistics
 
+        Raises:
+            InvalidParameterError: If both ``iterations`` and ``auto`` were given,
+                or neither was
+
         Example:
             >>> table = gpio.read('data.parquet')
             >>> stats = table.partition_by_kdtree('output/', iterations=6)
+            >>> auto = table.partition_by_kdtree('output/', auto=True)
         """
         from geoparquet_io.core.partition.by_kdtree import partition_by_kdtree
+
+        _require_auto_or_resolution(
+            auto,
+            {"iterations": iterations},
+            conflict=ITERATIONS_CONFLICT,
+            missing=ITERATIONS_MISSING,
+        )
 
         return _run_partition_with_temp_file(
             self._table,
@@ -3135,6 +3185,7 @@ class Table:
             temp_prefix="gpio_part_kd",
             core_kwargs={
                 "iterations": iterations,
+                "auto_target_rows": ("rows", target_rows) if auto else None,
                 "hive": hive,
                 "keep_kdtree_column": keep_kdtree_column,
                 "overwrite": overwrite,

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -3135,6 +3135,8 @@ class Table:
 
         Like ``gpio partition kdtree``, this refuses to guess: pass
         ``iterations``, or pass ``auto=True`` to size the tree from the row count.
+        A table already carrying a ``kdtree_cell`` column needs neither -- the
+        existing cells drive the partition and no tree is built.
 
         Args:
             output_dir: Output directory for partition files
@@ -3161,7 +3163,7 @@ class Table:
 
         Raises:
             InvalidParameterError: If both ``iterations`` and ``auto`` were given,
-                or neither was
+                or neither was and the table does not already carry the column
 
         Example:
             >>> table = gpio.read('data.parquet')
@@ -3170,12 +3172,23 @@ class Table:
         """
         from geoparquet_io.core.partition.by_kdtree import partition_by_kdtree
 
-        _require_auto_or_resolution(
-            auto,
-            {"iterations": iterations},
-            conflict=ITERATIONS_CONFLICT,
-            missing=ITERATIONS_MISSING,
-        )
+        if "kdtree_cell" in self._table.column_names:
+            # The table already carries the kdtree column: the add step is
+            # skipped and the existing cells drive the partition, so there is
+            # no tree to size (`add_kdtree(...).partition_by_kdtree(dir)` needs
+            # no sizing parameter). Only the contradiction of naming both is
+            # still refused, before any I/O is spent on it.
+            if auto and iterations is not None:
+                from geoparquet_io.core.exceptions import InvalidParameterError
+
+                raise InvalidParameterError("auto", ITERATIONS_CONFLICT)
+        else:
+            _require_auto_or_resolution(
+                auto,
+                {"iterations": iterations},
+                conflict=ITERATIONS_CONFLICT,
+                missing=ITERATIONS_MISSING,
+            )
 
         return _run_partition_with_temp_file(
             self._table,

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -105,19 +105,34 @@ def resolve_auto_iterations(
 
     Returns:
         The number of recursive splits to run (partitions are ``2 ** result``)
+
+    Raises:
+        InvalidParameterError: If the target is not positive (a zero target
+            would push the search to its 20-iteration ceiling -- 2^20 partitions
+            from any input), or an ``"mb"`` target was given for an input whose
+            size is unknown (``file_size_mb <= 0``)
     """
     if isinstance(auto_target_rows, tuple):
         mode, value = auto_target_rows
-        if mode == "mb":
-            # Rows that fit in the target size: (total_rows * target_mb) / file_mb
-            target_rows = int((total_count * value) / file_size_mb)
-            target_desc = f"{value:,.1f} MB"
-        else:
-            target_rows = value
-            target_desc = f"{value:,} rows"
     else:
-        target_rows = auto_target_rows
-        target_desc = f"{auto_target_rows:,} rows"
+        mode, value = "rows", auto_target_rows
+
+    if value <= 0:
+        raise InvalidParameterError("target_rows", f"must be positive, got {value}")
+
+    if mode == "mb":
+        if file_size_mb <= 0:
+            raise InvalidParameterError(
+                "auto",
+                "cannot size partitions from a MB target: the input's file size "
+                "is unknown; use a rows target instead",
+            )
+        # Rows that fit in the target size: (total_rows * target_mb) / file_mb
+        target_rows = max(1, int((total_count * value) / file_size_mb))
+        target_desc = f"{value:,.1f} MB"
+    else:
+        target_rows = value
+        target_desc = f"{value:,} rows"
 
     iterations = _find_optimal_iterations(total_count, target_rows, verbose)
 
@@ -341,9 +356,17 @@ def add_kdtree_table(
 
     Raises:
         InvalidParameterError: If both ``iterations`` and ``auto_target_rows``
-            were given, or neither was
+            were given, or neither was; if ``iterations`` is outside 1-20; or
+            if ``auto_target_rows`` names a non-positive target. (Not a
+            ``ValueError``: every parameter fault in this module raises the
+            same framework-agnostic type.)
     """
     require_iterations_or_auto(iterations, auto_target_rows)
+
+    # Validate before any work is spent on the call: serializing the table to a
+    # temp file used to happen first, so an invalid call paid a full write.
+    if iterations is not None and not 1 <= iterations <= 20:
+        raise InvalidParameterError("iterations", f"must be between 1 and 20, got {iterations}")
 
     # Find geometry column
     geom_col = geometry_column or find_geometry_column_from_table(table)
@@ -360,15 +383,12 @@ def add_kdtree_table(
         if iterations is None:
             # The temp copy's size stands in for the input's: an in-memory table
             # has no file, and the figure only feeds the report and the "mb" target.
+            # The resolver only ever returns 1-20, so no range check is needed here.
             iterations = resolve_auto_iterations(
                 table.num_rows,
                 auto_target_rows,
                 _file_size_mb(temp_path),
             )
-
-        # Validate iterations
-        if not 1 <= iterations <= 20:
-            raise InvalidParameterError("iterations", f"must be between 1 and 20, got {iterations}")
 
         # Process using file-based mode
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -38,6 +38,100 @@ from geoparquet_io.core.streaming import (
     should_stream_output,
 )
 
+#: Rows per partition that `gpio add kdtree` / `gpio partition kdtree` aim for
+#: when neither `--partitions` nor `--auto` is given, and the default the Python
+#: API's ``target_rows`` carries so `auto=True` reproduces the CLI exactly.
+DEFAULT_KDTREE_TARGET_ROWS = 120000
+
+#: Wording shared by every KD-tree front door, so the same mistake reads the same
+#: way whether it was made through the CLI, `ops` or `Table`.
+ITERATIONS_CONFLICT = "cannot specify both iterations and auto"
+ITERATIONS_MISSING = "must specify either iterations or auto"
+
+
+def _file_size_mb(path: str) -> float:
+    """Size of ``path`` in MB, or 0.0 when it cannot be stat'd (e.g. a URL)."""
+    try:
+        return os.path.getsize(path) / (1024 * 1024)
+    except OSError:
+        return 0.0
+
+
+def require_iterations_or_auto(
+    iterations: int | None, auto_target_rows: int | tuple | None
+) -> None:
+    """Refuse to guess a tree size, the way the CLI refuses to guess a resolution.
+
+    An unset ``iterations`` used to mean "512 partitions" in the Python API and
+    "size it from the row count" on the command line, so the same file through
+    the two front doors came out partitioned differently (#813). Neither is
+    guessed now: name one or the other.
+
+    Args:
+        iterations: Explicit number of recursive splits, or None
+        auto_target_rows: Auto-mode target (``N`` rows, or a ``(mode, value)``
+            pair), or None
+
+    Raises:
+        InvalidParameterError: If both were given, or neither was
+    """
+    if iterations is not None and auto_target_rows is not None:
+        raise InvalidParameterError("auto", ITERATIONS_CONFLICT)
+    if iterations is None and auto_target_rows is None:
+        raise InvalidParameterError("iterations", ITERATIONS_MISSING)
+
+
+def resolve_auto_iterations(
+    total_count: int,
+    auto_target_rows: int | tuple,
+    file_size_mb: float,
+    verbose: bool = False,
+    announce: bool = True,
+) -> int:
+    """Size a KD-tree from a row (or MB) target, and say what was picked.
+
+    One implementation for every caller: the file command, the partition command
+    and the in-memory table function all have to land on the same iteration count
+    for the same data, which is the whole point of #813.
+
+    Args:
+        total_count: Rows in the input
+        auto_target_rows: ``N`` rows, or a ``(mode, value)`` pair where mode is
+            ``"rows"`` or ``"mb"``
+        file_size_mb: Size of the input on disk, used by the ``"mb"`` mode and by
+            the per-partition estimate in the message
+        verbose: Whether the caller is in verbose mode
+        announce: Whether to report the choice to the user
+
+    Returns:
+        The number of recursive splits to run (partitions are ``2 ** result``)
+    """
+    if isinstance(auto_target_rows, tuple):
+        mode, value = auto_target_rows
+        if mode == "mb":
+            # Rows that fit in the target size: (total_rows * target_mb) / file_mb
+            target_rows = int((total_count * value) / file_size_mb)
+            target_desc = f"{value:,.1f} MB"
+        else:
+            target_rows = value
+            target_desc = f"{value:,} rows"
+    else:
+        target_rows = auto_target_rows
+        target_desc = f"{auto_target_rows:,} rows"
+
+    iterations = _find_optimal_iterations(total_count, target_rows, verbose)
+
+    if announce:
+        partition_count = 2**iterations
+        avg_rows = total_count / partition_count
+        avg_mb = file_size_mb / partition_count
+        info(
+            f"Auto-selected {partition_count} partitions (avg ~{avg_rows:,.0f} rows, "
+            f"~{avg_mb:,.1f} MB/partition, target: {target_desc})"
+        )
+
+    return iterations
+
 
 def _find_optimal_iterations(total_rows, target_rows, verbose=False):
     """
@@ -219,33 +313,42 @@ def _build_sampling_query(
 def add_kdtree_table(
     table: pa.Table,
     kdtree_column_name: str = "kdtree_cell",
-    iterations: int = 9,
+    iterations: int | None = None,
     sample_size: int = 100000,
     geometry_column: str | None = None,
+    auto_target_rows: int | tuple | None = None,
 ) -> pa.Table:
     """
     Add a KD-tree cell ID column to an Arrow Table.
 
-    This is the table-centric version for the Python API.
+    This is the table-centric version for the Python API. Like the file command
+    it will not guess a tree size: pass ``iterations``, or pass
+    ``auto_target_rows`` to size the tree from the row count.
 
     Args:
         table: Input PyArrow Table
         kdtree_column_name: Name for the KD-tree column (default: 'kdtree_cell')
         iterations: Number of recursive splits (1-20). Determines partition count: 2^iterations.
+            Required unless ``auto_target_rows`` is given.
         sample_size: Number of points to sample for computing boundaries
         geometry_column: Geometry column name (auto-detected if None)
+        auto_target_rows: Auto-size the tree to this many rows per partition,
+            as ``N`` or a ``(mode, value)`` pair. Mutually exclusive with
+            ``iterations``.
 
     Returns:
         New table with KD-tree column added
+
+    Raises:
+        InvalidParameterError: If both ``iterations`` and ``auto_target_rows``
+            were given, or neither was
     """
+    require_iterations_or_auto(iterations, auto_target_rows)
+
     # Find geometry column
     geom_col = geometry_column or find_geometry_column_from_table(table)
     if not geom_col:
         geom_col = "geometry"
-
-    # Validate iterations
-    if not 1 <= iterations <= 20:
-        raise ValueError(f"Iterations must be between 1 and 20, got {iterations}")
 
     # Write table to temp file for processing (kdtree needs file access)
     temp_fd, temp_path = tempfile.mkstemp(suffix=".parquet")
@@ -253,6 +356,19 @@ def add_kdtree_table(
 
     try:
         pq.write_table(table, temp_path)
+
+        if iterations is None:
+            # The temp copy's size stands in for the input's: an in-memory table
+            # has no file, and the figure only feeds the report and the "mb" target.
+            iterations = resolve_auto_iterations(
+                table.num_rows,
+                auto_target_rows,
+                _file_size_mb(temp_path),
+            )
+
+        # Validate iterations
+        if not 1 <= iterations <= 20:
+            raise InvalidParameterError("iterations", f"must be between 1 and 20, got {iterations}")
 
         # Process using file-based mode
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
@@ -280,7 +396,7 @@ def add_kdtree_column(
     input_parquet: str,
     output_parquet: str | None = None,
     kdtree_column_name: str = "kdtree_cell",
-    iterations: int = 9,
+    iterations: int | None = None,
     dry_run: bool = False,
     verbose: bool = False,
     compression: str = "ZSTD",
@@ -315,7 +431,8 @@ def add_kdtree_column(
         output_parquet: Path to output file, "-" for stdout, or None for auto-detect
         kdtree_column_name: Name for the KD-tree column (default: 'kdtree_cell')
         iterations: Number of recursive splits (1-20). Determines partition count: 2^iterations.
-                   If None, will be auto-computed based on auto_target_rows.
+                   Required unless auto_target_rows is given, in which case it is
+                   auto-computed from the row count.
         dry_run: Whether to print SQL commands without executing them
         verbose: Whether to print verbose output
         compression: Compression type (ZSTD, GZIP, BROTLI, LZ4, SNAPPY, UNCOMPRESSED)
@@ -330,6 +447,8 @@ def add_kdtree_column(
         memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
     """
     configure_verbose(verbose)
+
+    require_iterations_or_auto(iterations, auto_target_rows)
 
     # Check for streaming mode (stdin input or stdout output)
     is_streaming = is_stdin(input_parquet) or should_stream_output(output_parquet)
@@ -349,6 +468,7 @@ def add_kdtree_column(
             profile,
             geoparquet_version,
             memory_limit=memory_limit,
+            auto_target_rows=auto_target_rows,
         )
         return
 
@@ -370,39 +490,13 @@ def add_kdtree_column(
 
     # Auto-compute iterations if requested
     if iterations is None:
-        if auto_target_rows is None:
-            raise InvalidParameterError(
-                "iterations", "Either iterations or auto_target_rows must be specified"
-            )
-
-        # Get file size for MB calculations
-        import os
-
-        file_size_mb = os.path.getsize(input_parquet) / (1024 * 1024)
-
-        # Handle MB-based or row-based targets
-        if isinstance(auto_target_rows, tuple):
-            mode, value = auto_target_rows
-            if mode == "mb":
-                # Calculate target rows: (total_rows * target_mb) / file_size_mb
-                target_rows = int((total_count * value) / file_size_mb)
-                target_desc = f"{value:,.1f} MB"
-            else:
-                target_rows = value
-                target_desc = f"{value:,} rows"
-        else:
-            target_rows = auto_target_rows
-            target_desc = f"{auto_target_rows:,} rows"
-
-        iterations = _find_optimal_iterations(total_count, target_rows, verbose)
-        partition_count = 2**iterations
-
-        if verbose or not dry_run:
-            avg_rows = total_count / partition_count
-            avg_mb = file_size_mb / partition_count
-            info(
-                f"Auto-selected {partition_count} partitions (avg ~{avg_rows:,.0f} rows, ~{avg_mb:,.1f} MB/partition, target: {target_desc})"
-            )
+        iterations = resolve_auto_iterations(
+            total_count,
+            auto_target_rows,
+            _file_size_mb(input_parquet),
+            verbose=verbose,
+            announce=verbose or not dry_run,
+        )
 
     # Validate iterations
     if not 1 <= iterations <= 20:
@@ -557,7 +651,7 @@ def _add_kdtree_streaming(
     input_path: str,
     output_path: str | None,
     kdtree_column_name: str,
-    iterations: int,
+    iterations: int | None,
     verbose: bool,
     compression: str,
     compression_level: int | None,
@@ -567,6 +661,7 @@ def _add_kdtree_streaming(
     profile: str | None,
     geoparquet_version: str | None,
     memory_limit: str | None,
+    auto_target_rows: int | tuple | None = None,
 ) -> None:
     """Handle streaming input/output for add_kdtree."""
     # Suppress verbose when streaming to stdout
@@ -589,6 +684,21 @@ def _add_kdtree_streaming(
         try:
             # Find geometry column
             geom_col = find_primary_geometry_column(working_file, verbose)
+
+            if iterations is None:
+                # Auto mode: size the tree from the row count, as the file path
+                # does. The byte size is only used for the report here -- a
+                # streaming input may be a URL with no size to stat.
+                total_count = con.execute(
+                    f"SELECT COUNT(*) FROM {sql_path(working_path)}"
+                ).fetchone()[0]
+                iterations = resolve_auto_iterations(
+                    total_count,
+                    auto_target_rows,
+                    _file_size_mb(working_file),
+                    verbose=verbose,
+                    announce=verbose,
+                )
 
             # Validate iterations
             if not 1 <= iterations <= 20:

--- a/geoparquet_io/core/partition/by_kdtree.py
+++ b/geoparquet_io/core/partition/by_kdtree.py
@@ -6,7 +6,11 @@ import os
 import tempfile
 import uuid
 
-from geoparquet_io.core.add.kdtree import add_kdtree_column, require_iterations_or_auto
+from geoparquet_io.core.add.kdtree import (
+    ITERATIONS_CONFLICT,
+    add_kdtree_column,
+    require_iterations_or_auto,
+)
 from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
 from geoparquet_io.core.logging_config import (
     configure_verbose,
@@ -70,6 +74,11 @@ def _add_kdtree_column_to_temp(
             auto_target_rows=auto_target_rows,
         )
         return temp_file
+    except InvalidParameterError:
+        # A parameter fault is the caller's to fix, not a partition failure:
+        # let it surface under its own type, as it does through `add kdtree`.
+        _cleanup_temp_file(temp_file)
+        raise
     except Exception as e:
         _cleanup_temp_file(temp_file)
         raise PartitionError(f"Failed to add KD-tree column: {str(e)}") from e
@@ -149,7 +158,9 @@ def partition_by_kdtree(
         output_folder: Output directory
         kdtree_column_name: Name of KD-tree column (default: 'kdtree_cell')
         iterations: Number of recursive splits (1-20). Required unless
-            auto_target_rows is given, which sizes the tree from the row count.
+            auto_target_rows is given, which sizes the tree from the row count,
+            or the input already carries the kdtree column (nothing is added,
+            so there is no tree to size).
         hive: Use Hive-style partitioning
         overwrite: Overwrite existing files
         preview: Show preview of partitions without creating files
@@ -200,7 +211,14 @@ def partition_by_kdtree(
         # the tree from the row count below. Defaulting it to 9 here (as this did
         # until #813) silently overrode `--auto` with 512 partitions whatever the
         # input -- the same guess the Python API used to make.
-        require_iterations_or_auto(iterations, auto_target_rows)
+        #
+        # An input already carrying the kdtree column needs no sizing at all:
+        # the add step is skipped and the existing cells drive the partition, so
+        # only the contradiction of naming both is still refused.
+        if not column_exists:
+            require_iterations_or_auto(iterations, auto_target_rows)
+        elif iterations is not None and auto_target_rows is not None:
+            raise InvalidParameterError("auto", ITERATIONS_CONFLICT)
 
         # Note: With approximate mode (default), large datasets are handled efficiently
         if not column_exists and verbose and total_rows > 10_000_000:

--- a/geoparquet_io/core/partition/by_kdtree.py
+++ b/geoparquet_io/core/partition/by_kdtree.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import uuid
 
-from geoparquet_io.core.add.kdtree import add_kdtree_column
+from geoparquet_io.core.add.kdtree import add_kdtree_column, require_iterations_or_auto
 from geoparquet_io.core.exceptions import InvalidParameterError, PartitionError
 from geoparquet_io.core.logging_config import (
     configure_verbose,
@@ -31,7 +31,7 @@ def _cleanup_temp_file(temp_file: str | None, verbose: bool = False) -> None:
 def _add_kdtree_column_to_temp(
     input_file: str,
     kdtree_column_name: str,
-    iterations: int,
+    iterations: int | None,
     verbose: bool,
     force: bool,
     sample_size: int,
@@ -39,12 +39,14 @@ def _add_kdtree_column_to_temp(
 ) -> str:
     """Add KD-tree column to input and return path to temp file.
 
+    ``iterations`` is None in auto mode; `add_kdtree_column` then sizes the tree
+    from the row count and reports the partition count it settled on.
+
     Raises:
         PartitionError: If column addition fails
     """
-    partition_count = 2**iterations
-    if verbose:
-        debug(f"Adding KD-tree column '{kdtree_column_name}' with {partition_count} partitions...")
+    if verbose and iterations is not None:
+        debug(f"Adding KD-tree column '{kdtree_column_name}' with {2**iterations} partitions...")
 
     temp_dir = tempfile.gettempdir()
     temp_file = os.path.join(
@@ -146,7 +148,8 @@ def partition_by_kdtree(
         input_parquet: Input GeoParquet file (local, remote URL, or "-" for stdin)
         output_folder: Output directory
         kdtree_column_name: Name of KD-tree column (default: 'kdtree_cell')
-        iterations: Number of recursive splits (1-20, default: 9)
+        iterations: Number of recursive splits (1-20). Required unless
+            auto_target_rows is given, which sizes the tree from the row count.
         hive: Use Hive-style partitioning
         overwrite: Overwrite existing files
         preview: Show preview of partitions without creating files
@@ -193,16 +196,18 @@ def partition_by_kdtree(
 
         column_exists = kdtree_column_name in column_names
 
-        # Set default iterations if not provided
-        if iterations is None:
-            iterations = 9
+        # Auto mode leaves `iterations` None on purpose: `add_kdtree_column` sizes
+        # the tree from the row count below. Defaulting it to 9 here (as this did
+        # until #813) silently overrode `--auto` with 512 partitions whatever the
+        # input -- the same guess the Python API used to make.
+        require_iterations_or_auto(iterations, auto_target_rows)
 
         # Note: With approximate mode (default), large datasets are handled efficiently
         if not column_exists and verbose and total_rows > 10_000_000:
             info(f"Processing {total_rows:,} rows - this may take several minutes...")
 
         # If column doesn't exist, add it
-        partition_count = 2**iterations
+        partition_count = 2**iterations if iterations is not None else None
         working_input = actual_input
         temp_file = None
 
@@ -228,10 +233,10 @@ def partition_by_kdtree(
                 _cleanup_temp_file(temp_file)
             return
 
-        # Build description for user feedback
-        progress(
-            f"Partitioning into {partition_count} KD-tree cells (column: '{kdtree_column_name}')"
-        )
+        # Build description for user feedback. In auto mode the count is not known
+        # here -- `add_kdtree_column` reported the one it picked.
+        cell_count = "auto-selected" if partition_count is None else partition_count
+        progress(f"Partitioning into {cell_count} KD-tree cells (column: '{kdtree_column_name}')")
 
         try:
             num_partitions = partition_by_column(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1569,6 +1569,72 @@ class TestKdtreeAutoMode:
 
         assert len(set(result.to_arrow().column("kdtree_cell").to_pylist())) == 8
 
+    # -- a table already carrying the column needs no sizing -----------------
+
+    def test_partition_by_kdtree_uses_an_existing_column_without_sizing(
+        self, sample_table, tmp_path
+    ):
+        """`add_kdtree(...).partition_by_kdtree(dir)` worked on main; keep it working.
+
+        When the kdtree column is already on the table the add step is skipped
+        and the existing cells drive the partition, so there is no tree to size
+        and nothing for the iterations/auto gate to guard.
+        """
+        enriched = sample_table.add_kdtree(iterations=2)
+
+        enriched.partition_by_kdtree(tmp_path / "api")
+
+        assert len(self._partition_names(tmp_path / "api")) == 4
+
+    def test_ops_partition_by_kdtree_uses_an_existing_column_without_sizing(self, tmp_path):
+        enriched = ops.add_kdtree(pq.read_table(PLACES_PARQUET), iterations=2)
+
+        ops.partition_by_kdtree(enriched, tmp_path / "api")
+
+        assert len(self._partition_names(tmp_path / "api")) == 4
+
+    def test_an_existing_column_still_refuses_a_contradictory_call(self, sample_table, tmp_path):
+        """Skipping the gate must not also skip the iterations/auto conflict."""
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        enriched = sample_table.add_kdtree(iterations=2)
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            enriched.partition_by_kdtree(tmp_path / "out", iterations=3, auto=True)
+
+    # -- a non-positive target is refused, not derailed to 2^20 --------------
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            pytest.param(
+                lambda t, d: t.add_kdtree(auto=True, target_rows=0), id="Table.add_kdtree"
+            ),
+            pytest.param(
+                lambda t, d: ops.add_kdtree(t.to_arrow(), auto=True, target_rows=-5),
+                id="ops.add_kdtree",
+            ),
+            pytest.param(
+                lambda t, d: t.partition_by_kdtree(d, auto=True, target_rows=0),
+                id="Table.partition_by_kdtree",
+            ),
+            pytest.param(
+                lambda t, d: ops.partition_by_kdtree(t.to_arrow(), d, auto=True, target_rows=0),
+                id="ops.partition_by_kdtree",
+            ),
+        ],
+    )
+    def test_a_non_positive_target_rows_is_refused(self, sample_table, tmp_path, call):
+        """The CLI clamps ``--auto 0`` to the default; the API refuses it by name.
+
+        Without the guard, ``target_rows=0`` drove `_find_optimal_iterations` to
+        its 20-iteration ceiling -- 1,048,576 partitions from any input.
+        """
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="positive"):
+            call(sample_table, tmp_path / "out")
+
 
 class TestPublicExceptionExports:
     """The errors the docs tell users to catch must be importable from the package.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -235,7 +235,7 @@ class TestTable:
 
     def test_add_kdtree(self, sample_table):
         """Test add_kdtree() method."""
-        result = sample_table.add_kdtree()
+        result = sample_table.add_kdtree(auto=True)
         assert isinstance(result, Table)
         assert "kdtree_cell" in result.column_names
         assert result.num_rows == 766
@@ -1396,6 +1396,178 @@ class TestPartitionAutoResolution:
                 getattr(sample_table, method)(tmp_path / "out", **kwargs)
 
         write.assert_not_called()
+
+
+class TestKdtreeAutoMode:
+    """``auto=True`` sizes the KD-tree from the row count, exactly as the CLI does.
+
+    ``gpio add kdtree`` and ``gpio partition kdtree`` with no flags select auto
+    mode (``iterations=None``, ``auto_target_rows=('rows', 120000)``) and let core
+    size the tree from the row count. The API pinned ``iterations=9`` -- 512
+    partitions whatever the input -- so the same file through the two front doors
+    produced different output (#813). The API now mirrors what #800 did for the
+    resolution-bearing indices: name ``iterations``, or ask for ``auto=True``, and
+    a call that gives neither is refused rather than guessed at.
+    """
+
+    #: What `gpio {add,partition} kdtree` fall back to when neither --partitions
+    #: nor --auto is given (see `cli/main.py`).
+    CLI_AUTO_TARGET_ROWS = 120000
+
+    @pytest.fixture
+    def sample_table(self):
+        if not PLACES_PARQUET.exists():
+            pytest.skip("Test data not available")
+        return read(PLACES_PARQUET)
+
+    @staticmethod
+    def _run_cli(args):
+        from click.testing import CliRunner
+
+        from geoparquet_io.cli.main import cli
+
+        result = CliRunner().invoke(cli, [str(a) for a in args])
+        assert result.exit_code == 0, result.output
+        return result
+
+    @staticmethod
+    def _cells(path):
+        return pq.read_table(path).column("kdtree_cell").to_pylist()
+
+    @staticmethod
+    def _partition_names(output_dir):
+        files = sorted(Path(output_dir).rglob("*.parquet"))
+        assert files, f"no parquet files written to {output_dir}"
+        return sorted(f.name for f in files)
+
+    @property
+    def _auto_iterations(self):
+        """What core's auto mode picks for the 766-row sample at the CLI target."""
+        from geoparquet_io.core.add.kdtree import _find_optimal_iterations
+
+        return _find_optimal_iterations(766, self.CLI_AUTO_TARGET_ROWS)
+
+    def test_the_fixture_can_tell_auto_apart_from_the_old_default(self):
+        """Precondition: if auto picked 9 too, none of the tests below prove anything."""
+        assert self._auto_iterations != 9
+
+    # -- auto=True reproduces what the CLI writes ---------------------------
+
+    def test_add_kdtree_auto_matches_the_cli(self, sample_table, tmp_path):
+        cli_out = tmp_path / "cli.parquet"
+        self._run_cli(["add", "kdtree", PLACES_PARQUET, cli_out])
+
+        api_out = tmp_path / "api.parquet"
+        sample_table.add_kdtree(auto=True).write(api_out)
+
+        assert self._cells(api_out) == self._cells(cli_out)
+
+    def test_ops_add_kdtree_auto_matches_the_cli(self, tmp_path):
+        cli_out = tmp_path / "cli.parquet"
+        self._run_cli(["add", "kdtree", PLACES_PARQUET, cli_out])
+
+        result = ops.add_kdtree(pq.read_table(PLACES_PARQUET), auto=True)
+
+        assert result.column("kdtree_cell").to_pylist() == self._cells(cli_out)
+
+    def test_add_kdtree_auto_sizes_the_tree_from_the_row_count(self, sample_table):
+        result = sample_table.add_kdtree(auto=True)
+
+        cells = set(result.to_arrow().column("kdtree_cell").to_pylist())
+        assert len(cells) == 2**self._auto_iterations
+
+    def test_add_kdtree_target_rows_is_forwarded(self, sample_table):
+        default_target = sample_table.add_kdtree(auto=True)
+        small_target = sample_table.add_kdtree(auto=True, target_rows=100)
+
+        assert len(set(small_target.to_arrow().column("kdtree_cell").to_pylist())) > len(
+            set(default_target.to_arrow().column("kdtree_cell").to_pylist())
+        )
+
+    def test_partition_by_kdtree_auto_matches_the_cli(self, sample_table, tmp_path):
+        self._run_cli(["partition", "kdtree", PLACES_PARQUET, tmp_path / "cli"])
+        sample_table.partition_by_kdtree(tmp_path / "api", auto=True)
+
+        assert self._partition_names(tmp_path / "api") == self._partition_names(tmp_path / "cli")
+
+    def test_partition_by_kdtree_auto_sizes_the_tree_from_the_row_count(
+        self, sample_table, tmp_path
+    ):
+        sample_table.partition_by_kdtree(tmp_path / "api", auto=True)
+
+        assert len(self._partition_names(tmp_path / "api")) == 2**self._auto_iterations
+
+    def test_ops_partition_by_kdtree_accepts_auto(self, tmp_path):
+        ops.partition_by_kdtree(pq.read_table(PLACES_PARQUET), tmp_path / "api", auto=True)
+
+        assert len(self._partition_names(tmp_path / "api")) == 2**self._auto_iterations
+
+    # -- with neither iterations nor auto, refuse rather than guess ----------
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            pytest.param(lambda t, d: t.add_kdtree(), id="Table.add_kdtree"),
+            pytest.param(lambda t, d: ops.add_kdtree(t.to_arrow()), id="ops.add_kdtree"),
+            pytest.param(lambda t, d: t.partition_by_kdtree(d), id="Table.partition_by_kdtree"),
+            pytest.param(
+                lambda t, d: ops.partition_by_kdtree(t.to_arrow(), d),
+                id="ops.partition_by_kdtree",
+            ),
+        ],
+    )
+    def test_refuses_to_guess_an_iteration_count(self, sample_table, tmp_path, call):
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            call(sample_table, tmp_path / "out")
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            pytest.param(lambda t, d: t.add_kdtree(iterations=3, auto=True), id="Table.add_kdtree"),
+            pytest.param(
+                lambda t, d: ops.add_kdtree(t.to_arrow(), iterations=3, auto=True),
+                id="ops.add_kdtree",
+            ),
+            pytest.param(
+                lambda t, d: t.partition_by_kdtree(d, iterations=3, auto=True),
+                id="Table.partition_by_kdtree",
+            ),
+            pytest.param(
+                lambda t, d: ops.partition_by_kdtree(t.to_arrow(), d, iterations=3, auto=True),
+                id="ops.partition_by_kdtree",
+            ),
+        ],
+    )
+    def test_auto_and_an_explicit_iteration_count_are_mutually_exclusive(
+        self, sample_table, tmp_path, call
+    ):
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            call(sample_table, tmp_path / "out")
+
+    @pytest.mark.parametrize("kwargs", [{}, {"iterations": 3, "auto": True}])
+    def test_an_invalid_partition_call_never_serializes_the_table(
+        self, sample_table, tmp_path, kwargs
+    ):
+        """The gate belongs in front of the temp-file write, not behind it (#800)."""
+        from geoparquet_io.api import table as table_module
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with patch.object(table_module, "write_geoparquet_table") as write:
+            with pytest.raises(InvalidParameterError, match="auto"):
+                sample_table.partition_by_kdtree(tmp_path / "out", **kwargs)
+
+        write.assert_not_called()
+
+    # -- an explicit iteration count still works ----------------------------
+
+    def test_an_explicit_iteration_count_is_still_honoured(self, sample_table):
+        result = sample_table.add_kdtree(iterations=3)
+
+        assert len(set(result.to_arrow().column("kdtree_cell").to_pylist())) == 8
 
 
 class TestPublicExceptionExports:

--- a/tests/test_cli_api_call_parity_scaffold.py
+++ b/tests/test_cli_api_call_parity_scaffold.py
@@ -43,7 +43,7 @@ canonical name, repr(CLI value), repr(API value))`` with a written
 justification, following `collect_divergences()` in
 `tests/test_cli_api_default_parity.py`. The two reprs are part of the key on
 purpose: an allowlist recording only "these differ" would stay green if
-`Table.add_kdtree` changed `iterations` from 9 to 4 -- still a divergence, but a
+`ops.sort_str` changed `tile_size` from 50000 to 40000 -- still a divergence, but a
 different one nobody reviewed.
 
 A per-key allowlist is used rather than `xfail` on the parametrized case because
@@ -343,17 +343,27 @@ CASES: list[ParityCase] = [
             lambda c: ["add", "kdtree", c.input_file, c.output_file],
         ),
         ops=_ops(
-            "add_kdtree_table", core_kdtree.add_kdtree_table, lambda c: ops.add_kdtree(c.table)
+            "add_kdtree_table",
+            core_kdtree.add_kdtree_table,
+            lambda c: ops.add_kdtree(c.table, auto=True),
         ),
         table=_table(
             core_kdtree,
             "add_kdtree_table",
             core_kdtree.add_kdtree_table,
-            lambda c: c.gpio_table.add_kdtree(),
+            lambda c: c.gpio_table.add_kdtree(auto=True),
+        ),
+        notes=(
+            "`auto=True` is supplied on the API side because that is what the bare CLI "
+            "call selects: `gpio add kdtree in out` with no flags falls back to auto mode "
+            "(iterations=None, auto_target_rows=('rows', 120000)). The API no longer "
+            "guesses 512 partitions when neither is named -- it refuses, like the "
+            "resolution-bearing indices after #800 (#813).",
         ),
         normalize={
             "column_name": ("kdtree_column_name", "kdtree_column_name"),
             "iterations": ("iterations", "iterations"),
+            "auto_target_rows": ("auto_target_rows", "auto_target_rows"),
             "sample_size": ("sample_size", "sample_size"),
         },
     ),
@@ -605,7 +615,7 @@ CASES_BY_ID = {case.id: case for case in CASES}
 # Keys are (case id, front end, canonical name, repr(CLI value), repr(API value)),
 # following `collect_divergences()` in tests/test_cli_api_default_parity.py. The two
 # reprs are load-bearing: an allowlist that recorded only "these differ" would stay
-# green if `Table.add_kdtree` changed `iterations` from 9 to 4 -- still a divergence,
+# green if `ops.sort_str` changed `tile_size` from 50000 to 40000 -- still a divergence,
 # but a *different* one that nobody reviewed. Pinning the pair means any change to
 # either side has to come back through this table.
 KNOWN_PARITY_GAPS: dict[tuple[str, str, str, str, str], str] = {
@@ -651,27 +661,6 @@ KNOWN_PARITY_GAPS: dict[tuple[str, str, str, str, str], str] = {
         "The file core resolves row_group_rows=None to the sort default of 50,000 rows "
         "(DEFAULT_SORT_ROW_GROUP_ROWS); the fluent API spells that same effective default "
         "explicitly as tile_size=50000."
-    ),
-    (
-        "add kdtree",
-        "ops",
-        "iterations",
-        "None",
-        "9",
-    ): (
-        "The CLI has no --iterations: with no flags it selects auto mode (iterations=None, "
-        "auto_target_rows=('rows', 120000)) so core sizes the tree from the row count. The API "
-        "has no auto mode at all and pins iterations=9, i.e. 512 partitions whatever the input."
-    ),
-    (
-        "add kdtree",
-        "table",
-        "iterations",
-        "None",
-        "9",
-    ): (
-        "Same as ('add kdtree', 'ops', 'iterations'): Table.add_kdtree also pins iterations=9 "
-        "while the CLI defaults to auto-sizing from the row count."
     ),
 }
 
@@ -821,8 +810,8 @@ def test_known_parity_gap_still_diverges_the_same_way(gap, parity_ctx):
 
     Two ways this earns its keep. A gap fixed in the code would otherwise sit in
     the allowlist forever, silently re-permitting the divergence later. And a gap
-    whose values merely *shifted* -- `Table.add_kdtree` going from `iterations=9`
-    to `4` -- is a different divergence that nobody reviewed, so pinning only
+    whose values merely *shifted* -- `ops.sort_str` going from `tile_size=50000`
+    to `40000` -- is a different divergence that nobody reviewed, so pinning only
     "these differ" would let it through unnoticed.
     """
     case_id, side, canonical, cli_repr, api_repr = gap

--- a/tests/test_cli_api_default_parity.py
+++ b/tests/test_cli_api_default_parity.py
@@ -233,8 +233,32 @@ _KEEP_TRISTATE = (
     "Intentional. CLI flag False and API None both mean 'follow hive' at runtime; the API spells "
     "it as a tri-state so it can also express an explicit drop, which a bare Click flag cannot."
 )
+_KDTREE_AUTO_SPELLING = (
+    "Intentional. The KD-tree commands spell auto mode as `--auto N` -- one int option carrying "
+    "the target row count, unset meaning 'not asked for'. The API splits that into the `auto` "
+    "bool and `target_rows` the other index methods already take (#800), so `auto=True` reads "
+    "the same across every partition method. `auto=True` and `--auto` deliver the identical "
+    "auto_target_rows=('rows', 120000) to core, which is what "
+    "tests/test_cli_api_call_parity_scaffold.py's 'add kdtree' case compares."
+)
 
 KNOWN_DIVERGENCES: dict[tuple[str, str, str, str, str], str] = {
+    ("add kdtree", "ops.add_kdtree", "auto", "'<unset>'", "False"): _KDTREE_AUTO_SPELLING,
+    ("add kdtree", "Table.add_kdtree", "auto", "'<unset>'", "False"): _KDTREE_AUTO_SPELLING,
+    (
+        "partition kdtree",
+        "ops.partition_by_kdtree",
+        "auto",
+        "'<unset>'",
+        "False",
+    ): _KDTREE_AUTO_SPELLING,
+    (
+        "partition kdtree",
+        "Table.partition_by_kdtree",
+        "auto",
+        "'<unset>'",
+        "False",
+    ): _KDTREE_AUTO_SPELLING,
     (
         "sort hilbert",
         "ops.sort_hilbert",

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -5,6 +5,7 @@ Tests for KD-tree partitioning commands.
 import json
 import os
 import sys
+from unittest import mock
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -473,6 +474,168 @@ class TestKDTreeBinaryIDs:
         )
         assert result.exit_code != 0
         assert "mutually exclusive" in result.output.lower()
+
+
+class TestKdtreeAutoSizing:
+    """Unit contracts for the auto-sizing helpers in `core/add/kdtree.py` (#813).
+
+    These pin each branch the front doors route through: the bare-int and
+    ``("mb", value)`` shapes of ``auto_target_rows``, the unstat-able-path
+    fallback in ``_file_size_mb``, and the guards that turn a bad target into a
+    named error instead of a ZeroDivisionError or a 2^20-partition derail.
+    """
+
+    def test_file_size_mb_returns_zero_when_the_path_cannot_be_stated(self):
+        from geoparquet_io.core.add.kdtree import _file_size_mb
+
+        assert _file_size_mb("/no/such/dir/missing.parquet") == 0.0
+
+    def test_mb_target_sizes_from_the_file_size(self):
+        """1000 rows in 4 MB at a 1 MB target -> ~250 rows/partition -> 2 splits."""
+        from geoparquet_io.core.add.kdtree import resolve_auto_iterations
+
+        assert resolve_auto_iterations(1000, ("mb", 1.0), 4.0, announce=False) == 2
+
+    def test_bare_int_target_means_rows(self):
+        """A bare ``N`` is the same target as ``("rows", N)``."""
+        from geoparquet_io.core.add.kdtree import resolve_auto_iterations
+
+        assert resolve_auto_iterations(1000, 250, 4.0, announce=False) == 2
+        assert resolve_auto_iterations(1000, ("rows", 250), 4.0, announce=False) == 2
+
+    def test_mb_target_without_a_file_size_raises_instead_of_dividing_by_zero(self):
+        """A remote or in-memory input has no size to stat; say so, don't crash."""
+        from geoparquet_io.core.add.kdtree import resolve_auto_iterations
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="size"):
+            resolve_auto_iterations(1000, ("mb", 1.0), 0.0, announce=False)
+
+    @pytest.mark.parametrize("target", [0, -5, ("rows", 0), ("rows", -1), ("mb", 0), ("mb", -2.5)])
+    def test_non_positive_targets_are_refused(self, target):
+        """target_rows=0 used to derail auto to iterations=20 (2^20 partitions)."""
+        from geoparquet_io.core.add.kdtree import resolve_auto_iterations
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError, match="positive"):
+            resolve_auto_iterations(1000, target, 4.0, announce=False)
+
+    def test_add_kdtree_table_validates_iterations_before_serializing(self, monkeypatch):
+        """An out-of-range ``iterations`` must fail before the table is written out.
+
+        The check used to run only after ``pq.write_table`` had serialized the
+        whole table to a temp file, so an invalid call paid the full I/O cost of
+        a valid one first.
+        """
+        import types
+
+        import geoparquet_io.core.add.kdtree as kdtree_mod
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        serialized = []
+        monkeypatch.setattr(
+            kdtree_mod,
+            "pq",
+            types.SimpleNamespace(write_table=lambda *a, **k: serialized.append(a)),
+        )
+
+        with pytest.raises(InvalidParameterError, match="between 1 and 20"):
+            kdtree_mod.add_kdtree_table(pa.table({"a": [1]}), iterations=25)
+
+        assert serialized == []
+
+    @staticmethod
+    def _pipe_in(monkeypatch, parquet_path):
+        """Mock stdin to carry ``parquet_path`` as an Arrow IPC stream."""
+        import io
+
+        from pyarrow import ipc
+
+        source = pq.read_table(parquet_path)
+        ipc_buffer = io.BytesIO()
+        with ipc.RecordBatchStreamWriter(ipc_buffer, source.schema) as writer:
+            writer.write_table(source)
+        ipc_buffer.seek(0)
+
+        mock_stdin = mock.MagicMock()
+        mock_stdin.isatty.return_value = False
+        mock_stdin.buffer = ipc_buffer
+        monkeypatch.setattr(sys, "stdin", mock_stdin)
+
+    def test_streaming_auto_sizes_the_tree_from_the_row_count(
+        self, buildings_test_file, monkeypatch
+    ):
+        """A stdin-to-stdout pipe takes `_add_kdtree_streaming`; auto must work there too."""
+        import io
+
+        from pyarrow import ipc
+
+        from geoparquet_io.core.add.kdtree import add_kdtree_column
+
+        self._pipe_in(monkeypatch, buildings_test_file)
+        output_buffer = io.BytesIO()
+        mock_stdout = mock.MagicMock()
+        mock_stdout.buffer = output_buffer
+        mock_stdout.isatty.return_value = False
+        monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+        add_kdtree_column("-", "-", auto_target_rows=("rows", 10))
+
+        output_buffer.seek(0)
+        result = ipc.RecordBatchStreamReader(output_buffer).read_all()
+        assert "kdtree_cell" in result.column_names
+        # 42 rows at a 10-row target -> 2 splits -> ids of length 3 ('0' + 2)
+        assert {len(c) for c in result.column("kdtree_cell").to_pylist()} == {3}
+
+    def test_partition_reads_stdin_input(self, buildings_test_file, tmp_path, monkeypatch):
+        """`partition_by_kdtree("-", ...)` spools the piped stream to a temp file."""
+        from geoparquet_io.core.partition.by_kdtree import partition_by_kdtree
+
+        self._pipe_in(monkeypatch, buildings_test_file)
+        out_dir = tmp_path / "parts"
+
+        partition_by_kdtree("-", str(out_dir), iterations=2, skip_analysis=True)
+
+        assert len(list(out_dir.glob("*.parquet"))) == 4
+
+    def test_partition_verbose_announces_the_partition_count(self, buildings_test_file, tmp_path):
+        """The verbose pre-add debug line names the partition count it will build."""
+        from geoparquet_io.core.partition.by_kdtree import partition_by_kdtree
+
+        out_dir = tmp_path / "parts"
+        partition_by_kdtree(
+            buildings_test_file,
+            str(out_dir),
+            iterations=2,
+            verbose=True,
+            skip_analysis=True,
+        )
+
+        assert len(list(out_dir.glob("*.parquet"))) == 4
+
+    def test_partition_with_existing_column_needs_no_sizing_but_refuses_both(
+        self, buildings_test_file, tmp_path
+    ):
+        """A file already carrying the column partitions without a sizing parameter.
+
+        The add step is skipped and the existing cells drive the partition, as
+        before #813 -- only the contradiction of naming both iterations and an
+        auto target is still refused.
+        """
+        from geoparquet_io.core.add.kdtree import add_kdtree_column
+        from geoparquet_io.core.exceptions import InvalidParameterError
+        from geoparquet_io.core.partition.by_kdtree import partition_by_kdtree
+
+        enriched = str(tmp_path / "enriched.parquet")
+        add_kdtree_column(buildings_test_file, enriched, iterations=2)
+
+        with pytest.raises(InvalidParameterError, match="auto"):
+            partition_by_kdtree(
+                enriched, str(tmp_path / "out"), iterations=2, auto_target_rows=("rows", 100)
+            )
+
+        partition_by_kdtree(enriched, str(tmp_path / "out"), skip_analysis=True)
+        assert len(list((tmp_path / "out").glob("*.parquet"))) == 4
 
 
 class TestAddKDTreePythonAPI:

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -196,6 +196,23 @@ class TestPartitionKDTree:
         assert result.exit_code != 0
         assert "power of 2" in result.output.lower()
 
+    def test_partition_kdtree_auto_is_not_overridden_by_the_old_default(
+        self, buildings_test_file, cli_runner
+    ):
+        """Auto mode must size the tree, not fall through to 512 partitions (#813).
+
+        `partition_by_kdtree` used to answer an unset `iterations` with a hardcoded
+        9 *before* handing the file to `add_kdtree_column`, so `--auto` -- which is
+        what a bare `gpio partition kdtree` selects -- never reached the code that
+        sizes the tree from the row count. Every auto run produced 512 partitions
+        whatever the input, which is exactly the guess the Python API was blamed for.
+        """
+        result = cli_runner.invoke(partition, ["kdtree", buildings_test_file, "--preview"])
+
+        assert result.exit_code == 0, result.output
+        assert "Auto-selected 2 partitions" in result.output
+        assert "512" not in result.output
+
 
 @pytest.mark.slow
 class TestPartitionKDTreeOperations:


### PR DESCRIPTION
## What changed

`Table.add_kdtree`, `ops.add_kdtree`, `Table.partition_by_kdtree` and
`ops.partition_by_kdtree` take `auto` and `target_rows`, and `iterations`
defaults to `None` instead of a hardcoded `9`. **Breaking:** a call that names
neither `iterations` nor `auto` now raises `InvalidParameterError` instead of
silently producing 512 partitions — except when the input already carries the
kdtree column, which partitions without a sizing parameter exactly as before.
Also breaking: `add_kdtree_table` / `ops.add_kdtree` / `Table.add_kdtree`
raise `InvalidParameterError` (not `ValueError`) for an out-of-range
`iterations`, and validate it before serializing the table.

```python
Table.add_kdtree(column_name='kdtree_cell', iterations=None, sample_size=100000,
                 *, auto=False, target_rows=120000)
ops.add_kdtree(table, column_name='kdtree_cell', iterations=None, sample_size=100000,
               geometry_column=None, *, auto=False, target_rows=120000)
Table.partition_by_kdtree(output_dir, *, iterations=None, auto=False, target_rows=120000,
                          hive=False, keep_kdtree_column=None, overwrite=False,
                          compression='ZSTD', compression_level=None)
ops.partition_by_kdtree(table, output_dir, *, iterations=None, auto=False,
                        target_rows=120000, hive=False, keep_kdtree_column=None,
                        overwrite=False, compression='ZSTD', compression_level=None,
                        geometry_column=None)
```

Along the way this fixes a matching bug on the CLI side. `partition_by_kdtree`
answered an unset `iterations` with a hardcoded `9` *before* handing the file to
`add_kdtree_column`, so `--auto` — which a bare `gpio partition kdtree` selects —
never reached the code that sizes the tree. Every auto run produced 512
partitions, exactly the guess the API was being blamed for. `require_iterations_or_auto`
and `resolve_auto_iterations` are now shared by the file command, the partition
command, the streaming path and the in-memory table function, so one calculation
serves every door.

Also:

- deletes the two `('add kdtree', …, 'iterations', 'None', '9')` entries from
  `KNOWN_PARITY_GAPS`, and makes the scaffold's `add kdtree` case compare
  `auto_target_rows` with both sides in auto mode;
- adds four `KNOWN_DIVERGENCES` entries for the one thing that legitimately
  differs — the CLI spells auto mode as a single `--auto N` int option, the API
  as the `auto` bool plus `target_rows` that #800 gave the other index methods;
- adds migration warning boxes to `docs/guide/add.md`, `docs/guide/partition.md`
  and `docs/api/python-api.md`, matching the ones #800 added, and updates the
  in-repo callers that relied on the implicit `9`.

## Why

`gpio add kdtree in out` and `gpio partition kdtree in out/` with no flags select
auto mode (`iterations=None`, `auto_target_rows=('rows', 120000)`) and let core
size the tree from the row count. The API pinned `iterations=9` — 512 partitions
whatever the input — so the same file through the two front doors produced
different output. That is the divergence #799 / #800 closed for H3, S2, A5 and
quadkey; KD-tree was deliberately left out of #800 to keep it to the
resolution-bearing indices.

Following #800, the API does not guess: name an iteration count, or ask for
`auto=True`. Passing both is an error, as `--partitions` with `--auto` is on the
CLI.

Closes #813
Refs #799 #800

## Verification

Before the fix — the CLI's own auto mode never reached the sizing code, so the
766-row sample was cut into 512 partitions and the partition analysis refused it:

```
$ uv run gpio partition kdtree tests/data/places_test.parquet /tmp/kdpart
Added KD-tree column 'kdtree_cell' (512 partitions) to: /var/folders/…/kdtree_enriched_…parquet
Partitioning into 512 KD-tree cells (column: 'kdtree_cell')

Analyzing partition strategy for 'kdtree_cell'...
  Partitions: 487
  Total rows: 766
  Rows per partition: min=1, max=10, avg=2
Error: ❌ Tiny partitions: Average of 2 rows per partition is below minimum of 100.
```

After:

```
$ uv run gpio partition kdtree tests/data/places_test.parquet /tmp/kdpart2
Auto-selected 2 partitions (avg ~383 rows, ~0.0 MB/partition, target: 120,000 rows)
Added KD-tree column 'kdtree_cell' (2 partitions) to: /var/folders/…/kdtree_enriched_…parquet
Partitioning into auto-selected KD-tree cells (column: 'kdtree_cell')

Analyzing partition strategy for 'kdtree_cell'...
  Partitions: 2
  Total rows: 766
  Rows per partition: min=383, max=383, avg=383
$ ls /tmp/kdpart2
00.parquet
01.parquet
```

The new `TestKdtreeAutoMode` class asserts the two front doors now agree — the
API's `auto=True` reproduces the CLI's cells row for row and its partition file
names — and that neither-given and both-given are refused through all four entry
points. Written first; 17 of its 19 cases failed against `main`:

```
$ uv run pytest tests/test_api.py -q -k TestKdtreeAutoMode   # before implementing
FAILED tests/test_api.py::TestKdtreeAutoMode::test_add_kdtree_auto_matches_the_cli
FAILED tests/test_api.py::TestKdtreeAutoMode::test_ops_add_kdtree_auto_matches_the_cli
FAILED tests/test_api.py::TestKdtreeAutoMode::test_add_kdtree_auto_sizes_the_tree_from_the_row_count
FAILED tests/test_api.py::TestKdtreeAutoMode::test_add_kdtree_target_rows_is_forwarded
FAILED tests/test_api.py::TestKdtreeAutoMode::test_partition_by_kdtree_auto_matches_the_cli
FAILED tests/test_api.py::TestKdtreeAutoMode::test_partition_by_kdtree_auto_sizes_the_tree_from_the_row_count
FAILED tests/test_api.py::TestKdtreeAutoMode::test_ops_partition_by_kdtree_accepts_auto
FAILED tests/test_api.py::TestKdtreeAutoMode::test_refuses_to_guess_an_iteration_count[Table.add_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_refuses_to_guess_an_iteration_count[ops.add_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_refuses_to_guess_an_iteration_count[Table.partition_by_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_refuses_to_guess_an_iteration_count[ops.partition_by_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_auto_and_an_explicit_iteration_count_are_mutually_exclusive[Table.add_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_auto_and_an_explicit_iteration_count_are_mutually_exclusive[ops.add_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_auto_and_an_explicit_iteration_count_are_mutually_exclusive[Table.partition_by_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_auto_and_an_explicit_iteration_count_are_mutually_exclusive[ops.partition_by_kdtree]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_an_invalid_partition_call_never_serializes_the_table[kwargs0]
FAILED tests/test_api.py::TestKdtreeAutoMode::test_an_invalid_partition_call_never_serializes_the_table[kwargs1]
================= 17 failed, 2 passed, 184 deselected in 2.96s =================
```

After:

```
$ uv run pytest tests/test_kdtree.py tests/test_api.py tests/test_cli_api_call_parity_scaffold.py tests/test_cli_api_default_parity.py -q
================== 305 passed, 1 skipped in 82.10s (0:01:22) ===================

$ uv run pytest -q -m "not slow and not network and not meta" -k "kdtree or parity"
=============== 247 passed, 11 skipped, 6144 deselected in 6.45s ===============

$ uv run pytest -m "docs_example and not network" -q -k "add or partition"
docs/guide/add.md .s....s.s..ssss.s......s.                              [ 39%]
docs/guide/partition.md ..sss.ss..sssss.ss...ss...ss...s.s               [ 92%]
docs/guide/sub-partitioning.md F..
==== 1 failed, 36 passed, 27 skipped, 6337 deselected in 301.17s (0:05:01) =====
```

That one failure is `sub-partitioning.md:L7[bash]` ("timed out after 120s" on
`gpio partition h3 by_country/ --min-size 100MB --resolution 7 --in-place`),
caused by running two pytest sessions on this machine at once — it passes on its
own and the file has no KD-tree content:

```
$ uv run pytest -m docs_example -q docs/guide/sub-partitioning.md
docs/guide/sub-partitioning.md .....                                     [100%]
============================== 5 passed in 55.25s ==============================
```

`add.md`'s network-marked `admin-divisions` fences fail identically on `main`
(7 failures on a clean checkout with the changes stashed), so they are
pre-existing and untouched here.

```
$ uv run pytest -m meta -q
==================== 202 passed, 6200 deselected in 20.37s =====================

$ uv run pre-commit run --all-files
… 20 hooks, all Passed

$ uv run pre-commit run --all-files --hook-stage pre-push
deptry...................................................................Passed
mypy.....................................................................Passed
vulture..................................................................Passed
xenon....................................................................Passed
import-linter............................................................Passed
menard-check.............................................................Passed
fast-tests...............................................................Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic KD-tree sizing based on row counts, with configurable target rows.
  - Added automatic sizing support across Python APIs and CLI workflows.
  - Tables already containing a KD-tree column can be partitioned without specifying sizing parameters.

- **Bug Fixes**
  - KD-tree operations now reject missing or conflicting sizing options with a clear parameter error.

- **Documentation**
  - Updated API references and examples to explain automatic sizing, explicit iteration counts, defaults, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->