### PR TITLE
fix(validate): read X/Y from 6- and 8-element bboxes; handle antimeridian extents

### DIFF
--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -1461,17 +1461,17 @@ def _bbox_xy(bbox: list) -> tuple | None:
     return bbox[0], bbox[1], bbox[half], bbox[half + 1]
 
 
-def _x_within_sql(xmin_expr: str, xmax_expr: str, xmin, xmax) -> str:
-    """SQL predicate: the [xmin_expr, xmax_expr] range lies within the bbox X range.
+def _x_within_sql(geom_expr: str, xmin, xmax) -> str:
+    """SQL predicate: every X of the geometry lies within the bbox X range.
 
-    When xmin > xmax the bbox crosses the antimeridian (RFC 7946, 5.2) and a
-    geometry is outside only if one of its X extremes falls in the gap (xmax, xmin).
+    When xmin > xmax the bbox crosses the antimeridian (RFC 7946, 5.2): the
+    allowed longitudes are [xmin, 180] and [-180, xmax], checked per vertex.
     """
     if xmin <= xmax:
-        return f"{xmin_expr} >= {xmin} AND {xmax_expr} <= {xmax}"
+        return f"ST_XMin({geom_expr}) >= {xmin} AND ST_XMax({geom_expr}) <= {xmax}"
     return (
-        f"NOT ({xmin_expr} > {xmax} AND {xmin_expr} < {xmin}) AND "
-        f"NOT ({xmax_expr} > {xmax} AND {xmax_expr} < {xmin})"
+        f"list_bool_and([ST_X(p.geom) <= {xmax} OR ST_X(p.geom) >= {xmin} "
+        f"FOR p IN ST_Dump(ST_Points({geom_expr}))])"
     )
 
 
@@ -1504,8 +1504,8 @@ def _build_bbox_query(
         return f"""
             SELECT COUNT(*) as total,
                    COUNT(CASE WHEN
-                       {_x_within_sql("xmin", "xmax", xmin, xmax)} AND
-                       ymin >= {ymin} AND ymax <= {ymax}
+                       xmin >= {xmin} AND ymin >= {ymin} AND
+                       xmax <= {xmax} AND ymax <= {ymax}
                    THEN 1 END) as within_bbox
             FROM ({_geoarrow_bounds_subquery(raw_url, geom_col, encoding, limit_clause)})
         """
@@ -1522,7 +1522,7 @@ def _build_bbox_query(
     return f"""
         SELECT COUNT(*) as total,
                COUNT(CASE WHEN
-                   {_x_within_sql(f"ST_XMin({geom_expr})", f"ST_XMax({geom_expr})", xmin, xmax)} AND
+                   {_x_within_sql(geom_expr, xmin, xmax)} AND
                    ST_YMin({geom_expr}) >= {ymin} AND
                    ST_YMax({geom_expr}) <= {ymax}
                THEN 1 END) as within_bbox
@@ -1607,6 +1607,13 @@ def _check_bbox_contains_data(
             name=f"bbox_contains_data_{geom_col}",
             status=CheckStatus.SKIPPED,
             message=f"bbox has {len(bbox)} elements, expected 4, 6 or 8; skipping data check",
+            category="data_validation",
+        )
+    if xy[0] > xy[2] and _is_geoarrow_encoding(encoding):
+        return ValidationCheck(
+            name=f"bbox_contains_data_{geom_col}",
+            status=CheckStatus.SKIPPED,
+            message="antimeridian-crossing bbox is not checked for GeoArrow encodings",
             category="data_validation",
         )
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -537,7 +537,7 @@ def _check_edges_spherical_on_projected_crs(
 
 
 def _check_bbox_valid(col_meta: dict, col_name: str) -> ValidationCheck:
-    """Check 12: optional 'bbox' must be an array of 4 or 6 numbers."""
+    """Check 12: optional 'bbox' must be an array of 4, 6 or 8 numbers."""
     bbox = col_meta.get("bbox")
 
     if bbox is None:
@@ -556,11 +556,11 @@ def _check_bbox_valid(col_meta: dict, col_name: str) -> ValidationCheck:
             category="column_metadata",
         )
 
-    if len(bbox) not in [4, 6]:
+    if len(bbox) not in [4, 6, 8]:
         return ValidationCheck(
             name=f"bbox_valid_{col_name}",
             status=CheckStatus.FAILED,
-            message=f'column "{col_name}" bbox must have 4 or 6 elements (got {len(bbox)})',
+            message=f'column "{col_name}" bbox must have 4, 6 or 8 elements (got {len(bbox)})',
             category="column_metadata",
         )
 
@@ -1453,6 +1453,28 @@ def _check_orientation_matches_data(
     )
 
 
+def _bbox_xy(bbox: list) -> tuple | None:
+    """(xmin, ymin, xmax, ymax) of a 4-, 6- or 8-element GeoParquet bbox; None otherwise."""
+    if len(bbox) not in (4, 6, 8):
+        return None
+    half = len(bbox) // 2
+    return bbox[0], bbox[1], bbox[half], bbox[half + 1]
+
+
+def _x_within_sql(xmin_expr: str, xmax_expr: str, xmin, xmax) -> str:
+    """SQL predicate: the [xmin_expr, xmax_expr] range lies within the bbox X range.
+
+    When xmin > xmax the bbox crosses the antimeridian (RFC 7946, 5.2) and a
+    geometry is outside only if one of its X extremes falls in the gap (xmax, xmin).
+    """
+    if xmin <= xmax:
+        return f"{xmin_expr} >= {xmin} AND {xmax_expr} <= {xmax}"
+    return (
+        f"NOT ({xmin_expr} > {xmax} AND {xmin_expr} < {xmin}) AND "
+        f"NOT ({xmax_expr} > {xmax} AND {xmax_expr} < {xmin})"
+    )
+
+
 def _build_bbox_query(
     raw_url: str,
     geom_col: str,
@@ -1482,8 +1504,8 @@ def _build_bbox_query(
         return f"""
             SELECT COUNT(*) as total,
                    COUNT(CASE WHEN
-                       xmin >= {xmin} AND ymin >= {ymin} AND
-                       xmax <= {xmax} AND ymax <= {ymax}
+                       {_x_within_sql("xmin", "xmax", xmin, xmax)} AND
+                       ymin >= {ymin} AND ymax <= {ymax}
                    THEN 1 END) as within_bbox
             FROM ({_geoarrow_bounds_subquery(raw_url, geom_col, encoding, limit_clause)})
         """
@@ -1500,9 +1522,8 @@ def _build_bbox_query(
     return f"""
         SELECT COUNT(*) as total,
                COUNT(CASE WHEN
-                   ST_XMin({geom_expr}) >= {xmin} AND
+                   {_x_within_sql(f"ST_XMin({geom_expr})", f"ST_XMax({geom_expr})", xmin, xmax)} AND
                    ST_YMin({geom_expr}) >= {ymin} AND
-                   ST_XMax({geom_expr}) <= {xmax} AND
                    ST_YMax({geom_expr}) <= {ymax}
                THEN 1 END) as within_bbox
         FROM (
@@ -1580,17 +1601,18 @@ def _check_bbox_contains_data(
     raw_url = resolve_file_url(parquet_file, verbose=False)
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
-    try:
-        # Check if DuckDB already has it as a GEOMETRY type
-        col_type = _describe_geom_type(con, raw_url, geom_col)
-
-        # NOTE: bbox[:4] mishandles the spec's 6-element 3D form
-        # [xmin,ymin,zmin,xmax,ymax,zmax], comparing against
-        # [xmin,ymin,zmin,xmax]. Pre-existing and equally wrong for WKB;
-        # tracked as #603 item 1 (same line), so it is not fixed here.
-        query = _build_bbox_query(
-            raw_url, geom_col, col_type, tuple(bbox[:4]), limit_clause, encoding
+    xy = _bbox_xy(bbox)
+    if xy is None:
+        return ValidationCheck(
+            name=f"bbox_contains_data_{geom_col}",
+            status=CheckStatus.SKIPPED,
+            message=f"bbox has {len(bbox)} elements, expected 4, 6 or 8; skipping data check",
+            category="data_validation",
         )
+
+    try:
+        col_type = _describe_geom_type(con, raw_url, geom_col)
+        query = _build_bbox_query(raw_url, geom_col, col_type, xy, limit_clause, encoding)
         result = con.execute(query).fetchone()
         return _interpret_bbox_result(result, geom_col)
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -536,8 +536,12 @@ def _check_edges_spherical_on_projected_crs(
     )
 
 
-def _check_bbox_valid(col_meta: dict, col_name: str) -> ValidationCheck:
-    """Check 12: optional 'bbox' must be an array of 4, 6 or 8 numbers."""
+def _check_bbox_valid(col_meta: dict, col_name: str, geo_version: str = "1.0.0") -> ValidationCheck:
+    """Check 12: optional 'bbox' must be an array of 4, 6 or 8 numbers.
+
+    The 8-element (XYZM) form is spec text only on the 2.0 line; the released
+    1.x schemas allow only 4 or 6 elements.
+    """
     bbox = col_meta.get("bbox")
 
     if bbox is None:
@@ -561,6 +565,17 @@ def _check_bbox_valid(col_meta: dict, col_name: str) -> ValidationCheck:
             name=f"bbox_valid_{col_name}",
             status=CheckStatus.FAILED,
             message=f'column "{col_name}" bbox must have 4, 6 or 8 elements (got {len(bbox)})',
+            category="column_metadata",
+        )
+
+    if len(bbox) == 8 and not _version_at_least(geo_version, 2, 0):
+        return ValidationCheck(
+            name=f"bbox_valid_{col_name}",
+            status=CheckStatus.FAILED,
+            message=(
+                f'column "{col_name}" bbox has 8 elements (XYZM), which requires '
+                f"GeoParquet 2.0; version {geo_version} allows only 4 or 6"
+            ),
             category="column_metadata",
         )
 
@@ -1454,11 +1469,18 @@ def _check_orientation_matches_data(
 
 
 def _bbox_xy(bbox: list) -> tuple | None:
-    """(xmin, ymin, xmax, ymax) of a 4-, 6- or 8-element GeoParquet bbox; None otherwise."""
+    """(xmin, ymin, xmax, ymax) of a 4-, 6- or 8-element GeoParquet bbox; None otherwise.
+
+    Coerces through float() so a non-numeric metadata element can never reach
+    the SQL the values are interpolated into.
+    """
     if len(bbox) not in (4, 6, 8):
         return None
     half = len(bbox) // 2
-    return bbox[0], bbox[1], bbox[half], bbox[half + 1]
+    try:
+        return float(bbox[0]), float(bbox[1]), float(bbox[half]), float(bbox[half + 1])
+    except (TypeError, ValueError):
+        return None
 
 
 def _x_within_sql(geom_expr: str, xmin, xmax) -> str:
@@ -1466,6 +1488,9 @@ def _x_within_sql(geom_expr: str, xmin, xmax) -> str:
 
     When xmin > xmax the bbox crosses the antimeridian (RFC 7946, 5.2): the
     allowed longitudes are [xmin, 180] and [-180, xmax], checked per vertex.
+    A segment whose interior spans the gap between two in-range vertices is
+    undecidable from vertices alone; RFC 7946 tells producers to cut such
+    geometries at the antimeridian.
     """
     if xmin <= xmax:
         return f"ST_XMin({geom_expr}) >= {xmin} AND ST_XMax({geom_expr}) <= {xmax}"
@@ -1586,8 +1611,14 @@ def _check_bbox_contains_data(
     con,
     sample_size: int,
     encoding: Any = "WKB",
+    crs: Any = None,
 ) -> ValidationCheck:
-    """Check 20: all geometries must fall within 'bbox' metadata."""
+    """Check 20: all geometries must fall within 'bbox' metadata.
+
+    ``crs`` is the column's declared crs value (None means the CRS84 default):
+    xmin > xmax is read as an antimeridian-crossing extent (RFC 7946, 5.2) only
+    for a geographic CRS -- for a projected CRS it is broken metadata.
+    """
     if bbox is None:
         return ValidationCheck(
             name=f"bbox_contains_data_{geom_col}",
@@ -1606,10 +1637,24 @@ def _check_bbox_contains_data(
         return ValidationCheck(
             name=f"bbox_contains_data_{geom_col}",
             status=CheckStatus.SKIPPED,
-            message=f"bbox has {len(bbox)} elements, expected 4, 6 or 8; skipping data check",
+            message=(
+                f"bbox {bbox!r} is not valid, expected 4, 6 or 8 numbers; skipping data check"
+            ),
             category="data_validation",
         )
-    if xy[0] > xy[2] and _is_geoarrow_encoding(encoding):
+    wrapped = xy[0] > xy[2]
+    if wrapped and not is_geographic_crs(crs):
+        return ValidationCheck(
+            name=f"bbox_contains_data_{geom_col}",
+            status=CheckStatus.FAILED,
+            message=(
+                "declared bbox has xmin > xmax; the antimeridian wrap-around reading "
+                "(RFC 7946, 5.2) applies only to geographic CRS, so this bbox is "
+                "invalid for the declared projected CRS"
+            ),
+            category="data_validation",
+        )
+    if wrapped and _is_geoarrow_encoding(encoding):
         return ValidationCheck(
             name=f"bbox_contains_data_{geom_col}",
             status=CheckStatus.SKIPPED,
@@ -1621,7 +1666,11 @@ def _check_bbox_contains_data(
         col_type = _describe_geom_type(con, raw_url, geom_col)
         query = _build_bbox_query(raw_url, geom_col, col_type, xy, limit_clause, encoding)
         result = con.execute(query).fetchone()
-        return _interpret_bbox_result(result, geom_col)
+        check = _interpret_bbox_result(result, geom_col)
+        if wrapped and check.status != CheckStatus.SKIPPED:
+            # The wrap reading must never be invisible in the check output.
+            check.message += " (bbox interpreted as antimeridian-crossing, RFC 7946 5.2)"
+        return check
 
     except Exception as e:
         check_name = f"bbox_contains_data_{geom_col}"
@@ -3830,7 +3879,7 @@ def _run_geoparquet_checks(
         edges_crs_check = _check_edges_spherical_on_projected_crs(parquet_file, col_meta, col_name)
         if edges_crs_check:
             checks.append(edges_crs_check)
-        checks.append(_check_bbox_valid(col_meta, col_name))
+        checks.append(_check_bbox_valid(col_meta, col_name, geo_version))
         checks.append(_check_epoch_valid(col_meta, col_name))
 
         # Parquet schema checks
@@ -3865,12 +3914,14 @@ def _run_geoparquet_checks(
             )
 
             bbox = col_meta.get("bbox")
+            crs = col_meta.get("crs")
             checks.append(
-                _check_bbox_contains_data(parquet_file, col_name, bbox, con, sample_size, encoding)
+                _check_bbox_contains_data(
+                    parquet_file, col_name, bbox, con, sample_size, encoding, crs
+                )
             )
 
             # Check coordinates are valid for declared CRS
-            crs = col_meta.get("crs")
             checks.append(
                 _check_coordinates_valid_for_crs(
                     parquet_file, col_name, crs, con, sample_size, encoding

--- a/tests/test_validate_bbox_dimensions.py
+++ b/tests/test_validate_bbox_dimensions.py
@@ -1,0 +1,119 @@
+"""bbox checks for 6-element (XYZ) and 8-element (XYZM) bboxes and antimeridian extents (#603)."""
+
+import json
+
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_bbox_contains_data,
+    _check_bbox_valid,
+    validate_geoparquet,
+)
+
+
+def _write_v2(path, wkt_rows):
+    con = get_duckdb_connection(load_spatial=True)
+    values = ", ".join(f"({i}, ST_GeomFromText('{wkt}'))" for i, wkt in enumerate(wkt_rows, 1))
+    con.execute(
+        f"COPY (SELECT * FROM (VALUES {values}) t(id, geometry)) "
+        f"TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')"
+    )
+    con.close()
+    return path
+
+
+def _declared_bbox(path):
+    geo = json.loads(pq.read_metadata(path).metadata[b"geo"])
+    return geo["columns"]["geometry"]["bbox"]
+
+
+@pytest.fixture
+def xyz_file(tmp_path):
+    return _write_v2(
+        tmp_path / "xyz.parquet",
+        [
+            "POLYGON Z ((0 0 10, 4 0 12, 4 4 15, 0 4 11, 0 0 10))",
+            "POLYGON Z ((10 10 5, 12 10 5, 12 12 5, 10 12 5, 10 10 5))",
+        ],
+    )
+
+
+@pytest.fixture
+def xyzm_file(tmp_path):
+    return _write_v2(
+        tmp_path / "xyzm.parquet",
+        ["POINT ZM (1 2 3 4)", "POINT ZM (10 20 30 40)"],
+    )
+
+
+@pytest.fixture
+def antimeridian_file(tmp_path):
+    return _write_v2(tmp_path / "am.parquet", ["POINT (175 0)", "POINT (-175 5)"])
+
+
+@pytest.fixture
+def con():
+    con = get_duckdb_connection(load_spatial=True)
+    yield con
+    con.close()
+
+
+class TestBboxValid:
+    @pytest.mark.parametrize("n", [4, 6, 8])
+    def test_accepts_spec_lengths(self, n):
+        check = _check_bbox_valid({"bbox": [float(i) for i in range(n)]}, "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 5, 7, 9])
+    def test_rejects_other_lengths(self, n):
+        check = _check_bbox_valid({"bbox": [float(i) for i in range(n)]}, "geometry")
+        assert check.status == CheckStatus.FAILED
+        assert "4, 6 or 8" in check.message
+
+
+class TestBboxContainsData:
+    def test_duckdb_xyz_bbox_is_not_a_false_failure(self, xyz_file, con):
+        bbox = _declared_bbox(xyz_file)
+        assert len(bbox) == 6
+        check = _check_bbox_contains_data(str(xyz_file), "geometry", bbox, con, 0)
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_xyz_bbox_that_excludes_data_fails(self, xyz_file, con):
+        check = _check_bbox_contains_data(str(xyz_file), "geometry", [0, 0, 0, 5, 5, 20], con, 0)
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 2" in check.message
+
+    def test_xyzm_bbox(self, xyzm_file, con):
+        inside = [0, 0, 0, 0, 20, 30, 40, 50]
+        outside = [0, 0, 0, 0, 5, 30, 40, 50]
+        assert (
+            _check_bbox_contains_data(str(xyzm_file), "geometry", inside, con, 0).status
+            == CheckStatus.PASSED
+        )
+        check = _check_bbox_contains_data(str(xyzm_file), "geometry", outside, con, 0)
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 2" in check.message
+
+    def test_antimeridian_bbox(self, antimeridian_file, con):
+        # xmin > xmax means the extent wraps across the antimeridian (RFC 7946 5.2)
+        check = _check_bbox_contains_data(
+            str(antimeridian_file), "geometry", [170, -10, -170, 10], con, 0
+        )
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_antimeridian_bbox_excludes_geometry_in_the_gap(self, tmp_path, con):
+        path = _write_v2(tmp_path / "gap.parquet", ["POINT (175 0)", "POINT (0 0)"])
+        check = _check_bbox_contains_data(str(path), "geometry", [170, -10, -170, 10], con, 0)
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 2" in check.message
+
+    def test_full_validation_of_xyz_file_passes_bbox_checks(self, xyz_file):
+        result = validate_geoparquet(str(xyz_file))
+        bbox_checks = {c.name: c for c in result.checks if c.name.startswith("bbox_")}
+        assert bbox_checks, [c.name for c in result.checks]
+        assert all(c.status == CheckStatus.PASSED for c in bbox_checks.values()), [
+            (c.name, c.message) for c in bbox_checks.values()
+        ]

--- a/tests/test_validate_bbox_dimensions.py
+++ b/tests/test_validate_bbox_dimensions.py
@@ -110,6 +110,27 @@ class TestBboxContainsData:
         assert check.status == CheckStatus.FAILED
         assert "1 of 2" in check.message
 
+    def test_antimeridian_bbox_checks_every_vertex(self, tmp_path, con):
+        # X extremes sit in the two lobes, but the middle vertex is in the gap
+        path = _write_v2(tmp_path / "gap.parquet", ["MULTIPOINT (175 0, -175 0, 0 0)"])
+        check = _check_bbox_contains_data(str(path), "geometry", [170, -10, -170, 10], con, 0)
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 1" in check.message
+
+    def test_invalid_length_skips_data_check(self, xyz_file, con):
+        check = _check_bbox_contains_data(str(xyz_file), "geometry", [0, 0, 0, 5, 5], con, 0)
+        assert check.status == CheckStatus.SKIPPED
+        assert "expected 4, 6 or 8" in check.message
+
+    def test_geoarrow_encoding(self, con):
+        path = "tests/data/data-polygon-encoding_native.parquet"
+        wide = _check_bbox_contains_data(
+            path, "geometry", [-180, -90, -1, 180, 90, 1], con, 0, "polygon"
+        )
+        assert wide.status == CheckStatus.PASSED, wide.message
+        wrap = _check_bbox_contains_data(path, "geometry", [170, -90, -170, 90], con, 0, "polygon")
+        assert wrap.status == CheckStatus.SKIPPED
+
     def test_full_validation_of_xyz_file_passes_bbox_checks(self, xyz_file):
         result = validate_geoparquet(str(xyz_file))
         bbox_checks = {c.name: c for c in result.checks if c.name.startswith("bbox_")}

--- a/tests/test_validate_bbox_dimensions.py
+++ b/tests/test_validate_bbox_dimensions.py
@@ -30,6 +30,26 @@ def _declared_bbox(path):
     return geo["columns"]["geometry"]["bbox"]
 
 
+def _rewrite_geo(path, out_path, *, version=None, **column_updates):
+    """Copy a GeoParquet file with its geo metadata version/column fields edited."""
+    table = pq.read_table(path)
+    meta = dict(table.schema.metadata or {})
+    geo = json.loads(meta[b"geo"])
+    if version is not None:
+        geo["version"] = version
+    geo["columns"]["geometry"].update(column_updates)
+    meta[b"geo"] = json.dumps(geo).encode()
+    pq.write_table(table.replace_schema_metadata(meta), out_path)
+    return out_path
+
+
+UTM_33N = {
+    "type": "ProjectedCRS",
+    "name": "WGS 84 / UTM zone 33N",
+    "id": {"authority": "EPSG", "code": 32633},
+}
+
+
 @pytest.fixture
 def xyz_file(tmp_path):
     return _write_v2(
@@ -62,10 +82,22 @@ def con():
 
 
 class TestBboxValid:
-    @pytest.mark.parametrize("n", [4, 6, 8])
+    @pytest.mark.parametrize("n", [4, 6])
     def test_accepts_spec_lengths(self, n):
         check = _check_bbox_valid({"bbox": [float(i) for i in range(n)]}, "geometry")
         assert check.status == CheckStatus.PASSED, check.message
+
+    def test_accepts_xyzm_bbox_on_2_0(self):
+        check = _check_bbox_valid({"bbox": [float(i) for i in range(8)]}, "geometry", "2.0.0")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    @pytest.mark.parametrize("version", ["1.0.0", "1.1.0"])
+    def test_rejects_xyzm_bbox_below_2_0(self, version):
+        # The XYZM bbox is spec text only on the 2.0 line; the released 1.1.0
+        # schema allows only 4 or 6 elements.
+        check = _check_bbox_valid({"bbox": [float(i) for i in range(8)]}, "geometry", version)
+        assert check.status == CheckStatus.FAILED
+        assert "2.0" in check.message
 
     @pytest.mark.parametrize("n", [1, 2, 3, 5, 7, 9])
     def test_rejects_other_lengths(self, n):
@@ -103,6 +135,24 @@ class TestBboxContainsData:
             str(antimeridian_file), "geometry", [170, -10, -170, 10], con, 0
         )
         assert check.status == CheckStatus.PASSED, check.message
+        # The reinterpretation must never be invisible in the check output.
+        assert "antimeridian" in check.message
+
+    def test_wrap_bbox_on_projected_crs_fails(self, tmp_path, con):
+        # For a projected CRS xmin > xmax is not a wrap -- it is broken metadata,
+        # and the geometry must not be blessed by the wrap reading.
+        path = _write_v2(tmp_path / "proj.parquet", ["POINT (0 0)"])
+        check = _check_bbox_contains_data(
+            str(path), "geometry", [10, -10, 5, 10], con, 0, "WKB", crs=UTM_33N
+        )
+        assert check.status == CheckStatus.FAILED
+        assert "projected" in check.message.lower()
+
+    def test_wrap_fail_message_names_the_interpretation(self, tmp_path, con):
+        path = _write_v2(tmp_path / "gap2.parquet", ["POINT (0 0)"])
+        check = _check_bbox_contains_data(str(path), "geometry", [170, -10, -170, 10], con, 0)
+        assert check.status == CheckStatus.FAILED
+        assert "antimeridian" in check.message
 
     def test_antimeridian_bbox_excludes_geometry_in_the_gap(self, tmp_path, con):
         path = _write_v2(tmp_path / "gap.parquet", ["POINT (175 0)", "POINT (0 0)"])
@@ -122,6 +172,12 @@ class TestBboxContainsData:
         assert check.status == CheckStatus.SKIPPED
         assert "expected 4, 6 or 8" in check.message
 
+    def test_non_numeric_bbox_element_skips_data_check(self, xyz_file, con):
+        # A non-numeric metadata element must never reach the SQL f-string.
+        check = _check_bbox_contains_data(str(xyz_file), "geometry", [0, 0, "east", 5], con, 0)
+        assert check.status == CheckStatus.SKIPPED
+        assert "expected 4, 6 or 8" in check.message
+
     def test_geoarrow_encoding(self, con):
         path = "tests/data/data-polygon-encoding_native.parquet"
         wide = _check_bbox_contains_data(
@@ -130,6 +186,40 @@ class TestBboxContainsData:
         assert wide.status == CheckStatus.PASSED, wide.message
         wrap = _check_bbox_contains_data(path, "geometry", [170, -90, -170, 90], con, 0, "polygon")
         assert wrap.status == CheckStatus.SKIPPED
+
+    def test_full_validation_rejects_xyzm_bbox_on_1_1(self, xyz_file, tmp_path):
+        path = _rewrite_geo(
+            xyz_file,
+            tmp_path / "xyzm_11.parquet",
+            version="1.1.0",
+            bbox=[0.0, 0.0, 10.0, 0.0, 4.0, 4.0, 15.0, 0.0],
+        )
+        result = validate_geoparquet(str(path))
+        check = next(c for c in result.checks if c.name == "bbox_valid_geometry")
+        assert check.status == CheckStatus.FAILED, check.message
+        assert "2.0" in check.message
+
+    def test_full_validation_accepts_xyzm_bbox_on_2_0(self, xyz_file, tmp_path):
+        path = _rewrite_geo(
+            xyz_file,
+            tmp_path / "xyzm_20.parquet",
+            bbox=[0.0, 0.0, 10.0, 0.0, 4.0, 4.0, 15.0, 0.0],
+        )
+        result = validate_geoparquet(str(path))
+        check = next(c for c in result.checks if c.name == "bbox_valid_geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_full_validation_fails_wrap_bbox_on_projected_crs(self, xyz_file, tmp_path):
+        path = _rewrite_geo(
+            xyz_file,
+            tmp_path / "proj_wrap.parquet",
+            bbox=[170.0, -10.0, -170.0, 10.0],
+            crs=UTM_33N,
+        )
+        result = validate_geoparquet(str(path))
+        check = next(c for c in result.checks if c.name == "bbox_contains_data_geometry")
+        assert check.status == CheckStatus.FAILED, check.message
+        assert "projected" in check.message.lower()
 
     def test_full_validation_of_xyz_file_passes_bbox_checks(self, xyz_file):
         result = validate_geoparquet(str(xyz_file))


### PR DESCRIPTION
## Problem

`_check_bbox_contains_data` took `bbox[:4]` as `(xmin, ymin, xmax, ymax)`. For the spec's 6-element XYZ form `[xmin, ymin, zmin, xmax, ymax, zmax]` that compares against `(xmin, ymin, zmin, xmax)`, so a correct file fails. This is #603 item 1 (item 2 was fixed in #770). `bbox_valid` also rejected the 8-element XYZM form that GeoParquet 2.0 allows.

Repro on `main` with a file written by DuckDB itself:

```python
COPY (SELECT * FROM (VALUES
  (1, ST_GeomFromText('POLYGON Z ((0 0 10, 4 0 12, 4 4 15, 0 4 11, 0 0 10))')),
  (2, ST_GeomFromText('POLYGON Z ((10 10 5, 12 10 5, 12 12 5, 10 12 5, 10 10 5))'))
) t(id, geometry)) TO 'xyz.parquet' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')
-- geo bbox written by DuckDB: [0.0, 0.0, 5.0, 12.0, 12.0, 15.0]
```

```
$ gpio check spec xyz.parquet        # main
  ✓ column "geometry" has valid bbox: [0.0, 0.0, 5.0, 12.0, 12.0, 15.0]
  ✗ 1 of 2 geometries fall outside declared bbox
$ gpio check spec xyz.parquet        # this branch
  ✓ column "geometry" has valid bbox: [0.0, 0.0, 5.0, 12.0, 12.0, 15.0]
  ✓ all geometries fall within declared bbox (2 checked)
Summary: 32 passed, 0 warnings, 0 failed
```

## Change

- `_bbox_xy()` picks `(xmin, ymin, xmax, ymax)` by bbox length: 4, 6 or 8. Other lengths skip the data check with a message (`bbox_valid` already fails them).
- `bbox_valid` accepts 8 elements (`4, 6 or 8` in the message).
- `_x_within_sql()`: when `xmin > xmax` the extent crosses the antimeridian (RFC 7946 §5.2, referenced by the spec's `bbox` text). A geometry is then outside only if one of its X extremes falls in the gap `(xmax, xmin)`. Previously every geometry failed against such a bbox. Same predicate for the WKB/GEOMETRY and the GeoArrow paths.

## Tests

`tests/test_validate_bbox_dimensions.py`, written first (13 of 15 failed on `main`): DuckDB-written XYZ file with its own 6-element bbox passes; 6-element bbox excluding one polygon fails with `1 of 2`; 8-element XYZM inside/outside; antimeridian bbox with points on both sides passes, a point in the gap fails; lengths 1–9 for `bbox_valid`; full `validate_geoparquet` on the XYZ file has no failing `bbox_*` check.

Regression: `tests/test_validate_*`, `test_check.py`, `test_geoparquet_corpus.py`, `test_bbox_metadata_integrity.py`, `test_metadata_bbox_invalidation.py` — 509 passed, 8 xfailed. Pre-commit hooks pass.

## Adversarial pass (done before opening)

Probed by hand: integer bbox values; NULL and `POINT EMPTY` rows (excluded from the count, as before); `sample_size=1`; degenerate `xmin == xmax` (fails, correctly, for polygons with width); 8-element bbox over XYZ data; a `LINESTRING (179 0, -179 0)` that spans the antimeridian itself (passes against a wrap bbox, since neither extreme lies in the gap, and against a world bbox); the GeoArrow `point` and `polygon` native encodings with 4/6/8-element and wrap bboxes.

Known limitation, unchanged: the wrap interpretation is applied whenever `xmin > xmax`, without looking at the CRS. For a projected CRS `xmin > xmax` is simply invalid; the spec defines the wrap form for geographic CRSs only. Rejecting it for projected CRSs would need the column CRS in this check and is left out of this PR.

Found while mapping the OGC GeoParquet 2.0 abstract tests to `gpio` (opengeospatial/geoparquet#304). Closes #603.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GeoParquet bounding-box validation for 3D and 4D coordinate data.
  * Added support for antimeridian-crossing bounding boxes in geographic coordinate systems.
  * Corrected validation when bounding boxes exclude available data, including WKB geometries.
  * Invalid or non-numeric bounding-box dimensions are now handled safely.
  * Improved handling for projected coordinate systems and GeoArrow-encoded data.

* **Tests**
  * Added coverage for 4-, 6-, and 8-element bounding boxes, including XYZ, XYZM, antimeridian, CRS, and encoding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->