### PR TITLE
chore(release): mark #841 breaking in the changelog title override

### DIFF
--- a/scripts/release_title_overrides.json
+++ b/scripts/release_title_overrides.json
@@ -21,5 +21,6 @@
   "654": "docs(deps): record why the duckdb pin also holds the TRY() workaround",
   "656": "fix(convert): keep CSV rows whose geometry is NULL",
   "669": "build(deps): raise the pip floor to 26.2 for PYSEC-2026-3721",
-  "778": "fix(deps)!: require duckdb>=1.5.2 and withdraw S2 until the geography extension returns"
+  "778": "fix(deps)!: require duckdb>=1.5.2 and withdraw S2 until the geography extension returns",
+  "841": "fix(api)!: return the same dict from partition_by_admin as the other partition methods"
 }


### PR DESCRIPTION
## What changed
Adds a `release_title_overrides.json` entry giving #841 the `fix(api)!:` type for the changelog.

## Why
#841 replaces the documented `{'status': 'completed'}` return of `partition_by_kdtree`/`partition_by_string` (#808) with the uniform partition dict — a Python-API behavior change this repo marks with `!` (#845, #855). The retitle raced the auto-merge, so the squash commit on main lacks the marker; per the repo's convention, the override fixes the changelog without touching history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS