### PR TITLE
fix(validate): enforce the covering.bbox path, field-order and field-type rules

### DIFF
--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -1539,6 +1539,24 @@ def _check_covering_bbox_paths(col_meta: dict, col_name: str) -> ValidationCheck
                 category="geoparquet_1_1",
             )
 
+    wrong_field = [k for k in required_keys if bbox_covering[k][1] != k]
+    if wrong_field:
+        return ValidationCheck(
+            name=f"covering_bbox_paths_{col_name}",
+            status=CheckStatus.FAILED,
+            message=f"covering bbox path field must equal its key: {wrong_field}",
+            category="geoparquet_1_1",
+        )
+
+    columns = sorted({str(bbox_covering[k][0]) for k in required_keys})
+    if len(columns) > 1:
+        return ValidationCheck(
+            name=f"covering_bbox_paths_{col_name}",
+            status=CheckStatus.FAILED,
+            message=f"covering bbox paths must name a single column (found: {columns})",
+            category="geoparquet_1_1",
+        )
+
     return ValidationCheck(
         name=f"covering_bbox_paths_{col_name}",
         status=CheckStatus.PASSED,
@@ -1592,10 +1610,17 @@ def _check_covering_bbox_column_exists(
     )
 
 
+_BBOX_FIELDS = {
+    4: ["xmin", "ymin", "xmax", "ymax"],
+    6: ["xmin", "ymin", "zmin", "xmax", "ymax", "zmax"],
+}
+
+
 def _check_covering_bbox_structure(
     col_meta: dict, col_name: str, schema_info: list
 ) -> ValidationCheck:
-    """Check 1.1-4/5: covering bbox column must be a struct with xmin/ymin/xmax/ymax."""
+    """Check 1.1-4/5: covering bbox column is a struct of xmin/ymin/xmax/ymax or
+    xmin/ymin/zmin/xmax/ymax/zmax, in that order."""
     covering = col_meta.get("covering")
 
     if covering is None or "bbox" not in covering:
@@ -1617,41 +1642,26 @@ def _check_covering_bbox_structure(
             category="geoparquet_1_1",
         )
 
-    # Find the bbox column and check its structure
-    required_fields = {"xmin", "ymin", "xmax", "ymax"}
-    found_fields = set()
-
+    found_fields = []
     for i, col in enumerate(schema_info):
         if col.get("name") == bbox_col_name:
             num_children = col.get("num_children") or 0
-            if num_children < 4:
-                return ValidationCheck(
-                    name=f"covering_bbox_structure_{col_name}",
-                    status=CheckStatus.FAILED,
-                    message=f"bbox column must have at least 4 children (has {num_children})",
-                    category="geoparquet_1_1",
-                )
-
-            # Get child field names
-            for j in range(1, num_children + 1):
-                if i + j < len(schema_info):
-                    child_name = schema_info[i + j].get("name", "")
-                    found_fields.add(child_name)
+            found_fields = [c.get("name") for c in schema_info[i + 1 : i + 1 + num_children]]
             break
 
-    missing = required_fields - found_fields
-    if missing:
+    if found_fields != _BBOX_FIELDS.get(len(found_fields)):
         return ValidationCheck(
             name=f"covering_bbox_structure_{col_name}",
             status=CheckStatus.FAILED,
-            message=f"bbox column missing required fields: {missing}",
+            message=f"bbox column fields must be {_BBOX_FIELDS[4]} or {_BBOX_FIELDS[6]}, "
+            f"in that order (found: {found_fields})",
             category="geoparquet_1_1",
         )
 
     return ValidationCheck(
         name=f"covering_bbox_structure_{col_name}",
         status=CheckStatus.PASSED,
-        message="bbox column has valid structure with xmin/ymin/xmax/ymax",
+        message=f"bbox column has valid structure with {'/'.join(found_fields)}",
         category="geoparquet_1_1",
     )
 
@@ -1688,7 +1698,7 @@ def _check_covering_bbox_field_types(
     for i, col in enumerate(schema_info):
         if col.get("name") == bbox_col_name:
             num_children = col.get("num_children") or 0
-            for j in range(1, min(num_children + 1, 5)):  # Check first 4 children
+            for j in range(1, num_children + 1):
                 if i + j < len(schema_info):
                     # Same trap as _check_geometry_byte_array: a group child's
                     # type is an explicit None, so `or ""` is the guard here too.

--- a/tests/test_validate_covering_strictness.py
+++ b/tests/test_validate_covering_strictness.py
@@ -1,0 +1,134 @@
+"""covering.bbox rules the spec states that the checks did not verify: path field names,
+single column, child field order, zmin/zmax pairing and types of all children."""
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from geoparquet_io.core.duckdb_metadata import get_schema_info
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_covering_bbox_field_types,
+    _check_covering_bbox_paths,
+    _check_covering_bbox_structure,
+    validate_geoparquet,
+)
+
+WKB_POINT = bytes.fromhex("0101000000000000000000f03f0000000000000040")  # POINT (1 2)
+PATHS_4 = {k: ["bbox", k] for k in ("xmin", "ymin", "xmax", "ymax")}
+F64 = pa.float64()
+
+
+def _write(path, children, paths=PATHS_4):
+    struct = pa.StructArray.from_arrays(
+        [pa.array([0, 1], type=t) for _, t in children], names=[n for n, _ in children]
+    )
+    table = pa.table({"geometry": pa.array([WKB_POINT] * 2, pa.binary()), "bbox": struct})
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "covering": {"bbox": paths},
+            }
+        },
+    }
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), path)
+    return str(path)
+
+
+def _covering_checks(path):
+    col_meta = json.loads(pq.read_metadata(path).metadata[b"geo"])["columns"]["geometry"]
+    schema_info = get_schema_info(path)
+    return {
+        "paths": _check_covering_bbox_paths(col_meta, "geometry"),
+        "structure": _check_covering_bbox_structure(col_meta, "geometry", schema_info),
+        "types": _check_covering_bbox_field_types(col_meta, "geometry", schema_info),
+    }
+
+
+XY = [("xmin", F64), ("ymin", F64), ("xmax", F64), ("ymax", F64)]
+XYZ = [("xmin", F64), ("ymin", F64), ("zmin", F64), ("xmax", F64), ("ymax", F64), ("zmax", F64)]
+
+
+class TestPaths:
+    def test_second_element_must_be_the_field_name(self, tmp_path):
+        paths = dict(PATHS_4, xmin=["bbox", "minx"])
+        check = _covering_checks(_write(tmp_path / "f.parquet", XY, paths))["paths"]
+        assert check.status == CheckStatus.FAILED
+        assert "xmin" in check.message
+
+    def test_all_paths_must_name_one_column(self, tmp_path):
+        paths = dict(PATHS_4, ymax=["other", "ymax"])
+        check = _covering_checks(_write(tmp_path / "f.parquet", XY, paths))["paths"]
+        assert check.status == CheckStatus.FAILED
+        assert "other" in check.message
+
+
+class TestStructure:
+    def test_xy_order(self, tmp_path):
+        swapped = [XY[1], XY[0], XY[2], XY[3]]
+        check = _covering_checks(_write(tmp_path / "f.parquet", swapped))["structure"]
+        assert check.status == CheckStatus.FAILED
+
+    def test_xyz_order(self, tmp_path):
+        wrong = XY + [("zmin", F64), ("zmax", F64)]
+        assert (
+            _covering_checks(_write(tmp_path / "bad.parquet", wrong))["structure"].status
+            == CheckStatus.FAILED
+        )
+        assert (
+            _covering_checks(_write(tmp_path / "ok.parquet", XYZ))["structure"].status
+            == CheckStatus.PASSED
+        )
+
+    def test_zmin_requires_zmax(self, tmp_path):
+        check = _covering_checks(_write(tmp_path / "f.parquet", XYZ[:5]))["structure"]
+        assert check.status == CheckStatus.FAILED
+
+    def test_extra_child_fails(self, tmp_path):
+        check = _covering_checks(_write(tmp_path / "f.parquet", XY + [("area", F64)]))["structure"]
+        assert check.status == CheckStatus.FAILED
+
+
+class TestFieldTypes:
+    def test_all_children_are_checked(self, tmp_path):
+        children = XYZ[:5] + [("zmax", pa.int32())]
+        check = _covering_checks(_write(tmp_path / "f.parquet", children))["types"]
+        assert check.status == CheckStatus.FAILED
+        assert "int" in check.message.lower()
+
+    def test_float_children_pass(self, tmp_path):
+        children = [(n, pa.float32()) for n, _ in XYZ]
+        assert (
+            _covering_checks(_write(tmp_path / "f.parquet", children))["types"].status
+            == CheckStatus.PASSED
+        )
+
+
+class TestRealFiles:
+    def test_valid_xy_and_xyz_files_pass_everything(self, tmp_path):
+        for name, children in (("xy", XY), ("xyz", XYZ)):
+            checks = _covering_checks(_write(tmp_path / f"{name}.parquet", children))
+            assert all(c.status == CheckStatus.PASSED for c in checks.values()), {
+                k: c.message for k, c in checks.items()
+            }
+
+    def test_austria_covering_fixture_still_passes(self, test_data_dir):
+        result = validate_geoparquet(
+            str(test_data_dir / "austria_bbox_covering.parquet"), validate_data=False
+        )
+        covering = [c for c in result.checks if c.name.startswith("covering_")]
+        assert covering
+        assert all(c.status == CheckStatus.PASSED for c in covering), [
+            (c.name, c.message) for c in covering
+        ]
+
+    def test_full_validation_reports_bad_paths(self, tmp_path):
+        path = _write(tmp_path / "f.parquet", XY, dict(PATHS_4, xmin=["bbox", "minx"]))
+        result = validate_geoparquet(path, validate_data=False)
+        (check,) = [c for c in result.checks if c.name == "covering_bbox_paths_geometry"]
+        assert check.status == CheckStatus.FAILED


### PR DESCRIPTION
## Problem

The `covering.bbox` checks accepted files that violate rules the spec states as MUST (GeoParquet 1.1 "bbox covering encoding" and "Bounding Box Columns", same text in PR opengeospatial/geoparquet#302 for 2.0):

| Spec rule | Before |
| --- | --- |
| "the second item in each element MUST be `xmin`, `ymin`, etc." | not checked: `"xmin": ["bbox", "minx"]` passed |
| "All values MUST use the same column name" | not checked: `xmin` on `bbox`, `ymax` on `other` passed |
| child fields "MUST be ordered" `xmin, ymin, xmax, ymax` / `xmin, ymin, zmin, xmax, ymax, zmax` | only the set of names was compared; wrong order, 5 children, 7 children all passed |
| "If `zmin` is present then `zmax` MUST be present and vice versa" | not checked |
| "The fields MUST be of Parquet type FLOAT or DOUBLE and all columns MUST use the same type" | only the first four children were typed; `zmax INT32` passed |

## Change

Three functions, no new ones:

- `_check_covering_bbox_paths`: after the existing shape check, `path[1]` must equal its key, and all four `path[0]` must be the same column.
- `_check_covering_bbox_structure`: the child field names, in schema order, must equal `["xmin", "ymin", "xmax", "ymax"]` or `["xmin", "ymin", "zmin", "xmax", "ymax", "zmax"]` (module constant `_BBOX_FIELDS`). Replaces the "at least 4 children containing these names" logic.
- `_check_covering_bbox_field_types`: iterate all children instead of the first four.

## Tests

`tests/test_validate_covering_strictness.py` (8 of 11 failed on `main`). Files are real Parquet written with pyarrow, one per violation: bad second element, mixed columns, swapped XY order, XYZ in the wrong order, `zmin` without `zmax`, an extra fifth child, `zmax INT32`; valid XY and XYZ files pass all three checks; `tests/data/austria_bbox_covering.parquet` still passes; the bad-paths file fails through `validate_geoparquet`.

Regression: validate, check, corpus and bbox suites — 497 passed, 8 xfailed. Pre-commit passes.

```
$ gpio check spec cov_bad.parquet         # xmin -> ["bbox","minx"], ymax -> ["other","ymax"]
  ✓ column "geometry" has valid covering object
  ✗ covering bbox path field must equal its key: ['xmin']
$ gpio check spec cov_zmax_int.parquet
  ✗ bbox fields must be FLOAT or DOUBLE (found: {'INT32'})
```

## Adversarial pass (done before opening)

- Coverings written by gpio itself pass unchanged: `gpio convert … --geoparquet-version 1.1` + `gpio add bbox` (28 checks green), and `gpio add bbox` on `fields_gpq2_crs84_zstd.parquet` at 2.0 (36 checks green); `gpio check bbox` unaffected.
- Both `get_schema_info` paths (pyarrow fast path and DuckDB `parquet_schema()`) give the same verdicts.
- A covering that points at a nested list-of-struct group (not a bbox) is now rejected by the structure check on both paths; before, it passed the paths and (as the existing test shows) failed only on types.
- Non-string `path[0]` values and `num_children: None` do not raise.

Found while mapping the OGC GeoParquet 2.0 abstract tests to `gpio` (opengeospatial/geoparquet#304).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for covering bounding boxes.
  * Added support for correctly validating 3D bounding boxes.
  * Detects mismatched field names, invalid column paths, incorrect field ordering, extra fields, and incompatible data types.
  * Improved validation reporting for invalid bounding box paths.

* **Tests**
  * Added comprehensive coverage for valid and invalid 2D and 3D bounding box configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->