### PR TITLE
fix(reproject): drop a spherical edges declaration when the destination CRS is projected

### DIFF
--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -313,6 +313,14 @@ Validates file structure and metadata against the GeoParquet specification:
   scans read GeoArrow coordinates directly. GeoParquet 1.0 and 2.0 are
   WKB-only per their spec text, so a file claiming a GeoArrow encoding under
   either version fails.
+- **Spherical edges on a projected CRS** — a column declaring `edges` other
+  than `planar` while its CRS is projected **warns**
+  (`edges_spherical_on_projected_crs_<column>`). Great-circle edges are only
+  meaningful on an ellipsoid; in projected space the edge between two vertices
+  is a straight line, so readers will draw it that way. Files with this
+  combination exist in the wild, so it is a warning, not a failure — densify
+  the geometries and declare planar edges, or keep the data in a geographic
+  CRS.
 - **Native geospatial statistics** — for files using the Parquet `GEOMETRY` or
   `GEOGRAPHY` logical types, `native_geo_stats_*` reports the bounds a file
   declares and `native_geo_stats_contains_data_*` checks its geometries against

--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -372,6 +372,16 @@ GEOGRAPHY extracts) survives every rewrite: `convert`, `extract`, `sort`,
 `convert reproject`, and `partition` all carry it through to the output —
 including remote (S3/GCS/Azure) outputs.
 
+The one exception is reprojecting into a **projected** CRS. `gpio` reprojects
+vertices, not edges: it does not densify along great circles first, so the
+output's edges are straight lines in the destination CRS and the declaration is
+dropped (with a warning) rather than carried onto data it no longer describes —
+`planar`, the spec default, is what the output actually is. Densify before
+reprojecting if great-circle edges must be preserved. Reprojecting between two
+geographic CRSs (a datum shift, e.g. `EPSG:4326` → `EPSG:4269`) keeps the
+declaration unchanged. `gpio check spec` warns about files that carry
+`edges: spherical` on a projected CRS.
+
 === "CLI"
 
     ```bash

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import re
+from collections.abc import Collection
 from pathlib import Path
 from typing import Literal, TypedDict
 
@@ -2733,7 +2734,7 @@ def write_parquet_with_metadata(
     extra_kv_metadata: dict[str, str] | None = None,
     input_file: str | None = None,
     invalidate_derived_stats: bool = False,
-    carry_nonplanar_edges: bool = True,
+    drop_nonplanar_edges_columns: Collection[str] | None = None,
 ):
     """
     Write a parquet file with proper compression and metadata handling.
@@ -2784,12 +2785,15 @@ def write_parquet_with_metadata(
             carried metadata came from only the first file: the input's stats no
             longer describe the output, so they must be recomputed from the
             written data or omitted rather than carried.
-        carry_nonplanar_edges: When False, do not re-attach the input's
-            non-planar ``edges`` declaration to the output. Set by writes that
-            invalidate the edge interpretation itself — reprojecting to a
-            projected CRS turns great-circle edges into straight lines (#601) —
-            where planar (the spec default) is the truthful description of the
-            output. The caller warns; this only stops the carry.
+        drop_nonplanar_edges_columns: Geometry columns whose non-planar
+            ``edges`` declaration must neither be carried through nor
+            re-attached to the output. Set by writes that invalidate the edge
+            interpretation for the columns they transform — reprojecting the
+            primary geometry column to a projected CRS turns its great-circle
+            edges into straight lines (#601) — where planar (the spec default)
+            is the truthful description of the output. Columns not named here
+            (e.g. an untransformed secondary geometry column) keep their
+            declaration. The caller warns; this only stops the carry.
 
     Returns:
         None
@@ -2808,11 +2812,14 @@ def write_parquet_with_metadata(
     if invalidate_derived_stats:
         original_metadata = strip_derived_stats(original_metadata)
 
-    # A write that invalidates the edge interpretation itself (reprojecting into
-    # a projected CRS, #601) must neither carry the declaration through nor
-    # re-attach it afterwards; planar is then the truthful description.
-    if not carry_nonplanar_edges:
-        original_metadata = strip_nonplanar_edges(original_metadata)
+    # A write that invalidates the edge interpretation for the columns it
+    # transforms (reprojecting into a projected CRS, #601) must neither carry
+    # those columns' declaration through nor re-attach it afterwards; planar is
+    # then the truthful description. Untransformed columns keep theirs.
+    if drop_nonplanar_edges_columns:
+        original_metadata = strip_nonplanar_edges(
+            original_metadata, columns=drop_nonplanar_edges_columns
+        )
 
     # Use geometry column from geometry_info if provided, otherwise auto-detect
     # This ensures original column names are preserved (fixes #328)
@@ -2990,17 +2997,18 @@ def write_parquet_with_metadata(
         # Non-planar edges must survive every rewrite path (#588): DuckDB
         # regenerates geo metadata without `edges`, silently demoting geography
         # data to planar. Runs on the local temp file, so remote outputs are
-        # patched before upload.
-        if carry_nonplanar_edges:
-            _preserve_edges_after_write(
-                input_file,
-                original_metadata,
-                actual_output,
-                compression=compression,
-                compression_level=compression_level,
-                row_group_rows=row_group_rows,
-                verbose=verbose,
-            )
+        # patched before upload. Columns whose declaration this write
+        # invalidated (#601) are excluded rather than re-attached.
+        _preserve_edges_after_write(
+            input_file,
+            original_metadata,
+            actual_output,
+            compression=compression,
+            compression_level=compression_level,
+            row_group_rows=row_group_rows,
+            verbose=verbose,
+            exclude_columns=drop_nonplanar_edges_columns,
+        )
 
         # Auto-fix vecorel schema compliance when collection metadata is present
         if not is_remote:
@@ -3024,16 +3032,21 @@ def _preserve_edges_after_write(
     compression_level: int | None = None,
     row_group_rows: int | None = None,
     verbose: bool = False,
+    exclude_columns: Collection[str] | None = None,
 ) -> None:
     """Restore non-planar edges dropped by the writer, on any rewrite path.
 
     Prefers the input file (sees native GEOGRAPHY logical types as well as geo
     metadata); falls back to the input's KV metadata dict when only that is
-    available (e.g. partition staging rewrites).
+    available (e.g. partition staging rewrites). ``exclude_columns`` names
+    columns whose declaration the write itself invalidated (#601): the input
+    still declares them, but they must not come back.
     """
     edges_by_col = collect_nonplanar_edges(input_file) if input_file else {}
     if not edges_by_col:
         edges_by_col = _collect_nonplanar_edges_from_metadata(original_metadata)
+    if exclude_columns:
+        edges_by_col = {k: v for k, v in edges_by_col.items() if k not in exclude_columns}
     _apply_nonplanar_edges(
         edges_by_col,
         output_path,

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -46,6 +46,7 @@ from geoparquet_io.core.geo_metadata import (
     detect_bbox_column_from_schema,
     prune_geo_metadata_to_columns,
     strip_derived_stats,
+    strip_nonplanar_edges,
 )
 from geoparquet_io.core.geoarrow_encoding import (
     is_geoarrow_extension_field,
@@ -2732,6 +2733,7 @@ def write_parquet_with_metadata(
     extra_kv_metadata: dict[str, str] | None = None,
     input_file: str | None = None,
     invalidate_derived_stats: bool = False,
+    carry_nonplanar_edges: bool = True,
 ):
     """
     Write a parquet file with proper compression and metadata handling.
@@ -2782,6 +2784,12 @@ def write_parquet_with_metadata(
             carried metadata came from only the first file: the input's stats no
             longer describe the output, so they must be recomputed from the
             written data or omitted rather than carried.
+        carry_nonplanar_edges: When False, do not re-attach the input's
+            non-planar ``edges`` declaration to the output. Set by writes that
+            invalidate the edge interpretation itself — reprojecting to a
+            projected CRS turns great-circle edges into straight lines (#601) —
+            where planar (the spec default) is the truthful description of the
+            output. The caller warns; this only stops the carry.
 
     Returns:
         None
@@ -2799,6 +2807,12 @@ def write_parquet_with_metadata(
     # strategies recompute (or omit) them instead of describing the input.
     if invalidate_derived_stats:
         original_metadata = strip_derived_stats(original_metadata)
+
+    # A write that invalidates the edge interpretation itself (reprojecting into
+    # a projected CRS, #601) must neither carry the declaration through nor
+    # re-attach it afterwards; planar is then the truthful description.
+    if not carry_nonplanar_edges:
+        original_metadata = strip_nonplanar_edges(original_metadata)
 
     # Use geometry column from geometry_info if provided, otherwise auto-detect
     # This ensures original column names are preserved (fixes #328)
@@ -2977,15 +2991,16 @@ def write_parquet_with_metadata(
         # regenerates geo metadata without `edges`, silently demoting geography
         # data to planar. Runs on the local temp file, so remote outputs are
         # patched before upload.
-        _preserve_edges_after_write(
-            input_file,
-            original_metadata,
-            actual_output,
-            compression=compression,
-            compression_level=compression_level,
-            row_group_rows=row_group_rows,
-            verbose=verbose,
-        )
+        if carry_nonplanar_edges:
+            _preserve_edges_after_write(
+                input_file,
+                original_metadata,
+                actual_output,
+                compression=compression,
+                compression_level=compression_level,
+                row_group_rows=row_group_rows,
+                verbose=verbose,
+            )
 
         # Auto-fix vecorel schema compliance when collection metadata is present
         if not is_remote:

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -31,6 +31,8 @@ from geoparquet_io.core.duckdb_utils import (
 from geoparquet_io.core.logging_config import debug, warn
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     import pyarrow as pa
 
 # =============================================================================
@@ -380,8 +382,10 @@ def strip_orientation(metadata: dict | None, column: str) -> dict | None:
     return _rewrite_geo_metadata(metadata, _drop)
 
 
-def strip_nonplanar_edges(metadata: dict | None) -> dict | None:
-    """Return a copy of KV ``metadata`` without any non-planar ``edges`` (#601).
+def strip_nonplanar_edges(
+    metadata: dict | None, columns: Collection[str] | None = None
+) -> dict | None:
+    """Return a copy of KV ``metadata`` without non-planar ``edges`` (#601).
 
     Reprojection transforms vertices, not edges: gpio does not densify along
     great circles, so once the destination CRS is projected the output's edges
@@ -389,11 +393,17 @@ def strip_nonplanar_edges(metadata: dict | None) -> dict | None:
     the key's absence — is the truthful description. Like ``orientation``, the
     key is only removed, never rewritten to something gpio cannot vouch for.
 
+    ``columns`` limits the strip to those column entries; reproject transforms
+    only the primary geometry column, so a secondary column — still geographic,
+    still great-circle — keeps its declaration. ``None`` strips every column.
+
     Both ``"geo"`` and ``b"geo"`` keys are handled; the input is never mutated.
     """
 
     def _drop(geo_dict: dict) -> dict:
-        for col_meta in (geo_dict.get("columns") or {}).values():
+        for col_name, col_meta in (geo_dict.get("columns") or {}).items():
+            if columns is not None and col_name not in columns:
+                continue
             if isinstance(col_meta, dict) and col_meta.get("edges", "planar") != "planar":
                 del col_meta["edges"]
         return geo_dict

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -380,6 +380,27 @@ def strip_orientation(metadata: dict | None, column: str) -> dict | None:
     return _rewrite_geo_metadata(metadata, _drop)
 
 
+def strip_nonplanar_edges(metadata: dict | None) -> dict | None:
+    """Return a copy of KV ``metadata`` without any non-planar ``edges`` (#601).
+
+    Reprojection transforms vertices, not edges: gpio does not densify along
+    great circles, so once the destination CRS is projected the output's edges
+    really are straight lines and ``planar`` — the spec default, expressed by
+    the key's absence — is the truthful description. Like ``orientation``, the
+    key is only removed, never rewritten to something gpio cannot vouch for.
+
+    Both ``"geo"`` and ``b"geo"`` keys are handled; the input is never mutated.
+    """
+
+    def _drop(geo_dict: dict) -> dict:
+        for col_meta in (geo_dict.get("columns") or {}).values():
+            if isinstance(col_meta, dict) and col_meta.get("edges", "planar") != "planar":
+                del col_meta["edges"]
+        return geo_dict
+
+    return _rewrite_geo_metadata(metadata, _drop)
+
+
 def backfill_derived_stats(
     metadata: dict | None,
     table: pa.Table,

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -15,6 +15,7 @@ import pyarrow.parquet as pq
 
 from geoparquet_io.core.common import (
     check_bbox_structure,
+    collect_nonplanar_edges,
     get_parquet_metadata,
     validate_compression_settings,
     write_parquet_with_metadata,
@@ -25,6 +26,7 @@ from geoparquet_io.core.crs_utils import (
     crs_is_explicitly_null,
     extract_crs_from_parquet,
     geoparquet_crs_is_null,
+    is_geographic_crs,
     parse_crs_string_to_projjson,
     resolve_crs_to_string,
 )
@@ -32,7 +34,7 @@ from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identif
 from geoparquet_io.core.file_utils import safe_file_url
 from geoparquet_io.core.geo_metadata import strip_derived_stats
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
-from geoparquet_io.core.logging_config import debug, info, success
+from geoparquet_io.core.logging_config import debug, info, success, warn
 from geoparquet_io.core.remote import (
     needs_httpfs,
     remote_write_context,
@@ -119,6 +121,55 @@ def _table_geo_column_meta(table: pa.Table, geom_col: str) -> dict:
         except (json.JSONDecodeError, KeyError):
             return {}
     return {}
+
+
+def _target_crs_is_projected(target_crs: str, con=None) -> bool:
+    """True when reprojecting into ``target_crs`` lands in projected space.
+
+    Resolves the CRS string to PROJJSON first: ``is_geographic_crs`` reads the
+    CRS *type* from PROJJSON, while its string fallback only recognizes the
+    WGS84 spellings and would call a geographic datum like EPSG:4269 projected.
+    An unresolvable CRS falls back to that string heuristic.
+    """
+    return not is_geographic_crs(parse_crs_string_to_projjson(target_crs, con) or target_crs)
+
+
+def _warn_edges_dropped(col_name: str, edges: str, target_crs: str) -> None:
+    warn(
+        f"Dropped 'edges: {edges}' on column \"{col_name}\": the reprojected "
+        f"edges are straight lines in {target_crs}. Densify before reprojecting "
+        "if great-circle edges must be preserved."
+    )
+
+
+def _carry_edges_to_target(input_file: str | None, target_crs: str, con=None) -> bool:
+    """Whether a non-planar ``edges`` declaration survives this reprojection (#601).
+
+    Reprojection transforms vertices, not edges: gpio does not densify along
+    great circles, so in a projected destination the output's edges *are*
+    straight lines and planar (the spec default) is the truthful description.
+    A geographic destination is only a datum shift, so the declaration stands.
+    Warns once per column that loses its declaration.
+    """
+    if not _target_crs_is_projected(target_crs, con):
+        return True
+    if input_file:
+        for col_name, edges in sorted(collect_nonplanar_edges(input_file).items()):
+            _warn_edges_dropped(col_name, edges, target_crs)
+    return False
+
+
+def _drop_nonplanar_edges_from_geo_meta(geo_meta: dict, target_crs: str) -> None:
+    """Strip non-planar ``edges`` from an in-memory geo metadata dict (#601).
+
+    The counterpart of ``_carry_edges_to_target`` for the write paths that hand
+    the input's geo metadata straight through (Arrow tables, streaming).
+    """
+    for col_name, col_meta in (geo_meta.get("columns") or {}).items():
+        edges = col_meta.get("edges") if isinstance(col_meta, dict) else None
+        if edges and edges != "planar":
+            del col_meta["edges"]
+            _warn_edges_dropped(col_name, edges, target_crs)
 
 
 #: Raised by the Arrow/Python-API path on an explicit ``crs: null`` input.
@@ -222,6 +273,8 @@ def reproject_table(
                 try:
                     geo_meta = json.loads(new_metadata[b"geo"].decode("utf-8"))
                     apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
+                    if _target_crs_is_projected(target_crs, con):
+                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs)
                     new_metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
                     result = result.replace_schema_metadata(new_metadata)
                 except (json.JSONDecodeError, KeyError) as e:
@@ -533,6 +586,10 @@ def reproject_impl(
         # Read original metadata to preserve non-geo KV metadata (e.g., vecorel)
         original_metadata, _ = get_parquet_metadata(input_parquet, verbose)
 
+        # A projected destination invalidates a non-planar `edges` declaration:
+        # the reprojected edges are straight lines there (#601).
+        carry_edges = _carry_edges_to_target(read_source, target_crs, con)
+
         # Auto version mode: match convert's contract (todo 040) — preserve the
         # input's GeoParquet version and upgrade native-geo-only inputs to 2.0
         # instead of silently stripping native types to 1.1 WKB.
@@ -568,6 +625,7 @@ def reproject_impl(
                     memory_limit=memory_limit,
                     input_file=read_source,
                     invalidate_derived_stats=True,
+                    carry_nonplanar_edges=carry_edges,
                 )
                 # Replace original with temp file
                 shutil.move(str(tmp_path), str(out_path))
@@ -597,6 +655,7 @@ def reproject_impl(
                     memory_limit=memory_limit,
                     input_file=read_source,
                     invalidate_derived_stats=True,
+                    carry_nonplanar_edges=carry_edges,
                 )
 
                 if is_remote:
@@ -735,6 +794,8 @@ def _reproject_streaming(
                 try:
                     geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
                     apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
+                    if _target_crs_is_projected(target_crs, con):
+                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs)
                     metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
                 except (json.JSONDecodeError, KeyError) as e:
                     debug(f"Could not update CRS in geo metadata, leaving as-is: {e}")

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -142,34 +142,42 @@ def _warn_edges_dropped(col_name: str, edges: str, target_crs: str) -> None:
     )
 
 
-def _carry_edges_to_target(input_file: str | None, target_crs: str, con=None) -> bool:
-    """Whether a non-planar ``edges`` declaration survives this reprojection (#601).
+def _edges_columns_to_drop(
+    input_file: str | None, target_crs: str, geom_col: str, con=None
+) -> set[str]:
+    """Columns whose non-planar ``edges`` declaration this reprojection voids (#601).
 
     Reprojection transforms vertices, not edges: gpio does not densify along
     great circles, so in a projected destination the output's edges *are*
     straight lines and planar (the spec default) is the truthful description.
     A geographic destination is only a datum shift, so the declaration stands.
-    Warns once per column that loses its declaration.
+
+    Only ``geom_col`` — the one column reproject actually transforms — is ever
+    dropped: an untransformed secondary geometry column keeps its geographic
+    CRS, so its great-circle declaration still holds. Warns when ``geom_col``
+    loses a declaration the input actually made.
     """
     if not _target_crs_is_projected(target_crs, con):
-        return True
+        return set()
     if input_file:
-        for col_name, edges in sorted(collect_nonplanar_edges(input_file).items()):
-            _warn_edges_dropped(col_name, edges, target_crs)
-    return False
+        edges = collect_nonplanar_edges(input_file).get(geom_col)
+        if edges:
+            _warn_edges_dropped(geom_col, edges, target_crs)
+    return {geom_col}
 
 
-def _drop_nonplanar_edges_from_geo_meta(geo_meta: dict, target_crs: str) -> None:
-    """Strip non-planar ``edges`` from an in-memory geo metadata dict (#601).
+def _drop_nonplanar_edges_from_geo_meta(geo_meta: dict, target_crs: str, geom_col: str) -> None:
+    """Strip ``geom_col``'s non-planar ``edges`` from an in-memory geo dict (#601).
 
-    The counterpart of ``_carry_edges_to_target`` for the write paths that hand
-    the input's geo metadata straight through (Arrow tables, streaming).
+    The counterpart of ``_edges_columns_to_drop`` for the write paths that hand
+    the input's geo metadata straight through (Arrow tables, streaming). Other
+    columns are untransformed and keep their declaration.
     """
-    for col_name, col_meta in (geo_meta.get("columns") or {}).items():
-        edges = col_meta.get("edges") if isinstance(col_meta, dict) else None
-        if edges and edges != "planar":
-            del col_meta["edges"]
-            _warn_edges_dropped(col_name, edges, target_crs)
+    col_meta = (geo_meta.get("columns") or {}).get(geom_col)
+    edges = col_meta.get("edges") if isinstance(col_meta, dict) else None
+    if edges and edges != "planar":
+        del col_meta["edges"]
+        _warn_edges_dropped(geom_col, edges, target_crs)
 
 
 #: Raised by the Arrow/Python-API path on an explicit ``crs: null`` input.
@@ -274,7 +282,7 @@ def reproject_table(
                     geo_meta = json.loads(new_metadata[b"geo"].decode("utf-8"))
                     apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
                     if _target_crs_is_projected(target_crs, con):
-                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs)
+                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs, geom_col)
                     new_metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
                     result = result.replace_schema_metadata(new_metadata)
                 except (json.JSONDecodeError, KeyError) as e:
@@ -586,9 +594,10 @@ def reproject_impl(
         # Read original metadata to preserve non-geo KV metadata (e.g., vecorel)
         original_metadata, _ = get_parquet_metadata(input_parquet, verbose)
 
-        # A projected destination invalidates a non-planar `edges` declaration:
-        # the reprojected edges are straight lines there (#601).
-        carry_edges = _carry_edges_to_target(read_source, target_crs, con)
+        # A projected destination invalidates the transformed column's
+        # non-planar `edges` declaration: the reprojected edges are straight
+        # lines there (#601). Untransformed columns keep theirs.
+        drop_edges_columns = _edges_columns_to_drop(read_source, target_crs, geom_col, con)
 
         # Auto version mode: match convert's contract (todo 040) — preserve the
         # input's GeoParquet version and upgrade native-geo-only inputs to 2.0
@@ -625,7 +634,7 @@ def reproject_impl(
                     memory_limit=memory_limit,
                     input_file=read_source,
                     invalidate_derived_stats=True,
-                    carry_nonplanar_edges=carry_edges,
+                    drop_nonplanar_edges_columns=drop_edges_columns,
                 )
                 # Replace original with temp file
                 shutil.move(str(tmp_path), str(out_path))
@@ -655,7 +664,7 @@ def reproject_impl(
                     memory_limit=memory_limit,
                     input_file=read_source,
                     invalidate_derived_stats=True,
-                    carry_nonplanar_edges=carry_edges,
+                    drop_nonplanar_edges_columns=drop_edges_columns,
                 )
 
                 if is_remote:
@@ -795,7 +804,7 @@ def _reproject_streaming(
                     geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
                     apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
                     if _target_crs_is_projected(target_crs, con):
-                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs)
+                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs, geom_col)
                     metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
                 except (json.JSONDecodeError, KeyError) as e:
                     debug(f"Could not update CRS in geo metadata, leaving as-is: {e}")

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -487,6 +487,45 @@ def _check_edges_valid(
     )
 
 
+def _check_edges_spherical_on_projected_crs(
+    parquet_file: str, col_meta: dict, col_name: str
+) -> ValidationCheck | None:
+    """Warn when a non-planar ``edges`` sits on a projected CRS (#601).
+
+    Great-circle (or geodesic) edges are only meaningful on an ellipsoid: in a
+    projected CRS the vertices are plane coordinates and the edge between two of
+    them is a straight line, so ``spherical`` has no coherent interpretation
+    there. Files with this combination exist in the wild — reprojectors that
+    move vertices without densifying carry the declaration along — so this is a
+    warning, not a failure.
+
+    Returns ``None`` when there is nothing to say (planar or absent edges, or a
+    geographic/unknown CRS), so conformant files gain no output line.
+    """
+    from geoparquet_io.core.duckdb_metadata import resolve_crs_reference
+
+    edges = col_meta.get("edges")
+    if not edges or edges == "planar":
+        return None
+
+    # An absent or null CRS means "OGC:CRS84 default" / "unknown"; neither is a
+    # projected CRS, and _check_crs_valid is what reports a null.
+    crs = resolve_crs_reference(parquet_file, col_meta.get("crs"))
+    if is_geographic_crs(crs):
+        return None
+
+    return ValidationCheck(
+        name=f"edges_spherical_on_projected_crs_{col_name}",
+        status=CheckStatus.WARNING,
+        message=f'column "{col_name}" declares edges: {edges} on a projected CRS '
+        f"({get_crs_display_name(crs)})",
+        details="Edges are interpolated along the ellipsoid, which a projected CRS "
+        "cannot express; readers will draw straight lines. Densify the geometries "
+        "and declare planar edges, or store the data in a geographic CRS.",
+        category="column_metadata",
+    )
+
+
 def _check_bbox_valid(col_meta: dict, col_name: str) -> ValidationCheck:
     """Check 12: optional 'bbox' must be an array of 4 or 6 numbers."""
     bbox = col_meta.get("bbox")
@@ -3535,6 +3574,10 @@ def _run_geoparquet_checks(
         checks.append(_check_crs_valid(col_meta, col_name))
         checks.append(_check_orientation_valid(col_meta, col_name))
         checks.append(_check_edges_valid(col_meta, col_name, geo_version))
+        # Only reports when there is something to report (#601).
+        edges_crs_check = _check_edges_spherical_on_projected_crs(parquet_file, col_meta, col_name)
+        if edges_crs_check:
+            checks.append(edges_crs_check)
         checks.append(_check_bbox_valid(col_meta, col_name))
         checks.append(_check_epoch_valid(col_meta, col_name))
 

--- a/tests/test_preserve_geography_edges.py
+++ b/tests/test_preserve_geography_edges.py
@@ -141,11 +141,16 @@ def test_sort_by_column_preserves_spherical_edges(spherical_input, tmp_path):
     assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
 
 
-def test_reproject_preserves_spherical_edges(spherical_input, tmp_path):
+def test_reproject_to_geographic_crs_preserves_spherical_edges(spherical_input, tmp_path):
+    """A datum shift keeps great-circle semantics, so the declaration stands.
+
+    Reprojecting to a *projected* CRS drops it instead (#601) — see
+    tests/test_reproject_spherical_edges.py.
+    """
     from geoparquet_io.core.reproject import reproject
 
     out = tmp_path / "out.parquet"
-    reproject(str(spherical_input), str(out), target_crs="EPSG:3857")
+    reproject(str(spherical_input), str(out), target_crs="EPSG:4269")
     geo = get_geo_metadata(str(out))
     assert geo["columns"]["geometry"].get("edges") == "spherical", geo["columns"]["geometry"]
 

--- a/tests/test_reproject_spherical_edges.py
+++ b/tests/test_reproject_spherical_edges.py
@@ -1,0 +1,193 @@
+"""Reprojecting to a projected CRS must not carry `edges: spherical` (#601).
+
+Reprojection transforms *vertices*. gpio does not densify along great circles
+first, so the edges of the output are straight lines in the destination CRS.
+``planar`` (the spec default) is the truthful description of that output, so a
+non-planar ``edges`` declaration is dropped — with one warning per column —
+whenever the destination CRS is projected. A geographic destination (a datum
+shift, e.g. EPSG:4326 -> EPSG:4269) keeps great-circle semantics, so the
+declaration survives there unchanged.
+"""
+
+import json
+import logging
+
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.reproject import reproject, reproject_table
+from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+from tests.conftest import get_geo_metadata
+
+DROP_WARNING = "the reprojected edges are straight lines"
+
+
+def _write_crs84_points(path):
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        con.execute(f"""
+            COPY (
+              SELECT * FROM (VALUES
+                (1, ST_Point(1, 1)),
+                (2, ST_Point(3, 3))
+              ) t(id, geometry)
+            ) TO '{path.as_posix()}' (FORMAT PARQUET)
+        """)
+    finally:
+        con.close()
+
+
+def _set_edges(path, edges):
+    """Stamp an ``edges`` value onto the file's geo metadata, in place."""
+    table = pq.read_table(str(path))
+    kv = dict(table.schema.metadata or {})
+    geo = json.loads(kv[b"geo"].decode("utf-8"))
+    for col_meta in geo["columns"].values():
+        col_meta["edges"] = edges
+    kv[b"geo"] = json.dumps(geo).encode("utf-8")
+    pq.write_table(table.replace_schema_metadata(kv), str(path))
+
+
+@pytest.fixture
+def spherical_crs84(tmp_path):
+    """A CRS84 file declaring ``edges: spherical``."""
+    path = tmp_path / "spherical.parquet"
+    _write_crs84_points(path)
+    _set_edges(path, "spherical")
+    return path
+
+
+@pytest.fixture
+def planar_crs84(tmp_path):
+    """The same file with no ``edges`` declaration at all."""
+    path = tmp_path / "planar.parquet"
+    _write_crs84_points(path)
+    return path
+
+
+def _edges(path):
+    geo = get_geo_metadata(str(path))
+    return geo["columns"][geo["primary_column"]].get("edges")
+
+
+class TestReprojectToProjectedCrs:
+    """A projected destination drops the declaration and says so once."""
+
+    def test_edges_dropped_and_warned(self, spherical_crs84, tmp_path, caplog):
+        out = tmp_path / "out.parquet"
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            reproject(str(spherical_crs84), str(out), target_crs="EPSG:3857")
+
+        assert _edges(out) is None, get_geo_metadata(str(out))
+
+        warnings = [r for r in caplog.records if DROP_WARNING in r.message]
+        assert len(warnings) == 1, caplog.text
+        assert '"geometry"' in warnings[0].message
+        assert "spherical" in warnings[0].message
+        assert "EPSG:3857" in warnings[0].message
+
+    def test_cli_drops_edges(self, spherical_crs84, tmp_path):
+        out = tmp_path / "out.parquet"
+        result = CliRunner().invoke(
+            cli,
+            [
+                "convert",
+                "reproject",
+                str(spherical_crs84),
+                str(out),
+                "--dst-crs",
+                "EPSG:3857",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert _edges(out) is None, get_geo_metadata(str(out))
+
+    def test_planar_input_says_nothing(self, planar_crs84, tmp_path, caplog):
+        out = tmp_path / "out.parquet"
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            reproject(str(planar_crs84), str(out), target_crs="EPSG:3857")
+
+        assert _edges(out) is None
+        assert DROP_WARNING not in caplog.text
+
+    def test_python_api_table_drops_edges(self, spherical_crs84):
+        table = pq.read_table(str(spherical_crs84))
+        result = reproject_table(table, target_crs="EPSG:3857")
+        geo = json.loads(result.schema.metadata[b"geo"].decode("utf-8"))
+        assert geo["columns"]["geometry"].get("edges") is None, geo["columns"]["geometry"]
+
+
+class TestReprojectToGeographicCrs:
+    """A datum shift between geographic CRSs keeps great-circle semantics."""
+
+    def test_edges_preserved_without_warning(self, spherical_crs84, tmp_path, caplog):
+        out = tmp_path / "out.parquet"
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            reproject(str(spherical_crs84), str(out), target_crs="EPSG:4269")
+
+        assert _edges(out) == "spherical", get_geo_metadata(str(out))
+        assert DROP_WARNING not in caplog.text
+
+    def test_python_api_table_preserves_edges(self, spherical_crs84):
+        table = pq.read_table(str(spherical_crs84))
+        result = reproject_table(table, target_crs="EPSG:4269")
+        geo = json.loads(result.schema.metadata[b"geo"].decode("utf-8"))
+        assert geo["columns"]["geometry"].get("edges") == "spherical"
+
+
+class TestNonReprojectingRewrites:
+    """The drop is scoped to CRS-changing writes; other rewrites still carry."""
+
+    def test_sort_hilbert_keeps_spherical_edges(self, spherical_crs84, tmp_path):
+        from geoparquet_io.core.hilbert_order import hilbert_order
+
+        out = tmp_path / "sorted.parquet"
+        hilbert_order(str(spherical_crs84), str(out))
+        assert _edges(out) == "spherical", get_geo_metadata(str(out))
+
+
+def _new_check(result):
+    return [c for c in result.checks if c.name.startswith("edges_spherical_on_projected_crs")]
+
+
+class TestValidatorWarnsOnSphericalPlusProjected:
+    """`gpio check spec` flags the combination as a warning, never a failure."""
+
+    def test_spherical_on_projected_crs_warns_and_still_valid(self, spherical_crs84, tmp_path):
+        out = tmp_path / "out.parquet"
+        reproject(str(spherical_crs84), str(out), target_crs="EPSG:3857")
+        # Put the declaration back the way a third-party writer would leave it.
+        _set_edges(out, "spherical")
+
+        result = validate_geoparquet(str(out), validate_data=False)
+        checks = _new_check(result)
+        assert len(checks) == 1, [c.name for c in result.checks]
+        assert checks[0].status == CheckStatus.WARNING
+        assert "spherical" in checks[0].message
+        assert "geometry" in checks[0].message
+        assert result.is_valid, [c.message for c in result.checks if c.status == CheckStatus.FAILED]
+
+    def test_cli_check_spec_does_not_fail_the_file(self, spherical_crs84, tmp_path):
+        """Exit 2 is `check spec`'s warnings-only code; a failure would be exit 1."""
+        out = tmp_path / "out.parquet"
+        reproject(str(spherical_crs84), str(out), target_crs="EPSG:3857")
+        _set_edges(out, "spherical")
+
+        result = CliRunner().invoke(cli, ["check", "spec", str(out)])
+        assert result.exit_code == 2, result.output
+        assert "0 failed" in result.output
+        assert "projected CRS" in result.output
+
+    def test_spherical_on_geographic_crs_is_silent(self, spherical_crs84):
+        result = validate_geoparquet(str(spherical_crs84), validate_data=False)
+        assert _new_check(result) == []
+
+    def test_planar_on_projected_crs_is_silent(self, spherical_crs84, tmp_path):
+        out = tmp_path / "out.parquet"
+        reproject(str(spherical_crs84), str(out), target_crs="EPSG:3857")
+
+        result = validate_geoparquet(str(out), validate_data=False)
+        assert _new_check(result) == []

--- a/tests/test_reproject_spherical_edges.py
+++ b/tests/test_reproject_spherical_edges.py
@@ -120,6 +120,97 @@ class TestReprojectToProjectedCrs:
         assert geo["columns"]["geometry"].get("edges") is None, geo["columns"]["geometry"]
 
 
+def _write_crs84_two_geometry_columns(path):
+    """A file with a primary ``geometry`` and a secondary ``centerline`` column."""
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        con.execute(f"""
+            COPY (
+              SELECT * FROM (VALUES
+                (1, ST_Point(1, 1), ST_Point(10, 10)),
+                (2, ST_Point(3, 3), ST_Point(30, 30))
+              ) t(id, geometry, centerline)
+            ) TO '{path.as_posix()}' (FORMAT PARQUET)
+        """)
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def spherical_two_columns(tmp_path):
+    """Two geometry columns, both declaring ``edges: spherical``."""
+    path = tmp_path / "two_spherical.parquet"
+    _write_crs84_two_geometry_columns(path)
+    _set_edges(path, "spherical")
+    return path
+
+
+class TestMultiGeometryColumns:
+    """Only the column actually transformed loses its declaration.
+
+    Reproject transforms the primary geometry column only; a secondary column
+    keeps its geographic CRS and untransformed coordinates, so its great-circle
+    ``edges`` declaration still holds and must survive — without a warning
+    falsely claiming it was reprojected.
+    """
+
+    def test_only_transformed_column_loses_edges(self, spherical_two_columns, tmp_path, caplog):
+        out = tmp_path / "out.parquet"
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            reproject(str(spherical_two_columns), str(out), target_crs="EPSG:3857")
+
+        geo = get_geo_metadata(str(out))
+        assert geo["columns"]["geometry"].get("edges") is None, geo["columns"]["geometry"]
+        assert geo["columns"]["centerline"].get("edges") == "spherical", geo["columns"][
+            "centerline"
+        ]
+
+        warnings = [r for r in caplog.records if DROP_WARNING in r.message]
+        assert len(warnings) == 1, caplog.text
+        assert '"geometry"' in warnings[0].message
+        assert "centerline" not in caplog.text
+
+    def test_python_api_table_scopes_drop_to_transformed_column(
+        self, spherical_two_columns, caplog
+    ):
+        table = pq.read_table(str(spherical_two_columns))
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            result = reproject_table(table, target_crs="EPSG:3857")
+
+        geo = json.loads(result.schema.metadata[b"geo"].decode("utf-8"))
+        assert geo["columns"]["geometry"].get("edges") is None, geo["columns"]["geometry"]
+        assert geo["columns"]["centerline"].get("edges") == "spherical", geo["columns"][
+            "centerline"
+        ]
+        assert "centerline" not in caplog.text
+
+    def test_streaming_path_scopes_drop_to_transformed_column(
+        self, spherical_two_columns, tmp_path, caplog
+    ):
+        from geoparquet_io.core.reproject import _reproject_streaming
+
+        out = tmp_path / "streamed.parquet"
+        with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+            _reproject_streaming(
+                str(spherical_two_columns),
+                str(out),
+                "EPSG:3857",
+                None,  # source_crs
+                "ZSTD",  # compression
+                None,  # compression_level
+                False,  # verbose
+                None,  # profile
+                None,  # geoparquet_version
+            )
+
+        geo = get_geo_metadata(str(out))
+        assert geo["columns"]["geometry"].get("edges") is None, geo["columns"]["geometry"]
+        assert geo["columns"]["centerline"].get("edges") == "spherical", geo["columns"][
+            "centerline"
+        ]
+        assert "centerline" not in caplog.text
+
+
 class TestReprojectToGeographicCrs:
     """A datum shift between geographic CRSs keeps great-circle semantics."""
 


### PR DESCRIPTION
## What changed

`gpio convert reproject` no longer carries a non-planar `edges` declaration onto an output whose CRS is projected.

- **Projected destination** — the declaration is omitted (planar is the spec default, expressed by the key's absence) and one `warn()` per column says so: `Dropped 'edges: spherical' on column "geometry": the reprojected edges are straight lines in EPSG:3857. Densify before reprojecting if great-circle edges must be preserved.`
- **Geographic destination** (a datum shift, e.g. `EPSG:4326` → `EPSG:4269`) — preserved unchanged.
- **Non-reprojecting rewrites** (`convert`, `extract`, `sort`, `partition`) — unchanged; they still carry edges through, including to remote outputs.
- **`gpio check spec`** gains `edges_spherical_on_projected_crs_<column>`: a **warning** naming the column, the edges value and the CRS. It only emits when there is something to say, so conformant files gain no output line.
- **Docs**: `docs/guide/convert.md` (Edges Metadata Preservation) states that gpio reprojects vertices, not edges, and points at densifying; `docs/guide/check.md` lists the new warning check.

Where the hook landed: `write_parquet_with_metadata` gained `carry_nonplanar_edges: bool = True` — a parameter on the existing edges-carry machinery rather than a reproject-specific branch in `common.py`. It does two things there: it skips the post-write `_preserve_edges_after_write` re-attach, and it runs the carried input metadata through a new `geo_metadata.strip_nonplanar_edges()` (a sibling of the existing `strip_derived_stats` / `strip_orientation`), because the declaration reaches the output by both routes. The CRS decision and the warning text live in `reproject.py`, which is where the destination CRS is known: `_carry_edges_to_target()` warns once per column and returns the flag. The two write paths that hand the input's geo metadata straight through — `reproject_table` (the Python API twin) and `_reproject_streaming` — strip it in place via `_drop_nonplanar_edges_from_geo_meta()`.

The projected/geographic test is `crs_utils.is_geographic_crs`, applied to the *resolved PROJJSON* of the destination: its string fallback only recognizes the WGS84 spellings and would call a geographic datum like EPSG:4269 projected.

## Why

Reprojection transforms **vertices**. gpio does not densify along great circles first, so the edges of the output geometry are, by construction, straight lines in projected space. `planar` is therefore the truthful description of the output, not a downgrade — and `spherical` on a projected CRS has no coherent interpretation, which is why erroring-unless-opted-in would be wrong too: there is nothing coherent to opt into. Keeping the old behavior writes a declaration consumers would honor incorrectly.

A datum shift between two geographic CRSs is different: great-circle semantics survive it, so the declaration stands.

The validator side is a warning rather than a failure because third-party files with this combination exist in the wild — including every file gpio itself wrote before this change.

(Maintainer-approved ruling on #601, half 1. Half 2 — the stale degree-space bbox — was already fixed on `main` and is already pinned by `tests/test_metadata_bbox_invalidation.py::TestReprojectBboxRefreshed::test_bbox_in_meters_and_encloses_data`, which asserts the reprojected bbox is in metres and encloses the written coordinates for both 1.1 and 2.0. No new test was needed there.)

## Verification

Repro, exactly as the ruling describes it: stamp `edges: spherical` on `tests/data/places_test.parquet`'s geo metadata, reproject, read the output's metadata back.

**Before** (`main`):

```
input edges/bbox: ({'geometry': 'spherical'}, [-0.989, 9.799, 1.481, 12.391])

--- reproject -> EPSG:3857 (rc=0)
output edges/bbox: ({'geometry': 'spherical'}, [-110106.34, 1096126.76, 164844.67, 1390284.85])
check spec rc=0
    ✓ column "geometry" has valid edges: spherical
```

**After**:

```
--- reproject -> EPSG:3857 (rc=0)
Dropped 'edges: spherical' on column "geometry": the reprojected edges are straight
lines in EPSG:3857. Densify before reprojecting if great-circle edges must be preserved.
output edges/bbox: ({'geometry': '<absent>'}, [-110106.34, 1096126.76, 164844.67, 1390284.85])
check spec rc=0
    ✓ column "geometry" has no edges (defaults to planar)

--- reproject -> EPSG:4269 (rc=0)
output edges/bbox: ({'geometry': 'spherical'}, [-0.989, 9.799, 1.481, 12.391])
```

The new validator check, on a third-party-style file that carries `edges: spherical` on EPSG:3857:

```
  ✓ column "geometry" has valid edges: spherical
  ⚠ column "geometry" declares edges: spherical on a projected CRS (WGS 84 / Pseudo-Mercator (EPSG:3857))
      Edges are interpolated along the ellipsoid, which a projected CRS cannot
      express; readers will draw straight lines. Densify the geometries and declare
      planar edges, or store the data in a geographic CRS.

Summary: 28 passed, 1 warnings, 0 failed
```

`0 failed` — the file is still valid. `gpio check spec` exits **2** on it, which is that command's documented warnings-only code (`0=passed, 1=failed, 2=warnings only`), not the failure code; the test pins exit 2 with `0 failed` rather than exit 0, since exiting 0 would mean silently suppressing a warning the command already reports for every other warning check.

Tests — `tests/test_reproject_spherical_edges.py` (11 new):

- projected destination drops `edges` and emits exactly one warning naming the column, the value and the CRS (core + CLI)
- planar input emits nothing either way
- `reproject_table` (the `ops.reproject` / `Table.reproject` path) drops it, and preserves it for a geographic destination
- geographic destination (`EPSG:4269`) preserves `edges: spherical` with no warning
- `sort hilbert` on the same file still carries `edges: spherical` — the change is scoped to CRS-changing writes
- validator: spherical + EPSG:3857 warns and the file stays valid; `check spec` exit 2 with `0 failed`; spherical + CRS84 silent; planar + EPSG:3857 silent

`tests/test_preserve_geography_edges.py::test_reproject_preserves_spherical_edges` pinned the old behavior (spherical preserved onto EPSG:3857); it is now `test_reproject_to_geographic_crs_preserves_spherical_edges` and reprojects to EPSG:4269 instead, pointing at the new file for the projected case.

Fast suite: `5808 passed, 70 skipped, 1 xfailed` in 149s. (A later instrumented run flaked on `test_geojson_stream.py::test_streaming_handles_broken_pipe` under `-n auto`; it passes serially — the known xdist flake.)

diff-cover vs `origin/main`: **100%** (46 changed lines, 0 missing).

`pre-commit run --all-files` and `--hook-stage pre-push` (mypy, vulture, xenon, import-linter, deptry) both clean.

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reprojection to projected coordinate systems now warns when non-planar edge metadata is removed from transformed geometry columns.
  * Reprojection between geographic coordinate systems preserves non-planar edge declarations.
  * Unchanged secondary geometry columns retain their edge metadata during reprojection.
  * Validation reports non-planar edges on projected coordinate systems as warnings with remediation guidance.

* **Documentation**
  * Added guidance on edge metadata behavior, warnings, and recommended workflows when changing coordinate systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->