### PR TITLE
fix(validate): fail closed on a free-form Parquet GEOMETRY crs instead of reading it as CRS84

### DIFF
--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -292,7 +292,12 @@ Validates file structure and metadata against the GeoParquet specification:
   reference names a metadata key this check cannot look up, so it is compared
   conservatively: it reports a mismatch rather than guessing. A type whose CRS
   gpio cannot read would otherwise look like one that names no CRS, which the
-  Parquet spec defines as OGC:CRS84 — a claim the file never made.
+  Parquet spec defines as OGC:CRS84 — a claim the file never made. The Parquet
+  `crs` property is free-form, so an unrecognized value (`4326`, `WGS 84`, raw
+  WKT, an authority code PROJ does not carry) is treated the same way: it is
+  carried through verbatim, `native_crs_format` warns with the literal, and
+  `v2_crs_consistency` compares it as-is, so it fails closed and names the value
+  it could not read rather than reading it as the default.
 - **Datum-aware epoch validation** — a coordinate `epoch` on a datum ensemble
   (e.g. EPSG:4326, or the OGC:CRS84 default when `crs` is omitted) fails; on a
   specific static frame (e.g. GDA2020) it warns; on a dynamic frame (e.g. ITRF)

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -7,6 +7,7 @@ CRS information from GeoParquet files and other spatial formats.
 
 import json
 import os
+import re
 from functools import lru_cache
 from typing import Any
 
@@ -853,6 +854,19 @@ def parse_crs_string_to_projjson(crs_string, con=None):
 #: With ``SET geometry_always_xy = true`` this is interchangeable with EPSG:4326.
 DEFAULT_TARGET_CRS = "OGC:CRS84"
 
+#: The only shape :func:`crs_string_for_transform` may ever return.
+#:
+#: The same strict quote-free ``<authority>:<code>`` shape the logical-type
+#: parser enforced before #870 (``_AUTHORITY_CODE_CRS`` in
+#: ``core/duckdb_metadata.py``). #866/#870 made the parser carry *arbitrary*
+#: free-form ``crs`` strings through so validation can fail closed on them --
+#: but a value headed for ``ST_Transform`` is headed for SQL, so this choke
+#: point restores the old invariant for transforms: authority code or nothing.
+#: The sinks still SQL-escape on top of this (defense in depth, and the
+#: reproject path legitimately passes PROJJSON strings that bypass this
+#: helper).
+_TRANSFORM_CRS_SHAPE = re.compile(r"^[A-Za-z][A-Za-z0-9_.\-]*:[A-Za-z0-9_.\-]+$")
+
 
 def crs_string_for_transform(crs) -> str | None:
     """Return an ``"AUTH:CODE"`` CRS string for ``ST_Transform``, or ``None``.
@@ -861,6 +875,11 @@ def crs_string_for_transform(crs) -> str | None:
     default (OGC:CRS84 / EPSG:4326), or is not identifiable as an authority code.
     ``crs`` may be PROJJSON (as returned by :func:`extract_crs_from_parquet`) or
     an ``"AUTH:CODE"`` string.
+
+    The result is guaranteed to match :data:`_TRANSFORM_CRS_SHAPE`: a file's
+    free-form ``crs`` (carried through for validation since #866) or a hostile
+    PROJJSON ``id`` must never come out of here, because callers interpolate
+    the result into SQL.
     """
     if not crs or is_default_crs(crs):
         return None
@@ -868,7 +887,10 @@ def crs_string_for_transform(crs) -> str | None:
     if not identifier:
         return None
     authority, code = identifier
-    return f"{authority}:{code}"
+    candidate = f"{authority}:{code}"
+    if not _TRANSFORM_CRS_SHAPE.match(candidate):
+        return None
+    return candidate
 
 
 def transform_geom_sql(geom_expr: str, source_crs, target_crs: str = DEFAULT_TARGET_CRS) -> str:

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -701,23 +701,40 @@ def resolve_authority_code_crs(crs_value: Any) -> Any:
     return crs_value if projjson is None else json.loads(projjson)
 
 
+#: The DuckDB spellings of "this geo logical type declares no CRS at all".
+#:
+#: DuckDB renders a CRS-less type as ``crs=`` and a null one as ``crs=<null>``.
+#: These two are the *only* values that may become None here: the Parquet spec
+#: defines "no CRS" as OGC:CRS84, so anything else mapped to None would become a
+#: CRS84 claim the file never made (#866).
+_NO_CRS_TOKENS = frozenset({"", "<null>"})
+
+#: DuckDB's own parameter after ``crs=`` on a ``GEOGRAPHY`` logical type.
+#:
+#: The Parquet ``crs`` field is free-form and may itself contain commas (WKT
+#: does), so the value ends here rather than at the first comma.
+_ALGORITHM_PARAM = ", algorithm="
+
+
 def _parse_crs_property(params: str) -> Any:
     """The ``crs=`` property of a geo logical type's parameters, or None if it has none.
 
-    The property has four shapes, and this returns each one as the value it
-    means:
+    Returns the property as the value it means:
 
     - ``crs=`` / ``crs=<null>`` -- the type declares no CRS: None
     - ``crs={...}`` -- inline PROJJSON: the parsed dict
-    - ``crs=srid:XXXX`` / ``crs=projjson:key`` -- a reference: the string, for
-      :func:`resolve_crs_reference` to look up
-    - ``crs=EPSG:32633`` -- a bare authority code: the string, likewise
+    - anything else -- the literal string, for :func:`resolve_crs_reference` to
+      resolve. That covers the spec's named forms (``srid:XXXX``,
+      ``projjson:key``, a bare authority code like ``EPSG:32633``) *and* the
+      free-form values the Parquet spec also permits (``4326``, ``WGS 84``,
+      raw WKT). An unresolvable value stays a string all the way through, so
+      the CRS checks compare it as-is and fail closed.
 
     Returning None for "declares no CRS" is what keeps the ``crs`` key out of
     :func:`parse_geometry_logical_type`'s result; callers read that absence as
     the Parquet spec's OGC:CRS84 default, so no *unrecognized* value may reach
     it -- that would turn a CRS the file names into a CRS84 claim it never made
-    (#814).
+    (#814, #866).
     """
     crs_start = params.find("crs=")
     if crs_start == -1:
@@ -744,13 +761,10 @@ def _parse_crs_property(params: str) -> Any:
         except json.JSONDecodeError:
             return crs_json_str
 
-    # Every other form is a single token, ending at the next parameter.
-    token = crs_value.split(",", 1)[0].strip()
-    if token.lower().startswith(_PREFIXED_CRS_FORMS):
-        return token
-    if _authority_code_crs(token) is not None:
-        return token
-    return None
+    # Every other form is one free-form value, ending at DuckDB's own trailing
+    # algorithm parameter when there is one.
+    token = crs_value.split(_ALGORITHM_PARAM, 1)[0].strip()
+    return None if token.lower() in _NO_CRS_TOKENS else token
 
 
 def parse_geometry_logical_type(logical_type: str) -> dict | None:
@@ -764,6 +778,14 @@ def parse_geometry_logical_type(logical_type: str) -> dict | None:
     - GeometryType(crs=EPSG:32633)
 
     Returns dict with keys: geo_type, geometry_type, coordinate_dimension, crs, algorithm
+
+    The ``crs`` key tells three states apart, and callers must keep them apart:
+    *absent* means the type declares no CRS (the Parquet spec's OGC:CRS84
+    default), a dict is resolved inline PROJJSON, and a **string** is a CRS the
+    type does name but this function does not resolve -- a reference form for
+    :func:`resolve_crs_reference`, or a free-form value (``4326``, ``WGS 84``,
+    WKT) that nothing can resolve. A string is never the default: reading one as
+    CRS84 invents a claim the file never made (#866).
     """
     if not logical_type:
         return None

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -754,7 +754,11 @@ def _parse_crs_property(params: str) -> Any:
                     end_pos = i + 1
                     break
         if end_pos == 0:
-            return None
+            # Unbalanced braces: malformed, but still a CRS the type *declares*.
+            # Carry the raw value through as a string so it fails closed
+            # downstream, exactly like unparsable-JSON below -- mapping it to
+            # None would read as the OGC:CRS84 default (#866).
+            return crs_value
         crs_json_str = crs_value[:end_pos]
         try:
             return json.loads(crs_json_str)

--- a/geoparquet_io/core/geojson_stream.py
+++ b/geoparquet_io/core/geojson_stream.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import duckdb
 
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
 from geoparquet_io.core.geometry_detection import STANDARD_GEOMETRY_NAMES
 from geoparquet_io.core.geometry_repair import repair_geometry_sql
 
@@ -176,9 +176,12 @@ def _build_feature_query(
     # repair_geometry_sql repeats its argument, and ST_Transform is far too
     # expensive to evaluate once per repetition per row.
     if source_crs:
+        # source_crs comes straight out of a file's own geo metadata, so it can
+        # be any free-form string -- escape it like every other SQL literal.
+        source_crs_literal = _escape_sql_string(source_crs)
         source_ref = (
             f"(SELECT * REPLACE ("
-            f"ST_Transform({quoted_geom}, '{source_crs}', '{WGS84_CRS}') AS {quoted_geom}"
+            f"ST_Transform({quoted_geom}, '{source_crs_literal}', '{WGS84_CRS}') AS {quoted_geom}"
             f") FROM {source_ref} WHERE {quoted_geom} IS NOT NULL)"
         )
 

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -28,7 +28,11 @@ from geoparquet_io.core.crs_utils import (
     parse_crs_string_to_projjson,
     resolve_crs_to_string,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    get_duckdb_connection,
+    quote_identifier,
+)
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geo_metadata import strip_derived_stats
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
@@ -200,14 +204,18 @@ def reproject_table(
 
         # Build reprojection query
         # Use ST_AsWKB to convert back to WKB format for GeoParquet compatibility
+        # The CRS values come from file metadata (or the caller) and may be
+        # free-form strings, so they are escaped like any other SQL literal.
+        source_crs_literal = _escape_sql_string(effective_source_crs)
+        target_crs_literal = _escape_sql_string(target_crs)
         query = f"""
             SELECT
                 * EXCLUDE ({quote_identifier(geom_col)}),
                 ST_AsWKB(
                     ST_Transform(
                         {quote_identifier(geom_col)},
-                        '{effective_source_crs}',
-                        '{target_crs}'
+                        '{source_crs_literal}',
+                        '{target_crs_literal}'
                     )
                 ) AS {quote_identifier(geom_col)}
             FROM {source_table}
@@ -471,6 +479,12 @@ def reproject_impl(
         # geometry_always_xy is set at connection level (DuckDB 1.5+)
         log("Reprojecting...")
 
+        # The detected source CRS may be a free-form string a file carried in
+        # its metadata or Parquet geo type (#866), so both CRS values are
+        # escaped like any other SQL literal.
+        source_crs_literal = _escape_sql_string(effective_source_crs)
+        target_crs_literal = _escape_sql_string(target_crs)
+
         # Build bbox regeneration clause if input had bbox column
         if bbox_col:
             # Use CTE to avoid computing ST_Transform multiple times
@@ -480,8 +494,8 @@ def reproject_impl(
                         * EXCLUDE ({exclude_clause}),
                         ST_Transform(
                             {quote_identifier(geom_col)},
-                            '{effective_source_crs}',
-                            '{target_crs}'
+                            '{source_crs_literal}',
+                            '{target_crs_literal}'
                         ) AS {quote_identifier(geom_col)}
                     FROM '{input_url}'
                 )
@@ -503,8 +517,8 @@ def reproject_impl(
                     * EXCLUDE ({exclude_clause}),
                     ST_Transform(
                         {quote_identifier(geom_col)},
-                        '{effective_source_crs}',
-                        '{target_crs}'
+                        '{source_crs_literal}',
+                        '{target_crs_literal}'
                     ) AS {quote_identifier(geom_col)}
                 FROM '{input_url}'
             """
@@ -683,6 +697,12 @@ def _reproject_streaming(
             # Quote column names to handle special characters (colons, spaces, etc.)
             exclude_clause = ", ".join(quote_identifier(c) for c in exclude_cols)
 
+            # The detected source CRS may be a free-form string a file carried
+            # in its metadata or Parquet geo type (#866), so both CRS values
+            # are escaped like any other SQL literal.
+            source_crs_literal = _escape_sql_string(effective_source_crs)
+            target_crs_literal = _escape_sql_string(target_crs)
+
             # Build reprojection query with bbox regeneration if input had bbox
             if bbox_col:
                 # Use CTE to compute reprojected geometry once, then regenerate bbox
@@ -692,8 +712,8 @@ def _reproject_streaming(
                             * EXCLUDE ({exclude_clause}),
                             ST_Transform(
                                 {quote_identifier(geom_col)},
-                                '{effective_source_crs}',
-                                '{target_crs}'
+                                '{source_crs_literal}',
+                                '{target_crs_literal}'
                             ) AS {quote_identifier(geom_col)}
                         FROM '{working_url}'
                     )
@@ -713,8 +733,8 @@ def _reproject_streaming(
                         * EXCLUDE ({exclude_clause}),
                         ST_Transform(
                             {quote_identifier(geom_col)},
-                            '{effective_source_crs}',
-                            '{target_crs}'
+                            '{source_crs_literal}',
+                            '{target_crs_literal}'
                         ) AS {quote_identifier(geom_col)}
                     FROM '{working_url}'
                 """

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2566,9 +2566,25 @@ def _check_v2_crs_consistency(geo_meta: dict, schema_info: list, geom_col: str) 
         name=f"v2_crs_consistency_{geom_col}",
         status=CheckStatus.FAILED,
         message="CRS in geo metadata must match CRS in Parquet schema",
-        details=f"Metadata: {get_crs_display_name(metadata_crs)}, Schema: {get_crs_display_name(schema_crs)}",
+        details=f"Metadata: {get_crs_display_name(metadata_crs)}, "
+        f"Schema: {_schema_crs_display(schema_crs)}",
         category="geoparquet_2_0",
     )
+
+
+def _schema_crs_display(schema_crs: Any) -> str:
+    """The Parquet geo type's CRS, as it should read in a mismatch message.
+
+    A value still in string form is one gpio could not resolve to a CRS -- the
+    Parquet ``crs`` property is free-form, so it may be anything from a
+    ``projjson:<key>`` this check cannot look up to ``WGS 84`` or raw WKT. Print
+    it verbatim *and* say it was not recognized: on its own the literal reads
+    like a CRS gpio understood and rejected, which is the opposite of what
+    happened (#866).
+    """
+    if isinstance(schema_crs, str):
+        return f"{schema_crs} (unrecognized CRS form, compared as-is)"
+    return get_crs_display_name(schema_crs)
 
 
 def _edges_schema_facts(schema_info: list, geom_col: str) -> tuple[bool, bool, str | None]:
@@ -2692,6 +2708,22 @@ def _check_parquet_geo_only_crs(
 
             # Resolve CRS reference if needed for further checks
             crs = resolve_crs_reference(parquet_file, raw_crs)
+
+            # Still a string means nothing resolved it: the Parquet crs property
+            # is free-form, so this is a value like "4326" or "WGS 84" that no
+            # reader can be relied on to interpret. Report it before the
+            # is_geographic_crs heuristic below, which pattern-matches "4326"
+            # into a confident "CRS is geographic" gpio cannot back (#866).
+            if isinstance(crs, str):
+                return ValidationCheck(
+                    name=f"parquet_geo_only_crs_{geom_col}",
+                    status=CheckStatus.WARNING,
+                    message=f'column "{geom_col}" CRS format may not be widely recognized',
+                    details=f"CRS: {crs}. This is not inline PROJJSON, srid:<id>, "
+                    "projjson:<key> or a resolvable <authority>:<code>. "
+                    "Use 'gpio convert --geoparquet-version 2.0' to standardize.",
+                    category="parquet_geo_types",
+                )
 
             # Check if CRS is geographic (WGS84, EPSG:4326, OGC:CRS84)
             if is_geographic_crs(crs):

--- a/tests/test_crs_transform_injection.py
+++ b/tests/test_crs_transform_injection.py
@@ -1,0 +1,201 @@
+"""File-controlled CRS strings must never reach transform SQL unescaped.
+
+#866/#870 made the Parquet geo logical-type parser carry *arbitrary* free-form
+``crs`` strings through (so validation can fail closed on them, instead of
+misreading them as the OGC:CRS84 default). Before that, only quote-free
+``<authority>:<code>`` strings could come out of the parser, and the raw
+``'{source_crs}'`` interpolations in the ST_Transform sinks were safe by
+accident. Two layers now enforce what used to be incidental:
+
+1. :func:`crs_string_for_transform` -- the choke point every "give me a CRS
+   string for ST_Transform" helper funnels through -- only ever returns the
+   strict ``<authority>:<code>`` shape. A free-form value stays available for
+   validation, but never becomes a transform argument.
+2. The ST_Transform sinks (``core/reproject.py``, ``core/geojson_stream.py``)
+   escape whatever they interpolate via ``_escape_sql_string``, because the
+   reproject path may legitimately pass a PROJJSON *string* to ST_Transform.
+
+The probe values below were verified against the unfixed branch: a file whose
+geo type declares ``crs=EPSG:'||(SELECT '4326')||'`` reprojected successfully
+(the injected subquery evaluated to ``EPSG:4326``), and ``X:1'||(SELECT
+'pwned')||'`` failed with "Could not create projection: X:1PWNED" -- i.e. the
+attacker-controlled SQL executed inside the query.
+"""
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from pyproj import CRS as PyprojCRS
+
+from geoparquet_io.core.crs_utils import crs_string_for_transform
+from geoparquet_io.core.duckdb_metadata import parse_geometry_logical_type
+from geoparquet_io.core.duckdb_utils import _escape_sql_string
+from geoparquet_io.core.geojson_stream import _build_feature_query
+from geoparquet_io.core.reproject import reproject_impl, reproject_table
+from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+
+#: Values verified to execute as SQL on the unfixed branch (see module docstring).
+INJECTION_CRS_VALUES = [
+    "EPSG:'||(SELECT '4326')||'",
+    "X:1'||(SELECT 'pwned')||'",
+]
+
+#: Free-form values a Parquet writer may legally emit; none is an authority code.
+FREEFORM_CRS_VALUES = [
+    "4326",
+    "WGS 84",
+    'GEOGCS["WGS 84",DATUM["WGS_1984"]]',
+    "EPSG:12 34",  # colon-bearing, but not the quote-free authority-code shape
+]
+
+
+def _write_geo_type_crs_file(tmp_path, name: str, parquet_crs: str, metadata_crs) -> str:
+    """Write a real file whose Parquet geo type carries ``parquet_crs`` verbatim.
+
+    geoarrow-pyarrow writes the CRS string onto the GEOMETRY logical type
+    unchanged, which is exactly how a hostile or merely free-form value arrives
+    in the wild. ``metadata_crs="ABSENT"`` omits the geo-metadata ``crs`` key so
+    detection falls through to the Parquet geo type.
+    """
+    import geoarrow.pyarrow as ga
+    import shapely
+
+    wkb = [bytes(w) for w in shapely.to_wkb(shapely.points([[500000.0, 5000000.0]]))]
+    array = ga.wkb().with_crs(parquet_crs).wrap_array(pa.array(wkb, type=pa.binary()))
+    col_meta: dict = {"encoding": "WKB", "geometry_types": ["Point"]}
+    if metadata_crs != "ABSENT":
+        col_meta["crs"] = metadata_crs
+    geo = {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": col_meta}}
+    table = pa.table({"geometry": array})
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode("utf-8")})
+    out = tmp_path / name
+    pq.write_table(table, out)
+    return str(out)
+
+
+# =============================================================================
+# Layer 1: the transform choke point only returns the authority-code shape
+# =============================================================================
+
+
+class TestCrsStringForTransformRejectsFreeform:
+    @pytest.mark.parametrize("value", INJECTION_CRS_VALUES)
+    def test_the_verified_probe_values_return_none(self, value):
+        assert crs_string_for_transform(value) is None
+
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_free_form_values_return_none(self, value):
+        assert crs_string_for_transform(value) is None
+
+    def test_a_projjson_dict_with_an_injected_code_returns_none(self):
+        crs = {"id": {"authority": "EPSG", "code": "'||(SELECT '4326')||'"}}
+        assert crs_string_for_transform(crs) is None
+
+    def test_a_projjson_dict_with_an_injected_authority_returns_none(self):
+        crs = {"id": {"authority": "EPSG'||x||'", "code": 3857}}
+        assert crs_string_for_transform(crs) is None
+
+    def test_never_returns_a_string_containing_a_quote(self):
+        for value in INJECTION_CRS_VALUES:
+            result = crs_string_for_transform(value)
+            assert result is None or "'" not in result
+
+    def test_legitimate_authority_codes_still_pass(self):
+        assert crs_string_for_transform("EPSG:3857") == "EPSG:3857"
+        assert crs_string_for_transform("EPSG:28992") == "EPSG:28992"
+
+    def test_a_legitimate_projjson_dict_still_passes(self):
+        crs = {"id": {"authority": "EPSG", "code": 5070}}
+        assert crs_string_for_transform(crs) == "EPSG:5070"
+
+
+# =============================================================================
+# Layer 2: the ST_Transform sinks escape what they interpolate
+# =============================================================================
+
+
+class TestGeojsonFeatureQueryEscapesSourceCrs:
+    def test_a_quote_bearing_source_crs_is_escaped_in_the_query(self):
+        injected = INJECTION_CRS_VALUES[0]
+        query = _build_feature_query(
+            "'input.parquet'", "geometry", [], source_crs=injected, repair_geometry=False
+        )
+        assert f"'{injected}'" not in query  # the raw, executable form
+        assert _escape_sql_string(injected) in query  # the inert literal
+
+
+class TestReprojectInjectionIsInert:
+    """End to end: the injected SQL must not execute -- reproject must FAIL.
+
+    On the unfixed branch the first probe file reprojects *successfully*
+    because ``(SELECT '4326')`` runs inside the query and evaluates to a valid
+    CRS. A clean failure whose message carries the un-evaluated literal is the
+    proof the value arrived as data, not SQL.
+    """
+
+    def test_file_reproject_of_an_injected_geo_type_crs_fails_cleanly(self, tmp_path):
+        path = _write_geo_type_crs_file(
+            tmp_path, "inject.parquet", "EPSG:'||(SELECT '4326')||'", "ABSENT"
+        )
+        out = str(tmp_path / "out.parquet")
+        with pytest.raises(Exception) as excinfo:
+            reproject_impl(path, out, target_crs="EPSG:3857")
+        # The subquery arrived as data: it is still in the message, un-evaluated.
+        assert "(SELECT '4326')" in str(excinfo.value)
+
+    def test_table_reproject_of_an_injected_metadata_crs_fails_cleanly(self):
+        import shapely
+
+        wkb = [bytes(w) for w in shapely.to_wkb(shapely.points([[500000.0, 5000000.0]]))]
+        geo = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "crs": "X:1'||(SELECT 'pwned')||'"}},
+        }
+        table = pa.table({"geometry": pa.array(wkb, type=pa.binary())})
+        table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode("utf-8")})
+        with pytest.raises(Exception) as excinfo:
+            reproject_table(table, target_crs="EPSG:4326")
+        # On the unfixed branch this concatenates to "X:1PWNED" -- the injected
+        # SQL executed. Fixed, the quoted subquery survives as an inert literal
+        # (the identifier path upper-cases the carried string, hence lower()).
+        assert "X:1PWNED" not in str(excinfo.value)
+        assert "'||(select 'pwned')||'" in str(excinfo.value).lower()
+
+    def test_a_legitimate_epsg_3857_file_still_reprojects(self, tmp_path):
+        path = _write_geo_type_crs_file(
+            tmp_path,
+            "webmercator.parquet",
+            "EPSG:3857",
+            PyprojCRS.from_epsg(3857).to_json_dict(),
+        )
+        out = str(tmp_path / "out.parquet")
+        result = reproject_impl(path, out, target_crs="EPSG:4326")
+        assert result.feature_count == 1
+        assert Path(out).exists()
+
+
+# =============================================================================
+# S3: an unbalanced-brace PROJJSON crs must fail closed, not read as CRS84
+# =============================================================================
+
+
+class TestUnbalancedProjjsonFailsClosed:
+    def test_the_parser_carries_the_malformed_value_as_a_string(self):
+        result = parse_geometry_logical_type('GeometryType(crs={"type": "GeographicCRS")')
+        assert result is not None
+        assert "crs" in result
+        assert result["crs"] == '{"type": "GeographicCRS"'
+
+    def test_unbalanced_brace_crs_with_absent_metadata_fails_consistency(self, tmp_path):
+        """Was PASSED "both are OGC:CRS84" -- a claim the file never made."""
+        path = _write_geo_type_crs_file(
+            tmp_path, "unbalanced.parquet", '{"type": "GeographicCRS"', "ABSENT"
+        )
+        result = validate_geoparquet(path, validate_data=False)
+        check = next(c for c in result.checks if c.name == "v2_crs_consistency_geometry")
+        assert check.status is CheckStatus.FAILED
+        assert "GeographicCRS" in (check.details or "")

--- a/tests/test_parquet_authority_code_crs.py
+++ b/tests/test_parquet_authority_code_crs.py
@@ -12,6 +12,12 @@ That made ``_check_v2_crs_consistency`` wrong in both directions: a real mismatc
 match (both naming EPSG:3857) failed. The two prefix forms have the same
 ``a:b`` shape as the compact one, so the assertions below also pin that
 ``srid:``/``projjson:`` keep winning over the new branch.
+
+#866 is the same bug one step out: the Parquet spec's ``crs`` field is *free
+form*, so ``crs=4326``, ``crs=WGS 84`` or a raw WKT string are all legal values
+gpio cannot resolve. Those still fell off the end of the parser as "no crs key",
+i.e. as a positive OGC:CRS84 claim. They now come through as unresolved strings
+and fail closed, exactly like the unknown authority ``FOO:BAR`` already did.
 """
 
 import json
@@ -292,12 +298,13 @@ def _write_compact_crs_file(tmp_path, name: str, parquet_crs: str, metadata_crs)
 
     wkb = [bytes(w) for w in shapely.to_wkb(shapely.points([[500000.0, 5000000.0]]))]
     array = ga.wkb().with_crs(parquet_crs).wrap_array(pa.array(wkb, type=pa.binary()))
+    col_meta: dict = {"encoding": "WKB", "geometry_types": ["Point"]}
+    if metadata_crs != "ABSENT":  # "ABSENT" omits the key, i.e. the CRS84 default
+        col_meta["crs"] = metadata_crs
     geo = {
         "version": "2.0.0",
         "primary_column": "geometry",
-        "columns": {
-            "geometry": {"encoding": "WKB", "geometry_types": ["Point"], "crs": metadata_crs}
-        },
+        "columns": {"geometry": col_meta},
     }
     table = pa.table({"geometry": array})
     table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode("utf-8")})
@@ -339,3 +346,174 @@ class TestCompactCrsFileValidatesEndToEnd:
         crs = extract_crs_from_parquet(str(out))
         assert isinstance(crs, dict)
         assert crs["id"] == {"authority": "EPSG", "code": 32633}
+
+
+# =============================================================================
+# #866: a free-form crs the parser cannot resolve must never read as CRS84
+# =============================================================================
+
+#: Legal Parquet ``crs`` values gpio cannot resolve to a CRS.
+#:
+#: The Parquet geospatial spec leaves the field free form, so each of these is a
+#: value a writer may legitimately emit; none of them is "this type declares no
+#: CRS", which is the *only* thing the OGC:CRS84 default may be read from.
+FREEFORM_CRS_VALUES = [
+    "4326",  # a bare EPSG code, no authority
+    "WGS 84",  # a CRS name
+    "EPSG:",  # an authority with an empty code
+    "EPSG:abc",  # an authority with a code PROJ does not carry
+    'GEOGCS["WGS 84",DATUM["WGS_1984"]]',  # WKT1 — note the embedded comma
+    'PROJCRS["WGS 84 / UTM zone 33N"]',  # WKT2
+]
+
+
+class TestParserCarriesFreeformCrsThrough:
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_the_literal_value_arrives_under_the_crs_key(self, value):
+        """Was: no ``crs`` key at all, which callers read as the CRS84 default."""
+        result = parse_geometry_logical_type(f"GeometryType(crs={value})")
+        assert result is not None
+        assert result["crs"] == value
+
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_a_freeform_crs_is_distinguishable_from_declaring_no_crs(self, value):
+        declared = parse_geometry_logical_type(f"GeometryType(crs={value})")
+        absent = parse_geometry_logical_type("GeometryType(crs=)")
+        assert declared is not None and absent is not None
+        assert "crs" in declared and "crs" not in absent
+
+    def test_a_freeform_crs_survives_a_trailing_algorithm_parameter(self):
+        """The value ends at DuckDB's own ``, algorithm=``, not at the first comma."""
+        result = parse_geometry_logical_type(
+            'GeographyType(crs=GEOGCS["WGS 84",DATUM["WGS_1984"]], algorithm=spherical)'
+        )
+        assert result is not None
+        assert result["crs"] == 'GEOGCS["WGS 84",DATUM["WGS_1984"]]'
+        assert result["algorithm"] == "spherical"
+
+    def test_a_freeform_crs_alongside_positional_params(self):
+        result = parse_geometry_logical_type("GeometryType(Point, XY, crs=WGS 84)")
+        assert result is not None
+        assert result["crs"] == "WGS 84"
+        assert result["geometry_type"] == "Point"
+        assert result["coordinate_dimension"] == "XY"
+
+
+class TestFreeformCrsFailsClosedInConsistency:
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_an_absent_metadata_crs_is_a_mismatch_not_a_shared_crs84_claim(self, value):
+        """Was PASSED "both are OGC:CRS84" — a claim neither carrier ever made."""
+        check = _check_v2_crs_consistency(
+            _geo_meta({}), _schema(f"GeometryType(crs={value})"), "geometry"
+        )
+        assert check.status is CheckStatus.FAILED
+        assert value in (check.details or "")
+
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_a_named_metadata_crs_is_a_mismatch_showing_the_literal(self, value):
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": EPSG3857_PROJJSON}),
+            _schema(f"GeometryType(crs={value})"),
+            "geometry",
+        )
+        assert check.status is CheckStatus.FAILED
+        assert value in (check.details or "")
+        assert "unrecognized" in (check.details or "")
+
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_an_explicit_crs84_metadata_crs_is_still_a_mismatch(self, value):
+        check = _check_v2_crs_consistency(
+            _geo_meta({"crs": CRS84_ID}), _schema(f"GeometryType(crs={value})"), "geometry"
+        )
+        assert check.status is CheckStatus.FAILED
+
+
+class TestFreeformCrsIsReportedAsAnUnrecognizedForm:
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_native_crs_format_warns_with_the_literal(self, value):
+        check = _check_native_crs_format(_schema(f"GeometryType(crs={value})"), "geometry")
+        assert check.status is CheckStatus.WARNING
+        assert value in (check.details or "")
+
+    @pytest.mark.parametrize("value", FREEFORM_CRS_VALUES)
+    def test_parquet_geo_only_crs_warns_with_the_literal(self, value):
+        """``4326`` must not slip through the is-geographic heuristic as a pass."""
+        check = _check_parquet_geo_only_crs(
+            _schema(f"GeometryType(crs={value})"), "geometry", "any_file.parquet"
+        )
+        assert check.status is CheckStatus.WARNING
+        assert value in (check.details or "")
+
+
+class TestRecognizedFormsAreUnchangedByTheFreeformBranch:
+    """The four resolvable shapes and the no-CRS shape keep their #851 behavior."""
+
+    @pytest.mark.parametrize(
+        "logical_type",
+        [
+            "GeometryType(crs=<null>)",
+            "GeometryType(crs=)",
+            "GeographyType(crs=, algorithm=spherical)",
+            "GeographyType(crs=<null>, algorithm=spherical)",
+            "GeographyType(algorithm=spherical)",
+        ],
+    )
+    def test_no_crs_declared_still_leaves_no_crs_key(self, logical_type):
+        result = parse_geometry_logical_type(logical_type)
+        assert result is not None
+        assert "crs" not in result
+
+    @pytest.mark.parametrize(
+        "logical_type,expected",
+        [
+            ("GeometryType(crs=srid:5070)", "srid:5070"),
+            ("GeometryType(crs=srid:0)", "srid:0"),
+            ("GeometryType(crs=projjson:my_crs)", "projjson:my_crs"),
+            ("GeometryType(crs=EPSG:32633)", "EPSG:32633"),
+        ],
+    )
+    def test_the_reference_forms_still_parse_to_themselves(self, logical_type, expected):
+        result = parse_geometry_logical_type(logical_type)
+        assert result is not None
+        assert result["crs"] == expected
+
+    def test_inline_projjson_still_parses_to_a_dict(self):
+        result = parse_geometry_logical_type(
+            'GeometryType(crs={"type": "ProjectedCRS", '
+            '"id": {"authority": "EPSG", "code": 5070}}, algorithm=planar)'
+        )
+        assert result is not None
+        assert result["crs"]["id"]["code"] == 5070
+        assert result["algorithm"] == "planar"
+
+
+class TestFreeformCrsFileValidatesEndToEnd:
+    """A real file, because the parser and the checks must agree on a live schema."""
+
+    def test_a_freeform_crs_against_a_named_metadata_crs_fails(self, tmp_path):
+        path = _write_compact_crs_file(
+            tmp_path, "freeform_mismatch.parquet", "WGS 84", EPSG3857_PROJJSON
+        )
+        result = validate_geoparquet(path, validate_data=False)
+        check = next(c for c in result.checks if c.name == "v2_crs_consistency_geometry")
+        assert check.status is CheckStatus.FAILED
+        assert "Schema: WGS 84 (unrecognized" in (check.details or "")
+
+    def test_a_freeform_crs_against_an_absent_metadata_crs_fails(self, tmp_path):
+        """The #866 headline: this reported PASSED "both are OGC:CRS84"."""
+        path = _write_compact_crs_file(tmp_path, "freeform_absent.parquet", "WGS 84", "ABSENT")
+        result = validate_geoparquet(path, validate_data=False)
+        check = next(c for c in result.checks if c.name == "v2_crs_consistency_geometry")
+        assert check.status is CheckStatus.FAILED
+        assert "WGS 84" in (check.details or "")
+
+    def test_inspect_reports_the_freeform_crs_as_a_mismatch_naming_the_literal(self, tmp_path):
+        """``gpio inspect`` must render the string, not swallow it or show a dict."""
+        from geoparquet_io.core.inspect_utils import _format_crs_for_display, extract_geo_info
+
+        path = _write_compact_crs_file(
+            tmp_path, "freeform_inspect.parquet", "WGS 84", EPSG3857_PROJJSON
+        )
+        info = extract_geo_info(path)
+        assert any("WGS 84" in w for w in info["warnings"])
+        assert _format_crs_for_display("WGS 84") == "WGS 84"


### PR DESCRIPTION
## What changed

`_parse_crs_property` in `core/duckdb_metadata.py` no longer ends with a bare
`return None`. Only the two spellings of "this type declares no CRS" — `crs=`
and `crs=<null>` — become `None`; every other value is carried through as the
literal string, for `resolve_crs_reference` to resolve if it can. The value now
ends at DuckDB's own trailing `, algorithm=` parameter rather than at the first
comma, so a WKT literal (which contains commas) is reported whole.

Downstream, three checks in `core/validate.py`:

- `v2_crs_consistency` compares the unresolved string as-is, so it fails closed,
  and its details render it as `Schema: <literal> (unrecognized CRS form,
  compared as-is)` via a new `_schema_crs_display` helper.
- `native_crs_format` already warned for any value it did not recognize; it now
  actually sees these values and names the literal.
- `parquet_geo_only_crs` reports an unresolved string before reaching
  `is_geographic_crs`, whose substring heuristic turned the free-form string
  `4326` into a confident "CRS is geographic (widely supported)".

`parse_geometry_logical_type`'s docstring now states the three-state contract:
`crs` absent = declares no CRS (the OGC:CRS84 default), a dict = resolved
PROJJSON, a **string** = a CRS the type names but gpio has not resolved — never
the default. `docs/guide/check.md`'s CRS-form bullet says the same in one
sentence.

**Design choice: unresolved-string mismatch, not a new dedicated check.** A
dedicated "unrecognized CRS form" check would duplicate `native_crs_format`
(PGO-3), which already exists, already runs for GeoParquet 2.0 files, already
carries the literal, and now fires for exactly these values — and it would add a
new check name to the report, the summary counts and the docs for no new
information. Carrying the value through as an unresolved string is also the
mechanism #851 already established for an unknown authority like `FOO:BAR`, so
the two unreadable-CRS cases behave identically instead of diverging. The
mismatch details were extended so the literal does not read as a CRS gpio
understood and rejected.

## Why

The Parquet geospatial spec's `crs` field is free-form. `_parse_crs_property`
recognized four shapes and mapped everything else to `None`, which drops the
`crs` key — and every CRS consumer reads an absent key as the spec's OGC:CRS84
default. A file whose GEOMETRY type said `crs=4326`, `crs=WGS 84`, `crs=EPSG:`
or carried raw WKT was therefore validated as *declaring* OGC:CRS84, a claim it
never made. The function's own docstring said no unrecognized value may reach
that `None`; the final `return None` was the violation.

## Verification

Reproduction script (files written with geoarrow-pyarrow, which puts the CRS
string on the logical type verbatim), **before** on `origin/main`:

```
--- parquet crs='WGS 84'  geo metadata: absent-metadata-crs
    logical_type: GeometryType(crs=WGS 84)
    parsed:       {'geo_type': 'Geometry'}
    native_crs_format_geometry=passed: column "geometry" has no CRS (defaults to OGC:CRS84)
    v2_crs_consistency_geometry=passed: CRS matches: both are OGC:CRS84 (explicit or default)

--- parquet crs='GEOGCS["WGS 84",DATUM["WGS_1984"]]'  geo metadata: metadata-EPSG:3857
    logical_type: GeometryType(crs=GEOGCS["WGS 84",DATUM["WGS_1984"]])
    parsed:       {'geo_type': 'Geometry'}
    native_crs_format_geometry=passed: column "geometry" has no CRS (defaults to OGC:CRS84)
    v2_crs_consistency_geometry=failed: ... | Metadata: WGS 84 / Pseudo-Mercator (EPSG:3857), Schema: OGC:CRS84 (default)
```

**after**:

```
--- parquet crs='WGS 84'  geo metadata: absent-metadata-crs
    logical_type: GeometryType(crs=WGS 84)
    parsed:       {'geo_type': 'Geometry', 'crs': 'WGS 84'}
    native_crs_format_geometry=warning: column "geometry" CRS format may not be widely recognized | CRS: WGS 84. Use 'gpio convert --geoparquet-version 2.0' to standardize.
    v2_crs_consistency_geometry=failed: CRS in geo metadata must match CRS in Parquet schema | Metadata: OGC:CRS84 (default), Schema: WGS 84 (unrecognized CRS form, compared as-is)

--- parquet crs='GEOGCS["WGS 84",DATUM["WGS_1984"]]'  geo metadata: metadata-EPSG:3857
    logical_type: GeometryType(crs=GEOGCS["WGS 84",DATUM["WGS_1984"]])
    parsed:       {'geo_type': 'Geometry', 'crs': 'GEOGCS["WGS 84",DATUM["WGS_1984"]]'}
    native_crs_format_geometry=warning: column "geometry" CRS format may not be widely recognized | CRS: GEOGCS["WGS 84",DATUM["WGS_1984"]]. ...
    v2_crs_consistency_geometry=failed: CRS in geo metadata must match CRS in Parquet schema | Metadata: WGS 84 / Pseudo-Mercator (EPSG:3857), Schema: GEOGCS["WGS 84",DATUM["WGS_1984"]] (unrecognized CRS form, compared as-is)
```

40 new probes in `tests/test_parquet_authority_code_crs.py` (the #851 home),
parametrized over `4326`, `WGS 84`, `EPSG:`, `EPSG:abc`, `GEOGCS["WGS 84",...]`
and `PROJCRS[...]`: each arrives under the `crs` key as its literal and is
distinguishable from a CRS-less type; each is a `v2_crs_consistency` FAILED
against an absent, an explicit-CRS84 and an EPSG:3857 metadata crs, with the
literal in the details; each warns from `native_crs_format` and
`parquet_geo_only_crs`. A regression class pins that `crs=`, `crs=<null>`,
`srid:<id>`, `srid:0`, `projjson:<key>`, `<authority>:<code>` and inline
PROJJSON keep their #851 behavior, including alongside `algorithm=`. Two
end-to-end files and one `gpio inspect` probe cover the live path.

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5726 passed, 67 skipped, 1 xfailed, 103 warnings in 148.22s

$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
geoparquet_io/core/duckdb_metadata.py (100%)
geoparquet_io/core/validate.py (100%)
Total:   10 lines
Missing: 0 lines
Coverage: 100%
```

`uv run pre-commit run --all-files` and `--hook-stage pre-push` (mypy, vulture,
xenon, import-linter, deptry) both clean.

Left out: `v2_crs_in_parquet_type` now PASSES for a free-form value ("non-default
CRS is inline in Parquet geo type") where it used to FAIL, because the type does
carry *something*. That is the same generosity #851 already gave `srid:5070` and
`EPSG:32633`, and `v2_crs_consistency` fails immediately after, so it is left
alone rather than widened here. The `crs=4326` case is covered at unit level
only: geoarrow-pyarrow cannot read back a file it wrote with that CRS (its own
JSON deserializer turns `4326` into an int and raises), so no end-to-end fixture
can carry it.

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unrecognized or free-form CRS values, including EPSG codes, CRS names, authority codes, and WKT.
  * Preserved unrecognized CRS values verbatim instead of interpreting them as a default CRS.
  * Updated validation results to issue warnings or fail closed when CRS values cannot be resolved, with clearer diagnostic details.

* **Documentation**
  * Expanded CRS validation guidance to explain handling of unrecognized values and comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->