### PR TITLE
chore(sql): finish the sql_path migration and take the hand-written literal baseline to zero

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,12 +139,13 @@ repos:
             # sql_path(), which quotes and escapes in one step, so the escape
             # cannot be forgotten - it was forgotten for `add admin-divisions`,
             # which wrote its output file and then died with a ParserException on
-            # an output path containing an apostrophe (#718). Most existing sites
-            # interpolate an already-escaped safe_file_url() result and are
-            # correct, so this is a per-file ratchet over a checked-in baseline
-            # (counts may fall, never rise) rather than a ban that would demand a
-            # 160-site rewrite. Regenerate after migrating call sites:
-            #   uv run python scripts/check_sql_path_literals.py --update
+            # an output path containing an apostrophe (#718). This began as a
+            # per-file ratchet over a checked-in baseline, because the 118
+            # existing sites were correct (they interpolated an already-escaped
+            # safe_file_url() result) and could not be rewritten in one
+            # reviewable diff. #802 migrated all of them, so the baseline is
+            # empty and this is now a flat ban; `--update` exempts a file rather
+            # than recording progress, so use it only by agreement in review.
             # The -f guard keeps this block runnable from a scratch workspace
             # (tests/test_duckdb_connection_factory_bypass.py runs the script
             # against a synthetic tree); test_sql_path_escaping.py asserts the

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -21,7 +21,7 @@ import pyarrow.parquet as pq
 
 from geoparquet_io.core.common import _cast_table_to_schema, write_geoparquet_table
 from geoparquet_io.core.crs_utils import _extract_crs_identifier, parse_crs_string_to_projjson
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
 from geoparquet_io.core.exceptions import (
     BatchTooLargeError,
     GeoParquetError,
@@ -989,7 +989,7 @@ def _json_doc_to_table(doc: dict, exclude: str, suffix: str, con=None) -> pa.Tab
             SELECT
                 ST_AsWKB(geom) as geometry,
                 * EXCLUDE ({exclude})
-            FROM ST_Read('{temp_file}')
+            FROM ST_Read({sql_path(temp_file)})
         """
 
         # Allow arbitrarily large/complex single features through GDAL's parser

--- a/geoparquet_io/core/benchmark.py
+++ b/geoparquet_io/core/benchmark.py
@@ -26,6 +26,7 @@ from geoparquet_io.core.duckdb_utils import (
     _escape_sql_string,
     get_duckdb_connection,
     quote_identifier,
+    sql_path,
 )
 from geoparquet_io.core.exceptions import FileNotFoundGeoParquetError, GeoParquetError
 from geoparquet_io.core.geometry_detection import STANDARD_GEOMETRY_NAMES
@@ -118,17 +119,16 @@ def get_file_info(filepath: Path) -> dict[str, Any]:
         # leaked DuckDB handle breaks file cleanup on Windows.
         with get_duckdb_connection(load_httpfs=False) as conn:
             # Get feature count and basic info
-            safe_filepath = _escape_sql_string(str(filepath))
             result = conn.execute(f"""
                 SELECT COUNT(*) as cnt
-                FROM ST_Read('{safe_filepath}')
+                FROM ST_Read({sql_path(filepath)})
             """).fetchone()
 
             feature_count = result[0] if result else 0
 
             # Get schema to find geometry column
             schema = conn.execute(f"""
-                SELECT * FROM ST_Read('{safe_filepath}') LIMIT 0
+                SELECT * FROM ST_Read({sql_path(filepath)}) LIMIT 0
             """).description
 
             # Find geometry column (common names)
@@ -144,7 +144,7 @@ def get_file_info(filepath: Path) -> dict[str, Any]:
             if geom_col:
                 geom_result = conn.execute(f"""
                     SELECT ST_GeometryType({quote_identifier(geom_col)}) as geom_type
-                    FROM ST_Read('{safe_filepath}')
+                    FROM ST_Read({sql_path(filepath)})
                     LIMIT 1
                 """).fetchone()
                 geom_type = geom_result[0] if geom_result else "unknown"
@@ -251,15 +251,13 @@ def benchmark_duckdb(input_path: Path, output_path: Path) -> tuple[float, float]
     # and pyogrio arms never pay, so timing it here would bias the comparison
     # against DuckDB. Only the COPY is measured.
     conn = get_duckdb_connection(load_httpfs=False)
-    safe_input = _escape_sql_string(str(input_path))
-    safe_output = _escape_sql_string(str(output_path))
 
     tracemalloc.start()
     start = time.perf_counter()
     try:
         conn.execute(f"""
-            COPY (SELECT * FROM ST_Read('{safe_input}'))
-            TO '{safe_output}'
+            COPY (SELECT * FROM ST_Read({sql_path(input_path)}))
+            TO {sql_path(output_path)}
             (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
         """)
         elapsed = time.perf_counter() - start
@@ -876,11 +874,12 @@ def _get_explain_connection(file_path: str) -> duckdb.DuckDBPyConnection:
 
 def _build_explain_query(file_path: str, query: str | None) -> str:
     """Build the EXPLAIN ANALYZE query string."""
-    safe_path = _escape_sql_string(file_path)
     if query:
-        sql = query.replace("{file}", safe_path)
+        # The user's own query supplies the quotes around ``{file}``, so the
+        # placeholder takes a bare escaped literal rather than a complete one.
+        sql = query.replace("{file}", _escape_sql_string(file_path))
     else:
-        sql = f"SELECT * FROM read_parquet('{safe_path}')"
+        sql = f"SELECT * FROM read_parquet({sql_path(file_path)})"
     return f"EXPLAIN ANALYZE {sql}"
 
 

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -24,6 +24,7 @@ from geoparquet_io.core.common import (
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
 from geoparquet_io.core.duckdb_utils import (
     quote_identifier,
+    sql_path,
     validate_where_clause,
     where_condition_fragment,
 )
@@ -248,7 +249,9 @@ def _get_row_count(
 
     conn = get_duckdb_connection()
     conn.execute(f"SET http_timeout = {int(timeout * 1000)}")  # DuckDB uses milliseconds
-    result = conn.execute(f"SELECT rows[1].count FROM read_json_auto('{full_url}')").fetchone()
+    result = conn.execute(
+        f"SELECT rows[1].count FROM read_json_auto({sql_path(full_url)})"
+    ).fetchone()
 
     return int(result[0]) if result else 0
 
@@ -463,7 +466,7 @@ def _fetch_with_retry(
     if fmt == "GeoJSON":
         read_expr = f'ST_Read("{full_url}")'
     else:
-        read_expr = f"read_csv_auto('{full_url}')"
+        read_expr = f"read_csv_auto({sql_path(full_url)})"
 
     debug(f"Request URL: {full_url[:100]}...")
 

--- a/geoparquet_io/core/check_fixes.py
+++ b/geoparquet_io/core/check_fixes.py
@@ -13,9 +13,9 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
 from geoparquet_io.core.exceptions import GeoParquetError, RemoteAccessError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.hilbert_order import hilbert_order
 from geoparquet_io.core.logging_config import debug, info, progress
 from geoparquet_io.core.remote import (
@@ -69,7 +69,7 @@ def fix_compression(
         profile, parquet_file, actual_output if not is_remote_output else output_file
     )
 
-    safe_url = safe_file_url(parquet_file, verbose)
+    raw_url = resolve_file_url(parquet_file, verbose)
 
     # Get original metadata (only needed for v1.x)
     original_metadata = None
@@ -81,7 +81,7 @@ def fix_compression(
 
     try:
         # Preserve row order from input file (important after Hilbert sorting)
-        query = f"SELECT * FROM read_parquet('{safe_url}', hive_partitioning=false)"
+        query = f"SELECT * FROM read_parquet({sql_path(raw_url)}, hive_partitioning=false)"
 
         write_parquet_with_metadata(
             con=con,
@@ -203,7 +203,7 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, parquet_file, output_file)
 
-    safe_url = safe_file_url(parquet_file, verbose)
+    raw_url = resolve_file_url(parquet_file, verbose)
 
     # Detect file type to determine output version
     file_type_info = detect_geoparquet_file_type(parquet_file, verbose)
@@ -220,7 +220,7 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
 
     try:
         # Select all columns EXCEPT the bbox column
-        query = f"SELECT * EXCLUDE ({bbox_column_name}) FROM '{safe_url}'"
+        query = f"SELECT * EXCLUDE ({bbox_column_name}) FROM {sql_path(raw_url)}"
 
         write_parquet_with_metadata(
             con=con,
@@ -329,7 +329,7 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
     # Setup AWS profile if needed
     setup_aws_profile_if_needed(profile, parquet_file, output_file)
 
-    safe_url = safe_file_url(parquet_file, verbose)
+    raw_url = resolve_file_url(parquet_file, verbose)
 
     # Get original metadata (only needed for v1.x)
     original_metadata = None
@@ -340,7 +340,7 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
 
     try:
-        query = f"SELECT * FROM '{safe_url}'"
+        query = f"SELECT * FROM {sql_path(raw_url)}"
 
         write_parquet_with_metadata(
             con=con,

--- a/geoparquet_io/core/check_spatial_order.py
+++ b/geoparquet_io/core/check_spatial_order.py
@@ -4,8 +4,8 @@
 import random as _random
 from statistics import mean
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, progress
 from geoparquet_io.core.remote import needs_httpfs
@@ -39,13 +39,13 @@ def _bboxes_overlap(bbox1: dict, bbox2: dict) -> bool:
     return x_overlap and y_overlap
 
 
-def _calculate_consecutive_avg(con, safe_url, geometry_column, row_limit, verbose):
+def _calculate_consecutive_avg(con, raw_url, geometry_column, row_limit, verbose):
     """Calculate average distance between consecutive features."""
     quoted_geom = quote_identifier(geometry_column)
     query = f"""
     WITH numbered AS (
         SELECT ROW_NUMBER() OVER () as id, {quoted_geom} as geom
-        FROM '{safe_url}' {row_limit}
+        FROM {sql_path(raw_url)} {row_limit}
     )
     SELECT AVG(ST_Distance(a.geom, b.geom)) as avg_dist
     FROM numbered a JOIN numbered b ON b.id = a.id + 1;
@@ -59,11 +59,11 @@ def _calculate_consecutive_avg(con, safe_url, geometry_column, row_limit, verbos
     return avg
 
 
-def _calculate_random_avg(con, safe_url, geometry_column, row_limit, random_sample_size, verbose):
+def _calculate_random_avg(con, raw_url, geometry_column, row_limit, random_sample_size, verbose):
     """Calculate average distance between random pairs of features."""
     quoted_geom = quote_identifier(geometry_column)
     query = f"""
-    WITH sample AS (SELECT {quoted_geom} as geom FROM '{safe_url}' {row_limit}),
+    WITH sample AS (SELECT {quoted_geom} as geom FROM {sql_path(raw_url)} {row_limit}),
     random_pairs AS (
         SELECT a.geom as geom1, b.geom as geom2
         FROM (SELECT geom FROM sample ORDER BY random() LIMIT {random_sample_size}) a,
@@ -101,9 +101,9 @@ def _build_results_dict(ratio, consecutive_avg, random_avg):
     }
 
 
-def _get_row_limit_clause(con, safe_url, limit_rows, verbose):
+def _get_row_limit_clause(con, raw_url, limit_rows, verbose):
     """Determine row limit clause based on total rows."""
-    total_rows = con.execute(f"SELECT COUNT(*) FROM '{safe_url}'").fetchone()[0]
+    total_rows = con.execute(f"SELECT COUNT(*) FROM {sql_path(raw_url)}").fetchone()[0]
     if verbose:
         debug(f"Total rows in file: {total_rows:,}")
 
@@ -313,7 +313,7 @@ def check_spatial_order(
     )
     from geoparquet_io.core.logging_config import warn
 
-    safe_url = safe_file_url(parquet_file, verbose)
+    raw_url = resolve_file_url(parquet_file, verbose)
 
     # Try bbox-stats method first (faster)
     has_bbox, bbox_col_name = has_bbox_column(parquet_file)
@@ -361,13 +361,13 @@ def check_spatial_order(
 
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
     try:
-        row_limit = _get_row_limit_clause(con, safe_url, limit_rows, verbose)
+        row_limit = _get_row_limit_clause(con, raw_url, limit_rows, verbose)
 
         consecutive_avg = _calculate_consecutive_avg(
-            con, safe_url, geometry_column, row_limit, verbose
+            con, raw_url, geometry_column, row_limit, verbose
         )
         random_avg = _calculate_random_avg(
-            con, safe_url, geometry_column, row_limit, random_sample_size, verbose
+            con, raw_url, geometry_column, row_limit, random_sample_size, verbose
         )
 
         ratio = consecutive_avg / random_avg if consecutive_avg and random_avg else None

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -36,7 +36,7 @@ from geoparquet_io.core.exceptions import (
 )
 from geoparquet_io.core.file_utils import (
     is_partition_path,
-    safe_file_url,
+    resolve_file_url,
     validate_output_path,
 )
 from geoparquet_io.core.geo_metadata import build_bbox_covering
@@ -89,7 +89,7 @@ def _build_st_read_expr(input_path: str, layer: str | None = None, keep_wkb: boo
     Args:
         input_path: RAW (unescaped) path or URL to the spatial file. It is
             turned into a SQL literal here by ``sql_path`` -- exactly once, so
-            do not pass a ``safe_file_url`` result (issue #718).
+            do not pass an already-escaped path (issue #718).
         layer: Optional layer name for multi-layer formats (GeoPackage, FileGDB)
         keep_wkb: Return raw WKB blobs instead of parsed GEOMETRY (DuckDB's
             escape hatch for geometry subtypes it cannot represent)
@@ -370,19 +370,17 @@ def _build_csv_read_expr(input_url, delimiter):
     """Build DuckDB CSV read expression with geospatial-appropriate max_line_size.
 
     Args:
-        input_url: An **already SQL-escaped** ``safe_file_url()`` result, not a
-            raw path -- this function writes the surrounding quotes but does not
-            escape. (A raw path would need ``sql_path()`` instead; the CSV read
-            chain has not been migrated, see #718.)
+        input_url: A RAW path or URL. ``sql_path()`` quotes and escapes it
+            here, so callers must not pre-escape it (#802).
         delimiter: CSV delimiter, or None to auto-detect.
     """
     max_line_size = get_csv_max_line_size()
     if delimiter:
         return (
-            f"read_csv('{input_url}', delim='{delimiter}', header=true, "
+            f"read_csv({sql_path(input_url)}, delim='{delimiter}', header=true, "
             f"AUTO_DETECT=TRUE, max_line_size={max_line_size})"
         )
-    return f"read_csv_auto('{input_url}', max_line_size={max_line_size})"
+    return f"read_csv_auto({sql_path(input_url)}, max_line_size={max_line_size})"
 
 
 def _get_csv_columns(con, csv_read):
@@ -867,7 +865,7 @@ def _build_plain_select_query(input_url, is_parquet=False, is_csv=False, delimit
     """Build a SELECT * query for non-geometry file conversion.
 
     Args:
-        input_url: An **already SQL-escaped** ``safe_file_url()`` result, not a
+        input_url: A RAW path or URL, escaped here by ``sql_path()``; not a
             raw path -- this function writes the surrounding quotes but does not
             escape. (A raw path would need ``sql_path()`` instead; this branch
             has not been migrated, see #718.)
@@ -879,12 +877,12 @@ def _build_plain_select_query(input_url, is_parquet=False, is_csv=False, delimit
         SQL SELECT query string
     """
     if is_parquet:
-        return f"SELECT * FROM read_parquet('{input_url}')"
+        return f"SELECT * FROM read_parquet({sql_path(input_url)})"
     if is_csv:
         csv_read = _build_csv_read_expr(input_url, delimiter)
         return f"SELECT * FROM {csv_read}"
     # Spatial formats (GeoJSON, Shapefile, GeoPackage, etc.) - use ST_Read
-    return f"SELECT * FROM ST_Read('{input_url}')"
+    return f"SELECT * FROM ST_Read({sql_path(input_url)})"
 
 
 #: Warned when Hilbert ordering is skipped for want of an envelope (#649). Both
@@ -1396,8 +1394,8 @@ def read_spatial_to_arrow(
     # Show progress for remote files
     show_remote_read_message(input_file, verbose=False)
 
-    # Get safe URL
-    input_url = safe_file_url(input_file, verbose)
+    # RAW path: every SQL interpolation escapes it through sql_path (#802).
+    input_url = resolve_file_url(input_file, verbose)
 
     # Check input file type
     is_csv = _is_csv_file(input_file)
@@ -1473,7 +1471,7 @@ def read_spatial_to_arrow(
         # No geometry found — read as plain table
         if arrow_table is None:
             if is_parquet:
-                table_expr = f"read_parquet('{input_url}')"
+                table_expr = f"read_parquet({sql_path(input_url)})"
             elif is_csv:
                 table_expr = _build_csv_read_expr(input_url, delimiter)
             else:
@@ -1999,7 +1997,7 @@ def convert_to_geoparquet(
     validate_profile_for_urls(profile, input_file, output_file)
     setup_aws_profile_if_needed(profile, input_file, output_file)
     show_remote_read_message(input_file, verbose=False)
-    input_url = safe_file_url(input_file, verbose)
+    input_url = resolve_file_url(input_file, verbose)
     validate_output_path(output_file, verbose)
 
     progress(f"Converting {input_file}...")

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -11,7 +11,7 @@ import re
 from functools import lru_cache
 from typing import Any
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier, sql_path
 from geoparquet_io.core.logging_config import debug, warn
 
 
@@ -624,9 +624,8 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
 
     ``parquet_file`` must be a **RAW** path/URL: every helper it reaches
     (``get_geo_metadata``, ``get_schema_info``, ``resolve_crs_reference``)
-    SQL-escapes its own argument, so an already-escaped ``safe_file_url``
-    result is escaped twice and the existence check then fails on a file that
-    is plainly there (issue #718).
+    SQL-escapes its own argument, so a pre-escaped path is escaped twice and
+    the existence check then fails on a file that is plainly there (#718).
 
     Checks in order:
     1. GeoParquet metadata (columns.<geom_col>.crs)
@@ -687,10 +686,9 @@ def _detect_crs_from_filegdb(gdb_path, con, verbose=False):
 
     for gdbtable_file in gdbtable_files:
         gdbtable_path = os.path.join(gdb_path, gdbtable_file)
-        escaped_path = _escape_sql_string(gdbtable_path)
         try:
             result = con.execute(f"""
-                SELECT * FROM ST_Read_Meta('{escaped_path}')
+                SELECT * FROM ST_Read_Meta({sql_path(gdbtable_path)})
             """).fetchone()
 
             if not result or not result[3]:
@@ -732,10 +730,9 @@ def _detect_crs_from_filegdb(gdb_path, con, verbose=False):
 
 def detect_crs_from_spatial_file(input_file, con, verbose=False):
     """Detect CRS from a spatial file (GeoJSON, GPKG, Shapefile, FileGDB)."""
-    escaped_input_file = _escape_sql_string(input_file)
     try:
         result = con.execute(f"""
-            SELECT * FROM ST_Read_Meta('{escaped_input_file}')
+            SELECT * FROM ST_Read_Meta({sql_path(input_file)})
         """).fetchone()
 
         if result:

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -20,7 +20,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.crs_utils import geoarrow_crs_to_projjson
-from geoparquet_io.core.duckdb_utils import _escape_sql_string
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, sql_path
 from geoparquet_io.core.exceptions import GeoParquetError
 
 # =============================================================================
@@ -354,16 +354,21 @@ def _get_connection_for_file(parquet_file: str, existing_con=None, load_spatial=
         ), True
 
 
-def _safe_url(parquet_file: str) -> str:
-    """Get safe URL for DuckDB queries.
+def _metadata_path(parquet_file: str) -> str:
+    """Resolve the RAW path DuckDB should read for a metadata query.
 
     For partitioned datasets (directories or glob patterns), returns
     path to the first file for metadata operations that require a single file.
+
+    The result is **RAW**, not escaped: every caller hands it to
+    :func:`~geoparquet_io.core.duckdb_utils.sql_path`, which quotes and escapes
+    it in one step at the SQL boundary. Escaping here as well would double the
+    doubling (#802).
     """
     from geoparquet_io.core.file_utils import (
         get_first_parquet_file,
         is_partition_path,
-        safe_file_url,
+        resolve_file_url,
     )
 
     # For partitions, use first file for metadata operations
@@ -372,7 +377,7 @@ def _safe_url(parquet_file: str) -> str:
         if first_file:
             parquet_file = first_file
 
-    return safe_file_url(parquet_file, verbose=False)
+    return resolve_file_url(parquet_file, verbose=False)
 
 
 def get_kv_metadata(parquet_file: str, con=None) -> dict[bytes, bytes]:
@@ -393,14 +398,14 @@ def get_kv_metadata(parquet_file: str, con=None) -> dict[bytes, bytes]:
         return _pyarrow_get_kv_metadata(resolved_path)
 
     # Slow path: use DuckDB for remote files or when connection is provided
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con, load_spatial=False)
 
     try:
         # Get raw bytes to avoid DuckDB's VARCHAR escaping
         result = connection.execute(f"""
             SELECT key, value
-            FROM parquet_kv_metadata('{safe_url}')
+            FROM parquet_kv_metadata({sql_path(metadata_path)})
         """).fetchall()
 
         # Convert to dict with bytes keys for backward compatibility
@@ -445,14 +450,14 @@ def get_geo_metadata(parquet_file: str, con=None) -> dict | None:
         return _pyarrow_get_geo_metadata(resolved_path)
 
     # Slow path: use DuckDB for remote files or when connection is provided
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con, load_spatial=False)
 
     try:
         # Get raw bytes and decode manually to avoid DuckDB's VARCHAR escaping
         result = connection.execute(f"""
             SELECT value
-            FROM parquet_kv_metadata('{safe_url}')
+            FROM parquet_kv_metadata({sql_path(metadata_path)})
             WHERE key::VARCHAR = 'geo'
         """).fetchone()
 
@@ -497,12 +502,12 @@ def get_file_metadata(parquet_file: str, con=None) -> dict:
         return _pyarrow_get_file_metadata(resolved_path)
 
     # Slow path: use DuckDB for remote files or when connection is provided
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con, load_spatial=False)
 
     try:
         result = connection.execute(f"""
-            SELECT * FROM parquet_file_metadata('{safe_url}')
+            SELECT * FROM parquet_file_metadata({sql_path(metadata_path)})
         """).fetchone()
 
         columns = [desc[0] for desc in connection.description]
@@ -530,12 +535,12 @@ def get_schema_info(parquet_file: str, con=None) -> list[dict]:
         # Fall through to DuckDB if PyArrow couldn't handle the file
 
     # Slow path: use DuckDB for remote files or when connection is provided
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con, load_spatial=False)
 
     try:
         result = connection.execute(f"""
-            SELECT * FROM parquet_schema('{safe_url}')
+            SELECT * FROM parquet_schema({sql_path(metadata_path)})
         """).fetchall()
 
         columns = [desc[0] for desc in connection.description]
@@ -562,12 +567,12 @@ def get_usable_columns(parquet_file: str, con=None) -> list[dict]:
 
     Returns list of dicts with 'name' and 'type' keys.
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
         result = connection.execute(f"""
-            DESCRIBE SELECT * FROM read_parquet('{safe_url}')
+            DESCRIBE SELECT * FROM read_parquet({sql_path(metadata_path)})
         """).fetchall()
 
         # DESCRIBE returns: (column_name, column_type, null, key, default, extra)
@@ -583,12 +588,12 @@ def get_row_group_metadata(parquet_file: str, con=None) -> list[dict]:
 
     Returns list of dicts with row_group_id, path_in_schema, stats_min, stats_max, etc.
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
         result = connection.execute(f"""
-            SELECT * FROM parquet_metadata('{safe_url}')
+            SELECT * FROM parquet_metadata({sql_path(metadata_path)})
         """).fetchall()
 
         columns = [desc[0] for desc in connection.description]
@@ -616,7 +621,7 @@ def get_compression_stats(parquet_file: str, con=None) -> list[dict]:
         - uncompressed_bytes: Total uncompressed size in bytes
         - ratio: Compression ratio (uncompressed / compressed), rounded to 2 decimals
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con, load_spatial=False)
 
     try:
@@ -631,7 +636,7 @@ def get_compression_stats(parquet_file: str, con=None) -> list[dict]:
                     / NULLIF(SUM(total_compressed_size), 0),
                     2
                 ) AS ratio
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(metadata_path)})
             GROUP BY path_in_schema
             ORDER BY compressed_bytes DESC
         """).fetchall()
@@ -982,7 +987,7 @@ def get_bbox_from_row_group_stats(
     Queries parquet_metadata() for bbox columns (format: 'bbox, xmin' etc).
     Returns [xmin, ymin, xmax, ymax] or None if not available.
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
@@ -1000,7 +1005,7 @@ def get_bbox_from_row_group_stats(
                     FILTER (WHERE path_in_schema = '{escaped_bbox_col}, xmax') as xmax,
                 MAX(TRY_CAST(stats_max AS DOUBLE))
                     FILTER (WHERE path_in_schema = '{escaped_bbox_col}, ymax') as ymax
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(metadata_path)})
         """).fetchone()
 
         if result and all(v is not None for v in result):
@@ -1019,7 +1024,7 @@ def get_per_row_group_bbox_stats(
 
     Returns list of dicts with row_group_id, xmin, ymin, xmax, ymax.
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
@@ -1037,7 +1042,7 @@ def get_per_row_group_bbox_stats(
                     FILTER (WHERE path_in_schema = '{escaped_bbox_col}, xmax') as xmax,
                 MAX(TRY_CAST(stats_max AS DOUBLE))
                     FILTER (WHERE path_in_schema = '{escaped_bbox_col}, ymax') as ymax
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(metadata_path)})
             GROUP BY row_group_id
             ORDER BY row_group_id
         """).fetchall()
@@ -1064,13 +1069,13 @@ def get_compression_info(parquet_file: str, column_name: str | None = None, con=
 
     Returns dict mapping column path to compression algorithm.
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
         query = f"""
             SELECT DISTINCT path_in_schema, compression
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(metadata_path)})
         """
         if column_name:
             query += f" WHERE path_in_schema = '{_escape_sql_string(column_name)}'"
@@ -1088,7 +1093,7 @@ def get_row_group_stats_summary(parquet_file: str, con=None) -> dict:
 
     Returns dict with num_groups, total_rows, avg_rows_per_group, total_size, avg_group_size.
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
@@ -1101,7 +1106,7 @@ def get_row_group_stats_summary(parquet_file: str, con=None) -> dict:
         result = connection.execute(f"""
             SELECT
                 SUM(total_compressed_size) as total_size
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(metadata_path)})
         """).fetchone()
 
         total_size = result[0] if result and result[0] else 0
@@ -1133,7 +1138,7 @@ def get_bloom_filter_info(parquet_file: str, con=None) -> list[dict]:
         - bloom_filter_coverage_pct: Percentage of row groups with bloom filters
         - total_bloom_filter_bytes: Total size of bloom filter data in bytes
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con, load_spatial=False)
 
     try:
@@ -1146,7 +1151,7 @@ def get_bloom_filter_info(parquet_file: str, con=None) -> list[dict]:
                     100.0 * COUNT(bloom_filter_offset) / COUNT(*), 1
                 ) AS bloom_filter_coverage_pct,
                 COALESCE(SUM(bloom_filter_length), 0) AS total_bloom_filter_bytes
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(metadata_path)})
             GROUP BY path_in_schema
             ORDER BY row_groups_with_bloom_filter DESC, path_in_schema
         """).fetchall()
@@ -1243,7 +1248,7 @@ def get_native_geo_stats_by_row_group(
         unreachable or corrupt file as the failure it is instead of diagnosing
         it as a missing geometry column.
     """
-    safe_url = _safe_url(parquet_file)
+    metadata_path = _metadata_path(parquet_file)
     connection, should_close = _get_connection_for_file(parquet_file, con)
 
     try:
@@ -1252,7 +1257,7 @@ def get_native_geo_stats_by_row_group(
         escaped_geom_col = _escape_sql_string(geometry_column)
         rows = connection.execute(f"""
             SELECT row_group_id, geo_bbox, geo_types
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(metadata_path)})
             WHERE path_in_schema = '{escaped_geom_col}'
             ORDER BY row_group_id
         """).fetchall()

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -774,9 +774,7 @@ def get_duckdb_connection_for_s3(
     )
     try:
         # Lightweight test query - DuckDB handles glob patterns natively
-        # Escape single quotes in path to prevent SQL injection
-        safe_path = _escape_sql_string(path)
-        con.execute(f"SELECT 1 FROM read_parquet('{safe_path}') LIMIT 1").fetchone()
+        con.execute(f"SELECT 1 FROM read_parquet({sql_path(path)}) LIMIT 1").fetchone()
         return con
     except Exception as e:
         con.close()

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -27,6 +27,7 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     get_duckdb_connection_for_s3,
     quote_identifier,
+    sql_path,
     validate_where_clause,
 )
 from geoparquet_io.core.exceptions import (
@@ -37,7 +38,7 @@ from geoparquet_io.core.exceptions import (
 from geoparquet_io.core.file_utils import (
     handle_output_overwrite,
     is_partition_path,
-    safe_file_url,
+    resolve_file_url,
 )
 from geoparquet_io.core.geo_metadata import (
     backfill_derived_stats,
@@ -169,14 +170,14 @@ def _get_data_bounds(input_parquet: str, geometry_col: str) -> tuple | None:
     """Get actual data bounds from file."""
     try:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
-        safe_url = safe_file_url(input_parquet, verbose=False)
+        raw_url = resolve_file_url(input_parquet, verbose=False)
         result = con.execute(f"""
             SELECT
                 MIN(ST_XMin({quote_identifier(geometry_col)})) as xmin,
                 MIN(ST_YMin({quote_identifier(geometry_col)})) as ymin,
                 MAX(ST_XMax({quote_identifier(geometry_col)})) as xmax,
                 MAX(ST_YMax({quote_identifier(geometry_col)})) as ymax
-            FROM read_parquet('{safe_url}')
+            FROM read_parquet({sql_path(raw_url)})
         """).fetchone()
         con.close()
         if result and all(v is not None for v in result):
@@ -449,8 +450,8 @@ def get_schema_columns(input_parquet: str) -> list[str]:
     else:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
     try:
-        safe_url = safe_file_url(file_to_check, verbose=False)
-        result = con.execute(f"DESCRIBE SELECT * FROM read_parquet('{safe_url}')").fetchall()
+        raw_url = resolve_file_url(file_to_check, verbose=False)
+        result = con.execute(f"DESCRIBE SELECT * FROM read_parquet({sql_path(raw_url)})").fetchall()
         return [row[0] for row in result]
     finally:
         con.close()
@@ -1013,7 +1014,7 @@ def _print_dry_run_output(
 
     duckdb_compression = compression.lower() if compression != "UNCOMPRESSED" else "uncompressed"
     display_query = f"""COPY ({query})
-TO '{output_parquet}'
+TO {sql_path(output_parquet)}
 (FORMAT PARQUET, COMPRESSION '{duckdb_compression}');"""
 
     info("-- Main query:")
@@ -1025,7 +1026,6 @@ def _execute_extraction(
     input_parquet: str,
     output_parquet: str,
     query: str,
-    safe_url: str,
     spatial_filter: str | None,
     where: str | None,
     limit: int | None,
@@ -1326,8 +1326,6 @@ def _extract_impl(
         allow_schema_diff=allow_schema_diff,
         hive_input=hive_input,
     )
-    safe_url = safe_file_url(input_parquet, verbose)
-
     if dry_run:
         _print_dry_run_output(
             input_parquet,
@@ -1348,7 +1346,6 @@ def _extract_impl(
             input_parquet,
             output_parquet,
             query,
-            safe_url,
             spatial_filter,
             where,
             limit,

--- a/geoparquet_io/core/file_utils.py
+++ b/geoparquet_io/core/file_utils.py
@@ -513,9 +513,10 @@ def resolve_file_url(file_path, verbose=False):
     space themselves -- so encode it yourself rather than rely on that.
 
     Local paths are checked for existence. Nothing here escapes the result for
-    SQL -- use this for anything that opens the file directly (fsspec, pyarrow,
-    metadata helpers). :func:`safe_file_url` is the SQL-facing variant, and it
-    is the single point at which a path is escaped.
+    SQL, which is what makes it the right resolver for both cases: hand the
+    result to anything that opens the file directly (fsspec, pyarrow, metadata
+    helpers), or to :func:`~geoparquet_io.core.duckdb_utils.sql_path`, which is
+    the single point at which a path becomes a SQL literal (#802).
 
     Args:
         file_path: Local path or remote URL
@@ -553,6 +554,17 @@ def resolve_file_url(file_path, verbose=False):
 def safe_file_url(file_path, verbose=False):
     """
     Prepare a file path for safe use in SQL queries.
+
+    .. deprecated:: superseded by
+       :func:`~geoparquet_io.core.duckdb_utils.sql_path`
+
+       No gpio caller uses this any more (#802). It returns a *bare* escaped
+       value that the caller must quote itself, which is the shape that made
+       the path escape someone else's problem and produced #718's crashes:
+       write ``FROM {sql_path(raw_path)}`` instead, or
+       :func:`resolve_file_url` when the value is not going into SQL at all.
+       It is kept only because the escape-exactly-once contract these tests
+       pin is worth stating in one place.
 
     Resolves the path with :func:`resolve_file_url` -- which takes a remote URL
     as already percent-encoded (#825) -- and escapes single quotes to prevent

--- a/geoparquet_io/core/format_writers.py
+++ b/geoparquet_io/core/format_writers.py
@@ -20,12 +20,13 @@ from geoparquet_io.core.duckdb_utils import (
     _escape_sql_string,
     get_duckdb_connection,
     quote_identifier,
+    sql_path,
 )
 from geoparquet_io.core.exceptions import (
     GeoParquetError,
     InvalidParameterError,
 )
-from geoparquet_io.core.file_utils import resolve_file_url, safe_file_url, validate_output_path
+from geoparquet_io.core.file_utils import resolve_file_url, validate_output_path
 from geoparquet_io.core.geometry_detection import detect_parquet_geometry_column
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success, warn
 from geoparquet_io.core.remote import (
@@ -243,8 +244,6 @@ def write_gdal_format(
         # Execute write with SQL-escaped paths
         # Note: DuckDB's COPY statement doesn't support parameterized paths,
         # so we use SQL standard escaping (double single quotes)
-        safe_input_url = safe_file_url(input_path, verbose=False)
-        safe_output_path = _escape_sql_string(output_path)
 
         # GDAL formats don't support complex types (STRUCT, LIST, MAP), so select only compatible columns
         # Read schema to filter out incompatible columns
@@ -289,8 +288,8 @@ def write_gdal_format(
         select_clause = ", ".join(compatible_cols)
 
         query = f"""
-            COPY (SELECT {select_clause} FROM read_parquet('{safe_input_url}'))
-            TO '{safe_output_path}'
+            COPY (SELECT {select_clause} FROM read_parquet({sql_path(input_path)}))
+            TO {sql_path(output_path)}
             WITH (FORMAT GDAL, DRIVER '{config["driver"]}'{lco_clause}{srs_clause})
         """
 
@@ -409,18 +408,15 @@ def write_csv(
         if not select_cols:
             raise GeoParquetError("No columns to export after filtering geometry.")
 
-        # Write to CSV with SQL-escaped paths
         # Note: DuckDB's COPY statement doesn't support parameterized paths,
-        # so we use SQL standard escaping (double single quotes)
-        safe_input_url = safe_file_url(input_path, verbose=False)
-        safe_output_path = _escape_sql_string(output_path)
+        # so sql_path() supplies the quoted, escaped literal.
 
         query = f"""
             COPY (
                 SELECT {", ".join(select_cols)}
-                FROM read_parquet('{safe_input_url}')
+                FROM read_parquet({sql_path(input_path)})
             )
-            TO '{safe_output_path}'
+            TO {sql_path(output_path)}
             WITH (HEADER TRUE, DELIMITER ',')
         """
 

--- a/geoparquet_io/core/geojson_stream.py
+++ b/geoparquet_io/core/geojson_stream.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import duckdb
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier
+from geoparquet_io.core.duckdb_utils import _escape_sql_string, quote_identifier, sql_path
 from geoparquet_io.core.geometry_detection import STANDARD_GEOMETRY_NAMES
 from geoparquet_io.core.geometry_repair import repair_geometry_sql
 
@@ -474,7 +474,7 @@ def convert_to_geojson_stream(
         Number of features written
     """
     from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
     from geoparquet_io.core.logging_config import configure_verbose, debug, info, success
     from geoparquet_io.core.remote import needs_httpfs, setup_aws_profile_if_needed
     from geoparquet_io.core.streaming import is_stdin
@@ -501,7 +501,7 @@ def convert_to_geojson_stream(
     setup_aws_profile_if_needed(profile, input_path)
 
     # Get safe URL for input
-    input_url = safe_file_url(input_path, verbose)
+    input_url = resolve_file_url(input_path, verbose)
 
     # Check if reprojection is needed
     source_crs = _get_source_crs(input_path)
@@ -514,7 +514,7 @@ def convert_to_geojson_stream(
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_path))
 
     try:
-        source_ref = f"read_parquet('{input_url}')"
+        source_ref = f"read_parquet({sql_path(input_url)})"
 
         # Find geometry column
         geometry_column = _find_geometry_column(con, source_ref)

--- a/geoparquet_io/core/geometry_detection.py
+++ b/geoparquet_io/core/geometry_detection.py
@@ -28,12 +28,12 @@ def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> 
         The name of the detected geometry column, or None if not found.
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
-    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+    from geoparquet_io.core.file_utils import resolve_file_url
     from geoparquet_io.core.remote import needs_httpfs
 
     # Normalize path for consistent handling of URLs and local files
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
 
     # 1. Check GeoParquet metadata first
     geo_meta = get_geo_metadata(parquet_file)
@@ -47,8 +47,8 @@ def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> 
     # 2. Fall back to name-based detection from schema using DuckDB
     con = None
     try:
-        con = get_duckdb_connection(load_httpfs=needs_httpfs(safe_url))
-        result = con.execute(f"DESCRIBE SELECT * FROM read_parquet('{safe_url}')").fetchall()
+        con = get_duckdb_connection(load_httpfs=needs_httpfs(raw_url))
+        result = con.execute(f"DESCRIBE SELECT * FROM read_parquet({sql_path(raw_url)})").fetchall()
         column_names = [row[0] for row in result]
         for std_name in STANDARD_GEOMETRY_NAMES:
             for col in column_names:

--- a/geoparquet_io/core/hilbert_order.py
+++ b/geoparquet_io/core/hilbert_order.py
@@ -15,9 +15,9 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
 from geoparquet_io.core.exceptions import RemoteAccessError
-from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.file_utils import handle_output_overwrite, resolve_file_url
 from geoparquet_io.core.geo_metadata import DEFAULT_GEOPARQUET_VERSION
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
@@ -498,7 +498,7 @@ def _hilbert_order_file_based(
     setup_aws_profile_if_needed(profile, input_parquet, output_parquet)
     show_remote_read_message(working_parquet, verbose)
 
-    safe_url = safe_file_url(working_parquet, verbose)
+    working_url = resolve_file_url(working_parquet, verbose)
     # Read the metadata of the file the query actually reads. With --add-bbox
     # that is the working copy, whose `geo` block `add_bbox` just extended with
     # the `covering` describing the column it wrote. Reading the *original*
@@ -518,7 +518,7 @@ def _hilbert_order_file_based(
 
     # Count empty/null geometries
     empty_count_result = con.execute(f"""
-        SELECT COUNT(*) FROM '{safe_url}'
+        SELECT COUNT(*) FROM {sql_path(working_url)}
         WHERE {quote_identifier(geometry_column)} IS NULL OR ST_IsEmpty({quote_identifier(geometry_column)})
     """).fetchone()
     empty_count = empty_count_result[0] if empty_count_result else 0
@@ -535,7 +535,7 @@ def _hilbert_order_file_based(
     # If all geometries are empty/null, copy file unchanged
     if not bounds:
         warn("All geometries are empty or null. Writing file without Hilbert ordering.")
-        passthrough_query = f"SELECT * FROM '{safe_url}'"
+        passthrough_query = f"SELECT * FROM {sql_path(working_url)}"
         write_parquet_with_metadata(
             con,
             passthrough_query,
@@ -566,13 +566,13 @@ def _hilbert_order_file_based(
     # Non-empty geometries are ordered by Hilbert curve, empty/null appended at end
     order_query = f"""
         WITH non_empty AS (
-            SELECT * FROM '{safe_url}'
+            SELECT * FROM {sql_path(working_url)}
             WHERE {quote_identifier(geometry_column)} IS NOT NULL AND NOT ST_IsEmpty({quote_identifier(geometry_column)})
             ORDER BY ST_Hilbert({quote_identifier(geometry_column)},
                 ST_Extent(ST_MakeEnvelope({xmin}, {ymin}, {xmax}, {ymax})))
         ),
         empty_or_null AS (
-            SELECT * FROM '{safe_url}'
+            SELECT * FROM {sql_path(working_url)}
             WHERE {quote_identifier(geometry_column)} IS NULL OR ST_IsEmpty({quote_identifier(geometry_column)})
         )
         SELECT * FROM non_empty

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -249,7 +249,7 @@ def _detect_metadata_mismatches(
             geom_types_lower = [g.lower() for g in geoparquet_geom_types]
             if parquet_geom_type.lower() not in geom_types_lower:
                 warnings.append(
-                    f"Geometry type mismatch: Parquet geo type restricts to '{parquet_geom_type}' "
+                    f"Geometry type mismatch: Parquet geo type restricts to {parquet_geom_type!r} "
                     f"but GeoParquet metadata allows {geoparquet_geom_types}"
                 )
 

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -23,8 +23,8 @@ from geoparquet_io.core.crs_utils import (
     is_crs84_identifier,
     is_default_crs,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.metadata_utils import (
     extract_bbox_from_row_group_stats,
 )
@@ -649,7 +649,7 @@ def get_preview_data(
         get_row_count,
     )
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
     total_rows = get_row_count(parquet_file)
 
     # Create DuckDB connection
@@ -668,7 +668,7 @@ def get_preview_data(
 
         # Get all column names and DuckDB types from the parquet file
         schema_result = con.execute(
-            f"SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet('{safe_url}'))"
+            f"SELECT column_name, column_type FROM (DESCRIBE SELECT * FROM read_parquet({sql_path(raw_url)}))"
         ).fetchall()
         all_columns = [row[0] for row in schema_result]
         col_types = {row[0]: row[1] for row in schema_result}
@@ -695,7 +695,7 @@ def get_preview_data(
             start_row = max(0, total_rows - tail)
             num_rows = min(tail, total_rows)
             query = (
-                f"SELECT {select_clause} FROM read_parquet('{safe_url}') "
+                f"SELECT {select_clause} FROM read_parquet({sql_path(raw_url)}) "
                 f"OFFSET {start_row} LIMIT {num_rows}"
             )
             mode = "tail"
@@ -703,7 +703,9 @@ def get_preview_data(
             # Read from start (default if head is None, use 10)
             num_rows = head if head is not None else 10
             num_rows = min(num_rows, total_rows)
-            query = f"SELECT {select_clause} FROM read_parquet('{safe_url}') LIMIT {num_rows}"
+            query = (
+                f"SELECT {select_clause} FROM read_parquet({sql_path(raw_url)}) LIMIT {num_rows}"
+            )
             mode = "head"
 
         # Execute query and convert to PyArrow table
@@ -778,7 +780,7 @@ def get_column_statistics(
     Returns:
         dict: Statistics per column
     """
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
     con = get_duckdb_connection(load_httpfs=needs_httpfs(parquet_file))
 
     try:
@@ -794,7 +796,7 @@ def get_column_statistics(
                 query = f"""
                     SELECT
                         COUNT(*) FILTER (WHERE {quote_identifier(col_name)} IS NULL) as null_count
-                    FROM '{safe_url}'
+                    FROM {sql_path(raw_url)}
                 """
                 result = con.execute(query).fetchone()
                 stats[col_name] = {
@@ -811,7 +813,7 @@ def get_column_statistics(
                         MIN({quote_identifier(col_name)}) as min_val,
                         MAX({quote_identifier(col_name)}) as max_val,
                         APPROX_COUNT_DISTINCT({quote_identifier(col_name)}) as unique_count
-                    FROM '{safe_url}'
+                    FROM {sql_path(raw_url)}
                 """
                 try:
                     result = con.execute(query).fetchone()

--- a/geoparquet_io/core/layers.py
+++ b/geoparquet_io/core/layers.py
@@ -35,7 +35,7 @@ import sqlite3
 from pathlib import Path
 from urllib.parse import quote as url_quote
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string
+from geoparquet_io.core.duckdb_utils import sql_path
 from geoparquet_io.core.logging_config import debug
 from geoparquet_io.core.remote import is_remote_url
 
@@ -190,14 +190,11 @@ def _list_filegdb_via_catalog(path: str, con) -> list[str]:
     if not os.path.exists(gdb_items_path):
         raise FileNotFoundError(f"FileGDB catalog table not found: {gdb_items_path}")
 
-    # Escape path for SQL
-    safe_path = _escape_sql_string(gdb_items_path)
-
     try:
         result = con.execute(
             f"""
             SELECT DISTINCT Name
-            FROM ST_Read('{safe_path}')
+            FROM ST_Read({sql_path(gdb_items_path)})
             WHERE Name IS NOT NULL
               AND Name NOT LIKE 'GDB_%'
               AND PhysicalName IS NOT NULL
@@ -245,10 +242,8 @@ def _list_filegdb_layers_fallback(path: str, con) -> list[str]:
 
     for table_file in gdbtable_files:
         table_path = os.path.join(path, table_file)
-        safe_path = _escape_sql_string(table_path)
-
         try:
-            result = con.execute(f"SELECT * FROM ST_Read_Meta('{safe_path}')").fetchone()
+            result = con.execute(f"SELECT * FROM ST_Read_Meta({sql_path(table_path)})").fetchone()
 
             if result and result[0]:  # layer_name is first column
                 layer_name = result[0]

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -884,17 +884,18 @@ def format_row_group_geo_stats(
 def _get_num_rows_per_row_group(parquet_file: str, file_meta: dict) -> dict[int, int]:
     """Get num_rows per row group from file metadata.
 
-    Takes a RAW path: ``_safe_url`` is the single SQL-escaping point.
+    Takes a RAW path: ``sql_path`` is the single SQL-escaping point.
 
     Returns a mapping of row_group_id to row count.
     """
-    from geoparquet_io.core.duckdb_metadata import _get_connection_for_file, _safe_url
+    from geoparquet_io.core.duckdb_metadata import _get_connection_for_file, _metadata_path
+    from geoparquet_io.core.duckdb_utils import sql_path
 
     connection, should_close = _get_connection_for_file(parquet_file)
     try:
         result = connection.execute(f"""
             SELECT row_group_id, row_group_num_rows
-            FROM parquet_metadata('{_safe_url(parquet_file)}')
+            FROM parquet_metadata({sql_path(_metadata_path(parquet_file))})
             GROUP BY row_group_id, row_group_num_rows
             ORDER BY row_group_id
         """).fetchall()

--- a/geoparquet_io/core/partition/auto_resolution.py
+++ b/geoparquet_io/core/partition/auto_resolution.py
@@ -16,10 +16,11 @@ from geoparquet_io.core.crs_utils import source_crs_string, transform_geom_sql
 from geoparquet_io.core.duckdb_utils import (
     load_community_extension,
     quote_identifier,
+    sql_path,
     validate_where_clause,
     where_sql_fragment,
 )
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, warn
 
@@ -53,8 +54,11 @@ def _count_query(url: str, where: str | None) -> str:
     :func:`validate_where_clause` rejects separators as well (gpio #612).
     """
     if not where:
-        return f"SELECT COUNT(*) FROM '{url}'"
-    return f"SELECT COUNT(*) FROM (SELECT 1 FROM '{url}'{where_sql_fragment(where)}) AS __filtered"
+        return f"SELECT COUNT(*) FROM {sql_path(url)}"
+    return (
+        f"SELECT COUNT(*) FROM (SELECT 1 FROM {sql_path(url)}"
+        f"{where_sql_fragment(where)}) AS __filtered"
+    )
 
 
 def _get_total_row_count(
@@ -78,7 +82,7 @@ def _get_total_row_count(
     """
     from geoparquet_io.core.remote import setup_aws_profile_if_needed
 
-    input_url = safe_file_url(input_parquet, verbose)
+    input_url = resolve_file_url(input_parquet, verbose)
 
     # Create connection inside try block to ensure cleanup on any error
     con = None
@@ -365,7 +369,7 @@ def _geom_sql(con, url: str, geom_col: str) -> str:
     back as BLOB and must be decoded. Raises if the column is absent.
     """
     qcol = quote_identifier(geom_col)
-    desc = con.execute(f"DESCRIBE SELECT {qcol} FROM '{url}'").fetchall()
+    desc = con.execute(f"DESCRIBE SELECT {qcol} FROM {sql_path(url)}").fetchall()
     col_type = (desc[0][1] if desc else "").upper()
     if "GEOMETRY" in col_type:
         return qcol
@@ -402,7 +406,7 @@ def _probe_distinct_cell_counts(
     level of the statement, where it could otherwise chain a second one.
     """
     centroid = f"ST_Centroid({geom_sql})"
-    filtered = f"(SELECT {centroid} AS c FROM '{url}'{where_sql_fragment(where)})"
+    filtered = f"(SELECT {centroid} AS c FROM {sql_path(url)}{where_sql_fragment(where)})"
     sample_cte = f"SELECT ST_X(c) AS lon, ST_Y(c) AS lat FROM {filtered}{sample_clause}"
     if index_type == "quadkey":
         # A level-r quadkey is the length-r prefix of a finer one, so compute the
@@ -469,7 +473,7 @@ def _probe_extent_resolution(
     """
     from geoparquet_io.core.remote import setup_aws_profile_if_needed
 
-    url = safe_file_url(input_parquet, verbose)
+    url = resolve_file_url(input_parquet, verbose)
     resolutions = list(range(min_resolution, max_resolution + 1))
     con = None
     try:

--- a/geoparquet_io/core/partition/common.py
+++ b/geoparquet_io/core/partition/common.py
@@ -6,9 +6,9 @@ import shutil
 from contextlib import contextmanager
 
 from geoparquet_io.core.common import get_parquet_metadata
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
 from geoparquet_io.core.exceptions import PartitionError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.logging_config import debug, error, info, progress, warn
 from geoparquet_io.core.partition.staging import (
     PartitionWriteOptions,
@@ -313,7 +313,7 @@ def analyze_partition_strategy(
     # Show remote read message
     show_remote_read_message(input_parquet, verbose)
 
-    input_url = safe_file_url(input_parquet, verbose)
+    input_url = resolve_file_url(input_parquet, verbose)
 
     # Create DuckDB connection with httpfs if needed
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
@@ -333,7 +333,7 @@ def analyze_partition_strategy(
             SELECT
                 {column_expr} as partition_value,
                 COUNT(*) as row_count
-            FROM '{input_url}'
+            FROM {sql_path(input_url)}
             WHERE {quote_identifier(column_name)} IS NOT NULL
             GROUP BY partition_value
         )
@@ -607,7 +607,7 @@ def preview_partition(
     # Show remote read message
     show_remote_read_message(input_parquet, verbose)
 
-    input_url = safe_file_url(input_parquet, verbose)
+    input_url = resolve_file_url(input_parquet, verbose)
 
     # Create DuckDB connection with httpfs if needed
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_parquet))
@@ -625,7 +625,7 @@ def preview_partition(
         SELECT
             {column_expr} as partition_value,
             COUNT(*) as record_count
-        FROM '{input_url}'
+        FROM {sql_path(input_url)}
         WHERE {quote_identifier(column_name)} IS NOT NULL
         GROUP BY partition_value
         ORDER BY record_count DESC
@@ -726,7 +726,7 @@ def _build_staging_select(
 
     projection = "*" if keep_partition_column else f"* EXCLUDE ({qcol})"
 
-    return f"SELECT {projection}, {pexpr} AS {alias} FROM '{input_url}' WHERE {qcol} IS NOT NULL"
+    return f"SELECT {projection}, {pexpr} AS {alias} FROM {sql_path(input_url)} WHERE {qcol} IS NOT NULL"
 
 
 def _determine_output_path(
@@ -823,7 +823,7 @@ def partition_by_column(
     # Show remote read message
     show_remote_read_message(input_parquet, verbose)
 
-    input_url = safe_file_url(input_parquet, verbose)
+    input_url = resolve_file_url(input_parquet, verbose)
 
     # Run partition analysis unless skipped
     _run_partition_analysis(
@@ -849,7 +849,7 @@ def partition_by_column(
             # so it is the other place a non-conformant input surfaces -- probed
             # before the output directory exists, so a refusal leaves nothing behind.
             with readable_geoparquet(input_parquet):
-                describe = con.execute(f"SELECT * FROM '{input_url}' LIMIT 0").description
+                describe = con.execute(f"SELECT * FROM {sql_path(input_url)} LIMIT 0").description
             input_cols = [d[0] for d in describe]
             alias = make_partition_aliases(1, input_cols)[0]
 

--- a/geoparquet_io/core/partition/reader.py
+++ b/geoparquet_io/core/partition/reader.py
@@ -7,13 +7,14 @@ glob patterns, hive-style) across all gpio commands.
 
 import os
 
+from geoparquet_io.core.duckdb_utils import sql_path
 from geoparquet_io.core.file_utils import (
     get_all_parquet_files,
     get_first_parquet_file,
     has_glob_pattern,
     is_partition_path,
+    resolve_file_url,
     resolve_partition_path,
-    safe_file_url,
 )
 from geoparquet_io.core.logging_config import debug
 from geoparquet_io.core.remote import is_remote_url
@@ -56,8 +57,8 @@ def resolve_read_path(
     file at ``data/country=US/x.parquet`` must keep reading as itself, without
     the partition keys appearing as extra columns.
 
-    The result is RAW, so the caller still owes it exactly one escape --
-    :func:`safe_file_url` or ``sql_path``, never both.
+    The result is RAW, so the caller still owes it exactly one escape, and
+    ``sql_path`` is where that happens.
 
     Args:
         path: File path, directory, or glob pattern (local or remote)
@@ -109,7 +110,7 @@ def build_read_parquet_expr(
              "read_parquet('path/*.parquet', hive_partitioning=true)"
     """
     resolved_path, auto_options = resolve_read_path(path, hive_input, verbose=verbose)
-    safe_path = safe_file_url(resolved_path, verbose=False)
+    raw_path = resolve_file_url(resolved_path, verbose=False)
 
     # Build options list
     options = []
@@ -125,9 +126,9 @@ def build_read_parquet_expr(
     # Build expression
     if options:
         options_str = ", ".join(options)
-        return f"read_parquet('{safe_path}', {options_str})"
+        return f"read_parquet({sql_path(raw_path)}, {options_str})"
     else:
-        return f"read_parquet('{safe_path}')"
+        return f"read_parquet({sql_path(raw_path)})"
 
 
 def get_partition_info(path: str, verbose: bool = False) -> dict:

--- a/geoparquet_io/core/partition/staging.py
+++ b/geoparquet_io/core/partition/staging.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from urllib.parse import unquote
 
 from geoparquet_io.core.common import write_parquet_with_metadata
+from geoparquet_io.core.duckdb_utils import sql_path
 from geoparquet_io.core.exceptions import PartitionError
 from geoparquet_io.core.geo_metadata import strip_derived_stats
 from geoparquet_io.core.logging_config import debug
@@ -136,9 +137,8 @@ def run_partitioned_copy(con, select_sql, partition_cols, staging_dir, verbose, 
     con.execute(f"SET memory_limit = '{effective_limit}'")
 
     part_cols = ", ".join(partition_cols)
-    escaped_dir = staging_dir.replace("'", "''")
     copy_sql = (
-        f"COPY ({select_sql}) TO '{escaped_dir}' "
+        f"COPY ({select_sql}) TO {sql_path(staging_dir)} "
         f"(FORMAT PARQUET, PARTITION_BY ({part_cols}), "
         f"COMPRESSION SNAPPY, GEOPARQUET_VERSION 'NONE', OVERWRITE_OR_IGNORE)"
     )
@@ -203,8 +203,8 @@ def finalize_partition_file(
     # PARTITION_BY alias), and DuckDB would otherwise auto-detect that and re-add
     # the dropped alias as a data column, leaking ``__gpio_part`` into every
     # output file.
-    staging_glob = os.path.join(partition_dir, "*.parquet").replace("'", "''")
-    query = f"SELECT * FROM read_parquet('{staging_glob}', hive_partitioning=false)"
+    staging_glob = os.path.join(partition_dir, "*.parquet")
+    query = f"SELECT * FROM read_parquet({sql_path(staging_glob)}, hive_partitioning=false)"
     write_parquet_with_metadata(
         con,
         query,

--- a/geoparquet_io/core/process/aggregate/by_admin.py
+++ b/geoparquet_io/core/process/aggregate/by_admin.py
@@ -17,7 +17,7 @@ from geoparquet_io.core.duckdb_utils import (
     where_sql_fragment,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import configure_verbose, debug, info, success
 from geoparquet_io.core.partition.admin_hierarchical import (
@@ -240,7 +240,7 @@ def aggregate_by_admin(
     admin_geom_col = admin_dataset.get_geometry_column()
     admin_bbox_col = admin_dataset.get_bbox_column()
 
-    input_url = safe_file_url(input_parquet, verbose)
+    input_url = resolve_file_url(input_parquet, verbose)
     geom_col = find_primary_geometry_column(input_parquet, verbose) or "geometry"
 
     con = get_duckdb_connection(load_spatial=True, load_httpfs=True)

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -8,7 +8,7 @@ import re
 import string
 from dataclasses import dataclass
 
-from geoparquet_io.core.duckdb_utils import quote_identifier
+from geoparquet_io.core.duckdb_utils import quote_identifier, sql_path
 from geoparquet_io.core.exceptions import InvalidParameterError
 
 VALID_METRIC_FUNCS = {"sum", "avg", "min", "max"}
@@ -45,6 +45,9 @@ def _is_numeric_sql_type(col_type: str) -> bool:
 def aggregate_source_relation(input_url: str) -> str:
     """``read_parquet`` expression for the input scan of an aggregation.
 
+    ``input_url`` is a RAW path or URL; ``sql_path`` quotes and escapes it here,
+    so callers must not pre-escape it (#802).
+
     Hive partitioning is left to DuckDB's auto-detection (the default) rather
     than forced off, so ``--where "year = 2025"`` can filter on a partition
     column of a hive-style glob/directory -- the documented use case, which the
@@ -56,7 +59,7 @@ def aggregate_source_relation(input_url: str) -> str:
     fixed column list (bucket id, count, metrics, breakdown pivots, geometry),
     so a passthrough column added by the scan is dropped by the GROUP BY.
     """
-    return f"read_parquet('{input_url}', union_by_name=true)"
+    return f"read_parquet({sql_path(input_url)}, union_by_name=true)"
 
 
 def geometry_to_geom_expr(con, relation: str, geom_col: str) -> str:

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -29,11 +29,12 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
     quote_identifier,
+    sql_path,
     validate_where_clause,
     where_sql_fragment,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import configure_verbose, debug, info, success, warn
 from geoparquet_io.core.process.aggregate.common import (
@@ -474,13 +475,12 @@ def _warn_files_missing_column(con, input_path: str, column: str) -> None:
     """
     if not any(ch in input_path for ch in "*?["):
         return
-    url_lit = _escape_sql_string(input_path)
     col_lit = _escape_sql_string(column)
     try:
         total, with_col = con.execute(
             f"SELECT count(DISTINCT file_name), "
             f"count(DISTINCT file_name) FILTER (WHERE name = '{col_lit}') "
-            f"FROM parquet_schema('{url_lit}')"
+            f"FROM parquet_schema({sql_path(input_path)})"
         ).fetchone()
     except duckdb.Error:  # pragma: no cover - best-effort diagnostics only
         return
@@ -503,8 +503,8 @@ def _validate_keying_columns_for_file(
     """
     if bucket_point == BUCKET_POINT_GEOMETRY:
         return
-    input_url = safe_file_url(input_parquet, verbose=False)
-    relation = f"read_parquet('{input_url}', hive_partitioning=false, union_by_name=true)"
+    input_url = resolve_file_url(input_parquet, verbose=False)
+    relation = f"read_parquet({sql_path(input_url)}, hive_partitioning=false, union_by_name=true)"
     con = get_duckdb_connection(load_spatial=False, load_httpfs=needs_httpfs(input_parquet))
     try:
         if bucket_point == BUCKET_POINT_BBOX and bbox_column:
@@ -579,7 +579,7 @@ def aggregate_grid_file(
         scheme, input_parquet, resolution, auto, target_per_cell, max_cells, verbose, where=where
     )
 
-    input_url = safe_file_url(input_parquet, verbose)
+    input_url = resolve_file_url(input_parquet, verbose)
     geom_col = find_primary_geometry_column(input_parquet, verbose) or "geometry"
     source_crs = extract_crs_from_parquet(input_parquet, verbose)
 

--- a/geoparquet_io/core/process/overview/detect.py
+++ b/geoparquet_io/core/process/overview/detect.py
@@ -17,9 +17,10 @@ from geoparquet_io.core.duckdb_utils import (
     get_duckdb_connection,
     load_community_extension,
     quote_identifier,
+    sql_path,
 )
 from geoparquet_io.core.exceptions import InvalidParameterError
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.logging_config import warn
 from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME
 from geoparquet_io.core.process.aggregate.by_h3 import H3_SCHEME
@@ -287,11 +288,14 @@ def aggregate_connection(input_parquet: str, verbose: bool = False):
     (overview building, pyramid planning, file detection): spatial + httpfs
     connection, lon/lat axis order, and a ``read_parquet`` relation string.
     """
-    url = safe_file_url(input_parquet, verbose)
+    url = resolve_file_url(input_parquet, verbose)
     con = get_duckdb_connection(load_spatial=True, load_httpfs=True)
     try:
         con.execute("SET geometry_always_xy = true")
-        yield con, f"read_parquet('{url}', hive_partitioning=false, union_by_name=true)"
+        yield (
+            con,
+            f"read_parquet({sql_path(url)}, hive_partitioning=false, union_by_name=true)",
+        )
     finally:
         con.close()
         # Release GDAL/spatial native handles before the next spatial

--- a/geoparquet_io/core/process/overview/rollup.py
+++ b/geoparquet_io/core/process/overview/rollup.py
@@ -128,12 +128,13 @@ def build_admin_rollup_sql(
 
 def get_admin_country_context(con, verbose: bool = False) -> tuple[str, str, str]:
     """Return (country_ref, code_col, geom_expr) for the Overture country cache."""
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.duckdb_utils import sql_path
+    from geoparquet_io.core.file_utils import resolve_file_url
     from geoparquet_io.core.partition.admin_hierarchical import _setup_admin_dataset
 
     dataset, _boundary_columns = _setup_admin_dataset("overture", verbose, ["country"])
     path = dataset.get_source_for_level("country")
-    country_ref = f"read_parquet('{safe_file_url(path, verbose)}')"
+    country_ref = f"read_parquet({sql_path(resolve_file_url(path, verbose))})"
     code_col = quote_identifier(dataset.get_level_column_mapping()["country"])
     geom_expr = geometry_to_geom_expr(con, country_ref, dataset.get_geometry_column())
     return country_ref, code_col, geom_expr

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -34,8 +34,9 @@ from geoparquet_io.core.duckdb_utils import (
     _escape_sql_string,
     get_duckdb_connection,
     quote_identifier,
+    sql_path,
 )
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geo_metadata import strip_derived_stats
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, info, success, warn
@@ -495,7 +496,7 @@ def reproject_impl(
     )
 
     # Safe URL for SQL interpolation, computed from the (possibly sanitized) path.
-    input_url = safe_file_url(read_source, verbose=verbose)
+    input_url = resolve_file_url(read_source, verbose=verbose)
 
     # Create DuckDB connection with spatial extension
     con = get_duckdb_connection(
@@ -523,7 +524,7 @@ def reproject_impl(
         log(f"Target CRS: {target_crs}")
 
         # Get feature count
-        count = con.execute(f"SELECT COUNT(*) FROM '{input_url}'").fetchone()[0]
+        count = con.execute(f"SELECT COUNT(*) FROM {sql_path(input_url)}").fetchone()[0]
         log(f"Features: {count:,}")
 
         # Check for existing bbox column to exclude (will be regenerated)
@@ -558,7 +559,7 @@ def reproject_impl(
                             '{source_crs_literal}',
                             '{target_crs_literal}'
                         ) AS {quote_identifier(geom_col)}
-                    FROM '{input_url}'
+                    FROM {sql_path(input_url)}
                 )
                 SELECT
                     *,
@@ -581,7 +582,7 @@ def reproject_impl(
                         '{source_crs_literal}',
                         '{target_crs_literal}'
                     ) AS {quote_identifier(geom_col)}
-                FROM '{input_url}'
+                FROM {sql_path(input_url)}
             """
 
         # Determine output path
@@ -744,7 +745,7 @@ def _reproject_streaming(
         )
 
         # Get safe URL for SQL interpolation
-        working_url = safe_file_url(working_file, verbose=False)
+        working_url = resolve_file_url(working_file, verbose=False)
 
         # Create connection
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(working_file))
@@ -783,7 +784,7 @@ def _reproject_streaming(
                                 '{source_crs_literal}',
                                 '{target_crs_literal}'
                             ) AS {quote_identifier(geom_col)}
-                        FROM '{working_url}'
+                        FROM {sql_path(working_url)}
                     )
                     SELECT
                         *,
@@ -804,7 +805,7 @@ def _reproject_streaming(
                             '{source_crs_literal}',
                             '{target_crs_literal}'
                         ) AS {quote_identifier(geom_col)}
-                    FROM '{working_url}'
+                    FROM {sql_path(working_url)}
                 """
 
             # Get original metadata for preservation

--- a/geoparquet_io/core/sort_quadkey.py
+++ b/geoparquet_io/core/sort_quadkey.py
@@ -13,12 +13,12 @@ from geoparquet_io.core.add.quadkey import add_quadkey_column, add_quadkey_table
 from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
 from geoparquet_io.core.constants import DEFAULT_QUADKEY_COLUMN_NAME, DEFAULT_QUADKEY_RESOLUTION
 from geoparquet_io.core.duckdb_metadata import get_column_names, get_usable_columns
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
 from geoparquet_io.core.exceptions import GeoParquetError, InvalidParameterError
 from geoparquet_io.core.file_utils import (
     handle_output_overwrite,
     is_partition_path,
-    safe_file_url,
+    resolve_file_url,
 )
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
 from geoparquet_io.core.parquet_writer import resolve_sort_row_group_rows
@@ -411,7 +411,7 @@ def _sort_by_quadkey_streaming(
             actual_input = temp_quadkey_file
 
         # Build and execute sort query
-        actual_safe_url = safe_file_url(actual_input, verbose=False)
+        actual_url = resolve_file_url(actual_input, verbose=False)
         metadata, _ = get_parquet_metadata(actual_input, verbose=False)
 
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(actual_input))
@@ -429,7 +429,7 @@ def _sort_by_quadkey_streaming(
 
         query = f"""
             SELECT {select_clause}
-            FROM '{actual_safe_url}'
+            FROM {sql_path(actual_url)}
             ORDER BY {quote_identifier(quadkey_column_name)}
         """
 

--- a/geoparquet_io/core/str_order.py
+++ b/geoparquet_io/core/str_order.py
@@ -11,9 +11,9 @@ import duckdb
 import pyarrow as pa
 
 from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
 from geoparquet_io.core.exceptions import InvalidParameterError, RemoteAccessError
-from geoparquet_io.core.file_utils import handle_output_overwrite, safe_file_url
+from geoparquet_io.core.file_utils import handle_output_overwrite, resolve_file_url
 from geoparquet_io.core.geo_metadata import parse_geo_metadata
 from geoparquet_io.core.geometry_detection import (
     STANDARD_GEOMETRY_NAMES,
@@ -411,8 +411,7 @@ def _str_order_file_based(
     setup_aws_profile_if_needed(profile, input_parquet, output_parquet)
     show_remote_read_message(working_parquet, verbose)
 
-    safe_url = safe_file_url(working_parquet, verbose)
-    source = f"'{safe_url}'"
+    source = sql_path(resolve_file_url(working_parquet, verbose))
     metadata, _ = get_parquet_metadata(working_parquet, verbose)
     if geometry_column == "geometry":
         geometry_column = find_primary_geometry_column(working_parquet, verbose)

--- a/geoparquet_io/core/stream_io.py
+++ b/geoparquet_io/core/stream_io.py
@@ -22,8 +22,8 @@ import duckdb
 import pyarrow as pa
 
 from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier
-from geoparquet_io.core.file_utils import safe_file_url
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.geo_metadata import backfill_derived_stats, prune_geo_metadata_to_columns
 from geoparquet_io.core.logging_config import warn
 from geoparquet_io.core.remote import needs_httpfs
@@ -155,7 +155,7 @@ def _open_file_input(
     verbose: bool,
 ) -> Iterator[tuple[str, dict | None, bool, duckdb.DuckDBPyConnection]]:
     """Handle file-based input."""
-    safe_url = safe_file_url(path, verbose=verbose)
+    raw_url = resolve_file_url(path, verbose=verbose)
     file_metadata, _ = get_parquet_metadata(path, verbose=verbose)
 
     created_connection = con is None
@@ -163,7 +163,7 @@ def _open_file_input(
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(path))
 
     try:
-        yield f"read_parquet('{safe_url}')", file_metadata, False, con
+        yield f"read_parquet({sql_path(raw_url)})", file_metadata, False, con
     finally:
         if created_connection:
             con.close()

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -30,6 +30,7 @@ from geoparquet_io.core.duckdb_utils import (
     _escape_sql_string,
     _geoarrow_coord_exprs,
     quote_identifier,
+    sql_path,
 )
 from geoparquet_io.core.exceptions import GeoParquetError
 
@@ -1005,9 +1006,11 @@ def _check_geometry_not_repeated(schema_info: list, geom_col: str) -> Validation
 # =============================================================================
 
 
-def _describe_geom_type(con, safe_url: str, geom_col: str) -> str:
+def _describe_geom_type(con, raw_url: str, geom_col: str) -> str:
     """DuckDB's type string for a geometry column ('' when unavailable)."""
-    type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
+    type_query = (
+        f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet({sql_path(raw_url)})"
+    )
     type_result = con.execute(type_query).fetchone()
     return type_result[1] if type_result else ""
 
@@ -1032,9 +1035,7 @@ def _geoarrow_zm_suffix(col_type: str) -> str:
     return ""
 
 
-def _geoarrow_bounds_subquery(
-    safe_url: str, geom_col: str, encoding: str, limit_clause: str
-) -> str:
+def _geoarrow_bounds_subquery(raw_url: str, geom_col: str, encoding: str, limit_clause: str) -> str:
     """Per-row GeoArrow coordinate bounds, with empty geometries filtered out.
 
     Empty GeoArrow values are either an empty coordinate list (NULL bounds) or,
@@ -1045,7 +1046,7 @@ def _geoarrow_bounds_subquery(
     xmin, ymin, xmax, ymax, _, _ = _geoarrow_coord_exprs(quoted_geom, encoding)
     return f"""
         SELECT {xmin} AS xmin, {ymin} AS ymin, {xmax} AS xmax, {ymax} AS ymax
-        FROM read_parquet('{safe_url}')
+        FROM read_parquet({sql_path(raw_url)})
         WHERE {quoted_geom} IS NOT NULL
           AND isfinite({xmin}) AND isfinite({ymin})
         {limit_clause}
@@ -1067,7 +1068,7 @@ def _geoarrow_layout_error(
 
 
 def _check_geoarrow_encoding_matches_data(
-    safe_url: str, geom_col: str, encoding: str, con, limit_clause: str
+    raw_url: str, geom_col: str, encoding: str, con, limit_clause: str
 ) -> ValidationCheck:
     """Check 17 for GeoArrow columns: the stored nesting must fit the encoding.
 
@@ -1081,7 +1082,7 @@ def _check_geoarrow_encoding_matches_data(
     query = f"""
         SELECT COUNT(*) FROM (
             SELECT {xmin} AS xmin
-            FROM read_parquet('{safe_url}')
+            FROM read_parquet({sql_path(raw_url)})
             WHERE {quoted_geom} IS NOT NULL
             {limit_clause}
         )
@@ -1105,30 +1106,30 @@ def _check_encoding_matches_data(
     parquet_file: str, geom_col: str, encoding: str, con, sample_size: int
 ) -> ValidationCheck:
     """Check 17: all geometry values match the 'encoding' metadata."""
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
     quoted_geom = quote_identifier(geom_col)
 
     # For WKB encoding, verify we can parse geometries as WKB
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
     if _is_geoarrow_encoding(encoding):
-        return _check_geoarrow_encoding_matches_data(
-            safe_url, geom_col, encoding, con, limit_clause
-        )
+        return _check_geoarrow_encoding_matches_data(raw_url, geom_col, encoding, con, limit_clause)
 
     try:
         # First check if DuckDB already has it as a GEOMETRY type
         # In that case, the encoding was valid (DuckDB parsed it)
-        type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
+        type_query = (
+            f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet({sql_path(raw_url)})"
+        )
         type_result = con.execute(type_query).fetchone()
         col_type = type_result[1] if type_result else ""
 
         if "GEOMETRY" in col_type.upper():
             # DuckDB already parsed it as geometry - encoding is valid
             count_query = f"""
-                SELECT COUNT(*) FROM read_parquet('{safe_url}')
+                SELECT COUNT(*) FROM read_parquet({sql_path(raw_url)})
                 WHERE {quoted_geom} IS NOT NULL {limit_clause}
             """
             count_result = con.execute(count_query).fetchone()
@@ -1146,7 +1147,7 @@ def _check_encoding_matches_data(
                    COUNT(CASE WHEN ST_GeomFromWKB({quoted_geom}) IS NOT NULL THEN 1 END) as valid
             FROM (
                 SELECT {quoted_geom}
-                FROM read_parquet('{safe_url}')
+                FROM read_parquet({sql_path(raw_url)})
                 WHERE {quoted_geom} IS NOT NULL
                 {limit_clause}
             )
@@ -1245,7 +1246,7 @@ def _compare_geometry_types(
 
 
 def _check_geoarrow_geometry_types(
-    safe_url: str, geom_col: str, declared_types: list, con, limit_clause: str, encoding: str
+    raw_url: str, geom_col: str, declared_types: list, con, limit_clause: str, encoding: str
 ) -> ValidationCheck:
     """Check 18 for GeoArrow columns.
 
@@ -1262,10 +1263,10 @@ def _check_geoarrow_geometry_types(
     """
     quoted_geom = quote_identifier(geom_col)
     found = _GEOARROW_ENCODING_TYPE[encoding] + _geoarrow_zm_suffix(
-        _describe_geom_type(con, safe_url, geom_col)
+        _describe_geom_type(con, raw_url, geom_col)
     )
     count_query = f"""
-        SELECT COUNT(*) FROM read_parquet('{safe_url}')
+        SELECT COUNT(*) FROM read_parquet({sql_path(raw_url)})
         WHERE {quoted_geom} IS NOT NULL {limit_clause}
     """
     count_result = con.execute(count_query).fetchone()
@@ -1282,19 +1283,19 @@ def _check_geometry_types_match_data(
     encoding: Any = "WKB",
 ) -> ValidationCheck:
     """Check 18: all geometry types must be included in 'geometry_types' metadata."""
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
     try:
         if _is_geoarrow_encoding(encoding):
             return _check_geoarrow_geometry_types(
-                safe_url, geom_col, declared_types, con, limit_clause, encoding
+                raw_url, geom_col, declared_types, con, limit_clause, encoding
             )
 
         # Check if DuckDB already has it as a GEOMETRY type
-        col_type = _describe_geom_type(con, safe_url, geom_col)
+        col_type = _describe_geom_type(con, raw_url, geom_col)
 
         # Build the geometry expression based on column type
         if "GEOMETRY" in col_type.upper():
@@ -1310,7 +1311,7 @@ def _check_geometry_types_match_data(
             SELECT {typed_expr} as geom_type, COUNT(*) as cnt
             FROM (
                 SELECT {quote_identifier(geom_col)}
-                FROM read_parquet('{safe_url}')
+                FROM read_parquet({sql_path(raw_url)})
                 WHERE {quote_identifier(geom_col)} IS NOT NULL
                 {limit_clause}
             )
@@ -1363,7 +1364,7 @@ def _check_orientation_matches_data(
 
 
 def _build_bbox_query(
-    safe_url: str,
+    raw_url: str,
     geom_col: str,
     col_type: str,
     bbox: tuple,
@@ -1373,7 +1374,7 @@ def _build_bbox_query(
     """Build SQL query to check if geometries fall within bbox.
 
     Args:
-        safe_url: URL-safe file path
+        raw_url: RAW file path; ``sql_path`` escapes it at the SQL boundary
         geom_col: Name of geometry column
         col_type: DuckDB column type (to determine if GEOMETRY or binary)
         bbox: Tuple of (xmin, ymin, xmax, ymax)
@@ -1394,7 +1395,7 @@ def _build_bbox_query(
                        xmin >= {xmin} AND ymin >= {ymin} AND
                        xmax <= {xmax} AND ymax <= {ymax}
                    THEN 1 END) as within_bbox
-            FROM ({_geoarrow_bounds_subquery(safe_url, geom_col, encoding, limit_clause)})
+            FROM ({_geoarrow_bounds_subquery(raw_url, geom_col, encoding, limit_clause)})
         """
 
     # Use geometry column directly if native type, otherwise convert from WKB
@@ -1416,7 +1417,7 @@ def _build_bbox_query(
                THEN 1 END) as within_bbox
         FROM (
             SELECT {quoted_geom}
-            FROM read_parquet('{safe_url}')
+            FROM read_parquet({sql_path(raw_url)})
             WHERE {quoted_geom} IS NOT NULL
               AND NOT ST_IsEmpty({geom_expr_filter})
             {limit_clause}
@@ -1484,21 +1485,21 @@ def _check_bbox_contains_data(
             category="data_validation",
         )
 
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
     try:
         # Check if DuckDB already has it as a GEOMETRY type
-        col_type = _describe_geom_type(con, safe_url, geom_col)
+        col_type = _describe_geom_type(con, raw_url, geom_col)
 
         # NOTE: bbox[:4] mishandles the spec's 6-element 3D form
         # [xmin,ymin,zmin,xmax,ymax,zmax], comparing against
         # [xmin,ymin,zmin,xmax]. Pre-existing and equally wrong for WKB;
         # tracked as #603 item 1 (same line), so it is not fixed here.
         query = _build_bbox_query(
-            safe_url, geom_col, col_type, tuple(bbox[:4]), limit_clause, encoding
+            raw_url, geom_col, col_type, tuple(bbox[:4]), limit_clause, encoding
         )
         result = con.execute(query).fetchone()
         return _interpret_bbox_result(result, geom_col)
@@ -1981,13 +1982,13 @@ def _check_geography_coordinate_bounds(
             category="parquet_geo_types",
         )
 
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
     try:
-        result = _execute_bounds_query(con, safe_url, geom_col, limit_clause)
+        result = _execute_bounds_query(con, raw_url, geom_col, limit_clause)
         if not result:
             return ValidationCheck(
                 name=f"geography_coordinate_bounds_{geom_col}",
@@ -2023,9 +2024,11 @@ def _check_geography_coordinate_bounds(
         )
 
 
-def _execute_bounds_query(con, safe_url: str, geom_col: str, limit_clause: str):
+def _execute_bounds_query(con, raw_url: str, geom_col: str, limit_clause: str):
     """Execute query to get coordinate bounds for a geometry column."""
-    type_query = f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet('{safe_url}')"
+    type_query = (
+        f"DESCRIBE SELECT {quote_identifier(geom_col)} FROM read_parquet({sql_path(raw_url)})"
+    )
     type_result = con.execute(type_query).fetchone()
     col_type = type_result[1] if type_result else ""
 
@@ -2042,7 +2045,7 @@ def _execute_bounds_query(con, safe_url: str, geom_col: str, limit_clause: str):
             MAX(ST_YMax({geom_expr})) as max_y
         FROM (
             SELECT {quote_identifier(geom_col)}
-            FROM read_parquet('{safe_url}')
+            FROM read_parquet({sql_path(raw_url)})
             WHERE {quote_identifier(geom_col)} IS NOT NULL
             {limit_clause}
         )
@@ -2220,7 +2223,7 @@ def _check_native_geo_stats_contains_data(
 ) -> ValidationCheck:
     """Check that sampled geometries fall within declared geospatial statistics (geo_bbox)."""
     from geoparquet_io.core.duckdb_metadata import get_aggregated_native_geo_stats
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
     from geoparquet_io.core.remote import is_remote_url
 
     try:
@@ -2233,7 +2236,7 @@ def _check_native_geo_stats_contains_data(
                 category="parquet_geo_types",
             )
 
-        safe_url = safe_file_url(parquet_file, verbose=False)
+        raw_url = resolve_file_url(parquet_file, verbose=False)
 
         # The sample below spans the whole file, so it is judged against the
         # whole file's statistics -- the union over every row group, not the
@@ -2288,7 +2291,7 @@ def _check_native_geo_stats_contains_data(
                    THEN 1 END) as within_bbox
             FROM (
                 SELECT {quote_identifier(geom_col)}
-                FROM read_parquet('{safe_url}')
+                FROM read_parquet({sql_path(raw_url)})
                 WHERE {quote_identifier(geom_col)} IS NOT NULL
                   AND NOT ST_IsEmpty({quote_identifier(geom_col)})
                 {limit_clause}
@@ -2341,16 +2344,16 @@ def _check_native_geo_types_match(
     parquet_file: str, geom_col: str, sample_size: int, con
 ) -> ValidationCheck:
     """Check that declared geo_types match actual geometry types in the data."""
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
 
     try:
-        safe_url = safe_file_url(parquet_file, verbose=False)
+        raw_url = resolve_file_url(parquet_file, verbose=False)
 
         # Get declared geo_types from parquet metadata
         escaped_geom_col = _escape_sql_string(geom_col)
         meta_result = con.execute(f"""
             SELECT DISTINCT unnest(geo_types) as geo_type
-            FROM parquet_metadata('{safe_url}')
+            FROM parquet_metadata({sql_path(raw_url)})
             WHERE path_in_schema = '{escaped_geom_col}'
               AND geo_types IS NOT NULL
         """).fetchall()
@@ -2375,7 +2378,7 @@ def _check_native_geo_types_match(
             # Check all rows
             actual_result = con.execute(f"""
                 SELECT DISTINCT {typed_expr} as geom_type
-                FROM read_parquet('{safe_url}')
+                FROM read_parquet({sql_path(raw_url)})
                 WHERE {quote_identifier(geom_col)} IS NOT NULL
             """).fetchall()
         else:
@@ -2384,7 +2387,7 @@ def _check_native_geo_types_match(
                 SELECT DISTINCT {typed_expr} as geom_type
                 FROM (
                     SELECT {quote_identifier(geom_col)}
-                    FROM read_parquet('{safe_url}')
+                    FROM read_parquet({sql_path(raw_url)})
                     WHERE {quote_identifier(geom_col)} IS NOT NULL
                     LIMIT {sample_size}
                 )
@@ -3004,7 +3007,7 @@ def _detect_geographic_in_projected(
 
 
 def _get_geometry_bounds(
-    con, safe_url: str, geom_col: str, limit_clause: str, encoding: Any = "WKB"
+    con, raw_url: str, geom_col: str, limit_clause: str, encoding: Any = "WKB"
 ) -> tuple[float, float, float, float, int] | None:
     """Query actual coordinate bounds from geometry data."""
     if _is_geoarrow_encoding(encoding):
@@ -3012,7 +3015,7 @@ def _get_geometry_bounds(
             SELECT MIN(xmin) as min_x, MAX(xmax) as max_x,
                    MIN(ymin) as min_y, MAX(ymax) as max_y,
                    COUNT(*) as total
-            FROM ({_geoarrow_bounds_subquery(safe_url, geom_col, encoding, limit_clause)})
+            FROM ({_geoarrow_bounds_subquery(raw_url, geom_col, encoding, limit_clause)})
         """
         result = con.execute(query).fetchone()
         if result is None or result[0] is None:
@@ -3020,7 +3023,7 @@ def _get_geometry_bounds(
         return result[0], result[1], result[2], result[3], result[4]
 
     # Check if DuckDB already has it as a GEOMETRY type
-    col_type = _describe_geom_type(con, safe_url, geom_col)
+    col_type = _describe_geom_type(con, raw_url, geom_col)
 
     geom_expr = (
         quote_identifier(geom_col)
@@ -3037,7 +3040,7 @@ def _get_geometry_bounds(
             COUNT(*) as total
         FROM (
             SELECT {quote_identifier(geom_col)}
-            FROM read_parquet('{safe_url}')
+            FROM read_parquet({sql_path(raw_url)})
             WHERE {quote_identifier(geom_col)} IS NOT NULL
             {limit_clause}
         )
@@ -3059,9 +3062,9 @@ def _check_coordinates_valid_for_crs(
     encoding: Any = "WKB",
 ) -> ValidationCheck:
     """Check that geometry coordinates are within valid bounds for the declared CRS."""
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
 
-    safe_url = safe_file_url(parquet_file, verbose=False)
+    raw_url = resolve_file_url(parquet_file, verbose=False)
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
     check_name = f"coordinates_valid_for_crs_{geom_col}"
 
@@ -3077,7 +3080,7 @@ def _check_coordinates_valid_for_crs(
         )
 
     try:
-        bounds_result = _get_geometry_bounds(con, safe_url, geom_col, limit_clause, encoding)
+        bounds_result = _get_geometry_bounds(con, raw_url, geom_col, limit_clause, encoding)
         if bounds_result is None:
             return ValidationCheck(
                 name=check_name,

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -52,7 +52,6 @@ from geoparquet_io.core.common import (
 )
 from geoparquet_io.core.crs_utils import parse_crs_string_to_projjson
 from geoparquet_io.core.duckdb_utils import (
-    _escape_sql_string,
     get_duckdb_connection,
     quote_identifier,
     sql_path,
@@ -1472,7 +1471,7 @@ def _infer_column_types(table: pa.Table) -> pa.Table:
 
 
 def _probe_properties_type(
-    con: duckdb.DuckDBPyConnection, safe_path: str, max_object_size: int
+    con: duckdb.DuckDBPyConnection, response_path: str, max_object_size: int
 ) -> tuple[str, bool]:
     """
     Probe the type of feature.properties to determine if unnest() will work.
@@ -1483,7 +1482,7 @@ def _probe_properties_type(
 
     Args:
         con: DuckDB connection with spatial extension loaded
-        safe_path: Path to the GeoJSON file (already escaped for SQL)
+        response_path: RAW path to the GeoJSON file; escaped here by ``sql_path``
         max_object_size: Maximum JSON object size for read_json_auto
 
     Returns:
@@ -1495,7 +1494,7 @@ def _probe_properties_type(
         props_type_result = con.execute(f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
+                FROM read_json_auto({sql_path(response_path)}, maximum_object_size={max_object_size})
             )
             SELECT typeof(feature.properties) AS props_type
             FROM features
@@ -1514,13 +1513,13 @@ def _probe_properties_type(
 
 
 def _build_wfs_feature_query(
-    safe_path: str, extract_fid: bool, can_unnest_props: bool, max_object_size: int
+    response_path: str, extract_fid: bool, can_unnest_props: bool, max_object_size: int
 ) -> str:
     """
     Build SQL query to extract WFS features from GeoJSON.
 
     Args:
-        safe_path: Path to the GeoJSON file (already escaped for SQL)
+        response_path: RAW path to the GeoJSON file; escaped here by ``sql_path``
         extract_fid: If True, include feature.id as _wfs_fid column
         can_unnest_props: If True, unnest properties into columns; otherwise geometry-only
         max_object_size: Maximum JSON object size for read_json_auto
@@ -1536,7 +1535,7 @@ def _build_wfs_feature_query(
         return f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
+                FROM read_json_auto({sql_path(response_path)}, maximum_object_size={max_object_size})
             ),
             extracted AS (
                 SELECT
@@ -1553,7 +1552,7 @@ def _build_wfs_feature_query(
         return f"""
             WITH features AS (
                 SELECT unnest(features) AS feature
-                FROM read_json_auto('{safe_path}', maximum_object_size={max_object_size})
+                FROM read_json_auto({sql_path(response_path)}, maximum_object_size={max_object_size})
             )
             SELECT
                 {fid_col}
@@ -1563,7 +1562,7 @@ def _build_wfs_feature_query(
 
 
 def _read_count_and_server_crs(
-    con: duckdb.DuckDBPyConnection, safe_path: str
+    con: duckdb.DuckDBPyConnection, response_path: str
 ) -> tuple[int, str | None]:
     """Read the feature count and the server-declared CRS in a single pass.
 
@@ -1588,7 +1587,7 @@ def _read_count_and_server_crs(
         SELECT
             json_array_length(content, '$.features') AS cnt,
             json_extract_string(content, '$.crs.properties.name') AS crs_name
-        FROM read_text('{safe_path}')
+        FROM read_text({sql_path(response_path)})
     """).fetchone()
     if not row:
         return 0, None
@@ -1983,7 +1982,6 @@ def _fetch_wfs_page(
     con = None
     try:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
-        safe_path = _escape_sql_string(tmp_path)
 
         if body_kind == "gml":
             parse_start = time.time()
@@ -1997,7 +1995,7 @@ def _fetch_wfs_page(
         # Read the feature count (DuckDB can't UNNEST empty JSON arrays) and the
         # authoritative CRS the server reported in its GeoJSON response, if any,
         # in a single scan over the response.
-        feature_count, server_crs = _read_count_and_server_crs(con, safe_path)
+        feature_count, server_crs = _read_count_and_server_crs(con, tmp_path)
 
         if feature_count == 0:
             debug("Empty response, returning empty table")
@@ -2005,13 +2003,13 @@ def _fetch_wfs_page(
             return _with_server_crs(empty, server_crs)
 
         # Detect property type and build extraction query
-        props_type, can_unnest_props = _probe_properties_type(con, safe_path, _MAX_JSON_OBJECT_SIZE)
+        props_type, can_unnest_props = _probe_properties_type(con, tmp_path, _MAX_JSON_OBJECT_SIZE)
         if not can_unnest_props:
             debug(f"Properties type is {props_type}, cannot unnest - returning geometry-only table")
 
         parse_start = time.time()
         query = _build_wfs_feature_query(
-            safe_path, extract_fid, can_unnest_props, _MAX_JSON_OBJECT_SIZE
+            tmp_path, extract_fid, can_unnest_props, _MAX_JSON_OBJECT_SIZE
         )
 
         result = con.execute(query)

--- a/geoparquet_io/core/write_strategies/disk_rewrite.py
+++ b/geoparquet_io/core/write_strategies/disk_rewrite.py
@@ -20,9 +20,9 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.duckdb_utils import (
-    _escape_sql_string,
     get_duckdb_connection,
     quote_identifier,
+    sql_path,
 )
 from geoparquet_io.core.geoarrow_encoding import arrow_extension_name, native_wkb_type
 from geoparquet_io.core.logging_config import configure_verbose, debug, progress, success
@@ -182,13 +182,12 @@ class DiskRewriteStrategy(BaseWriteStrategy):
 
             final_query = _wrap_query_with_wkb_conversion(query, geometry_column, con)
 
-            escaped_temp = _escape_sql_string(temp_path)
             copy_options = ["FORMAT PARQUET", f"COMPRESSION {duckdb_compression}"]
             if resolved_row_group_rows:
                 copy_options.append(f"ROW_GROUP_SIZE {resolved_row_group_rows}")
             copy_query = f"""
                 COPY ({final_query})
-                TO '{escaped_temp}'
+                TO {sql_path(temp_path)}
                 ({", ".join(copy_options)})
             """
 
@@ -412,10 +411,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
         work_dir = tempfile.mkdtemp(prefix="gpio_disk_rewrite_") if is_remote else None
 
         try:
-            from geoparquet_io.core.duckdb_utils import _escape_sql_string
-
             local_path = os.path.join(work_dir, "output.parquet") if is_remote else output_path
-            escaped_path = _escape_sql_string(local_path)
 
             copy_options = ["FORMAT PARQUET", f"COMPRESSION {duckdb_compression}"]
             if row_group_rows:
@@ -423,7 +419,7 @@ class DiskRewriteStrategy(BaseWriteStrategy):
 
             copy_query = f"""
                 COPY ({query})
-                TO '{escaped_path}'
+                TO {sql_path(local_path)}
                 ({", ".join(copy_options)})
             """
 

--- a/geoparquet_io/core/write_strategies/duckdb_kv.py
+++ b/geoparquet_io/core/write_strategies/duckdb_kv.py
@@ -26,6 +26,7 @@ from geoparquet_io.core.duckdb_utils import (
     _escape_sql_string,
     build_kv_metadata_clause,
     quote_identifier,
+    sql_path,
     validate_compression_level,
 )
 from geoparquet_io.core.geo_metadata import declare_carried_bbox_column
@@ -445,7 +446,6 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         # geometry encoding directly. No WKB conversion needed.
         # Apply CRS via ST_SetCRS so DuckDB writes it into the schema natively.
         final_query = _wrap_query_with_crs(query, geometry_column, input_crs)
-        escaped_path = _escape_sql_string(local_path)
 
         copy_options = _build_copy_options(
             compression,
@@ -453,7 +453,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             extra_kv_metadata=extra_kv_metadata,
             compression_level=compression_level,
         )
-        copy_query = f"COPY ({final_query}) TO '{escaped_path}' ({', '.join(copy_options)})"
+        copy_query = f"COPY ({final_query}) TO {sql_path(local_path)} ({', '.join(copy_options)})"
         con.execute(copy_query)
 
         if verbose:
@@ -511,12 +511,10 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         else:
             final_query = _wrap_query_with_crs(query, geometry_column, input_crs)
 
-        escaped_path = _escape_sql_string(local_path)
-
         copy_options = _build_copy_options(
             compression, row_group_rows, json.dumps(geo_meta), extra_kv_metadata, compression_level
         )
-        copy_query = f"COPY ({final_query}) TO '{escaped_path}' ({', '.join(copy_options)})"
+        copy_query = f"COPY ({final_query}) TO {sql_path(local_path)} ({', '.join(copy_options)})"
 
         if verbose:
             debug(f"Writing via DuckDB COPY TO with {compression} compression...")
@@ -673,7 +671,6 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
         try:
             con.register("input_table", table)
-            escaped_path = _escape_sql_string(local_path)
 
             options = [
                 "FORMAT PARQUET",
@@ -685,7 +682,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             if row_group_rows:
                 options.append(f"ROW_GROUP_SIZE {row_group_rows}")
 
-            copy_query = f"COPY input_table TO '{escaped_path}' ({', '.join(options)})"
+            copy_query = f"COPY input_table TO {sql_path(local_path)} ({', '.join(options)})"
 
             if verbose:
                 debug(f"Writing plain Parquet with {compression_upper} compression...")
@@ -723,8 +720,6 @@ class DuckDBKVStrategy(BaseWriteStrategy):
         local_path = self._get_local_path(output_path, is_remote)
 
         try:
-            escaped_path = _escape_sql_string(local_path)
-
             options = [
                 "FORMAT PARQUET",
                 f"COMPRESSION {compression}",
@@ -735,7 +730,7 @@ class DuckDBKVStrategy(BaseWriteStrategy):
             if row_group_rows:
                 options.append(f"ROW_GROUP_SIZE {row_group_rows}")
 
-            copy_query = f"COPY ({query}) TO '{escaped_path}' ({', '.join(options)})"
+            copy_query = f"COPY ({query}) TO {sql_path(local_path)} ({', '.join(options)})"
 
             if verbose:
                 debug(f"Writing plain Parquet with {compression} compression...")

--- a/plugins/gpio-fiboa/gpio_fiboa/improve.py
+++ b/plugins/gpio-fiboa/gpio_fiboa/improve.py
@@ -362,7 +362,8 @@ def _add_schemas_metadata(
     )
     from geoparquet_io.core.constants import build_collection_metadata
     from geoparquet_io.core.duckdb_metadata import get_column_names
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.duckdb_utils import sql_path
+    from geoparquet_io.core.file_utils import resolve_file_url
 
     verbose = kwargs.pop("verbose", False)
 
@@ -379,10 +380,10 @@ def _add_schemas_metadata(
     extra_kv = build_collection_metadata(schemas, metadata)
 
     actual_output = output_file or input_file
-    input_url = safe_file_url(input_file, verbose)
+    input_url = resolve_file_url(input_file, verbose)
 
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_file))
-    query = f"SELECT * FROM '{input_url}'"
+    query = f"SELECT * FROM {sql_path(input_url)}"
 
     write_parquet_with_metadata(
         con,

--- a/plugins/gpio-fiboa/tests/test_fiboa.py
+++ b/plugins/gpio-fiboa/tests/test_fiboa.py
@@ -11,6 +11,8 @@ from click.testing import CliRunner
 from gpio_fiboa.cli import fiboa
 from gpio_fiboa.improve import improve_fiboa
 
+from geoparquet_io.core.duckdb_utils import sql_path
+
 TEST_DATA_DIR = Path(__file__).resolve().parent.parent.parent.parent / "tests" / "data"
 BUILDINGS_TEST_FILE = TEST_DATA_DIR / "buildings_test.parquet"
 
@@ -181,7 +183,7 @@ class TestFiboaImprove:
         with duckdb.connect() as con:
             con.execute("LOAD spatial;")
             vals = con.execute(
-                f"""SELECT DISTINCT "determination:method" FROM read_parquet('{temp_output}')"""
+                f"""SELECT DISTINCT "determination:method" FROM read_parquet({sql_path(temp_output)})"""
             ).fetchall()
             assert vals == [("auto-imagery",)]
 
@@ -197,8 +199,8 @@ class TestFiboaImprove:
                 con.execute("LOAD spatial;")
                 con.execute(
                     f"COPY (SELECT *, TIMESTAMP '2024-01-01' AS time FROM "
-                    f"'{os.path.normpath(buildings_file)}') "
-                    f"TO '{with_time}' (FORMAT PARQUET)"
+                    f"{sql_path(os.path.normpath(buildings_file))}) "
+                    f"TO {sql_path(with_time)} (FORMAT PARQUET)"
                 )
 
             runner = CliRunner()
@@ -213,7 +215,7 @@ class TestFiboaImprove:
                 cols = [
                     c[0]
                     for c in con.execute(
-                        f"DESCRIBE SELECT * FROM read_parquet('{temp_output}')"
+                        f"DESCRIBE SELECT * FROM read_parquet({sql_path(temp_output)})"
                     ).fetchall()
                 ]
                 assert "determination:datetime" in cols
@@ -234,8 +236,8 @@ class TestFiboaImprove:
                 con.execute("LOAD spatial;")
                 con.execute(
                     f"COPY (SELECT *, TIMESTAMP '2024-01-01' AS time FROM "
-                    f"'{os.path.normpath(buildings_file)}') "
-                    f"TO '{with_time}' (FORMAT PARQUET)"
+                    f"{sql_path(os.path.normpath(buildings_file))}) "
+                    f"TO {sql_path(with_time)} (FORMAT PARQUET)"
                 )
 
             runner = CliRunner()
@@ -257,7 +259,7 @@ class TestFiboaImprove:
                 cols = [
                     c[0]
                     for c in con.execute(
-                        f"DESCRIBE SELECT * FROM read_parquet('{temp_output}')"
+                        f"DESCRIBE SELECT * FROM read_parquet({sql_path(temp_output)})"
                     ).fetchall()
                 ]
                 assert "determination:datetime" in cols
@@ -288,7 +290,7 @@ class TestFiboaImprove:
             cols = [
                 c[0]
                 for c in con.execute(
-                    f"DESCRIBE SELECT * FROM read_parquet('{temp_output}')"
+                    f"DESCRIBE SELECT * FROM read_parquet({sql_path(temp_output)})"
                 ).fetchall()
             ]
             assert "determination:datetime" in cols
@@ -308,7 +310,7 @@ class TestFiboaImprove:
             cols = [
                 c[0]
                 for c in con.execute(
-                    f"DESCRIBE SELECT * FROM read_parquet('{temp_output}')"
+                    f"DESCRIBE SELECT * FROM read_parquet({sql_path(temp_output)})"
                 ).fetchall()
             ]
             assert "category" in cols
@@ -345,8 +347,8 @@ class TestFiboaImprove:
             with _duckdb.connect() as con:
                 con.execute("LOAD spatial;")
                 con.execute(
-                    f"COPY (SELECT * FROM '{buildings_file}' LIMIT 10) "
-                    f"TO '{v2_file}' (FORMAT PARQUET, GEOPARQUET_VERSION 'NONE')"
+                    f"COPY (SELECT * FROM {sql_path(buildings_file)} LIMIT 10) "
+                    f"TO {sql_path(v2_file)} (FORMAT PARQUET, GEOPARQUET_VERSION 'NONE')"
                 )
 
             runner = CliRunner()

--- a/scripts/check_sql_path_literals.py
+++ b/scripts/check_sql_path_literals.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Ratchet: no NEW hand-written ``FROM '{path}'`` SQL interpolations.
+"""No hand-written ``FROM '{path}'`` SQL interpolations.
 
 Writing the quotes by hand is what let ``gpio add admin-divisions`` interpolate
 an unescaped CLI argument and die with a ``ParserException`` on an output path
@@ -10,12 +10,15 @@ complete, quoted, escaped literal::
     FROM {sql_path(path)}          # good -- one escape, no hand-written quotes
     FROM '{path}'                  # bad  -- the escape is the author's problem
 
-Most of the existing sites are correct: they interpolate a ``safe_file_url``
-result, which is already escaped. Rewriting all of them at once would be churn
-on working code and unreviewable, so this is a **ratchet**, not a ban: each
-file's current count is recorded in the baseline, and the check fails only when
-a file's count *goes up* (or a file not in the baseline grows one). Lowering a
-count is always allowed -- run ``--update`` after migrating call sites.
+This started as a **ratchet**: 118 existing sites across 34 files were correct
+but hand-written (they interpolated an already-escaped ``safe_file_url``
+result), and rewriting them in one go would have been an unreviewable diff, so
+each file's count was recorded in the baseline and the check failed only when a
+count went up. Issue #802 finished the migration, so the baseline is now empty
+and the mechanism is a flat ban: any occurrence at all fails. The per-file
+machinery stays because a stalled migration is the normal way this file gets
+reused, and ``--update`` still records one -- but a non-empty baseline is a
+deliberate exception that needs saying out loud in review, not a default.
 
 Only real call sites are counted: comments and docstrings are skipped, so a
 file's baseline is not a budget that a reworded docstring can free up for a
@@ -128,10 +131,11 @@ def read_baseline() -> dict[str, int]:
 
 def write_baseline(counts: dict[str, int]) -> None:
     header = (
-        "# Hand-written `FROM '{path}'` SQL interpolations per file (issue #718).\n"
-        "# A ratchet, not a target: counts may fall, never rise. New code must use\n"
-        "# sql_path() from geoparquet_io/core/duckdb_utils.py instead.\n"
-        "# Regenerate with: uv run python scripts/check_sql_path_literals.py --update\n"
+        "# Hand-written `FROM '{path}'` SQL interpolations per file (issues #718, #802).\n"
+        "# EMPTY ON PURPOSE: the migration finished in #802, so any occurrence now\n"
+        "# fails. Use sql_path() from geoparquet_io/core/duckdb_utils.py instead.\n"
+        "# Adding a line back here exempts a file -- say why in review; do not run\n"
+        "# `--update` just to get a red check green.\n"
     )
     body = "".join(f"{n} {rel}\n" for rel, n in sorted(counts.items()))
     BASELINE.write_text(header + body, encoding="utf-8")
@@ -165,8 +169,9 @@ def main() -> int:
     for rel, (was, now) in sorted(regressions.items()):
         print(f"  {rel}: {was} -> {now}")
     print()
-    print("       Deliberately keeping an old-style site? Lower the count elsewhere, or")
-    print("       run: uv run python scripts/check_sql_path_literals.py --update")
+    print("       The baseline is empty on purpose (#802 migrated all 118 old sites).")
+    print("       `--update` would exempt the file above rather than fix it, so reach")
+    print("       for it only when a reviewer has agreed the site cannot migrate.")
     return 1
 
 

--- a/scripts/sql_path_literals_baseline.txt
+++ b/scripts/sql_path_literals_baseline.txt
@@ -2,37 +2,3 @@
 # A ratchet, not a target: counts may fall, never rise. New code must use
 # sql_path() from geoparquet_io/core/duckdb_utils.py instead.
 # Regenerate with: uv run python scripts/check_sql_path_literals.py --update
-1 geoparquet_io/core/arcgis.py
-6 geoparquet_io/core/benchmark.py
-2 geoparquet_io/core/carto.py
-3 geoparquet_io/core/check_fixes.py
-3 geoparquet_io/core/check_spatial_order.py
-5 geoparquet_io/core/convert.py
-2 geoparquet_io/core/crs_utils.py
-13 geoparquet_io/core/duckdb_metadata.py
-1 geoparquet_io/core/duckdb_utils.py
-3 geoparquet_io/core/extract.py
-4 geoparquet_io/core/format_writers.py
-1 geoparquet_io/core/geojson_stream.py
-1 geoparquet_io/core/geometry_detection.py
-4 geoparquet_io/core/hilbert_order.py
-6 geoparquet_io/core/inspect_utils.py
-2 geoparquet_io/core/layers.py
-1 geoparquet_io/core/metadata_utils.py
-4 geoparquet_io/core/partition/auto_resolution.py
-4 geoparquet_io/core/partition/common.py
-2 geoparquet_io/core/partition/reader.py
-2 geoparquet_io/core/partition/staging.py
-1 geoparquet_io/core/process/aggregate/common.py
-2 geoparquet_io/core/process/aggregate/grid_common.py
-1 geoparquet_io/core/process/overview/detect.py
-1 geoparquet_io/core/process/overview/rollup.py
-5 geoparquet_io/core/reproject.py
-1 geoparquet_io/core/sort_quadkey.py
-1 geoparquet_io/core/stream_io.py
-16 geoparquet_io/core/validate.py
-4 geoparquet_io/core/wfs.py
-2 geoparquet_io/core/write_strategies/disk_rewrite.py
-4 geoparquet_io/core/write_strategies/duckdb_kv.py
-1 plugins/gpio-fiboa/gpio_fiboa/improve.py
-9 plugins/gpio-fiboa/tests/test_fiboa.py

--- a/tests/test_partition_auto_resolution.py
+++ b/tests/test_partition_auto_resolution.py
@@ -263,7 +263,7 @@ class TestProbeFallbackIsAnnounced:
 
     def test_a_failed_probe_warns_without_verbose(self, caplog, monkeypatch):
         module = "geoparquet_io.core.partition.auto_resolution"
-        monkeypatch.setattr(f"{module}.safe_file_url", lambda *a, **k: "u")
+        monkeypatch.setattr(f"{module}.resolve_file_url", lambda *a, **k: "u")
 
         def _boom(**kwargs):
             raise RuntimeError("HTTP 404 no geography")
@@ -278,7 +278,7 @@ class TestProbeFallbackIsAnnounced:
 
     def test_an_empty_probe_warns_without_verbose(self, caplog, monkeypatch):
         module = "geoparquet_io.core.partition.auto_resolution"
-        monkeypatch.setattr(f"{module}.safe_file_url", lambda *a, **k: "u")
+        monkeypatch.setattr(f"{module}.resolve_file_url", lambda *a, **k: "u")
         monkeypatch.setattr(f"{module}.get_duckdb_connection", lambda **k: _NullConnection())
         monkeypatch.setattr(f"{module}.find_primary_geometry_column", lambda *a, **k: "geometry")
         monkeypatch.setattr(f"{module}.source_crs_string", lambda *a, **k: None)

--- a/tests/test_sql_path_escaping.py
+++ b/tests/test_sql_path_escaping.py
@@ -2,16 +2,16 @@
 
 ``file_utils.safe_file_url()`` escapes a path for interpolation into SQL
 (``'`` -> ``''``) *and* validates that the raw path exists.
-``duckdb_metadata._safe_url()`` delegates to it, so every public
-``duckdb_metadata`` getter escapes its own ``parquet_file`` argument.
+Every public ``duckdb_metadata`` getter used to escape its own ``parquet_file``
+argument through it.
 
 Callers that passed their already-escaped ``safe_url`` into those getters
 therefore escaped twice: the getter re-escaped ``o''brien`` to ``o''''brien``,
 and ``safe_file_url``'s existence check then failed on the *escaped* string,
 raising ``FileNotFoundGeoParquetError`` for a file that is plainly there.
 
-The contract is now: ``safe_file_url``/``_safe_url`` is the single escape
-point, and every ``duckdb_metadata`` getter takes a RAW path.
+The contract is now: every ``duckdb_metadata`` getter takes a RAW path and
+escapes it exactly once, at the SQL boundary, through ``sql_path`` (#802).
 
 Issue #718 found three more paths of the same family:
 

--- a/tests/test_sql_path_escaping.py
+++ b/tests/test_sql_path_escaping.py
@@ -417,17 +417,34 @@ class TestApostropheInOutputPath:
 
 
 class TestSqlPathLiteralRatchet:
-    """The pre-commit ratchet that stops new hand-written ``FROM '{path}'``.
+    """The pre-commit check that stops hand-written ``FROM '{path}'``.
 
-    Most of the existing sites interpolate an already-escaped ``safe_file_url``
-    result and are correct, so a flat ban would demand an unreviewable rewrite.
-    The ratchet records each file's count and fails only when one goes up --
-    counting real call sites only, never prose.
+    It began as a ratchet -- 118 correct-but-hand-written sites across 34 files,
+    each file's count recorded so only an increase failed. #802 migrated all of
+    them, so the baseline is empty and the check is now a flat ban, counting
+    real call sites only, never prose.
     """
 
     @staticmethod
     def _checker():
         return REPO_ROOT / "scripts" / "check_sql_path_literals.py"
+
+    def test_baseline_is_empty(self):
+        """Nothing is exempt any more, and nothing may be re-exempted quietly.
+
+        ``--update`` rewrites the baseline from whatever the tree currently
+        contains, so a new hand-written literal can be made to "pass" by
+        recording it. An empty baseline is the whole guarantee: adding a line
+        back has to break this test and be argued for in review.
+        """
+        entries = [
+            line
+            for line in (REPO_ROOT / "scripts" / "sql_path_literals_baseline.txt")
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+        assert entries == []
 
     def test_checker_is_wired_into_the_precommit_hook(self):
         """The hook's ``-f`` guard means a missing script would silently pass."""


### PR DESCRIPTION
## What changed

Finishes the `sql_path()` migration started in #718. Three commits:

1. **`chore(sql): read metadata, validation and inspection through sql_path`** — `duckdb_metadata`, `metadata_utils`, `validate`, `inspect_utils`, `check_fixes`, `check_spatial_order` and `extract`. `duckdb_metadata._safe_url` is renamed `_metadata_path` and returns a RAW path; `validate.py`'s `safe_url` parameter, which was threaded through eight private helpers as an already-escaped value, is renamed `raw_url` and escaped at each SQL boundary instead.
2. **`chore(sql): migrate the last hand-written FROM '{path}' interpolations`** — `convert`, `reproject`, `benchmark`, `carto`, `arcgis`, `geojson_stream`, `layers`, `crs_utils`, `hilbert_order`, `sort_quadkey`, `str_order`, `stream_io`, `format_writers`, `partition/*`, `process/*`, the write strategies, and the `gpio-fiboa` plugin.
3. **`chore(sql): take the sql_path baseline to zero and make the check a ban`** — empties the baseline, rewords the checker and the pre-commit hook comment, and adds a test asserting the baseline stays empty.

Parts 1 and 2 of issue #802 (escaped paths shown to the user; escaped values crossing a function boundary) **were already on `main`** — `common.add_computed_column`, `add/kdtree`, `add/quadkey`, `add/admin_divisions`, `add/country_codes._get_countries_config` and `_print_dry_run_header`, `partition/admin_hierarchical._get_input_file_info`, and both `current_source` sites all resolve a RAW path already, with regression tests in `tests/test_sql_path_escaping.py` (`TestDisplayedPathsAreNotEscaped`, `TestEscapedValuesDoNotCrossFunctionBoundaries`). This PR is part 3 plus the two things part 3 turned up on its own (below).

`add/country_codes.py::_print_dry_run_bounds_info` was **left alone**, as the issue asks: it echoes *SQL*, where `o''brien` is the correct literal and the printed statement has to be runnable. Its docstring already says so, and `TestDisplayedPathsAreNotEscaped._assert_shows_raw` only checks `--` prose lines for that reason.

Two things the sweep found that are not pure cleanup:

- **`extract.py::_print_dry_run_output` echoed `TO '{output_parquet}'` with no escape at all.** The printed `COPY` was not runnable for an output path containing an apostrophe. It goes through `sql_path` now (`before`/`after` below).
- **`_execute_extraction`'s `safe_url` parameter was unused**, so the `safe_file_url()` call that computed it is deleted rather than migrated.

Two sites deliberately keep `_escape_sql_string`, and are not `sql_path` candidates:

- `benchmark._build_explain_query` substitutes into the user's own `{file}` placeholder, and the user's query supplies the surrounding quotes — a complete literal would produce `''path''`.
- `inspect_utils`' geometry-type-mismatch message is prose, not SQL. It switches to `{parquet_geom_type!r}`, which renders identically but no longer trips the checker's `to '{` pattern.

No production caller reaches `safe_file_url` any more. It is kept (with a note pointing at `sql_path`) because the tests that pin the escape-exactly-once contract still exercise it; `resolve_file_url` — same validation, no escape — is what the migrated call sites use.

## Why

`safe_file_url()` returns a *bare* escaped value that the caller has to quote itself, so the escape outlives the function that applied it and the next consumer has to know. That is the exact shape that produced #718's crashes: a second escape turns `o''brien` into `o''''brien`, and the existence check then fails on a file that is plainly there. `sql_path(raw_path)` returns a complete quoted-and-escaped literal, so the escape happens once, at the boundary, and cannot be forgotten or repeated.

Landing it as one sweep is deliberate: it touches 34 files across every command group, and after the CLI split it would conflict with every per-group PR.

## Verification

**Baseline: 118 interpolations across 34 files → 0.**

```
$ uv run python scripts/check_sql_path_literals.py
$ echo $?
0
$ cat scripts/sql_path_literals_baseline.txt
# Hand-written `FROM '{path}'` SQL interpolations per file (issues #718, #802).
# EMPTY ON PURPOSE: the migration finished in #802, so any occurrence now
# fails. Use sql_path() from geoparquet_io/core/duckdb_utils.py instead.
# Adding a line back here exempts a file -- say why in review; do not run
# `--update` just to get a red check green.
```

No site was left unmigrated.

**Apostrophe in the path — `gpio extract --dry-run`, whose echoed `TO` clause was unescaped:**

```
$ git show origin/main:geoparquet_io/core/extract.py | grep -n "TO '{output_parquet}'"
1016:TO '{output_parquet}'
$ grep -n "TO {sql_path(output_parquet)}" geoparquet_io/core/extract.py
1017:TO {sql_path(output_parquet)}
```

before (`origin/main`), for `.../o'brien/out.parquet` — invalid SQL, the literal ends at the apostrophe:

```
TO '/…/demo-802/o'brien/out.parquet'
```

after (this branch), the same run end to end:

```
$ uv run gpio extract "/…/demo-802/o'brien/in.parquet" "/…/demo-802/o'brien/out.parquet" --limit 5 --dry-run
=== DRY RUN MODE - SQL Commands that would be executed ===

-- Input: /…/demo-802/o'brien/in.parquet
-- Output: /…/demo-802/o'brien/out.parquet
-- Geometry column: geometry
…
-- Main query:
COPY (SELECT … FROM read_parquet('/…/demo-802/o''brien/in.parquet') LIMIT 5)
TO '/…/demo-802/o''brien/out.parquet'
(FORMAT PARQUET, COMPRESSION 'zstd');

$ uv run gpio extract "/…/demo-802/o'brien/in.parquet" "/…/demo-802/o'brien/out.parquet" --limit 5
Extracted 5 rows (out of 100 total) to /…/demo-802/o'brien/out.parquet
```

The `--` prose lines show the path the user typed; the echoed SQL escapes both sides and is runnable.

**Fast suite:**

```
$ uv run pytest -n auto -m "not slow and not network and not meta" -q
1 failed, 6149 passed, 70 skipped, 9 xfailed in 156.49s
FAILED tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe
```

That is the known `-n auto` flake; serially it passes, together with the other two that flake in this family:

```
$ uv run pytest tests/e2e/test_journeys.py::test_journey_01_geojson_to_geoparquet_and_back \
    tests/test_geojson_stream.py::TestPipelineIntegration::test_streaming_handles_broken_pipe \
    tests/test_pipe_integration.py::TestTwoStagePipelines::test_add_bbox_to_sort_hilbert -q
3 passed in 35.44s
```

**diff-cover: 92% of 151 changed lines (gate 90).**

```
$ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
Total:   151 lines
Missing: 11 lines
Coverage: 92%
```

The 11 uncovered lines are the remote/optional branches that were uncovered before the change too: `carto` (live Carto SQL API), `duckdb_utils` S3 no-credentials probe, `layers` FileGDB table scan, and four `validate`/`convert`/`extract`/`duckdb_metadata` fallbacks.

**Hooks:**

```
$ uv run pre-commit run --all-files                     # all Passed
$ uv run pre-commit run --all-files --hook-stage pre-push  # all Passed (deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests)
```

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
