### PR TITLE
test(kdtree): pin '512 partitions', not bare digits a temp filename can contain

### DIFF
--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -212,7 +212,9 @@ class TestPartitionKDTree:
 
         assert result.exit_code == 0, result.output
         assert "Auto-selected 2 partitions" in result.output
-        assert "512" not in result.output
+        # "512" alone can appear by chance inside a random temp-file name in the
+        # output (it did, on CI); pin the failure shape, not the bare digits.
+        assert "512 partitions" not in result.output
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## What changed
The #813 auto-mode guard asserted `"512" not in result.output`. A random temp-file UUID containing `512` (e.g. `kdtree_enriched_…-9136-512efe0d381e_…`) made it fail — observed on PR #861's ubuntu/3.11 run, which is untouched WFS code. Pin the failure shape (`"512 partitions"`) instead of bare digits.

## Verification
The test passes locally; the flake mechanism is visible in the CI log's assertion message, where the matched `512` sits inside the temp path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS