### PR TITLE
fix(wfs): reword the GML-path error, sanitize advertised formats, refuse XML with a DTD

### DIFF
--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -19,7 +19,7 @@ import json
 import re
 import tempfile
 import time
-import xml.etree.ElementTree as ET  # nosec B405 - stdlib ET never resolves external entities; see _is_empty_gml_collection
+import xml.etree.ElementTree as ET  # nosec B405 - the one parse here (_is_empty_gml_collection) refuses any body declaring a DTD, so no entity expansion is possible; stdlib ET never resolves external entities regardless
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
@@ -954,6 +954,30 @@ def _first_matching_format(
     return None
 
 
+# C0 controls and DEL. h11 refuses to put any of these in a header value, and
+# a WFS outputFormat is a media type or a bare token -- never a control byte.
+_CONTROL_CHARACTERS: Final = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _sanitize_output_format(fmt: str) -> str:
+    """Drop control characters from a format string the server advertised.
+
+    A capabilities document is server-controlled text, and a value such as
+    ``application/json;\\r\\nX-Evil: 1`` matches ``application/json`` on the
+    normalized comparison (which drops whitespace) while being returned in the
+    server's own spelling. Echoed back unchanged it is not an injection -- h11
+    rejects an illegal header value before it reaches the socket -- but the user
+    pays three retries to reach an opaque "Illegal header value" (issue #838).
+
+    Sanitizing here, at the single point where a negotiated format is produced,
+    rather than inside ``_accept_header_for``, is deliberate: the same value is
+    also sent back as the ``outputFormat=`` query parameter, where urlencode
+    would percent-encode the control bytes into the URL instead of rejecting
+    them.
+    """
+    return _CONTROL_CHARACTERS.sub("", fmt)
+
+
 def _detect_best_output_format(available_formats: list[str]) -> str | None:
     """
     Detect the best output format from available formats.
@@ -987,9 +1011,10 @@ def _detect_best_output_format(available_formats: list[str]) -> str | None:
     available_norm = [_normalize_output_format(f) for f in available_formats]
 
     # GeoJSON is preferred - faster to parse - then GML.
-    return _first_matching_format(
+    matched = _first_matching_format(
         available_formats, available_norm, GEOJSON_FORMATS
     ) or _first_matching_format(available_formats, available_norm, GML_FORMATS)
+    return _sanitize_output_format(matched) if matched is not None else None
 
 
 def _negotiate_crs(layer_info: WFSLayerInfo, output_crs: str | None = None) -> str:
@@ -1609,9 +1634,14 @@ def _classify_wfs_content_type(content_type: str) -> str:
 
 
 def _error_page_error(content_type: str, preview: str) -> WFSError:
-    """Build the "server returned an error page" failure with a body preview."""
+    """Build the "server returned an error page" failure with a body preview.
+
+    The wording is format-neutral because this is raised from the GML path too,
+    where gpio deliberately requested GML: naming JSON there told the user the
+    server had failed to send a format gpio never asked for (issue #838).
+    """
     return WFSError(
-        f"Expected JSON response but got {content_type}. "
+        f"Expected a feature collection (GeoJSON or GML) but got {content_type}. "
         f"Server may have returned an error page:\n{preview}"
     )
 
@@ -1639,21 +1669,43 @@ def _local_name(tag: str) -> str:
     return tag.rpartition("}")[2]
 
 
+# Every entity-expansion attack (billion laughs, quadratic blowup) needs one of
+# these; a WFS FeatureCollection needs neither.
+_DTD_MARKERS: Final = (b"<!doctype", b"<!entity")
+
+
+def _declares_a_dtd(body: bytes) -> bool:
+    """True when ``body`` declares a doctype or an entity, in any casing."""
+    lowered = body.lower()
+    return any(marker in lowered for marker in _DTD_MARKERS)
+
+
 def _is_empty_gml_collection(body: bytes) -> bool:
     """True when ``body`` is a GML FeatureCollection holding zero features.
 
     A zero-feature collection is a legitimate WFS answer (an empty bbox), but
     GDAL cannot open one -- and on Linux builds ``ST_Read`` *segfaults* on it
     rather than raising -- so the body must be recognized as empty before GDAL
-    ever sees it. stdlib ElementTree ignores external entities by default, so
-    parsing the raw server bytes is safe. Anything that is not XML, not a
-    FeatureCollection, or has any feature-bearing child goes to GDAL, keeping
-    the error-page WFSError for genuinely broken bodies.
+    ever sees it. Anything that is not XML, not a FeatureCollection, or has any
+    feature-bearing child goes to GDAL, keeping the error-page WFSError for
+    genuinely broken bodies.
+
+    A body declaring a DTD is refused before it is parsed. Entity expansion is
+    the attack class that matters for untrusted XML -- a couple of kilobytes of
+    nested ``<!ENTITY>`` definitions expand to gigabytes on an expat built
+    without amplification protection, which the size cap does nothing about --
+    and every form of it needs a DTD. A WFS FeatureCollection never carries one,
+    so refusing it costs nothing: such a body takes the same route as any other
+    unrecognized one (issue #840).
     """
-    if len(body) > _EMPTY_GML_SNIFF_MAX_BYTES:
+    if len(body) > _EMPTY_GML_SNIFF_MAX_BYTES or _declares_a_dtd(body):
         return False
     try:
-        root = ET.fromstring(body)  # nosec B314 - no external entity resolution; body capped at 1MB, only gates the empty check
+        # nosec B314 - the body reaching this line declares no DTD (checked
+        # above), so no entity expansion is possible; stdlib ET never resolves
+        # external entities regardless; the body is capped at 1MB; and the parse
+        # only gates an empty-collection check whose fallback is GDAL.
+        root = ET.fromstring(body)  # nosec B314
     except ET.ParseError:
         return False
     if _local_name(root.tag) != "FeatureCollection":

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1675,9 +1675,45 @@ _DTD_MARKERS: Final = (b"<!doctype", b"<!entity")
 
 
 def _declares_a_dtd(body: bytes) -> bool:
-    """True when ``body`` declares a doctype or an entity, in any casing."""
+    """True when ``body`` declares a doctype or an entity, in any casing.
+
+    The scan is over ASCII bytes, so it only holds for ASCII-compatible
+    encodings -- which is why ``_xml_body_must_be_refused`` rejects UTF-16 and
+    UTF-32 bodies before relying on it.
+    """
     lowered = body.lower()
     return any(marker in lowered for marker in _DTD_MARKERS)
+
+
+# UTF-16/UTF-32 byte-order marks (the UTF-32 BE mark starts with NUL bytes and
+# is also caught by the prolog NUL scan; it is listed for completeness).
+_UTF16_UTF32_BOMS: Final = (b"\xff\xfe", b"\xfe\xff", b"\x00\x00\xfe\xff")
+
+# How far into the body to look for NUL bytes. The XML prolog and root-element
+# open tag of any real response fall well inside this window, and in a UTF-16
+# or UTF-32 body every ASCII character in that window carries NUL padding.
+_XML_PROLOG_SNIFF_BYTES: Final = 256
+
+
+def _xml_body_must_be_refused(body: bytes) -> bool:
+    """True when an XML body may not be parsed -- or handed to GDAL -- at all.
+
+    Two shapes are refused, neither of which a legitimate WFS GetFeature
+    response can have:
+
+    - **A DTD** (``<!DOCTYPE``/``<!ENTITY`` in any casing). Every
+      entity-expansion attack (billion laughs, quadratic blowup) needs one --
+      a couple of kilobytes of nested ``<!ENTITY>`` definitions expand to
+      gigabytes on an expat built without amplification protection -- and GML
+      uses XML Schema, never a DTD (issue #840).
+    - **A UTF-16/UTF-32 body**: a byte-order mark, or NUL bytes in the prolog
+      region. expat auto-detects those encodings, so a UTF-16 payload carries
+      no ASCII ``<!doctype`` bytes for the marker scan to find yet still gets
+      its entities expanded; real servers send UTF-8/ASCII XML.
+    """
+    if body.startswith(_UTF16_UTF32_BOMS) or b"\x00" in body[:_XML_PROLOG_SNIFF_BYTES]:
+        return True
+    return _declares_a_dtd(body)
 
 
 def _is_empty_gml_collection(body: bytes) -> bool:
@@ -1690,21 +1726,19 @@ def _is_empty_gml_collection(body: bytes) -> bool:
     feature-bearing child goes to GDAL, keeping the error-page WFSError for
     genuinely broken bodies.
 
-    A body declaring a DTD is refused before it is parsed. Entity expansion is
-    the attack class that matters for untrusted XML -- a couple of kilobytes of
-    nested ``<!ENTITY>`` definitions expand to gigabytes on an expat built
-    without amplification protection, which the size cap does nothing about --
-    and every form of it needs a DTD. A WFS FeatureCollection never carries one,
-    so refusing it costs nothing: such a body takes the same route as any other
-    unrecognized one (issue #840).
+    A body ``_xml_body_must_be_refused`` rejects (a DTD, or a UTF-16/UTF-32
+    encoding that would smuggle one past the ASCII scan) never reaches the
+    parse below. ``_parse_gml_response`` refuses such bodies with a WFSError
+    before this sniff is consulted; the check is repeated here so the parse
+    stays safe for any caller.
     """
-    if len(body) > _EMPTY_GML_SNIFF_MAX_BYTES or _declares_a_dtd(body):
+    if len(body) > _EMPTY_GML_SNIFF_MAX_BYTES or _xml_body_must_be_refused(body):
         return False
     try:
-        # nosec B314 - the body reaching this line declares no DTD (checked
-        # above), so no entity expansion is possible; stdlib ET never resolves
-        # external entities regardless; the body is capped at 1MB; and the parse
-        # only gates an empty-collection check whose fallback is GDAL.
+        # The body reaching this line declares no DTD and is ASCII-compatible
+        # (both checked above), so no entity expansion is possible; stdlib ET
+        # never resolves external entities regardless; the body is capped at
+        # 1MB; and the parse only gates an empty-collection check.
         root = ET.fromstring(body)  # nosec B314
     except ET.ParseError:
         return False
@@ -1770,12 +1804,21 @@ def _parse_gml_response(
     is kept, so everything downstream (repair, CRS validation, type inference,
     tile deduplication) works unchanged.
     """
+    # A DTD or a UTF-16/UTF-32 body is refused outright: no legitimate WFS
+    # GetFeature response has either shape (GML uses XML Schema; servers send
+    # UTF-8), and falling through to GDAL is not a safe default -- a DOCTYPE'd
+    # *empty* FeatureCollection is a zero-layer GML dataset, exactly the shape
+    # Linux ST_Read segfaults on instead of raising.
+    body = Path(tmp_path).read_bytes()
+    if _xml_body_must_be_refused(body):
+        raise _error_page_error(content_type, _read_body_preview(tmp_path))
+
     # Zero-feature collection: same shape the JSON path returns for an empty
     # ``features`` array (geometry-only, no _wfs_fid), so pagination and tiled
     # fetches see an empty page, not a failure. Decided from the bytes, before
     # ST_Read -- Linux GDAL segfaults on a zero-layer GML dataset. The
     # ``described is None`` branch is the fallback for platforms that raise.
-    if _is_empty_gml_collection(Path(tmp_path).read_bytes()):
+    if _is_empty_gml_collection(body):
         debug("Empty GML response, returning empty table")
         return pa.table({"geometry": pa.array([], type=pa.binary())})
 

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -7,6 +7,8 @@ Network tests are marked separately for optional integration testing.
 
 import logging
 import os
+import re
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1666,7 +1668,10 @@ class TestGMLOnlyServerEndToEnd:
 
 
 def _mock_wfs_http_response(
-    body: bytes, content_type: str = "application/json", status_code: int = 200
+    body: bytes,
+    content_type: str = "application/json",
+    status_code: int = 200,
+    sent_headers: dict | None = None,
 ):
     """Patch httpx.Client.stream to return a canned response.
 
@@ -1674,6 +1679,10 @@ def _mock_wfs_http_response(
     previously each carried a near-identical inline mock class (issue #666
     item 7). The response supports both ``read()`` (error-page validation path)
     and ``iter_bytes()`` (streaming JSON path).
+
+    Pass ``sent_headers`` to have the request headers gpio would have put on the
+    wire copied into it, for tests that assert on what was requested rather than
+    on what came back.
     """
     import httpx
 
@@ -1682,6 +1691,9 @@ def _mock_wfs_http_response(
     response_status = status_code
 
     def mock_stream(*args, **kwargs):
+        if sent_headers is not None:
+            sent_headers.update(kwargs.get("headers") or {})
+
         class MockResponse:
             status_code = response_status
             headers = {"content-type": content_type}
@@ -1709,6 +1721,23 @@ def _mock_wfs_http_response(
 _EMPTY_FEATURE_COLLECTION = b'{"type": "FeatureCollection", "features": []}'
 
 
+def _billion_laughs_gml(levels: int = 10) -> bytes:
+    """A FeatureCollection whose internal DTD expands to ``10**levels`` entities.
+
+    The classic entity-expansion bomb: about a kilobyte of markup that a parser
+    with no expansion limit turns into gigabytes. It wears a FeatureCollection
+    root on purpose, so nothing but the DTD guard itself can turn it away.
+    """
+    entities = ['<!ENTITY lol0 "lol">']
+    entities += [f'<!ENTITY lol{i} "{f"&lol{i - 1};" * 10}">' for i in range(1, levels + 1)]
+    return (
+        '<?xml version="1.0"?>\n'
+        "<!DOCTYPE wfs:FeatureCollection [\n" + "\n".join(entities) + "\n]>\n"
+        '<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0">'
+        f"&lol{levels};</wfs:FeatureCollection>"
+    ).encode()
+
+
 class TestContentTypeValidation:
     """Test content-type validation catches error pages returned with 200 OK."""
 
@@ -1718,13 +1747,13 @@ class TestContentTypeValidation:
             pytest.param(
                 "text/html; charset=utf-8",
                 b"<html><body>Error: Service unavailable</body></html>",
-                "Expected JSON.*text/html",
+                "Expected a feature collection.*text/html",
                 id="rejects-html",
             ),
             pytest.param(
                 "application/xml",
                 b"<ows:ExceptionReport>Service error</ows:ExceptionReport>",
-                "Expected JSON.*application/xml",
+                "Expected a feature collection.*application/xml",
                 id="rejects-xml",
             ),
             pytest.param(
@@ -1735,13 +1764,13 @@ class TestContentTypeValidation:
                 b'locator="outputFormat"><ows:ExceptionText>Unsupported '
                 b"outputFormat</ows:ExceptionText></ows:Exception>"
                 b"</ows:ExceptionReport>",
-                "Expected JSON.*text/xml",
+                "Expected a feature collection.*text/xml",
                 id="rejects-exception-report",
             ),
             pytest.param(
                 "text/plain",
                 b"Error: Invalid request parameters",
-                "Expected JSON.*text/plain",
+                "Expected a feature collection.*text/plain",
                 id="rejects-text-plain",
             ),
             pytest.param(
@@ -1833,20 +1862,28 @@ class TestGMLResponseParsing:
         table = self._fetch_gml()
         assert table.schema.metadata.get(_SERVER_CRS_METADATA_KEY) == b"EPSG:4326"
 
-    def test_leaves_no_temp_files_behind(self):
+    def test_leaves_no_temp_files_behind(self, tmp_path, monkeypatch):
         """GDAL writes a .gfs sidecar for schema-less GML; nothing may survive.
 
         The GeoJSON path used a NamedTemporaryFile and unlinked exactly that one
         path, which would strand the sidecar. The GML path must use a temporary
         *directory* so every file GDAL creates is removed.
+
+        The assertion is on the ``gpio-wfs-*`` *directory*, not on file suffixes
+        directly under the temp root: the response body and its sidecar live one
+        level down, so a suffix filter over ``gettempdir()`` sees nothing either
+        way and stays green even when the directory is stranded (issue #838).
+
+        Redirecting ``tempfile.tempdir`` at a per-test directory keeps this from
+        reading other xdist workers' in-flight fetches as leaks.
         """
         import tempfile
 
-        before = set(os.listdir(tempfile.gettempdir()))
+        monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
         self._fetch_gml()
-        after = set(os.listdir(tempfile.gettempdir()))
-        leaked = {name for name in after - before if name.endswith((".gml", ".gfs", ".xml"))}
-        assert not leaked, f"GML parse leaked temp files: {sorted(leaked)}"
+
+        leaked = sorted(p.name for p in tmp_path.glob("gpio-wfs-*"))
+        assert not leaked, f"GML parse leaked temp directories: {leaked}"
 
     def test_extract_fid_uses_gml_id(self):
         """Tiled fetches dedupe on gml:id, the GML analogue of a GeoJSON feature id."""
@@ -1942,6 +1979,32 @@ class TestGMLResponseParsing:
             ),
             pytest.param(b"<html><body>Error</body></html>", False, id="html-error-page"),
             pytest.param(b"not xml at all", False, id="not-xml"),
+            # A WFS FeatureCollection never carries a DTD, so any body that
+            # declares one is refused before it reaches the parser (issue #840).
+            pytest.param(
+                b'<!DOCTYPE wfs:FeatureCollection [<!ENTITY x "y">]>'
+                b'<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0"/>',
+                False,
+                id="doctype-with-entity",
+            ),
+            pytest.param(
+                b'<!doctype wfs:FeatureCollection [<!entity x "y">]>'
+                b'<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0"/>',
+                False,
+                id="doctype-lowercase",
+            ),
+            pytest.param(
+                b'<!DoCtYpE wfs:FeatureCollection [<!EnTiTy x "y">]>'
+                b'<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0"/>',
+                False,
+                id="doctype-mixed-case",
+            ),
+            pytest.param(
+                b'<!ENTITY x SYSTEM "file:///etc/passwd">'
+                b'<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0"/>',
+                False,
+                id="entity-without-doctype",
+            ),
         ],
     )
     def test_is_empty_gml_collection(self, body, expected):
@@ -1950,6 +2013,22 @@ class TestGMLResponseParsing:
         from geoparquet_io.core.wfs import _is_empty_gml_collection
 
         assert _is_empty_gml_collection(body) is expected
+
+    def test_entity_expansion_bomb_is_refused_immediately(self):
+        """A billion-laughs body is rejected on the DTD, not parsed (issue #840).
+
+        Without the guard this hands ~1KB of markup to expat and asks it to
+        build 10**10 entity expansions. A libexpat with amplification protection
+        (>= 2.4) raises quickly, so the guard is what makes the outcome the same
+        on a build that has the protection compiled out: refused in constant
+        time instead of hanging or exhausting memory. The 1MB body cap does not
+        help here -- expansion is what is unbounded, not size.
+        """
+        from geoparquet_io.core.wfs import _is_empty_gml_collection
+
+        start = time.perf_counter()
+        assert _is_empty_gml_collection(_billion_laughs_gml()) is False
+        assert time.perf_counter() - start < 1.0, "the DTD was handed to the parser"
 
     def test_idless_features_get_null_fid(self):
         """Features without gml:id must get a NULL _wfs_fid, not GDAL's ''.
@@ -2118,6 +2197,67 @@ class TestFormatPrefixMatching:
         from geoparquet_io.core.wfs import _detect_best_output_format
 
         assert _detect_best_output_format([advertised]) is None
+
+
+# h11 refuses to put any of these on the wire, so a format carrying one turns
+# into three retries and an opaque "Illegal header value" (issue #838).
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+# A capabilities document is server-controlled text. This value matches
+# ``application/json`` once normalized -- whitespace is dropped for the
+# comparison -- so without sanitizing it would be echoed back verbatim.
+_HOSTILE_FORMAT = "application/json;\r\nX-Evil: 1"
+
+
+class TestHostileAdvertisedFormat:
+    """A control character in an advertised outputFormat never leaves gpio."""
+
+    def test_negotiated_format_has_no_control_characters(self):
+        """The value is still matched, but returned without the control bytes."""
+        from geoparquet_io.core.wfs import _detect_best_output_format
+
+        negotiated = _detect_best_output_format([_HOSTILE_FORMAT])
+
+        assert negotiated is not None, "normalized matching must still find the format"
+        assert negotiated.startswith("application/json")
+        assert not _CONTROL_CHARS.search(negotiated)
+
+    def test_request_still_goes_out_with_a_legal_accept_header(self):
+        """Sanitizing must not break the request: it is sent, with a legal header."""
+        from geoparquet_io.core.wfs import _accept_header_for, _detect_best_output_format
+
+        negotiated = _detect_best_output_format([_HOSTILE_FORMAT])
+        accept = _accept_header_for(negotiated)
+        assert not _CONTROL_CHARS.search(accept)
+
+        sent: dict = {}
+        with _mock_wfs_http_response(
+            _EMPTY_FEATURE_COLLECTION, "application/json", sent_headers=sent
+        ):
+            table = wfs_module._fetch_wfs_page(
+                "http://mock.wfs/wfs?service=WFS", output_format=negotiated
+            )
+
+        assert table.num_rows == 0
+        assert not _CONTROL_CHARS.search(sent["Accept"])
+
+    def test_sanitizing_covers_the_output_format_parameter_too(self):
+        """The negotiated value is also the ``outputFormat=`` query parameter.
+
+        Sanitizing at ``_detect_best_output_format`` -- rather than inside
+        ``_accept_header_for`` -- is what keeps the control bytes out of the URL
+        as well as out of the header.
+        """
+        from geoparquet_io.core.wfs import _build_wfs_url, _detect_best_output_format
+
+        negotiated = _detect_best_output_format([_HOSTILE_FORMAT])
+        url = _build_wfs_url(
+            "http://mock.wfs/wfs", "topp:states", "2.0.0", output_format=negotiated
+        )
+
+        assert "outputFormat" in url
+        assert not _CONTROL_CHARS.search(url)
+        assert "%0D" not in url.upper()
 
 
 _OMIT_PROPERTIES = object()

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -1980,7 +1980,10 @@ class TestGMLResponseParsing:
             pytest.param(b"<html><body>Error</body></html>", False, id="html-error-page"),
             pytest.param(b"not xml at all", False, id="not-xml"),
             # A WFS FeatureCollection never carries a DTD, so any body that
-            # declares one is refused before it reaches the parser (issue #840).
+            # declares one is refused before it reaches the parser (issue
+            # #840). The fetch path raises a WFSError for these instead of
+            # calling this sniff at all; False here keeps the sniff itself
+            # safe for any caller.
             pytest.param(
                 b'<!DOCTYPE wfs:FeatureCollection [<!ENTITY x "y">]>'
                 b'<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0"/>',
@@ -2029,6 +2032,96 @@ class TestGMLResponseParsing:
         start = time.perf_counter()
         assert _is_empty_gml_collection(_billion_laughs_gml()) is False
         assert time.perf_counter() - start < 1.0, "the DTD was handed to the parser"
+
+    def test_utf16_bomb_never_reaches_the_parser(self):
+        """A UTF-16 body must be refused before the ASCII DTD scan can miss it.
+
+        expat auto-detects UTF-16, so an entity bomb encoded that way carries no
+        ASCII ``<!doctype``/``<!entity`` bytes for the marker scan to find: it
+        sailed past the guard, was parsed, had its entities expanded, and --
+        with only text content inside the root -- was even reported as an empty
+        collection. The small expansion here stays under libexpat's
+        amplification threshold on purpose: on an unfixed build it parses
+        cleanly and returns True, so this asserts the refusal, not a parser
+        error.
+        """
+        from geoparquet_io.core.wfs import _is_empty_gml_collection
+
+        body = _billion_laughs_gml(levels=3).decode().encode("utf-16")
+        start = time.perf_counter()
+        assert _is_empty_gml_collection(body) is False
+        assert time.perf_counter() - start < 1.0, "the UTF-16 body was handed to the parser"
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            pytest.param(b"\xfe\xff\x00<\x00a\x00>", True, id="utf16-be-bom"),
+            pytest.param(b"\xff\xfe<\x00a\x00>\x00", True, id="utf16-le-bom"),
+            pytest.param(b"\x00\x00\xfe\xff", True, id="utf32-be-bom"),
+            pytest.param(b"\xff\xfe\x00\x00", True, id="utf32-le-bom"),
+            pytest.param(
+                '<?xml version="1.0"?><a/>'.encode("utf-16-le"),
+                True,
+                id="bomless-utf16-nul-in-prolog",
+            ),
+            pytest.param(
+                b'<?xml version="1.0"?><!DOCTYPE a><a/>',
+                True,
+                id="doctype",
+            ),
+            pytest.param(MOCK_EMPTY_GML_WFS20.encode(), False, id="utf8-empty-collection"),
+            pytest.param(MOCK_GML_RESPONSE.encode(), False, id="utf8-collection"),
+        ],
+    )
+    def test_xml_body_refusal(self, body, expected):
+        """DTDs and UTF-16/UTF-32 bodies are refused; plain UTF-8 GML is not."""
+        from geoparquet_io.core.wfs import _xml_body_must_be_refused
+
+        assert _xml_body_must_be_refused(body) is expected
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(
+                b'<?xml version="1.0"?>\n'
+                b"<!DOCTYPE wfs:FeatureCollection [<!ELEMENT a EMPTY>]>\n"
+                b'<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0"/>',
+                id="ascii-doctype-empty-collection",
+            ),
+            pytest.param(_billion_laughs_gml(), id="ascii-entity-bomb"),
+            pytest.param(
+                _billion_laughs_gml(levels=3).decode().encode("utf-16"),
+                id="utf16-bom-entity-bomb",
+            ),
+            pytest.param(
+                _billion_laughs_gml(levels=3).decode().encode("utf-16-le"),
+                id="utf16-bomless-entity-bomb",
+            ),
+        ],
+    )
+    def test_refused_xml_raises_wfs_error_without_reaching_gdal(self, body):
+        """A DTD or UTF-16 body gets the clean error-page WFSError, never GDAL.
+
+        Two crash routes are closed at once. Falling through to GDAL is not a
+        safe default: a DOCTYPE'd *empty* FeatureCollection is a zero-layer GML
+        dataset, exactly the shape Linux ST_Read segfaults on instead of
+        raising. And a UTF-16 body used to slip past the ASCII DTD scan into
+        the sniffer's XML parse, entities and all. No legitimate WFS GetFeature
+        response has either shape (GML uses XML Schema, servers send UTF-8), so
+        both are refused with the standard error-page WFSError and its body
+        preview -- the tripwire proves ST_Read is never invoked.
+        """
+        from geoparquet_io.core import wfs as wfs_module
+
+        def _tripwire(*args, **kwargs):
+            raise AssertionError("refused XML body reached ST_Read")
+
+        with (
+            _mock_wfs_http_response(body, "text/xml"),
+            patch.object(wfs_module, "_gml_geometry_column", side_effect=_tripwire),
+            pytest.raises(wfs_module.WFSError, match="Expected a feature collection"),
+        ):
+            wfs_module._fetch_wfs_page("http://mock.wfs/wfs?service=WFS")
 
     def test_idless_features_get_null_fid(self):
         """Features without gml:id must get a NULL _wfs_fid, not GDAL's ''.


### PR DESCRIPTION
## What changed

Four items in `geoparquet_io/core/wfs.py` and `tests/test_wfs.py`, all follow-ups to #835.

**#838.1 — the temp-leak test can now detect a leak.** `test_leaves_no_temp_files_behind` diffed top-level `tempfile.gettempdir()` entries filtered by `.gml`/`.gfs`/`.xml` suffix, but the response body and its GDAL sidecar live one level down inside `gpio-wfs-<random>/`, so the filter matched nothing whether or not the directory survived. It now redirects `tempfile.tempdir` at a per-test `tmp_path` (so it cannot read another xdist worker's in-flight fetch as a leak) and asserts no `gpio-wfs-*` entry survives.

**#838.2 — format-neutral error-page message.** `_error_page_error` said `"Expected JSON response but got …"`. It is now also raised from `_gml_geometry_column`, where gpio deliberately requested GML, so the message named a format gpio never asked for. It now reads `"Expected a feature collection (GeoJSON or GML) but got {content_type}. Server may have returned an error page:"`, keeping the body preview. The four `Expected JSON.*` test matchers were updated.

**#838.3 — control characters stripped from advertised formats.** A capabilities value like `application/json;\r\nX-Evil: 1` matched `application/json` in `_first_matching_format` pass 2 (compared normalized, returned raw) and went verbatim into the `Accept` header. New `_sanitize_output_format` drops `[\x00-\x1f\x7f]` and is applied to the return of `_detect_best_output_format`. That choke point rather than `_accept_header_for` is deliberate, and the reasoning is in the docstring: the same negotiated value is also sent as the `outputFormat=` query parameter, where `urlencode` would percent-encode the control bytes into the URL rather than reject them. `_normalize_output_format` already drops all whitespace, so matching is unaffected — the hostile value is still found, just returned clean.

**#840 — DTD guard instead of a defusedxml dependency.** `_is_empty_gml_collection` now returns `False` for any body containing `<!DOCTYPE` or `<!ENTITY` (case-insensitive, on bytes) before `ET.fromstring` is reached; such a body takes the GDAL path like any other unrecognized one. Both `# nosec` justifications were rewritten to state what is true after the change. No new dependency; `pyproject.toml` is untouched.

## Why

**On #840 (the maintainer's call to overrule).** The attack class that actually matters for untrusted XML is *entity expansion* — billion laughs and quadratic blowup — not external entity resolution. The old `# nosec` justification ("stdlib ET never resolves external entities; body capped at 1MB") was true but answered the wrong question: a size cap bounds input, and expansion is precisely the thing that is unbounded relative to input. About a kilobyte of nested `<!ENTITY>` definitions expands to gigabytes on an expat built without amplification protection, well under the 1MB cap.

Every form of that attack requires a DTD, and a WFS FeatureCollection never carries one, so scanning the bytes for `<!DOCTYPE`/`<!ENTITY` and bailing out closes the gap exactly, with no dependency and no behavior change for any real server response — a body that is refused simply goes to GDAL, which is where every non-empty and every malformed body already goes. (GDAL's own XML handling is the same surface `gpio convert` exposes for any GML file, and is out of scope here.) If you would rather have the canonical answer, switching to `defusedxml.ElementTree.fromstring` is a two-line change — the import and the call — plus a line in `pyproject.toml`; the DTD guard and its tests can stay or go independently of that.

**On the leak test.** Worth recording: the leak the old test documents cannot be reproduced by simply deleting `tmp_dir.cleanup()` — `tempfile.TemporaryDirectory` registers a `weakref.finalize` that removes the directory when the object is collected, so that mutation stays green for a legitimate reason. The regression the test actually guards is the *shape* of the temp allocation (a managed directory, not a bare path), so the proof below mutates it to an unmanaged `mkdtemp` with a no-op cleanup — the state the code would be in if someone reverted to per-file cleanup and stranded the `.gfs` sidecar.

## Verification

**#838.1 — the leak test, red then green.** Under the mutation (`tmp_dir` becomes an unmanaged `mkdtemp` with a no-op `cleanup`):

```
--- MUTATED: temp dir is never cleaned up ---
___________ TestGMLResponseParsing.test_leaves_no_temp_files_behind ____________
tests/test_wfs.py:1886: in test_leaves_no_temp_files_behind
    assert not leaked, f"GML parse leaked temp directories: {leaked}"
E   AssertionError: GML parse leaked temp directories: ['gpio-wfs-_wpdmzqs']
E   assert not ['gpio-wfs-_wpdmzqs']
=========================== short test summary info ============================
FAILED tests/test_wfs.py::TestGMLResponseParsing::test_leaves_no_temp_files_behind
============================== 1 failed in 0.41s ===============================
--- RESTORED ---
tests/test_wfs.py .                                                      [100%]
============================== 1 passed in 0.21s ===============================
```

And the *old* assertion under that same real leak, showing it could not have caught it:

```
OLD assertion (suffix filter) leaked = [] -> PASSES (green)
NEW assertion (gpio-wfs- prefix) leaked = ['gpio-wfs-avewup0x'] -> FAILS (red)
  leaked dir contents: ['response.gfs', 'response.gml']
```

**Red phase for the rest**, before the implementation landed (8 failures, all expected):

```
FAILED tests/test_wfs.py::TestContentTypeValidation::test_content_type_validation[rejects-html]
FAILED tests/test_wfs.py::TestContentTypeValidation::test_content_type_validation[rejects-xml]
FAILED tests/test_wfs.py::TestContentTypeValidation::test_content_type_validation[rejects-exception-report]
FAILED tests/test_wfs.py::TestContentTypeValidation::test_content_type_validation[rejects-text-plain]
FAILED tests/test_wfs.py::TestGMLResponseParsing::test_is_empty_gml_collection[doctype-with-entity]
FAILED tests/test_wfs.py::TestHostileAdvertisedFormat::test_negotiated_format_has_no_control_characters
FAILED tests/test_wfs.py::TestHostileAdvertisedFormat::test_request_still_goes_out_with_a_legal_accept_header
FAILED tests/test_wfs.py::TestHostileAdvertisedFormat::test_sanitizing_covers_the_output_format_parameter_too
================= 8 failed, 16 passed, 272 deselected in 9.08s =================
```

**Fast suite** (`uv run pytest -n auto -m "not slow and not network and not meta" -q`):

```
==== 5405 passed, 65 skipped, 2 xfailed, 105 warnings in 151.73s (0:02:31) =====
```

**diff-cover** against `origin/main`:

```
geoparquet_io/core/wfs.py (100%)
-------------
Total:   12 lines
Missing: 0 lines
Coverage: 100%
```

**Hooks** — `uv run pre-commit run --all-files` and `--hook-stage pre-push` both fully green (deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests). Bandit still reports both `# nosec` suppressions as recognized (`Total potential issues skipped due to specifically being disabled: 2`).

One note on the entity-expansion test: this machine links libexpat 2.6.3, which has amplification protection on by default, so the bomb payload raises `ParseError` in ~0.24s even without the guard. The guard is what makes the outcome independent of the linked expat — refused in constant time on a build with the protection compiled out — and the test's sub-second bound is what would catch that build hanging. The test docstring says so rather than overclaiming.

Closes #838
Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened WFS XML and GML response handling against malicious entity expansion and encoded payloads.
  * Refused unsupported DTD declarations and UTF-16/UTF-32 encoded GML responses.
  * Sanitized control characters from advertised output formats before sending requests.
  * Improved error messages for invalid feature collection responses.
  * Improved temporary-file cleanup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->