### PR TITLE
test(docs-harness): keep network-only guide fences out of the default lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,11 @@ not all: commitizen is a `commit-msg`-stage hook and mutmut has no hook, so
 | `@pytest.mark.docs_example` | a fenced example block executed out of docs/guide/*.md |
 <!-- END GENERATED: test-markers -->
 
+Run the docs lane as `uv run pytest docs/guide -n 4 -m "not network"`. The bare
+form also collects the 29 `network` blocks, which each download hundreds of MB
+of administrative boundaries from a live service — they belong to the network CI
+lane, and locally they time out and read as a flaky docs lane.
+
 ---
 
 ## Code Quality

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -138,6 +138,11 @@ to the next person.
 uv run pytest docs/guide -n 4 -m "not network"   # run the guides' examples
 ```
 
+Keep the `-m "not network"`. Without it the run also picks up the 29 blocks
+marked `network`, each of which downloads hundreds of megabytes of
+administrative boundaries from a live service; they belong to the network CI
+lane, and locally they mostly just time out.
+
 ## Code Quality
 
 `.pre-commit-config.yaml` is the **single source of truth** for every quality

--- a/docs/guide/partition.md
+++ b/docs/guide/partition.md
@@ -787,6 +787,7 @@ output/
 
 Add `--prefix NAME` to prepend a custom prefix to partition filenames:
 
+<!-- doctest: network -->
 ```bash
 # Standard: fields_USA.parquet, fields_Kenya.parquet
 gpio partition admin input.parquet output/ --dataset gaul --levels country --prefix fields

--- a/tests/docs_examples/README.md
+++ b/tests/docs_examples/README.md
@@ -9,6 +9,12 @@ uv run pytest "docs/guide/sort.md"               # one page
 uv run pytest "docs/guide/sort.md::guide/sort.md:L14[bash]"   # one block
 ```
 
+**Keep the `-m "not network"`.** Dropping it adds 29 blocks that download
+hundreds of megabytes of administrative boundaries from live services. Those
+belong to the network CI lane; run without the filter and you get a dozen or so
+timeouts whose count drifts with the state of your boundary cache, which looks
+like a flaky docs lane and is not.
+
 Each block runs in its own throwaway directory, seeded from
 `tests/data/canonical/` under the placeholder names the guides already use —
 `input.parquet`, `data.parquet`, `buildings.parquet`, `places.geojson`,
@@ -31,7 +37,7 @@ gpio add bbox s3://bucket/in.parquet s3://bucket/out.parquet
 | Directive | Effect |
 |---|---|
 | `skip="reason"` | Not executed. **The reason is required** and must be true of the whole fence. |
-| `network` | Runs only in the network CI lane (`-m network`). |
+| `network` | Runs only in the network CI lane (`-m network`), with a 600 s block timeout instead of the usual 120 s — a boundary download cannot finish in two minutes. Required on any fence that needs the internet; the meta-test checks the known ones. |
 | `slow` / `fast` | Force the block out of / into the fast suite, whatever page it is on. |
 | `needs-tippecanoe` | Skipped when `tippecanoe` is not installed. Use it for anything piping to tippecanoe or calling `gpio pmtiles`. |
 | `needs-ogr` | Skipped when `ogr2ogr` is not installed. |
@@ -53,6 +59,9 @@ Combine with commas: `<!-- doctest: network, setup="gpio add bbox in.parquet out
 - a directive is misspelled or malformed;
 - a block is skipped without a reason;
 - a command-shaped snippet hides in a prose fence with no directive;
+- a fence runs a command that cannot work without the internet (`gpio add
+  admin-divisions`, `gpio partition admin`, `gpio process aggregate admin`,
+  `--dataset gaul`, a `source.coop` URL, …) without `network` or `skip`;
 - the number of opted-out blocks drifts past the agreed ceiling.
 
 `tests/test_docs_examples_coverage.py` (slow lane) adds the expensive one: it

--- a/tests/docs_examples/collector.py
+++ b/tests/docs_examples/collector.py
@@ -39,6 +39,16 @@ FAST_PAGES = frozenset({"sort.md", "piping.md", "check.md"})
 #: prompting or hanging command from wedging CI, not to police runtimes.
 BLOCK_TIMEOUT_SECONDS = 120
 
+#: Ceiling for a ``network``-marked example, which has to finish a real download
+#: before it can run anything. The largest of these is the GAUL boundary
+#: dataset at ~724 MB: at a pessimistic-but-plausible 2 MB/s that is six
+#: minutes, so 120 s could never have been enough and the block could only ever
+#: time out (#894). 600 s clears that fetch with headroom while still capping a
+#: genuinely wedged command. It applies only to blocks that opted into the
+#: network lane; every other block keeps the 120 s default, so a hanging local
+#: example still fails fast.
+NETWORK_BLOCK_TIMEOUT_SECONDS = 600
+
 
 def find_bash() -> str | None:
     """Locate a bash that can actually run scripts, or ``None``.
@@ -145,7 +155,7 @@ class DocExampleItem(pytest.Item):
                 capture_output=True,
                 encoding="utf-8",
                 errors="replace",
-                timeout=BLOCK_TIMEOUT_SECONDS,
+                timeout=block_timeout(self.block),
                 check=False,
             )
         except subprocess.TimeoutExpired as exc:
@@ -193,12 +203,31 @@ class DocExampleFailure(Exception):
             parts += ["", "--- stdout ---", _tail(self.stdout)]
         if self.stderr.strip():
             parts += ["", "--- stderr ---", _tail(self.stderr)]
-        parts += [
-            "",
-            "Fix the example, or mark it in the doc with an HTML comment on the",
-            'line above the fence, e.g. <!-- doctest: skip="needs credentials" -->.',
-        ]
+        parts += ["", *self._advice()]
         return "\n".join(parts)
+
+    def _advice(self) -> list[str]:
+        """Closing lines: what the reader should actually do about this failure.
+
+        A network block failing is usually not a documentation error — it is a
+        real download that did not happen — so say that instead of pointing at
+        the doc, which has sent more than one reader hunting for a broken
+        example that was fine (#894).
+        """
+        if not self.block.directives.network:
+            return [
+                "Fix the example, or mark it in the doc with an HTML comment on the",
+                'line above the fence, e.g. <!-- doctest: skip="needs credentials" -->.',
+            ]
+        return [
+            "This block is marked <!-- doctest: network -->: it needs the internet",
+            "and a real download (the boundary datasets run to hundreds of MB), so",
+            "it runs only in the network lane and only against live third-party",
+            "services. A failure here usually means the download was slow, blocked",
+            "or unavailable — not that the documented command is wrong. Check the",
+            "network before editing the doc, and note that the whole docs lane is",
+            'meant to be run as -m "docs_example and not network".',
+        ]
 
 
 #: Shell syntax that makes "one line, one independent command" untrue. A menu
@@ -261,6 +290,17 @@ def check_menu_is_splittable(source: str) -> str | None:
             f"({match.group(0).strip()!r}); the lines are a script, not a menu"
         )
     return None
+
+
+def block_timeout(block: Block) -> int:
+    """Seconds this block gets before it is killed.
+
+    A module-level function rather than a method so the choice is testable
+    without building a pytest item around a fence.
+    """
+    if block.directives.network:
+        return NETWORK_BLOCK_TIMEOUT_SECONDS
+    return BLOCK_TIMEOUT_SECONDS
 
 
 def _is_slow(block: Block) -> bool:

--- a/tests/test_docs_examples_harness.py
+++ b/tests/test_docs_examples_harness.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 import pytest
 
 from tests.docs_examples.collector import (
+    BLOCK_TIMEOUT_SECONDS,
+    NETWORK_BLOCK_TIMEOUT_SECONDS,
+    DocExampleFailure,
+    block_timeout,
     check_menu_is_splittable,
     menu_refusal_reason,
     split_statements,
@@ -217,6 +221,43 @@ def test_menu_on_a_plain_bash_list_is_allowed():
 
 def test_menu_refusal_is_none_without_the_directive():
     assert menu_refusal_reason("bash", "for f in *; do :; done", parse_directives("slow")) is None
+
+
+def _block(tmp_path, directive: str):
+    """One bash block carrying ``directive``, parsed the way the collector sees it."""
+    comment = f"<!-- doctest: {directive} -->\n" if directive else ""
+    page = _write(
+        tmp_path, "t.md", f"{comment}```bash\ngpio partition admin input.parquet out/\n```\n"
+    )
+    (block,) = iter_blocks(page, tmp_path)
+    return block
+
+
+def test_network_blocks_get_the_longer_timeout(tmp_path):
+    """120 s cannot cover a 724 MB boundary download; the network lane gets 600 s."""
+    assert block_timeout(_block(tmp_path, "network")) == NETWORK_BLOCK_TIMEOUT_SECONDS
+    assert NETWORK_BLOCK_TIMEOUT_SECONDS > BLOCK_TIMEOUT_SECONDS
+
+
+def test_ordinary_blocks_keep_the_short_timeout(tmp_path):
+    """A hanging local example must still fail fast — the bump is network-only."""
+    assert block_timeout(_block(tmp_path, "")) == BLOCK_TIMEOUT_SECONDS
+    assert block_timeout(_block(tmp_path, "slow")) == BLOCK_TIMEOUT_SECONDS
+
+
+def test_a_network_failure_reads_as_a_download_not_a_doc_error(tmp_path):
+    """The closing advice is the part a reader acts on, so it has to be right."""
+    block = _block(tmp_path, "network")
+    message = str(DocExampleFailure(block, "block", "gpio ...", -1, "", "timed out after 600s"))
+    assert "needs the internet" in message
+    assert 'doctest: skip="needs credentials"' not in message
+
+
+def test_a_local_failure_still_points_at_the_doc(tmp_path):
+    block = _block(tmp_path, "")
+    message = str(DocExampleFailure(block, "block", "gpio ...", 1, "", "boom"))
+    assert 'doctest: skip="needs credentials"' in message
+    assert "needs the internet" not in message
 
 
 def test_end_line_points_at_the_closing_fence(tmp_path):

--- a/tests/test_docs_examples_meta.py
+++ b/tests/test_docs_examples_meta.py
@@ -65,6 +65,31 @@ _MUTATES_ENVIRONMENT = re.compile(
     r"|rm\s+-[a-z]*rf?\s+[~/])"
 )
 
+#: Commands that cannot run without the internet. Each downloads a boundary
+#: dataset or reads a remote object; the largest is a 724 MB GAUL fetch, so an
+#: unmarked one does not fail fast — it sits in the default lane until the
+#: block timeout fires, and reads as a flaky doc error rather than as "this
+#: needs the network lane" (#894).
+#:
+#: Matching is per line of a bash fence, against the same source the harness
+#: would execute.
+_NEEDS_NETWORK = {
+    # Downloads GAUL/Overture administrative boundaries to tag each row.
+    "gpio add admin-divisions": re.compile(r"^\s*gpio\s+add\s+admin-divisions\b"),
+    # Same download, then splits the file by the boundaries it fetched.
+    "gpio partition admin": re.compile(r"^\s*gpio\s+partition\s+admin\b"),
+    # Aggregates into Overture administrative regions; fetches them first.
+    "gpio process aggregate admin": re.compile(r"^\s*gpio\s+process\s+aggregate\s+admin\b"),
+    # Resolves ISO country codes against the remote boundary dataset.
+    "--country-codes": re.compile(r"--country-codes\b"),
+    # Names the remote boundary dataset for any of the commands above.
+    "--dataset gaul/overture": re.compile(r"--dataset[= ]\s*(gaul|overture)\b"),
+    # Reads a hosted GeoParquet over https/S3 (Source Cooperative).
+    "source.coop": re.compile(r"\bdata\.source\.coop\b"),
+    # The upstream Overture CLI, which streams from their S3 bucket.
+    "overturemaps": re.compile(r"\boverturemaps\b"),
+}
+
 GUIDE_PAGES = sorted(GUIDE_DIR.glob("*.md"))
 
 
@@ -188,6 +213,33 @@ def test_no_runnable_fence_mutates_the_real_environment(page: Path):
         "Runnable fence(s) contain commands that mutate the real environment:\n  "
         + "\n  ".join(offenders)
         + '\nMark the fence <!-- doctest: skip="..." --> so the harness never runs it.'
+    )
+
+
+@pytest.mark.parametrize("page", GUIDE_PAGES, ids=lambda p: p.name)
+def test_network_fences_carry_the_network_directive(page: Path):
+    """A fence that downloads boundaries must be deselected by ``-m "not network"``.
+
+    Without the directive the block runs in the default lane, where it has 120
+    seconds to fetch hundreds of megabytes. It cannot, so it fails — and the
+    number of such failures drifts run to run with the state of the boundary
+    cache, which makes the whole docs lane read as flaky (#894). ``skip`` also
+    satisfies this: a block that never runs cannot download anything.
+    """
+    offenders = [
+        f"{block.path.name}:{block.line}: matched {name!r} in {line.strip()!r}"
+        for block in iter_fences(page, DOCS_ROOT)
+        if block.lang == "bash" and not (block.directives.network or block.directives.skip)
+        for line in block.source.split("\n")
+        for name, pattern in _NEEDS_NETWORK.items()
+        if pattern.search(line)
+    ]
+    assert not offenders, (
+        "Fence(s) needing the network but not marked for the network lane:\n  "
+        + "\n  ".join(offenders)
+        + "\nPut <!-- doctest: network --> on the line above the fence so it runs"
+        ' only in the network CI lane, or <!-- doctest: skip="why" --> if it'
+        " cannot run at all."
     )
 
 


### PR DESCRIPTION
## What changed

Four things, none of which change what any guide says:

1. **The one unmarked fence.** `docs/guide/partition.md` "Custom Filename Prefix" (L790) runs two `gpio partition admin … --dataset gaul` lines and carried no directive. It now has `<!-- doctest: network -->`, matching the six sibling `partition admin` fences on the same page.

2. **A collection-time guard.** `tests/test_docs_examples_meta.py` gains `test_network_fences_carry_the_network_directive`: a `bash` fence whose source matches any pattern in the new `_NEEDS_NETWORK` constant must carry `network` or `skip`. The constant holds seven patterns, each with a comment saying why it needs the internet (`gpio add admin-divisions`, `gpio partition admin`, `gpio process aggregate admin`, `--country-codes`, `--dataset gaul|overture`, a `data.source.coop` URL, `overturemaps`). The failure names the page, the line, the pattern it matched and the offending line, and says to add `<!-- doctest: network -->`.

3. **A survivable network timeout, and legible network failures.** `NETWORK_BLOCK_TIMEOUT_SECONDS = 600` applies to `network`-marked blocks only; every other block keeps `BLOCK_TIMEOUT_SECONDS = 120`. The choice is made by a new module-level `block_timeout(block)` so it is testable without building a pytest item. `DocExampleFailure.__str__` now branches: a network block's closing advice says it needs the internet and a real download and that a failure is usually not a doc error, instead of pointing the reader at a fence that is fine.

4. **The right invocation, said where people look.** One clause each in `CLAUDE.md` (after the generated markers table) and `docs/contributing.md` (after the existing `docs/guide -n 4 -m "not network"` block), plus a bolded note in `tests/docs_examples/README.md`. All three keep the README's existing spelling; no restructuring.

## Why

`uv run pytest -m docs_example` was reporting a drifting 12–16 failures over identical content — PR #893 touches zero files under `docs/guide/` and still saw them. The cause is not flakiness: the bare marker expression collects the 29 `network`-marked blocks along with the 456 local ones, and each of those 29 tries a GAUL/Overture download against a 120 s ceiling. The count drifts with the state of the boundary cache, so the lane reads as unreliable when it is being run wrong. And a ~724 MB fetch could never have finished in 120 s, so those blocks could only ever time out even in the network lane — at a pessimistic 2 MB/s that is six minutes, hence 600.

Every agent and contributor was re-deriving this from scratch. The guard makes the next unmarked fence impossible to add silently; the docs make the correct command hard to miss; the message makes the remaining failures self-explaining.

## Verification

**Audit, before and after.** 23 fences in `docs/guide/*.md` run a command that cannot work offline:

```
before:  network-touching fences: 23   marked: 22   UNMARKED: 1
           guide/partition.md:790  [partition admin, dataset gaul]
after:   network-touching fences: 23   marked: 23   UNMARKED: 0
```

Marked, by page, after: add.md 4, extract.md 6, partition.md 4, process-aggregate.md 4, remote-files.md 3, stac.md 1, sub-partitioning.md 1.

**Collection counts.** Exactly one block moved lanes:

| marker expression | before | after |
|---|---|---|
| `-m docs_example` | 485 | 485 |
| `-m "docs_example and not network"` | 456 | 455 |
| `-m "docs_example and network"` | 29 | 30 |

**The docs lane, run correctly:**

```
$ uv run pytest -m "docs_example and not network" -q -n 4 --dist=loadfile
================= 234 passed, 221 skipped in 92.07s (0:01:32) ==================
```

(235 on main; 234 here because the newly-marked block left this lane.)

**Meta and harness tests, including the four new ones:**

```
$ uv run pytest tests/test_docs_examples_meta.py tests/test_docs_examples_harness.py -q
============================= 194 passed in 1.00s ==============================

$ uv run pytest -m meta -q -n 4
============================= 202 passed in 11.01s =============================
```

**Mutation proof that the guard is not vacuous.** With the directive added in item 1 temporarily removed, the new meta-test goes red naming exactly that fence:

```
$ uv run pytest tests/test_docs_examples_meta.py -k "network_fences and partition" -q
________ test_network_fences_carry_the_network_directive[partition.md] _________
E   AssertionError: Fence(s) needing the network but not marked for the network lane:
E       partition.md:790: matched 'gpio partition admin' in 'gpio partition admin input.parquet output/ --dataset gaul --levels country --prefix fields'
E       partition.md:790: matched '--dataset gaul/overture' in 'gpio partition admin input.parquet output/ --dataset gaul --levels country --prefix fields'
E       partition.md:790: matched 'gpio partition admin' in 'gpio partition admin input.parquet output/ --dataset gaul --levels country --prefix fields --hive'
E       partition.md:790: matched '--dataset gaul/overture' in 'gpio partition admin input.parquet output/ --dataset gaul --levels country --prefix fields --hive'
E     Put <!-- doctest: network --> on the line above the fence so it runs only in the network CI lane, or <!-- doctest: skip="why" --> if it cannot run at all.
================= 1 failed, 1 passed, 148 deselected in 0.18s ==================
```

Restored, it is green: `2 passed, 148 deselected`.

**Hooks:** `uv run pre-commit run --all-files` clean, then `--hook-stage pre-push` clean (deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests all pass).

**The 30 network blocks were not run.** They need live downloads of hundreds of megabytes from third-party services; this PR does not claim they pass, only that they no longer run in the default lane.

## Notes for the reviewer

- **What runs the docs lane in CI.** No workflow names `docs_example` or `docs/guide`. `pyproject.toml` sets `testpaths = ["tests", "docs/guide"]`, so the docs blocks are collected by *every* CI pytest invocation and sorted purely by marker. The `test` job's `-m "not slow and not network and not meta"` picks up the fast-page blocks; the slow job's `-m "(slow or meta) and not network"` picks up the rest; the `network-tests` job's `-m network` picks up these 30. There is no dedicated docs job.
- **A follow-up the 600 s does not reach.** The `network-tests` job also passes `--timeout=180 --timeout-method=thread`, so in CI pytest-timeout still fires at 180 s and caps the new 600 s ceiling. The bump helps local `-m network` runs today; making it effective in CI means raising that workflow timeout, which would relax the hung-remote cap for every other network test, so I left it alone rather than widening the blast radius here.
- The newly-marked fence writes to `output/` twice (second line adds `--hive`), so it may need `menu` to pass in the network lane. Its six siblings on the page have the same shape and the same absence of `menu`, so I matched them rather than diverging; that is a pre-existing question about the whole page, not something this PR introduces.

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
