### PR TITLE
feat(s2)!: bring S2 back by requiring duckdb>=1.5.5, where the geography extension is published

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,7 +48,7 @@ uv sync --all-extras
 
 - **Python**: 3.10+
 - **PyArrow**: 12.0.0+
-- **DuckDB**: 1.5.5+
+- **DuckDB**: >=1.5.5,<1.6 (the range the `geography` extension is published for)
 
 All dependencies are installed automatically.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,7 +48,7 @@ uv sync --all-extras
 
 - **Python**: 3.10+
 - **PyArrow**: 12.0.0+
-- **DuckDB**: 1.5.0+
+- **DuckDB**: 1.5.5+
 
 All dependencies are installed automatically.
 

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -1123,7 +1123,7 @@ def _convert_csv_path(
     # the optimizer, causing repeated re-evaluation when downstream metadata
     # queries (ST_GeometryType, ST_XMin, etc.) wrap the query. Materializing
     # parses CSV once and eliminates the unsafe TRY() re-evaluation.
-    # pyproject now floors DuckDB at 1.5.2, which does not have that bug, so
+    # pyproject now floors DuckDB at 1.5.5, which does not have that bug, so
     # this full materialization is pure overhead on every supported version.
     # Left in place deliberately: removing it needs its own benchmarking.
     if skip_invalid and geom_info["type"] == "wkt":

--- a/geoparquet_io/core/exceptions.py
+++ b/geoparquet_io/core/exceptions.py
@@ -167,11 +167,12 @@ def is_unpublished_extension_error(exc: BaseException | str | None) -> bool:
 # cannot say.
 _UNPUBLISHED_EXTENSION_HINTS = {
     "geography": (
-        "'geography' is published for every DuckDB gpio supports, so this is "
-        "almost always the download failing rather than a missing build: check "
-        "network access to community-extensions.duckdb.org (proxy, firewall, "
-        "offline). For a hierarchical cell index meanwhile, use `gpio add a5` "
-        "or `gpio partition a5`."
+        "'geography' is published for gpio's whole DuckDB range on mainstream "
+        "platforms (Linux/macOS amd64+arm64, Windows amd64), so a 404 here "
+        "means a platform the registry carries no community builds for "
+        "(Windows ARM, musl/Alpine, a source-built DuckDB) or a proxy "
+        "answering in the registry's place. For a hierarchical cell index "
+        "meanwhile, use `gpio add a5` or `gpio partition a5`."
     ),
 }
 

--- a/geoparquet_io/core/exceptions.py
+++ b/geoparquet_io/core/exceptions.py
@@ -167,10 +167,11 @@ def is_unpublished_extension_error(exc: BaseException | str | None) -> bool:
 # cannot say.
 _UNPUBLISHED_EXTENSION_HINTS = {
     "geography": (
-        "'geography' is published for the newest DuckDB in gpio's supported "
-        "range but not for every older patch release in it, so upgrading DuckDB "
-        "is usually the fix. For a hierarchical cell index that works meanwhile, "
-        "use `gpio add a5` or `gpio partition a5`."
+        "'geography' is published for every DuckDB gpio supports, so this is "
+        "almost always the download failing rather than a missing build: check "
+        "network access to community-extensions.duckdb.org (proxy, firewall, "
+        "offline). For a hierarchical cell index meanwhile, use `gpio add a5` "
+        "or `gpio partition a5`."
     ),
 }
 

--- a/geoparquet_io/core/geometry_repair.py
+++ b/geoparquet_io/core/geometry_repair.py
@@ -60,8 +60,8 @@ def _layered_invalid_count_sql(source_sql: str, parsed_expr: str) -> str:
     one WHERE clause segfaults DuckDB <= 1.5.1's spatial extension when the
     column contains NULLs: its TRY() applies the selection vector twice under
     conditional execution, reading uninitialized vector memory (issues #642 and
-    #737; fixed in DuckDB 1.5.2 — duckdb/duckdb-spatial#858 — which pyproject
-    now requires). Verified on issue #642's reproduction: projecting the parsed
+    #737; fixed in DuckDB 1.5.2 — duckdb/duckdb-spatial#858 — well below the
+    pyproject floor). Verified on issue #642's reproduction: projecting the parsed
     geometry first, filtering NULLs in a middle layer, and running
     ``ST_IsValid`` outermost is logically identical and crash-free.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,20 +29,22 @@ dependencies = [
     "click>=8.0.0",
     "click-plugins>=1.1.1",  # Plugin system for extending CLI
     "pyarrow>=23.0.1",  # PYSEC-2026-113 fix
-    # Floor at 1.5.2: DuckDB <= 1.5.1 applies the selection vector twice in TRY()
-    # under conditional execution (duckdb/duckdb-spatial#858), so TRY() over a
-    # blob segfaults and over a fixed-width type can silently return another
-    # row's value. That crashed geometry repair on ordinary extractions (#737)
-    # and is why core/geometry_repair.py counts invalid geometry in layers (#645).
+    # Floor at 1.5.5: it is the DuckDB release the 'geography' community
+    # extension is published for, so S2 (`gpio add s2`, `gpio partition s2`)
+    # works on every supported version rather than only some of them (#737).
+    # The floor also has to stay above 1.5.1, which applies the selection vector
+    # twice in TRY() under conditional execution (duckdb/duckdb-spatial#858):
+    # TRY() over a blob segfaults and over a fixed-width type can silently
+    # return another row's value, crashing geometry repair on ordinary
+    # extractions (#737) and why core/geometry_repair.py counts invalid
+    # geometry in layers (#645).
     #
-    # The floor briefly cost S2: the 'geography' community extension would not
-    # build past DuckDB 1.5.1 (a plan_serializer link error). That was fixed
-    # upstream and 'geography' is published for DuckDB 1.5.5 -- what uv.lock
-    # resolves -- so `gpio add s2` / `gpio partition s2` work again (#737).
-    # Community extensions are built per DuckDB release, so a hand-pinned
-    # 1.5.2-1.5.4 still has no build; core/duckdb_utils.require_community_extension
-    # fails fast and says so.
-    "duckdb>=1.5.2,<1.6",
+    # The <1.6 cap is unchanged from #778. Keeping it is what makes the S2
+    # claim above hold: community extensions are built per DuckDB release, so
+    # if 1.6 ships before 'geography' is published for it, an uncapped range
+    # would let `uv sync` pull a DuckDB that silently breaks S2. Lift it in a
+    # deliberate step once 1.6 exists and the extension is published for it.
+    "duckdb>=1.5.5,<1.6",
     "pandas>=1.0.0",
     "fsspec>=2023.9.0",
     "rich>=13.0.0",

--- a/scripts/release_title_overrides.json
+++ b/scripts/release_title_overrides.json
@@ -22,5 +22,6 @@
   "656": "fix(convert): keep CSV rows whose geometry is NULL",
   "669": "build(deps): raise the pip floor to 26.2 for PYSEC-2026-3721",
   "778": "fix(deps)!: require duckdb>=1.5.2 and withdraw S2 until the geography extension returns",
-  "841": "fix(api)!: return the same dict from partition_by_admin as the other partition methods"
+  "841": "fix(api)!: return the same dict from partition_by_admin as the other partition methods",
+  "860": "docs: S2 is available again -- the geography extension is published for DuckDB 1.5.5"
 }

--- a/tests/test_core_exceptions.py
+++ b/tests/test_core_exceptions.py
@@ -67,18 +67,16 @@ class TestCoreExceptions:
     def test_geography_hint_offers_a5_and_never_a_forbidden_downgrade(self):
         """The 404 branch must be actionable without violating the pin (#778).
 
-        'geography' is published again for the newest DuckDB in gpio's supported
-        range (1.5.5, what uv.lock resolves), but not for every older patch
-        release — so a 404 can still mean the registry has no build for a
-        hand-pinned older DuckDB. Either way the hint must
-        not tell a user to install duckdb 1.5.1: pyproject requires >=1.5.2, so
-        that leaves `uv pip check` failing and any `uv sync` silently reverting
-        it. `gpio add a5` is the substitute that works without S2.
+        The floor is duckdb>=1.5.5, the release 'geography' is published for,
+        so a 404 now points at this machine rather than at the registry. Either
+        way the hint must not tell a user to install duckdb 1.5.1: that is below
+        the floor, so it leaves `uv pip check` failing and any `uv sync`
+        silently reverting it. `gpio add a5` is the substitute without S2.
         """
         message = str(ExtensionUnavailableError("geography", "1.5.5", _NOT_PUBLISHED))
 
         assert "a5" in message
-        assert "upgrading DuckDB" in message
+        assert "published for every DuckDB gpio supports" in message
         assert "is not published for this one" in message
         # Never recommend a DuckDB the pin forbids.
         assert "duckdb==1.5.1" not in message
@@ -95,7 +93,7 @@ class TestCoreExceptions:
         """
         message = str(ExtensionUnavailableError("geography", "1.5.5", _OFFLINE))
 
-        assert "upgrading DuckDB" not in message
+        assert "published for every DuckDB gpio supports" not in message
         assert "is not published for this one" not in message
         assert "reachable" in message
         assert "proxy" in message
@@ -111,13 +109,13 @@ class TestCoreExceptions:
 
         assert "may not be published" in message
         assert "proxy" not in message
-        assert "upgrading DuckDB" not in message
+        assert "published for every DuckDB gpio supports" not in message
 
     def test_extension_unavailable_error_hint_is_extension_specific(self):
         """Other community extensions must not inherit the geography guidance."""
         message = str(ExtensionUnavailableError("h3", "1.5.5", _NOT_PUBLISHED))
 
-        assert "upgrading DuckDB" not in message
+        assert "published for every DuckDB gpio supports" not in message
         assert "a5" not in message
         assert "h3" in message
 

--- a/tests/test_core_exceptions.py
+++ b/tests/test_core_exceptions.py
@@ -47,16 +47,16 @@ class TestCoreExceptions:
 
     def test_extension_unavailable_error(self):
         """ExtensionUnavailableError names the extension and DuckDB version (issue #491)."""
-        exc = ExtensionUnavailableError("geography", "1.5.4")
+        exc = ExtensionUnavailableError("geography", "1.5.5")
         assert isinstance(exc, GeoParquetError)
         assert exc.name == "geography"
-        assert exc.duckdb_version == "1.5.4"
+        assert exc.duckdb_version == "1.5.5"
         message = str(exc)
         assert "geography" in message
-        assert "1.5.4" in message
+        assert "1.5.5" in message
 
     def test_extension_unavailable_error_with_detail(self):
-        exc = ExtensionUnavailableError("geography", "1.5.4", "HTTP 404")
+        exc = ExtensionUnavailableError("geography", "1.5.5", "HTTP 404")
         assert "HTTP 404" in str(exc)
 
     def test_extension_unavailable_error_names_the_feature(self):
@@ -67,17 +67,23 @@ class TestCoreExceptions:
     def test_geography_hint_offers_a5_and_never_a_forbidden_downgrade(self):
         """The 404 branch must be actionable without violating the pin (#778).
 
-        The floor is duckdb>=1.5.5, the release 'geography' is published for,
-        so a 404 now points at this machine rather than at the registry. Either
-        way the hint must not tell a user to install duckdb 1.5.1: that is below
-        the floor, so it leaves `uv pip check` failing and any `uv sync`
-        silently reverting it. `gpio add a5` is the substitute without S2.
+        The floor is duckdb>=1.5.5, the release 'geography' is published for
+        on mainstream platforms, so a 404 now points at a platform the
+        registry has no builds for (Windows ARM, musl, source builds) or an
+        intercepting proxy — not at the version, and not primarily at this
+        machine's network. Either way the hint must not tell a user to
+        install duckdb 1.5.1: that is below the floor, so it leaves
+        `uv pip check` failing and any `uv sync` silently reverting it.
+        `gpio add a5` is the substitute without S2.
         """
         message = str(ExtensionUnavailableError("geography", "1.5.5", _NOT_PUBLISHED))
 
         assert "a5" in message
-        assert "published for every DuckDB gpio supports" in message
+        assert "mainstream platforms" in message
+        assert "no community builds" in message
         assert "is not published for this one" in message
+        # The 404 branch must not repeat the connectivity branch's diagnosis.
+        assert "check network access" not in message
         # Never recommend a DuckDB the pin forbids.
         assert "duckdb==1.5.1" not in message
         assert "pip install" not in message

--- a/tests/test_duckdb_utils.py
+++ b/tests/test_duckdb_utils.py
@@ -299,9 +299,9 @@ class TestDuckDBVersionFloor:
         it -- only the version floor prevents it.
         """
         version = tuple(int(part) for part in duckdb.__version__.split(".")[:3])
-        assert version >= (1, 5, 2), (
+        assert version >= (1, 5, 5), (
             f"DuckDB {duckdb.__version__} segfaults in geometry repair (#737); "
-            f"pyproject requires >= 1.5.2"
+            f"pyproject requires >= 1.5.5"
         )
 
     # A behavioural probe would be better than the version string above, which is

--- a/tests/test_native_geo_statistics.py
+++ b/tests/test_native_geo_statistics.py
@@ -5,7 +5,7 @@ GEOMETRY column on Windows: pyarrow writing them, or DuckDB's
 ``parquet_metadata()`` reading them. These tests answered it — the reader, and
 only on DuckDB <= 1.5.1, which reported [0, 0, 0, 0] on Windows for a
 pyarrow-written file whose statistics pyarrow read back correctly from those
-same bytes. gpio's floor is now ``duckdb>=1.5.2`` (#737, taken for an unrelated
+same bytes. gpio's floor is now ``duckdb>=1.5.5`` (#737, taken for an unrelated
 segfault), and on that floor Windows reads them correctly.
 
 The watch is what caught it. These assertions carried a *strict* xfail on

--- a/tests/test_s2_extension_preflight.py
+++ b/tests/test_s2_extension_preflight.py
@@ -1,15 +1,12 @@
 """S2 commands check for the 'geography' extension before doing any work (#737).
 
-The `geography` community extension is published again for the newest DuckDB in
-gpio's supported range (1.5.5, what uv.lock resolves), so S2 works out of the
-box — but not for every older patch release. The guard still matters: a
-community extension is downloaded on first use, so an offline machine, a proxy,
-or a hand-pinned DuckDB the registry has no artifact for can still leave it
-unloadable.
-When that happens every S2 entry point must fail immediately, with an actionable
-message, rather than reading the input and failing deep in the pipeline. These
-tests mock the extension load to fail, so they exercise the guard regardless of
-whether the extension is installable here.
+The `geography` community extension is published for every DuckDB gpio supports
+-- that is why the floor is duckdb>=1.5.5 -- so S2 works out of the box. The
+guard still matters: a community extension is downloaded on first use, so an
+offline machine, a proxy or a firewall can still leave it unloadable. When that
+happens every S2 entry point must fail immediately, with an actionable message,
+rather than reading the input and failing deep in the pipeline. These tests mock
+the extension load to fail, so they exercise the guard either way.
 """
 
 from pathlib import Path

--- a/tests/test_streaming_write_determinism.py
+++ b/tests/test_streaming_write_determinism.py
@@ -150,7 +150,7 @@ def _failed_checks(path: str) -> list[str]:
 
     The `native_geo_stats_contains_data_*` checks used to be excused on win32:
     DuckDB <= 1.5.1 misread the geospatial statistics of a native GEOMETRY
-    column there (#721). gpio now floors DuckDB at 1.5.2, which reads them
+    column there (#721). gpio now floors DuckDB at 1.5.5, which reads them
     correctly, so nothing is excused any more.
     """
     result = validate_geoparquet(path)

--- a/tests/test_write_contract.py
+++ b/tests/test_write_contract.py
@@ -418,7 +418,7 @@ def assert_valid_geoparquet_output(path: str, expect: Expect) -> list[str]:
 
     result = validate_geoparquet(path, validate_data=True, sample_size=0)
     # No platform is excused: DuckDB <= 1.5.1 misread native-geo statistics on
-    # Windows (#721), but gpio now floors DuckDB at 1.5.2, which reads them
+    # Windows (#721), but gpio now floors DuckDB at 1.5.5, which reads them
     # correctly, so the oracle is enforced everywhere.
     return [c.name for c in result.checks if c.status == CheckStatus.FAILED]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1429,7 +1429,7 @@ requires-dist = [
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.0" },
-    { name = "duckdb", specifier = ">=1.5.2,<1.6" },
+    { name = "duckdb", specifier = ">=1.5.5,<1.6" },
     { name = "fiona", marker = "extra == 'benchmark'", specifier = ">=1.9.0" },
     { name = "fsspec", specifier = ">=2023.9.0" },
     { name = "geoarrow-pyarrow", specifier = ">=0.1.0" },


### PR DESCRIPTION
Follow-up to #860 (merged as `b424aa7`), which removed the "S2 is unavailable" caveats. That PR's claim was true for the DuckDB `uv.lock` resolves, but not for the whole supported range. This makes it unconditional.

**Why this is `feat` and not `fix(deps)`:** for anyone on duckdb 1.5.2–1.5.4, S2 does not work today and starts working after this change. That is a capability arriving, so it belongs under Added.

Refs #737, #778, #733, #790. `CHANGELOG.md` untouched.

## What changed

**The floor — the substance of this PR**

`pyproject.toml`: `duckdb>=1.5.2,<1.6` → `duckdb>=1.5.5,<1.6`.

The `geography` community extension is built per DuckDB release and is published for **1.5.5 only** within the old range. Probed directly:

```
v1.5.5/linux_amd64   -> 200      v1.5.4/linux_amd64 -> 404
v1.5.5/linux_arm64   -> 200      v1.5.3/linux_amd64 -> 404
v1.5.5/osx_amd64     -> 200      v1.5.2/linux_amd64 -> 404
v1.5.5/osx_arm64     -> 200      v1.5.4/osx_arm64   -> 404
v1.5.5/windows_amd64 -> 200
```

So `>=1.5.2` let a user land on a DuckDB where `gpio add s2` still fails, while the docs (post-#860) say it works. Raising the floor to 1.5.5 makes the claim true for every version gpio supports.

**Impact on users:** anyone pinned to duckdb 1.5.2–1.5.4 gets a **patch-level duckdb upgrade** on their next `uv sync` / `pip install -U`. 1.5.5 is the current latest release (PyPI shows no 1.5.6 or 1.6), so for almost everyone this is a no-op — `uv.lock` already resolved 1.5.5.

**`uv.lock` — yes, it changed, but only the recorded specifier.** One line, no package churn, because the resolution was already 1.5.5:

```diff
-    { name = "duckdb", specifier = ">=1.5.2,<1.6" },
+    { name = "duckdb", specifier = ">=1.5.5,<1.6" },
```

**Docs and the guard hint, now unconditional**

- `geoparquet_io/core/exceptions.py` — the geography 404 hint no longer talks about DuckDB versions. Since the floor guarantees a DuckDB the extension is published for, a 404 now means the *download* failed, so the hint points at network access to `community-extensions.duckdb.org` (proxy, firewall, offline) and offers `gpio add a5` meanwhile. **The guard itself is unchanged** — it is still correct and still fires.
- `docs/getting-started/installation.md` — the Requirements list said **DuckDB 1.5.0+**, which was already stale under the old 1.5.2 floor. Now 1.5.5+.

## The `<1.6` cap: kept, and here is the evidence

**I did not introduce it.** It is pre-existing on `main`, added by #778 (`1cb40ab`) — the same PR that set the 1.5.2 floor, whose message reads "Floor the dependency at duckdb>=1.5.2,<1.6". This PR moves only the lower bound; the cap is carried through untouched.

```
$ git log --oneline -S"<1.6" -- pyproject.toml
1cb40ab fix(deps): require duckdb>=1.5.2 and guard S2 on the geography extension (#778)
```

Beyond being the status quo, it is now **load-bearing for this PR's own claim**. Community extensions are built per DuckDB release. If 1.6 ships before `geography` is published for it, an uncapped range would let `uv sync` pull a DuckDB with no geography build and silently break S2 — exactly the failure this PR exists to close. DuckDB 1.6 does not exist yet (PyPI latest: 1.5.5), so the cap blocks nothing today.

I have recorded that reasoning in the pyproject comment rather than leaving it bare. If you would still rather drop it, that is a deliberate policy change about a version that does not exist yet, and I would rather not smuggle it into an S2 PR — happy to do it as a one-line follow-up.

For completeness: no other runtime dependency carries an upper cap (`tomli` has only a `python_version` marker, not a version ceiling), so this is a DuckDB-specific choice, not a project-wide convention.

## Per-file verdict on the non-docs files

To be direct: these are **not** version-conditional workarounds becoming dead code. I checked for that specifically — the codebase has exactly one version-conditional site, and it is the floor test itself:

```
$ grep -rn "duckdb.__version__" geoparquet_io/ tests/ | grep -v "ExtensionUnavailableError\|benchmark\|conftest"
tests/test_duckdb_utils.py:301:  version = tuple(int(part) for part in duckdb.__version__.split(".")[:3])
```

Five of the six files are text-only; one is the floor assertion. Nothing is deleted, and no runtime behaviour changes.

| File | What it was | Verdict |
|---|---|---|
| `core/convert.py` | **Comment only.** `# pyproject now floors DuckDB at 1.5.2` → `1.5.5`. The CSV `CREATE TEMP TABLE` materialization it describes is untouched — the very next line says "Left in place deliberately: removing it needs its own benchmarking." | **Keep.** Quotes the floor value; zero behaviour change. |
| `core/geometry_repair.py` | **Docstring only.** "fixed in DuckDB 1.5.2 … which pyproject now requires" → "… well below the pyproject floor". 1.5.2 is still the fix version; it is just no longer the floor, so the old phrasing became false. The layered SQL is untouched. | **Keep.** Zero behaviour change. |
| `tests/test_native_geo_statistics.py` | **Module docstring only.** "gpio's floor is now ``duckdb>=1.5.2``" → `1.5.5`. | **Keep.** Text. |
| `tests/test_streaming_write_determinism.py` | **Function docstring only.** "gpio now floors DuckDB at 1.5.2" → `1.5.5`. | **Keep.** Text. |
| `tests/test_write_contract.py` | **Inline comment only.** Same sentence, same edit. | **Keep.** Text. |
| `tests/test_duckdb_utils.py` | **The one behaviour change.** `TestDuckDBVersionFloor` asserts the installed DuckDB meets the pyproject floor: `assert version >= (1, 5, 2)` → `(1, 5, 5)`. | **Keep — required.** Leaving it at 1.5.2 would let the test pass on a DuckDB below the new floor, i.e. it would stop testing the thing it is named for. |
| `tests/test_core_exceptions.py`, `tests/test_s2_extension_preflight.py` | Re-pin the assertions and docstrings that quote the guard hint text I changed. | **Keep.** Required by the hint edit. |

If you disagree with any of these, the five text-only ones can be dropped with no functional effect; the `test_duckdb_utils.py` one cannot, without the floor test going stale.

## Verification

```
$ uv sync --all-extras
Installed 1 package in 1ms

$ uv pip check --python .venv/bin/python
Checked 200 packages in 4ms
All installed packages are compatible

$ uv run python -c "import duckdb; print(duckdb.__version__)"
1.5.5

$ grep -n 'duckdb>=' pyproject.toml
47:    "duckdb>=1.5.5,<1.6",
```

(`uv pip check` needs the explicit `--python`: bare, it inspects the ambient conda env, not this project's venv.)

**S2 end to end**

```
$ uv run gpio add s2 tests/data/canonical/places.parquet s2rebased.parquet
Adding S2 column 's2_cell' (level 13)...
Processing 766 features...
Successfully added S2 column 's2_cell' (level 13) to: .../s2rebased.parquet
EXIT=0
```

**Meta lane** (validate-claude-md, doc-sync, sync-dependencies, mypy, codespell, mutmut, commitizen)

```
$ uv run pytest -m meta -q
202 passed, 6931 deselected in 11.26s
```

**S2 and guard tests**

```
$ uv run pytest tests/test_s2_extension_preflight.py tests/test_spatial_index_family.py \
    tests/test_sub_partition.py tests/test_api.py tests/test_core_exceptions.py \
    tests/test_duckdb_utils.py -q -rs
544 passed, 2 skipped in 35.43s
SKIPPED [2] tests/conftest.py:614: DuckDB community extension 'geography' (S2) is
published for DuckDB 1.5.5, so S2 no longer raises
```

The 2 skips are `skip_if_geography_available`, the deliberate mirror that retires the "S2 raises" assertions now that S2 works. The guard is still exercised: the 6 preflight tests mock the extension load to raise and assert the fail-fast path.

**Docs harness, three guide pages**

```
$ uv run pytest -m docs_example docs/guide/add.md docs/guide/partition.md \
    docs/guide/sub-partitioning.md -q -rfs
16 failed, 50 passed, 21 skipped in 1639.08s (0:27:19)
```

No geography-named skip remains, and every live S2 fence passes:

```
$ uv run pytest -m docs_example <the 8 S2 fences> -v
docs/guide/add.md::guide/add::md:L190[bash] PASSED                       [ 12%]
docs/guide/add.md::guide/add::md:L202[python] PASSED                     [ 25%]
docs/guide/add.md::guide/add::md:L220[bash] PASSED                       [ 37%]
docs/guide/partition.md::guide/partition::md:L257[bash] PASSED           [ 50%]
docs/guide/partition.md::guide/partition::md:L316[bash] PASSED           [ 62%]
docs/guide/partition.md::guide/partition::md:L332[python] PASSED         [ 75%]
docs/guide/sub-partitioning.md::guide/sub-partitioning::md:L135[bash] PASSED [ 87%]
docs/guide/sub-partitioning.md::guide/sub-partitioning::md:L140[python] PASSED [100%]
============================== 8 passed in 10.56s ==============================
```

**The 16 failures are pre-existing on `main` and cannot be caused by this diff — it touches no guide page at all:**

```
$ git diff --name-only origin/main | grep -c "docs/guide/"
0
```

Every one is a `gpio add admin-divisions` / `gpio partition admin` fence that downloads the GAUL/Overture boundary datasets (a 724 MB fetch). Causes observed across runs: `timed out after 120s` and `IO Error: Could not resolve hostname … data.source.coop`. The count varies run to run (12 → 16 on identical content), which is what a network-bound suite looks like on a slow link. Worth its own issue; not this PR.

**Repo gates**

```
$ uv run pre-commit run --all-files                       # 20 hooks — all Passed
$ uv run pre-commit run --all-files --hook-stage pre-push # deptry, mypy, vulture, xenon,
                                                          # import-linter, menard-check,
                                                          # fast-tests — all Passed
```

## CI

Nothing further needed. #860 already added `INSTALL geography FROM community` to the "Pre-install DuckDB extensions" step in all three jobs, so the download shares the existing 5-attempt retry-with-backoff. The CDN probe above confirms artifacts exist for every runner platform at 1.5.5, including `windows_amd64`, so the unconditional pre-install is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013chA7FNLsnXBhwwxUYfuhV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Raised the minimum supported DuckDB version to 1.5.5 while retaining support below version 1.6.
  - Updated installation guidance and compatibility checks to reflect the new requirement.

- **Bug Fixes**
  - Improved geography extension error guidance: installation failures now point users toward network access issues when the extension is unavailable, rather than recommending a DuckDB upgrade.

- **Documentation**
  - Updated compatibility notes and troubleshooting guidance across the project to reflect current DuckDB and geography extension support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->