### PR TITLE
fix(convert): keep the source CRS in the geo block for M and ZM geometry at 2.0

### DIFF
--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -3,13 +3,14 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 import duckdb
 import pyarrow.parquet as pq
 
 # Internal imports - used by functions in this module
 from geoparquet_io.core.crs_utils import (
+    NULL_CRS_HINT,
     _format_crs_display,
     _wrap_query_with_crs,
     apply_output_crs,
@@ -2086,7 +2087,37 @@ def _geography_edges_from_logical(logical: str) -> str | None:
     return match.group(1).lower() if match else "spherical"
 
 
-def _geo_col_meta_from_stats(pf, col_index: int, logical: str) -> dict:
+def _crs_from_geo_logical(logical: str, parquet_file: str) -> tuple[bool, Any]:
+    """The CRS a native Geometry/Geography logical type declares.
+
+    Returns ``(present, crs)``. ``present`` is False when the type names no CRS
+    or names the OGC:CRS84 / EPSG:4326 default, both of which GeoParquet spells
+    by *omitting* the key. Otherwise ``crs`` is the resolved PROJJSON dict, or
+    ``None`` for a reference this build cannot resolve -- an explicit
+    ``"crs": null`` (CRS unknown), which is the honest reading and never the
+    silent CRS84 claim that omitting it would make (#785).
+    """
+    from geoparquet_io.core.duckdb_metadata import (
+        parse_geometry_logical_type,
+        resolve_crs_reference,
+    )
+
+    parsed = parse_geometry_logical_type(logical) or {}
+    raw = parsed.get("crs")
+    if raw is None:
+        return False, None
+    crs = resolve_crs_reference(parquet_file, raw)
+    if isinstance(crs, dict):
+        return (False, None) if is_default_crs(crs) else (True, crs)
+    warn(
+        f"Native geometry type declares a CRS this build cannot resolve to PROJJSON: {crs!r}. "
+        "Writing an explicit null CRS (unknown) rather than claiming the OGC:CRS84 default. "
+        + NULL_CRS_HINT
+    )
+    return True, None
+
+
+def _geo_col_meta_from_stats(pf, col_index: int, logical: str, parquet_file: str) -> dict:
     """Build one geo column metadata dict from a column's native geo statistics."""
     codes: set[int] = set()
     bbox = None
@@ -2124,6 +2155,14 @@ def _geo_col_meta_from_stats(pf, col_index: int, logical: str) -> dict:
             col_meta["bbox"] = [bbox[0], bbox[1], zrange[0], bbox[2], bbox[3], zrange[1]]
         else:
             col_meta["bbox"] = bbox
+    # The rebuilt block is the file's only geo metadata, so a CRS left behind
+    # here is not merely missing: an absent `crs` *means* OGC:CRS84, which
+    # relabels projected coordinates as lon/lat while the Parquet logical type
+    # still names the real CRS (#785). Mirror the logical type, which is the
+    # authority at 2.0.
+    crs_present, crs = _crs_from_geo_logical(logical, parquet_file)
+    if crs_present:
+        col_meta["crs"] = crs
     # A Geography logical type carries edge semantics the geo metadata must
     # not drop: synthesize the matching edges declaration (#588).
     edges = _geography_edges_from_logical(logical)
@@ -2143,9 +2182,9 @@ def _ensure_v2_geo_metadata(
     """Attach GeoParquet 2.0 geo metadata if the writer omitted it (#589).
 
     DuckDB 1.5.4's V2 writer skips the geo KV metadata for M/ZM geometries.
-    Rebuild it from the file's native geospatial statistics, mirroring the
-    shape DuckDB writes for XY/XYZ data, and rewrite the file in place.
-    ``primary_column`` names the real geometry column for multi-geometry
+    Rebuild it from the file's native geospatial statistics and logical types,
+    mirroring the shape DuckDB writes for XY/XYZ data, and rewrite the file in
+    place. ``primary_column`` names the real geometry column for multi-geometry
     files; without it the fallback is "geometry", then alphabetical.
     """
     pf = pq.ParquetFile(output_path)
@@ -2163,7 +2202,7 @@ def _ensure_v2_geo_metadata(
             return
 
         columns = {
-            name: _geo_col_meta_from_stats(pf, i, logical)
+            name: _geo_col_meta_from_stats(pf, i, logical, output_path)
             for i, (name, logical) in geo_cols.items()
         }
 

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -756,7 +756,7 @@ def _parse_crs_property(params: str) -> Any:
 
 def parse_geometry_logical_type(logical_type: str) -> dict | None:
     """
-    Parse Geometry/Geography logical type string from DuckDB schema.
+    Parse a Geometry/Geography logical type string from a Parquet schema.
 
     Handles strings like:
     - GeometryType(crs={"$schema": "...", "id": {"authority": "EPSG", "code": 4326}})
@@ -764,13 +764,18 @@ def parse_geometry_logical_type(logical_type: str) -> dict | None:
     - GeometryType(crs=<null>)
     - GeometryType(crs=EPSG:32633)
 
+    The two readers spell the same type differently -- DuckDB's
+    ``parquet_schema()`` renders ``GeometryType(...)``, PyArrow's
+    ``ParquetLogicalType`` renders ``Geometry(...)`` -- so the ``Type`` suffix is
+    optional. Rejecting PyArrow's spelling made the CRS invisible to the callers
+    that read the schema through PyArrow (#785).
+
     Returns dict with keys: geo_type, geometry_type, coordinate_dimension, crs, algorithm
     """
     if not logical_type:
         return None
 
-    # Match GeometryType(...) or GeographyType(...) - DuckDB's format from parquet_schema()
-    match = re.match(r"(Geometry|Geography)Type\((.*)\)$", logical_type, re.DOTALL)
+    match = re.match(r"(Geometry|Geography)(?:Type)?\((.*)\)$", logical_type, re.DOTALL)
     if not match:
         return None
 
@@ -880,13 +885,19 @@ def resolve_crs_reference(parquet_file: str, crs_value: Any) -> Any:
             import pyarrow.parquet as pq
 
             pf = pq.ParquetFile(parquet_file)
-            file_metadata = pf.metadata.metadata
-            if file_metadata:
-                # Keys are bytes in PyArrow metadata
-                key_bytes = key_name.encode("utf-8")
-                if key_bytes in file_metadata:
-                    projjson_str = file_metadata[key_bytes].decode("utf-8")
-                    return json.loads(projjson_str)
+            try:
+                file_metadata = pf.metadata.metadata
+                if file_metadata:
+                    # Keys are bytes in PyArrow metadata
+                    key_bytes = key_name.encode("utf-8")
+                    if key_bytes in file_metadata:
+                        projjson_str = file_metadata[key_bytes].decode("utf-8")
+                        return json.loads(projjson_str)
+            finally:
+                # Callers resolve a CRS on the way to rewriting the file in
+                # place; a lingering read handle makes os.replace fail on
+                # Windows.
+                pf.close()
         except Exception:
             pass  # Fall through to return the reference string
         return crs_value  # Return the reference string if resolution failed

--- a/tests/test_v2_zm_geo_metadata.py
+++ b/tests/test_v2_zm_geo_metadata.py
@@ -148,3 +148,139 @@ def test_repair_uses_real_primary_column_not_alphabetical(tmp_path):
     geo = json.loads(pq.ParquetFile(str(path)).metadata.metadata[b"geo"])
     assert set(geo["columns"]) == {"a_geom", "the_geom"}
     assert geo["primary_column"] == "the_geom"
+
+
+# --- CRS must survive the repair, for every dimension and version (#785) ---
+#
+# The repair rebuilds the geo block from scratch, so anything it does not carry
+# over is *lost*, and a missing `crs` is not a gap: the spec reads it as the
+# OGC:CRS84 default. On M/ZM data in a projected CRS that silently relabelled
+# UTM metres as lon/lat while the Parquet logical type still said EPSG:25830.
+
+_PROJECTED_WKT = {
+    "XY": "POLYGON ((440000 4470000, 440010 4470000, 440010 4470010, 440000 4470000))",
+    "Z": "POLYGON Z ((440000 4470000 1, 440010 4470000 2, 440010 4470010 3, 440000 4470000 1))",
+    "M": "POLYGON M ((440000 4470000 10, 440010 4470000 20, 440010 4470010 30, 440000 4470000 10))",
+    "ZM": "POLYGON ZM ((440000 4470000 1 10, 440010 4470000 2 20, 440010 4470010 3 30, "
+    "440000 4470000 1 10))",
+}
+_WRITE_VERSIONS = ["1.1", "1.1-geoarrow", "2.0"]
+
+
+def _wkb_source(path, wkt: str, crs) -> str:
+    """A minimal GeoParquet 1.1 WKB source declaring ``crs`` (omitted when None)."""
+    con = get_duckdb_connection(load_spatial=True)
+    table = (
+        con.execute(f"SELECT 1 AS id, ST_AsWKB(ST_GeomFromText('{wkt}')) AS geometry")
+        .arrow()
+        .read_all()
+    )
+    con.close()
+    col_meta: dict = {"encoding": "WKB", "geometry_types": []}
+    if crs is not None:
+        col_meta["crs"] = crs
+    geo = {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": col_meta}}
+    table = table.replace_schema_metadata({"geo": json.dumps(geo)})
+    pq.write_table(table, str(path))
+    return str(path)
+
+
+@pytest.fixture
+def epsg_25830():
+    from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
+
+    return parse_crs_string_to_projjson("EPSG:25830")
+
+
+def _primary_col_meta(parquet_file: str) -> dict:
+    geo = get_geo_metadata(parquet_file)
+    return geo["columns"][geo["primary_column"]]
+
+
+def _schema_crs(parquet_file: str):
+    """The CRS the Parquet native GEOMETRY logical type declares, or None."""
+    from geoparquet_io.core.duckdb_metadata import (
+        parse_geometry_logical_type,
+        resolve_crs_reference,
+    )
+
+    pf = pq.ParquetFile(parquet_file)
+    try:
+        schema = pf.metadata.schema
+        for i in range(len(schema)):
+            parsed = parse_geometry_logical_type(str(schema.column(i).logical_type))
+            if parsed:
+                return resolve_crs_reference(parquet_file, parsed.get("crs"))
+    finally:
+        pf.close()
+    return None
+
+
+@pytest.mark.parametrize("dim", list(_PROJECTED_WKT))
+@pytest.mark.parametrize("version", _WRITE_VERSIONS)
+def test_projected_crs_survives_every_dimension_and_version(dim, version, tmp_path, epsg_25830):
+    src = _wkb_source(tmp_path / "src.parquet", _PROJECTED_WKT[dim], epsg_25830)
+    out = tmp_path / f"out_{dim}_{version}.parquet"
+    convert_to_geoparquet(src, str(out), skip_hilbert=True, geoparquet_version=version)
+
+    col = _primary_col_meta(str(out))
+    assert "crs" in col, f"{dim} at {version}: geo block lost `crs` (reads as OGC:CRS84)"
+    assert col["crs"] is not None, f"{dim} at {version}: geo `crs` is null (unknown)"
+    assert col["crs"].get("id") == {"authority": "EPSG", "code": 25830}, col["crs"]
+
+
+@pytest.mark.parametrize("dim", list(_PROJECTED_WKT))
+def test_v2_geo_crs_agrees_with_parquet_logical_type(dim, tmp_path, epsg_25830):
+    """At 2.0 both halves of the file are authoritative; they must not disagree."""
+    src = _wkb_source(tmp_path / "src.parquet", _PROJECTED_WKT[dim], epsg_25830)
+    out = tmp_path / f"out_{dim}.parquet"
+    convert_to_geoparquet(src, str(out), skip_hilbert=True, geoparquet_version="2.0")
+
+    from geoparquet_io.core.validate import _crs_equals
+
+    schema_crs = _schema_crs(str(out))
+    assert schema_crs is not None, f"{dim}: native logical type carries no CRS"
+    assert _crs_equals(_primary_col_meta(str(out))["crs"], schema_crs)
+
+
+@pytest.mark.parametrize("dim", list(_PROJECTED_WKT))
+def test_v2_projected_output_passes_crs_and_range_validation(dim, tmp_path, epsg_25830):
+    from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+
+    src = _wkb_source(tmp_path / "src.parquet", _PROJECTED_WKT[dim], epsg_25830)
+    out = tmp_path / f"out_{dim}.parquet"
+    convert_to_geoparquet(src, str(out), skip_hilbert=True, geoparquet_version="2.0")
+
+    failed = [
+        f"{c.name}: {c.message}"
+        for c in validate_geoparquet(str(out)).checks
+        if c.status is CheckStatus.FAILED and ("crs" in c.name or "coordinate" in c.name)
+    ]
+    assert not failed, f"{dim}: {failed}"
+
+
+@pytest.mark.parametrize("dim", list(_PROJECTED_WKT))
+@pytest.mark.parametrize("version", _WRITE_VERSIONS)
+def test_crs84_input_still_omits_the_crs_key(dim, version, tmp_path):
+    """Absent *is* the spec spelling of OGC:CRS84 -- the repair must not invent one."""
+    wkt = _PROJECTED_WKT[dim].replace("440000 4470000", "1 2").replace("440010 4470000", "3 2")
+    wkt = wkt.replace("440010 4470010", "3 4")
+    src = _wkb_source(tmp_path / "src.parquet", wkt, None)
+    out = tmp_path / f"out_{dim}_{version}.parquet"
+    convert_to_geoparquet(src, str(out), skip_hilbert=True, geoparquet_version=version)
+
+    assert "crs" not in _primary_col_meta(str(out))
+
+
+def test_unresolvable_native_crs_becomes_explicit_null_not_the_default(tmp_path):
+    """A CRS reference that resolves to no PROJJSON must not read as OGC:CRS84.
+
+    Omitting the key would *mean* the default; an explicit null says "unknown",
+    which is what the file actually tells us.
+    """
+    from geoparquet_io.core.common import _crs_from_geo_logical
+
+    present, crs = _crs_from_geo_logical(
+        "Geometry(crs=projjson:absent_key)", str(tmp_path / "nonexistent.parquet")
+    )
+    assert (present, crs) == (True, None)


### PR DESCRIPTION
## What changed

DuckDB's V2 writer omits the `geo` key-value metadata for geometries carrying an M dimension, so gpio rebuilds the block from the file's own native geospatial statistics (`_ensure_v2_geo_metadata`, #589). That rebuild read the geometry types, the bbox and the Geography edges — and never the CRS. An absent `crs` is not a gap in GeoParquet, it *means* OGC:CRS84, so the output declared projected coordinates to be WGS84 lon/lat while the Parquet `GEOMETRY` logical type, written from the same source in the same COPY, still named EPSG:25830. XY and Z data never reach the rebuild, which is why only M and ZM were affected.

- **`core/common.py`** — new `_crs_from_geo_logical()`; `_geo_col_meta_from_stats()` now carries the CRS the logical type declares, which is the authority at 2.0. A default CRS stays omitted (that *is* how GeoParquet spells OGC:CRS84 — the fix does not start writing an explicit CRS84 key), and a reference that resolves to no PROJJSON becomes an explicit `"crs": null` (unknown) with a warning, rather than a silent CRS84 claim.
- **`core/duckdb_metadata.py`** — `parse_geometry_logical_type()` accepted only DuckDB's `GeometryType(...)` spelling. This path reads the schema through PyArrow, which renders `Geometry(...)`, so the CRS was invisible to it; the `Type` suffix is now optional. Also closes the `ParquetFile` that `resolve_crs_reference()` opens for a `projjson:` reference — callers resolve a CRS on the way to rewriting the file in place, and a lingering read handle makes `os.replace` fail on Windows.

Not changed: `convert` still exits 0 on a file that fails its own post-write validation. That is #705, and it stays there.

## Why

The file was internally contradictory, and each half is authoritative to a different reader: the `geo` block said CRS84, the Parquet schema said EPSG:25830. Nothing about the data looks wrong on inspection — the issue reports a 492,776-feature `Polygon ZM` dataset where the mislabelled CRS only surfaced three pipeline stages later, when a downstream tool range-checked the coordinates.

## Verification

The issue's reproducer verbatim (`ogr2ogr` was available, so no substitute input was needed): one-polygon `POLYGON M` CSV → shapefile in EPSG:25830 → `gpio convert geoparquet --geoparquet-version 2.0`.

**Before** (`gpio check spec`):

```
GeoParquet 2.0 Requirements:
  ✓ column "geom" uses required Parquet native geo type
  ✓ using default CRS (OGC:CRS84), no inline CRS required
  ✗ CRS in geo metadata must match CRS in Parquet schema
      Metadata: OGC:CRS84 (default), Schema: ETRS89 / UTM zone 30N (EPSG:25830)

Data Validation:
  ✗ coordinates outside valid range for CRS (1 checked)
      max_x=440010.0000 > 180.0; max_y=4470010.0000 > 90.0

Summary: 30 passed, 0 warnings, 2 failed
```

**After**:

```
Data Validation:
  ✓ coordinates appear valid for ETRS89 / UTM zone 30N (EPSG:25830) (1 checked)
GeoParquet 2.0 Requirements:
  ✓ column "geom" uses required Parquet native geo type
  ✓ non-default CRS is inline in Parquet geo type
  ✓ CRS in metadata matches CRS in Parquet schema

Summary: 32 passed, 0 warnings, 0 failed
```

Full dimension × version matrix, same one-polygon input, `<geo block crs>|<check spec failures>`:

```
== source CRS EPSG:25830 ==            BEFORE
dim  1.1                    1.1-geoarrow           2.0                    parquet-geo-only
XY   EPSG:25830|0fail       EPSG:25830|0fail       EPSG:25830|0fail       NO-GEO-KEY|0fail
Z    EPSG:25830|0fail       EPSG:25830|0fail       EPSG:25830|1fail       NO-GEO-KEY|0fail
M    EPSG:25830|0fail       EPSG:25830|0fail       absent(=CRS84)|2fail   NO-GEO-KEY|0fail
ZM   EPSG:25830|0fail       EPSG:25830|0fail       absent(=CRS84)|3fail   NO-GEO-KEY|0fail

== source CRS EPSG:25830 ==            AFTER
XY   EPSG:25830|0fail       EPSG:25830|0fail       EPSG:25830|0fail       NO-GEO-KEY|0fail
Z    EPSG:25830|0fail       EPSG:25830|0fail       EPSG:25830|1fail       NO-GEO-KEY|0fail
M    EPSG:25830|0fail       EPSG:25830|0fail       EPSG:25830|0fail       NO-GEO-KEY|0fail
ZM   EPSG:25830|0fail       EPSG:25830|0fail       EPSG:25830|1fail       NO-GEO-KEY|0fail

== source CRS EPSG:4326 (lon/lat coordinates) ==   AFTER
XY   absent(=CRS84)|0fail   absent(=CRS84)|0fail   EPSG:4326|0fail        NO-GEO-KEY|0fail
Z    absent(=CRS84)|0fail   absent(=CRS84)|0fail   EPSG:4326|1fail        NO-GEO-KEY|0fail
M    absent(=CRS84)|0fail   absent(=CRS84)|0fail   absent(=CRS84)|0fail   NO-GEO-KEY|0fail
ZM   absent(=CRS84)|0fail   absent(=CRS84)|0fail   absent(=CRS84)|1fail   NO-GEO-KEY|0fail
```

The `1fail` left on `Z` and `ZM` at 2.0 is **pre-existing and unrelated to the CRS**: it is `bbox_contains_data`, which rejects the six-element `[xmin, ymin, zmin, xmax, ymax, zmax]` bbox that a Z range produces. It is identical before and after this change, and it fails on plain `Z` data too — which never enters the code this PR touches. Not fixed here: it wants its own issue rather than being widened into this one.

New tests (`tests/test_v2_zm_geo_metadata.py`), parametrized over {XY, Z, M, ZM} × {1.1, 1.1-geoarrow, 2.0} on an EPSG:25830 source: the geo block names the source CRS; at 2.0 it agrees with the Parquet logical type (`_crs_equals`); `validate_geoparquet` reports no failed CRS or coordinate-range check. A CRS84 input case over the same matrix asserts the `crs` key stays *absent* — the spec spelling of the default. Plus a unit test that an unresolvable CRS reference becomes an explicit null.

Run against the pre-fix tree, 8 of these fail: M and ZM at 2.0 lose the CRS outright, and the logical-type agreement assertion fails for *every* dimension because PyArrow's `Geometry(...)` spelling did not parse. All 40 pass here.

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
5858 passed, 70 skipped, 1 xfailed in 150.54s

$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
geoparquet_io/core/common.py (100%)
geoparquet_io/core/duckdb_metadata.py (100%)
Total: 25 lines / Missing: 0 lines / Coverage: 100%

$ uv run pre-commit run --all-files                        # all passed
$ uv run pre-commit run --all-files --hook-stage pre-push  # deptry, mypy, vulture, xenon, import-linter all passed
```

## Relation to open work

#869 fixes a different CRS-on-2.0 defect — the in-memory and streaming write strategies typed the native geometry column from `input_crs`, which only a reprojection supplies. Same symptom class (`geo` block and logical type disagreeing at 2.0), different cause and different code: that one is about which CRS reaches the *type*, this one is about the M/ZM rebuild dropping the CRS from the *block*. Both touch `common.py`, but different functions (`_apply_geoparquet_metadata` there, `_ensure_v2_geo_metadata` here), so no duplicated change. #844/#881 touches `convert.py`/`crs_utils.py` for a verbose-note gap; untouched here.

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
