### PR TITLE
fix(crs): keep a GeoArrow file's CRS when it has no geo block

### DIFF
--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -972,6 +972,71 @@ _GEOARROW_EXTENSION_NAMES = frozenset(
 )
 
 
+def geoarrow_crs_to_projjson(crs: object) -> dict | str | None:
+    """Return an Arrow extension type's ``.crs`` as PROJJSON, or ``None``.
+
+    The single reader for "what is on ``field.type.crs``" — ``streaming``,
+    ``duckdb_metadata`` and :func:`_crs_from_extension_type` all delegate here so
+    the same object cannot resolve three different ways depending on which read
+    path touched it (issue #863).
+
+    ``geom_type.crs`` is whatever the extension type chose to hold. Once
+    ``geoarrow.pyarrow`` is imported, PyArrow resolves ``geoarrow.wkb`` fields
+    into real extension types and this is a ``geoarrow.types.crs.Crs`` object
+    (``ProjJsonCrs``, ``StringCrs``, or a ``pyproj.CRS``) — never a plain value.
+
+    Those objects must be read through their PROJJSON accessor. ``str()`` on one
+    returns its *repr* (``"ProjJsonCrs(OGC:CRS84)"``), which downstream code then
+    split on ``:`` into the fabricated identifier
+    ``{"id": {"authority": "PROJJSONCRS(OGC", "code": "CRS84)"}}`` — invalid
+    GeoParquet that gpio's own validator rejects (issue #816).
+
+    Unknown objects are rejected (``None`` + a warning) rather than stringified: a
+    repr is never a CRS, and inventing one writes a file that lies about its
+    coordinates. ``None`` lets the caller fall back to the ``geo`` metadata, which
+    is where the truth usually is; raising would fail an otherwise-fine read over
+    a metadata detail this function documents as optional. Every rejection warns,
+    so a CRS is never dropped silently.
+    """
+    if crs is None:
+        return None
+
+    # Already a usable representation: PROJJSON dict, or a string identifier
+    # such as "EPSG:3857" that callers normalise themselves. An *empty* dict or
+    # string is not a CRS — returning it would shadow the real `geo` metadata on
+    # the caller's ``is not None`` check, so it is rejected like any other
+    # unreadable value.
+    if isinstance(crs, dict | str):
+        return crs or None
+    if isinstance(crs, bytes | bytearray):
+        try:
+            decoded = crs.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            warn(f"Ignoring geometry CRS: {len(crs)} bytes that are not valid UTF-8 ({exc})")
+            return None
+        return decoded or None
+
+    # The geoarrow ``Crs`` protocol (and pyproj.CRS) expose PROJJSON directly:
+    # ``to_json_dict()`` returns a Mapping, ``to_json()`` the same as a string.
+    for accessor, parse in (("to_json_dict", dict), ("to_json", json.loads)):
+        method = getattr(crs, accessor, None)
+        if not callable(method):
+            continue
+        try:
+            resolved = parse(method())
+        except Exception as exc:  # pyproj lookup failure, malformed PROJJSON, ...
+            warn(f"Could not read PROJJSON from CRS object {type(crs).__name__}: {exc}")
+            return None
+        # An empty PROJJSON object is not a CRS; let the caller fall back.
+        return resolved if isinstance(resolved, dict) and resolved else None
+
+    warn(
+        f"Ignoring geometry CRS of unsupported type {type(crs).__name__}: it exposes no "
+        "PROJJSON accessor, and its text form is not a coordinate reference system."
+    )
+    return None
+
+
 def _crs_from_extension_type(field_type):
     """Extract a ``crs`` (PROJJSON dict/str) from a registered GeoArrow type.
 
@@ -983,12 +1048,9 @@ def _crs_from_extension_type(field_type):
     """
     if getattr(field_type, "extension_name", None) not in _GEOARROW_EXTENSION_NAMES:
         return None
-    crs_obj = getattr(field_type, "crs", None)
-    if crs_obj is not None and hasattr(crs_obj, "to_json_dict"):
-        try:
-            return crs_obj.to_json_dict()
-        except Exception:
-            pass
+    resolved = geoarrow_crs_to_projjson(getattr(field_type, "crs", None))
+    if resolved is not None:
+        return resolved
     ext_meta = getattr(field_type, "extension_metadata", None)
     if ext_meta:
         try:

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -19,6 +19,7 @@ import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from geoparquet_io.core.crs_utils import geoarrow_crs_to_projjson
 from geoparquet_io.core.duckdb_utils import _escape_sql_string
 from geoparquet_io.core.exceptions import GeoParquetError
 
@@ -214,6 +215,17 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
         del pf
 
 
+def _format_geometry_type_crs(crs) -> str:
+    """Render a CRS into DuckDB's ``GeometryType(crs=...)`` logical-type string.
+
+    A string stays verbatim (a reference such as ``projjson:key_name``,
+    ``srid:5070`` or a bare ``EPSG:32633``); PROJJSON is inlined as JSON.
+    """
+    if isinstance(crs, str):
+        return f"GeometryType(crs={crs})"
+    return f"GeometryType(crs={json.dumps(crs)})"
+
+
 def _get_pyarrow_logical_type(field) -> str | None:
     """Extract logical type string from PyArrow field, including geo types.
 
@@ -245,13 +257,14 @@ def _get_pyarrow_logical_type(field) -> str | None:
         ext_name = field.type.extension_name
         if ext_name in geoarrow_extensions:
             # Case 1: geoarrow-pyarrow is imported - CRS is in field.type.crs
-            # This takes priority because geoarrow-pyarrow consumes the metadata
-            if hasattr(field.type, "crs") and field.type.crs is not None:
-                crs_obj = field.type.crs
-                # geoarrow-pyarrow provides .to_json_dict() for PROJJSON
-                if hasattr(crs_obj, "to_json_dict"):
-                    crs_dict = crs_obj.to_json_dict()
-                    return f"GeometryType(crs={json.dumps(crs_dict)})"
+            # This takes priority because geoarrow-pyarrow consumes the metadata.
+            # `geoarrow_crs_to_projjson` is the one reader for that attribute
+            # (issue #863): it tries to_json_dict() then to_json(), passes plain
+            # dicts/strings/bytes through, and warns instead of raising or
+            # silently dropping a CRS it cannot read.
+            resolved = geoarrow_crs_to_projjson(getattr(field.type, "crs", None))
+            if resolved is not None:
+                return _format_geometry_type_crs(resolved)
 
             # Case 2: Try extension_metadata (older geoarrow or direct Arrow)
             if hasattr(field.type, "extension_metadata") and field.type.extension_metadata:
@@ -259,13 +272,7 @@ def _get_pyarrow_logical_type(field) -> str | None:
                     ext_meta = json.loads(field.type.extension_metadata)
                     crs = ext_meta.get("crs")
                     if crs:
-                        # Format CRS like DuckDB does
-                        if isinstance(crs, str):
-                            # Reference string like "projjson:key_name" or "srid:5070"
-                            return f"GeometryType(crs={crs})"
-                        elif isinstance(crs, dict):
-                            # Inline PROJJSON
-                            return f"GeometryType(crs={json.dumps(crs)})"
+                        return _format_geometry_type_crs(crs)
                 except (json.JSONDecodeError, TypeError):
                     pass
             return "GeometryType()"
@@ -298,13 +305,7 @@ def _get_pyarrow_logical_type(field) -> str | None:
                         ext_meta = json.loads(ext_meta_str)
                         crs = ext_meta.get("crs")
                         if crs:
-                            # Format CRS like DuckDB does
-                            if isinstance(crs, str):
-                                # Reference string like "projjson:key_name" or "srid:5070"
-                                return f"GeometryType(crs={crs})"
-                            elif isinstance(crs, dict):
-                                # Inline PROJJSON
-                                return f"GeometryType(crs={json.dumps(crs)})"
+                            return _format_geometry_type_crs(crs)
                     except (json.JSONDecodeError, TypeError):
                         pass
                 return "GeometryType()"

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -527,62 +527,6 @@ def apply_geoarrow_extension_type(
         ) from e
 
 
-def _geoarrow_crs_to_projjson(crs: object) -> dict | str | None:
-    """Return an Arrow extension type's ``.crs`` as PROJJSON, or None.
-
-    ``geom_type.crs`` is whatever the extension type chose to hold. Once
-    ``geoarrow.pyarrow`` is imported, PyArrow resolves ``geoarrow.wkb`` fields
-    into real extension types and this is a ``geoarrow.types.crs.Crs`` object
-    (``ProjJsonCrs``, ``StringCrs``, or a ``pyproj.CRS``) — never a plain value.
-
-    Those objects must be read through their PROJJSON accessor. ``str()`` on one
-    returns its *repr* (``"ProjJsonCrs(OGC:CRS84)"``), which downstream code then
-    split on ``:`` into the fabricated identifier
-    ``{"id": {"authority": "PROJJSONCRS(OGC", "code": "CRS84)"}}`` — invalid
-    GeoParquet that gpio's own validator rejects (issue #816).
-
-    Unknown objects are rejected (None + a warning) rather than stringified: a
-    repr is never a CRS, and inventing one writes a file that lies about its
-    coordinates. Returning None lets the caller fall back to the ``geo``
-    metadata, which is where the truth usually is; raising would fail an
-    otherwise-fine read over a metadata detail this function documents as
-    optional.
-    """
-    from geoparquet_io.core.logging_config import warn
-
-    # Already a usable representation: PROJJSON dict, or a string identifier
-    # such as "EPSG:3857" that callers normalise themselves.
-    if isinstance(crs, dict):
-        return crs
-    if isinstance(crs, str):
-        return crs
-    if isinstance(crs, bytes | bytearray):
-        try:
-            return crs.decode("utf-8")
-        except UnicodeDecodeError:
-            return None
-
-    # The geoarrow ``Crs`` protocol (and pyproj.CRS) expose PROJJSON directly:
-    # ``to_json_dict()`` returns a Mapping, ``to_json()`` the same as a string.
-    for accessor, parse in (("to_json_dict", dict), ("to_json", json.loads)):
-        method = getattr(crs, accessor, None)
-        if not callable(method):
-            continue
-        try:
-            resolved = parse(method())
-        except Exception as exc:  # pyproj lookup failure, malformed PROJJSON, ...
-            warn(f"Could not read PROJJSON from CRS object {type(crs).__name__}: {exc}")
-            return None
-        # An empty PROJJSON object is not a CRS; let the caller fall back.
-        return resolved if isinstance(resolved, dict) and resolved else None
-
-    warn(
-        f"Ignoring geometry CRS of unsupported type {type(crs).__name__}: it exposes no "
-        "PROJJSON accessor, and its text form is not a coordinate reference system."
-    )
-    return None
-
-
 def extract_crs_from_table(
     table: pa.Table,
     geometry_column: str | None = None,
@@ -591,8 +535,14 @@ def extract_crs_from_table(
     Extract CRS from Arrow table.
 
     Checks in order:
-    1. Geoarrow extension type CRS
+    1. Geoarrow extension type CRS (``field.type.crs`` — the shape PyArrow
+       produces once ``geoarrow.pyarrow`` has registered its extension types)
     2. GeoParquet geo metadata
+    3. The geometry field's raw ``ARROW:extension:metadata`` — the *other*
+       import state, where nothing registered the extension type and the CRS is
+       still sitting on the field. Without it a GeoArrow file with no ``geo``
+       block returned None and the write labelled projected data as the CRS84
+       default (issue #863).
 
     Args:
         table: PyArrow Table to inspect
@@ -601,6 +551,8 @@ def extract_crs_from_table(
     Returns:
         CRS as PROJJSON dict, string, or None if not found
     """
+    from geoparquet_io.core.crs_utils import _crs_from_geoarrow_field, geoarrow_crs_to_projjson
+
     # Find geometry column if not specified
     if geometry_column is None:
         geometry_column = find_geometry_column_from_table(table)
@@ -610,7 +562,7 @@ def extract_crs_from_table(
 
         # Check for geoarrow extension type with CRS
         if hasattr(geom_type, "crs") and geom_type.crs is not None:
-            resolved = _geoarrow_crs_to_projjson(geom_type.crs)
+            resolved = geoarrow_crs_to_projjson(geom_type.crs)
             if resolved is not None:
                 return resolved
             # Unreadable CRS object: fall through to the geo metadata rather
@@ -634,6 +586,13 @@ def extract_crs_from_table(
                     return columns[geom_col_name].get("crs")
         except (json.JSONDecodeError, UnicodeDecodeError):
             pass
+
+    # Last resort: a GeoArrow field whose extension type nothing registered, so
+    # the CRS is still in `ARROW:extension:metadata`. Reached only when the file
+    # has no `geo` block for this column at all — a `geo` block that declares a
+    # null CRS returns above, because "unknown" is an answer.
+    if geometry_column:
+        return _crs_from_geoarrow_field(table, geometry_column)
 
     return None
 

--- a/tests/test_geoarrow_crs_reader.py
+++ b/tests/test_geoarrow_crs_reader.py
@@ -1,0 +1,418 @@
+"""One geoarrow-CRS reader, four entry points, and the no-`geo`-block gap (#863).
+
+Three modules used to carry their own "read the CRS off a geoarrow extension
+type" code, each subtly different: ``streaming._geoarrow_crs_to_projjson`` tried
+``to_json_dict()`` then ``to_json()`` and warned on failure, while
+``crs_utils._crs_from_extension_type`` and ``duckdb_metadata`` tried only
+``to_json_dict()`` and swallowed the failure. The same ``Crs`` object therefore
+resolved differently depending on which read path touched it.
+
+`TestCrsShapeMatrix` runs one shape table through every entry point that
+delegates to the consolidated ``crs_utils.geoarrow_crs_to_projjson`` and demands
+the *same* answer from each. `TestNoGeoBlockCrs` covers the second half of the
+issue: a GeoArrow file with no ``geo`` key-value metadata, read in a process
+that never imported ``geoarrow.pyarrow``, used to lose its CRS entirely and be
+written back out labelled with the CRS84 default.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+import subprocess
+import sys
+import textwrap
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.crs_utils import _crs_from_extension_type, geoarrow_crs_to_projjson
+from geoparquet_io.core.duckdb_metadata import _get_pyarrow_logical_type
+from geoparquet_io.core.streaming import extract_crs_from_table
+
+# ---------------------------------------------------------------------------
+# Carrier shapes
+# ---------------------------------------------------------------------------
+
+
+class _OpaqueCrs:
+    """A CRS-ish object exposing neither PROJJSON accessor."""
+
+    def __repr__(self) -> str:
+        return "Opaque(EPSG:9999)"
+
+
+class _ExplodingCrs:
+    """A geoarrow-shaped ``Crs`` whose PROJJSON accessor raises.
+
+    Real ``StringCrs.to_json_dict()`` calls pyproj, which raises for an
+    identifier PROJ does not know.
+    """
+
+    def to_json_dict(self):
+        raise ValueError("crs not found: EPSG:999999")
+
+
+class _ToJsonOnlyCrs:
+    """A ``Crs`` exposing only the string accessor -- the fallback rung."""
+
+    def to_json(self) -> str:
+        return json.dumps({"id": {"authority": "EPSG", "code": 26918}})
+
+
+def _projjson(identifier: str) -> dict:
+    import pyproj
+
+    return pyproj.CRS(identifier).to_json_dict()
+
+
+class _AuthCode:
+    """Expectation marker: "a PROJJSON dict whose ``id`` is this pair"."""
+
+    def __init__(self, authority: str, code):
+        self.expected = {"authority": authority, "code": code}
+
+    def __repr__(self) -> str:
+        return f"_AuthCode({self.expected})"
+
+
+def _carrier_shapes():
+    """(id, carrier value, expected resolved CRS) for every shape ``.crs`` takes."""
+    import pyproj
+    from geoarrow.types.crs import ProjJsonCrs, StringCrs
+
+    crs84 = _projjson("OGC:CRS84")
+    return [
+        ("projjson_crs_object", ProjJsonCrs(crs84), _AuthCode("OGC", "CRS84")),
+        ("string_crs_object", StringCrs("EPSG:3857"), _AuthCode("EPSG", 3857)),
+        ("pyproj_crs_object", pyproj.CRS("EPSG:4326"), _AuthCode("EPSG", 4326)),
+        ("to_json_only_object", _ToJsonOnlyCrs(), _AuthCode("EPSG", 26918)),
+        ("projjson_dict", crs84, crs84),
+        ("identifier_string", "EPSG:3857", "EPSG:3857"),
+        ("utf8_bytes", b"EPSG:3857", "EPSG:3857"),
+        ("empty_dict", {}, None),
+        ("empty_string", "", None),
+        ("undecodable_bytes", b"\xff\xfe not utf-8", None),
+        ("accessor_raises", _ExplodingCrs(), None),
+        ("no_accessor", _OpaqueCrs(), None),
+    ]
+
+
+SHAPES = _carrier_shapes()
+SHAPE_PARAMS = [pytest.param(carrier, expected, id=name) for name, carrier, expected in SHAPES]
+
+
+def _assert_resolved(resolved, expected):
+    if expected is None:
+        assert resolved is None, f"expected rejection, got {resolved!r}"
+    elif isinstance(expected, _AuthCode):
+        assert isinstance(resolved, dict), f"expected PROJJSON dict, got {resolved!r}"
+        assert resolved["id"] == expected.expected
+    else:
+        assert resolved == expected
+
+
+# ---------------------------------------------------------------------------
+# Entry points: each returns the resolved CRS value for one carrier
+# ---------------------------------------------------------------------------
+
+
+class _FakeGeoArrowType:
+    """A duck-typed registered GeoArrow extension type holding a ``.crs``."""
+
+    extension_name = "geoarrow.wkb"
+    extension_metadata = None
+
+    def __init__(self, crs):
+        self.crs = crs
+
+    def __str__(self) -> str:  # `_get_pyarrow_logical_type` falls back to str()
+        return "extension<geoarrow.wkb>"
+
+
+class _FakeField:
+    def __init__(self, field_type, metadata=None):
+        self.type = field_type
+        self.metadata = metadata
+
+
+# PyArrow rebuilds an extension type from its serialized form while a table is
+# assembled, so the payload cannot live on the instance; a module-level registry
+# keyed by the serialized token survives any number of round-trips.
+_CRS_PAYLOADS: dict[bytes, object] = {}
+
+
+class _CrsCarrierType(pa.ExtensionType):
+    """An Arrow extension type exposing an arbitrary value as ``.crs``."""
+
+    def __init__(self, token: bytes):
+        self._token = token
+        super().__init__(pa.binary(), "gpio.test.crs_reader_carrier")
+
+    def __arrow_ext_serialize__(self) -> bytes:
+        return self._token
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, _storage_type, serialized):
+        return cls(serialized)
+
+    @property
+    def crs(self):
+        return _CRS_PAYLOADS[self._token]
+
+
+def _wkb_point(x: float, y: float) -> bytes:
+    return struct.pack("<BIdd", 1, 1, x, y)
+
+
+def _via_helper(carrier):
+    return geoarrow_crs_to_projjson(carrier)
+
+
+def _via_streaming(carrier):
+    token = f"crs-{len(_CRS_PAYLOADS)}".encode()
+    _CRS_PAYLOADS[token] = carrier
+    storage = pa.array([_wkb_point(0.0, 0.0)], type=pa.binary())
+    geom = pa.ExtensionArray.from_storage(_CrsCarrierType(token), storage)
+    return extract_crs_from_table(pa.table({"id": [1], "geometry": geom}), "geometry")
+
+
+def _via_crs_utils(carrier):
+    return _crs_from_extension_type(_FakeGeoArrowType(carrier))
+
+
+def _via_duckdb_metadata(carrier):
+    """Read back the CRS ``_get_pyarrow_logical_type`` embedded in its type string."""
+    logical = _get_pyarrow_logical_type(_FakeField(_FakeGeoArrowType(carrier)))
+    if logical == "GeometryType()":
+        return None
+    assert logical.startswith("GeometryType(crs=") and logical.endswith(")"), logical
+    inner = logical[len("GeometryType(crs=") : -1]
+    try:
+        return json.loads(inner)
+    except json.JSONDecodeError:
+        return inner
+
+
+ENTRY_POINTS = [
+    pytest.param(_via_helper, id="crs_utils.geoarrow_crs_to_projjson"),
+    pytest.param(_via_streaming, id="streaming.extract_crs_from_table"),
+    pytest.param(_via_crs_utils, id="crs_utils._crs_from_extension_type"),
+    pytest.param(_via_duckdb_metadata, id="duckdb_metadata._get_pyarrow_logical_type"),
+]
+
+
+class TestCrsShapeMatrix:
+    """Every carrier shape must resolve identically through every entry point."""
+
+    @pytest.mark.parametrize("entry_point", ENTRY_POINTS)
+    @pytest.mark.parametrize("carrier,expected", SHAPE_PARAMS)
+    def test_shape_resolves_the_same_everywhere(self, entry_point, carrier, expected):
+        _assert_resolved(entry_point(carrier), expected)
+
+
+class TestGeometryTypeCrsFormatting:
+    """Both ``extension_metadata`` rungs render a CRS the way DuckDB does.
+
+    These are the fallbacks ``_get_pyarrow_logical_type`` drops to when
+    ``field.type.crs`` yields nothing, and they now share one formatter with the
+    ``.crs`` rung -- so a PROJJSON dict is inlined as JSON and a reference string
+    (``srid:5070``, ``projjson:key``) stays verbatim, wherever it came from.
+    """
+
+    @pytest.mark.parametrize(
+        "crs,expected",
+        [
+            ({"id": {"authority": "EPSG", "code": 5070}}, 'GeometryType(crs={"id": '),
+            ("srid:5070", "GeometryType(crs=srid:5070)"),
+        ],
+        ids=["inline_projjson", "reference_string"],
+    )
+    def test_registered_type_falls_back_to_extension_metadata(self, crs, expected):
+        field_type = _FakeGeoArrowType(None)
+        field_type.extension_metadata = json.dumps({"crs": crs})
+
+        logical = _get_pyarrow_logical_type(_FakeField(field_type))
+
+        assert logical.startswith(expected)
+
+    @pytest.mark.parametrize(
+        "crs,expected",
+        [
+            ({"id": {"authority": "EPSG", "code": 5070}}, 'GeometryType(crs={"id": '),
+            ("srid:5070", "GeometryType(crs=srid:5070)"),
+        ],
+        ids=["inline_projjson", "reference_string"],
+    )
+    def test_unregistered_field_reads_its_raw_metadata(self, crs, expected):
+        """No extension type registered: the CRS is on ``field.metadata``."""
+        field = _FakeField(
+            pa.binary(),
+            metadata={
+                b"ARROW:extension:name": b"geoarrow.wkb",
+                b"ARROW:extension:metadata": json.dumps({"crs": crs}).encode("utf-8"),
+            },
+        )
+
+        logical = _get_pyarrow_logical_type(field)
+
+        assert logical.startswith(expected)
+
+
+class TestRejectionsAreReported:
+    """Every rejection warns -- silence is how a wrong CRS gets written (#863)."""
+
+    @pytest.mark.parametrize(
+        "carrier,fragment",
+        [
+            (_OpaqueCrs(), "_OpaqueCrs"),
+            (_ExplodingCrs(), "crs not found: EPSG:999999"),
+            (b"\xff\xfe not utf-8", "bytes"),
+        ],
+        ids=["no_accessor", "accessor_raises", "undecodable_bytes"],
+    )
+    def test_rejection_warns(self, caplog, carrier, fragment):
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            assert geoarrow_crs_to_projjson(carrier) is None
+        assert fragment in caplog.text
+
+    def test_repr_is_never_offered_as_a_crs(self, caplog):
+        """A repr is not a CRS; it must not appear in the warning either."""
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            geoarrow_crs_to_projjson(_OpaqueCrs())
+        assert "Opaque(EPSG:9999)" not in caplog.text
+
+
+class TestEmptyValuesFallThrough:
+    """An empty dict/string is not a CRS and must not shadow the `geo` block."""
+
+    @pytest.mark.parametrize("empty", [{}, ""], ids=["empty_dict", "empty_string"])
+    def test_empty_carrier_falls_back_to_geo_metadata(self, empty):
+        geo = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": [],
+                    "crs": _projjson("EPSG:3857"),
+                }
+            },
+        }
+        token = f"crs-empty-{len(_CRS_PAYLOADS)}".encode()
+        _CRS_PAYLOADS[token] = empty
+        storage = pa.array([_wkb_point(0.0, 0.0)], type=pa.binary())
+        geom = pa.ExtensionArray.from_storage(_CrsCarrierType(token), storage)
+        table = pa.table({"id": [1], "geometry": geom}).replace_schema_metadata(
+            {b"geo": json.dumps(geo).encode("utf-8")}
+        )
+
+        crs = extract_crs_from_table(table, "geometry")
+
+        assert isinstance(crs, dict)
+        assert crs["id"] == {"authority": "EPSG", "code": 3857}
+
+
+# ---------------------------------------------------------------------------
+# Issue #863 item 2: GeoArrow file with no `geo` block
+# ---------------------------------------------------------------------------
+
+
+def _write_geoarrow_only_parquet(path, identifier: str = "EPSG:3857") -> dict:
+    """A Parquet file carrying its CRS ONLY in ``ARROW:extension:metadata``.
+
+    No ``geo`` key-value metadata at all -- the shape a plain GeoArrow writer
+    produces. Coordinates are Web Mercator metres, impossible as lon/lat.
+    """
+    projjson = _projjson(identifier)
+    field = pa.field(
+        "geometry",
+        pa.binary(),
+        metadata={
+            b"ARROW:extension:name": b"geoarrow.wkb",
+            b"ARROW:extension:metadata": json.dumps({"crs": projjson}).encode("utf-8"),
+        },
+    )
+    schema = pa.schema([pa.field("id", pa.int64()), field])
+    table = pa.table(
+        [
+            pa.array([1, 2]),
+            pa.array([_wkb_point(1e6, 5e6), _wkb_point(2e6, 6e6)], type=pa.binary()),
+        ],
+        schema=schema,
+    )
+    pq.write_table(table, path)
+    written_meta = pq.read_schema(path).metadata or {}
+    assert b"geo" not in written_meta, "fixture must have no geo block"
+    return projjson
+
+
+class TestNoGeoBlockCrs:
+    """A GeoArrow input with no ``geo`` block must keep its CRS (#863)."""
+
+    def test_table_crs_reads_the_extension_metadata(self, tmp_path):
+        """``Table.crs`` used to be None, so the write labelled it CRS84."""
+        import geoparquet_io as gpio
+
+        src = tmp_path / "in.parquet"
+        _write_geoarrow_only_parquet(src)
+
+        crs = gpio.read(str(src)).crs
+
+        assert crs is not None, "CRS lost: the write would label this data CRS84"
+        assert isinstance(crs, dict)
+        assert crs["id"] == {"authority": "EPSG", "code": 3857}
+
+    def test_write_preserves_the_projected_crs(self, tmp_path):
+        import geoparquet_io as gpio
+
+        src = tmp_path / "in.parquet"
+        out = tmp_path / "out.parquet"
+        _write_geoarrow_only_parquet(src)
+
+        gpio.read(str(src)).write(str(out))
+
+        geo = json.loads(pq.read_schema(out).metadata[b"geo"].decode("utf-8"))
+        written = geo["columns"][geo["primary_column"]].get("crs")
+        assert written is not None, "projected data written as the CRS84 default"
+        assert written["id"] == {"authority": "EPSG", "code": 3857}
+
+    def test_write_preserves_the_crs_without_geoarrow_pyarrow_imported(self, tmp_path):
+        """The mirror-image import state of #816, pinned in a clean subprocess.
+
+        ``geoarrow.pyarrow`` registers its extension types globally, and whether
+        some earlier import in the session did so decides *where* PyArrow puts
+        the CRS. This test owns its process so the unregistered state -- the one
+        that lost the CRS -- is the one actually exercised.
+        """
+        src = tmp_path / "in.parquet"
+        out = tmp_path / "out.parquet"
+        _write_geoarrow_only_parquet(src)
+
+        script = textwrap.dedent(
+            """
+            import json, sys
+            import pyarrow.parquet as pq
+            import geoparquet_io as gpio
+
+            src, out = sys.argv[1], sys.argv[2]
+            assert "geoarrow.pyarrow" not in sys.modules, "geoarrow.pyarrow was imported"
+            gpio.read(src).write(out)
+            assert "geoarrow.pyarrow" not in sys.modules, "geoarrow.pyarrow was imported"
+            geo = json.loads(pq.read_schema(out).metadata[b"geo"].decode("utf-8"))
+            print(json.dumps(geo["columns"][geo["primary_column"]].get("crs")))
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", script, str(src), str(out)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        written = json.loads(proc.stdout.strip().splitlines()[-1])
+        assert written is not None, "projected data written as the CRS84 default"
+        assert written["id"] == {"authority": "EPSG", "code": 3857}


### PR DESCRIPTION
## What changed

`extract_crs_from_table` (`core/streaming.py`) gains a third and final rung:
when neither `field.type.crs` nor the `geo` key-value metadata answers, it
falls back to `crs_utils._crs_from_geoarrow_field`, which reads the geometry
field's raw `ARROW:extension:metadata`. A `geo` block that declares the column
still wins, including one whose CRS is explicitly null — "unknown" is an
answer, not a gap.

The three parallel readers of "the CRS on a geoarrow extension type" are
consolidated into one helper, `crs_utils.geoarrow_crs_to_projjson`:

| Site | Before | Now |
|---|---|---|
| `core/crs_utils.py` | `_crs_from_extension_type` (`to_json_dict()` only, failure swallowed) | **owns** `geoarrow_crs_to_projjson`; `_crs_from_extension_type` delegates |
| `core/streaming.py` | `_geoarrow_crs_to_projjson` (the most complete of the three) | deleted; `extract_crs_from_table` delegates |
| `core/duckdb_metadata.py` | inline `to_json_dict()` in `_get_pyarrow_logical_type`, unguarded | delegates; shares a new `_format_geometry_type_crs` with the two `extension_metadata` rungs |

The merged behaviour is the union of the best of the three: `to_json_dict()`
falling back to `to_json()`, dict/str/bytes passthrough, and warn-and-return-None
on an object it cannot read. Two rejections are tightened while collapsing them:

- an empty dict or string is now rejected like any other unreadable value
  instead of being passed through, where it shadowed real `geo` metadata on the
  caller's `is not None` check;
- bytes that are not UTF-8 now warn on the way out. Every other rejection
  already warned, and a silently dropped CRS is how a file ends up lying about
  its coordinates.

## Why

Follow-ups from the review of #846.

The CRS-loss gap is the mirror image of #816: same file, opposite import state,
opposite failure. Nothing in gpio imports `geoarrow.pyarrow`, so PyArrow does
not resolve `geoarrow.wkb` fields into extension types and leaves the CRS on
`field.metadata[b"ARROW:extension:metadata"]` — where `extract_crs_from_table`
never looked. #846's `test_unregistered_extension_shape_falls_back_to_geo_metadata`
covered only the case where a `geo` block was present to catch the fall.

Three implementations of one read is how that drift happened in the first
place: the same `Crs` object resolved three different ways depending on which
path touched it, and `duckdb_metadata` let a raising accessor escape entirely.

`crs_utils` was the right home — it already owns `_crs_from_geoarrow_field` and
imports only `duckdb_utils` and `logging_config` at module scope, so
`duckdb_metadata` can import it at the top without a cycle (`crs_utils` reaches
back into `duckdb_metadata` only from inside functions). import-linter agrees.

## Verification

Reproduction — a Parquet file whose geometry field carries
`ARROW:extension:name=geoarrow.wkb` and an `ARROW:extension:metadata` holding
EPSG:3857 PROJJSON, with **no** `geo` key-value metadata, read and written back
through `gpio.read(...).write(...)`. Coordinates are Web Mercator metres
(1e6, 5e6), impossible as lon/lat.

Before (`origin/main`):

```
input geo block present: False
geoarrow.pyarrow imported: False
Table.crs -> None
written CRS -> None          # i.e. the CRS84 default, for projected data
```

After:

```
input geo block present: False
geoarrow.pyarrow imported: False
Table.crs id -> {'authority': 'EPSG', 'code': 3857}
written CRS id -> {'authority': 'EPSG', 'code': 3857}
geoarrow.pyarrow imported at end: False
```

New `tests/test_geoarrow_crs_reader.py` runs one shape table through all four
entry points and demands the same answer from each — `ProjJsonCrs`, `StringCrs`,
`pyproj.CRS`, a `to_json()`-only object, a PROJJSON dict, an identifier string,
UTF-8 bytes, an empty dict, an empty string, undecodable bytes, an accessor that
raises, and an object with neither accessor (48 cases), plus the warning
assertions, the empty-value fall-through to `geo`, and the no-`geo`-block
reproduction — the last of which also runs in a clean `sys.executable -c`
subprocess that asserts `geoarrow.pyarrow` never enters `sys.modules`, so the
import state that lost the CRS is the one actually exercised.

```
tests/test_geoarrow_crs_reader.py .............................................
61 passed in 1.00s
```

Fast suite:

```
5730 passed, 67 skipped, 1 xfailed, 103 warnings in 146.22s (0:02:26)
```

diff-cover against `origin/main`:

```
geoparquet_io/core/crs_utils.py (100%)
geoparquet_io/core/duckdb_metadata.py (100%)
geoparquet_io/core/streaming.py (100%)
Total:   41 lines
Missing: 0 lines
Coverage: 100%
```

`pre-commit run --all-files` and `--hook-stage pre-push` (mypy, vulture, xenon,
import-linter, deptry) both clean.

Not consolidated: `common.py::_crs_as_projjson`, a fourth cousin outside this
issue's scope. It deliberately returns the CRS *unchanged* when there is no
accessor rather than rejecting it, so folding it in is a behaviour change to
the v1.x write path that deserves its own change.

Closes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4