### PR TITLE
test(spatial): catch a future spatial index that joins a family with blank knobs

### DIFF
--- a/tests/test_spatial_index_family.py
+++ b/tests/test_spatial_index_family.py
@@ -68,7 +68,7 @@ import io
 import json
 import sys
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -421,26 +421,112 @@ def test_add_table_custom_column_name(spec, sample_table):
     assert result.num_rows == sample_table.num_rows
 
 
+def _specs(params):
+    """The IndexSpec carried by each pytest param in a family list."""
+    return [param.values[0] for param in params]
+
+
+def _check_add_family_specs(params, family="ADD_FAMILY"):
+    """Every add-family member must carry non-empty resolution knobs.
+
+    ``invalid_resolution_match`` included: ``pytest.raises(..., match="")``
+    matches any message, so a blank one silently downgrades
+    ``test_add_table_invalid_resolution`` to a bare "some ValueError" check.
+    """
+    for spec in _specs(params):
+        assert spec.valid_resolutions, f"{spec.name}: empty valid_resolutions in {family}"
+        assert spec.invalid_resolutions, f"{spec.name}: empty invalid_resolutions in {family}"
+        assert spec.invalid_resolution_match, (
+            f"{spec.name}: empty invalid_resolution_match in {family}"
+        )
+
+
+def _check_partition_family_specs(params, family="PARTITION_FAMILY"):
+    """Every partition-family member must carry its invalid pair and Hive prefix.
+
+    ``hive_prefix`` included: ``test_partition_hive_style`` asserts
+    ``spec.hive_prefix in d.name``, and ``"" in name`` is always True.
+    """
+    for spec in _specs(params):
+        assert spec.partition_invalid_resolution is not None, (
+            f"{spec.name}: partition_invalid_resolution unset in {family}"
+        )
+        assert spec.partition_invalid_match, (
+            f"{spec.name}: partition_invalid_match unset in {family}"
+        )
+        assert spec.hive_prefix, f"{spec.name}: empty hive_prefix in {family}"
+
+
+def _check_auto_family_specs(params, family="AUTO_FAMILY"):
+    """Every auto-family member must carry its Hive directory prefix.
+
+    ``test_partition_auto_with_hive`` asserts ``name.startswith(prefix)``,
+    which is always True for the ``""`` default.
+    """
+    for spec in _specs(params):
+        assert spec.auto_hive_prefix, f"{spec.name}: empty auto_hive_prefix in {family}"
+
+
 def test_family_specs_are_not_vacuous():
     """A spec that joins a family with empty knobs must fail loudly, not pass.
 
     Every other spec-table mistake surfaces as a failing parametrized case;
     an empty resolutions tuple (quadkey's spec carries them today, outside
-    the families) or an unset partition-invalid pair would instead collect
-    zero cases and silently green.
+    the families), an unset partition-invalid pair, a blank ``match`` pattern
+    or a blank Hive prefix would instead collect zero cases, or collect cases
+    whose assertion is a tautology, and silently green.
     """
-    for param in ADD_FAMILY:
-        spec = param.values[0]
-        assert spec.valid_resolutions, f"{spec.name}: empty valid_resolutions in ADD_FAMILY"
-        assert spec.invalid_resolutions, f"{spec.name}: empty invalid_resolutions in ADD_FAMILY"
-    for param in PARTITION_FAMILY:
-        spec = param.values[0]
-        assert spec.partition_invalid_resolution is not None, (
-            f"{spec.name}: partition_invalid_resolution unset in PARTITION_FAMILY"
-        )
-        assert spec.partition_invalid_match, (
-            f"{spec.name}: partition_invalid_match unset in PARTITION_FAMILY"
-        )
+    _check_add_family_specs(ADD_FAMILY)
+    _check_partition_family_specs(PARTITION_FAMILY)
+    _check_auto_family_specs(AUTO_FAMILY)
+
+
+@pytest.mark.parametrize(
+    ("check", "blank_field", "blank_value"),
+    [
+        (_check_add_family_specs, "valid_resolutions", ()),
+        (_check_add_family_specs, "invalid_resolutions", ()),
+        (_check_add_family_specs, "invalid_resolution_match", ""),
+        (_check_partition_family_specs, "partition_invalid_resolution", None),
+        (_check_partition_family_specs, "partition_invalid_match", ""),
+        (_check_partition_family_specs, "hive_prefix", ""),
+        (_check_auto_family_specs, "auto_hive_prefix", ""),
+    ],
+    ids=lambda value: getattr(value, "__name__", None) if callable(value) else None,
+)
+def test_vacuity_checks_reject_a_blank_field(check, blank_field, blank_value):
+    """Each guarded field, blanked on an otherwise-complete spec, is rejected.
+
+    Without this the guard itself could regress to a no-op unnoticed: it only
+    ever runs against the four real specs, all of which already pass.
+    """
+    vacuous = replace(A5, name="future", **{blank_field: blank_value})
+    with pytest.raises(AssertionError, match=blank_field):
+        check([pytest.param(vacuous, id=vacuous.name)])
+
+
+def test_family_membership_is_pinned():
+    """Dropping a spec from a family list must fail, not quietly shrink coverage.
+
+    Removing a member is otherwise invisible: the remaining params still pass,
+    so the suite stays green while covering one index less.
+    """
+    assert {spec.name for spec in _specs(ADD_FAMILY)} == {"a5", "h3", "s2"}
+    assert {spec.name for spec in _specs(ADD_CLI)} == {"a5", "h3", "s2", "quadkey"}
+    assert {spec.name for spec in _specs(PARTITION_FAMILY)} == {"a5", "s2"}
+    assert {spec.name for spec in _specs(PARTITION_CLI)} == {"a5", "s2", "quadkey"}
+    assert {spec.name for spec in _specs(AUTO_FAMILY)} == {"a5", "h3", "quadkey"}
+    assert {spec.name for spec in _specs(CALC_FAMILY)} == {"a5", "h3", "s2", "quadkey"}
+    # One case per (spec, out-of-range value); pinned as pairs so dropping
+    # either a spec or one end of a range is loud.
+    assert {(param.values[0].name, param.values[1]) for param in ADD_INVALID_RESOLUTION} == {
+        ("a5", -1),
+        ("a5", 31),
+        ("h3", -1),
+        ("h3", 16),
+        ("s2", -1),
+        ("s2", 31),
+    }
 
 
 @pytest.mark.parametrize("spec", ADD_FAMILY)


### PR DESCRIPTION
## What changed

Test-only. `test_family_specs_are_not_vacuous` in `tests/test_spatial_index_family.py` guarded only the resolution tuples and the partition-invalid pair, leaving three ways for a future `IndexSpec` to join a family and test nothing:

1. **Hive prefixes are now guarded.** `hive_prefix` and `auto_hive_prefix` both default to `""`. `test_partition_hive_style` asserts `spec.hive_prefix in d.name` and `test_partition_auto_with_hive` asserts `subdir.name.startswith(spec.auto_hive_prefix)` — both are tautologies for `""`. `hive_prefix` is now required for every `PARTITION_FAMILY` member and `auto_hive_prefix` for every `AUTO_FAMILY` member, scoped to exactly the family that consumes each (h3 carries no `hive_prefix` and s2 no `auto_hive_prefix`, and neither sits in the family that reads it).
2. **`invalid_resolution_match` must be non-empty** for every `ADD_FAMILY` member. `pytest.raises(ValueError, match="")` matches any message, downgrading `test_add_table_invalid_resolution` to a bare "some ValueError" check. Verified that quadkey's deliberate `""` sits outside both `ADD_FAMILY` and `ADD_INVALID_RESOLUTION` (both are built from `(A5, H3, S2)`), so the guard is correctly scoped and quadkey is untouched.
3. **Family membership is pinned by name** in a new `test_family_membership_is_pinned`, covering all six family lists in the module (`ADD_FAMILY`, `ADD_CLI`, `PARTITION_FAMILY`, `PARTITION_CLI`, `AUTO_FAMILY`, `CALC_FAMILY`) plus `ADD_INVALID_RESOLUTION` as `(spec, value)` pairs, so dropping a spec — or one end of a range — fails loudly instead of quietly shrinking coverage.

The three checks are extracted into `_check_add_family_specs` / `_check_partition_family_specs` / `_check_auto_family_specs`, which take an arbitrary param list. That lets a new negative test, `test_vacuity_checks_reject_a_blank_field`, blank one field at a time on an otherwise-complete spec and assert the check rejects it — so the guard itself cannot regress to a no-op unnoticed (it only ever runs against four real specs, all of which pass).

No production code touched; no other refactoring of the module.

## Why

Follow-up from the review of #830. Every other spec-table mistake surfaces as a failing parametrized case, but a blank knob either collects zero cases or collects cases whose assertion is always true — the suite stays green while testing less. These are future-member traps: they cost nothing today and are invisible on the day someone adds a fifth index.

## Verification

Demonstrated the gaps were real before fixing them (throwaway script against the pre-change guard):

```
1. current guard PASSES for a member with blank hive_prefix/auto_hive_prefix/invalid_resolution_match
2. 'hive_prefix in name' with blank -> True (always True)
   startswith(blank) -> True (always True)
3. pytest.raises(ValueError, match='') accepted an unrelated ValueError
4. current guard PASSES with h3 dropped from ADD_FAMILY (2 members)
```

Mutation checks against the strengthened guard — each real spec field blanked in turn, suite confirmed red, then restored:

```
# A5.hive_prefix = ""
E   AssertionError: a5: empty hive_prefix in PARTITION_FAMILY
FAILED tests/test_spatial_index_family.py::test_family_specs_are_not_vacuous

# A5.auto_hive_prefix = ""
E   ...auto_hive_prefix
FAILED tests/test_spatial_index_family.py::test_family_specs_are_not_vacuous

# S2.invalid_resolution_match = ""
E   ...invalid_resolution_match
FAILED tests/test_spatial_index_family.py::test_family_specs_are_not_vacuous

# ADD_FAMILY = _params((A5, S2), ...)   # h3 dropped
E     'h3'
FAILED tests/test_spatial_index_family.py::test_family_membership_is_pinned
```

New and changed guards, unmutated:

```
tests/test_spatial_index_family.py::test_family_specs_are_not_vacuous PASSED
tests/test_spatial_index_family.py::test_vacuity_checks_reject_a_blank_field[_check_add_family_specs-valid_resolutions-blank_value0] PASSED
tests/test_spatial_index_family.py::test_vacuity_checks_reject_a_blank_field[_check_add_family_specs-invalid_resolutions-blank_value1] PASSED
tests/test_spatial_index_family.py::test_vacuity_checks_reject_a_blank_field[_check_add_family_specs-invalid_resolution_match-] PASSED
tests/test_spatial_index_family.py::test_vacuity_checks_reject_a_blank_field[_check_partition_family_specs-partition_invalid_resolution-None] PASSED
tests/test_spatial_index_family.py::test_vacuity_checks_reject_a_blank_field[_check_partition_family_specs-partition_invalid_match-] PASSED
tests/test_spatial_index_family.py::test_vacuity_checks_reject_a_blank_field[_check_partition_family_specs-hive_prefix-] PASSED
tests/test_spatial_index_family.py::test_vacuity_checks_reject_a_blank_field[_check_auto_family_specs-auto_hive_prefix-] PASSED
tests/test_spatial_index_family.py::test_family_membership_is_pinned PASSED

9 passed, 138 deselected in 0.18s
```

Fast suite:

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5405 passed, 65 skipped, 2 xfailed, 99 warnings in 164.98s (0:02:44)
```

diff-cover (test-only change, so no instrumented lines in the diff):

```
$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
Diff: origin/main...HEAD, staged and unstaged changes
No lines with coverage information in this diff.
```

pre-commit, both stages:

```
$ uv run pre-commit run --all-files          # 20 hooks, all Passed
$ uv run pre-commit run --all-files --hook-stage pre-push
deptry...................................................................Passed
mypy.....................................................................Passed
vulture..................................................................Passed
xenon....................................................................Passed
import-linter............................................................Passed
menard-check.............................................................Passed
fast-tests...............................................................Passed
```

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
