### PR TITLE
ci: run the guide's examples on every pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,6 +251,86 @@ jobs:
         run: |
           uv run pytest --nbmake examples/*.ipynb -v --nbmake-timeout=120 --no-cov
 
+  docs-examples:
+    # Every fenced example in docs/guide/ that does not need the internet, run on
+    # every pull request. `testpaths` already collects docs/guide, so these blocks
+    # were reaching CI sorted only by marker: 57 landed in the fast matrix, ~398 in
+    # slow-tests -- which does NOT run on pull requests. The large majority of the
+    # documented commands were therefore verified only after merge (#896).
+    #
+    # One runner, not the ten of the fast matrix: these assert that a documented
+    # command still works, which is not per-interpreter behaviour. The 57 blocks
+    # already in the fast lane keep their Windows and macOS coverage there; the
+    # rest stay Linux-only until slow-tests picks them up on merge. That is a real
+    # gap for the shell-quoting and path-encoding bugs this repo has seen only on
+    # Windows -- named here rather than glossed, and cheap to close later by adding
+    # an os matrix if it ever bites.
+    #
+    # Deliberately NOT in the required-checks list yet. #894 was this lane reading
+    # as flaky; its network blocks are excluded here, but the ~234 that execute all
+    # spawn CLI subprocesses, the same shape as the known xdist flakes in
+    # test_pipe_integration / test_geojson_stream / e2e/test_journeys. Let it report
+    # for a couple of weeks before promoting it to a gate.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      # ogr2ogr backs 8 convert.md fences and tippecanoe 11 in geojson.md; without
+      # them those blocks skip via needs-ogr / needs-tippecanoe rather than fail, so
+      # installing both is what makes this job cover the pages it claims to.
+      - name: Install GDAL
+        run: sudo apt-get update && sudo apt-get install -y gdal-bin
+
+      - name: Install tippecanoe
+        run: sudo apt-get install -y tippecanoe
+
+      - name: Pre-install DuckDB extensions
+        run: |
+          # Same transient-failure retry as the fast matrix: extensions.duckdb.org
+          # occasionally drops a request and breaks an otherwise-green build.
+          install="import duckdb; con = duckdb.connect(); con.execute('INSTALL spatial'); con.execute('INSTALL httpfs'); con.execute('INSTALL h3 FROM community'); con.execute('INSTALL geography FROM community')"
+          for attempt in 1 2 3 4 5; do
+            if uv run python -c "$install"; then
+              echo "DuckDB extensions installed (attempt $attempt)."
+              exit 0
+            fi
+            echo "Extension install failed (attempt $attempt). Retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
+          echo "Failed to install DuckDB extensions after 5 attempts." >&2
+          exit 1
+
+      - name: Run guide examples
+        run: |
+          # network-marked fences need multi-hundred-MB downloads and live in the
+          # non-blocking network-tests job; --no-cov because this lane exists to
+          # check the guide, not to move the coverage number.
+          #
+          # -n 4, not -n auto, and the difference is not cosmetic. Every block
+          # shells out to `gpio`, which itself opens a multi-threaded DuckDB, so
+          # one pytest worker is already several busy cores. Measured locally:
+          # -n auto (12 workers) produced 35 failures in 857s, all of them
+          # BLOCK_TIMEOUT_SECONDS expiring under contention rather than a broken
+          # example -- add.md:L62 alone passes in 14.5s. The same selection run
+          # serially was 235 passed / 0 failed in 271s. -n 4 matches what the
+          # harness README and every other job here already use.
+          uv run pytest -n 4 -m "docs_example and not network" \
+            --no-cov --tb=short --durations=15 --durations-min=1.0
+
   slow-tests:
     # Slow tests run on merge to main, schedule, and manual dispatch. They do NOT
     # run on every PR (too slow), but can be opted in per-PR by adding the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,10 +81,16 @@ Add `--cov-fail-under=0` when you opt in on a subset: `[tool.coverage.report]`
 sets `fail_under = 80`, so coverage re-arms the floor on any `--cov` run even
 though `addopts` no longer requests one.
 
-CI runs three test tiers:
+CI runs four test tiers:
 
 - **Fast tests** (`not slow and not network and not meta`) — run on every PR
   across the full OS/Python matrix and **block merging**.
+- **Docs examples** (`docs_example and not network`) — the guide's fenced
+  examples, run on every PR on one ubuntu runner with GDAL and tippecanoe
+  installed so the `needs-ogr`/`needs-tippecanoe` fences execute instead of
+  skipping. Advisory for now (not a required check). Network-marked fences
+  stay in the network tier below, so a docs fence marked `slow` or `network`
+  still waits for its tier despite this pre-merge lane.
 - **Slow tests** (`(slow or meta) and not network`) — run after merge to main
   and nightly; opt in on a PR by adding the `run-slow-tests` label. This tier
   also carries the `meta` lane: repo-tooling checks (codespell, commitizen,


### PR DESCRIPTION
## What changed

A `docs-examples` job in `.github/workflows/tests.yml` running `-m "docs_example and not network"` on every pull request — ubuntu-latest, Python 3.11, one runner.

It installs GDAL and tippecanoe alongside the DuckDB extensions, because 8 fences in `convert.md` and 11 in `geojson.md` otherwise skip themselves through `needs-ogr` / `needs-tippecanoe`. A job that silently skips the pages it claims to cover is worse than no job.

## Why

`pyproject.toml` sets `testpaths = ["tests", "docs/guide"]`, so guide fences were already reaching CI — but sorted only by marker, and no job was named for them:

| Where they landed | Count | Ran on a PR? |
| --- | --- | --- |
| Fast lane | 57 | Yes, all 10 OS × Python jobs |
| `network-tests` | 30 | Non-blocking |
| Slow lane + runtime-skipped | ~398 | **No** |

`slow-tests` runs on push-to-main, schedule, dispatch or the `run-slow-tests` label — deliberately not on PRs, and that is right for the suite as a whole. The consequence was narrower and not intended: **most documented commands were verified only after merge.** That is precisely the drift docs-as-tests (#667, #732) exists to catch, caught a merge too late.

Docs are only 57 of 6,409 fast-lane items — 0.9% — so there was no matrix waste to reclaim and no reason to touch `testpaths`. The marker sorting is right; what was missing was a pre-merge run.

## `-n 4`, not `-n auto`

Load-bearing, and the reasoning is in the job. Every block shells out to `gpio`, which opens its own multi-threaded DuckDB, so one pytest worker is already several busy cores. Measured locally:

```
-n auto (12 workers):  35 failed, 200 passed, 221 skipped in 857.27s
serial:               235 passed,             221 skipped in 271.10s
```

Every one of the 35 was `BLOCK_TIMEOUT_SECONDS` expiring under contention, not a broken example — `docs/guide/add.md:L62` passes alone in 14.55 s. The parallel run was three times *slower* than serial, which is the tell. `-n 4` is what the harness README and every other job in this file already use.

## Verification

- `-m "docs_example and not network"` serially: **235 passed, 221 skipped, 0 failed** (271 s)
- workflow YAML parses; `actionlint` and `zizmor` clean via `pre-commit run --files .github/workflows/tests.yml`
- the job's own run in this PR is the real check of the `-n 4` setting on a CI runner — if it is red, that is the finding and I will fix it before this is ready

## Two things deliberately not done

**Not added to the required checks.** #894 was this exact lane reading as flaky. Its network blocks are excluded here, but the ~234 that execute all spawn CLI subprocesses — the same shape as the known xdist flakes in `test_pipe_integration`, `test_geojson_stream` and `e2e/test_journeys`. Let it report for a couple of weeks before promoting it to a gate; adding a flaky required check immediately before the CLI-split refactor would undo the point of fixing #894.

**Windows and macOS coverage unchanged.** The 57 fast-lane blocks keep theirs in the matrix; the slow-lane ones stay covered by `slow-tests` after merge. Given this repo's history of Windows-only path, encoding and shell-quoting bugs, that is a real if small gap — named in the job comment rather than glossed, and an os matrix away from closing if it bites.

Closes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated validation for documentation examples on every pull request.
  - Examples requiring GDAL and tippecanoe are now exercised, while network-dependent examples remain excluded from this check.

- **Documentation**
  - Updated contributor guidance to describe the fourth documentation-example testing tier and its advisory status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->