### PR TITLE
fix(partition): forward --use-centroid and refuse a lone --resolution up front in quadkey directory mode

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1148,7 +1148,7 @@ for file_path in large_files:
 
 **Returns:** List of file paths sorted by size (largest first)
 
-#### `sub_partition_directory(directory, partition_type, min_size_bytes, resolution=None, level=None, in_place=False, hive=False, overwrite=False, verbose=False, force=False, skip_analysis=True, compression='ZSTD', compression_level=None, auto=False, target_rows=100000, max_partitions=10000, partition_resolution=None)`
+#### `sub_partition_directory(directory, partition_type, min_size_bytes, resolution=None, level=None, partition_resolution=None, use_centroid=False, in_place=False, hive=False, overwrite=False, verbose=False, force=False, skip_analysis=True, compression='ZSTD', compression_level=None, auto=False, target_rows=100000, max_partitions=10000)`
 
 Sub-partition large files in a directory using spatial indexing.
 
@@ -1178,12 +1178,14 @@ result = sub_partition_directory(
     skip_analysis=True  # Skip per-file analysis for speed
 )
 
-# Sub-partition quadkey files
+# Sub-partition quadkey files: the cell column is built at `resolution` and
+# the sub-partitions are the first `partition_resolution` characters of it
 result = sub_partition_directory(
     directory='/data/quadkey_partitions/',
     partition_type='quadkey',
     min_size_bytes=200 * 1024 * 1024,
-    resolution=8,
+    resolution=13,
+    partition_resolution=8,
     hive=True
 )
 ```
@@ -1193,8 +1195,9 @@ result = sub_partition_directory(
 - `partition_type` (str): Type of partition ("h3", "a5", "s2", "quadkey")
 - `min_size_bytes` (int): Minimum file size to process
 - `resolution` (int | None): Resolution for H3/quadkey (0-15 for H3)
-- `partition_resolution` (int | None): Quadkey partition prefix length (0-23, no greater than `resolution`); required with explicit quadkey `resolution`
 - `level` (int | None): Level for S2 (alias for resolution)
+- `partition_resolution` (int | None): Quadkey only — prefix length the sub-partitions are split on (0-23). Required alongside `resolution` unless `auto=True`
+- `use_centroid` (bool): Quadkey only — use the geometry centroid when adding the quadkey column (default: False)
 - `in_place` (bool): Delete originals after successful sub-partition (default: False)
 - `hive` (bool): Use Hive-style partitioning (default: False)
 - `overwrite` (bool): Overwrite existing output directories (default: False)
@@ -1583,13 +1586,12 @@ The return value is a dict with `processed`, `skipped`, `errors`, `candidates`
 - Any per-file failure raises `PartitionError` once the run finishes, so a
   partial run is never read as a complete one. `exc.result` carries the run dict,
   including the files that succeeded.
+- `ops.sub_partition_by_quadkey` takes two resolutions, like the command it
+  mirrors: `resolution=` builds the cell column and `partition_resolution=` is
+  the prefix length the sub-partitions are split on. Pass both, or `auto=True`.
 - `column_name=` and `output_dir=` are refused: in directory mode each file gets
   its own sibling directory and the default index column name. Partition a single
   file with `ops.partition_by_<index>` if you need to control those.
-- `ops.sub_partition_by_quadkey` accepts both `resolution` for column precision and
-  `partition_resolution` for the output prefix length (0-23, no greater than
-  `resolution`), or `auto=True` to calculate both. Directory mode forwards these
-  to the same validated partitioner as single-file mode.
 - `ops.sub_partition_by_s2` uses the `geography` DuckDB community extension,
   which gpio installs on first use; where that extension cannot load it raises
   `ExtensionUnavailableError` before touching a file, like every other S2
@@ -1634,7 +1636,7 @@ The return value is a dict with `processed`, `skipped`, `errors`, `candidates`
 | `ops.partition_by_admin(table, output_dir, dataset='gaul', levels=None, hive=False, overwrite=False, vecorel=False, compression='ZSTD', compression_level=None, geometry_column=None)` | Partition into a directory by administrative boundaries |
 | `ops.sub_partition_by_h3(directory, min_size, resolution=None, auto=False, in_place=False, preview=False, hive=False, overwrite=False, force=False, skip_analysis=False, compression='ZSTD', compression_level=None, ...)` | Split every file in a directory over `min_size` into H3 sub-partitions |
 | `ops.sub_partition_by_a5(directory, min_size, resolution=None, auto=False, in_place=False, preview=False, ...)` | Split every file in a directory over `min_size` into A5 sub-partitions |
-| `ops.sub_partition_by_quadkey(directory, min_size, resolution=None, partition_resolution=None, auto=False, in_place=False, preview=False, ...)` | Split every file in a directory over `min_size` into quadkey sub-partitions (pass both resolutions or use `auto=True`) |
+| `ops.sub_partition_by_quadkey(directory, min_size, resolution=None, partition_resolution=None, use_centroid=False, auto=False, in_place=False, preview=False, ...)` | Split every file in a directory over `min_size` into quadkey sub-partitions (pass both resolutions, or `auto=True`) |
 | `ops.sub_partition_by_s2(directory, min_size, level=None, auto=False, in_place=False, preview=False, ...)` | Split every file in a directory over `min_size` into S2 sub-partitions |
 | `ops.get_row_group_geo_stats(parquet_file)` | Per-row-group geo bbox statistics |
 | `ops.compression_stats(path)` | Per-column compression ratios |

--- a/docs/guide/sub-partitioning.md
+++ b/docs/guide/sub-partitioning.md
@@ -74,8 +74,9 @@ by_country/
 | `--in-place` | `in_place=` | Delete original files after successful sub-partitioning |
 | `--preview` | `preview=` | List the files that would be processed, then stop |
 | `--resolution` / `--level` | `resolution=` / `level=` | Spatial index resolution (or use `--auto`) |
+| `--partition-resolution` | `partition_resolution=` | Quadkey only: prefix length the sub-partitions are split on. Required alongside `--resolution` unless `--auto` |
+| `--use-centroid` | `use_centroid=` | Quadkey only: use the geometry centroid when adding the quadkey column |
 | `--auto` | `auto=` | Auto-calculate optimal resolution |
-| `--partition-resolution` | `partition_resolution=` | Quadkey partition prefix length, no greater than `resolution` |
 
 `OUTPUT_FOLDER` and the index column name options (`--h3-name`, `--a5-name`,
 `--s2-name`, `--quadkey-column`) apply to single-file runs only: in directory
@@ -152,22 +153,28 @@ they are reached through `--min-size`.
 
 === "Quadkey"
 
-    Pass both a column resolution and a partition resolution, just as in single-file
-    mode. The partition resolution must be between zero and the column resolution
-    (at most 23). Alternatively, use `--auto` / `auto=True` to calculate both.
+    Quadkey takes two numbers: the cell column is built at `--resolution` and the
+    sub-partitions are the first `--partition-resolution` characters of each cell.
+    Pass both, or `--auto` / `auto=True` to size them from the data. As in the A5
+    tab, a tiny threshold makes the example split the small sample directory.
 
     <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
     ```bash
-    gpio partition quadkey by_country/ --min-size 1B --resolution 13 --partition-resolution 6 --in-place
+    gpio partition quadkey by_country/ --min-size 1B --resolution 6 --partition-resolution 3 --in-place
     ```
 
     <!-- doctest: setup="gpio partition quadkey input.parquet by_country/ --resolution 6 --partition-resolution 2" -->
     ```python
     from geoparquet_io.api import ops
 
-    ops.sub_partition_by_quadkey(
-        'by_country/', min_size='1B', resolution=13, partition_resolution=6, in_place=True
+    result = ops.sub_partition_by_quadkey(
+        'by_country/',
+        min_size='1B',
+        resolution=6,
+        partition_resolution=3,
+        in_place=True,
     )
+    print(f"{result['processed']} file(s) sub-partitioned, {len(result['errors'])} failed")
     ```
 
 ## From Python

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1258,8 +1258,9 @@ def _sub_partition(
     *,
     min_size: str | int,
     resolution: int | None = None,
-    partition_resolution: int | None = None,
     level: int | None = None,
+    partition_resolution: int | None = None,
+    use_centroid: bool = False,
     auto: bool = False,
     target_rows: int = 100000,
     max_partitions: int = 10000,
@@ -1325,7 +1326,19 @@ def _sub_partition(
         }
 
     argument = _SUB_PARTITION_RESOLUTION_ARG.get(partition_type, "resolution")
-    if not auto and (resolution if resolution is not None else level) is None:
+    if partition_type == "quadkey":
+        # Quadkey takes two resolutions; refuse once here rather than per file
+        # (#854), spelled as keyword arguments rather than CLI flags.
+        missing = core_sub_partition.quadkey_resolution_error(
+            resolution,
+            partition_resolution,
+            auto=auto,
+            labels=("resolution=<int>", "partition_resolution=<int>"),
+            auto_label="auto=True",
+        )
+        if missing:
+            raise InvalidParameterError(argument, missing)
+    elif not auto and (resolution if resolution is not None else level) is None:
         raise InvalidParameterError(
             argument,
             f"pass {argument}=<int> or auto=True -- gpio does not guess a "
@@ -1341,8 +1354,9 @@ def _sub_partition(
         partition_type=partition_type,
         min_size_bytes=min_size_bytes,
         resolution=resolution,
-        partition_resolution=partition_resolution,
         level=level,
+        partition_resolution=partition_resolution,
+        use_centroid=use_centroid,
         in_place=in_place,
         hive=hive,
         overwrite=overwrite,
@@ -1551,6 +1565,7 @@ def sub_partition_by_quadkey(
     min_size: str | int,
     resolution: int | None = None,
     partition_resolution: int | None = None,
+    use_centroid: bool = False,
     auto: bool = False,
     target_rows: int = 100000,
     max_partitions: int = 10000,
@@ -1573,17 +1588,21 @@ def sub_partition_by_quadkey(
     over the threshold is partitioned into a sibling ``<file>_quadkey/``
     directory; files under it are left alone.
 
-    Pass both ``resolution`` (column precision) and ``partition_resolution``
-    (partition prefix length), or use ``auto=True`` to size both from the data.
+    Quadkey is the one index that takes two numbers: the cell column is built at
+    ``resolution`` and the sub-partitions are the first ``partition_resolution``
+    characters of each cell. Pass both, or ``auto=True`` to size them from the
+    data; a lone ``resolution`` is refused before any file is touched (#854).
     The partition resolution cannot exceed the column resolution, matching
     single-file partitioning.
 
     Args:
         directory: Directory of parquet files, searched recursively
         min_size: Size threshold -- ``'100MB'`` or a byte count
-        resolution: Quadkey column resolution 0-23
-        partition_resolution: Quadkey partition prefix length 0-23, at most resolution
-        auto: Size the resolution from each file (default: False)
+        resolution: Quadkey resolution 0-23 the cell column is built at
+        partition_resolution: Prefix length 0-23 the sub-partitions are split
+            on. Required alongside ``resolution`` unless ``auto=True``
+        use_centroid: Use the geometry centroid when adding the quadkey column
+        auto: Size both resolutions from each file (default: False)
         target_rows: Target rows per partition when ``auto=True`` (default: 100000)
         max_partitions: Maximum partitions when ``auto=True`` (default: 10000)
         in_place: Delete each original once its sub-partitions hold every row it
@@ -1613,7 +1632,8 @@ def sub_partition_by_quadkey(
 
     Example:
         >>> from geoparquet_io.api import ops
-        >>> ops.sub_partition_by_quadkey('by_country/', min_size='100MB', auto=True,
+        >>> ops.sub_partition_by_quadkey('by_country/', min_size='100MB',
+        ...                              resolution=13, partition_resolution=6,
         ...                              in_place=True)
     """
     return _sub_partition(
@@ -1622,6 +1642,7 @@ def sub_partition_by_quadkey(
         min_size=min_size,
         resolution=resolution,
         partition_resolution=partition_resolution,
+        use_centroid=use_centroid,
         auto=auto,
         target_rows=target_rows,
         max_partitions=max_partitions,

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -762,6 +762,8 @@ def handle_directory_sub_partition(
     min_size: str | None,
     resolution: int | None = None,
     level: int | None = None,
+    partition_resolution: int | None = None,
+    use_centroid: bool = False,
     in_place: bool = False,
     hive: bool = False,
     overwrite: bool = False,
@@ -776,7 +778,6 @@ def handle_directory_sub_partition(
     preview: bool = False,
     column_name: str | None = None,
     output_folder: str | None = None,
-    partition_resolution: int | None = None,
 ) -> bool:
     """
     Handle directory input with --min-size for partition commands.
@@ -790,8 +791,10 @@ def handle_directory_sub_partition(
         partition_type: Type of partition ("a5", "h3", "s2", "quadkey")
         min_size: Size threshold string (e.g., "100MB") or None
         resolution: Resolution for A5/H3/quadkey
-        partition_resolution: Quadkey partition prefix length
         level: Level for S2
+        partition_resolution: Quadkey only -- the --partition-resolution the
+            directories are split on, required alongside --resolution (#854)
+        use_centroid: Quadkey only -- the --use-centroid flag
         in_place: Delete originals after sub-partition
         hive: Use Hive-style partitioning
         overwrite: Overwrite existing output
@@ -856,8 +859,9 @@ def handle_directory_sub_partition(
             partition_type=partition_type,
             min_size_bytes=min_size_bytes,
             resolution=resolution,
-            partition_resolution=partition_resolution,
             level=level,
+            partition_resolution=partition_resolution,
+            use_centroid=use_centroid,
             in_place=in_place,
             hive=hive,
             overwrite=overwrite,

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -5988,6 +5988,7 @@ def partition_quadkey(
             min_size=min_size,
             resolution=resolution,
             partition_resolution=partition_resolution,
+            use_centroid=use_centroid,
             preview=preview,
             column_name=quadkey_column,
             output_folder=output_folder,

--- a/geoparquet_io/core/sub_partition.py
+++ b/geoparquet_io/core/sub_partition.py
@@ -135,6 +135,42 @@ def _assert_no_rows_lost(source_file: str, output_dir: str) -> None:
         )
 
 
+def quadkey_resolution_error(
+    resolution: int | None,
+    partition_resolution: int | None,
+    *,
+    auto: bool,
+    labels: tuple[str, str] = ("--resolution", "--partition-resolution"),
+    auto_label: str = "--auto",
+) -> str | None:
+    """Say what a quadkey run is missing, or None when it has what it needs.
+
+    Quadkey is the one index that takes two numbers: the cell column is built at
+    ``resolution`` and the directories are split on the first
+    ``partition_resolution`` characters of it. Directory mode used to forward
+    only the first, so every file tripped the single-file gate (#854); the check
+    now runs once, before the loop, through either front door.
+
+    Args:
+        resolution: Resolution the cell column would be built at
+        partition_resolution: Prefix length the partitions would be split on
+        auto: Whether both are to be calculated from the data instead
+        labels: How to spell the two arguments back at the caller
+        auto_label: How to spell the auto argument back at the caller
+
+    Returns:
+        The message to report, or None when the combination is usable.
+    """
+    if auto or (resolution is not None and partition_resolution is not None):
+        return None
+
+    return (
+        f"must specify either {auto_label} or both {labels[0]} and {labels[1]} -- "
+        "quadkey builds its cell column at one resolution and splits the "
+        "directories on a prefix of it."
+    )
+
+
 def find_large_files(
     directory: str,
     min_size_bytes: int,
@@ -174,6 +210,8 @@ def sub_partition_directory(
     min_size_bytes: int,
     resolution: int | None = None,
     level: int | None = None,
+    partition_resolution: int | None = None,
+    use_centroid: bool = False,
     in_place: bool = False,
     hive: bool = False,
     overwrite: bool = False,
@@ -185,7 +223,6 @@ def sub_partition_directory(
     auto: bool = False,
     target_rows: int = 100000,
     max_partitions: int = 10000,
-    partition_resolution: int | None = None,
 ) -> dict:
     """
     Sub-partition large files in a directory.
@@ -199,6 +236,10 @@ def sub_partition_directory(
         min_size_bytes: Minimum file size to process
         resolution: Resolution for A5/H3/quadkey (0-15 for H3, 0-30 for A5)
         level: Level for S2 (alias for resolution)
+        partition_resolution: Quadkey only -- prefix length the partitions are
+            split on (0-23). Required alongside ``resolution`` unless ``auto``
+        use_centroid: Quadkey only -- use the geometry centroid when adding the
+            quadkey column
         in_place: If True, delete original after successful sub-partition
         hive: Use Hive-style partitioning
         overwrite: Overwrite existing output directories
@@ -210,7 +251,6 @@ def sub_partition_directory(
         auto: Auto-calculate resolution
         target_rows: Target rows per partition for auto mode
         max_partitions: Max partitions for auto mode
-        partition_resolution: Quadkey partition prefix length (0-23), at most resolution
 
     Returns:
         dict with keys: processed, skipped, errors
@@ -249,7 +289,13 @@ def sub_partition_directory(
 
     # Handle resolution/level parameter
     res_value = resolution if resolution is not None else level
-    if not auto and res_value is None:
+    if partition_type == "quadkey":
+        # Quadkey wants two numbers, and wanted them per file before this ran
+        # once here (#854).
+        missing = quadkey_resolution_error(resolution, partition_resolution, auto=auto)
+        if missing:
+            raise ValueError(missing)
+    elif not auto and res_value is None:
         raise ValueError(f"Must specify resolution/level or auto for {partition_type} partitioning")
 
     # Preflight once, not once per file: a missing community extension fails
@@ -303,7 +349,11 @@ def sub_partition_directory(
                 kwargs[res_param] = res_value
 
             if partition_type == "quadkey":
+                # The two options only this partitioner has. Forwarding them is
+                # the whole of #854: without partition_resolution every file
+                # failed, and use_centroid was silently ignored.
                 kwargs["partition_resolution"] = partition_resolution
+                kwargs["use_centroid"] = use_centroid
 
             func(**kwargs)
 

--- a/tests/test_sub_partition.py
+++ b/tests/test_sub_partition.py
@@ -315,6 +315,141 @@ class TestSubPartitionCLI:
         assert os.path.isdir(os.path.join(temp_partition_dir, "test_quadkey"))
 
 
+class TestQuadkeyDirectoryResolutions:
+    """Quadkey takes two resolutions, and directory mode has to forward both (#854).
+
+    ``gpio partition quadkey`` builds the cell column at ``--resolution`` and
+    splits on the first ``--partition-resolution`` characters of it. Directory
+    mode forwarded only the first, so the documented
+    ``--min-size ... --resolution N`` run failed once per file on the single-file
+    gate ("must specify either --auto or both ...") and ``--auto`` was the only
+    way through.
+    """
+
+    @staticmethod
+    def _seed(directory) -> tuple[str, str]:
+        """A file in ``directory`` plus the ``--min-size`` that selects it."""
+        from pathlib import Path
+
+        buildings = Path(__file__).parent / "data" / "buildings_test.parquet"
+        test_file = os.path.join(directory, "test.parquet")
+        shutil.copy(buildings, test_file)
+        return test_file, f"{os.path.getsize(test_file) - 100}B"
+
+    def test_both_resolutions_are_forwarded_to_each_file(self, cli_runner, temp_partition_dir):
+        """The run in the issue, with the partition resolution it always needed."""
+        test_file, threshold = self._seed(temp_partition_dir)
+
+        result = cli_runner.invoke(
+            partition,
+            [
+                "quadkey",
+                temp_partition_dir,
+                "--min-size",
+                threshold,
+                "--resolution",
+                "13",
+                "--partition-resolution",
+                "6",
+                "--in-place",
+                "--force",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert not os.path.exists(test_file), "--in-place left the original behind"
+
+        output_dir = os.path.join(temp_partition_dir, "test_quadkey")
+        assert _total_rows(output_dir) == BUILDINGS_ROWS
+        # Partition names are the first --partition-resolution characters of the
+        # quadkey, so a forwarded 6 shows up as 6-character stems.
+        assert {f.stem for f in _partition_files(output_dir)} == {"120203"}
+
+    def test_auto_still_works(self, cli_runner, temp_partition_dir):
+        """The workaround stays a working option, not a casualty of the fix."""
+        test_file, threshold = self._seed(temp_partition_dir)
+
+        result = cli_runner.invoke(
+            partition,
+            [
+                "quadkey",
+                temp_partition_dir,
+                "--min-size",
+                threshold,
+                "--auto",
+                "--in-place",
+                "--force",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert not os.path.exists(test_file)
+        assert _total_rows(os.path.join(temp_partition_dir, "test_quadkey")) == BUILDINGS_ROWS
+
+    def test_a_lone_resolution_is_refused_once_up_front(self, cli_runner, temp_partition_dir):
+        """Name the missing flag before the loop, not once per file."""
+        test_file, threshold = self._seed(temp_partition_dir)
+
+        result = cli_runner.invoke(
+            partition,
+            [
+                "quadkey",
+                temp_partition_dir,
+                "--min-size",
+                threshold,
+                "--resolution",
+                "13",
+                "--in-place",
+                "--force",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--partition-resolution" in result.output
+        assert "ERROR:" not in result.output, "reported per file instead of once up front"
+        assert os.path.exists(test_file), "the original was touched by a refused run"
+
+    def test_neither_resolution_nor_auto_is_refused(self, cli_runner, temp_partition_dir):
+        """No resolutions at all is still a clear message, not a crash."""
+        _test_file, threshold = self._seed(temp_partition_dir)
+
+        result = cli_runner.invoke(
+            partition,
+            ["quadkey", temp_partition_dir, "--min-size", threshold, "--in-place"],
+        )
+
+        assert result.exit_code != 0
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "--auto" in result.output
+        assert "--partition-resolution" in result.output
+
+    def test_quadkey_only_options_reach_the_partitioner(self, temp_partition_dir, monkeypatch):
+        """``--use-centroid`` was dropped by directory mode the same way (#854)."""
+        from geoparquet_io.core import sub_partition as core_sub_partition
+
+        _test_file, threshold = self._seed(temp_partition_dir)
+        calls = []
+
+        def _record(**kwargs):
+            calls.append(kwargs)
+
+        monkeypatch.setattr("geoparquet_io.core.partition.by_quadkey.partition_by_quadkey", _record)
+
+        core_sub_partition.sub_partition_directory(
+            directory=temp_partition_dir,
+            partition_type="quadkey",
+            min_size_bytes=int(threshold.rstrip("B")),
+            resolution=13,
+            partition_resolution=6,
+            use_centroid=True,
+        )
+
+        assert len(calls) == 1
+        assert calls[0]["resolution"] == 13
+        assert calls[0]["partition_resolution"] == 6
+        assert calls[0]["use_centroid"] is True
+
+
 class TestSubPartitionFailuresAreReported:
     """A directory sub-partition that partitions nothing must not exit 0 (#778)."""
 
@@ -839,13 +974,7 @@ class TestApiDirectorySubPartition:
         assert _total_rows(os.path.join(temp_partition_dir, "large_a5")) == BUILDINGS_ROWS
 
     def test_quadkey_partitions_by_its_own_index(self, temp_partition_dir):
-        """auto=True is what a quadkey directory run takes, exactly as on the CLI.
-
-        The quadkey partitioner needs both a column resolution and a partition
-        resolution, and directory mode forwards only one -- so a lone
-        ``resolution`` fails there through either front door (see
-        ``test_a_lone_quadkey_resolution_fails_the_same_way_as_the_cli``).
-        """
+        """auto=True is one of the two ways through, exactly as on the CLI."""
         from geoparquet_io.api import ops
 
         large, _small = self._seed(temp_partition_dir)
@@ -960,12 +1089,38 @@ class TestApiDirectorySubPartition:
         assert all(Path(path).read_bytes() == data for path, data in originals.items())
         assert not (Path(temp_partition_dir) / "large_quadkey").exists()
 
-    def test_a_lone_quadkey_resolution_fails_the_same_way_as_the_cli(
+    def test_quadkey_takes_both_resolutions(self, temp_partition_dir):
+        """The API twin of the fixed CLI run: two resolutions, no auto (#854)."""
+        from geoparquet_io.api import ops
+
+        large, _small = self._seed(temp_partition_dir)
+
+        result = ops.sub_partition_by_quadkey(
+            temp_partition_dir,
+            min_size=os.path.getsize(large) - 100,
+            resolution=13,
+            partition_resolution=6,
+            in_place=True,
+            force=True,
+        )
+
+        assert result["errors"] == []
+        assert result["processed"] == 1
+
+        output_dir = os.path.join(temp_partition_dir, "large_quadkey")
+        assert _total_rows(output_dir) == BUILDINGS_ROWS
+        assert {f.stem for f in _partition_files(output_dir)} == {"120203"}
+
+    def test_a_lone_quadkey_resolution_is_refused_up_front_on_both_doors(
         self, cli_runner, temp_partition_dir
     ):
-        """Explicit mode requires both resolutions, just like single-file mode."""
+        """Both doors say which resolution is missing, before any file is touched.
+
+        This used to be a per-file failure on the single-file gate through the
+        CLI, and the API mirrored it (#854).
+        """
         from geoparquet_io.api import ops
-        from geoparquet_io.core.exceptions import PartitionError
+        from geoparquet_io.core.exceptions import InvalidParameterError
 
         large, _small = self._seed(temp_partition_dir)
         threshold = f"{os.path.getsize(large) - 100}B"
@@ -983,14 +1138,15 @@ class TestApiDirectorySubPartition:
             ],
         )
         assert cli.exit_code != 0
-        assert "partition-resolution" in cli.output
+        assert "--partition-resolution" in cli.output
 
-        with pytest.raises(PartitionError) as exc:
+        with pytest.raises(InvalidParameterError) as exc:
             ops.sub_partition_by_quadkey(
                 temp_partition_dir, min_size=threshold, resolution=6, force=True
             )
 
-        assert "partition-resolution" in str(exc.value)
+        assert "partition_resolution" in str(exc.value)
+        assert os.path.exists(large), "a refused run touched the originals"
 
     def test_preview_lists_candidates_and_writes_nothing(self, temp_partition_dir):
         """The CLI's --preview: say what would happen, change nothing (#790)."""
@@ -1193,8 +1349,8 @@ class TestSubPartitionFrontDoorParity:
         (
             "quadkey",
             "sub_partition_by_quadkey",
-            ["--resolution", "13", "--partition-resolution", "6"],
-            {"resolution": 13, "partition_resolution": 6},
+            ["--resolution", "6", "--partition-resolution", "3", "--use-centroid"],
+            {"resolution": 6, "partition_resolution": 3, "use_centroid": True},
         ),
     ]
 


### PR DESCRIPTION
## What changed

This is now a refinement on #900, which landed first and fixed the core of #854: `gpio partition quadkey <dir>/ --min-size` forwards `--partition-resolution` to each per-file run since `ff5be62` — credit to that PR. Rebased on top of it, this PR keeps the two pieces #900 did not cover: `--use-centroid` is forwarded too (it was dropped silently at the same site), and a lone `--resolution` is refused **once, up front, before any file is touched** — on both the CLI and the Python API — instead of failing per file. The notes below describe the combined behavior; where they mention `partition_resolution` forwarding, that part shipped with #900.

- `core/sub_partition.py`: `sub_partition_directory()` takes `partition_resolution` and `use_centroid`, and adds them to the per-file kwargs for `quadkey` (the other three indexes have neither option).
- The two-resolution requirement is checked **once, before the file loop**, by a new `quadkey_resolution_error()` helper, instead of N times inside it on the single-file gate. A lone `--resolution` now names the missing flag in one message; the originals are untouched.
- `cli/decorators.py` (`handle_directory_sub_partition`) and `cli/main.py` (`partition_quadkey`) thread the two options through. No new CLI options, so `tests/data/cli_surface.json` is unchanged.
- `ops.sub_partition_by_quadkey()` gains `partition_resolution=` and `use_centroid=`, plus the same up-front refusal spelled as keyword arguments (`InvalidParameterError`, not a per-file `PartitionError`). #853 mirrored the broken CLI behaviour deliberately; both doors now agree, pinned by the existing front-door call-parity test.
- Docs: the Quadkey tab in `docs/guide/sub-partitioning.md` is a real two-resolution run instead of the "use `--auto`" workaround, plus rows for both options in the Options table; `docs/api/python-api.md` updates the `sub_partition_directory` and `ops.sub_partition_by_quadkey` signatures and adds a note. No `<!-- doctest: network -->` marks were added or removed; the edited fences run in the fast docs lane.

**The other dropped option.** `--use-centroid` was being dropped at the same site — silently, which is worse than an error — so it is forwarded too. The remaining gaps there are *not* quadkey-specific and are left alone: `--prefix`, `--row-group-size*`, `--write-memory`, `--geoparquet-version`, `--keep-*-column` and `--preview-limit` come from the shared `@partition_options` / `@output_format_options` decorators and are dropped for all four indexes. That is one cross-cutting change deserving its own issue and PR, not a rider on this one.

## Why

Quadkey is the only index that takes two numbers: the cell column is built at `--resolution` and the directories are split on the first `--partition-resolution` characters of it. Directory mode's registry entry was `("quadkey": partition_by_quadkey, "resolution")` — a single `(func, param_name)` pair — so the partition depth was never passed and every file tripped the single-file gate. The documented directory workflow only worked with `--auto`.

## Verification

Repro from the issue, on `main` (`da331b6`):

```
$ gpio partition quadkey repro854/by_country/ --min-size 1KB --resolution 13 --in-place
Found 2 file(s) exceeding threshold
Processing: a.parquet (0.1MB)
  ERROR: Invalid parameter 'resolution': must specify either --auto or both --resolution and --partition-resolution
Processing: b.parquet (0.0MB)
  ERROR: Invalid parameter 'resolution': must specify either --auto or both --resolution and --partition-resolution
Error: 2 of 2 file(s) failed to sub-partition; see the errors above.
EXIT=1
```

Passing `--partition-resolution 6` as well failed identically on `main` — the value was dropped.

After, the same directory:

```
$ gpio partition quadkey repro854/by_country/ --min-size 1KB --resolution 13 --partition-resolution 6 --in-place --force
Found 2 file(s) exceeding threshold
Processing: a.parquet (0.1MB)
Partitioning by quadkey at resolution 6 (column: 'quadkey')
Created 4 partition(s) in repro854/by_country/a_quadkey (total: 0.06 MB, avg: 0.02 MB)
Processing: b.parquet (0.0MB)
Created 1 partition(s) in repro854/by_country/b_quadkey (total: 0.00 MB, avg: 0.00 MB)
EXIT=0

$ find repro854 -name '*.parquet' | sort
repro854/by_country/a_quadkey/033313.parquet
repro854/by_country/a_quadkey/033331.parquet
repro854/by_country/a_quadkey/122202.parquet
repro854/by_country/a_quadkey/122220.parquet
repro854/by_country/b_quadkey/120203.parquet
```

Six-character stems: the forwarded `--partition-resolution 6`. A lone `--resolution` is now one message, before anything runs:

```
$ gpio partition quadkey repro854/by_country/ --min-size 1KB --resolution 13 --in-place
Usage: gpio partition quadkey [OPTIONS] INPUT_PARQUET [OUTPUT_FOLDER]
Error: must specify either --auto or both --resolution and --partition-resolution -- quadkey builds its cell column at one resolution and splits the directories on a prefix of it.
EXIT=2
```

Tests — 8 new/rewritten, in `tests/test_sub_partition.py`:

- `TestQuadkeyDirectoryResolutions`: both resolutions forwarded end-to-end (asserts the 6-character partition stems and that no rows were lost), `--auto` still works, a lone `--resolution` refused once up front (no per-file `ERROR:`, original untouched), neither resolution nor `--auto` refused with a clear message rather than a traceback, and `--use-centroid`/`--partition-resolution` reaching `partition_by_quadkey`.
- `TestApiDirectorySubPartition`: new `test_quadkey_takes_both_resolutions` (API twin of the fixed run); `test_a_lone_quadkey_resolution_fails_the_same_way_as_the_cli` became `..._is_refused_up_front_on_both_doors` and now expects `InvalidParameterError` on both doors instead of pinning the failure.
- `TestSubPartitionFrontDoorParity`: the quadkey case carries `--partition-resolution 3 --use-centroid`, so the CLI and `ops` are diffed on the new arguments too.

```
$ uv run pytest tests/test_sub_partition.py -q
48 passed, 1 skipped in 8.80s

$ uv run pytest -n auto -m "not slow and not network and not meta" -q --cov=geoparquet_io --cov-report=xml --cov-fail-under=0
6155 passed, 70 skipped, 9 xfailed, 116 warnings in 191.69s

$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
geoparquet_io/api/ops.py (100%)
geoparquet_io/core/sub_partition.py (100%)
Total:   17 lines
Missing: 0 lines
Coverage: 100%

$ uv run pytest -m "docs_example and not network" -q -k "sub-partitioning"
13 passed, 7151 deselected in 58.18s

$ uv run pre-commit run --all-files
(all hooks Passed)

$ uv run pre-commit run --all-files --hook-stage pre-push
deptry / mypy / vulture / xenon / import-linter / menard-check / fast-tests .... Passed
```

An earlier `-n auto` fast-suite run reported 13 failures in `tests/e2e/test_journeys.py`, `tests/test_pipe_integration.py`, `tests/test_geojson_stream.py` and `tests/test_geometry_repair_integration.py`; all 91 of those pass serially (`218.86s`), and the clean run quoted above is the same command. That is the known cold-run xdist flake, not this change.

Closes #854
Refs #811, #853, #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quadkey partition-resolution controls for CLI and Python APIs.
  * Added an option to use centroids when creating quadkey partitions.
  * Quadkey directory workflows now support explicit cell and partition resolutions, or automatic resolution selection.
  * Added validation with clearer errors when required resolution settings are incomplete.

* **Documentation**
  * Updated API references, command options, examples, and usage guidance for the new quadkey settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
