### PR TITLE
test(write): pin the parquet-geo-only geo-key leak and native-geo auto-version downgrade as xfail-strict contracts

### DIFF
--- a/tests/test_write_facade_contract.py
+++ b/tests/test_write_facade_contract.py
@@ -1,0 +1,299 @@
+"""Contracts the write-facade refactor (Deep Review 3.3) has to turn green.
+
+Two open bugs share one shape: the same fact about an output file is decided
+independently in N write paths, and the paths disagree. Patching each path now
+would mean N edits that the facade would then have to unpick, so the fix belongs
+inside the refactor -- and the refactor should be a pure move, not a move that
+also quietly changes behavior. So the behavior is pinned here first.
+
+- #773: ``geoparquet_version="parquet-geo-only"`` on a table whose geometry
+  column has been projected away. Three of the four write strategies return
+  early and pass the carried ``geo`` key straight through.
+- #600: auto version mode (no ``--geoparquet-version``) on a parquet-geo-only
+  input. ``convert`` resolves the version from the file and keeps it native;
+  ``sort``/``extract``/``partition`` fall through to a 1.1.0 WKB default and
+  strip the native Parquet GEOMETRY logical type.
+
+Every ``xfail`` in this file is ``strict=True``. That is the point: when the
+facade lands and routes these paths through one place, the tests xpass, strict
+mode turns the xpass into a failure, and the facade PR has to delete the marker.
+That deletion is the signal -- a green suite that silently stopped testing
+anything is not.
+
+Two kinds of test live here alongside the xfails:
+
+- **controls** (not marked): a path that already behaves correctly today. They
+  prove the assertion is reachable, so an xfail next to them is a real defect
+  rather than an oracle that can never pass.
+- **current-behavior pins** (not marked, and named ``_today``): they assert what
+  the code does *now*, not what it should do. They exist so the facade cannot
+  change an unrelated mode without someone noticing.
+
+Refs: https://github.com/geoparquet/geoparquet-io/issues/773
+Refs: https://github.com/geoparquet/geoparquet-io/issues/600
+"""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.api.table import Table
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+
+# ---------------------------------------------------------------------------
+# #773 -- parquet-geo-only leaks the carried `geo` key when geometry is absent
+# ---------------------------------------------------------------------------
+
+WRITE_STRATEGIES = ["in-memory", "streaming", "disk-rewrite", "duckdb-kv"]
+
+CARRIED_GEO = {
+    "version": "1.1.0",
+    "primary_column": "geometry",
+    "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+}
+
+#: An unrelated sidecar key, of the kind fiboa and STAC writers attach. It has
+#: nothing to do with GeoParquet, so no version choice may drop it.
+SIDECAR_KEY = b'{"schemas":["example"]}'
+
+
+def _attributes_only_with_geo() -> pa.Table:
+    """A table whose geometry column was projected away, still carrying ``geo``.
+
+    This is the #701/#753 situation: the ``geo`` key describes a
+    ``primary_column`` named ``geometry`` that the table no longer has.
+    """
+    return pa.table({"id": pa.array([1, 2])}).replace_schema_metadata(
+        {b"geo": json.dumps(CARRIED_GEO).encode(), b"fiboa": SIDECAR_KEY}
+    )
+
+
+def _kv_keys(path) -> list[str]:
+    """Key-value metadata keys of a written file, minus pyarrow's own bookkeeping.
+
+    ``ARROW:schema`` is round-trip plumbing rather than a payload, so it is not
+    part of what a version choice is allowed to decide.
+    """
+    metadata = pq.ParquetFile(str(path)).metadata.metadata or {}
+    return sorted(k.decode() for k in metadata if k != b"ARROW:schema")
+
+
+#: The three strategies whose ``write_from_table`` guards its metadata work on
+#: the geometry column being present and otherwise writes ``table.schema``
+#: verbatim (arrow_memory.py, arrow_streaming.py, disk_rewrite.py).
+_GEO_LEAK_REASON = (
+    "#773: {strategy} returns early when the geometry column is absent and "
+    "writes the carried 'geo' key through, even though parquet-geo-only was "
+    "asked for explicitly"
+)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        pytest.param(
+            "in-memory",
+            marks=pytest.mark.xfail(
+                strict=True, reason=_GEO_LEAK_REASON.format(strategy="in-memory")
+            ),
+        ),
+        pytest.param(
+            "streaming",
+            marks=pytest.mark.xfail(
+                strict=True, reason=_GEO_LEAK_REASON.format(strategy="streaming")
+            ),
+        ),
+        pytest.param(
+            "disk-rewrite",
+            marks=pytest.mark.xfail(
+                strict=True, reason=_GEO_LEAK_REASON.format(strategy="disk-rewrite")
+            ),
+        ),
+        # Control: duckdb-kv (the Table.write() default) already lands here. The
+        # issue also reported it dropping the sidecar key; that half no longer
+        # reproduces, so this param is the proof the assertion is satisfiable.
+        "duckdb-kv",
+    ],
+)
+def test_parquet_geo_only_drops_geo_and_keeps_sidecar(strategy, tmp_path):
+    """Explicit parquet-geo-only writes no ``geo`` key and keeps unrelated keys.
+
+    ``parquet-geo-only`` means "carry no GeoParquet metadata". A ``geo`` key in
+    the output would name a ``primary_column`` the file does not have and would
+    declare a GeoParquet version for a file explicitly asked to declare none.
+    An unrelated sidecar key is not GeoParquet metadata, so it survives: the
+    single correct answer for all four strategies is ``['fiboa']``.
+    """
+    out = tmp_path / f"{strategy}.parquet"
+
+    Table(_attributes_only_with_geo()).write(
+        out, geoparquet_version="parquet-geo-only", write_strategy=strategy
+    )
+
+    assert _kv_keys(out) == ["fiboa"]
+
+
+@pytest.mark.parametrize("strategy", WRITE_STRATEGIES)
+def test_auto_version_metadata_keys_today(strategy, tmp_path):
+    """Pins *current* auto-mode behavior, not desired behavior.
+
+    #753 deliberately scoped its fix to an *explicit* ``parquet-geo-only``
+    request and left auto mode (``geoparquet_version=None``) alone, so the
+    carried ``geo`` key surviving here is today's contract, not a bug this file
+    claims. The assertion exists so that the facade refactor cannot change auto
+    mode as a side effect of fixing the explicit mode above: if it does, this
+    test fails and the change has to be argued for on purpose.
+    """
+    out = tmp_path / f"auto_{strategy}.parquet"
+
+    Table(_attributes_only_with_geo()).write(out, geoparquet_version=None, write_strategy=strategy)
+
+    expected = ["fiboa"] if strategy == "duckdb-kv" else ["fiboa", "geo"]
+    assert _kv_keys(out) == expected
+
+
+# ---------------------------------------------------------------------------
+# #600 -- auto version mode downgrades native-geo-only inputs to 1.1 WKB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def parquet_geo_only_file(tmp_path):
+    """A native-geo-only input: Parquet GEOMETRY logical type, no ``geo`` key.
+
+    ``GEOPARQUET_VERSION 'NONE'`` is how DuckDB spells parquet-geo-only, the
+    same spelling ``tests/conftest.py`` uses. ``grp`` is a low-cardinality
+    string so ``partition string`` has something to split on.
+    """
+    path = tmp_path / "pgo.parquet"
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        con.execute(
+            f"""
+            COPY (
+                SELECT i AS id, 'g' || (i % 3) AS grp, ST_Point(i, i) AS geometry
+                FROM range(50) t(i)
+            ) TO {sql_path(str(path))} (FORMAT PARQUET, GEOPARQUET_VERSION 'NONE')
+            """
+        )
+    finally:
+        con.close()
+
+    # Non-vacuity: the fixture must really be native-geo-only, or every
+    # assertion below is measuring the wrong thing.
+    assert b"geo" not in (pq.ParquetFile(str(path)).metadata.metadata or {})
+    assert _is_native_geometry(path), "fixture did not get a native GEOMETRY type"
+    return path
+
+
+def _is_native_geometry(path, column: str = "geometry") -> bool:
+    """True when ``column`` carries a Parquet GEOMETRY/GEOGRAPHY logical type.
+
+    Read without the spatial extension so the answer is the file's own schema
+    rather than something DuckDB reconstructed, the same way
+    ``tests/test_write_strategies.py`` reads carriers.
+    """
+    con = get_duckdb_connection(load_spatial=False)
+    try:
+        rows = con.execute(
+            f"SELECT name, logical_type FROM parquet_schema({sql_path(str(path))})"
+        ).fetchall()
+    finally:
+        con.close()
+    return any(name == column and logical and "Geometry" in str(logical) for name, logical in rows)
+
+
+def _geo_version(path) -> str | None:
+    metadata = pq.ParquetFile(str(path)).metadata.metadata or {}
+    if b"geo" not in metadata:
+        return None
+    return json.loads(metadata[b"geo"].decode("utf-8")).get("version")
+
+
+def _assert_native_geo_preserved(path) -> None:
+    """The #600 contract: auto mode upgrades native-geo-only to native 2.0.
+
+    This is what ``resolve_geoparquet_version_from_file`` already gives
+    ``convert`` and ``reproject`` (PR #594). Both halves matter: a 2.0 version
+    string over a WKB column would be a spec violation, and a native column
+    under a 1.1 declaration would be one too.
+    """
+    version = _geo_version(path)
+    assert version is not None and version.startswith("2.0"), (
+        f"expected a 2.0.x geo version, got {version!r}"
+    )
+    assert _is_native_geometry(path), (
+        "geometry column lost its native Parquet GEOMETRY logical type"
+    )
+
+
+def _run_cli(*args) -> None:
+    result = CliRunner().invoke(cli, [str(a) for a in args])
+    assert result.exit_code == 0, result.output
+
+
+_DOWNGRADE_REASON = (
+    "#600: {command} passes geoparquet_version=None straight to "
+    "write_parquet_with_metadata, whose extract_version_from_metadata returns "
+    "None for a native-geo-only input, so the write defaults to 1.1.0 WKB and "
+    "strips the native GEOMETRY logical type"
+)
+
+
+def _downgrade_param(command: str, *args, control: bool = False):
+    marks = (
+        ()
+        if control
+        else (pytest.mark.xfail(strict=True, reason=_DOWNGRADE_REASON.format(command=command)),)
+    )
+    return pytest.param(command, args, marks=marks, id=command.replace(" ", "-"))
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_args"),
+    [
+        # Control: convert already resolves the version from the input file, so
+        # this param proves the oracle above is reachable -- and pins the
+        # behavior every other entry point has to reach.
+        _downgrade_param("convert geoparquet", control=True),
+        _downgrade_param("sort hilbert"),
+        _downgrade_param("sort column", "id"),
+        _downgrade_param("sort quadkey"),
+        _downgrade_param("extract geoparquet", "--limit", "10"),
+    ],
+)
+def test_auto_mode_preserves_native_geo(command, extra_args, parquet_geo_only_file, tmp_path):
+    """Auto mode must not silently rewrite a native-geo-only input as 1.1 WKB.
+
+    No ``--geoparquet-version`` is passed, which is the mode the shared help
+    text documents as "preserve the input's version". For a parquet-geo-only
+    input that means native 2.0, which is what ``convert`` does.
+    """
+    out = tmp_path / "out.parquet"
+
+    _run_cli(*command.split(), parquet_geo_only_file, out, *extra_args)
+
+    _assert_native_geo_preserved(out)
+
+
+@pytest.mark.xfail(strict=True, reason=_DOWNGRADE_REASON.format(command="partition string"))
+def test_partition_auto_mode_preserves_native_geo(parquet_geo_only_file, tmp_path):
+    """The partition staging write takes the same fall-through (staging.py).
+
+    ``--force`` only silences the tiny-partition advisory; 50 rows over three
+    groups is deliberately small so the test stays fast.
+    """
+    out_dir = tmp_path / "parts"
+
+    _run_cli("partition", "string", parquet_geo_only_file, out_dir, "--column", "grp", "--force")
+
+    written = sorted(out_dir.rglob("*.parquet"))
+    assert written, "partition wrote no files"
+    for part in written:
+        _assert_native_geo_preserved(part)


### PR DESCRIPTION
## What changed

One new file, `tests/test_write_facade_contract.py`. No production code changes.

**#773 — `test_parquet_geo_only_drops_geo_and_keeps_sidecar`** (4 params). The
issue's reproducer: `Table.write(out, geoparquet_version="parquet-geo-only",
write_strategy=S)` on a table whose geometry column has been projected away but
which still carries a `geo` key plus an unrelated `fiboa` sidecar key. The
single correct answer for every strategy is key-value metadata of exactly
`['fiboa']` (excluding `ARROW:schema`). `in-memory`, `streaming` and
`disk-rewrite` are `xfail(strict=True)`; `duckdb-kv` is a live control.

**#773 sibling — `test_auto_version_metadata_keys_today`** (4 params, none
marked). Pins what auto mode (`geoparquet_version=None`) does *today* on the
same table — `['fiboa', 'geo']` for the three Arrow strategies, `['fiboa']` for
`duckdb-kv`. The docstring says explicitly that this is current behavior, not
desired behavior: #753 scoped its fix to the *explicit* request and left auto
mode alone, so this exists only so the facade cannot change auto mode as an
unremarked side effect.

**#600 — `test_auto_mode_preserves_native_geo`** (5 params) and
`test_partition_auto_mode_preserves_native_geo`. A parquet-geo-only fixture
(DuckDB `GEOPARQUET_VERSION 'NONE'`, native GEOMETRY logical type, no `geo`
key), run through the CLI with `CliRunner` and no `--geoparquet-version`. Each
asserts both halves of the contract on the output: geo version is `2.0.x` **and**
the geometry column still carries a native Parquet GEOMETRY logical type (read
back through `parquet_schema` without the spatial extension, so the answer is
the file's own schema). `sort hilbert`, `sort column`, `sort quadkey`,
`extract geoparquet` and `partition string` are `xfail(strict=True)`;
`convert geoparquet` is a live control.

## Why

Both issues are the same shape: one fact about an output file is stated
independently in N write paths, and the paths disagree. The fix for each is not
N patches but routing every path through one place — which is the upcoming
write-facade refactor (Deep Review item 3.3). Patching them now would create
edits the refactor has to unpick, and folding them into the refactor would make
it a PR that both moves code and changes behavior, which is the hardest kind to
review.

So the behavior gets pinned first, and the refactor gets to be a pure move that
happens to turn these green. `strict=True` is doing real work here: today each
marked test xfails, so CI is green; the day the facade lands they xpass, strict
mode converts that xpass into a failure, and the facade PR is forced to delete
the marker. That deletion is the signal we want — a suite that silently stopped
testing anything is not.

The non-xfail controls (`duckdb-kv`, `convert geoparquet`) exist so an xfail
next to them is demonstrably a defect rather than an oracle nothing could ever
satisfy.

## Verification

### Both contracts XFAIL today

```
$ uv run pytest tests/test_write_facade_contract.py -q -rxX

tests/test_write_facade_contract.py xxx......xxxxx                       [100%]

=========================== short test summary info ============================
XFAIL ...::test_parquet_geo_only_drops_geo_and_keeps_sidecar[in-memory] - #773: in-memory returns early when the geometry column is absent and writes the carried 'geo' key through, even though parquet-geo-only was asked for explicitly
XFAIL ...::test_parquet_geo_only_drops_geo_and_keeps_sidecar[streaming] - #773: streaming returns early ...
XFAIL ...::test_parquet_geo_only_drops_geo_and_keeps_sidecar[disk-rewrite] - #773: disk-rewrite returns early ...
XFAIL ...::test_auto_mode_preserves_native_geo[sort-hilbert] - #600: sort hilbert passes geoparquet_version=None straight to write_parquet_with_metadata, whose extract_version_from_metadata returns None for a native-geo-only input, so the write defaults to 1.1.0 WKB and strips the native GEOMETRY logical type
XFAIL ...::test_auto_mode_preserves_native_geo[sort-column] - #600: sort column ...
XFAIL ...::test_auto_mode_preserves_native_geo[sort-quadkey] - #600: sort quadkey ...
XFAIL ...::test_auto_mode_preserves_native_geo[extract-geoparquet] - #600: extract geoparquet ...
XFAIL ...::test_partition_auto_mode_preserves_native_geo - #600: partition string ...
========================= 6 passed, 8 xfailed in 1.67s =========================
```

`xxx` then `......` then `xxxxx` — every pinned param is `x` (xfailed), not `f`
and not `X`. The 6 passes are the two controls plus the four current-behavior
pins.

### Non-vacuity: each assertion goes green when the behavior is right

Two throwaway patches, applied and then reverted, one per issue.

For **#773**, in `arrow_memory.py`, route the geometry-absent +
explicit-parquet-geo-only case through `_strip_geo_metadata_key` — the fix the
issue itself suggests:

```python
 has_geometry = geometry_column in table.column_names
+if not has_geometry and geoparquet_version == "parquet-geo-only":
+    from geoparquet_io.core.common import _strip_geo_metadata_key
+
+    table = _strip_geo_metadata_key(table, verbose)
 if has_geometry:
```

For **#600**, in `hilbert_order.py`'s `_hilbert_order_file_based`, resolve auto
mode from the input file as `convert` does:

```python
 """Handle file-based hilbert_order operation."""
+if geoparquet_version is None:
+    from geoparquet_io.core.common import resolve_geoparquet_version_from_file
+
+    geoparquet_version = resolve_geoparquet_version_from_file(input_parquet, verbose)
```

With just those two lines in place:

```
$ uv run pytest "tests/test_write_facade_contract.py::test_parquet_geo_only_drops_geo_and_keeps_sidecar[in-memory]" \
                "tests/test_write_facade_contract.py::test_auto_mode_preserves_native_geo[sort-hilbert]" -v

tests/test_write_facade_contract.py::test_parquet_geo_only_drops_geo_and_keeps_sidecar[in-memory] FAILED [ 50%]
tests/test_write_facade_contract.py::test_auto_mode_preserves_native_geo[sort-hilbert] FAILED [100%]

=================================== FAILURES ===================================
_________ test_parquet_geo_only_drops_geo_and_keeps_sidecar[in-memory] _________
[XPASS(strict)] #773: in-memory returns early when the geometry column is absent and writes the carried 'geo' key through, even though parquet-geo-only was asked for explicitly
______________ test_auto_mode_preserves_native_geo[sort-hilbert] _______________
[XPASS(strict)] #600: sort hilbert passes geoparquet_version=None straight to write_parquet_with_metadata, whose extract_version_from_metadata returns None for a native-geo-only input, so the write defaults to 1.1.0 WKB and strips the native GEOMETRY logical type
============================== 2 failed in 0.51s ===============================
```

Both assertions become satisfiable the moment the routing is right, so neither
is vacuous — and the `XPASS(strict)` failure is exactly the alarm the facade PR
is meant to trip. Both patches were reverted; `git status` was clean apart from
the new test file before committing.

### Suite

```
$ uv run pre-commit run --all-files                        # all Passed
$ uv run pre-commit run --all-files --hook-stage pre-push   # all Passed (deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests)
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5 failed, 5739 passed, 67 skipped, 9 xfailed in 303.80s
```

The 5 failures are the known xdist cold-run flakes (`tests/e2e/test_journeys.py`
×2, `test_geojson_stream.py`, `test_pipe_integration.py`,
`test_geometry_repair_integration.py`); all 5 pass serially:

```
$ uv run pytest <those 5 node ids> -q
============================== 5 passed in 5.51s ===============================
```

### Two notes on what the issues say vs. what reproduces now

- **#773's second defect is gone.** The issue reports `duckdb-kv` producing `[]`
  — dropping the unrelated `fiboa` sidecar along with `geo`. On `main` today it
  produces `['fiboa']`, which is the correct answer. So `duckdb-kv` is a live
  control here rather than a fifth xfail; marking it `xfail(strict=True)` would
  xpass immediately. The issue can drop that half.
- **`check --fix` is left out.** The issue lists it as affected, but it does not
  reproduce: `gpio check all pgo.parquet --fix --fix-output out.parquet` on a
  parquet-geo-only input writes an output that still has the native GEOMETRY
  logical type and still has no `geo` key (verified directly against the fixed
  file's `parquet_schema`). It changed compression only. Pinning it would mean
  asserting a *new* contract — that an optimizer should upgrade a file to 2.0 —
  which is a different question from #600's downgrade, and not one this PR
  should decide.

Refs #773
Refs #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
