### PR TITLE
fix(extract): say what --write-memory does on extract bigquery

### DIFF
--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -870,6 +870,10 @@ Other limitations:
 
 - **BIGNUMERIC columns**: Not supported (76-digit precision exceeds DuckDB's 38-digit limit)
 - **Large results**: Consider using `--limit` and `--where` to reduce data transfer
+- **`--write-memory` bounds the scan, not the write**: this command writes through
+  PyArrow, so the value is applied as DuckDB's `memory_limit` on the connection
+  running the BigQuery scan. It is not a cap on the command's peak memory — see
+  [Write Strategies](write-strategies.md#explicit-memory-limits)
 
 ## Extracting from ArcGIS Feature Services
 

--- a/docs/guide/write-strategies.md
+++ b/docs/guide/write-strategies.md
@@ -160,10 +160,9 @@ Override auto-detection when needed:
         no spill path. Size a BigQuery extract against the result set, not
         against `--write-memory`.
 
-        The shared `--help` text still describes the flag as a "Memory limit for
-        streaming writes"; on this command it is the scan. Whether the flag
-        should be renamed or removed here is tracked in
-        [#760](https://github.com/geoparquet/geoparquet-io/issues/760).
+        The flag keeps its name here — it is the same knob, spelled the same way
+        — but `gpio extract bigquery --help` describes it accurately: "Memory
+        limit for the DuckDB scan of the BigQuery result."
 
 === "Python"
 

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -146,18 +146,24 @@ def row_group_options(func=None, *, default_rows: int | None = None):
     return func
 
 
-def output_format_options(func=None, *, default_rows: int | None = None):
+def output_format_options(
+    func=None, *, default_rows: int | None = None, write_memory_help: str | None = None
+):
     """
     Add all output format options (compression + row groups + memory limit).
 
     This is a convenience decorator that combines compression_options, row_group_options,
-    and write_memory_option. ``default_rows`` is forwarded to ``row_group_options``.
+    and write_memory_option. ``default_rows`` is forwarded to ``row_group_options``;
+    ``write_memory_help`` is forwarded to ``write_memory_option`` for the one command
+    where the limit governs a read rather than a write (see ``write_memory_option``).
     """
     if func is None:
-        return lambda inner: output_format_options(inner, default_rows=default_rows)
+        return lambda inner: output_format_options(
+            inner, default_rows=default_rows, write_memory_help=write_memory_help
+        )
     func = compression_options(func)
     func = row_group_options(func, default_rows=default_rows)
-    func = write_memory_option(func)
+    func = write_memory_option(func, help=write_memory_help)
     return func
 
 
@@ -266,23 +272,37 @@ def _validate_write_memory(ctx, param, value):
     return value
 
 
-def write_memory_option(func):
+# Click does not printf-format help text, so a literal "%%" would be rendered
+# verbatim.
+_WRITE_MEMORY_HELP = (
+    "Memory limit for streaming writes (e.g., '512MB', '2GB'). "
+    "Default: 50% of available RAM (container-aware)."
+)
+
+
+def write_memory_option(func=None, *, help: str | None = None):
     """
     Add --write-memory option to a command.
 
     Allows specifying the DuckDB memory limit for streaming writes.
     When set, DuckDB uses single-threaded mode for memory control.
     Accepts values like '512MB', '2GB', '4GB'.
+
+    Usable bare (``@write_memory_option``) or called
+    (``@write_memory_option(help="…")``). The ``help`` override exists for
+    commands where the limit does not govern a write: ``gpio extract bigquery``
+    writes through PyArrow and applies the value to the DuckDB scan instead
+    (gpio #760). Overriding it there must not change any other command, so the
+    default lives in ``_WRITE_MEMORY_HELP`` and is never mutated.
     """
+    if func is None:
+        return lambda inner: write_memory_option(inner, help=help)
     return click.option(
         "--write-memory",
         type=str,
         default=None,
         callback=_validate_write_memory,
-        # Click does not printf-format help text, so a literal "%%" would be
-        # rendered verbatim.
-        help="Memory limit for streaming writes (e.g., '512MB', '2GB'). "
-        "Default: 50% of available RAM (container-aware).",
+        help=help or _WRITE_MEMORY_HELP,
     )(func)
 
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -2953,7 +2953,12 @@ def extract_arcgis(
     "Native GEOGRAPHY columns default to 'spherical' (BigQuery uses S2). "
     "VARCHAR columns default to 'planar'. Use this to override.",
 )
-@output_format_options
+@output_format_options(
+    write_memory_help=(
+        "Memory limit for the DuckDB scan of the BigQuery result (e.g., '512MB', '4GB'). "
+        "This command writes through PyArrow, so the limit bounds the read, not the write."
+    )
+)
 @geoparquet_version_option
 @overwrite_option
 @repair_geometry_option

--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -824,6 +824,8 @@ def extract_bigquery(
         row_group_size_mb: Target row group size in MB
         row_group_rows: Exact rows per row group
         geoparquet_version: GeoParquet version to write
+        memory_limit: DuckDB memory_limit for the BigQuery scan (e.g. "4GB").
+            The write goes through PyArrow, so this bounds the read side only.
 
     Returns:
         PyArrow Table if output_parquet is None, otherwise None

--- a/tests/test_write_memory_forwarding.py
+++ b/tests/test_write_memory_forwarding.py
@@ -732,3 +732,46 @@ class TestStdoutStreamingIgnoresMemoryLimit:
             con.close()
         mocked.assert_called_once()
         assert "memory" in capsys.readouterr().err.lower()
+
+
+class TestWriteMemoryHelpTextIsPerCommand:
+    """`extract bigquery` writes through PyArrow, so its --write-memory bounds the
+    DuckDB scan of the BigQuery result, not a write. Its help text has to say so
+    (gpio #760) — and overriding it there must not change every other command."""
+
+    def test_bigquery_help_describes_the_scan_not_a_streaming_write(self):
+        result = CliRunner().invoke(cli, ["extract", "bigquery", "--help"])
+        assert result.exit_code == 0
+        help_text = " ".join(result.output.split())
+        assert "Memory limit for the DuckDB scan of the BigQuery result" in help_text
+        assert "writes through PyArrow" in help_text
+        assert "streaming writes" not in help_text
+
+    def test_sibling_command_keeps_the_generic_streaming_write_wording(self):
+        result = CliRunner().invoke(cli, ["sort", "hilbert", "--help"])
+        assert result.exit_code == 0
+        help_text = " ".join(result.output.split())
+        assert "Memory limit for streaming writes" in help_text
+        assert "BigQuery" not in help_text
+
+    def test_decorator_works_bare_and_called(self):
+        """Both spellings of the decorator attach the same option."""
+        from geoparquet_io.cli.decorators import write_memory_option
+
+        @click.command()
+        @write_memory_option
+        def bare(write_memory):  # pragma: no cover - help only
+            pass
+
+        @click.command()
+        @write_memory_option(help="Custom wording.")
+        def overridden(write_memory):  # pragma: no cover - help only
+            pass
+
+        runner = CliRunner()
+        bare_help = " ".join(runner.invoke(bare, ["--help"]).output.split())
+        overridden_help = " ".join(runner.invoke(overridden, ["--help"]).output.split())
+
+        assert "Memory limit for streaming writes" in bare_help
+        assert "Custom wording." in overridden_help
+        assert "streaming writes" not in overridden_help


### PR DESCRIPTION
## What changed

`gpio extract bigquery --write-memory` now describes itself accurately:

```
  --write-memory TEXT             Memory limit for the DuckDB scan of the
                                  BigQuery result (e.g., '512MB', '4GB'). This
                                  command writes through PyArrow, so the limit
                                  bounds the read, not the write.
```

Previously it inherited the shared decorator's wording, "Memory limit for
streaming writes (e.g., '512MB', '2GB'). Default: 50% of available RAM
(container-aware)."

- `write_memory_option` in `cli/decorators.py` takes an optional `help`
  override. The bare `@write_memory_option` form is unchanged; the default
  string moved to a module constant that is read, never mutated.
- `output_format_options` forwards a `write_memory_help` kwarg to it, so the
  one call site (`extract bigquery`) is a one-line change and the option order
  in `--help` is identical to before.
- `docs/guide/write-strategies.md` no longer says the help text is wrong (it
  isn't any more); the BigQuery limitations list in `docs/guide/extract.md`
  gains a bullet pointing at that section. `docs/cli/extract.md` is
  hand-maintained and does not enumerate options, so it needed no change.
- `extract_bigquery`'s docstring gained the `memory_limit` Args entry it was
  missing.

No behavior change: the value is validated and applied exactly as before
(#663). No Python API change either — `ops.read_bigquery` /
`Table.from_bigquery` never exposed this knob, so there was no "write"-named
parameter to rename.

## Why

`extract bigquery` writes through PyArrow (`write_geoparquet_table`), so it has
no DuckDB write engine and no `--write-strategy` flag. #663 wired
`--write-memory` into the DuckDB connection running the BigQuery scan — which
is where that command's memory actually goes — so the flag is useful, just
misdescribed. Only the naming and documentation were left, which is what #760
asks about.

The issue offered dropping the flag on this command. Rejected: it is a real,
honoured knob on the connection that does the heavy lifting, so removing it
would take away the only memory control the command has, and it would be a CLI
break for anyone who already scripts it — a break that buys nothing, since the
underlying behavior would be unchanged.

The issue also offered renaming it here (say `--scan-memory`, with
`--write-memory` kept as an alias). Rejected: an alias means two spellings of
one flag to document and keep in sync forever, and `--write-memory` would have
to stay anyway to avoid the break. Every other command spells this knob
`--write-memory`; making one command different costs a user more than one
accurate help sentence does. If you would rather rename it, the decorator seam
added here is exactly what a rename would build on.

## Verification

```
$ uv run gpio extract bigquery --help | grep -A3 write-memory
  --write-memory TEXT             Memory limit for the DuckDB scan of the
                                  BigQuery result (e.g., '512MB', '4GB'). This
                                  command writes through PyArrow, so the limit
                                  bounds the read, not the write.

$ uv run gpio sort hilbert --help | grep -A2 write-memory
  --write-memory TEXT             Memory limit for streaming writes (e.g.,
                                  '512MB', '2GB'). Default: 50% of available
                                  RAM (container-aware).
```

Fast suite:

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5740 passed, 67 skipped, 1 xfailed, 103 warnings in 167.12s (0:02:47)
```

Diff coverage on changed lines:

```
$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
geoparquet_io/cli/decorators.py (100%)
geoparquet_io/cli/main.py (100%)
Total:   8 lines
Missing: 0 lines
Coverage: 100%
```

`uv run pre-commit run --all-files` and `--hook-stage pre-push` both clean.
`tests/test_cli_surface.py` passes unrecorded: the snapshot stores option
structure (name, opts, type, default), not help prose, so a help-only change
does not touch it.

New tests in `tests/test_write_memory_forwarding.py`
(`TestWriteMemoryHelpTextIsPerCommand`): `extract bigquery --help` carries the
new wording and not "streaming writes"; `sort hilbert --help` still carries the
generic wording and never mentions BigQuery (the override is per-command, not
global); and the decorator works in both its bare and called forms.

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
