### PR TITLE
feat(sort): guard against re-reading the output as input, and accept --allow-schema-diff on directory input

### DIFF
--- a/docs/guide/sort.md
+++ b/docs/guide/sort.md
@@ -265,6 +265,59 @@ result would make conformant readers skip data.
 `sort hilbert` and `sort str` take a single file only; they stop with a message
 pointing at `gpio extract` to consolidate first.
 
+### Write the output somewhere else
+
+The output must land **outside** the input directory (and must not match the
+input glob). A directory input is re-expanded on every run, so an output left
+inside it joins the dataset: the next run reads its own previous output back
+and counts every row twice. gpio refuses that write up front — including under
+`--overwrite`, which would otherwise read the stale output while replacing it.
+
+<!-- doctest: skip="needs a directory of parquet files the sample data does not have" -->
+```bash
+# Refused: sorted.parquet would become part of parts/
+gpio sort column parts/ parts/sorted.parquet name
+
+# Fine
+gpio sort column parts/ sorted/places.parquet name
+```
+
+### Files with different columns
+
+By default the files must share one schema, and DuckDB reads them all as the
+first file's — so a column only some files carry is dropped without a word.
+`--allow-schema-diff` reads the union instead, filling `NULL` where a file has
+no such column. It is the same flag, spelled the same way, that `gpio extract`
+takes:
+
+=== "CLI"
+
+    <!-- doctest: skip="needs a directory of parquet files the sample data does not have" -->
+    ```bash
+    gpio sort column parts/ sorted.parquet name --allow-schema-diff
+
+    gpio sort quadkey parts/ sorted.parquet --allow-schema-diff
+    ```
+
+=== "Python"
+
+    <!-- doctest: skip="needs a directory of parquet files the sample data does not have" -->
+    ```python
+    import geoparquet_io as gpio
+
+    gpio.read_partition('parts/', allow_schema_diff=True) \
+        .sort_column('name') \
+        .write('sorted.parquet', row_group_rows=50000)
+    ```
+
+Files that disagree about the *same* column — a geometry column named
+`geometry` in one and `geom` in another — are not reconciled by the flag, and
+never silently: gpio stops and points at `gpio extract ... --allow-schema-diff`
+to merge them into one file first.
+
+An empty directory, or a glob that matches nothing, fails with
+`No .parquet files found in: <path>`.
+
 ## Output Format
 
 The output file:

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -537,6 +537,23 @@ def partition_options(func):
     return func
 
 
+def allow_schema_diff_option(func):
+    """Add --allow-schema-diff to a command that reads multi-file input.
+
+    One definition, shared: `extract` and the two sorts that accept a directory
+    (`sort column`, `sort quadkey`) must spell this flag and its help text
+    identically, or the same opt-in reads as two different features (#867).
+    The sorts take no `--hive-input`, so this is a separate decorator rather
+    than part of `partition_input_options`.
+    """
+    return click.option(
+        "--allow-schema-diff",
+        is_flag=True,
+        help="Combine files with different schemas (fills NULL for missing columns). "
+        "Default: strict schema matching (all files must have same schema).",
+    )(func)
+
+
 def partition_input_options(func):
     """
     Add options for reading partitioned input data.
@@ -545,12 +562,7 @@ def partition_input_options(func):
     - --allow-schema-diff: Combine files with different schemas (fills NULL for missing columns)
     - --hive-input: Explicitly enable hive partitioning on input
     """
-    func = click.option(
-        "--allow-schema-diff",
-        is_flag=True,
-        help="Combine files with different schemas (fills NULL for missing columns). "
-        "Default: strict schema matching (all files must have same schema).",
-    )(func)
+    func = allow_schema_diff_option(func)
     func = click.option(
         "--hive-input",
         is_flag=True,

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -12,6 +12,7 @@ from click_plugins import with_plugins
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
     SingleFileCommand,
+    allow_schema_diff_option,
     any_extension_option,
     aws_profile_option,
     bucket_point_options,
@@ -3808,6 +3809,7 @@ def str_order_command(
     is_flag=True,
     help="Sort in descending order (default: ascending)",
 )
+@allow_schema_diff_option
 @output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
 @geoparquet_version_option
 @overwrite_option
@@ -3821,6 +3823,7 @@ def sort_column(
     output_parquet,
     columns,
     descending,
+    allow_schema_diff,
     compression,
     compression_level,
     row_group_size,
@@ -3865,6 +3868,7 @@ def sort_column(
             geoparquet_version=geoparquet_version,
             overwrite=overwrite,
             memory_limit=write_memory,
+            allow_schema_diff=allow_schema_diff,
         )
 
 
@@ -3892,6 +3896,7 @@ def sort_column(
     is_flag=True,
     help="Exclude quadkey column from output after sorting",
 )
+@allow_schema_diff_option
 @output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
 @geoparquet_version_option
 @overwrite_option
@@ -3907,6 +3912,7 @@ def sort_quadkey(
     resolution,
     use_centroid,
     remove_quadkey_column,
+    allow_schema_diff,
     compression,
     compression_level,
     row_group_size,
@@ -3952,6 +3958,7 @@ def sort_quadkey(
             geoparquet_version=geoparquet_version,
             overwrite=overwrite,
             memory_limit=write_memory,
+            allow_schema_diff=allow_schema_diff,
         )
 
 

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -333,6 +333,8 @@ def add_quadkey_column(
     geoparquet_version: str | None = None,
     overwrite: bool = False,
     memory_limit: str | None = None,
+    allow_schema_diff: bool = False,
+    hive_input: bool | None = None,
 ) -> None:
     """
     Add a quadkey column to a GeoParquet file.
@@ -359,6 +361,10 @@ def add_quadkey_column(
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
         memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
+        allow_schema_diff: Read a multi-file input as the union of its columns
+            (DuckDB ``union_by_name``) rather than the first file's schema
+        hive_input: Read a multi-file input with hive partitioning on, so the
+            ``key=value`` directory names come through as columns
     """
     # Check for streaming mode (stdin input or stdout output)
     is_streaming = is_stdin(input_parquet) or should_stream_output(output_parquet)
@@ -398,6 +404,8 @@ def add_quadkey_column(
         geoparquet_version,
         overwrite,
         memory_limit=memory_limit,
+        allow_schema_diff=allow_schema_diff,
+        hive_input=hive_input,
     )
 
 
@@ -516,6 +524,25 @@ def _add_quadkey_streaming(
             )
 
 
+def _quadkey_from_clause(path: str, allow_schema_diff: bool, hive_input: bool | None) -> str:
+    """The FROM target for the add, RAW path escaped exactly once by sql_path.
+
+    Options are attached only when a caller asked for them, so the ordinary
+    single-file add keeps reading through a bare path literal exactly as it
+    always has. `sort quadkey` is the caller that needs them: its auto-add step
+    is the FIRST read of a directory, so a union or a hive setting that only
+    reached the sort afterwards would arrive one read too late (#867).
+    """
+    options = []
+    if hive_input:
+        options.append("hive_partitioning=true")
+    if allow_schema_diff:
+        options.append("union_by_name=true")
+    if not options:
+        return sql_path(path)
+    return f"read_parquet({sql_path(path)}, {', '.join(options)})"
+
+
 def _add_quadkey_file_based(
     input_parquet: str,
     output_parquet: str | None,
@@ -532,6 +559,8 @@ def _add_quadkey_file_based(
     geoparquet_version: str | None,
     overwrite: bool,
     memory_limit: str | None,
+    allow_schema_diff: bool = False,
+    hive_input: bool | None = None,
 ) -> None:
     """Handle file-based add_quadkey operation."""
     configure_verbose(verbose)
@@ -646,7 +675,7 @@ def _add_quadkey_file_based(
         query = f"""
             SELECT *,
                    lat_lon_to_quadkey({lat_expr}, {lon_expr}, {resolution}) AS {quote_identifier(quadkey_column_name)}
-            FROM {sql_path(input_file_path)}
+            FROM {_quadkey_from_clause(input_file_path, allow_schema_diff, hive_input)}
         """
 
         if verbose:

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -51,6 +51,7 @@ from geoparquet_io.core.geometry_detection import (
 )
 from geoparquet_io.core.geometry_repair import repair_query_geometry
 from geoparquet_io.core.logging_config import debug, info, progress, success, warn
+from geoparquet_io.core.partition.reader import require_parquet_files
 from geoparquet_io.core.remote import (
     _sanitize_url_for_logging,
     is_remote_url,
@@ -1291,6 +1292,10 @@ def _extract_impl(
         )
 
     # File-based mode
+    # Every read below goes at the first file's footer, so an empty dataset has
+    # to be named here -- the shared resolver only sees it once the read
+    # expression is built, several DuckDB errors too late (#867).
+    require_parquet_files(input_parquet)
     all_columns = get_schema_columns(input_parquet)
     geometry_col = find_primary_geometry_column(input_parquet, verbose)
     bbox_info = check_bbox_structure(input_parquet, verbose=False)

--- a/geoparquet_io/core/file_utils.py
+++ b/geoparquet_io/core/file_utils.py
@@ -3,9 +3,10 @@ File path utilities for GeoParquet files.
 """
 
 import contextlib
+import fnmatch
 import glob as glob_module
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from geoparquet_io.core.duckdb_utils import _escape_sql_string
 from geoparquet_io.core.exceptions import (
@@ -154,11 +155,99 @@ def validate_parquet_extension(output_file: str, any_extension: bool = False) ->
         )
 
 
+def _match_path_segments(pattern: tuple[str, ...], path: tuple[str, ...]) -> bool:
+    """True when ``path``'s segments satisfy glob ``pattern``'s segments.
+
+    Segment-aware on purpose: :func:`fnmatch.fnmatch` on whole paths lets a
+    single ``*`` swallow separators, which would call ``parts/sub/out.parquet``
+    a match for ``parts/*.parquet`` -- a pattern DuckDB does not read
+    recursively. Only ``**`` spans segments, and it spans zero or more.
+    """
+    if not pattern:
+        return not path
+    head, rest = pattern[0], pattern[1:]
+    if head == "**":
+        return any(_match_path_segments(rest, path[i:]) for i in range(len(path) + 1))
+    if not path or not fnmatch.fnmatchcase(path[0], head):
+        return False
+    return _match_path_segments(rest, path[1:])
+
+
+def _absolute_glob_segments(pattern: str) -> tuple[str, ...]:
+    """Absolute segments of a glob, its magic-free prefix symlink-resolved.
+
+    Only the leading directories can be resolved: ``Path.resolve()`` on a
+    pattern would treat ``*`` as a literal directory name, and the answer has
+    to be comparable with a resolved output path (``/var`` vs ``/private/var``
+    on macOS is exactly this trap).
+    """
+    parts = PurePath(pattern).parts
+    first_magic = next((i for i, p in enumerate(parts) if has_glob_pattern(p)), len(parts))
+    return (*Path(*parts[:first_magic]).resolve().parts, *parts[first_magic:])
+
+
+def _output_is_read_as_input(input_path: str, output_path: str) -> bool:
+    """Would a multi-file read of ``input_path`` pick ``output_path`` up?"""
+    output = Path(output_path).resolve()
+    if os.path.isdir(input_path):
+        return Path(input_path).resolve() in output.parents
+    return _match_path_segments(_absolute_glob_segments(input_path), output.parts)
+
+
+def guard_output_not_read_as_input(input_path: str | None, output_path: str | None) -> None:
+    """Refuse an output the *next* run would read back as part of its input.
+
+    A directory or glob input is re-expanded on every run, so an output written
+    inside it joins the dataset. The second run then reads its own first output
+    back and every row it holds is counted twice -- exit 0, no warning, and the
+    counts merely grow (#867). ``--overwrite`` is no defence either: the stale
+    output is read before it is replaced.
+
+    Nothing downstream can notice, because the read genuinely succeeds. So the
+    write is refused up front, before the first run creates the file that
+    poisons the dataset -- which is why this runs whether or not the output
+    already exists.
+
+    Single-file inputs are not this guard's business: they name exactly one
+    file, and :func:`handle_output_overwrite`'s equality check already covers
+    writing over it. Remote paths are skipped -- gpio does not enumerate them
+    here, so there is nothing local to compare.
+
+    Args:
+        input_path: The RAW input path the user gave (file, directory or glob)
+        output_path: The output path the command is about to write
+
+    Raises:
+        GeoParquetError: When the output lies inside the input directory, or
+            matches the input glob.
+    """
+    from geoparquet_io.core.remote import is_remote_url
+
+    if not input_path or not output_path or "-" in (input_path, output_path):
+        return
+    if is_remote_url(input_path) or is_remote_url(output_path):
+        return
+    if not is_partition_path(input_path) or not _output_is_read_as_input(input_path, output_path):
+        return
+
+    where = "inside the input directory" if os.path.isdir(input_path) else "matched by the input"
+    raise GeoParquetError(
+        f"Output '{output_path}' is {where} '{input_path}'.\n\n"
+        "Writing it there would add it to the dataset, so the next run would "
+        "read it back as input and count every row twice.\n\n"
+        "Write the output somewhere else, outside the input dataset."
+    )
+
+
 def handle_output_overwrite(
     output_path: str | None, overwrite: bool, input_path: str | None = None
 ) -> None:
     if not output_path:
         return
+
+    # Before the existence check: on the FIRST run the offending file does not
+    # exist yet, and creating it is what breaks every later run (#867).
+    guard_output_not_read_as_input(input_path, output_path)
 
     output_file = Path(output_path)
 

--- a/geoparquet_io/core/partition/reader.py
+++ b/geoparquet_io/core/partition/reader.py
@@ -19,6 +19,25 @@ from geoparquet_io.core.logging_config import debug
 from geoparquet_io.core.remote import is_remote_url
 
 
+def require_parquet_files(path: str) -> None:
+    """Name the empty dataset, rather than letting DuckDB blame its reader.
+
+    An empty directory reached DuckDB as the directory itself and came back as
+    ``Cannot read file: <dir> ... is a directory`` -- true, and no help at all
+    in finding out that the directory simply holds nothing to read (#867). A
+    glob that matches nothing is the same question with a different spelling.
+
+    Remote paths are left alone: :func:`get_all_parquet_files` cannot enumerate
+    them, and reports the URL itself as the single match.
+    """
+    from geoparquet_io.core.exceptions import GeoParquetError
+
+    if is_remote_url(path):
+        return
+    if not get_all_parquet_files(path):
+        raise GeoParquetError(f"No .parquet files found in: {path}")
+
+
 def resolve_read_path(
     path: str,
     hive_input: bool | None = None,
@@ -47,10 +66,14 @@ def resolve_read_path(
 
     Returns:
         tuple: (raw path for DuckDB, read_parquet options dict)
+
+    Raises:
+        GeoParquetError: When a local directory or glob holds no parquet files.
     """
     if not is_partition_path(path):
         return path, {}
 
+    require_parquet_files(path)
     resolved_path, auto_options = resolve_partition_path(path, hive_input)
     if verbose:
         debug(f"Resolved partition path: {resolved_path}")

--- a/geoparquet_io/core/sort_by_column.py
+++ b/geoparquet_io/core/sort_by_column.py
@@ -81,6 +81,26 @@ def sort_by_column_table(
         con.close()
 
 
+def _sortable_columns(input_parquet: str, read_expr: str, allow_schema_diff: bool) -> list[str]:
+    """The column names the sort may be asked for.
+
+    ``get_usable_columns`` describes the FIRST file of a multi-file input, which
+    is the right answer for a strict read -- that first file's schema is exactly
+    what DuckDB will return. Under ``--allow-schema-diff`` it is the wrong one:
+    the read returns the union, and validating against the first file would
+    reject the very column the flag was turned on to keep (#867). So describe
+    the read expression itself instead.
+    """
+    if not allow_schema_diff:
+        return [c["name"] for c in get_usable_columns(input_parquet)]
+
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
+    try:
+        return [row[0] for row in con.execute(f"DESCRIBE SELECT * FROM {read_expr}").fetchall()]
+    finally:
+        con.close()
+
+
 def sort_by_column(
     input_parquet: str,
     output_parquet: str | None = None,
@@ -95,6 +115,7 @@ def sort_by_column(
     geoparquet_version: str | None = None,
     overwrite: bool = False,
     memory_limit: str | None = None,
+    allow_schema_diff: bool = False,
 ) -> None:
     """
     Sort a GeoParquet file by specified column(s).
@@ -121,6 +142,9 @@ def sort_by_column(
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
         memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
+        allow_schema_diff: For multi-file input, read the union of the files'
+            columns (DuckDB ``union_by_name``) instead of the first file's
+            schema, which silently drops any column the others add
     """
     configure_verbose(verbose)
     row_group_rows = resolve_sort_row_group_rows(row_group_rows, row_group_size_mb)
@@ -169,14 +193,15 @@ def sort_by_column(
 
     # A directory or glob reads as every parquet file under it, the way
     # `extract` reads one (#817). The helper owns the single escape.
-    read_expr = build_read_parquet_expr(input_parquet, verbose=verbose)
+    read_expr = build_read_parquet_expr(
+        input_parquet, allow_schema_diff=allow_schema_diff, verbose=verbose
+    )
 
     # Get metadata from original file
     metadata, schema = get_parquet_metadata(input_parquet, verbose)
 
     # Validate that specified columns exist - use get_usable_columns for actual DuckDB column names
-    usable_cols = get_usable_columns(input_parquet)
-    existing_columns = [c["name"] for c in usable_cols]
+    existing_columns = _sortable_columns(input_parquet, read_expr, allow_schema_diff)
     for col in column_list:
         if col not in existing_columns:
             raise InvalidParameterError(

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -32,6 +32,7 @@ from geoparquet_io.core.remote import (
     setup_aws_profile_if_needed,
     validate_profile_for_urls,
 )
+from geoparquet_io.core.sort_by_column import _sortable_columns
 from geoparquet_io.core.stream_io import write_output
 from geoparquet_io.core.streaming import is_stdin, read_stdin_to_temp_file, should_stream_output
 
@@ -264,9 +265,11 @@ def sort_by_quadkey(
     )
     metadata, _ = get_parquet_metadata(actual_input, verbose)
 
-    # Get usable columns for building SELECT clause
-    usable_cols = get_usable_columns(actual_input)
-    existing_columns = [c["name"] for c in usable_cols]
+    # Get the columns for building the SELECT clause. Under --allow-schema-diff
+    # the read expression carries union_by_name, so the list must describe the
+    # read itself rather than the first file -- or the remove-column branch
+    # silently drops the very columns the flag was turned on to keep.
+    existing_columns = _sortable_columns(actual_input, read_expr, allow_schema_diff)
 
     # Bound before the try: the `finally` below closes it, and a constructor
     # that throws would otherwise be masked by an UnboundLocalError (#867).

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -109,6 +109,7 @@ def sort_by_quadkey(
     geoparquet_version: str | None = None,
     overwrite: bool = False,
     memory_limit: str | None = None,
+    allow_schema_diff: bool = False,
 ) -> None:
     """
     Sort a GeoParquet file by quadkey column.
@@ -138,6 +139,9 @@ def sort_by_quadkey(
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
         memory_limit: DuckDB memory limit for the write (e.g., '2GB', '512MB')
+        allow_schema_diff: For multi-file input, read the union of the files'
+            columns (DuckDB ``union_by_name``) instead of the first file's
+            schema, which silently drops any column the others add
     """
     configure_verbose(verbose)
     row_group_rows = resolve_sort_row_group_rows(row_group_rows, row_group_size_mb)
@@ -174,6 +178,16 @@ def sort_by_quadkey(
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, input_parquet, output_parquet)
 
+    # A directory has to become the glob over its files before anything reads
+    # it (#817). `input_parquet` itself stays raw: it is what messages quote and
+    # what the multi-file stats guard below is asked about. The options travel
+    # with the path: dropping them left hive keys to DuckDB's auto-detect,
+    # which agrees only by coincidence (#867). Resolving first also means an
+    # empty directory is named as one, rather than reaching the schema read
+    # below and coming back as "Cannot read schema: <dir> ... is a directory".
+    actual_input, read_options = resolve_read_path(input_parquet, verbose=verbose)
+    hive_input: bool | None = True if read_options.get("hive_partitioning") else None
+
     # Check if quadkey column exists
     column_names = get_column_names(input_parquet)
     column_exists = quadkey_column_name in column_names
@@ -181,10 +195,6 @@ def sort_by_quadkey(
 
     # Track if we created a temporary file with quadkey
     temp_file = None
-    # A directory has to become the glob over its files before anything reads
-    # it (#817). `input_parquet` itself stays raw: it is what messages quote and
-    # what the multi-file stats guard below is asked about.
-    actual_input = resolve_read_path(input_parquet, verbose=verbose)[0]
 
     if not column_exists:
         if not using_default_name:
@@ -223,8 +233,14 @@ def sort_by_quadkey(
                 row_group_size_mb=None,
                 row_group_rows=None,
                 profile=profile,
+                allow_schema_diff=allow_schema_diff,
+                hive_input=hive_input,
             )
+            # The scratch file already holds the union (and the materialised
+            # hive keys), so the sort below reads it as the plain single file
+            # it is.
             actual_input = temp_file
+            hive_input = None
             if verbose:
                 debug(f"Quadkey column added successfully at resolution {resolution}")
         except Exception as e:
@@ -240,13 +256,21 @@ def sort_by_quadkey(
         debug(f"Using existing quadkey column '{quadkey_column_name}'")
 
     # Get metadata from input file (use actual_input in case we added quadkey)
-    read_expr = build_read_parquet_expr(actual_input, verbose=verbose)
+    read_expr = build_read_parquet_expr(
+        actual_input,
+        allow_schema_diff=allow_schema_diff,
+        hive_input=hive_input,
+        verbose=verbose,
+    )
     metadata, _ = get_parquet_metadata(actual_input, verbose)
 
     # Get usable columns for building SELECT clause
     usable_cols = get_usable_columns(actual_input)
     existing_columns = [c["name"] for c in usable_cols]
 
+    # Bound before the try: the `finally` below closes it, and a constructor
+    # that throws would otherwise be masked by an UnboundLocalError (#867).
+    con = None
     try:
         # Create DuckDB connection
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(actual_input))
@@ -305,7 +329,8 @@ def sort_by_quadkey(
         raise_for_schema_mismatch(e, input_parquet)
         raise
     finally:
-        con.close()
+        if con:
+            con.close()
         # Clean up temp file if we created one
         if temp_file and os.path.exists(temp_file):
             if verbose:

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -12643,6 +12643,22 @@
        "is_flag": true,
        "metavar": null,
        "multiple": false,
+       "name": "allow_schema_diff",
+       "nargs": 1,
+       "opts": [
+        "--allow-schema-diff"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "boolean"
+      },
+      {
+       "default": "False",
+       "hidden": false,
+       "is_flag": true,
+       "metavar": null,
+       "multiple": false,
        "name": "any_extension",
        "nargs": 1,
        "opts": [
@@ -13102,6 +13118,22 @@
      "hidden": false,
      "kind": "command",
      "params": [
+      {
+       "default": "False",
+       "hidden": false,
+       "is_flag": true,
+       "metavar": null,
+       "multiple": false,
+       "name": "allow_schema_diff",
+       "nargs": 1,
+       "opts": [
+        "--allow-schema-diff"
+       ],
+       "param_type": "Option",
+       "required": false,
+       "secondary_opts": [],
+       "type": "boolean"
+      },
       {
        "default": "False",
        "hidden": false,

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -21,6 +21,7 @@ from geoparquet_io.core.file_utils import (
     _get_file_cache_key,
     get_all_parquet_files,
     get_first_parquet_file,
+    guard_output_not_read_as_input,
     handle_output_overwrite,
     has_glob_pattern,
     is_partition_path,
@@ -353,6 +354,113 @@ class TestHandleOutputOverwrite:
     def test_none_output_path_ok(self):
         """None output path does nothing."""
         handle_output_overwrite(None, overwrite=False)
+
+
+# =============================================================================
+# Tests for guard_output_not_read_as_input()
+# =============================================================================
+
+
+@pytest.fixture
+def parts_dir(tmp_path):
+    """A directory holding two parquet files, plus a sibling output directory."""
+    parts = tmp_path / "parts"
+    parts.mkdir()
+    (parts / "a.parquet").write_bytes(b"a")
+    (parts / "b.parquet").write_bytes(b"b")
+    (tmp_path / "out").mkdir()
+    return parts
+
+
+class TestGuardOutputNotReadAsInput:
+    """An output written into the input dataset is refused (#867).
+
+    A directory or glob input is re-globbed on every run, so an output written
+    inside it joins the dataset: the next run reads its own previous output
+    back and duplicates every row it holds. Nothing downstream can notice --
+    the read succeeds and the counts merely grow -- so the write is refused up
+    front, before anything is created.
+    """
+
+    def test_output_inside_input_directory_raises(self, parts_dir):
+        with pytest.raises(GeoParquetError) as exc:
+            guard_output_not_read_as_input(str(parts_dir), str(parts_dir / "sorted.parquet"))
+        message = str(exc.value)
+        assert "sorted.parquet" in message
+        assert str(parts_dir) in message
+        assert "somewhere else" in message
+
+    def test_output_deeper_inside_input_directory_raises(self, parts_dir):
+        nested = parts_dir / "nested"
+        nested.mkdir()
+        with pytest.raises(GeoParquetError, match="somewhere else"):
+            guard_output_not_read_as_input(str(parts_dir), str(nested / "sorted.parquet"))
+
+    def test_trailing_separator_on_the_directory_still_raises(self, parts_dir):
+        with pytest.raises(GeoParquetError, match="somewhere else"):
+            guard_output_not_read_as_input(
+                f"{parts_dir}{os.sep}", str(parts_dir / "sorted.parquet")
+            )
+
+    def test_output_matching_input_glob_raises(self, parts_dir):
+        with pytest.raises(GeoParquetError, match="somewhere else"):
+            guard_output_not_read_as_input(
+                str(parts_dir / "*.parquet"), str(parts_dir / "sorted.parquet")
+            )
+
+    def test_output_matching_recursive_input_glob_raises(self, parts_dir):
+        nested = parts_dir / "nested"
+        nested.mkdir()
+        with pytest.raises(GeoParquetError, match="somewhere else"):
+            guard_output_not_read_as_input(
+                str(parts_dir / "**" / "*.parquet"), str(nested / "sorted.parquet")
+            )
+
+    def test_output_the_input_glob_does_not_match_is_allowed(self, parts_dir):
+        """``parts/*.parquet`` is not read recursively, so a subdirectory is safe."""
+        nested = parts_dir / "nested"
+        nested.mkdir()
+        guard_output_not_read_as_input(str(parts_dir / "*.parquet"), str(nested / "sorted.parquet"))
+
+    def test_output_with_another_extension_under_the_glob_is_allowed(self, parts_dir):
+        guard_output_not_read_as_input(str(parts_dir / "*.parquet"), str(parts_dir / "sorted.fgb"))
+
+    def test_sibling_directory_output_is_allowed(self, parts_dir):
+        guard_output_not_read_as_input(str(parts_dir), str(parts_dir.parent / "out" / "s.parquet"))
+
+    def test_single_file_input_is_not_this_guard_s_business(self, tmp_path):
+        """A single file input names exactly one file; the equality check in
+        handle_output_overwrite covers it, and writing next to it is fine."""
+        single = tmp_path / "in.parquet"
+        single.write_bytes(b"x")
+        guard_output_not_read_as_input(str(single), str(tmp_path / "out.parquet"))
+        guard_output_not_read_as_input(str(single), str(single))
+
+    def test_missing_paths_and_streams_are_ignored(self, parts_dir):
+        guard_output_not_read_as_input(None, str(parts_dir / "s.parquet"))
+        guard_output_not_read_as_input(str(parts_dir), None)
+        guard_output_not_read_as_input(str(parts_dir), "-")
+        guard_output_not_read_as_input("-", str(parts_dir / "s.parquet"))
+
+    def test_remote_paths_are_ignored(self, parts_dir):
+        """Remote datasets are not enumerated here; nothing local to compare."""
+        guard_output_not_read_as_input("s3://bucket/parts/", "s3://bucket/parts/out.parquet")
+        guard_output_not_read_as_input(str(parts_dir), "s3://bucket/out.parquet")
+
+    def test_handle_output_overwrite_refuses_before_the_output_exists(self, parts_dir):
+        """The very first run must be refused: the file it would create is the
+        one that poisons the dataset, and it does not exist yet."""
+        target = parts_dir / "sorted.parquet"
+        assert not target.exists()
+        with pytest.raises(GeoParquetError, match="somewhere else"):
+            handle_output_overwrite(str(target), overwrite=False, input_path=str(parts_dir))
+
+    def test_overwrite_does_not_bypass_the_guard(self, parts_dir):
+        target = parts_dir / "sorted.parquet"
+        target.write_bytes(b"stale")
+        with pytest.raises(GeoParquetError, match="somewhere else"):
+            handle_output_overwrite(str(target), overwrite=True, input_path=str(parts_dir))
+        assert target.exists(), "a refused write must not delete anything"
 
 
 # =============================================================================

--- a/tests/test_partition_input.py
+++ b/tests/test_partition_input.py
@@ -9,6 +9,7 @@ These tests verify that gpio commands properly handle partition input:
 """
 
 import os
+import shutil
 
 import pyarrow.parquet as pq
 import pytest
@@ -385,3 +386,90 @@ class TestPartitionDataIntegrity:
         # All files should have the same GeoParquet version
         assert len(set(versions)) == 1
         assert versions[0] == "1.1.0"
+
+
+class TestOutputInsideInputDataset:
+    """``extract`` refuses to write into the dataset it is reading (#867).
+
+    A directory or glob is re-globbed on every run, so an output left inside
+    it silently joins the input: the second run reads its own first output
+    back and the row count doubles, exit 0, no warning. The guard lives in
+    ``handle_output_overwrite``, the one call every directory-reading command
+    already makes, so ``extract`` and both sorts inherit it together.
+    """
+
+    def test_extract_refuses_an_output_inside_the_input_directory(self, tmp_path, places_test_file):
+        parts = tmp_path / "parts"
+        parts.mkdir()
+        shutil.copy(places_test_file, parts / "a.parquet")
+        output = parts / "merged.parquet"
+
+        result = CliRunner().invoke(extract, [str(parts), str(output)])
+        assert result.exit_code != 0
+        assert "somewhere else" in result.output
+        assert not output.exists()
+
+    def test_extract_refuses_an_output_matching_the_input_glob(self, tmp_path, places_test_file):
+        parts = tmp_path / "parts"
+        parts.mkdir()
+        shutil.copy(places_test_file, parts / "a.parquet")
+        output = parts / "merged.parquet"
+
+        result = CliRunner().invoke(extract, [str(parts / "*.parquet"), str(output)])
+        assert result.exit_code != 0
+        assert "somewhere else" in result.output
+        assert not output.exists()
+
+    def test_extract_still_writes_to_a_sibling_directory(self, tmp_path, places_test_file):
+        parts = tmp_path / "parts"
+        parts.mkdir()
+        shutil.copy(places_test_file, parts / "a.parquet")
+        output = tmp_path / "merged.parquet"
+
+        result = CliRunner().invoke(extract, [str(parts), str(output)])
+        assert result.exit_code == 0, result.output
+        assert pq.read_metadata(output).num_rows == 766
+
+    def test_a_dry_run_inside_the_input_directory_is_untouched(self, tmp_path, places_test_file):
+        """--dry-run writes nothing, so there is nothing to poison."""
+        parts = tmp_path / "parts"
+        parts.mkdir()
+        shutil.copy(places_test_file, parts / "a.parquet")
+
+        result = CliRunner().invoke(
+            extract, [str(parts), str(parts / "merged.parquet"), "--dry-run"]
+        )
+        assert result.exit_code == 0, result.output
+
+
+class TestEmptyPartitionDirectory:
+    """An empty directory names itself instead of blaming the reader (#867)."""
+
+    def test_resolve_read_path_reports_no_parquet_files(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with pytest.raises(GeoParquetError, match="No .parquet files found"):
+            resolve_read_path(str(empty))
+
+    def test_a_glob_that_matches_nothing_reports_the_pattern(self, tmp_path):
+        with pytest.raises(GeoParquetError, match="No .parquet files found"):
+            resolve_read_path(str(tmp_path / "*.parquet"))
+
+    def test_extract_reports_no_parquet_files(self, tmp_path, temp_output_file):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        result = CliRunner().invoke(extract, [str(empty), temp_output_file])
+        assert result.exit_code != 0
+        assert "No .parquet files found" in result.output
+        assert "Traceback" not in result.output
+
+    def test_a_populated_directory_is_unaffected(self, country_partition_dir):
+        resolved, _options = resolve_read_path(country_partition_dir)
+        assert resolved.endswith(".parquet")
+
+    def test_a_remote_glob_is_left_to_the_reader(self):
+        """gpio cannot enumerate a remote prefix, so it must not claim it is
+        empty -- the read itself reports what is or is not there."""
+        remote = "s3://bucket/parts/*.parquet"
+        resolved, _options = resolve_read_path(remote)
+        assert resolved == remote

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -622,3 +622,217 @@ class TestSortPartitionSchemaMismatch:
         ):
             with pytest.raises(duckdb.InvalidInputException, match="something else entirely"):
                 sort_by_quadkey(str(parts_dir), temp_output_file)
+
+
+@pytest.fixture
+def schema_diff_parts_dir(places_test_file, tmp_path):
+    """Two parquet files where the second carries a column the first lacks.
+
+    DuckDB's multi-file reader defaults to the first file's schema, so ``note``
+    is dropped without a word unless the read asks for ``union_by_name``.
+    Returns ``(directory, total_rows)``.
+    """
+    table = pq.read_table(places_test_file).slice(0, 200)
+    parts_dir = tmp_path / "schema_diff_parts"
+    parts_dir.mkdir()
+    first = table.slice(0, 100)
+    pq.write_table(first, parts_dir / "a.parquet")
+
+    second = table.slice(100, 100)
+    second = second.append_column("note", pa.array(["later"] * second.num_rows))
+    pq.write_table(second.replace_schema_metadata(first.schema.metadata), parts_dir / "b.parquet")
+    return parts_dir, 200
+
+
+class TestSortAllowSchemaDiff:
+    """``sort column``/``sort quadkey`` take ``--allow-schema-diff`` (#867).
+
+    Without it a column only some files carry vanishes from the merged output,
+    exactly as DuckDB's glob reader defaults. ``extract`` has spelled the
+    opt-in ``--allow-schema-diff`` since it learned to read directories, so the
+    sorts reuse that flag rather than inventing a second name for it.
+    """
+
+    def test_sort_column_drops_the_extra_column_by_default(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        parts_dir, total = schema_diff_parts_dir
+        result = CliRunner().invoke(sort, ["column", str(parts_dir), temp_output_file, "name"])
+        assert result.exit_code == 0, result.output
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == total
+        assert "note" not in out.column_names
+
+    def test_sort_column_allow_schema_diff_keeps_the_extra_column(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        parts_dir, total = schema_diff_parts_dir
+        result = CliRunner().invoke(
+            sort, ["column", str(parts_dir), temp_output_file, "name", "--allow-schema-diff"]
+        )
+        assert result.exit_code == 0, result.output
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == total
+        assert "note" in out.column_names
+        assert out.column("note").to_pylist().count("later") == 100
+
+    def test_sort_column_allow_schema_diff_can_sort_by_the_extra_column(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        """The column check must see the union too, or the flag is unusable
+        for the very column it was turned on to keep."""
+        parts_dir, _ = schema_diff_parts_dir
+        result = CliRunner().invoke(
+            sort, ["column", str(parts_dir), temp_output_file, "note", "--allow-schema-diff"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "note" in pq.read_schema(temp_output_file).names
+
+    def test_sort_column_without_the_flag_still_rejects_an_unknown_column(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        parts_dir, _ = schema_diff_parts_dir
+        result = CliRunner().invoke(sort, ["column", str(parts_dir), temp_output_file, "note"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_sort_quadkey_allow_schema_diff_keeps_the_extra_column(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        """The auto-add step reads the glob first, so the flag has to reach it."""
+        parts_dir, total = schema_diff_parts_dir
+        result = CliRunner().invoke(
+            sort, ["quadkey", str(parts_dir), temp_output_file, "--allow-schema-diff"]
+        )
+        assert result.exit_code == 0, result.output
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == total
+        assert "note" in out.column_names
+
+    def test_sort_quadkey_drops_the_extra_column_by_default(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        parts_dir, total = schema_diff_parts_dir
+        result = CliRunner().invoke(sort, ["quadkey", str(parts_dir), temp_output_file])
+        assert result.exit_code == 0, result.output
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == total
+        assert "note" not in out.column_names
+
+    def test_core_sort_by_column_takes_the_same_keyword(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        parts_dir, _ = schema_diff_parts_dir
+        sort_by_column(str(parts_dir), temp_output_file, "name", allow_schema_diff=True)
+        assert "note" in pq.read_schema(temp_output_file).names
+
+    def test_core_sort_by_quadkey_takes_the_same_keyword(
+        self, schema_diff_parts_dir, temp_output_file
+    ):
+        parts_dir, _ = schema_diff_parts_dir
+        sort_by_quadkey(str(parts_dir), temp_output_file, allow_schema_diff=True)
+        assert "note" in pq.read_schema(temp_output_file).names
+
+
+class TestSortSelfReadGuard:
+    """An output written inside the input dataset is refused (#867).
+
+    The directory input #852 added is re-globbed on every run, so an output
+    left inside it becomes part of the input: the next run reads its own
+    previous output back and the row count grows. Both sorts refuse before
+    writing anything.
+    """
+
+    def test_sort_column_refuses_an_output_inside_the_input_directory(self, places_parts_dir):
+        parts_dir, _ = places_parts_dir
+        output = parts_dir / "sorted.parquet"
+        result = CliRunner().invoke(sort, ["column", str(parts_dir), str(output), "name"])
+        assert result.exit_code != 0
+        assert str(parts_dir) in result.output
+        assert "sorted.parquet" in result.output
+        assert "somewhere else" in result.output
+        assert not output.exists()
+
+    def test_sort_column_refuses_an_output_matching_the_input_glob(self, places_parts_dir):
+        parts_dir, _ = places_parts_dir
+        output = parts_dir / "sorted.parquet"
+        result = CliRunner().invoke(
+            sort, ["column", str(parts_dir / "*.parquet"), str(output), "name"]
+        )
+        assert result.exit_code != 0
+        assert "somewhere else" in result.output
+        assert not output.exists()
+
+    def test_sort_column_overwrite_does_not_bypass_the_guard(self, places_parts_dir):
+        parts_dir, _ = places_parts_dir
+        output = parts_dir / "sorted.parquet"
+        output.write_bytes(b"stale")
+        result = CliRunner().invoke(
+            sort, ["column", str(parts_dir), str(output), "name", "--overwrite"]
+        )
+        assert result.exit_code != 0
+        assert "somewhere else" in result.output
+        assert output.read_bytes() == b"stale"
+
+    def test_sort_quadkey_refuses_an_output_inside_the_input_directory(self, places_parts_dir):
+        parts_dir, _ = places_parts_dir
+        output = parts_dir / "sorted.parquet"
+        result = CliRunner().invoke(sort, ["quadkey", str(parts_dir), str(output)])
+        assert result.exit_code != 0
+        assert "somewhere else" in result.output
+        assert not output.exists()
+
+    def test_a_sibling_directory_is_still_accepted(self, places_parts_dir, tmp_path):
+        parts_dir, _ = places_parts_dir
+        output = tmp_path / "elsewhere.parquet"
+        result = CliRunner().invoke(sort, ["column", str(parts_dir), str(output), "name"])
+        assert result.exit_code == 0, result.output
+        assert pq.read_metadata(output).num_rows == 766
+
+
+class TestSortEmptyDirectory:
+    """An empty directory says so, instead of blaming the reader (#867)."""
+
+    def test_sort_column_reports_no_parquet_files(self, tmp_path, temp_output_file):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        result = CliRunner().invoke(sort, ["column", str(empty), temp_output_file, "name"])
+        assert result.exit_code != 0
+        assert "No .parquet files found" in result.output
+        assert str(empty) in result.output
+
+    def test_sort_quadkey_reports_no_parquet_files(self, tmp_path, temp_output_file):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        result = CliRunner().invoke(sort, ["quadkey", str(empty), temp_output_file])
+        assert result.exit_code != 0
+        assert "No .parquet files found" in result.output
+
+
+class TestSortQuadkeyHiveInput:
+    """``sort quadkey`` threads the resolved read options, not just the path."""
+
+    def test_hive_partition_keys_survive_the_sort(self, tmp_path, places_test_file):
+        table = pq.read_table(places_test_file).slice(0, 60)
+        root = tmp_path / "hive_root"
+        for i, country in enumerate(("US", "CA")):
+            part_dir = root / f"country={country}"
+            part_dir.mkdir(parents=True)
+            pq.write_table(table.slice(i * 30, 30), part_dir / "part.parquet")
+
+        output = tmp_path / "sorted.parquet"
+        result = CliRunner().invoke(sort, ["quadkey", str(root), str(output)])
+        assert result.exit_code == 0, result.output
+        out = pq.read_table(output)
+        assert out.num_rows == 60
+        assert "country" in out.column_names
+        assert set(out.column("country").to_pylist()) == {"US", "CA"}
+
+    def test_a_failing_connection_does_not_mask_itself(self, places_parts_dir, temp_output_file):
+        """``con.close()`` in the ``finally`` used to raise UnboundLocalError
+        when the constructor itself threw, hiding the real failure."""
+        parts_dir, _ = places_parts_dir
+        boom = RuntimeError("no connection for you")
+        with mock.patch.object(sort_quadkey_module, "get_duckdb_connection", side_effect=boom):
+            with pytest.raises(RuntimeError, match="no connection for you"):
+                sort_by_quadkey(str(parts_dir), temp_output_file)

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -644,6 +644,24 @@ def schema_diff_parts_dir(places_test_file, tmp_path):
     return parts_dir, 200
 
 
+@pytest.fixture
+def schema_diff_quadkey_parts_dir(places_test_file, tmp_path):
+    """Like ``schema_diff_parts_dir``, but both files already carry a
+    ``quadkey`` column, so ``sort quadkey`` skips the auto-add step and reads
+    the directory glob directly. Returns ``(directory, total_rows)``."""
+    table = pq.read_table(places_test_file).slice(0, 200)
+    table = table.append_column("quadkey", pa.array([f"{i:03d}" for i in range(200)]))
+    parts_dir = tmp_path / "schema_diff_quadkey_parts"
+    parts_dir.mkdir()
+    first = table.slice(0, 100)
+    pq.write_table(first, parts_dir / "a.parquet")
+
+    second = table.slice(100, 100)
+    second = second.append_column("note", pa.array(["later"] * second.num_rows))
+    pq.write_table(second.replace_schema_metadata(first.schema.metadata), parts_dir / "b.parquet")
+    return parts_dir, 200
+
+
 class TestSortAllowSchemaDiff:
     """``sort column``/``sort quadkey`` take ``--allow-schema-diff`` (#867).
 
@@ -732,6 +750,45 @@ class TestSortAllowSchemaDiff:
         parts_dir, _ = schema_diff_parts_dir
         sort_by_quadkey(str(parts_dir), temp_output_file, allow_schema_diff=True)
         assert "note" in pq.read_schema(temp_output_file).names
+
+    def test_sort_quadkey_remove_column_allow_schema_diff_keeps_the_extra_column(
+        self, schema_diff_quadkey_parts_dir, temp_output_file
+    ):
+        """``--remove-quadkey-column`` builds an explicit SELECT list, which
+        must describe the union the read returns, not the first file's schema
+        -- or the very column the flag protects is silently dropped."""
+        parts_dir, total = schema_diff_quadkey_parts_dir
+        result = CliRunner().invoke(
+            sort,
+            [
+                "quadkey",
+                str(parts_dir),
+                temp_output_file,
+                "--remove-quadkey-column",
+                "--allow-schema-diff",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == total
+        assert "note" in out.column_names
+        assert out.column("note").to_pylist().count("later") == 100
+        assert "quadkey" not in out.column_names
+
+    def test_sort_quadkey_remove_column_without_the_flag_keeps_first_file_schema(
+        self, schema_diff_quadkey_parts_dir, temp_output_file
+    ):
+        """Without the flag the strict read returns the first file's columns,
+        so the SELECT list built from that first file stays correct."""
+        parts_dir, total = schema_diff_quadkey_parts_dir
+        result = CliRunner().invoke(
+            sort, ["quadkey", str(parts_dir), temp_output_file, "--remove-quadkey-column"]
+        )
+        assert result.exit_code == 0, result.output
+        out = pq.read_table(temp_output_file)
+        assert out.num_rows == total
+        assert "note" not in out.column_names
+        assert "quadkey" not in out.column_names
 
 
 class TestSortSelfReadGuard:


### PR DESCRIPTION
## What changed

Three follow-ups from the review of #852, which taught `sort column` and `sort quadkey` to read a bare directory.

**1. An output written inside the input dataset is refused.** A directory or glob input is re-expanded on every run, so an output left inside it joins the input, and the next run reads its own previous output back. The guard lives in `handle_output_overwrite` — the one call `extract`, `sort column` and `sort quadkey` all already make — and runs *before* its existence check, because on the first run the offending file does not exist yet and creating it is what breaks every run after. `--overwrite` does not bypass it. Matching is segment-aware (`geoparquet_io/core/file_utils.py`): `parts/*.parquet` covers `parts/out.parquet` but not `parts/sub/out.parquet`, which DuckDB would not read; `parts/**/*.parquet` covers both. Remote paths and single-file inputs are left alone (the existing input==output equality check still covers the latter).

**2. `sort column` and `sort quadkey` accept `--allow-schema-diff`.** Extract's option definition became a shared `allow_schema_diff_option` decorator in `cli/decorators.py`, reused by `partition_input_options` and by both sorts, so the flag and its help text cannot drift. The core functions take `allow_schema_diff=` and pass it to `build_read_parquet_expr`. Two details that would otherwise make the flag useless:
- the column-existence check for `sort column` describes the read expression when the flag is on, so you can sort *by* the column the flag was turned on to keep;
- `sort quadkey`'s auto-add step is the **first** read of the directory, so the option reaches `add_quadkey_column` too (a new private-by-default `_quadkey_from_clause`; the ordinary single-file add still reads through a bare `sql_path()` literal, unchanged).

`sort hilbert` and `sort str` still reject multi-file input, and gain nothing.

**3. Three smaller repairs.**
- An empty directory (or a glob matching nothing) fails with `No .parquet files found in: <path>` from the shared `require_parquet_files`, called from `resolve_read_path` and once early in `extract`'s file-based path, which reads the first file's footer before the shared resolver ever runs.
- `sort quadkey` threads `resolve_read_path`'s **options**, not just its path. The resolved glob (`root/**/*.parquet`) carries no `key=value` segment, so re-deriving hive partitioning from it found nothing and the partition keys were dropped.
- `con = None` before the `try` in `sort_quadkey`, and `if con:` in the `finally`, so a throwing connection constructor is not masked by `UnboundLocalError`.

**Python API.** `--allow-schema-diff` is a *read-time* option, and the API's sort twins (`ops.sort_column`, `Table.sort_quadkey`, …) are table-centric — they are handed a `pa.Table` that has already been read. The API already spells this as `gpio.read_partition(path, allow_schema_diff=True)`, so the parameter was **not** bolted onto the table-centric twins as a dead argument; `docs/guide/sort.md` shows the Python tab using `read_partition`. The CLI/API parity suites pick the new option up and stay green (a param absent from one side is skipped by design, and no new `KNOWN_DIVERGENCES` entry was needed).

## Why

`gpio sort column parts/ parts/sorted.parquet name` silently doubled its own dataset, and a column only some files carry disappeared from the merged output without a word. Both are failures the user cannot see: the command exits 0 and the read genuinely succeeds. Fixing the self-read at the shared choke point rather than in `sort` means `extract`, which had the identical hazard, is covered by the same code and the same message.

## Verification

Reproductions on `tests/data/places_test.parquet` copied into a temp directory, **before** the change:

```
$ for i in 1 2 3; do gpio sort column parts/ parts/sorted$i.parquet name; done
run1 rows: 766
run2 rows: 1532
run3 rows: 3064

$ for i in 1 2 3; do gpio extract ex/ ex/out$i.parquet; done
extract run1 rows: 766
extract run2 rows: 1532
extract run3 rows: 3064

# b.parquet adds an 'extra' column a.parquet does not have
$ gpio sort column parts/ out/sorted.parquet name
sorted cols ['fsq_place_id', 'name', 'address', 'placemaker_url', 'geometry', 'bbox'] rows 200

$ gpio sort column empty/ out/o.parquet name
Error: Cannot read file: .../empty/
Cannot open for reading: path '.../empty/' is a directory
$ gpio extract empty/ out/o3.parquet
_duckdb.IOException: IO Error: No files found that match the pattern ".../empty/"
LINE 1: DESCRIBE SELECT * FROM read_parquet('/private/tmp/claude-501/-Users-cholmes...
```

**After:**

```
$ gpio sort column parts/ parts/sorted.parquet name
Error: Output '.../parts/sorted.parquet' is inside the input directory '.../parts/'.

Writing it there would add it to the dataset, so the next run would read it back as input and count every row twice.

Write the output somewhere else, outside the input dataset.

$ gpio sort column parts/ parts/sorted.parquet name --overwrite
Error: Output '.../parts/sorted.parquet' is inside the input directory '.../parts/'.
[...same message; the stale output is not deleted...]

$ gpio extract "parts/*.parquet" parts/out.parquet
Error: Output '.../parts/out.parquet' is matched by the input '.../parts/*.parquet'.
[...]

$ gpio sort column parts/ out/sorted.parquet name        # sibling directory
Sorted by name to: .../out/sorted.parquet
rows: 766

$ gpio sort column parts/ out/a.parquet name
['fsq_place_id', 'name', 'address', 'placemaker_url', 'geometry', 'bbox']
$ gpio sort column parts/ out/b.parquet name --allow-schema-diff
['fsq_place_id', 'name', 'address', 'placemaker_url', 'geometry', 'bbox', 'extra']
$ gpio sort quadkey parts/ out/c.parquet --allow-schema-diff
['fsq_place_id', 'name', 'address', 'placemaker_url', 'geometry', 'bbox', 'extra', 'quadkey']

$ gpio sort column empty/ out/d.parquet name
Error: No .parquet files found in: .../empty
$ gpio sort quadkey empty/ out/e.parquet
Error: No .parquet files found in: .../empty
$ gpio extract empty/ out/f.parquet
Error: No .parquet files found in: .../empty
```

Gates:

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5707 passed, 70 skipped, 1 xfailed in 151.68s

$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
Total:   70 lines
Missing: 1 line          # since covered by a remote-glob test
Coverage: 98%

$ uv run pre-commit run --all-files                          # clean
$ uv run pre-commit run --all-files --hook-stage pre-push    # clean (mypy, vulture, xenon, import-linter, deptry)
```

`tests/data/cli_surface.json` was re-recorded with `GPIO_UPDATE_SNAPSHOT=1`; the diff is exactly two identical 16-line `allow_schema_diff` option blocks, one under `sort column` and one under `sort quadkey`, and nothing else.

New tests: `TestGuardOutputNotReadAsInput` (13 cases) in `tests/test_file_utils.py`; `TestOutputInsideInputDataset` and `TestEmptyPartitionDirectory` in `tests/test_partition_input.py`; `TestSortAllowSchemaDiff`, `TestSortSelfReadGuard`, `TestSortEmptyDirectory` and `TestSortQuadkeyHiveInput` in `tests/test_sort.py`.

## Known gap

`gpio add quadkey` gained the plumbing for `hive_input`/`allow_schema_diff` but does **not** expose either as a CLI option — nothing asked for that, and it would be a separate CLI surface change. Its own multi-file behaviour is otherwise untouched.

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--allow-schema-diff` to column and quadkey sorting commands, allowing files with different columns to be combined while preserving all fields.
  - Added clear errors for empty directories and unmatched file patterns.
  - Prevented outputs from being written inside, or matching, the input dataset to avoid accidental reprocessing.

- **Documentation**
  - Added guidance and examples covering output locations, differing input schemas, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->