### PR TITLE
fix(write): keep the declared CRS on in-memory and streaming 2.0 geometry types

### DIFF
--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1400,36 +1400,26 @@ def _compute_bbox_from_data(table, geometry_column: str, verbose: bool) -> list[
 
 def _assemble_and_apply_geo_metadata(
     table,
-    geometry_column: str,
     geo_meta: dict,
-    input_crs: dict | None,
     metadata_version: str,
     verbose: bool,
 ):
     """
-    Assemble final geo metadata and apply it to the table.
+    Apply the finished geo metadata to the table's schema.
 
-    Adds CRS to geo metadata if provided and applies the complete
-    metadata to the table schema.
+    The geometry column's ``crs`` is already resolved by the caller, which has to
+    do it before this point: the native Parquet GEOMETRY logical types are built
+    from what the block declares, so the block is finished first (#848).
 
     Args:
         table: PyArrow Table to modify
-        geometry_column: Name of the geometry column
-        geo_meta: Geo metadata dict to finalize
-        input_crs: PROJJSON dict with CRS (optional)
+        geo_meta: Geo metadata dict to apply
         metadata_version: GeoParquet metadata version string
         verbose: Whether to print verbose output
 
     Returns:
         pa.Table: Table with geo metadata applied
     """
-    # Set/clear the geometry column's crs per the GeoParquet null-vs-default rule
-    # (shared helper is the single source of truth across all write paths).
-    columns = geo_meta.setdefault("columns", {})
-    apply_output_crs(columns.setdefault(geometry_column, {}), input_crs)
-    if verbose and input_crs and not is_default_crs(input_crs):
-        debug(f"Added CRS to geo metadata: {_format_crs_display(input_crs)}")
-
     # Apply metadata to table
     existing_metadata = dict(table.schema.metadata) if table.schema.metadata else {}
     new_metadata = {}
@@ -1667,7 +1657,57 @@ def _apply_geoparquet_metadata(
             debug(f"Geometry column '{geometry_column}' not found in table, skipping metadata")
         return table
 
-    # Step 1: Handle geometry columns based on version.
+    from geoparquet_io.core.write_strategies.base import (
+        native_geometry_crs,
+        resolve_geometry_columns,
+    )
+
+    # The table entry points (`write_geoparquet_table`, the strategies'
+    # `write_from_table`) get no `geometry_info`, so fall back to naming the
+    # secondaries from the carried geo metadata -- otherwise they would silently
+    # keep the single-column behaviour the loop below exists to replace.
+    # `original_metadata` is deliberately None on the table entry points (passing
+    # it there would smuggle the input's stale geo block into the output), so the
+    # secondary names come from the table's own carried key instead.
+    carried_geo = _parse_geo_metadata_quietly(original_metadata) or _parse_geo_metadata_quietly(
+        table.schema.metadata
+    )
+
+    # Step 1: Build the geo metadata, BEFORE the geometry columns are retyped.
+    #
+    # The 2.0 / parquet-geo-only native Parquet GEOMETRY types take each column's
+    # CRS from the entry that declares it, so that entry has to exist first --
+    # otherwise the primary is typed from `input_crs`, which only a reprojection
+    # supplies, and an ordinary write leaves the type bare beside a block still
+    # declaring the source's EPSG:3857 (#848).
+    #
+    # Built for parquet-geo-only too, which drops it again below: there the
+    # logical type is the column's only geometry identity, so losing the CRS is
+    # not a disagreement but a silent relabelling of projected coordinates.
+    geo_meta = _build_geo_block(
+        table,
+        geometry_column,
+        original_metadata,
+        input_crs,
+        custom_metadata,
+        metadata_version,
+        edges,
+        geometry_info,
+        verbose,
+    )
+
+    # A column the block does not name falls back to what the input declared for
+    # it: on the table entry points the block is built from `original_metadata`,
+    # which is None there, while the carrier decision still has to see the
+    # secondaries the table's own carried key names.
+    declared_crs = dict(carried_geo.get("columns") or {})
+    declared_crs.update((geometry_info or {}).get("metadata", {}))
+    declared_crs.update(geo_meta.get("columns") or {})
+    native_crs = native_geometry_crs(
+        effective_version, {"columns": declared_crs}, geometry_column, geometry_info
+    )
+
+    # Step 2: Handle geometry columns based on version.
     #
     # EVERY geometry column, not just the primary: validation applies the same
     # per-version requirements to each column in geo["columns"], and a secondary
@@ -1675,30 +1715,11 @@ def _apply_geoparquet_metadata(
     # version and dependent on whether anything imported geoarrow.pyarrow (#706).
     # Each column carries its OWN crs -- giving a secondary the primary's fails
     # v2_crs_consistency.
-    from geoparquet_io.core.write_strategies.base import resolve_geometry_columns
-
-    # The table entry points (`write_geoparquet_table`, the strategies'
-    # `write_from_table`) get no `geometry_info`, so fall back to naming the
-    # secondaries from the carried geo metadata -- otherwise they would silently
-    # keep the single-column behaviour this loop exists to replace.
-    # `original_metadata` is deliberately None on the table entry points (passing
-    # it there would smuggle the input's stale geo block into the output), so the
-    # secondary names come from the table's own carried key instead. This feeds
-    # the carrier decision only -- step 2 still builds metadata from
-    # `original_metadata` as passed.
-    carried_geo = _parse_geo_metadata_quietly(original_metadata) or _parse_geo_metadata_quietly(
-        table.schema.metadata
-    )
-    column_metadata = dict(carried_geo.get("columns") or {})
-    column_metadata.update((geometry_info or {}).get("metadata", {}))
     for column in sorted(resolve_geometry_columns(geometry_column, geometry_info, carried_geo)):
         if column not in table.column_names:
             continue
-        column_crs = (
-            input_crs if column == geometry_column else column_metadata.get(column, {}).get("crs")
-        )
         table = _process_geometry_column_for_version(
-            table, column, effective_version, column_crs, verbose
+            table, column, effective_version, native_crs.get(column), verbose
         )
 
     if effective_version in ("1.0", "1.1"):
@@ -1706,72 +1727,70 @@ def _apply_geoparquet_metadata(
             table, resolve_geometry_columns(geometry_column, geometry_info, carried_geo), verbose
         )
 
-    # Step 2: Build and apply geo metadata (unless parquet-geo-only)
+    # Step 3: Apply the geo metadata (unless parquet-geo-only)
     if not should_add_geo_metadata:
-        # parquet-geo-only means no GeoParquet metadata at all. Step 1 has just
+        # parquet-geo-only means no GeoParquet metadata at all. Step 2 has just
         # given the column a native Parquet GEOMETRY logical type, so a 'geo'
         # key carried in from the input would declare a version whose spec
         # forbids that type (issue #687). Drop it, keeping unrelated KV
         # metadata, to match the other write paths.
         return _strip_geo_metadata_key(table, verbose)
 
-    # Detect bbox column from table schema
-    bbox_column = _detect_bbox_column_from_table(table, verbose)
-    bbox_info = {
-        "has_bbox_column": bbox_column is not None,
-        "bbox_column_name": bbox_column,
-    }
+    # Stats are read off the written data, so they are filled in after step 2.
+    col_meta = geo_meta["columns"][geometry_column]
+    if "geometry_types" not in col_meta:
+        col_meta["geometry_types"] = _compute_geometry_types(table, geometry_column, verbose)
 
-    # Create geo metadata using existing helper
+    computed_bbox = _compute_bbox_from_data(table, geometry_column, verbose)
+    if computed_bbox:
+        col_meta["bbox"] = computed_bbox
+
+    return _assemble_and_apply_geo_metadata(table, geo_meta, metadata_version, verbose)
+
+
+def _build_geo_block(
+    table,
+    geometry_column: str,
+    original_metadata: dict | None,
+    input_crs: dict | None,
+    custom_metadata: dict | None,
+    metadata_version: str,
+    edges: str | None,
+    geometry_info: dict | None,
+    verbose: bool,
+) -> dict:
+    """Build the output's ``geo`` block, with the primary column's CRS resolved.
+
+    Everything here reads the table's *schema* only -- the bbox-covering probe --
+    so it can run before the geometry columns are retyped, which is what lets the
+    native Parquet GEOMETRY types be built from the CRS this declares (#848).
+    The per-column stats that need the data (``geometry_types``, ``bbox``) are
+    filled in by the caller afterwards.
+    """
+    bbox_column = _detect_bbox_column_from_table(table, verbose)
     geo_meta = create_geo_metadata(
         original_metadata,
         geometry_column,
-        bbox_info,
+        {"has_bbox_column": bbox_column is not None, "bbox_column_name": bbox_column},
         custom_metadata,
         verbose,
         version=metadata_version,
         edges=edges,
     )
 
-    # Ensure geometry_types is set (required by GeoParquet spec)
-    col_meta = geo_meta.get("columns", {}).get(geometry_column, {})
-    if "geometry_types" not in col_meta:
-        col_meta["geometry_types"] = _compute_geometry_types(table, geometry_column, verbose)
-        geo_meta["columns"][geometry_column] = col_meta
+    # Set/clear the geometry column's crs per the GeoParquet null-vs-default rule
+    # (shared helper is the single source of truth across all write paths).
+    columns = geo_meta.setdefault("columns", {})
+    apply_output_crs(columns.setdefault(geometry_column, {}), input_crs)
+    if verbose and input_crs and not is_default_crs(input_crs):
+        debug(f"Added CRS to geo metadata: {_format_crs_display(input_crs)}")
 
-    # Compute file-level bbox from geometry data
-    computed_bbox = _compute_bbox_from_data(table, geometry_column, verbose)
-    if computed_bbox:
-        col_meta["bbox"] = computed_bbox
-        geo_meta["columns"][geometry_column] = col_meta
+    # Secondary entries are merged in here rather than after the stats pass, so
+    # each one's own `crs` is available to the native-type decision.
+    from geoparquet_io.core.write_strategies.base import merge_secondary_geometry_metadata
 
-    # Handle secondary geometry columns from geometry_info
-    if geometry_info:
-        secondary_columns = geometry_info.get("secondary", [])
-        column_metadata = geometry_info.get("metadata", {})
-
-        for sec_col in secondary_columns:
-            if sec_col not in geo_meta["columns"]:
-                geo_meta["columns"][sec_col] = {}
-
-            sec_meta = geo_meta["columns"][sec_col]
-
-            # Copy metadata from input for secondary columns
-            if sec_col in column_metadata:
-                input_sec_meta = column_metadata[sec_col]
-                for key, value in input_sec_meta.items():
-                    # Preserve input metadata (crs, encoding, geometry_types, etc.)
-                    if key not in sec_meta:
-                        sec_meta[key] = value
-
-            # Ensure encoding is set (required by spec)
-            if "encoding" not in sec_meta:
-                sec_meta["encoding"] = "WKB"
-
-    # Assemble and apply final metadata
-    return _assemble_and_apply_geo_metadata(
-        table, geometry_column, geo_meta, input_crs, metadata_version, verbose
-    )
+    merge_secondary_geometry_metadata(geo_meta, geometry_info)
+    return geo_meta
 
 
 def _estimate_row_size(table) -> int:

--- a/geoparquet_io/core/write_strategies/arrow_streaming.py
+++ b/geoparquet_io/core/write_strategies/arrow_streaming.py
@@ -25,7 +25,11 @@ from geoparquet_io.core.geoarrow_encoding import (
     native_wkb_type,
 )
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
-from geoparquet_io.core.write_strategies.base import BaseWriteStrategy
+from geoparquet_io.core.write_strategies.base import (
+    BaseWriteStrategy,
+    merge_secondary_geometry_metadata,
+    native_geometry_crs,
+)
 
 if TYPE_CHECKING:
     import duckdb
@@ -340,7 +344,10 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 f"Available columns: {schema.names}"
             )
 
-        # Build geo metadata
+        # Build geo metadata. Built even for parquet-geo-only, which writes no
+        # `geo` block: the native Parquet GEOMETRY types below are keyed off the
+        # CRS the block declares per column, so it is what the types come from
+        # before it is dropped (#848). Discarded immediately afterwards.
         geo_meta = self._build_geo_metadata_for_query(
             schema,
             geometry_column,
@@ -348,12 +355,16 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             input_crs,
             verbose,
             version_config["metadata_version"],
-            should_add_geo_metadata,
             precomputed_geom_types,
             precomputed_bbox,
             geometry_info,
             geoarrow_encoding=geoarrow_encoding,
         )
+        native_crs = native_geometry_crs(
+            geoparquet_version, geo_meta, geometry_column, geometry_info
+        )
+        if not should_add_geo_metadata:
+            geo_meta = None
 
         # Prepare writer kwargs
         writer_kwargs = {"compression": validated_compression or "NONE"}
@@ -378,7 +389,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             geometry_column,
             geo_meta,
             use_native_geometry,
-            input_crs,
+            native_crs,
             precomputed_geom_types,
             writer_kwargs,
             verbose,
@@ -416,18 +427,18 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         input_crs: dict | None,
         verbose: bool,
         metadata_version: str,
-        should_add_geo_metadata: bool,
         precomputed_geom_types: list[str],
         precomputed_bbox: list[float] | None,
         geometry_info: dict | None = None,
         geoarrow_encoding: str | None = None,
-    ) -> dict | None:
-        """Build geo metadata for query results."""
+    ) -> dict:
+        """Build geo metadata for query results.
+
+        Always returns a block, even for parquet-geo-only: the caller keys the
+        native Parquet GEOMETRY types off it and then drops it (#848).
+        """
         from geoparquet_io.core.crs_utils import apply_output_crs
         from geoparquet_io.core.geo_metadata import create_geo_metadata
-
-        if not should_add_geo_metadata:
-            return None
 
         bbox_info = _detect_bbox_column(schema)
         geo_meta = create_geo_metadata(
@@ -452,27 +463,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             col_meta["encoding"] = geoarrow_encoding
 
         # Handle secondary geometry columns from geometry_info
-        if geometry_info:
-            secondary_columns = geometry_info.get("secondary", [])
-            column_metadata = geometry_info.get("metadata", {})
-
-            for sec_col in secondary_columns:
-                if sec_col not in geo_meta["columns"]:
-                    geo_meta["columns"][sec_col] = {}
-
-                sec_meta = geo_meta["columns"][sec_col]
-
-                # Copy metadata from input for secondary columns
-                if sec_col in column_metadata:
-                    input_sec_meta = column_metadata[sec_col]
-                    for key, value in input_sec_meta.items():
-                        # Preserve input metadata (crs, encoding, geometry_types, etc.)
-                        if key not in sec_meta:
-                            sec_meta[key] = value
-
-                # Ensure encoding is set (required by spec)
-                if "encoding" not in sec_meta:
-                    sec_meta["encoding"] = "WKB"
+        merge_secondary_geometry_metadata(geo_meta, geometry_info)
 
         return geo_meta
 
@@ -484,7 +475,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geometry_column: str,
         geo_meta: dict | None,
         use_native_geometry: bool,
-        input_crs: dict | None,
+        native_crs: dict[str, dict | None],
         precomputed_geom_types: list[str],
         writer_kwargs: dict,
         verbose: bool,
@@ -503,7 +494,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 geometry_column,
                 geo_meta,
                 use_native_geometry,
-                input_crs,
+                native_crs,
                 writer_kwargs,
                 verbose,
                 extra_kv_metadata=extra_kv_metadata,
@@ -517,7 +508,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             geometry_column=geometry_column,
             geo_meta=geo_meta,
             use_native_geometry=use_native_geometry,
-            input_crs=input_crs,
+            native_crs=native_crs,
             geom_types=precomputed_geom_types,
             verbose=verbose,
             extra_kv_metadata=extra_kv_metadata,
@@ -553,7 +544,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geometry_column: str,
         geo_meta: dict | None,
         use_native_geometry: bool,
-        input_crs: dict | None,
+        native_crs: dict[str, dict | None],
         writer_kwargs: dict,
         verbose: bool,
         extra_kv_metadata: dict[str, str] | None = None,
@@ -566,7 +557,7 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             geometry_column=geometry_column,
             geo_meta=geo_meta,
             use_native_geometry=use_native_geometry,
-            input_crs=input_crs,
+            native_crs=native_crs,
             geom_types=[],
             verbose=verbose,
             extra_kv_metadata=extra_kv_metadata,
@@ -715,9 +706,8 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geoarrow_target_type = None
         geoarrow_encoding = None
 
-        geo_meta = None
+        geom_types: list[str] = []
         if should_add_geo_metadata:
-            bbox_info = {"has_bbox_column": False, "bbox_column_name": None}
             geom_types = _compute_geometry_types(table, geometry_column, verbose)
 
             if geoarrow_native:
@@ -736,30 +726,37 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
                 if verbose:
                     debug(f"1.1-geoarrow target encoding: {geoarrow_encoding}")
 
-            geo_meta = create_geo_metadata(
-                original_metadata=None,
-                geom_col=geometry_column,
-                bbox_info=bbox_info,
-                custom_metadata=custom_metadata,
-                verbose=verbose,
-                version=metadata_version,
-            )
-            geo_meta["columns"][geometry_column]["encoding"] = "WKB"
-            geo_meta["columns"][geometry_column]["geometry_types"] = geom_types
+        # Built for every version, parquet-geo-only included: it writes no `geo`
+        # block, but the native Parquet GEOMETRY types are keyed off the CRS this
+        # resolves per column, so it is built first and dropped after (#848).
+        geo_meta = create_geo_metadata(
+            original_metadata=None,
+            geom_col=geometry_column,
+            bbox_info={"has_bbox_column": False, "bbox_column_name": None},
+            custom_metadata=custom_metadata,
+            verbose=verbose,
+            version=metadata_version,
+        )
+        geo_meta["columns"][geometry_column]["encoding"] = "WKB"
+        geo_meta["columns"][geometry_column]["geometry_types"] = geom_types
 
-            apply_output_crs(geo_meta["columns"][geometry_column], input_crs)
+        apply_output_crs(geo_meta["columns"][geometry_column], input_crs)
 
-            # Override encoding when geoarrow_target_type resolved a native encoding.
-            # geoarrow_encoding is "WKB" for mixed/unconvertible geometry — no override.
-            if geoarrow_encoding is not None and geoarrow_encoding != "WKB":
-                geo_meta["columns"][geometry_column]["encoding"] = geoarrow_encoding
+        # Override encoding when geoarrow_target_type resolved a native encoding.
+        # geoarrow_encoding is "WKB" for mixed/unconvertible geometry — no override.
+        if geoarrow_encoding is not None and geoarrow_encoding != "WKB":
+            geo_meta["columns"][geometry_column]["encoding"] = geoarrow_encoding
+
+        native_crs = native_geometry_crs(effective_version, geo_meta, geometry_column)
+        if not should_add_geo_metadata:
+            geo_meta = None
 
         schema_with_meta = self._build_streaming_schema(
             schema=table.schema,
             geometry_column=geometry_column,
             geo_meta=geo_meta,
             use_native_geometry=use_native_geometry,
-            input_crs=input_crs,
+            native_crs=native_crs,
             geom_types=geo_meta["columns"][geometry_column]["geometry_types"] if geo_meta else [],
             verbose=verbose,
             extra_kv_metadata=extra_kv_metadata,
@@ -801,14 +798,22 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
         geometry_column: str,
         geo_meta: dict | None,
         use_native_geometry: bool,
-        input_crs: dict | None,
+        native_crs: dict[str, dict | None],
         geom_types: list[str],
         verbose: bool,
         extra_kv_metadata: dict[str, str] | None = None,
         geoarrow_target_type=None,
         geometry_columns: set[str] | None = None,
     ) -> pa.Schema:
-        """Build the output schema for streaming write."""
+        """Build the output schema for streaming write.
+
+        ``native_crs`` maps each geometry column to the CRS its ``geo`` entry
+        declares, from ``native_geometry_crs``; empty when the target version
+        writes plain BYTE_ARRAY WKB. It replaces the ``input_crs`` this used to
+        take: a caller only supplies one when it is *changing* the CRS, so on
+        every other write the primary column was typed with ``None`` while the
+        block kept the source's EPSG:3857 -- the disagreement in #848.
+        """
         schema_metadata = dict(schema.metadata or {})
 
         geo_columns = set(geometry_columns or ())
@@ -820,19 +825,13 @@ class ArrowStreamingStrategy(BaseWriteStrategy):
             # validation requires a native Parquet GEOMETRY type for each column in
             # geo["columns"], and under parquet-geo-only (which writes no geo
             # metadata) the logical type is a column's only geometry identity.
-            # Each column carries its own CRS — the primary's from input_crs, a
-            # secondary's from its geo metadata — so the native type stays
-            # consistent with what the metadata declares.
-            column_crs = {
-                name: (geo_meta or {}).get("columns", {}).get(name, {}).get("crs")
-                for name in geo_columns
-            }
-            column_crs[geometry_column] = input_crs
+            # Each column's CRS comes from the geo entry built for that same
+            # column, so the type and the block cannot disagree (#848).
             if verbose:
-                with_crs = sorted(name for name, crs in column_crs.items() if crs)
+                with_crs = sorted(name for name, crs in native_crs.items() if crs)
                 debug(f"Native Parquet GEOMETRY type for {sorted(geo_columns)}, CRS on {with_crs}")
             new_fields = [
-                pa.field(field.name, native_wkb_type(column_crs[field.name]))
+                pa.field(field.name, native_wkb_type(native_crs.get(field.name)))
                 if field.name in geo_columns
                 else field
                 for field in schema

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -50,6 +50,74 @@ def resolve_geometry_columns(
     return columns
 
 
+def native_geometry_crs(
+    geoparquet_version: str,
+    geo_meta: dict | None,
+    geometry_column: str,
+    geometry_info: dict | None = None,
+) -> dict[str, dict | None]:
+    """Geometry columns needing a native Parquet GEOMETRY type, each with its CRS.
+
+    Empty below 2.0, where geometry is plain BYTE_ARRAY WKB and the CRS lives in
+    the ``geo`` block alone.
+
+    EVERY declared geometry column, not just the primary: 2.0 validation applies
+    the same requirement to each column in ``geo["columns"]``, and under
+    parquet-geo-only -- which writes no ``geo`` block at all -- the logical type
+    is a column's only geometry identity (#706).
+
+    Each CRS is read back out of the metadata just built for the file, so the
+    type and the block cannot disagree (``v2_crs_consistency``). A column the
+    block gives no ``crs`` is the spec default, and carries none in its type.
+
+    ``geo_meta`` is therefore the *output's* block, after ``apply_output_crs``
+    has resolved a requested ``input_crs`` against what the source declared --
+    never the source's own. Callers that write no block (parquet-geo-only) still
+    build one and key the types off it, because the alternative is what #848 was:
+    the primary column typed from an ``input_crs`` that is ``None`` on every
+    write except a reprojection, and so left bare beside a block declaring
+    EPSG:3857.
+
+    One definition, shared by every strategy: the streaming writer's output
+    schema, the disk-rewrite writer's, and the in-memory path in
+    ``common._apply_geoparquet_metadata``.
+    """
+    if geoparquet_version not in ("2.0", "parquet-geo-only"):
+        return {}
+
+    column_metadata = (geo_meta or {}).get("columns") or {}
+    return {
+        column: (column_metadata.get(column) or {}).get("crs")
+        for column in resolve_geometry_columns(geometry_column, geometry_info, geo_meta)
+    }
+
+
+def merge_secondary_geometry_metadata(geo_meta: dict, geometry_info: dict | None) -> None:
+    """Give every secondary geometry column an entry in ``geo["columns"]``.
+
+    Each secondary keeps the metadata the input declared for it -- crucially its
+    own ``crs``, which is what the native Parquet GEOMETRY type is then built
+    from -- and gains the ``encoding`` the spec requires when the input named
+    none. Existing keys win, so a caller that has already resolved something for
+    the column is not overwritten.
+
+    Mutates ``geo_meta`` in place. Shared by the three write paths that build a
+    block from ``geometry_info``: this module's ``build_geo_metadata``, the
+    streaming strategy's, and ``common._apply_geoparquet_metadata``.
+    """
+    if not geometry_info:
+        return
+
+    column_metadata = geometry_info.get("metadata") or {}
+    for sec_col in geometry_info.get("secondary") or ():
+        sec_meta = geo_meta.setdefault("columns", {}).setdefault(sec_col, {})
+        for key, value in column_metadata.get(sec_col, {}).items():
+            if key not in sec_meta:
+                sec_meta[key] = value
+        if "encoding" not in sec_meta:
+            sec_meta["encoding"] = "WKB"
+
+
 def build_geo_metadata(
     geometry_column: str,
     geoparquet_version: str,
@@ -137,27 +205,7 @@ def build_geo_metadata(
                 col_meta[key] = value
 
     # Handle secondary geometry columns from geometry_info
-    if geometry_info:
-        secondary_columns = geometry_info.get("secondary", [])
-        column_metadata = geometry_info.get("metadata", {})
-
-        for sec_col in secondary_columns:
-            if sec_col not in geo_meta["columns"]:
-                geo_meta["columns"][sec_col] = {}
-
-            sec_meta = geo_meta["columns"][sec_col]
-
-            # Copy metadata from input for secondary columns
-            if sec_col in column_metadata:
-                input_sec_meta = column_metadata[sec_col]
-                for key, value in input_sec_meta.items():
-                    # Preserve input metadata (crs, encoding, geometry_types, etc.)
-                    if key not in sec_meta:
-                        sec_meta[key] = value
-
-            # Ensure encoding is set (required by spec)
-            if "encoding" not in sec_meta:
-                sec_meta["encoding"] = "WKB"
+    merge_secondary_geometry_metadata(geo_meta, geometry_info)
 
     # 'covering' is 1.1-only: drop whatever the source file or custom_metadata carried
     return strip_unsupported_covering(geo_meta, geoparquet_version)

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -30,7 +30,7 @@ from geoparquet_io.core.write_strategies.arrow_streaming import to_geoarrow_colu
 from geoparquet_io.core.write_strategies.base import (
     BaseWriteStrategy,
     build_geo_metadata,
-    resolve_geometry_columns,
+    native_geometry_crs,
 )
 from geoparquet_io.core.write_strategies.row_group_sizing import (
     _resolve_row_group_rows,
@@ -39,36 +39,6 @@ from geoparquet_io.core.write_strategies.row_group_sizing import (
 
 if TYPE_CHECKING:
     import duckdb
-
-
-def _native_geometry_crs(
-    geoparquet_version: str,
-    geo_meta: dict,
-    geometry_column: str,
-    geometry_info: dict | None,
-) -> dict[str, dict | None]:
-    """Geometry columns needing a native Parquet GEOMETRY type, each with its CRS.
-
-    Empty below 2.0, where geometry is plain BYTE_ARRAY WKB and the CRS lives in
-    the ``geo`` block alone.
-
-    EVERY declared geometry column, not just the primary: 2.0 validation applies
-    the same requirement to each column in ``geo["columns"]``, and under
-    parquet-geo-only -- which writes no ``geo`` block at all -- the logical type
-    is a column's only geometry identity (#706).
-
-    Each CRS is read back out of the metadata just built for the file, so the
-    type and the block cannot disagree (``v2_crs_consistency``). A column the
-    block gives no ``crs`` is the spec default, and carries none in its type.
-    """
-    if geoparquet_version not in ("2.0", "parquet-geo-only"):
-        return {}
-
-    column_metadata = geo_meta.get("columns") or {}
-    return {
-        column: (column_metadata.get(column) or {}).get("crs")
-        for column in resolve_geometry_columns(geometry_column, geometry_info, geo_meta)
-    }
 
 
 def _native_geometry_schema(schema: pa.Schema, native_crs: dict[str, dict | None]) -> pa.Schema:
@@ -251,7 +221,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
             # (#764). parquet-geo-only additionally writes no `geo` block: the
             # one built above is still what the native types are keyed off, but
             # it names a null version, which DuckDB refuses to open.
-            native_crs = _native_geometry_crs(
+            native_crs = native_geometry_crs(
                 geoparquet_version, geo_meta, geometry_column, geometry_info
             )
             if verbose and native_crs:

--- a/tests/test_streaming_write_determinism.py
+++ b/tests/test_streaming_write_determinism.py
@@ -173,7 +173,7 @@ class TestCanonicalStreamingSchema:
             geometry_column="geometry",
             geo_meta=json.loads(json.dumps(GEO_1_1)),
             use_native_geometry=False,
-            input_crs=None,
+            native_crs={},
             geom_types=["Point"],
             verbose=False,
         )

--- a/tests/test_write_strategies.py
+++ b/tests/test_write_strategies.py
@@ -1488,43 +1488,6 @@ class TestNativeGeometryTypeAcrossStrategies:
         assert _failed_checks(out) == []
         assert json.loads(pq.read_schema(out).metadata[b"geo"])["version"] == f"{version}.0"
 
-    def test_disk_rewrite_native_type_carries_the_declared_crs(self, tmp_path):
-        """A projected CRS reaches the logical type, which is where 2.0 keeps it.
-
-        Asserted on the file's own logical type rather than on the Arrow field:
-        ``WkbType.__eq__`` ignores the CRS, so comparing PyArrow types cannot
-        tell a CRS84 column from an EPSG:3857 one. ``v2_crs_consistency`` is the
-        check that notices, and it is in ``_failed_checks`` below.
-        """
-        import pyproj
-
-        crs = pyproj.CRS.from_authority("EPSG", "3857").to_json_dict()
-        geo_meta = {
-            "version": "1.1.0",
-            "primary_column": "geometry",
-            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"], "crs": crs}},
-        }
-        points = [struct.pack("<BI2d", 1, 1, float(i) * 1000, float(i) * 1000) for i in range(3)]
-        table = pa.table({"id": [0, 1, 2], "geometry": points})
-        source = str(tmp_path / "src_3857.parquet")
-        pq.write_table(
-            table.replace_schema_metadata({b"geo": json.dumps(geo_meta).encode()}), source
-        )
-        out = str(tmp_path / "disk_rewrite_crs.parquet")
-
-        _write_via_query(source, out, "2.0", "disk-rewrite")
-
-        con = get_duckdb_connection(load_spatial=False)
-        try:
-            logical = con.execute(
-                f"SELECT logical_type FROM parquet_schema({sql_path(out)}) WHERE name = 'geometry'"
-            ).fetchone()[0]
-        finally:
-            con.close()
-        assert "Pseudo-Mercator" in str(logical)
-        assert json.loads(pq.read_schema(out).metadata[b"geo"])["columns"]["geometry"]["crs"] == crs
-        assert _failed_checks(out) == []
-
     @pytest.mark.parametrize("strategy", ["disk-rewrite", "streaming"])
     def test_verbose_write_names_the_native_columns(self, strategy, tmp_path, caplog):
         """The verbose branch of the native path is code too, and says which columns.
@@ -1602,3 +1565,235 @@ class TestNativeWkbTypeHelpers:
 
         assert converted.type.storage_type == pa.large_binary()
         assert converted.storage.to_pylist() == [self.WKB_POINT]
+
+
+# ---------------------------------------------------------------------------
+# The native GEOMETRY type's CRS agrees with the geo block's (#848)
+# ---------------------------------------------------------------------------
+
+
+def _type_crs(path: str) -> dict[str, tuple[str, int] | None]:
+    """``(authority, code)`` carried by each geometry column's Parquet logical type.
+
+    Read back through PyArrow with ``geoarrow.pyarrow`` imported, which is what
+    resolves a native GEOMETRY logical type into a typed field carrying its CRS.
+    ``None`` means the type carries no CRS, i.e. the file claims the spec default.
+
+    Not comparable by PyArrow type equality: ``WkbType.__eq__`` ignores the CRS,
+    so a CRS84 column and an EPSG:3857 one compare equal.
+    """
+    import geoarrow.pyarrow  # noqa: F401  -- registers the extension type
+
+    schema = pq.read_schema(path)
+    return {
+        name: _crs_identity(getattr(schema.field(name).type, "crs", None))
+        for name in ("geometry", "geom2")
+        if name in schema.names
+    }
+
+
+def _block_crs(path: str) -> dict[str, tuple[str, int] | None]:
+    """``(authority, code)`` each column's ``geo`` entry declares; ``{}`` with no block."""
+    geo = json.loads((pq.read_schema(path).metadata or {}).get(b"geo") or b"{}")
+    return {
+        name: _crs_identity(entry.get("crs")) for name, entry in (geo.get("columns") or {}).items()
+    }
+
+
+def _crs_identity(crs) -> tuple[str, int] | None:
+    """Normalize a PROJJSON dict or a geoarrow CRS object down to its authority code."""
+    if crs is None:
+        return None
+    if not isinstance(crs, dict):
+        crs = json.loads(crs.to_json())
+    identity = crs.get("id") or {}
+    return (identity.get("authority"), identity.get("code")) if identity else None
+
+
+def _projected_source(tmp_path, *, secondary: bool) -> str:
+    """A 1.1 source whose geometry columns each declare their own projected CRS."""
+    import pyproj
+
+    columns = {
+        "geometry": {
+            "encoding": "WKB",
+            "geometry_types": ["Point"],
+            "crs": pyproj.CRS.from_authority("EPSG", "3857").to_json_dict(),
+        }
+    }
+    points = [struct.pack("<BI2d", 1, 1, float(i) * 1000, float(i) * 1000) for i in range(6)]
+    data = {"id": [0, 1, 2], "geometry": points[:3]}
+    if secondary:
+        columns["geom2"] = {
+            "encoding": "WKB",
+            "geometry_types": ["Point"],
+            "crs": pyproj.CRS.from_authority("EPSG", "27700").to_json_dict(),
+        }
+        data["geom2"] = points[3:]
+
+    geo_meta = {"version": "1.1.0", "primary_column": "geometry", "columns": columns}
+    source = str(tmp_path / "projected.parquet")
+    pq.write_table(
+        pa.table(data).replace_schema_metadata({b"geo": json.dumps(geo_meta).encode()}), source
+    )
+    return source
+
+
+class TestNativeGeometryCrsAcrossStrategies:
+    """Every strategy takes the logical type's CRS from the ``geo`` block it just built.
+
+    Regression suite for #848. At 2.0 the CRS lives in both the native Parquet
+    GEOMETRY logical type and the ``geo`` block, and ``gpio check spec`` requires
+    them to agree. ``duckdb-kv`` and (since #764) ``disk-rewrite`` read each
+    column's CRS out of the metadata built for that same file; the two Arrow-side
+    strategies built the type from the incoming Arrow field alone, so a write that
+    threads no ``input_crs`` -- the ordinary case, since only a reprojection
+    supplies one -- produced a bare Geometry type beside a block declaring
+    EPSG:3857, failing ``v2_crs_consistency_geometry`` and
+    ``v2_crs_in_parquet_type_geometry`` on gpio's own output.
+
+    Under parquet-geo-only there is no block to disagree with and nothing fails
+    those two checks -- the type is the column's only geometry identity, so
+    dropping the CRS silently relabels projected coordinates as CRS84. That is
+    the worse bug of the two, and it is ``coordinates_valid_for_crs`` that
+    catches it.
+    """
+
+    @pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+    @pytest.mark.parametrize("version", NATIVE_VERSIONS)
+    def test_primary_crs_reaches_the_logical_type(self, strategy, version, tmp_path):
+        """The issue's reproducer: one projected geometry column, no ``input_crs``."""
+        source = _projected_source(tmp_path, secondary=False)
+        out = str(tmp_path / f"{strategy}_{version}.parquet")
+
+        _write_via_query(source, out, version, strategy)
+
+        assert _type_crs(out) == {"geometry": ("EPSG", 3857)}
+        if version == "2.0":
+            assert _block_crs(out) == {"geometry": ("EPSG", 3857)}
+        assert _failed_checks(out) == []
+
+    @pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+    @pytest.mark.parametrize("version", NATIVE_VERSIONS)
+    def test_each_column_takes_its_own_crs(self, strategy, version, tmp_path):
+        """A secondary column's type carries *its* CRS, not the primary's (#706)."""
+        source = _projected_source(tmp_path, secondary=True)
+        out = str(tmp_path / f"{strategy}_{version}_two.parquet")
+
+        _write_via_query(
+            source,
+            out,
+            version,
+            strategy,
+            geometry_info={
+                "primary": "geometry",
+                "secondary": ["geom2"],
+                "metadata": {
+                    "geom2": json.loads(pq.read_schema(source).metadata[b"geo"])["columns"]["geom2"]
+                },
+            },
+        )
+
+        assert _type_crs(out) == {"geometry": ("EPSG", 3857), "geom2": ("EPSG", 27700)}
+        if version == "2.0":
+            assert _block_crs(out) == {"geometry": ("EPSG", 3857), "geom2": ("EPSG", 27700)}
+        assert _failed_checks(out) == []
+
+    @pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+    def test_a_requested_crs_still_wins_over_the_source_crs(self, strategy, tmp_path):
+        """``input_crs`` is the output CRS when a caller threads one, on every strategy.
+
+        The reprojection case, and the guard against fixing one disagreement into
+        another: the block applies ``input_crs``, so the type has to follow it
+        rather than the CRS the *source* declared.
+        """
+        import pyproj
+
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        crs = pyproj.CRS.from_authority("EPSG", "3857").to_json_dict()
+        out = str(tmp_path / f"{strategy}_requested.parquet")
+
+        _write_via_query(source, out, "2.0", strategy, input_crs=crs)
+
+        assert _type_crs(out) == {"geometry": ("EPSG", 3857)}
+        assert _block_crs(out) == {"geometry": ("EPSG", 3857)}
+
+    def test_streaming_table_entry_point_keeps_the_crs_with_no_geo_block(self, tmp_path):
+        """``Table.write()`` under parquet-geo-only: the type is the only identity left.
+
+        The streaming strategy builds a block for this version too and drops it
+        again, which is the only thing keeping a requested CRS on the column once
+        there is no ``geo`` key to read it back out of.
+
+        Asserted on the logical type alone: this entry point still lets the
+        *input's* carried ``geo`` key ride into the output, which is the separate
+        leak tracked in #773 and is not what this write path decides.
+        """
+        import pyproj
+
+        crs = pyproj.CRS.from_authority("EPSG", "3857").to_json_dict()
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / "streaming_table_geo_only.parquet")
+
+        WriteStrategyFactory.get_strategy(WriteStrategy.ARROW_STREAMING).write_from_table(
+            table=pq.read_table(source),
+            output_path=out,
+            geometry_column="geometry",
+            geoparquet_version="parquet-geo-only",
+            compression="ZSTD",
+            compression_level=None,
+            row_group_size_mb=None,
+            row_group_rows=None,
+            verbose=False,
+            input_crs=crs,
+        )
+
+        assert _type_crs(out) == {"geometry": ("EPSG", 3857)}
+
+    def test_verbose_write_names_the_crs_it_put_in_the_block(self, tmp_path, caplog):
+        """The in-memory path logs the CRS it resolved; an f-string only ``--verbose`` runs."""
+        import pyproj
+
+        source = _write_points_geoparquet(tmp_path / "src.parquet", 3)
+        out = str(tmp_path / "verbose_crs.parquet")
+
+        with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+            _write_via_query(
+                source,
+                out,
+                "2.0",
+                "in-memory",
+                verbose=True,
+                input_crs=pyproj.CRS.from_authority("EPSG", "3857").to_json_dict(),
+            )
+
+        assert "added crs to geo metadata" in caplog.text.lower()
+        assert _type_crs(out) == {"geometry": ("EPSG", 3857)}
+
+
+class TestMergeSecondaryGeometryMetadata:
+    """The one definition of "give every secondary column a ``geo`` entry"."""
+
+    def test_an_undeclared_secondary_still_gets_the_required_encoding(self):
+        """``encoding`` is required by the spec, so a column the input left bare gets WKB."""
+        from geoparquet_io.core.write_strategies.base import merge_secondary_geometry_metadata
+
+        geo_meta = {"columns": {"geometry": {"encoding": "WKB"}}}
+
+        merge_secondary_geometry_metadata(geo_meta, {"secondary": ["geom2"], "metadata": {}})
+
+        assert geo_meta["columns"]["geom2"] == {"encoding": "WKB"}
+
+    def test_the_input_metadata_wins_over_the_default(self):
+        """A declared secondary keeps its own crs and encoding -- what the native type reads."""
+        from geoparquet_io.core.write_strategies.base import merge_secondary_geometry_metadata
+
+        crs = {"id": {"authority": "EPSG", "code": 27700}}
+        geo_meta = {"columns": {"geometry": {"encoding": "WKB"}}}
+
+        merge_secondary_geometry_metadata(
+            geo_meta,
+            {"secondary": ["geom2"], "metadata": {"geom2": {"encoding": "point", "crs": crs}}},
+        )
+
+        assert geo_meta["columns"]["geom2"] == {"encoding": "point", "crs": crs}


### PR DESCRIPTION
> **Stacked on #847** (`fix/disk-rewrite-native-geometry-types-764`), because this reuses the `_native_geometry_crs()` helper that PR introduced. **Retarget to `main` after #847 merges.**

## What changed

At 2.0 the CRS lives in *both* the native Parquet GEOMETRY logical type and the `geo` block, and `gpio check spec` requires them to agree. `duckdb-kv` and (since #847) `disk-rewrite` read each column's CRS out of the metadata built for that same file. The two Arrow-side strategies built the type from the incoming Arrow field plus `input_crs` — and only a reprojection supplies an `input_crs` — so an ordinary write left the primary column's type bare beside a block still declaring the source's EPSG:3857.

- **`core/write_strategies/base.py`** — #847's `_native_geometry_crs()` moved here from `disk_rewrite.py` as `native_geometry_crs()`, so all four strategies share one definition (`geo_meta` may now be `None`). New `merge_secondary_geometry_metadata()` replaces the same 20-line secondary-column loop that was open-coded in three places.
- **`core/write_strategies/arrow_streaming.py`** — `_build_streaming_schema` (and the two frames that feed it) take `native_crs` instead of `input_crs`; that parameter existed *only* to type the native geometry column, so this is a replacement, not an addition. Both entry points now build the `geo` block for parquet-geo-only as well, key the native types off it, and then drop it — which is what restores the CRS on a version that writes no block at all.
- **`core/common.py`** (`_apply_geoparquet_metadata`, the in-memory path) — the block is built **before** the geometry columns are retyped rather than after, extracted into `_build_geo_block()`; every column's carrier now takes its CRS from `native_crs`. `_assemble_and_apply_geo_metadata` loses the `geometry_column`/`input_crs` parameters, since the CRS is resolved upstream now.
- **`core/write_strategies/disk_rewrite.py`** — import-only: the helper it defined now lives in `base`. This is the one file of #847's that this PR touches, and only to avoid duplicating the helper the issue asked me to reuse.

Where the output block does not name a column (the `Table.write()` entry points build it from `original_metadata=None`), the carrier decision still falls back to what the input declared for that column, so no secondary loses the CRS it had.

## Why

`gpio check spec` failed on gpio's own output. Under parquet-geo-only it was worse rather than better: there is no block to disagree with, the logical type is the column's only geometry identity, and the missing CRS silently relabelled projected coordinates as CRS84.

## Verification

Reproducer: a 1.1 source declaring EPSG:3857 on `geometry` and EPSG:27700 on a secondary `geom2`, rewritten through each strategy with no `input_crs`.

**Before** (`origin/fix/disk-rewrite-native-geometry-types-764`):

```
=== 2.0 / duckdb-kv        types: {geometry: EPSG:3857, geom2: EPSG:27700}   failed: []
=== 2.0 / in-memory        types: {geometry: None,      geom2: EPSG:27700}   failed: ['v2_crs_consistency_geometry', 'v2_crs_in_parquet_type_geometry']
=== 2.0 / streaming        types: {geometry: None,      geom2: EPSG:27700}   failed: ['v2_crs_consistency_geometry', 'v2_crs_in_parquet_type_geometry']
=== 2.0 / disk-rewrite     types: {geometry: EPSG:3857, geom2: EPSG:27700}   failed: []

=== parquet-geo-only / duckdb-kv     types: {geometry: EPSG:3857, geom2: EPSG:27700}   failed: []
=== parquet-geo-only / in-memory     types: {geometry: None,      geom2: EPSG:27700}   failed: ['coordinates_valid_for_crs_geometry']
=== parquet-geo-only / streaming     types: {geometry: None,      geom2: None}         failed: ['coordinates_valid_for_crs_geom2', 'coordinates_valid_for_crs_geometry']
=== parquet-geo-only / disk-rewrite  types: {geometry: EPSG:3857, geom2: EPSG:27700}   failed: []
```

The `geo` block declared `EPSG:3857` / `EPSG:27700` in every 2.0 row above — that is the disagreement.

**After** — all eight rows are `types: {geometry: EPSG:3857, geom2: EPSG:27700}` / `failed: []`.

New tests (`tests/test_write_strategies.py::TestNativeGeometryCrsAcrossStrategies`), four strategies × `2.0` and `parquet-geo-only`: 8 failed / 12 passed before the fix, all pass after. #847's single-strategy `test_disk_rewrite_native_type_carries_the_declared_crs` is subsumed by the parametrized version and was removed.

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5447 passed, 64 skipped, 2 xfailed in 136.46s

$ uv run diff-cover coverage.xml --compare-branch=origin/fix/disk-rewrite-native-geometry-types-764 --fail-under=90
geoparquet_io/core/common.py (100%)
geoparquet_io/core/write_strategies/arrow_streaming.py (100%)
geoparquet_io/core/write_strategies/base.py (100%)
geoparquet_io/core/write_strategies/disk_rewrite.py (100%)
Total: 56 lines / Missing: 0 lines / Coverage: 100%

$ uv run pre-commit run --all-files                          # all passed
$ uv run pre-commit run --all-files --hook-stage pre-push    # mypy, vulture, xenon, import-linter, deptry all passed
```

No new row-group geo-statistics assertions were added, so the win32 exclusions in the existing matrix helper (`_failed_checks`) are untouched.

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
