### PR TITLE
fix(write): don't crash on a malformed 'geo' block carried from the input

### DIFF
--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -45,6 +45,7 @@ from geoparquet_io.core.geo_metadata import (
     create_geo_metadata,
     detect_bbox_column_from_schema,
     prune_geo_metadata_to_columns,
+    sanitize_geo_metadata,
     strip_derived_stats,
 )
 from geoparquet_io.core.geoarrow_encoding import (
@@ -1569,22 +1570,13 @@ def _parse_geo_metadata_quietly(original_metadata) -> dict:
         parsed = json.loads(raw)
     except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
         return {}
-    if not isinstance(parsed, dict):
-        return {}
-
     # Callers read ``columns`` as a mapping of column name to a dict of that
     # column's metadata. A carried block is arbitrary JSON from the input file,
-    # so anything else is dropped here rather than allowed to raise a TypeError
-    # three frames away, in the middle of a write. `create_geo_metadata` reads
-    # the raw block itself and still does; that is pre-existing, tracked in #771.
-    columns = parsed.get("columns")
-    if isinstance(columns, dict):
-        parsed["columns"] = {
-            name: entry for name, entry in columns.items() if isinstance(entry, dict)
-        }
-    else:
-        parsed.pop("columns", None)
-    return parsed
+    # so anything else is dropped rather than allowed to raise a TypeError three
+    # frames away, in the middle of a write. The check lives in one place --
+    # ``sanitize_geo_metadata`` -- that every write-path reader goes through
+    # (#771); this function is one of them.
+    return sanitize_geo_metadata(parsed) or {}
 
 
 def _apply_geoparquet_metadata(

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -79,7 +79,9 @@ def _pyarrow_get_geo_metadata(parquet_file: str) -> dict | None:
         if metadata and b"geo" in metadata:
             return json.loads(metadata[b"geo"].decode("utf-8"))
         return None
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Unparsable 'geo' bytes mean "no usable geo metadata", the same answer
+        # invalid JSON already got -- not an unreadable file.
         return None
     except Exception as e:
         error_msg = str(e)
@@ -472,7 +474,8 @@ def get_geo_metadata(parquet_file: str, con=None) -> dict | None:
     except duckdb.IOException as e:
         # File not found, permission denied, or other I/O error
         raise GeoParquetError(f"Cannot read file: {parquet_file}\n{str(e)}") from e
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Same answer as the PyArrow fast path: unparsable bytes = no metadata.
         return None
     finally:
         if should_close:

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import copy
 import json
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import duckdb
@@ -77,6 +78,121 @@ _DIMENSION_SUFFIXES = {
 
 
 # =============================================================================
+# Carried-block shape check
+# =============================================================================
+
+#: Python type -> the JSON type name a user would recognize in their own file.
+_JSON_TYPE_NAMES = {
+    type(None): "null",
+    bool: "boolean",
+    int: "number",
+    float: "number",
+    str: "string",
+    list: "array",
+    tuple: "array",
+    dict: "object",
+}
+
+
+def _json_type_name(value) -> str:
+    """Name ``value``'s JSON type, so a warning can say what the file actually holds."""
+    return _JSON_TYPE_NAMES.get(type(value), type(value).__name__)
+
+
+@lru_cache(maxsize=256)
+def _emit_malformed_geo_warning(detail: str) -> None:
+    """Emit the malformed-block warning once per distinct ``detail`` (LRU-bounded)."""
+    warn(f"Ignoring malformed 'geo' metadata on the input: {detail}")
+
+
+def reset_malformed_geo_warnings() -> None:
+    """Clear the malformed-``geo`` warn-once cache. Intended for tests."""
+    _emit_malformed_geo_warning.cache_clear()
+
+
+def sanitize_geo_metadata(geo_meta):
+    """Drop the parts of a carried ``geo`` block that are not the shape readers expect.
+
+    The ``geo`` key on an input file is arbitrary JSON written by some other
+    tool, but every writer here reads it as ``geo["columns"][name][key]``. A
+    block whose ``columns`` is null, an array, a string, or a mapping to
+    non-objects used to abort the write with a bare ``TypeError`` raised three
+    frames deep, in the middle of building the output metadata (#771).
+
+    A malformed block is a property of the *input*, not a caller error, so it is
+    treated the way an absent one is: the malformed parts are dropped so fresh
+    metadata gets built from the table, and one warning names what was wrong.
+
+    This is the single shape check every write-path reader of the raw block goes
+    through. The read-only readers (``parse_geo_metadata``,
+    ``crs_utils.parse_geo_metadata_from_schema``,
+    ``duckdb_metadata.get_geo_metadata``) deliberately do *not* sanitize:
+    ``gpio check`` has to see the file as it really is.
+
+    Args:
+        geo_meta: A decoded ``geo`` block, or None.
+
+    Returns:
+        ``geo_meta`` itself when it is already well-shaped, a repaired shallow
+        copy when it is not, or None when nothing usable is left.
+    """
+    if geo_meta is None:
+        return None
+
+    if not isinstance(geo_meta, dict):
+        _emit_malformed_geo_warning(
+            f"the block is {_article(_json_type_name(geo_meta))}, expected an object"
+        )
+        return None
+
+    problems: list[str] = []
+    cleaned = geo_meta
+
+    primary = geo_meta.get("primary_column")
+    if "primary_column" in geo_meta and not isinstance(primary, str):
+        problems.append(
+            f"'primary_column' is {_article(_json_type_name(primary))}, expected a string"
+        )
+        cleaned = dict(cleaned)
+        cleaned.pop("primary_column")
+
+    if "columns" in geo_meta:
+        columns = geo_meta["columns"]
+        if not isinstance(columns, dict):
+            problems.append(
+                f"'columns' is {_article(_json_type_name(columns))}, "
+                "expected an object keyed by column name"
+            )
+            cleaned = dict(cleaned)
+            cleaned.pop("columns")
+        else:
+            kept = {
+                name: entry
+                for name, entry in columns.items()
+                if isinstance(name, str) and isinstance(entry, dict)
+            }
+            if len(kept) != len(columns):
+                dropped = sorted(str(name) for name in columns if name not in kept)
+                problems.append(
+                    f"'columns' entries {', '.join(repr(n) for n in dropped)} "
+                    "are not objects, expected an object per column"
+                )
+                cleaned = dict(cleaned)
+                cleaned["columns"] = kept
+
+    for problem in problems:
+        _emit_malformed_geo_warning(problem)
+    return cleaned
+
+
+def _article(type_name: str) -> str:
+    """``"a list"`` / ``"an object"`` -- correct article for a JSON type name."""
+    if type_name == "null":
+        return "null"
+    return f"{'an' if type_name[0] in 'aeiou' else 'a'} {type_name}"
+
+
+# =============================================================================
 # Metadata Parsing Functions
 # =============================================================================
 
@@ -113,18 +229,22 @@ def _parse_existing_geo_metadata(original_metadata: dict | None) -> dict | None:
     """
     Parse existing geo metadata from original parquet metadata.
 
+    This is a write-path reader: what it returns is indexed into while building
+    the output block, so it goes through :func:`sanitize_geo_metadata` (#771).
+
     Args:
         original_metadata: Original parquet file metadata dict
 
     Returns:
-        Parsed geo metadata dict, or None if not present
+        Parsed geo metadata dict, or None if not present or not usable
     """
     if not original_metadata or b"geo" not in original_metadata:
         return None
     try:
-        return json.loads(original_metadata[b"geo"].decode("utf-8"))
+        parsed = json.loads(original_metadata[b"geo"].decode("utf-8"))
     except json.JSONDecodeError:
         return None
+    return sanitize_geo_metadata(parsed)
 
 
 # =============================================================================
@@ -152,6 +272,12 @@ def _initialize_geo_metadata(geo_meta: dict | None, geom_col: str, version: str 
 
     # Set the specified version
     geo_meta["version"] = version
+    # `primary_column` is required by every version of the spec. A carried block
+    # can arrive without one -- absent in the input, or dropped by
+    # `sanitize_geo_metadata` because it was not a string (#771) -- and the
+    # output would then be invalid. Matches `write_strategies.base`.
+    if "primary_column" not in geo_meta:
+        geo_meta["primary_column"] = geom_col
     if "columns" not in geo_meta:
         geo_meta["columns"] = {}
     if geom_col not in geo_meta["columns"]:

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -110,14 +110,119 @@ def reset_malformed_geo_warnings() -> None:
     _emit_malformed_geo_warning.cache_clear()
 
 
+def decode_carried_geo(raw):
+    """Decode a raw carried ``geo`` value (bytes or str) to JSON, or None.
+
+    The decode step can fail one call before :func:`sanitize_geo_metadata` ever
+    sees a shape: bytes that are not UTF-8 crash ``.decode`` and a truncated
+    payload crashes ``json.loads``. Both get the malformed-block treatment --
+    the value is dropped so fresh metadata gets built, and one warning names
+    the cause -- instead of aborting the write with a raw decoder traceback.
+
+    Already-decoded values (a dict handed over directly) pass through untouched.
+    """
+    try:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        if isinstance(raw, str):
+            return json.loads(raw)
+    except UnicodeDecodeError:
+        _emit_malformed_geo_warning("the value is not valid UTF-8; fresh metadata will be written")
+        return None
+    except json.JSONDecodeError:
+        _emit_malformed_geo_warning("the value is not valid JSON; fresh metadata will be written")
+        return None
+    return raw
+
+
+def _is_json_number(value) -> bool:
+    """A JSON number: int or float, but not the bool subtype of int."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+#: Carried per-column keys that write paths pass through to the output
+#: verbatim, with the values they may hold. A well-shaped entry can still
+#: poison the output -- ``"crs": 42`` survives a shape-only check and the
+#: written file is then refused by DuckDB ("has invalid CRS") and by
+#: ``gpio check spec``. Each key maps to (predicate, expected-phrase); a value
+#: the predicate rejects is dropped with a warning naming both. ``crs: null``
+#: stays: JSON null is the spec's spelling of "CRS is unknown".
+_COLUMN_VALUE_CHECKS: dict[str, tuple] = {
+    "crs": (lambda v: v is None or isinstance(v, (dict, str)), "an object, a string or null"),
+    "encoding": (lambda v: isinstance(v, str), "a string"),
+    "epoch": (_is_json_number, "a number"),
+    "orientation": (lambda v: isinstance(v, str), "a string"),
+    "edges": (lambda v: isinstance(v, str), "a string"),
+    "covering": (lambda v: isinstance(v, dict), "an object"),
+    "geometry_types": (
+        lambda v: isinstance(v, list) and all(isinstance(t, str) for t in v),
+        "an array of strings",
+    ),
+    "bbox": (
+        lambda v: isinstance(v, list) and len(v) in (4, 6) and all(_is_json_number(x) for x in v),
+        "an array of 4 or 6 numbers",
+    ),
+}
+
+
+def _sanitize_column_entry(name: str, entry: dict) -> tuple[dict, list[str]]:
+    """Drop wrong-typed carried values from one column entry; never mutates.
+
+    Returns ``entry`` itself when every value is acceptable, else a cleaned
+    shallow copy, plus the problems to warn about.
+    """
+    problems: list[str] = []
+    cleaned = entry
+    for key, (accepts, expected) in _COLUMN_VALUE_CHECKS.items():
+        if key in entry and not accepts(entry[key]):
+            problems.append(
+                f"'{key}' on column '{name}' is "
+                f"{_article(_json_type_name(entry[key]))}, expected {expected}"
+            )
+            if cleaned is entry:
+                cleaned = dict(entry)
+            cleaned.pop(key)
+    return cleaned, problems
+
+
+def _sanitize_columns(columns: dict) -> tuple[dict, list[str]]:
+    """Sanitize a ``columns`` mapping known to be a dict; never mutates.
+
+    Returns ``columns`` itself when nothing needed dropping, else a cleaned
+    copy, plus the problems to warn about.
+    """
+    problems: list[str] = []
+    kept: dict = {}
+    dropped: list[str] = []
+    changed = False
+    for name, entry in columns.items():
+        if not (isinstance(name, str) and isinstance(entry, dict)):
+            dropped.append(str(name))
+            changed = True
+            continue
+        entry_clean, entry_problems = _sanitize_column_entry(name, entry)
+        changed = changed or entry_clean is not entry
+        problems.extend(entry_problems)
+        kept[name] = entry_clean
+    if dropped:
+        problems.append(
+            f"'columns' entries {', '.join(repr(n) for n in sorted(dropped))} "
+            "are not objects, expected an object per column"
+        )
+    return (kept if changed else columns), problems
+
+
 def sanitize_geo_metadata(geo_meta):
-    """Drop the parts of a carried ``geo`` block that are not the shape readers expect.
+    """Drop the parts of a carried ``geo`` block that readers cannot accept.
 
     The ``geo`` key on an input file is arbitrary JSON written by some other
     tool, but every writer here reads it as ``geo["columns"][name][key]``. A
     block whose ``columns`` is null, an array, a string, or a mapping to
     non-objects used to abort the write with a bare ``TypeError`` raised three
-    frames deep, in the middle of building the output metadata (#771).
+    frames deep, in the middle of building the output metadata (#771). And a
+    well-shaped entry can still carry a wrong-typed value (``"crs": 42``) that
+    makes the *output* unreadable, so the carried values write paths pass
+    through verbatim are type-checked too (:data:`_COLUMN_VALUE_CHECKS`).
 
     A malformed block is a property of the *input*, not a caller error, so it is
     treated the way an absent one is: the malformed parts are dropped so fresh
@@ -166,17 +271,9 @@ def sanitize_geo_metadata(geo_meta):
             cleaned = dict(cleaned)
             cleaned.pop("columns")
         else:
-            kept = {
-                name: entry
-                for name, entry in columns.items()
-                if isinstance(name, str) and isinstance(entry, dict)
-            }
-            if len(kept) != len(columns):
-                dropped = sorted(str(name) for name in columns if name not in kept)
-                problems.append(
-                    f"'columns' entries {', '.join(repr(n) for n in dropped)} "
-                    "are not objects, expected an object per column"
-                )
+            kept, column_problems = _sanitize_columns(columns)
+            problems.extend(column_problems)
+            if kept is not columns:
                 cleaned = dict(cleaned)
                 cleaned["columns"] = kept
 
@@ -240,11 +337,7 @@ def _parse_existing_geo_metadata(original_metadata: dict | None) -> dict | None:
     """
     if not original_metadata or b"geo" not in original_metadata:
         return None
-    try:
-        parsed = json.loads(original_metadata[b"geo"].decode("utf-8"))
-    except json.JSONDecodeError:
-        return None
-    return sanitize_geo_metadata(parsed)
+    return sanitize_geo_metadata(decode_carried_geo(original_metadata[b"geo"]))
 
 
 # =============================================================================

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -572,9 +572,13 @@ def extract_crs_from_table(
     if table.schema.metadata and b"geo" in table.schema.metadata:
         try:
             from geoparquet_io.core.crs_utils import crs_is_explicitly_null, warn_null_crs_once
+            from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
 
             geo_bytes = table.schema.metadata[b"geo"]
-            geo_meta = json.loads(geo_bytes.decode("utf-8"))
+            # `Table.write()` resolves the CRS through here before it builds any
+            # metadata, so this reader sees a malformed carried block first and
+            # has to survive it too (#771).
+            geo_meta = sanitize_geo_metadata(json.loads(geo_bytes.decode("utf-8")))
             if isinstance(geo_meta, dict):
                 columns = geo_meta.get("columns", {})
                 geom_col_name = geometry_column or geo_meta.get("primary_column", "geometry")

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -164,23 +164,35 @@ def build_geo_metadata(
 
 
 def _parse_existing_geo_metadata(original_metadata: dict | None) -> dict | None:
-    """Parse existing geo metadata from file metadata."""
-    if not original_metadata:
+    """Parse existing geo metadata from file metadata.
+
+    A write-path reader: the result is indexed into while the output block is
+    built, so it goes through ``sanitize_geo_metadata`` -- a carried block whose
+    ``columns`` is not an object per column would otherwise abort the write with
+    a bare ``TypeError`` (#771).
+    """
+    from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
+
+    return sanitize_geo_metadata(_decode_geo_key(original_metadata))
+
+
+def _decode_geo_key(original_metadata: dict | None):
+    """Decode the raw ``geo`` key, accepting bytes or str keys and values."""
+    if not isinstance(original_metadata, dict) or not original_metadata:
         return None
 
-    if isinstance(original_metadata, dict):
-        if "geo" in original_metadata:
-            geo_data = original_metadata["geo"]
-            if isinstance(geo_data, str):
-                return json.loads(geo_data)
-            return geo_data
-        if b"geo" in original_metadata:
-            geo_data = original_metadata[b"geo"]
-            if isinstance(geo_data, bytes):
-                return json.loads(geo_data.decode("utf-8"))
-            if isinstance(geo_data, str):
-                return json.loads(geo_data)
-            return geo_data
+    if "geo" in original_metadata:
+        geo_data = original_metadata["geo"]
+        if isinstance(geo_data, str):
+            return json.loads(geo_data)
+        return geo_data
+    if b"geo" in original_metadata:
+        geo_data = original_metadata[b"geo"]
+        if isinstance(geo_data, bytes):
+            return json.loads(geo_data.decode("utf-8"))
+        if isinstance(geo_data, str):
+            return json.loads(geo_data)
+        return geo_data
 
     return None
 

--- a/geoparquet_io/core/write_strategies/base.py
+++ b/geoparquet_io/core/write_strategies/base.py
@@ -8,7 +8,6 @@ varying memory and performance characteristics.
 
 from __future__ import annotations
 
-import json
 import os
 import re
 import tempfile
@@ -177,22 +176,21 @@ def _parse_existing_geo_metadata(original_metadata: dict | None) -> dict | None:
 
 
 def _decode_geo_key(original_metadata: dict | None):
-    """Decode the raw ``geo`` key, accepting bytes or str keys and values."""
+    """Decode the raw ``geo`` key, accepting bytes or str keys and values.
+
+    Bytes that are not UTF-8 and JSON that does not parse are treated like a
+    malformed block -- dropped with a warning, so fresh metadata gets built --
+    via :func:`geo_metadata.decode_carried_geo` (#771 follow-up).
+    """
+    from geoparquet_io.core.geo_metadata import decode_carried_geo
+
     if not isinstance(original_metadata, dict) or not original_metadata:
         return None
 
     if "geo" in original_metadata:
-        geo_data = original_metadata["geo"]
-        if isinstance(geo_data, str):
-            return json.loads(geo_data)
-        return geo_data
+        return decode_carried_geo(original_metadata["geo"])
     if b"geo" in original_metadata:
-        geo_data = original_metadata[b"geo"]
-        if isinstance(geo_data, bytes):
-            return json.loads(geo_data.decode("utf-8"))
-        if isinstance(geo_data, str):
-            return json.loads(geo_data)
-        return geo_data
+        return decode_carried_geo(original_metadata[b"geo"])
 
     return None
 
@@ -420,19 +418,19 @@ def needs_metadata_rewrite(
             return False
         # For 2.0 output, check if input has different version that needs updating
         if original_metadata:
-            import json
+            from geoparquet_io.core.geo_metadata import decode_carried_geo
 
             geo_data = original_metadata.get("geo") or original_metadata.get(b"geo")
             if geo_data:
-                if isinstance(geo_data, bytes):
-                    geo_data = geo_data.decode("utf-8")
-                if isinstance(geo_data, str):
-                    geo_meta = json.loads(geo_data)
-                else:
-                    geo_meta = geo_data
+                # Undecodable or non-object carried metadata cannot vouch for a
+                # 2.x version, so it needs the rewrite (which builds fresh
+                # metadata); a raw json.loads here aborted the write instead.
+                geo_meta = decode_carried_geo(geo_data)
+                if not isinstance(geo_meta, dict):
+                    return True
                 input_version = geo_meta.get("version", "")
                 # Need rewrite if input version is not 2.x
-                if not input_version.startswith("2."):
+                if not isinstance(input_version, str) or not input_version.startswith("2."):
                     return True
         return False
 

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -282,3 +282,251 @@ def test_table_write_survives_a_malformed_columns_block(case, columns, _hint, st
 
     written = pq.ParquetFile(out).schema_arrow.metadata
     _assert_fresh_and_valid(json.loads(written[b"geo"].decode("utf-8")))
+
+
+# =============================================================================
+# Undecodable ``geo`` bytes: truncated JSON and invalid UTF-8
+# =============================================================================
+
+# A `geo` value can fail one step before the shape check: bytes that are not
+# UTF-8 crash `.decode`, and a truncated payload crashes `json.loads`. Both are
+# properties of the input, so they get the same treatment as a malformed shape:
+# fresh metadata, one warning naming the cause (#883 review).
+
+UNDECODABLE_GEO = [
+    ("truncated_json", b'{"version": "1.1.0", "columns": {', "JSON"),
+    ("invalid_utf8", b'\xff\xfe{"columns": {}}', "UTF-8"),
+]
+
+
+def _corrupt_geo_file(tmp_path, cause: str):
+    """A real GeoParquet file whose ``geo`` bytes are overwritten in place.
+
+    Byte surgery on a valid gpio-written 2.0 file keeps the thrift footer and
+    the native GEOMETRY logical type intact, so only the ``geo`` value itself
+    is undecodable -- the shape a partially-written or wrongly-encoded footer
+    actually takes in the wild.
+    """
+    from geoparquet_io.api import Table
+
+    src = tmp_path / "valid_src.parquet"
+    table = pa.table({"id": [1], "geometry": pa.array([POINT_WKB], type=pa.binary())})
+    Table(table).write(src, geoparquet_version="2.0", compression="SNAPPY")
+
+    geo = pq.read_metadata(src).metadata[b"geo"]
+    raw = src.read_bytes()
+    assert raw.count(geo) == 1
+    replacement = b"{" + b" " * (len(geo) - 1) if cause == "JSON" else b"\xff" * len(geo)
+    corrupted = tmp_path / "corrupt_geo.parquet"
+    corrupted.write_bytes(raw.replace(geo, replacement))
+    return corrupted
+
+
+@pytest.mark.parametrize("cause", ["JSON", "UTF-8"])
+def test_get_geo_metadata_tolerates_undecodable_bytes_on_both_paths(cause, tmp_path):
+    """Both readers give the answer invalid JSON already got: no usable metadata."""
+    from geoparquet_io.core.common import get_duckdb_connection
+    from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+
+    src = _corrupt_geo_file(tmp_path, cause)
+    assert get_geo_metadata(str(src)) is None  # PyArrow fast path
+    con = get_duckdb_connection()
+    assert get_geo_metadata(str(src), con=con) is None  # DuckDB path (remote files)
+
+
+@pytest.mark.parametrize("version", ["1.1", "2.0"])
+@pytest.mark.parametrize("cause", ["JSON", "UTF-8"])
+def test_extract_survives_undecodable_geo_bytes(cause, version, tmp_path, caplog):
+    """The reviewer's repro: ``gpio extract geoparquet in.parquet out.parquet --limit 1``.
+
+    2.0 output takes a second raw-decode path before the rewrite decision
+    (``needs_metadata_rewrite``), so both versions must survive.
+    """
+    from geoparquet_io.core.extract import extract
+
+    reset_malformed_geo_warnings()
+    src = _corrupt_geo_file(tmp_path, cause)
+    out = tmp_path / "out.parquet"
+
+    with caplog.at_level(logging.WARNING):
+        extract(str(src), str(out), limit=1, geoparquet_version=version)
+
+    _assert_fresh_and_valid(_geo_of_file(out))
+    messages = _malformed_warnings(caplog.records)
+    assert any("'geo'" in m and cause in m for m in messages), messages
+
+
+@pytest.mark.parametrize(("case", "geo_bytes", "cause"), UNDECODABLE_GEO)
+def test_apply_metadata_survives_undecodable_geo_bytes(case, geo_bytes, cause, caplog):
+    """The exact bytes-level repro from the #883 review of `_parse_existing_geo_metadata`."""
+    reset_malformed_geo_warnings()
+    table = pa.table({"id": [1], "geometry": pa.array([POINT_WKB], type=pa.binary())})
+
+    with caplog.at_level(logging.WARNING):
+        result = _apply_geoparquet_metadata(
+            table, "geometry", "1.1", original_metadata={b"geo": geo_bytes}
+        )
+
+    _assert_fresh_and_valid(_geo_of(result))
+    messages = _malformed_warnings(caplog.records)
+    assert len(messages) == 1, messages
+    assert cause in messages[0]
+
+
+@pytest.mark.parametrize("version", ["1.1", "2.0"])
+@pytest.mark.parametrize("strategy", WRITE_STRATEGIES)
+@pytest.mark.parametrize(("case", "geo_bytes", "_cause"), UNDECODABLE_GEO)
+def test_table_write_survives_undecodable_geo_bytes(
+    case, geo_bytes, _cause, strategy, version, tmp_path
+):
+    """Undecodable bytes must not abort any strategy (2.0 also reads them pre-rewrite)."""
+    from geoparquet_io.api import Table
+
+    reset_malformed_geo_warnings()
+    table = pa.table({"id": [1], "geometry": pa.array([POINT_WKB], type=pa.binary())})
+    table = table.replace_schema_metadata({b"geo": geo_bytes})
+    out = tmp_path / f"{case}_{strategy}_{version}.parquet"
+    Table(table).write(
+        out, write_strategy=strategy, geoparquet_version=version, compression="SNAPPY"
+    )
+    _assert_fresh_and_valid(_geo_of_file(out))
+
+
+# =============================================================================
+# Wrong-typed carried values: well-shaped entries whose values readers reject
+# =============================================================================
+
+# A column entry can be an object and still poison the output: `"crs": 42`
+# passes a shape-only check, is carried verbatim, and the written file is then
+# refused by DuckDB ("has invalid CRS") and by `gpio check spec`. The decision
+# from the #883 review: type-check the carried values too, drop-and-warn the
+# wrong-typed ones.
+
+WRONG_TYPED_VALUES = [
+    ("crs", 42, "number"),
+    ("crs", [4326], "array"),
+    ("crs", True, "boolean"),
+    ("encoding", 7, "number"),
+    ("epoch", "2020", "string"),
+    ("epoch", True, "boolean"),
+    ("orientation", 1, "number"),
+    ("edges", {"type": "spherical"}, "object"),
+    ("covering", "bbox", "string"),
+    ("geometry_types", "Point", "string"),
+    ("geometry_types", [1, 2], "array"),
+    ("bbox", "0,0,1,1", "string"),
+    ("bbox", [0.0, 0.0, 1.0], "array"),
+]
+
+#: Values of the right type must carry through untouched -- including the
+#: spec-sanctioned ``crs: null`` ("CRS is unknown"), which is not wrong-typed.
+WELL_TYPED_VALUES = [
+    ("crs", None),
+    ("crs", "OGC:CRS84"),
+    ("crs", {"type": "GeographicCRS", "id": {"authority": "OGC", "code": "CRS84"}}),
+    ("encoding", "WKB"),
+    ("epoch", 2020),
+    ("epoch", 2020.5),
+    ("orientation", "counterclockwise"),
+    ("edges", "spherical"),
+    ("covering", {"bbox": {"xmin": ["bbox", "xmin"]}}),
+    ("geometry_types", ["Point", "MultiPolygon Z"]),
+    ("bbox", [0.0, 0.0, 1.0, 1.0]),
+    ("bbox", [0, 0, 0, 1, 1, 1]),
+]
+
+
+def _geo_of_file(path) -> dict:
+    return json.loads(pq.ParquetFile(path).schema_arrow.metadata[b"geo"].decode("utf-8"))
+
+
+class TestSanitizeWrongTypedValues:
+    @pytest.mark.parametrize(("key", "value", "type_name"), WRONG_TYPED_VALUES)
+    def test_drops_and_names_the_key_and_type(self, key, value, type_name, caplog):
+        reset_malformed_geo_warnings()
+        block = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", key: value}},
+        }
+        if key == "encoding":
+            block["columns"]["geometry"] = {key: value}
+
+        with caplog.at_level(logging.WARNING):
+            cleaned = sanitize_geo_metadata(block)
+
+        assert key not in cleaned["columns"]["geometry"]
+        messages = _malformed_warnings(caplog.records)
+        assert len(messages) == 1, messages
+        assert f"'{key}'" in messages[0]
+        assert "'geometry'" in messages[0]
+        assert type_name in messages[0]
+
+    @pytest.mark.parametrize(("key", "value"), WELL_TYPED_VALUES)
+    def test_keeps_well_typed_values_untouched(self, key, value, caplog):
+        reset_malformed_geo_warnings()
+        block = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", key: value}},
+        }
+        with caplog.at_level(logging.WARNING):
+            assert sanitize_geo_metadata(block) is block
+        assert _malformed_warnings(caplog.records) == []
+
+    def test_does_not_mutate_the_carried_entry(self):
+        reset_malformed_geo_warnings()
+        entry = {"encoding": "WKB", "crs": 42}
+        block = {"columns": {"geometry": entry}}
+        cleaned = sanitize_geo_metadata(block)
+        assert entry["crs"] == 42
+        assert block["columns"]["geometry"] is entry
+        assert "crs" not in cleaned["columns"]["geometry"]
+
+    def test_keeps_the_rest_of_the_entry(self):
+        reset_malformed_geo_warnings()
+        cleaned = sanitize_geo_metadata(
+            {"columns": {"geometry": {"encoding": "WKB", "crs": 42, "epoch": 2020.0}}}
+        )
+        assert cleaned["columns"]["geometry"] == {"encoding": "WKB", "epoch": 2020.0}
+
+
+@pytest.mark.parametrize("strategy", WRITE_STRATEGIES)
+def test_table_write_drops_a_wrong_typed_crs(strategy, tmp_path, caplog):
+    """The reviewer's exact repro: ``"crs": 42`` must not reach the output.
+
+    The recovered output must actually be *valid*: gpio's own ``check spec``
+    passes and DuckDB agrees to open it (it refuses a non-object ``crs`` with
+    "Geoparquet column 'geometry' has invalid CRS").
+    """
+    from geoparquet_io.api import Table
+    from geoparquet_io.core.common import get_duckdb_connection
+    from geoparquet_io.core.duckdb_utils import sql_path
+    from geoparquet_io.core.validate import validate_geoparquet
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "crs": 42}},
+        }
+    )
+    out = tmp_path / f"crs42_{strategy}.parquet"
+    with caplog.at_level(logging.WARNING):
+        Table(table).write(
+            out, write_strategy=strategy, geoparquet_version="1.1", compression="SNAPPY"
+        )
+
+    geo = _geo_of_file(out)
+    _assert_fresh_and_valid(geo)
+    assert "crs" not in geo["columns"]["geometry"]
+
+    messages = _malformed_warnings(caplog.records)
+    assert any("'crs'" in m and "number" in m for m in messages), messages
+
+    failed = {c.name for c in validate_geoparquet(str(out)).checks if c.status.value == "failed"}
+    assert not failed
+
+    con = get_duckdb_connection(load_spatial=True)
+    assert con.execute(f"SELECT count(*) FROM read_parquet({sql_path(out)})").fetchone()[0] == 1

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -1,0 +1,284 @@
+"""A malformed carried ``geo`` block must not crash the write (#771).
+
+The ``geo`` key on an input file is arbitrary JSON written by somebody else's
+tool. gpio's writers read it and index into it -- ``geo["columns"][col]`` --
+without checking that ``columns`` is the mapping-of-mappings the spec requires,
+so a block whose ``columns`` is null, a list, a string, or a mapping to
+non-objects aborted the write with a bare ``TypeError`` from three frames deep.
+
+The decision recorded in #771: a malformed block is a property of the *input*,
+not a caller error, so it is treated the way an absent block is -- the malformed
+parts are dropped, fresh metadata is built from the table, and one warning names
+what was wrong. Nothing raises.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.common import _apply_geoparquet_metadata
+from geoparquet_io.core.geo_metadata import (
+    reset_malformed_geo_warnings,
+    sanitize_geo_metadata,
+)
+
+# One WKB point (1.0, 2.0), little-endian.
+POINT_WKB = struct.pack("<BI2d", 1, 1, 1.0, 2.0)
+
+WRITE_STRATEGIES = ["in-memory", "streaming", "disk-rewrite", "duckdb-kv"]
+
+# (id, the value carried as geo["columns"], the substring the warning must name)
+MALFORMED_COLUMNS = [
+    ("null", None, "'columns'"),
+    ("list", ["geometry"], "'columns'"),
+    ("string", "geometry", "'columns'"),
+    ("entry_not_an_object", {"geometry": "WKB"}, "'columns'"),
+]
+
+
+def _table_with_geo(geo_block) -> pa.Table:
+    table = pa.table({"id": [1], "geometry": pa.array([POINT_WKB], type=pa.binary())})
+    return table.replace_schema_metadata({b"geo": json.dumps(geo_block).encode("utf-8")})
+
+
+def _malformed_table(columns) -> pa.Table:
+    return _table_with_geo({"version": "1.1.0", "primary_column": "geometry", "columns": columns})
+
+
+def _geo_of(table: pa.Table) -> dict:
+    return json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
+
+
+def _malformed_warnings(records) -> list[str]:
+    return [r.getMessage() for r in records if "malformed" in r.getMessage().lower()]
+
+
+def _assert_fresh_and_valid(geo: dict) -> None:
+    """The rebuilt block must be the one gpio would have written with no input block."""
+    assert geo["primary_column"] == "geometry"
+    assert isinstance(geo["columns"], dict)
+    assert isinstance(geo["columns"]["geometry"], dict)
+    assert geo["columns"]["geometry"]["encoding"]
+
+
+# =============================================================================
+# The sanitizer itself
+# =============================================================================
+
+
+class TestSanitizeGeoMetadata:
+    @pytest.mark.parametrize(("case", "columns", "_hint"), MALFORMED_COLUMNS)
+    def test_drops_malformed_columns(self, case, columns, _hint):
+        reset_malformed_geo_warnings()
+        cleaned = sanitize_geo_metadata(
+            {"version": "1.1.0", "primary_column": "geometry", "columns": columns}
+        )
+        assert cleaned is not None
+        assert cleaned.get("columns", {}) == {}
+
+    def test_keeps_the_good_entries_beside_a_bad_one(self):
+        reset_malformed_geo_warnings()
+        cleaned = sanitize_geo_metadata(
+            {"columns": {"geometry": {"encoding": "WKB"}, "other": "WKB"}}
+        )
+        assert cleaned["columns"] == {"geometry": {"encoding": "WKB"}}
+
+    def test_drops_a_non_string_primary_column(self):
+        reset_malformed_geo_warnings()
+        cleaned = sanitize_geo_metadata({"primary_column": 123, "columns": {}})
+        assert "primary_column" not in cleaned
+
+    def test_a_block_that_is_not_an_object_is_dropped_entirely(self):
+        reset_malformed_geo_warnings()
+        assert sanitize_geo_metadata(["geometry"]) is None
+        reset_malformed_geo_warnings()
+        assert sanitize_geo_metadata("geometry") is None
+
+    def test_none_passes_through(self):
+        assert sanitize_geo_metadata(None) is None
+
+    def test_a_well_formed_block_is_returned_unchanged(self):
+        block = {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "bbox": [0, 0, 1, 1]}},
+        }
+        assert sanitize_geo_metadata(block) is block
+
+    def test_does_not_mutate_the_caller_s_dict(self):
+        reset_malformed_geo_warnings()
+        block = {"primary_column": "geometry", "columns": None}
+        sanitize_geo_metadata(block)
+        assert block["columns"] is None
+
+    def test_names_the_offending_key_and_its_json_type(self, caplog):
+        reset_malformed_geo_warnings()
+        with caplog.at_level(logging.WARNING):
+            sanitize_geo_metadata({"columns": ["geometry"]})
+        messages = _malformed_warnings(caplog.records)
+        assert len(messages) == 1
+        assert "'geo'" in messages[0]
+        assert "'columns'" in messages[0]
+        assert "array" in messages[0]
+
+    def test_warns_once_per_distinct_problem(self, caplog):
+        reset_malformed_geo_warnings()
+        with caplog.at_level(logging.WARNING):
+            sanitize_geo_metadata({"columns": None})
+            sanitize_geo_metadata({"columns": None})
+        assert len(_malformed_warnings(caplog.records)) == 1
+
+
+# =============================================================================
+# The helper the issue reproduces on
+# =============================================================================
+
+
+@pytest.mark.parametrize(("case", "columns", "hint"), MALFORMED_COLUMNS)
+@pytest.mark.parametrize("version", ["1.1", "2.0"])
+def test_apply_metadata_survives_a_malformed_columns_block(case, columns, hint, version, caplog):
+    reset_malformed_geo_warnings()
+    table = _malformed_table(columns)
+
+    with caplog.at_level(logging.WARNING):
+        result = _apply_geoparquet_metadata(
+            table, "geometry", version, original_metadata=table.schema.metadata
+        )
+
+    _assert_fresh_and_valid(_geo_of(result))
+
+    messages = _malformed_warnings(caplog.records)
+    assert len(messages) == 1, messages
+    assert "'geo'" in messages[0]
+    assert hint in messages[0]
+
+
+@pytest.mark.parametrize("version", ["1.1", "2.0"])
+def test_apply_metadata_rebuilds_a_non_string_primary_column(version):
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {"version": "1.1.0", "primary_column": 123, "columns": {"geometry": {"encoding": "WKB"}}}
+    )
+    result = _apply_geoparquet_metadata(
+        table, "geometry", version, original_metadata=table.schema.metadata
+    )
+    _assert_fresh_and_valid(_geo_of(result))
+
+
+@pytest.mark.parametrize("version", ["1.1", "2.0"])
+def test_apply_metadata_survives_a_geo_block_that_is_not_an_object(version):
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(["geometry"])
+    result = _apply_geoparquet_metadata(
+        table, "geometry", version, original_metadata=table.schema.metadata
+    )
+    _assert_fresh_and_valid(_geo_of(result))
+
+
+def test_a_well_formed_block_still_carries_through(caplog):
+    """Regression: the shape check must not disturb a valid input block."""
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "orientation": "counterclockwise"}},
+        }
+    )
+    with caplog.at_level(logging.WARNING):
+        result = _apply_geoparquet_metadata(
+            table, "geometry", "1.1", original_metadata=table.schema.metadata
+        )
+
+    geo = _geo_of(result)
+    _assert_fresh_and_valid(geo)
+    assert geo["columns"]["geometry"]["orientation"] == "counterclockwise"
+    assert _malformed_warnings(caplog.records) == []
+
+
+def test_an_absent_geo_block_still_works(caplog):
+    reset_malformed_geo_warnings()
+    table = pa.table({"id": [1], "geometry": pa.array([POINT_WKB], type=pa.binary())})
+    with caplog.at_level(logging.WARNING):
+        result = _apply_geoparquet_metadata(table, "geometry", "1.1", original_metadata=None)
+    _assert_fresh_and_valid(_geo_of(result))
+    assert _malformed_warnings(caplog.records) == []
+
+
+# =============================================================================
+# Every write-path reader of the raw block goes through the one shape check
+# =============================================================================
+
+
+@pytest.mark.parametrize(("case", "columns", "_hint"), MALFORMED_COLUMNS)
+def test_strategy_base_reader_sanitizes(case, columns, _hint):
+    """``write_strategies.base`` builds metadata through its own reader (#771)."""
+    from geoparquet_io.core.write_strategies.base import build_geo_metadata
+
+    reset_malformed_geo_warnings()
+    raw = json.dumps({"primary_column": "geometry", "columns": columns}).encode("utf-8")
+    geo = build_geo_metadata("geometry", "1.1", original_metadata={b"geo": raw})
+    _assert_fresh_and_valid(geo)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {b"geo": json.dumps({"columns": None}).encode("utf-8")},
+        {b"geo": json.dumps({"columns": None})},
+        {b"geo": {"columns": None}},
+        {"geo": json.dumps({"columns": None})},
+        {"geo": {"columns": None}},
+    ],
+    ids=["bytes_key_bytes", "bytes_key_str", "bytes_key_dict", "str_key_str", "str_key_dict"],
+)
+def test_strategy_base_reader_sanitizes_every_key_shape(metadata):
+    """The shape check applies whichever way the ``geo`` key was handed over."""
+    from geoparquet_io.core.write_strategies.base import _parse_existing_geo_metadata
+
+    reset_malformed_geo_warnings()
+    assert _parse_existing_geo_metadata(metadata) == {}
+
+
+def test_parse_geo_metadata_quietly_delegates_to_the_shared_check():
+    """``common._parse_geo_metadata_quietly`` must not keep a second copy of the check."""
+    from geoparquet_io.core.common import _parse_geo_metadata_quietly
+
+    reset_malformed_geo_warnings()
+    raw = json.dumps({"primary_column": 1, "columns": ["geometry"]}).encode("utf-8")
+    assert _parse_geo_metadata_quietly({b"geo": raw}) == {}
+
+
+def test_extract_crs_from_table_survives_a_malformed_block():
+    """``Table.write`` resolves the CRS before building metadata, through this reader."""
+    from geoparquet_io.core.streaming import extract_crs_from_table
+
+    reset_malformed_geo_warnings()
+    assert extract_crs_from_table(_malformed_table({"geometry": "WKB"}), "geometry") is None
+    assert extract_crs_from_table(_malformed_table(None), "geometry") is None
+
+
+# =============================================================================
+# The public API boundary -- every write strategy
+# =============================================================================
+
+
+@pytest.mark.parametrize("strategy", WRITE_STRATEGIES)
+@pytest.mark.parametrize(("case", "columns", "_hint"), MALFORMED_COLUMNS)
+def test_table_write_survives_a_malformed_columns_block(case, columns, _hint, strategy, tmp_path):
+    from geoparquet_io.api import Table
+
+    reset_malformed_geo_warnings()
+    out = tmp_path / f"{case}_{strategy}.parquet"
+    Table(_malformed_table(columns)).write(
+        out, write_strategy=strategy, geoparquet_version="1.1", compression="SNAPPY"
+    )
+
+    written = pq.ParquetFile(out).schema_arrow.metadata
+    _assert_fresh_and_valid(json.loads(written[b"geo"].decode("utf-8")))


### PR DESCRIPTION
## What changed

`geo_metadata.sanitize_geo_metadata()` is a new single shape check for a carried
`geo` block. It drops the parts that are not the shape every reader assumes —
a `columns` that is not an object, a `columns` entry whose value is not an
object, a `primary_column` that is not a string, a whole block that is not an
object — and emits one `warn()` naming the offending key and the JSON type
actually found. It returns the caller's dict unchanged (by identity) when the
block is already well-shaped, and never mutates its argument.

Four write-path readers of the raw block now go through it:

| Reader | Reached by |
|---|---|
| `geo_metadata._parse_existing_geo_metadata` | `create_geo_metadata` → `_apply_geoparquet_metadata` and all four strategies |
| `write_strategies.base._parse_existing_geo_metadata` | `build_geo_metadata` |
| `common._parse_geo_metadata_quietly` | `_apply_geoparquet_metadata`, `duckdb_kv` |
| `streaming.extract_crs_from_table` | `Table.crs`, which `Table.write()` calls **before** any metadata is built |

These four are the ones this PR fixes. Two further raw-block readers —
`crs_utils.extract_crs_from_parquet` / `crs_utils.extract_crs_from_table` and
the readers in `convert` — have the same pre-existing exposure; they are
cross-cutting and left for a follow-up issue/PR per repo convention.

`_parse_geo_metadata_quietly` had its own copy of this check (added in #765);
it is now a one-line delegation, so there is one implementation, not two.
`streaming.extract_crs_from_table` is the reader that bypassed the fix at the
API boundary — every strategy crashed there first, before reaching
`create_geo_metadata` — so it is fixed too.

`_initialize_geo_metadata` in `geo_metadata.py` now fills in a missing
`primary_column`, matching the copy in `write_strategies/base.py`. Without it a
block whose `primary_column` was dropped as malformed would be written back
missing a key the spec requires.

The **read-only** readers (`parse_geo_metadata`,
`crs_utils.parse_geo_metadata_from_schema`, `duckdb_metadata.get_geo_metadata`)
deliberately do **not** sanitize, and `tests/test_geo_metadata_parity.py` is
untouched: `gpio check` has to see the file as it really is.

The warning is deduped per distinct problem with an `lru_cache`, the same
warn-once idiom as `crs_utils.warn_null_crs_once`, with
`reset_malformed_geo_warnings()` for tests. So one malformed input produces
exactly one warning no matter how many readers see it.

## Review follow-up (second commit)

Three findings from review, same family — the carried `geo` value trusted one
step too far:

- **Undecodable bytes crashed before the shape check ran.** `geo` bytes that
  are not UTF-8 crashed `.decode`, and a truncated payload crashed
  `json.loads` — a raw decoder traceback out of
  `gpio extract geoparquet in.parquet out.parquet --limit 1`, from
  `base._decode_geo_key`, from `geo_metadata._parse_existing_geo_metadata`
  (which caught only `JSONDecodeError`), and from the raw loads in
  `needs_metadata_rewrite` on the 2.0 path. All now decode through one
  `geo_metadata.decode_carried_geo`, which treats an undecodable value the way
  a malformed shape is treated: dropped so fresh metadata gets built, with one
  warning naming the cause (JSON vs UTF-8) — not silently (the S3 finding).
  The read-only `duckdb_metadata` readers widen their existing
  `JSONDecodeError` catch to `UnicodeDecodeError` — same answer invalid JSON
  already got, no sanitizing.
- **Well-shaped entries could carry values that poison the output.** The shape
  check was one level deep, so `"crs": 42` passed untouched and the written
  file was refused by DuckDB (`Geoparquet column 'geometry' has invalid CRS`)
  and by `gpio check spec` — breaking the invariant that the recovered output
  is valid. `sanitize_geo_metadata` now type-checks the carried per-column
  values it passes through verbatim (`crs`, `encoding`, `epoch`,
  `orientation`, `edges`, `covering`, `geometry_types`, `bbox`) and drops
  wrong-typed ones with a warning naming the key, the column, and the JSON
  type found. `crs: null` stays: JSON null is the spec's spelling of "CRS is
  unknown", and the null-CRS warning machinery depends on seeing it.

New tests: the extract repro end-to-end on real byte-corrupted files (footer
surgery keeps the native GEOMETRY type intact) at 1.1 and 2.0; the bytes-level
`_apply_geoparquet_metadata` repros; undecodable bytes across all four write
strategies × {1.1, 2.0}; wrong-typed value matrix (13 dropped, 12 kept
untouched by identity, no mutation); and the `"crs": 42` repro through every
strategy asserting the output has no `crs` key, warns, passes
`validate_geoparquet`, and opens in DuckDB.

## Why

Refs #771. The `geo` key on an input file is arbitrary JSON written by
somebody else's tool, but `_initialize_geo_metadata` did
`if geom_col not in geo_meta["columns"]` with no shape check, so a malformed
block aborted the write with a bare `TypeError` from three frames deep. A
malformed `geo` key is a property of the input, not a caller error, so it is
now treated the way an absent one is: build fresh metadata from the table and
say what was ignored. (#771 stays open for the `crs_utils`/`convert` readers
noted above.)

## Verification

The reproducer from the issue, extended to both metadata versions, a non-string
`primary_column`, and `Table(...).write()` on all four write strategies.

**Before** (`origin/main`):

```
=== _apply_geoparquet_metadata ===
  columns=null                 1.1: TypeError: argument of type 'NoneType' is not iterable
  columns=null                 2.0: TypeError: argument of type 'NoneType' is not iterable
  columns=["geometry"]         1.1: TypeError: list indices must be integers or slices, not str
  columns=["geometry"]         2.0: TypeError: list indices must be integers or slices, not str
  columns="geometry"           1.1: TypeError: string indices must be integers, not 'str'
  columns="geometry"           2.0: TypeError: string indices must be integers, not 'str'
  columns={"geometry":"WKB"}   1.1: TypeError: 'str' object does not support item assignment
  columns={"geometry":"WKB"}   2.0: TypeError: 'str' object does not support item assignment
  primary_column=123           1.1: OK   {"version": "1.1.0", "primary_column": 123, "columns": {...}}
=== Table(...).write() per strategy ===
  columns=null                 in-memory    : TypeError: argument of type 'NoneType' is not iterable
  columns=null                 streaming    : TypeError: argument of type 'NoneType' is not iterable
  columns=null                 disk-rewrite : TypeError: argument of type 'NoneType' is not iterable
  columns=null                 duckdb-kv    : TypeError: argument of type 'NoneType' is not iterable
  columns=["geometry"]         in-memory    : TypeError: list indices must be integers or slices, not str
  columns=["geometry"]         streaming    : TypeError: list indices must be integers or slices, not str
  columns=["geometry"]         disk-rewrite : TypeError: list indices must be integers or slices, not str
  columns=["geometry"]         duckdb-kv    : TypeError: list indices must be integers or slices, not str
  columns="geometry"           in-memory    : TypeError: string indices must be integers, not 'str'
  columns="geometry"           streaming    : TypeError: string indices must be integers, not 'str'
  columns="geometry"           disk-rewrite : TypeError: string indices must be integers, not 'str'
  columns="geometry"           duckdb-kv    : TypeError: string indices must be integers, not 'str'
  columns={"geometry":"WKB"}   in-memory    : AttributeError: 'str' object has no attribute 'get'
  columns={"geometry":"WKB"}   streaming    : AttributeError: 'str' object has no attribute 'get'
  columns={"geometry":"WKB"}   disk-rewrite : AttributeError: 'str' object has no attribute 'get'
  columns={"geometry":"WKB"}   duckdb-kv    : AttributeError: 'str' object has no attribute 'get'
```

Note `primary_column=123` did not raise on main — it wrote an *invalid* block
back out, which is the quieter half of the same bug.

**After** (this branch) — the warnings, then every case succeeding:

```
Ignoring malformed 'geo' metadata on the input: 'columns' is null, expected an object keyed by column name
Ignoring malformed 'geo' metadata on the input: 'columns' is an array, expected an object keyed by column name
Ignoring malformed 'geo' metadata on the input: 'columns' is a string, expected an object keyed by column name
Ignoring malformed 'geo' metadata on the input: 'columns' entries 'geometry' are not objects, expected an object per column
Ignoring malformed 'geo' metadata on the input: 'primary_column' is a number, expected a string
=== _apply_geoparquet_metadata ===
  columns=null                 1.1: OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  columns=null                 2.0: OK   {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  columns=["geometry"]         1.1: OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  columns=["geometry"]         2.0: OK   {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  columns="geometry"           1.1: OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  columns="geometry"           2.0: OK   {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  columns={"geometry":"WKB"}   1.1: OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  columns={"geometry":"WKB"}   2.0: OK   {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types
  primary_column=123           1.1: OK   {"version": "1.1.0", "columns": {"geometry": {...}}, "primary_column": "geometry"}
=== Table(...).write() per strategy ===
  columns=null                 in-memory    : OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geom
  columns=null                 streaming    : OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geom
  columns=null                 disk-rewrite : OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geom
  columns=null                 duckdb-kv    : OK   {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "bbox
  columns=["geometry"]         in-memory    : OK   ...
  columns=["geometry"]         streaming    : OK   ...
  columns=["geometry"]         disk-rewrite : OK   ...
  columns=["geometry"]         duckdb-kv    : OK   ...
  columns="geometry"           in-memory    : OK   ...
  columns="geometry"           streaming    : OK   ...
  columns="geometry"           disk-rewrite : OK   ...
  columns={"geometry":"WKB"}   in-memory    : OK   ...
  columns={"geometry":"WKB"}   streaming    : OK   ...
  columns={"geometry":"WKB"}   disk-rewrite : OK   ...
  columns={"geometry":"WKB"}   duckdb-kv    : OK   ...
```

### New tests — `tests/test_malformed_geo_metadata.py`, 108 cases

- `sanitize_geo_metadata` unit tests: each malformed shape, good entries kept
  beside a bad one, non-string `primary_column`, a block that is not an object,
  `None`, a well-formed block returned *by identity*, no mutation of the
  caller's dict, the message naming the key and JSON type, warn-once.
- `_apply_geoparquet_metadata` × 4 malformed shapes × {1.1, 2.0}: no exception,
  a valid fresh block out, and **exactly one** warning mentioning `geo` and the
  offending key.
- Regressions: a well-formed block still carries through unchanged with no
  warning; an absent block still works.
- Reader coverage: `build_geo_metadata`, `base._parse_existing_geo_metadata`
  across all five `geo`-key shapes (bytes/str key, bytes/str/dict value),
  `common._parse_geo_metadata_quietly`, `streaming.extract_crs_from_table`.
- `Table(...).write()` × 4 malformed shapes × 4 write strategies: no exception,
  and the block read back off disk is valid.
- Review follow-up (second commit): undecodable-bytes and wrong-typed-value
  cases listed in the section above.

### Suite

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5846 passed, 67 skipped, 1 xfailed, 103 warnings in 182.73s (0:03:02)

$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
geoparquet_io/core/common.py (100%)
geoparquet_io/core/duckdb_metadata.py (100%)
geoparquet_io/core/geo_metadata.py (100%)
geoparquet_io/core/streaming.py (100%)
geoparquet_io/core/write_strategies/base.py (100%)
Total:   77 lines
Missing: 0 lines
Coverage: 100%
```

`uv run pre-commit run --all-files` and
`uv run pre-commit run --all-files --hook-stage pre-push` (mypy, vulture,
xenon, import-linter, deptry) both clean.

Refs #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
