### PR TITLE
fix(convert): report when an input's explicit default CRS is normalized away

### DIFF
--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -338,6 +338,14 @@ GeoParquet files can have multiple geometry columns (e.g., `geometry` for point 
     `gpio check spec` would reject. Fix such a CRS in the source data, or
     re-export it from a tool that writes valid PROJJSON.
 
+!!! note "An explicit default CRS is normalized, not preserved"
+    GeoParquet writes its default CRS (OGC:CRS84, equivalently EPSG:4326) by
+    *omitting* the `crs` key, so an input that spells that default out comes back
+    without the key. The coordinates and their meaning are unchanged, but a
+    byte-for-byte diff of the `geo` metadata will show the key gone. `convert`
+    rebuilds the `geo` block from the converted data, so this applies at every
+    `--geoparquet-version`. Run with `--verbose` to see a note when it happens.
+
 ### Custom Geometry Column Names
 
 GeoParquet files can use non-standard geometry column names (e.g., `the_geom`, `my_geometry`). These names are preserved during conversion:

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -18,6 +18,7 @@ from geoparquet_io.core.crs_utils import (
     extract_crs_from_parquet,
     is_default_crs,
     normalize_projjson_crs,
+    note_default_crs_normalized,
     parse_crs_string_to_projjson,
 )
 from geoparquet_io.core.duckdb_utils import (
@@ -2090,6 +2091,16 @@ def convert_to_geoparquet(
         if has_geometry:
             geom_col = "geometry" if is_csv else geometry_info["primary"]
             query = repair_query_geometry(con, query, geom_col, repair=repair_geometry)
+
+            # This convert rebuilds the output's `geo` block from the converted
+            # data (`original_metadata=None` below, and at 2.0 DuckDB regenerates
+            # the block outright on the plain-COPY fast path), so an input `crs`
+            # that spelled out the default never reaches `apply_output_crs` and
+            # its note never fired here. Emit the same note from the same helper
+            # so the key does not vanish unannounced on this path alone (#844).
+            note_default_crs_normalized(
+                (geometry_info or {}).get("metadata", {}).get(geom_col, {}).get("crs")
+            )
 
         # Sidecar KV payloads (fiboa, vecorel, STAC fragments) live next to the
         # 'geo' key and are rebuilt from scratch by every write strategy, so a

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -223,6 +223,35 @@ def is_default_crs(crs):
     return False
 
 
+def note_default_crs_normalized(declared) -> None:
+    """Note at ``--verbose`` that a declared default ``crs`` is dropped on write.
+
+    GeoParquet signals the default CRS (OGC:CRS84 / EPSG:4326) by *omitting* the
+    ``crs`` key, so an input that spelled it out loses that key on write. The
+    output is correct GeoParquet, but the drop is invisible — a caller diffing
+    ``geo`` blocks sees a key they wrote go missing (#815).
+
+    ``declared`` is the input's raw ``crs`` value. Only a value that really names
+    the default is noted: an empty value names nothing, and an explicit
+    ``crs: null`` means *unknown*, which has its own warning
+    (:data:`NULL_CRS_HINT`). :func:`is_default_crs` is the sole predicate here so
+    the note and the drop can never disagree about what the default is (#796).
+
+    This is the single wording of the note. :func:`apply_output_crs` calls it for
+    every write path that carries the input's ``geo`` block through; paths that
+    rebuild the block from the converted data (``gpio convert geoparquet``, whose
+    2.0 fast path lets DuckDB regenerate it) call it themselves, because their
+    input's ``crs`` never reaches ``apply_output_crs`` (#844).
+    """
+    if not declared or not is_default_crs(declared):
+        return
+    debug(
+        "Normalized an explicit default CRS: dropped the geometry column's "
+        "`crs` key, which is how GeoParquet spells the OGC:CRS84 / EPSG:4326 "
+        "default (the coordinates are unchanged)."
+    )
+
+
 def apply_output_crs(col_meta: dict, input_crs) -> None:
     """Set or clear a geometry column's ``crs`` for the requested output CRS.
 
@@ -238,29 +267,20 @@ def apply_output_crs(col_meta: dict, input_crs) -> None:
       still strip a stray default/null one the source or DuckDB may have attached.
 
     Dropping a ``crs`` the input *spelled out* as the default is invisible in the
-    output — the file is correct GeoParquet, but a caller diffing ``geo`` blocks
-    sees a key they wrote go missing (#815). Note it once at ``--verbose``. An
-    explicit ``crs: null`` is excluded: that means *unknown*, and it has its own
-    warning (:data:`NULL_CRS_HINT`).
+    output, so :func:`note_default_crs_normalized` reports it once at
+    ``--verbose`` (#815).
 
     Mutates ``col_meta`` in place.
     """
+    # Captured before the pop: the note describes what the input declared.
     declared = col_meta.get("crs")
-    # Only a value that actually names the default counts: ``None`` is the
-    # unknown-CRS case and an empty value names nothing at all.
-    declared_the_default = bool(declared) and is_default_crs(declared)
 
     if input_crs and not is_default_crs(input_crs):
         col_meta["crs"] = input_crs
         return
     if input_crs or is_default_crs(col_meta.get("crs")):
         col_meta.pop("crs", None)
-        if declared_the_default:
-            debug(
-                "Normalized an explicit default CRS: dropped the geometry column's "
-                "`crs` key, which is how GeoParquet spells the OGC:CRS84 / EPSG:4326 "
-                "default (the coordinates are unchanged)."
-            )
+        note_default_crs_normalized(declared)
 
 
 #: Shared guidance appended to null-CRS warnings and the validate message.

--- a/tests/test_crs_null_vs_default.py
+++ b/tests/test_crs_null_vs_default.py
@@ -436,3 +436,89 @@ def test_sort_hilbert_verbose_is_silent_for_a_non_default_crs(buildings_test_fil
     assert result.exit_code == 0, result.output
     assert "explicit default CRS" not in result.output
     assert _col_crs(out)[0] is True
+
+
+# --------------------------------------------------------------------------- #
+# `gpio convert geoparquet` rebuilds the `geo` block from the converted data,
+# so the input's block never reaches apply_output_crs and the note above never
+# fired there -- loudest at 2.0, whose plain-COPY fast path lets DuckDB
+# regenerate the block outright (#844).
+# --------------------------------------------------------------------------- #
+
+
+def _convert_geoparquet(*args):
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import convert
+
+    return CliRunner().invoke(convert, ["geoparquet", *args])
+
+
+def _parquet_with_crs(source, dest, crs):
+    """Write a copy of ``source`` whose geometry column declares ``crs``."""
+    import json
+
+    table = pq.read_table(source)
+    meta = dict(table.schema.metadata)
+    geo = json.loads(meta[b"geo"].decode("utf-8"))
+    geo["columns"][geo.get("primary_column", "geometry")]["crs"] = crs
+    meta[b"geo"] = json.dumps(geo).encode("utf-8")
+    pq.write_table(table.replace_schema_metadata(meta), dest)
+    return str(dest)
+
+
+@pytest.mark.parametrize("version", ["1.1", "2.0"])
+def test_convert_geoparquet_verbose_notes_the_normalization(default_crs_parquet, tmp_path, version):
+    """The drop is reported once, on the fast path (2.0) and the rewrite (1.1)."""
+    out = str(tmp_path / f"converted_{version}.parquet")
+    result = _convert_geoparquet(
+        default_crs_parquet, out, "--geoparquet-version", version, "--verbose"
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.count("explicit default CRS") == 1
+
+
+def test_convert_geoparquet_v2_leaves_the_output_bytes_alone(default_crs_parquet, tmp_path):
+    """The note is a diagnostic: the output still omits the crs key, as before."""
+    out = str(tmp_path / "converted.parquet")
+    result = _convert_geoparquet(
+        default_crs_parquet, out, "--geoparquet-version", "2.0", "--verbose"
+    )
+    assert result.exit_code == 0, result.output
+    assert _col_crs(out) == (False, None)
+
+
+def test_convert_geoparquet_v2_is_quiet_about_it_without_verbose(default_crs_parquet, tmp_path):
+    out = str(tmp_path / "converted.parquet")
+    result = _convert_geoparquet(default_crs_parquet, out, "--geoparquet-version", "2.0")
+    assert result.exit_code == 0, result.output
+    assert "explicit default CRS" not in result.output
+
+
+def test_convert_geoparquet_v2_verbose_is_silent_for_an_absent_crs(absent_crs_parquet, tmp_path):
+    """Nothing was declared, so nothing is normalized away."""
+    out = str(tmp_path / "converted.parquet")
+    result = _convert_geoparquet(
+        absent_crs_parquet, out, "--geoparquet-version", "2.0", "--verbose"
+    )
+    assert result.exit_code == 0, result.output
+    assert "explicit default CRS" not in result.output
+
+
+def test_convert_geoparquet_v2_verbose_is_silent_for_a_non_default_crs(
+    buildings_test_file, tmp_path
+):
+    """A projected input keeps its CRS through the convert, so there is no note."""
+    src = _parquet_with_crs(buildings_test_file, tmp_path / "epsg3857.parquet", EPSG_3857)
+    out = str(tmp_path / "converted_3857.parquet")
+    result = _convert_geoparquet(src, out, "--geoparquet-version", "2.0", "--verbose")
+    assert result.exit_code == 0, result.output
+    assert "explicit default CRS" not in result.output
+    assert _col_crs(out)[0] is True
+
+
+def test_convert_geoparquet_v2_verbose_is_silent_for_a_null_crs(null_crs_parquet, tmp_path):
+    """``crs: null`` is *unknown*, not the default; it keeps its own warning."""
+    out = str(tmp_path / "converted_null.parquet")
+    result = _convert_geoparquet(null_crs_parquet, out, "--geoparquet-version", "2.0", "--verbose")
+    assert "explicit default CRS" not in result.output


### PR DESCRIPTION
## What changed

`gpio convert geoparquet` now emits the #815 `--verbose` note when the input's
geometry column declares a `crs` that spells out the GeoParquet default
(`OGC:CRS84` / `EPSG:4326`) and the output omits the key, as the spec requires.

The note text and the "is this the default?" predicate are factored into
`note_default_crs_normalized()` in `core/crs_utils.py`. `apply_output_crs()` now
calls it instead of inlining the message, and `convert_to_geoparquet()` calls it
too, reading the declared CRS from the input `geo` block it has already parsed
into `geometry_info["metadata"]`. Both use `is_default_crs` — the predicate with
the CRS-equality bug history (#796) — so the note and the drop cannot drift apart.

Diagnostic only: no change to the bytes DuckDB writes.

## Why

The #842 note lives in `apply_output_crs`, which only sees the input's `crs` on
write paths that carry the input's `geo` block through it (sort, add, partition,
the 2.0 fast-path carry). `convert_to_geoparquet` passes `original_metadata=None`
and rebuilds the block from the converted data, and at 2.0 it takes the
"No metadata rewrite needed — using plain COPY TO" route where
`_geo_block_to_carry_on_fast_path` returns `None` immediately (no
`original_metadata`) and DuckDB regenerates `geo` from scratch. So the input's
`crs` never reached `apply_output_crs` and the key vanished with nothing said,
while the same input through `sort` got a line.

Because the cause is the rebuild rather than the fast path specifically, the note
was missing at **every** `--geoparquet-version` for `convert geoparquet`, not just
2.0 — measured below. Placing the call where `convert` has the parsed input block
fixes all of them with one line; there is no double-note risk, since
`apply_output_crs` sees no `crs` on this path.

`docs/guide/convert.md` claimed the conversion preserves the "CRS"; it now carries
the same note `docs/guide/sort.md` got in #842.

**Python API twin:** `gpio.convert()` (`api/table.py`) routes through
`read_spatial_to_arrow` and returns a `Table` — it never calls
`convert_to_geoparquet`, so it does not take the plain-COPY branch, and there is no
`ops` twin of `convert geoparquet`. Left alone deliberately. (`Table.write()` at
2.0 also drops an explicit default key silently, but through the Arrow write
strategy and with no verbosity plumbed to it — a separate path, not this one.)

## Verification

Input: `tests/data/buildings_test.parquet` with `crs: {"id": {"authority": "EPSG", "code": 4326}}`.

**Before** — `convert geoparquet` at 2.0 with `--verbose`, no note:

```
$ gpio convert geoparquet default_crs.parquet out20.parquet --geoparquet-version 2.0 --verbose
Converting default_crs.parquet...
Detected geometry columns - primary: geometry, secondary: []
Calculating dataset bounds...
Dataset bounds: (6.123943, 50.120524, 6.151465, 50.137757)
Pass 1: Reading input and applying Hilbert ordering (skipping bbox)...
Writing GeoParquet version: 2.0
No metadata rewrite needed for 2.0 - using plain COPY TO
Executing plain COPY TO with ZSTD compression...
Wrote 42 rows to out20.parquet
Done in 0.0s
Output: out20.parquet (4.71 KB)
✓ Output passes GeoParquet validation (metadata checks)
```

...while `sort hilbert` on the same input did report it:

```
$ gpio sort hilbert default_crs.parquet sorted.parquet --verbose
...
Writing GeoParquet version: 1.1
Using write strategy: duckdb-kv
DuckDB memory limit: 1.7GB
Normalized an explicit default CRS: dropped the geometry column's `crs` key, which is how GeoParquet spells the OGC:CRS84 / EPSG:4326 default (the coordinates are unchanged).
Writing via DuckDB COPY TO with ZSTD compression...
Wrote 42 rows to sorted.parquet
```

Note count per `convert --geoparquet-version`, before the fix — silent everywhere:

```
=== 1.0 === 0
=== 1.1 === 0
=== 1.1-geoarrow === 0
=== 2.0 === 0
```

**After**:

```
$ gpio convert geoparquet default_crs.parquet after20.parquet --geoparquet-version 2.0 --verbose
Detected geometry columns - primary: geometry, secondary: []
Calculating dataset bounds...
Dataset bounds: (6.123943, 50.120524, 6.151465, 50.137757)
Pass 1: Reading input and applying Hilbert ordering (skipping bbox)...
Normalized an explicit default CRS: dropped the geometry column's `crs` key, which is how GeoParquet spells the OGC:CRS84 / EPSG:4326 default (the coordinates are unchanged).
Writing GeoParquet version: 2.0
No metadata rewrite needed for 2.0 - using plain COPY TO
Executing plain COPY TO with ZSTD compression...
Wrote 42 rows to after20.parquet
Done in 0.1s
Output: after20.parquet (4.71 KB)
✓ Output passes GeoParquet validation (metadata checks)
```

The output is untouched — the `geo` block still omits `crs`, and the file is
byte-identical to the pre-fix one:

```
crs key present: False
{"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Polygon"], "bbox": [6.123943, 50.120524, 6.1514648, 50.1377572]}}}

bytes identical to pre-fix output: True
```

New tests (in `tests/test_crs_null_vs_default.py`, reusing #842's
`default_crs_parquet` fixture) pin: exactly one note at 1.1 and at 2.0 with
`--verbose`; the output still omits the `crs` key; silence without `--verbose`;
silence for an absent `crs`, for a non-default `EPSG:3857` (which is carried
through), and for an explicit `crs: null` (unknown, which keeps its own warning).

Suite and gates:

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5745 passed, 67 skipped, 1 xfailed, 103 warnings in 160.97s (0:02:40)

$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
geoparquet_io/core/convert.py (100%)
geoparquet_io/core/crs_utils.py (100%)
Total:   6 lines
Missing: 0 lines
Coverage: 100%
```

`uv run pre-commit run --all-files` and `--hook-stage pre-push` (mypy, vulture,
xenon, import-linter, deptry) both clean.

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
