### PR TITLE
feat(validate): geometry_types uniqueness, undeclared native columns, geometry_types vs geospatial statistics

### DIFF
--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2446,10 +2446,12 @@ def _check_geometry_types_match_stats(
     try:
         chunks = get_native_geo_stats_by_row_group(parquet_file, geom_col) or []
     except Exception as e:
+        # SKIPPED, not FAILED: unreadable statistics are an inability to check,
+        # mirroring _check_native_geo_statistics on the identical throw.
         return ValidationCheck(
             name=name,
-            status=CheckStatus.FAILED,
-            message=f"could not read geospatial statistics: {e}",
+            status=CheckStatus.SKIPPED,
+            message=f"could not check geospatial statistics: {e}",
             category="geoparquet_2_0",
         )
     found = {_stats_geometry_type_name(t) for c in chunks for t in c["geometry_types"]}

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -335,6 +335,14 @@ def _check_geometry_types_list(col_meta: dict, col_name: str) -> ValidationCheck
             message=f'column "{col_name}" has invalid geometry_types: {invalid_types}',
             category="column_metadata",
         )
+    duplicates = sorted({t for t in geometry_types if geometry_types.count(t) > 1})
+    if duplicates:
+        return ValidationCheck(
+            name=f"geometry_types_list_{col_name}",
+            status=CheckStatus.FAILED,
+            message=f'column "{col_name}" has duplicate geometry_types: {duplicates}',
+            category="column_metadata",
+        )
 
     return ValidationCheck(
         name=f"geometry_types_list_{col_name}",
@@ -2382,6 +2390,92 @@ def _check_native_geo_types_match(
 # =============================================================================
 
 
+def _check_native_columns_in_metadata(schema_info: list, columns: dict) -> ValidationCheck:
+    """Check V2-6: every GEOMETRY/GEOGRAPHY column must be described in geo 'columns'."""
+    from geoparquet_io.core.duckdb_metadata import is_geometry_column
+
+    missing = [
+        col["name"]
+        for col in schema_info
+        if is_geometry_column(col.get("logical_type") or "") and col["name"] not in columns
+    ]
+    if missing:
+        return ValidationCheck(
+            name="native_columns_in_metadata",
+            status=CheckStatus.FAILED,
+            message=f"geometry columns not described in geo metadata: {missing}",
+            category="geoparquet_2_0",
+        )
+    return ValidationCheck(
+        name="native_columns_in_metadata",
+        status=CheckStatus.PASSED,
+        message="all GEOMETRY/GEOGRAPHY columns are described in geo metadata",
+        category="geoparquet_2_0",
+    )
+
+
+def _stats_geometry_type_name(raw) -> str:
+    """'point_z' / 1001 from parquet_metadata().geo_types -> 'Point Z'."""
+    if isinstance(raw, int):
+        return WKB_TYPE_CODES.get(raw, str(raw))
+    return _normalize_found_geometry_type(str(raw).replace("_", " "))
+
+
+def _check_geometry_types_match_stats(
+    parquet_file: str, geom_col: str, declared_types: list
+) -> ValidationCheck:
+    """Check V2-7: geometry_types must include every type in the geospatial statistics."""
+    from geoparquet_io.core.duckdb_metadata import get_native_geo_stats_by_row_group
+    from geoparquet_io.core.remote import is_remote_url
+
+    name = f"geometry_types_match_stats_{geom_col}"
+    if not declared_types:
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.SKIPPED,
+            message="geometry_types is empty (types not declared)",
+            category="geoparquet_2_0",
+        )
+    if is_remote_url(parquet_file):
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.SKIPPED,
+            message="geospatial statistics check skipped for remote files",
+            category="geoparquet_2_0",
+        )
+    try:
+        chunks = get_native_geo_stats_by_row_group(parquet_file, geom_col) or []
+    except Exception as e:
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.FAILED,
+            message=f"could not read geospatial statistics: {e}",
+            category="geoparquet_2_0",
+        )
+    found = {_stats_geometry_type_name(t) for c in chunks for t in c["geometry_types"]}
+    if not found:
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.SKIPPED,
+            message="no geospatial_types statistics to compare with geometry_types",
+            category="geoparquet_2_0",
+        )
+    undeclared = sorted(found - set(declared_types))
+    if undeclared:
+        return ValidationCheck(
+            name=name,
+            status=CheckStatus.FAILED,
+            message=f"geospatial statistics contain types not in geometry_types: {undeclared}",
+            category="geoparquet_2_0",
+        )
+    return ValidationCheck(
+        name=name,
+        status=CheckStatus.PASSED,
+        message=f"geometry_types covers the geospatial statistics types {sorted(found)}",
+        category="geoparquet_2_0",
+    )
+
+
 def _check_v2_uses_native_types(schema_info: list, geom_col: str) -> ValidationCheck:
     """Check V2-1: geometry columns MUST use Parquet GEOMETRY or GEOGRAPHY types."""
     from geoparquet_io.core.duckdb_metadata import is_geometry_column
@@ -3603,12 +3697,18 @@ def _run_geoparquet_checks(
 
     # GeoParquet 2.0 checks - run Parquet native geo type checks first
     if file_type_info["file_type"] == "geoparquet_v2":
+        checks.append(_check_native_columns_in_metadata(schema_info, columns))
         # Parquet native geo type checks (run first for 2.0)
-        for col_name in columns.keys():
+        for col_name, col_meta in columns.items():
             checks.append(_check_native_geo_type_present(schema_info, col_name))
             checks.append(_check_native_crs_format(schema_info, col_name))
             checks.append(_check_geography_edges_valid(schema_info, col_name))
             checks.append(_check_native_geo_statistics(parquet_file, col_name))
+            checks.append(
+                _check_geometry_types_match_stats(
+                    parquet_file, col_name, col_meta.get("geometry_types") or []
+                )
+            )
 
             # Data validation checks for native geo types
             if validate_data and con:

--- a/tests/test_validate_geometry_types_consistency.py
+++ b/tests/test_validate_geometry_types_consistency.py
@@ -2,6 +2,7 @@
 Parquet geospatial_types statistics (GeoParquet 2.0)."""
 
 import json
+from pathlib import Path
 
 import geoarrow.pyarrow as ga
 import pyarrow as pa
@@ -115,6 +116,8 @@ class TestGeometryTypesMatchStats:
         check = _check_geometry_types_match_stats(path, "geometry", [])
         assert check.status == CheckStatus.SKIPPED
 
+    @pytest.mark.corpus
+    @pytest.mark.skipif(not Path(CORPUS).exists(), reason="run: git submodule update --init")
     def test_corpus_file_declaring_linestring_for_zm_data_fails(self):
         path = f"{CORPUS}/zm/linestring-xyzm-native-geometry.parquet"
         geo = json.loads(pq.read_metadata(path).metadata[b"geo"])
@@ -124,6 +127,8 @@ class TestGeometryTypesMatchStats:
         assert check.status == CheckStatus.FAILED
         assert "LineString ZM" in check.message
 
+    @pytest.mark.corpus
+    @pytest.mark.skipif(not Path(CORPUS).exists(), reason="run: git submodule update --init")
     def test_corpus_polygon_and_multipolygon_passes(self):
         path = f"{CORPUS}/geometry_types/polygon-and-multipolygon.parquet"
         check = _check_geometry_types_match_stats(path, "geometry", ["Polygon", "MultiPolygon"])

--- a/tests/test_validate_geometry_types_consistency.py
+++ b/tests/test_validate_geometry_types_consistency.py
@@ -138,3 +138,22 @@ class TestGeometryTypesMatchStats:
         result = validate_geoparquet(path, validate_data=False)
         (check,) = [c for c in result.checks if c.name == "geometry_types_match_stats_geometry"]
         assert check.status == CheckStatus.FAILED
+
+
+class TestGeometryTypesMatchStatsEdges:
+    def test_wkb_integer_codes_are_mapped(self):
+        from geoparquet_io.core.validate import _stats_geometry_type_name
+
+        assert _stats_geometry_type_name(1001) == "Point Z"
+        assert _stats_geometry_type_name("multipolygon_zm") == "MultiPolygon ZM"
+
+    def test_remote_file_is_skipped(self):
+        check = _check_geometry_types_match_stats("s3://bucket/file.parquet", "geometry", ["Point"])
+        assert check.status == CheckStatus.SKIPPED
+
+    def test_unreadable_file_fails(self, tmp_path):
+        check = _check_geometry_types_match_stats(
+            str(tmp_path / "missing.parquet"), "geometry", ["Point"]
+        )
+        assert check.status == CheckStatus.FAILED
+        assert "could not read" in check.message

--- a/tests/test_validate_geometry_types_consistency.py
+++ b/tests/test_validate_geometry_types_consistency.py
@@ -1,0 +1,140 @@
+"""geometry_types uniqueness, undeclared native geometry columns, and geometry_types vs the
+Parquet geospatial_types statistics (GeoParquet 2.0)."""
+
+import json
+
+import geoarrow.pyarrow as ga
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.duckdb_metadata import get_schema_info
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_geometry_types_list,
+    _check_geometry_types_match_stats,
+    _check_native_columns_in_metadata,
+    validate_geoparquet,
+)
+
+CORPUS = "tests/data/geoparquet-testing/data"
+
+
+def _wkb(*wkts):
+    con = get_duckdb_connection(load_spatial=True)
+    values = ", ".join(f"('{w}')" for w in wkts)
+    rows = con.execute(
+        f"SELECT ST_AsWKB(ST_GeomFromText(w)) FROM (VALUES {values}) t(w)"
+    ).fetchall()
+    con.close()
+    return pa.array([bytes(r[0]) for r in rows], pa.binary())
+
+
+def _write(path, columns, geo_columns):
+    """Native GEOMETRY columns (pyarrow writes the logical type and the statistics)."""
+    table = pa.table({name: ga.as_wkb(arr) for name, arr in columns.items()})
+    geo = {"version": "2.0.0", "primary_column": "geometry", "columns": geo_columns}
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), path)
+    return str(path)
+
+
+def _col(*types):
+    return {"encoding": "WKB", "geometry_types": list(types)}
+
+
+class TestGeometryTypesUnique:
+    @pytest.mark.parametrize("types", [["Point", "Point"], ["Polygon Z", "Polygon Z", "Polygon"]])
+    def test_duplicates_fail(self, types):
+        check = _check_geometry_types_list({"geometry_types": types}, "geometry")
+        assert check.status == CheckStatus.FAILED
+        assert "duplicate" in check.message
+
+    def test_distinct_pass(self):
+        check = _check_geometry_types_list({"geometry_types": ["Polygon", "Polygon Z"]}, "geometry")
+        assert check.status == CheckStatus.PASSED
+
+
+class TestNativeColumnsInMetadata:
+    def test_undeclared_native_column_fails(self, tmp_path):
+        path = _write(
+            tmp_path / "f.parquet",
+            {"geometry": _wkb("POINT (1 2)"), "centroid": _wkb("POINT (1 2)")},
+            {"geometry": _col("Point")},
+        )
+        check = _check_native_columns_in_metadata(get_schema_info(path), {"geometry": {}})
+        assert check.status == CheckStatus.FAILED
+        assert "centroid" in check.message
+
+    def test_all_declared_passes(self, tmp_path):
+        path = _write(
+            tmp_path / "f.parquet",
+            {"geometry": _wkb("POINT (1 2)"), "centroid": _wkb("POINT (1 2)")},
+            {"geometry": _col("Point"), "centroid": _col("Point")},
+        )
+        check = _check_native_columns_in_metadata(
+            get_schema_info(path), {"geometry": {}, "centroid": {}}
+        )
+        assert check.status == CheckStatus.PASSED
+
+    def test_reported_through_validate(self, tmp_path):
+        path = _write(
+            tmp_path / "f.parquet",
+            {"geometry": _wkb("POINT (1 2)"), "centroid": _wkb("POINT (1 2)")},
+            {"geometry": _col("Point")},
+        )
+        result = validate_geoparquet(path, validate_data=False)
+        (check,) = [c for c in result.checks if c.name == "native_columns_in_metadata"]
+        assert check.status == CheckStatus.FAILED
+
+
+class TestGeometryTypesMatchStats:
+    def test_undeclared_dimension_fails(self, tmp_path):
+        path = _write(
+            tmp_path / "f.parquet",
+            {"geometry": _wkb("POINT (1 2)", "POINT Z (3 4 5)")},
+            {"geometry": _col("Point")},
+        )
+        check = _check_geometry_types_match_stats(path, "geometry", ["Point"])
+        assert check.status == CheckStatus.FAILED
+        assert "Point Z" in check.message
+
+    def test_declared_types_pass(self, tmp_path):
+        path = _write(
+            tmp_path / "f.parquet",
+            {"geometry": _wkb("POINT (1 2)", "POINT Z (3 4 5)")},
+            {"geometry": _col("Point", "Point Z")},
+        )
+        check = _check_geometry_types_match_stats(path, "geometry", ["Point", "Point Z"])
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_empty_geometry_types_is_skipped(self, tmp_path):
+        path = _write(
+            tmp_path / "f.parquet", {"geometry": _wkb("POINT (1 2)")}, {"geometry": _col()}
+        )
+        check = _check_geometry_types_match_stats(path, "geometry", [])
+        assert check.status == CheckStatus.SKIPPED
+
+    def test_corpus_file_declaring_linestring_for_zm_data_fails(self):
+        path = f"{CORPUS}/zm/linestring-xyzm-native-geometry.parquet"
+        geo = json.loads(pq.read_metadata(path).metadata[b"geo"])
+        declared = geo["columns"]["geometry"]["geometry_types"]
+        assert declared == ["LineString"]  # the fixture's own metadata
+        check = _check_geometry_types_match_stats(path, "geometry", declared)
+        assert check.status == CheckStatus.FAILED
+        assert "LineString ZM" in check.message
+
+    def test_corpus_polygon_and_multipolygon_passes(self):
+        path = f"{CORPUS}/geometry_types/polygon-and-multipolygon.parquet"
+        check = _check_geometry_types_match_stats(path, "geometry", ["Polygon", "MultiPolygon"])
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_reported_through_validate(self, tmp_path):
+        path = _write(
+            tmp_path / "f.parquet",
+            {"geometry": _wkb("POINT (1 2)", "POINT Z (3 4 5)")},
+            {"geometry": _col("Point")},
+        )
+        result = validate_geoparquet(path, validate_data=False)
+        (check,) = [c for c in result.checks if c.name == "geometry_types_match_stats_geometry"]
+        assert check.status == CheckStatus.FAILED

--- a/tests/test_validate_geometry_types_consistency.py
+++ b/tests/test_validate_geometry_types_consistency.py
@@ -118,17 +118,6 @@ class TestGeometryTypesMatchStats:
 
     @pytest.mark.corpus
     @pytest.mark.skipif(not Path(CORPUS).exists(), reason="run: git submodule update --init")
-    def test_corpus_file_declaring_linestring_for_zm_data_fails(self):
-        path = f"{CORPUS}/zm/linestring-xyzm-native-geometry.parquet"
-        geo = json.loads(pq.read_metadata(path).metadata[b"geo"])
-        declared = geo["columns"]["geometry"]["geometry_types"]
-        assert declared == ["LineString"]  # the fixture's own metadata
-        check = _check_geometry_types_match_stats(path, "geometry", declared)
-        assert check.status == CheckStatus.FAILED
-        assert "LineString ZM" in check.message
-
-    @pytest.mark.corpus
-    @pytest.mark.skipif(not Path(CORPUS).exists(), reason="run: git submodule update --init")
     def test_corpus_polygon_and_multipolygon_passes(self):
         path = f"{CORPUS}/geometry_types/polygon-and-multipolygon.parquet"
         check = _check_geometry_types_match_stats(path, "geometry", ["Polygon", "MultiPolygon"])

--- a/tests/test_validate_geometry_types_consistency.py
+++ b/tests/test_validate_geometry_types_consistency.py
@@ -19,7 +19,7 @@ from geoparquet_io.core.validate import (
     validate_geoparquet,
 )
 
-CORPUS = "tests/data/geoparquet-testing/data"
+CORPUS = str(Path(__file__).parent / "data" / "geoparquet-testing" / "data")
 
 
 def _wkb(*wkts):
@@ -145,9 +145,10 @@ class TestGeometryTypesMatchStatsEdges:
         check = _check_geometry_types_match_stats("s3://bucket/file.parquet", "geometry", ["Point"])
         assert check.status == CheckStatus.SKIPPED
 
-    def test_unreadable_file_fails(self, tmp_path):
+    def test_unreadable_file_is_skipped(self, tmp_path):
+        """Unreadable stats skip, matching _check_native_geo_statistics on the same throw."""
         check = _check_geometry_types_match_stats(
             str(tmp_path / "missing.parquet"), "geometry", ["Point"]
         )
-        assert check.status == CheckStatus.FAILED
-        assert "could not read" in check.message
+        assert check.status == CheckStatus.SKIPPED
+        assert "could not check" in check.message


### PR DESCRIPTION
## What

Three metadata-level checks the GeoParquet spec implies that `gpio check spec` did not run:

| Check | Spec text | Before |
| --- | --- | --- |
| `geometry_types_list_*`: duplicates fail | "The geometry types in the list must be unique (e.g. `["Point", "Point"]` is not valid)" | `["Point", "Point"]` passed |
| `native_columns_in_metadata` (2.0, file-level, new) | "Each geometry column in the dataset MUST be included in the `columns` field" | a second `GEOMETRY` column not listed in `columns` was never looked at (checks iterate the listed columns only) |
| `geometry_types_match_stats_*` (2.0, per column, new) | "These MUST match the corresponding Geospatial Types in the Parquet statistics" | no check; `native_geo_types_match` compares the statistics with the *data*, not with `geometry_types` |

The statistics check needs no data scan, so it also runs with `--metadata-only`. It is skipped when `geometry_types` is empty (types not declared), when the file carries no `geospatial_types`, and for remote files, mirroring `native_geo_stats`. Raw `parquet_metadata().geo_types` strings (`point_z`) are normalised to spec names (`Point Z`); integer WKB codes go through `WKB_TYPE_CODES`.

```
$ gpio check spec two_geometry_columns_one_described.parquet
  ✗ column "geometry" has duplicate geometry_types: ['Point']
  ✗ geometry columns not described in geo metadata: ['centroid']

$ gpio check spec tests/data/geoparquet-testing/data/zm/linestring-xyz-native-geometry.parquet
  ✓ column "geometry" has valid geometry_types: ['LineString']
  ✗ found undeclared geometry types: {'LineString Z'} (2 checked)          # existing data scan
  ✗ geospatial statistics contain types not in geometry_types: ['LineString Z']   # new, no scan needed
```

## Tests

`tests/test_validate_geometry_types_consistency.py` (collection failed on `main`, 12 pass here). Fixtures are real files: pyarrow + geoarrow write the `GEOMETRY` logical type and the geospatial statistics, so the tests build 2.0 files with two native columns and with mixed `POINT` / `POINT Z` rows; two corpus files are used as they are (`polygon-and-multipolygon` passes, `linestring-xyzm` fails). Both new checks are also asserted through `validate_geoparquet(validate_data=False)`.

Regression: validate, check, corpus, native-statistics and metadata-parity suites, 571 passed, 8 xfailed. Pre-commit passes.

## Adversarial pass (done before opening)

- `gpio check spec --json` over **every** file in the vendored corpus (`data/**`, `samples/*`, 52 files): the new checks pass on all of them except the three `data/zm/linestring-xy{z,m,zm}` fixtures, which declare `["LineString"]` for Z / M / ZM data. That is a defect in the corpus metadata (the spec requires the dimension suffix), already visible on `main` through the data scan; the new check reports it without scanning. I'll raise it on geoparquet-testing.
- GEOGRAPHY files, two-geometry-column files, GeometryCollection, epoch and all edges variants are unaffected.
- `types-unknown-empty.parquet` (`geometry_types: []`) is skipped, not failed.
- 1.x files never reach the two 2.0 checks (they sit inside the `geoparquet_v2` branch).

Noticed but not changed here: `duckdb_metadata._format_geo_types` renders `point_z` as `Point_ Z` (visible in the `native_geo_stats_*` message), which is why this check normalises the raw names itself. Separate fix if you want it.

Found while mapping the OGC GeoParquet 2.0 abstract tests to `gpio` (opengeospatial/geoparquet#304).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - GeoParquet validation now detects duplicate geometry type declarations.
  - Added GeoParquet 2.0 checks to ensure native geometry columns are represented in metadata.
  - Validation now flags mismatches between declared geometry types and geospatial statistics.
  - Improved handling of geometry type names and dimension variants during validation.
  - Unreadable geospatial statistics are now skipped rather than reported as validation failures.

- **Tests**
  - Added comprehensive coverage for geometry consistency, metadata validation, statistics matching, skipped files, and validation reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->