### PR TITLE
feat(validate): implement the orientation-vs-data check (exterior CCW, holes CW)

### DIFF
--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -1302,28 +1302,39 @@ def _check_geometry_types_match_data(
         )
 
 
-def _polygon_orientation_violations(polygon_wkbs: list) -> int:
-    """Polygons whose exterior ring is not counterclockwise or whose holes are not clockwise.
+def _polygon_orientation_violations(polygon_wkbs: list, geodesic: bool = False) -> tuple[int, int]:
+    """(violations, checked): polygons whose exterior ring is not counterclockwise or whose
+    holes are not clockwise, and how many polygons could be judged.
 
     Ring orientation is the sign of the shoelace sum (positive is counterclockwise).
     Rings with fewer than four vertices or zero area cannot be oriented and are ignored.
+    With geodesic edges a ring spanning more than 180 degrees of longitude crosses the
+    antimeridian or encloses a pole, where planar winding is meaningless; it is ignored too.
     """
     import geoarrow.pyarrow as ga
     import pyarrow as pa
 
     polygons = ga.as_geoarrow(pa.array(polygon_wkbs, pa.binary()), ga.polygon())
-    violations = 0
+    violations = checked = 0
     for rings in polygons.storage.to_pylist():
+        judged = False
         for i, ring in enumerate(rings):
             if len(ring) < 4:
+                continue
+            xs = [p["x"] for p in ring]
+            if geodesic and max(xs) - min(xs) > 180:
                 continue
             area2 = sum(
                 a["x"] * b["y"] - b["x"] * a["y"] for a, b in zip(ring, ring[1:], strict=False)
             )
-            if area2 and (area2 > 0) != (i == 0):
+            if not area2:
+                continue
+            judged = True
+            if (area2 > 0) != (i == 0):
                 violations += 1
                 break
-    return violations
+        checked += judged
+    return violations, checked
 
 
 def _check_orientation_matches_data(
@@ -1333,6 +1344,7 @@ def _check_orientation_matches_data(
     con,
     sample_size: int,
     encoding: Any = "WKB",
+    edges: Any = "planar",
 ) -> ValidationCheck:
     """Check 19: all polygon geometries must follow 'orientation' metadata."""
     name = f"orientation_matches_data_{geom_col}"
@@ -1373,18 +1385,22 @@ def _check_orientation_matches_data(
         """).fetchall()
         if not rows:
             return _result(CheckStatus.SKIPPED, "no polygons to check against declared orientation")
-        violations = _polygon_orientation_violations([bytes(r[0]) for r in rows])
+        violations, checked = _polygon_orientation_violations(
+            [bytes(r[0]) for r in rows], geodesic=edges != "planar"
+        )
     except Exception as e:
         return _result(CheckStatus.FAILED, f"failed to validate orientation: {e}")
 
+    if not checked:
+        return _result(CheckStatus.SKIPPED, "no polygons whose ring orientation can be determined")
     if violations:
         return _result(
             CheckStatus.FAILED,
-            f'{violations} of {len(rows)} polygons violate orientation "{orientation}"',
+            f'{violations} of {checked} polygons violate orientation "{orientation}"',
         )
     return _result(
         CheckStatus.PASSED,
-        f'all {len(rows)} polygon{"s" if len(rows) != 1 else ""} follow orientation "{orientation}"',
+        f'all {checked} polygon{"s" if checked != 1 else ""} follow orientation "{orientation}"',
     )
 
 
@@ -3624,7 +3640,13 @@ def _run_geoparquet_checks(
             orientation = col_meta.get("orientation")
             checks.append(
                 _check_orientation_matches_data(
-                    parquet_file, col_name, orientation, con, sample_size, encoding
+                    parquet_file,
+                    col_name,
+                    orientation,
+                    con,
+                    sample_size,
+                    encoding,
+                    col_meta.get("edges") or "planar",
                 )
             )
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -111,7 +111,8 @@ _GEOARROW_ENCODING_TYPE = {
     "multilinestring": "MultiLineString",
     "multipolygon": "MultiPolygon",
 }
-VALID_ORIENTATIONS = ["counterclockwise"]
+OrientationCounterClockwise = "counterclockwise"
+VALID_ORIENTATIONS = [OrientationCounterClockwise]
 VALID_EDGES_GEOPARQUET = ["planar", "spherical"]
 VALID_EDGES_PARQUET_GEO = ["spherical", "vincenty", "thomas", "andoyer", "karney"]
 VALID_GEOMETRY_TYPES = [
@@ -1301,25 +1302,89 @@ def _check_geometry_types_match_data(
         )
 
 
+def _polygon_orientation_violations(polygon_wkbs: list) -> int:
+    """Polygons whose exterior ring is not counterclockwise or whose holes are not clockwise.
+
+    Ring orientation is the sign of the shoelace sum (positive is counterclockwise).
+    Rings with fewer than four vertices or zero area cannot be oriented and are ignored.
+    """
+    import geoarrow.pyarrow as ga
+    import pyarrow as pa
+
+    polygons = ga.as_geoarrow(pa.array(polygon_wkbs, pa.binary()), ga.polygon())
+    violations = 0
+    for rings in polygons.storage.to_pylist():
+        for i, ring in enumerate(rings):
+            if len(ring) < 4:
+                continue
+            area2 = sum(
+                a["x"] * b["y"] - b["x"] * a["y"] for a, b in zip(ring, ring[1:], strict=False)
+            )
+            if area2 and (area2 > 0) != (i == 0):
+                violations += 1
+                break
+    return violations
+
+
 def _check_orientation_matches_data(
-    parquet_file: str, geom_col: str, orientation: str | None, con, sample_size: int
+    parquet_file: str,
+    geom_col: str,
+    orientation: str | None,
+    con,
+    sample_size: int,
+    encoding: Any = "WKB",
 ) -> ValidationCheck:
     """Check 19: all polygon geometries must follow 'orientation' metadata."""
-    if orientation is None:
+    name = f"orientation_matches_data_{geom_col}"
+
+    def _result(status, message):
         return ValidationCheck(
-            name=f"orientation_matches_data_{geom_col}",
-            status=CheckStatus.SKIPPED,
-            message="no orientation specified, skipping check",
-            category="data_validation",
+            name=name, status=status, message=message, category="data_validation"
         )
 
-    # This check would require inspecting ring orientations which is complex
-    # For now, we'll mark it as passed with a note
-    return ValidationCheck(
-        name=f"orientation_matches_data_{geom_col}",
-        status=CheckStatus.PASSED,
-        message=f'orientation "{orientation}" declared (ring order validation not implemented)',
-        category="data_validation",
+    if orientation is None:
+        return _result(CheckStatus.SKIPPED, "no orientation specified, skipping check")
+    if orientation != OrientationCounterClockwise:
+        return _result(CheckStatus.SKIPPED, f'unknown orientation "{orientation}", skipping check')
+    if _is_geoarrow_encoding(encoding):
+        return _result(
+            CheckStatus.SKIPPED, f'orientation check not implemented for encoding "{encoding}"'
+        )
+
+    from geoparquet_io.core.duckdb_utils import sql_path
+    from geoparquet_io.core.file_utils import safe_file_url
+
+    limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
+    quoted_geom = quote_identifier(geom_col)
+    try:
+        col_type = _describe_geom_type(con, safe_file_url(parquet_file, verbose=False), geom_col)
+        geom_expr = (
+            quoted_geom if "GEOMETRY" in col_type.upper() else f"ST_GeomFromWKB({quoted_geom})"
+        )
+        rows = con.execute(f"""
+            SELECT ST_AsWKB(ST_Force2D(part.geom))
+            FROM (
+                SELECT {geom_expr} AS g
+                FROM read_parquet({sql_path(parquet_file)})
+                WHERE {quoted_geom} IS NOT NULL
+                {limit_clause}
+            ) t, UNNEST(ST_Dump(t.g)) AS u(part)
+            WHERE ST_GeometryType(part.geom) = 'POLYGON' AND NOT ST_IsEmpty(part.geom)
+        """).fetchall()
+        if not rows:
+            return _result(CheckStatus.SKIPPED, "no polygons to check against declared orientation")
+        violations = _polygon_orientation_violations([bytes(r[0]) for r in rows])
+    except Exception as e:
+        return _result(CheckStatus.FAILED, f"failed to validate orientation: {e}")
+
+    if violations:
+        return _result(
+            CheckStatus.FAILED,
+            f'{violations} of {len(rows)} polygons violate orientation "{orientation}"',
+        )
+    return _result(
+        CheckStatus.PASSED,
+        f'all {len(rows)} polygon{"s" if len(rows) != 1 else ""} follow orientation "{orientation}"',
     )
 
 
@@ -3559,7 +3624,7 @@ def _run_geoparquet_checks(
             orientation = col_meta.get("orientation")
             checks.append(
                 _check_orientation_matches_data(
-                    parquet_file, col_name, orientation, con, sample_size
+                    parquet_file, col_name, orientation, con, sample_size, encoding
                 )
             )
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -111,8 +111,8 @@ _GEOARROW_ENCODING_TYPE = {
     "multilinestring": "MultiLineString",
     "multipolygon": "MultiPolygon",
 }
-OrientationCounterClockwise = "counterclockwise"
-VALID_ORIENTATIONS = [OrientationCounterClockwise]
+ORIENTATION_COUNTERCLOCKWISE = "counterclockwise"
+VALID_ORIENTATIONS = [ORIENTATION_COUNTERCLOCKWISE]
 VALID_EDGES_GEOPARQUET = ["planar", "spherical"]
 VALID_EDGES_PARQUET_GEO = ["spherical", "vincenty", "thomas", "andoyer", "karney"]
 VALID_GEOMETRY_TYPES = [
@@ -1356,7 +1356,7 @@ def _check_orientation_matches_data(
 
     if orientation is None:
         return _result(CheckStatus.SKIPPED, "no orientation specified, skipping check")
-    if orientation != OrientationCounterClockwise:
+    if orientation != ORIENTATION_COUNTERCLOCKWISE:
         return _result(CheckStatus.SKIPPED, f'unknown orientation "{orientation}", skipping check')
     if _is_geoarrow_encoding(encoding):
         return _result(
@@ -1400,7 +1400,8 @@ def _check_orientation_matches_data(
         )
     return _result(
         CheckStatus.PASSED,
-        f'all {checked} polygon{"s" if checked != 1 else ""} follow orientation "{orientation}"',
+        f"all {checked} "
+        f'{"polygons follow" if checked != 1 else "polygon follows"} orientation "{orientation}"',
     )
 
 

--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -273,11 +273,7 @@ BAD_DATA_EXPECTATIONS = {
     "missing-geo-metadata.parquet": ("2.0", [r"version_match"], None),
     "missing-primary-column.parquet": ("auto", [r"primary_column_present"], None),
     "missing-version.parquet": ("auto", [r"version_present"], None),
-    "orientation-ccw-declared-rings-cw.parquet": (
-        "auto",
-        [r"orientation"],
-        "#586 no orientation-vs-data check",
-    ),
+    "orientation-ccw-declared-rings-cw.parquet": ("auto", [r"orientation_matches_data_"], None),
     "primary-column-not-in-columns.parquet": ("auto", [r"primary_column_in_columns"], None),
     "version-1-0-with-2-0-features.parquet": ("auto", [r"version_features"], None),
     "version-unknown.parquet": ("auto", [r"version_known"], None),

--- a/tests/test_validate_orientation.py
+++ b/tests/test_validate_orientation.py
@@ -1,0 +1,101 @@
+"""orientation_matches_data: exterior rings CCW and holes CW when orientation is declared (#586)."""
+
+import pytest
+
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.validate import (
+    CheckStatus,
+    _check_orientation_matches_data,
+    validate_geoparquet,
+)
+
+CORPUS = "tests/data/geoparquet-testing"
+CCW = "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))"
+CW = "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))"
+CCW_WITH_CW_HOLE = "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))"
+CCW_WITH_CCW_HOLE = "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1))"
+
+
+def _write_v2(path, wkts):
+    con = get_duckdb_connection(load_spatial=True)
+    values = ", ".join("(NULL)" if w is None else f"(ST_GeomFromText('{w}'))" for w in wkts)
+    con.execute(
+        f"COPY (SELECT * FROM (VALUES {values}) t(geometry)) "
+        f"TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')"
+    )
+    con.close()
+    return str(path)
+
+
+@pytest.fixture
+def con():
+    con = get_duckdb_connection(load_spatial=True)
+    yield con
+    con.close()
+
+
+def _check(path, con, orientation="counterclockwise", sample_size=0, **kw):
+    return _check_orientation_matches_data(path, "geometry", orientation, con, sample_size, **kw)
+
+
+class TestCorpusFiles:
+    def test_declared_ccw_with_cw_rings_fails(self, con):
+        check = _check(f"{CORPUS}/bad_data/orientation-ccw-declared-rings-cw.parquet", con)
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 1" in check.message
+
+    def test_declared_ccw_with_ccw_rings_passes(self, con):
+        check = _check(f"{CORPUS}/data/orientation/polygon-ccw.parquet", con)
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_no_orientation_declared_is_skipped(self, con):
+        check = _check(f"{CORPUS}/data/orientation/polygon-cw.parquet", con, orientation=None)
+        assert check.status == CheckStatus.SKIPPED
+
+    def test_reported_through_validate(self):
+        result = validate_geoparquet(f"{CORPUS}/bad_data/orientation-ccw-declared-rings-cw.parquet")
+        (check,) = [c for c in result.checks if c.name == "orientation_matches_data_geometry"]
+        assert check.status == CheckStatus.FAILED
+
+
+class TestRings:
+    def test_holes_must_be_clockwise(self, tmp_path, con):
+        good = _write_v2(tmp_path / "good.parquet", [CCW_WITH_CW_HOLE])
+        bad = _write_v2(tmp_path / "bad.parquet", [CCW_WITH_CCW_HOLE])
+        assert _check(good, con).status == CheckStatus.PASSED
+        assert _check(bad, con).status == CheckStatus.FAILED
+
+    def test_multipolygon_parts_are_checked(self, tmp_path, con):
+        wkt = (
+            "MULTIPOLYGON (((10 10, 12 10, 12 12, 10 12, 10 10)), "
+            "((20 20, 20 22, 22 22, 22 20, 20 20)))"
+        )
+        check = _check(_write_v2(tmp_path / "f.parquet", [wkt]), con)
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 2 polygons" in check.message
+
+    def test_polygons_inside_collections_and_z_are_checked(self, tmp_path, con):
+        wkt = "GEOMETRYCOLLECTION Z (POINT Z (1 1 1), POLYGON Z ((0 0 1, 0 4 1, 4 4 1, 4 0 1, 0 0 1)))"
+        check = _check(_write_v2(tmp_path / "f.parquet", [wkt]), con)
+        assert check.status == CheckStatus.FAILED
+
+    def test_null_empty_and_non_polygons_are_ignored(self, tmp_path, con):
+        path = _write_v2(tmp_path / "f.parquet", [CCW, None, "POLYGON EMPTY", "POINT (1 1)"])
+        check = _check(path, con)
+        assert check.status == CheckStatus.PASSED
+        assert "1 polygon" in check.message
+
+    def test_no_polygons_is_skipped(self, tmp_path, con):
+        check = _check(
+            _write_v2(tmp_path / "f.parquet", ["POINT (1 1)", "LINESTRING (0 0, 1 1)"]), con
+        )
+        assert check.status == CheckStatus.SKIPPED
+
+    def test_sample_size_limits_rows(self, tmp_path, con):
+        path = _write_v2(tmp_path / "f.parquet", [CCW, CW])
+        assert _check(path, con, sample_size=1).status == CheckStatus.PASSED
+        assert _check(path, con, sample_size=0).status == CheckStatus.FAILED
+
+    def test_geoarrow_encoding_is_skipped(self, con):
+        check = _check("tests/data/data-polygon-encoding_native.parquet", con, encoding="polygon")
+        assert check.status == CheckStatus.SKIPPED

--- a/tests/test_validate_orientation.py
+++ b/tests/test_validate_orientation.py
@@ -1,5 +1,7 @@
 """orientation_matches_data: exterior rings CCW and holes CW when orientation is declared (#586)."""
 
+from pathlib import Path
+
 import pytest
 
 from geoparquet_io.core.common import get_duckdb_connection
@@ -38,6 +40,8 @@ def _check(path, con, orientation="counterclockwise", sample_size=0, **kw):
     return _check_orientation_matches_data(path, "geometry", orientation, con, sample_size, **kw)
 
 
+@pytest.mark.corpus
+@pytest.mark.skipif(not Path(CORPUS, "data").exists(), reason="run: git submodule update --init")
 class TestCorpusFiles:
     def test_declared_ccw_with_cw_rings_fails(self, con):
         check = _check(f"{CORPUS}/bad_data/orientation-ccw-declared-rings-cw.parquet", con)
@@ -102,11 +106,22 @@ class TestRings:
 
 
 class TestEdges:
-    def test_rings_with_fewer_than_four_vertices_are_ignored(self, tmp_path, con):
+    def test_zero_area_rings_are_not_judged(self, tmp_path, con):
         path = _write_v2(tmp_path / "f.parquet", ["POLYGON ((0 0, 1 1, 2 2, 0 0))", CCW])
         check = _check(path, con)
         assert check.status == CheckStatus.PASSED
-        assert "2 polygons" in check.message
+        assert "all 1 polygon " in check.message
+
+    def test_spherical_polygon_across_the_antimeridian_is_not_judged_planar(self, tmp_path, con):
+        # counterclockwise on the sphere, clockwise when read as planar lon/lat
+        wkt = "POLYGON ((170 -10, -170 -10, -170 10, 170 10, 170 -10))"
+        path = _write_v2(tmp_path / "f.parquet", [wkt])
+        assert _check(path, con, edges="planar").status == CheckStatus.FAILED
+        assert _check(path, con, edges="spherical").status == CheckStatus.SKIPPED
+        both = _write_v2(tmp_path / "g.parquet", [wkt, CCW])
+        check = _check(both, con, edges="spherical")
+        assert check.status == CheckStatus.PASSED
+        assert "all 1 polygon " in check.message
 
     def test_unknown_orientation_value_is_skipped(self, tmp_path, con):
         check = _check(_write_v2(tmp_path / "f.parquet", [CCW]), con, orientation="clockwise")

--- a/tests/test_validate_orientation.py
+++ b/tests/test_validate_orientation.py
@@ -110,7 +110,12 @@ class TestEdges:
         path = _write_v2(tmp_path / "f.parquet", ["POLYGON ((0 0, 1 1, 2 2, 0 0))", CCW])
         check = _check(path, con)
         assert check.status == CheckStatus.PASSED
-        assert "all 1 polygon " in check.message
+        assert "all 1 polygon follows" in check.message
+
+    def test_passing_message_uses_plural_verb_for_many_polygons(self, tmp_path, con):
+        check = _check(_write_v2(tmp_path / "f.parquet", [CCW, CCW]), con)
+        assert check.status == CheckStatus.PASSED
+        assert "all 2 polygons follow " in check.message
 
     def test_spherical_polygon_across_the_antimeridian_is_not_judged_planar(self, tmp_path, con):
         # counterclockwise on the sphere, clockwise when read as planar lon/lat
@@ -121,7 +126,7 @@ class TestEdges:
         both = _write_v2(tmp_path / "g.parquet", [wkt, CCW])
         check = _check(both, con, edges="spherical")
         assert check.status == CheckStatus.PASSED
-        assert "all 1 polygon " in check.message
+        assert "all 1 polygon follows" in check.message
 
     def test_unknown_orientation_value_is_skipped(self, tmp_path, con):
         check = _check(_write_v2(tmp_path / "f.parquet", [CCW]), con, orientation="clockwise")

--- a/tests/test_validate_orientation.py
+++ b/tests/test_validate_orientation.py
@@ -99,3 +99,20 @@ class TestRings:
     def test_geoarrow_encoding_is_skipped(self, con):
         check = _check("tests/data/data-polygon-encoding_native.parquet", con, encoding="polygon")
         assert check.status == CheckStatus.SKIPPED
+
+
+class TestEdges:
+    def test_rings_with_fewer_than_four_vertices_are_ignored(self, tmp_path, con):
+        path = _write_v2(tmp_path / "f.parquet", ["POLYGON ((0 0, 1 1, 2 2, 0 0))", CCW])
+        check = _check(path, con)
+        assert check.status == CheckStatus.PASSED
+        assert "2 polygons" in check.message
+
+    def test_unknown_orientation_value_is_skipped(self, tmp_path, con):
+        check = _check(_write_v2(tmp_path / "f.parquet", [CCW]), con, orientation="clockwise")
+        assert check.status == CheckStatus.SKIPPED
+
+    def test_unreadable_file_fails(self, tmp_path, con):
+        check = _check(str(tmp_path / "missing.parquet"), con)
+        assert check.status == CheckStatus.FAILED
+        assert "failed to validate orientation" in check.message


### PR DESCRIPTION
## Problem

`orientation_matches_data` was a placeholder that returned **PASSED** with the message `orientation "counterclockwise" declared (ring order validation not implemented)`. A file that declares `orientation: counterclockwise` with clockwise rings therefore passed `gpio check spec` (#586, first row of the table). The spec: "All vertices of exterior polygon rings MUST be ordered in the counterclockwise direction and all interior rings MUST be ordered in the clockwise direction."

```
$ gpio check spec tests/data/geoparquet-testing/bad_data/orientation-ccw-declared-rings-cw.parquet   # main
  ✓ column "geometry" has valid orientation: counterclockwise
  ✓ orientation "counterclockwise" declared (ring order validation not implemented)
Summary: 32 passed, 0 warnings, 0 failed

$ gpio check spec … orientation-ccw-declared-rings-cw.parquet   # this branch
  ✓ column "geometry" has valid orientation: counterclockwise
  ✗ 1 of 1 polygons violate orientation "counterclockwise"
Summary: 31 passed, 0 warnings, 1 failed
```

## Change

DuckDB spatial has no ring-orientation function, so the check is split in two:

1. SQL: `UNNEST(ST_Dump(g))` explodes each sampled geometry into its parts (handles MultiPolygon and GeometryCollection, recursively); keep parts with `ST_GeometryType = 'POLYGON'` and not empty; `ST_Force2D` so Z/M columns decode to one geoarrow type; `ST_AsWKB`.
2. Python: `geoarrow.pyarrow.as_geoarrow(…, ga.polygon())` (already a dependency) turns the polygons into rings of coordinates, and `_polygon_orientation_violations` applies the shoelace sign: exterior ring positive (counterclockwise), holes negative (clockwise). Rings with fewer than four vertices or zero signed area cannot be oriented and are ignored; a polygon counts once however many of its rings are wrong.

Same semantics as BigQuery's GEOGRAPHY normalisation (exterior CCW, holes CW, tiny rings skipped) and GDAL's `validate_geoparquet.py --check-data`. `sample_size` is honoured like the other data checks. GeoArrow native encodings are skipped with a message (the caller now passes `encoding`). `OrientationCounterClockwise` names the one allowed value so it is not repeated. No new dependency, no numpy.

## Tests

`tests/test_validate_orientation.py` (9 of 11 failed on `main`): the corpus negative fixture fails with `1 of 1`; `data/orientation/polygon-ccw.parquet` passes; undeclared orientation is skipped; a CCW polygon with a CW hole passes and with a CCW hole fails; a MultiPolygon with one bad part fails with `1 of 2 polygons`; a CW `POLYGON Z` inside a `GEOMETRYCOLLECTION Z` fails; NULL, `POLYGON EMPTY` and points are ignored; a column with no polygons is skipped; `sample_size=1` sees only the first (good) row; the GeoArrow `polygon` encoding is skipped; the failure is reported through `validate_geoparquet`.

`tests/test_geoparquet_corpus.py`: the orientation fixture's "#586 no orientation-vs-data check" gap entry is removed; the corpus test now requires it to be detected by `orientation_matches_data_`.

Regression: validate, check, corpus and convert-validation suites, 432 passed, 7 xfailed (one fewer xfail: the corpus gap). Pre-commit passes, including the `sql_path` literal count.

## Adversarial pass (done before opening)

- Real data with orientation forced on: `samples/buildings-3d.parquet` (3,947 `POLYGON Z`, all CCW) in 0.02 s; `samples/us-states.parquet` (404 polygons across 51 MultiPolygons, clockwise as most shapefile-derived data is) reports 404 of 404, which is the right answer if that file ever declared counterclockwise; the GEOGRAPHY and MultiPolygon corpus files pass; `airports-global` (points) is skipped.
- A zero-area "ring" (`POLYGON ((0 0, 1 1, 2 2, 0 0))`) next to a good polygon: not counted as a violation.
- An orientation value other than `counterclockwise` is skipped here (`orientation_valid` already fails it).
- `tests/data/idecor_carlospaz_invalid_wkb.parquet` (real file with broken WKB) does not crash: 104 of 110 polygons reported.

Found while mapping the OGC GeoParquet 2.0 abstract tests to `gpio` (opengeospatial/geoparquet#304). Addresses the orientation row of #586.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GeoParquet validation now checks whether polygon rings match the declared counterclockwise orientation.
  - Validation reports clear failures for polygons and multipolygons with incorrectly ordered rings.
  - Orientation checks now account for geometry encoding and safely handle supported edge cases, including holes, nested geometries, and 3D coordinates.
  - Invalid datasets are rejected for the specific orientation mismatch rather than being incorrectly accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->