### PR TITLE
test(cli): resolve click 8.5's UNSET flag sentinel to False in surface/parity introspection

### DIFF
--- a/tests/test_cli_api_default_parity.py
+++ b/tests/test_cli_api_default_parity.py
@@ -166,9 +166,22 @@ def _same_default(cli_value, api_value) -> bool:
     return cli_value == api_value
 
 
+def _click_default(param):
+    """Return a Click parameter's default as it resolves at runtime.
+
+    A flag with no explicit ``default=`` resolves to ``False`` at runtime under
+    every click version, but click 8.5 ("Streamline Option flag handling")
+    introspects it as ``UNSET`` where 8.4 materialized ``False``. Resolve the
+    sentinel the way click's parser does so parity compares runtime meaning.
+    """
+    if param.default is UNSET and getattr(param, "is_flag", False):
+        return False
+    return param.default
+
+
 def _cli_defaults(cmd) -> dict:
     return {
-        p.name: p.default
+        p.name: _click_default(p)
         for p in cmd.params
         if not isinstance(p, click.Argument) and p.name not in IGNORE_PARAMS
     }
@@ -552,7 +565,7 @@ def _cli_option_default(command, opt_name):
     """Return the normalized Click default for an option like '--dataset'."""
     for param in command.params:
         if opt_name in param.opts:
-            return _normalize(param.default)
+            return _normalize(_click_default(param))
     raise AssertionError(f"{opt_name!r} not found on command {command.name!r}")
 
 

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -107,8 +107,15 @@ def _default_repr(param: click.Parameter) -> str:
 
     Click's "no default declared" sentinel is normalized to ``<unset>`` so the
     snapshot does not churn wholesale when click changes the sentinel's repr.
+
+    A flag with no explicit ``default=`` resolves to ``False`` at runtime under
+    every click version, but click 8.5 ("Streamline Option flag handling")
+    introspects it as ``UNSET`` where 8.4 materialized ``False``. Resolve the
+    sentinel the way click's parser does so the snapshot matches both versions.
     """
     default = param.default
+    if default is _UNSET and getattr(param, "is_flag", False):
+        return repr(False)
     if default is _UNSET:
         return UNSET_TOKEN
     if callable(default):


### PR DESCRIPTION
## What changed

The CLI-surface snapshot (`tests/test_cli_surface.py::_default_repr`) and the CLI/API default-parity helpers (`tests/test_cli_api_default_parity.py`, via a new shared `_click_default()`) now resolve click's `UNSET` sentinel on an `is_flag` option to `False` — the value click's parser resolves it to at runtime under every version.

`tests/data/cli_surface.json` is deliberately untouched: it records `'False'` for these flags, which is what both normalizations now produce under both click versions.

## Why

click 8.5.0 ("Streamline Option flag handling", see the 8.5.0 changelog) changed flag *introspection*: an `is_flag=True` option declared without an explicit `default=` now introspects as `UNSET` where 8.4.2 materialized `False`. Runtime parsing is unchanged — callbacks still receive `False`/`True`. Under 8.5.0 this made 5 tests fail (the surface snapshot plus 4 parity tests, including hive-default `is False` assertions and KNOWN_DIVERGENCES churn in both directions).

This change is a no-op under the locked 8.4.2, so it can land on main first and unblock the dependabot click bump #899 after a rebase.

## Verification

Under the locked click 8.4.2:

```
$ uv run pytest tests/test_cli_surface.py tests/test_cli_api_default_parity.py tests/test_cli_api_call_parity_scaffold.py -q -m "not network and not slow"
============================= 150 passed in 11.62s =============================
```

Under click 8.5.0 (previously 5 failures):

```
$ uv run --with click==8.5.0 pytest tests/test_cli_surface.py tests/test_cli_api_default_parity.py -q -m "not network and not slow"
============================= 116 passed in 0.29s ==============================
```

ruff check and ruff format clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS