### PR TITLE
chore(tests): bump geoparquet-testing to 0a78e0d; drop the fixed data/zm corpus-bug entries

### DIFF
--- a/tests/test_geoparquet_corpus.py
+++ b/tests/test_geoparquet_corpus.py
@@ -20,13 +20,11 @@ assumed to be gpio bugs. Confirmed gpio bugs are tracked in GitHub issues and
 appear here as KNOWN_VALIDATION_BUGS entries or xfail marks referencing the
 issue; they turn into hard failures/XPASS as fixes land.
 
-One corpus bug was found (CORPUS_BUG_FILES): the data/zm/ fixtures declare
-geometry_types ["LineString"] without the " Z"/" M"/" ZM" suffix the spec
-mandates for 3D/measured data ("a ' Z' suffix gets added", "It is expected
-that this field is strictly correct") — the very violation bad_data/
-zm-declared-xy-actual-xyz.parquet exists to test. Reported upstream; once a
-fixed corpus pin lands, test_validates_clean fails loudly on each stale entry
-so CORPUS_BUG_FILES gets cleaned up instead of masking future regressions.
+Corpus bugs go in CORPUS_BUG_FILES while they reproduce; once a fixed corpus
+pin lands, test_validates_clean fails loudly on each stale entry so the map
+gets cleaned up instead of masking future regressions. (The data/zm/
+geometry_types suffix bug found in July 2026 was fixed upstream in
+geoparquet-testing 87891e7 and its entries removed with the pin bump.)
 """
 
 import json
@@ -87,17 +85,7 @@ def test_corpus_tier_minimum_files(tier, minimum):
 # Fixtures that themselves violate the spec (upstream geoparquet-testing bugs).
 # test_validates_clean xfails while an entry still reproduces and fails hard
 # once it stops reproducing, forcing removal of stale entries after a pin bump.
-CORPUS_BUG_FILES = {
-    "data/zm/linestring-xyz-native-geometry.parquet": (
-        "corpus bug: declares ['LineString'] for XYZ data; spec requires 'LineString Z'"
-    ),
-    "data/zm/linestring-xym-native-geometry.parquet": (
-        "corpus bug: declares ['LineString'] for XYM data; spec requires 'LineString M'"
-    ),
-    "data/zm/linestring-xyzm-native-geometry.parquet": (
-        "corpus bug: declares ['LineString'] for XYZM data; spec requires 'LineString ZM'"
-    ),
-}
+CORPUS_BUG_FILES: dict[str, str] = {}
 
 
 def _corpus_files(*subdirs):
@@ -193,10 +181,6 @@ class TestValidFilesSpotChecks:
             ("linestring-xym-native-geometry.parquet", "XYM"),
             ("linestring-xyzm-native-geometry.parquet", "XYZM"),
         ],
-    )
-    @pytest.mark.xfail(
-        strict=False,
-        reason="corpus bug: gen_zm.py writes unsuffixed geometry_types (see CORPUS_BUG_FILES)",
     )
     def test_zm_dimensions_parsed(self, name, expected_dim):
         """Spec: 'a \" Z\" suffix gets added' and geometry_types is 'strictly correct'."""


### PR DESCRIPTION
The corpus fixed the `data/zm` `geometry_types` suffixes in geoparquet/geoparquet-testing@87891e7 (2026-07-21); our submodule pin `5799448` (2026-07-10) predates it. `git log 5799448..0a78e0d` shows that fix as the only change (three files).

With the fixed files, `test_validates_clean` fails loudly on each stale `CORPUS_BUG_FILES` entry, exactly as the test was designed to; this PR empties the map (keeping the mechanism and the docstring), removes the matching `xfail` on `test_zm_dimensions_parsed` (which now passes for real), and updates the module docstring.

Locally: `test_geoparquet_corpus.py`, `test_validate_v2_fixes.py`, `test_validate_review_fixes.py`, `test_native_geo_statistics.py`, `test_geo_metadata_parity.py` pass. Follows the correction posted on #879; the new fixtures proposed in geoparquet/geoparquet-testing#5 would need a further bump once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the geospatial test corpus to reflect corrected geometry type metadata.
  - Removed an expected-failure condition for Z/M dimension parsing; these fixtures now validate successfully.

- **Tests**
  - Updated corpus tracking and test documentation to reflect resolved upstream fixture issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->