### PR TITLE
fix(check): explain that check stac wants the STAC JSON, not the Parquet file

### DIFF
--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -344,6 +344,9 @@ Validates file structure and metadata against the GeoParquet specification:
         print("Valid STAC!")
     ```
 
+The argument is the STAC Item or Collection JSON — the file `gpio publish stac`
+writes — not the GeoParquet data file it describes.
+
 Validates STAC Item or Collection JSON:
 
 - STAC spec compliance

--- a/geoparquet_io/core/stac_check.py
+++ b/geoparquet_io/core/stac_check.py
@@ -23,9 +23,11 @@ def _not_stac_json_error(stac_path: str) -> ValueError:
 
 def _load_stac_json(stac_path: str) -> dict:
     """Load STAC JSON file."""
-    # A .parquet argument is the data file, not the STAC JSON: say so up front
-    # rather than reporting that it is missing or undecodable.
-    if stac_path.lower().endswith(".parquet"):
+    # A .parquet argument is the data file, and a directory is partitioned
+    # GeoParquet output — neither is the STAC JSON: say so up front rather
+    # than reporting it missing, undecodable, or (for a directory) letting
+    # open() raise a platform-dependent OSError.
+    if stac_path.lower().endswith(".parquet") or Path(stac_path).is_dir():
         raise _not_stac_json_error(stac_path)
     try:
         with open(stac_path, encoding="utf-8") as f:

--- a/geoparquet_io/core/stac_check.py
+++ b/geoparquet_io/core/stac_check.py
@@ -12,13 +12,28 @@ from geoparquet_io.core.exceptions import ValidationError
 from geoparquet_io.core.logging_config import debug, error, progress, success, warn
 
 
+def _not_stac_json_error(stac_path: str) -> ValueError:
+    """Explain that the argument should have been the STAC JSON, not the data."""
+    return ValueError(
+        f"{stac_path} is not a STAC JSON file (check stac validates the STAC "
+        "Item/Collection JSON, not the GeoParquet data file — generate one "
+        "with gpio publish stac)"
+    )
+
+
 def _load_stac_json(stac_path: str) -> dict:
     """Load STAC JSON file."""
+    # A .parquet argument is the data file, not the STAC JSON: say so up front
+    # rather than reporting that it is missing or undecodable.
+    if stac_path.lower().endswith(".parquet"):
+        raise _not_stac_json_error(stac_path)
     try:
-        with open(stac_path) as f:
+        with open(stac_path, encoding="utf-8") as f:
             return json.load(f)
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid JSON: {e}") from e
+    except UnicodeDecodeError as e:
+        raise _not_stac_json_error(stac_path) from e
     except FileNotFoundError:
         raise FileNotFoundError(f"File not found: {stac_path}") from None
 

--- a/tests/test_stac_check.py
+++ b/tests/test_stac_check.py
@@ -255,3 +255,81 @@ def test_check_stac_invalid_raises(temp_output_dir):
         check_stac(output_path, verbose=False)
 
     assert "validation failed" in str(exc_info.value).lower()
+
+
+def _assert_not_stac_json_message(message: str, path: str) -> None:
+    """The wrong-input message names the file and says what was expected."""
+    assert path in message
+    assert "not a STAC JSON file" in message
+    assert "Item/Collection JSON" in message
+    assert "gpio publish stac" in message
+    assert "codec can't decode" not in message
+
+
+def test_validate_parquet_file_says_it_wants_stac_json(places_test_file):
+    """A GeoParquet file gets an explanation, not a raw UnicodeDecodeError."""
+    results = validate_stac_file(places_test_file, verbose=False)
+
+    assert results["valid"] is False
+    assert len(results["errors"]) == 1
+    _assert_not_stac_json_message(results["errors"][0], places_test_file)
+
+
+def test_validate_parquet_extension_beats_file_not_found(temp_output_dir):
+    """A .parquet path is called out before the file is opened at all.
+
+    Precedence is pinned deliberately: someone who passed a .parquet path used
+    the wrong argument, so "File not found" would send them hunting for a file
+    instead of telling them the command wants the STAC JSON.
+    """
+    missing = os.path.join(temp_output_dir, "does_not_exist.parquet")
+    results = validate_stac_file(missing, verbose=False)
+
+    assert results["valid"] is False
+    _assert_not_stac_json_message(results["errors"][0], missing)
+    assert "File not found" not in results["errors"][0]
+
+
+def test_validate_non_utf8_json_named_file(temp_output_dir):
+    """Non-UTF-8 bytes behind a .json name still get the clear message."""
+    output_path = os.path.join(temp_output_dir, "binary.json")
+    with open(output_path, "wb") as f:
+        f.write(b"PAR1\x00\x9e\xff\xfe garbage")
+
+    results = validate_stac_file(output_path, verbose=False)
+
+    assert results["valid"] is False
+    _assert_not_stac_json_message(results["errors"][0], output_path)
+
+
+def test_validate_missing_json_file_message_unchanged(temp_output_dir):
+    """A missing .json path still reports File not found, not the new message."""
+    missing = os.path.join(temp_output_dir, "does_not_exist.json")
+    results = validate_stac_file(missing, verbose=False)
+
+    assert results["valid"] is False
+    assert "File not found" in results["errors"][0]
+    assert "not a STAC JSON file" not in results["errors"][0]
+
+
+def test_check_stac_cli_reports_wrong_input(places_test_file):
+    """The CLI surfaces the explanation for a GeoParquet argument."""
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    result = CliRunner().invoke(cli, ["check", "stac", places_test_file])
+
+    assert result.exit_code != 0
+    _assert_not_stac_json_message(result.output, places_test_file)
+
+
+def test_validate_stac_api_reports_wrong_input(places_test_file):
+    """The Python API twin surfaces the same explanation."""
+    from geoparquet_io.api.stac import validate_stac
+
+    result = validate_stac(places_test_file)
+
+    assert result.passed() is False
+    failures = "\n".join(str(f) for f in result.failures())
+    _assert_not_stac_json_message(failures, places_test_file)

--- a/tests/test_stac_check.py
+++ b/tests/test_stac_check.py
@@ -302,6 +302,14 @@ def test_validate_non_utf8_json_named_file(temp_output_dir):
     _assert_not_stac_json_message(results["errors"][0], output_path)
 
 
+def test_validate_directory_input_gets_wrong_input_message(temp_output_dir):
+    """A directory (partitioned GeoParquet output) gets the message, not a traceback."""
+    results = validate_stac_file(temp_output_dir, verbose=False)
+
+    assert results["valid"] is False
+    _assert_not_stac_json_message(results["errors"][0], temp_output_dir)
+
+
 def test_validate_missing_json_file_message_unchanged(temp_output_dir):
     """A missing .json path still reports File not found, not the new message."""
     missing = os.path.join(temp_output_dir, "does_not_exist.json")


### PR DESCRIPTION
## What changed

`core/stac_check.py::_load_stac_json` now catches `UnicodeDecodeError`
alongside `json.JSONDecodeError`, and short-circuits on a `.parquet` extension
before the file is opened at all, raising:

```
<path> is not a STAC JSON file (check stac validates the STAC Item/Collection
JSON, not the GeoParquet data file — generate one with gpio publish stac)
```

The file is also read with an explicit `encoding="utf-8"` so the same bytes
behave identically on Windows, where the locale default would have produced a
`JSONDecodeError` instead of a decode error.

The `.parquet` check deliberately takes precedence over "File not found":
someone who passed a `.parquet` path used the wrong argument, so a missing-file
message would send them hunting for the file instead of telling them the command
wants the JSON. A test pins that precedence.

`docs/guide/check.md` gains one sentence saying the argument is the STAC JSON
that `gpio publish stac` writes, not the data file it describes.

## Why

Handed a data file, `gpio check stac` printed a raw codec error that reads like
an internal crash and never said what the argument was supposed to be.
`UnicodeDecodeError` is a `ValueError` subclass but not a `JSONDecodeError`, so
it escaped both existing handlers and `check_stac` reported the exception text
verbatim.

## Verification

Before:

```
$ gpio check stac tests/data/canonical/places.parquet
✗ STAC validation failed

Errors:
  ✗ 'utf-8' codec can't decode byte 0x9e in position 7: invalid start byte
Error: STAC validation failed
```

After:

```
$ gpio check stac tests/data/canonical/places.parquet
✗ STAC validation failed

Errors:
  ✗ tests/data/canonical/places.parquet is not a STAC JSON file (check stac validates the STAC Item/Collection JSON, not the GeoParquet data file — generate one with gpio publish stac)
Error: STAC validation failed
$ echo $?
1
```

Six new tests in `tests/test_stac_check.py` (all failed before the fix, pass
after): a real GeoParquet path, `.parquet` precedence over file-not-found,
non-UTF-8 bytes behind a `.json` name, the unchanged missing-`.json` message,
the CLI via `CliRunner`, and the `api.stac.validate_stac` twin.

```
$ uv run pytest tests/test_stac_check.py -q
17 passed in 0.15s

$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5403 passed, 65 skipped, 2 xfailed in 151.46s

$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
geoparquet_io/core/stac_check.py (100%)
Total:   7 lines
Missing: 0 lines
Coverage: 100%
```

`uv run pre-commit run --all-files` and `--hook-stage pre-push` (mypy, vulture,
xenon, import-linter, deptry) both pass.

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
