### PR TITLE
fix(aggregate): cut grid cell rings at the antimeridian into MultiPolygons

### DIFF
--- a/docs/guide/process-aggregate.md
+++ b/docs/guide/process-aggregate.md
@@ -543,6 +543,30 @@ Regardless of the chosen bucket scheme, every output file contains:
 | `count_other` | BIGINT | Count for categories beyond `--breakdown-limit` |
 | `geometry` | WKB | Bucket polygon or centroid (absent when `--out-geometry none`) |
 
+### Cells at the antimeridian and the poles
+
+A grid cell is a region of the sphere, and a few of them cannot be drawn as a
+single flat polygon. Those are written the way [RFC 7946
+3.1.9](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.9) prescribes:
+
+- a cell straddling the antimeridian is **cut at ±180 into a `MultiPolygon`**,
+  with one part either side of the line, rather than a ring that stretches
+  across the whole map;
+- a cell holding a pole is closed through an explicit seam that runs up to
+  ±90, so it covers the polar cap instead of self-intersecting;
+- every coordinate written stays inside `[-180, 180]`, which is what
+  `gpio check spec` requires of a geographic CRS.
+
+So `geometry_types` in the output's GeoParquet metadata reads
+`["Polygon", "MultiPolygon"]` (or just `["MultiPolygon"]`) for any dataset that
+reaches the antimeridian, and consumers must expect both. A dataset that sits
+astride the line — rather than spanning the globe — also gets the RFC 7946 5.2
+wrap-around `bbox`, with `xmin > xmax`.
+
+`--out-geometry centroid` and `both` take the centroid from the grid library's
+own cell-centre function, which reports lon/lat in range, so it always falls
+inside the polygon on the same row.
+
 ---
 
 ## Common Options

--- a/docs/guide/process-overview.md
+++ b/docs/guide/process-overview.md
@@ -53,6 +53,8 @@ Outputs are written next to the input (override with `--output-dir`):
 
 Cells roll up by **true hierarchy** — `a5_cell_to_parent` / `h3_cell_to_parent` for grids, the ISO country prefix of `admin_code` (`US-CA` → `US`) for admin — and parent geometry is regenerated from the parent cell id (grids) or cached Overture country polygons (admin).
 
+A coarser parent cell straddles the antimeridian more readily than its children, so grid rollups go through the same seam handling as `gpio process aggregate`: crossing cells are cut into `MultiPolygon`s at ±180 and pole cells are closed through a seam. See [Cells at the antimeridian and the poles](process-aggregate.md#cells-at-the-antimeridian-and-the-poles).
+
 | Column | Rollup | Exactness |
 |--------|--------|-----------|
 | `count` | sum | exact |

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -1600,6 +1600,7 @@ def _apply_geoparquet_metadata(
     verbose: bool = False,
     edges: str | None = None,
     geometry_info: dict | None = None,
+    geo_bbox: list[float] | None = None,
 ):
     """
     Apply GeoParquet metadata to an Arrow Table based on version.
@@ -1628,6 +1629,11 @@ def _apply_geoparquet_metadata(
             - "primary": primary geometry column name
             - "secondary": list of secondary geometry column names
             - "metadata": dict mapping column names to their metadata
+        geo_bbox: Pre-computed [xmin, ymin, xmax, ymax] for the primary column,
+            used instead of the plain min/max taken off the data. A caller that
+            knows the data crosses the antimeridian passes the RFC 7946 5.2
+            wrap form (xmin > xmax) here, which cannot be recovered from
+            per-geometry extents alone.
 
     Returns:
         pa.Table: Table with GeoParquet metadata applied
@@ -1775,7 +1781,7 @@ def _apply_geoparquet_metadata(
     if "geometry_types" not in col_meta:
         col_meta["geometry_types"] = _compute_geometry_types(table, geometry_column, verbose)
 
-    computed_bbox = _compute_bbox_from_data(table, geometry_column, verbose)
+    computed_bbox = geo_bbox or _compute_bbox_from_data(table, geometry_column, verbose)
     if computed_bbox:
         col_meta["bbox"] = computed_bbox
 
@@ -3197,6 +3203,7 @@ def write_geoparquet_table(
     verbose: bool = False,
     profile: str | None = None,
     edges: str | None = None,
+    geo_bbox: list[float] | None = None,
 ) -> None:
     """
     Write a PyArrow Table to a GeoParquet file with proper metadata.
@@ -3217,6 +3224,9 @@ def write_geoparquet_table(
         profile: AWS profile name (S3 only, optional)
         edges: Edge interpretation, "spherical" or "planar" (default None = planar).
                Use "spherical" for data from BigQuery or other S2-based sources.
+        geo_bbox: Pre-computed [xmin, ymin, xmax, ymax] for the geometry column.
+               Pass the RFC 7946 5.2 wrap form (xmin > xmax) for data that
+               crosses the antimeridian; None computes a plain extent.
     """
     # Auto-detect geometry column if not provided
     if geometry_column is None:
@@ -3285,6 +3295,7 @@ def write_geoparquet_table(
                 custom_metadata=None,
                 verbose=verbose,
                 edges=edges,
+                geo_bbox=geo_bbox,
             )
 
         # Write to disk with proper settings

--- a/geoparquet_io/core/process/aggregate/by_a5.py
+++ b/geoparquet_io/core/process/aggregate/by_a5.py
@@ -22,13 +22,15 @@ A5_SCHEME = GridScheme(
     max_resolution=30,
     default_column=DEFAULT_A5_COLUMN_NAME,
     key_template="a5_lonlat_to_cell(ST_X({pt}), ST_Y({pt}), {res})",
-    boundary_template="a5_cell_to_boundary({cell})",
-    latlng_template="a5_cell_to_lonlat({cell})",
-    # a5_cell_to_boundary returns DOUBLE[2][]; close the ring and build a polygon.
-    poly_wkb_template=(
-        "ST_AsWKB(ST_MakePolygon(ST_MakeLine("
-        "list_transform(list_append({bnd}, {bnd}[1]), p -> ST_Point(p[1], p[2])))))"
+    # a5_cell_to_boundary returns an open DOUBLE[2][] ring that stays contiguous
+    # but lets longitudes run outside [-180, 180] (267.0 is a real value), so the
+    # shared builder still has to bring the polygon back into range.
+    boundary_template=(
+        "ST_MakePolygon(ST_MakeLine(list_transform("
+        "list_append(a5_cell_to_boundary({cell}), a5_cell_to_boundary({cell})[1]), "
+        "p -> ST_Point(p[1], p[2]))))"
     ),
+    latlng_template="a5_cell_to_lonlat({cell})",
     # a5_cell_to_lonlat returns [lon, lat].
     centroid_wkb_template="ST_AsWKB(ST_Point({ll}[1], {ll}[2]))",
 )

--- a/geoparquet_io/core/process/aggregate/by_h3.py
+++ b/geoparquet_io/core/process/aggregate/by_h3.py
@@ -23,10 +23,11 @@ H3_SCHEME = GridScheme(
     default_column=DEFAULT_H3_COLUMN_NAME,
     # h3_latlng_to_cell_string takes (lat, lng) -> note Y before X.
     key_template="h3_latlng_to_cell_string(ST_Y({pt}), ST_X({pt}), {res})",
-    # h3_cell_to_boundary_wkt returns a WKT polygon directly.
-    boundary_template="h3_cell_to_boundary_wkt({cell})",
+    # The WKB form parses straight to a GEOMETRY -- no WKT round trip. Every
+    # vertex comes back wrapped into [-180, 180], so a cell straddling the
+    # antimeridian arrives torn; the shared builder repairs it.
+    boundary_template="ST_GeomFromWKB(h3_cell_to_boundary_wkb({cell}))",
     latlng_template="h3_cell_to_latlng({cell})",
-    poly_wkb_template="ST_AsWKB(ST_GeomFromText({bnd}))",
     # h3_cell_to_latlng returns [lat, lng]; ST_Point wants (lng, lat).
     centroid_wkb_template="ST_AsWKB(ST_Point({ll}[2], {ll}[1]))",
 )

--- a/geoparquet_io/core/process/aggregate/common.py
+++ b/geoparquet_io/core/process/aggregate/common.py
@@ -423,3 +423,65 @@ def build_breakdown_select(
                 other_clause = "TRUE"
             parts.append(f'COUNT(*) FILTER (WHERE {other_clause}) AS "count_other"')
     return ", ".join(parts)
+
+
+# Grid-cell output and the antimeridian
+# -------------------------------------
+# A cell that straddles the antimeridian is written cut into a MultiPolygon with
+# parts at both -180 and +180 (RFC 7946 3.1.9). Plain min/max over such a
+# dataset reports a bbox of [-180, ..., 180, ...] -- true, but it claims the
+# whole globe for data that only touches the seam. RFC 7946 5.2, which
+# GeoParquet's `bbox` follows, writes the crossing extent as xmin > xmax
+# instead; gpio's own validator already reads it that way (#876).
+_ANTIMERIDIAN_EPS = 1e-6
+
+_PLAIN_EXTENT_SQL = """
+SELECT min(ST_XMin(g)), max(ST_XMax(g)), min(ST_YMin(g)), max(ST_YMax(g))
+FROM (SELECT {geom_expr} AS g FROM {relation} WHERE {qcol} IS NOT NULL)
+"""
+
+# Widest longitude gap between the parts, found with a running max over the
+# sorted part extents -- the standard interval merge. The parts, not the whole
+# geometries: a cut cell's own extent already spans -180 to 180 and would hide
+# the gap that makes the crossing visible.
+_WIDEST_LON_GAP_SQL = """
+WITH parts AS (
+    SELECT ST_XMin(p) AS lo, ST_XMax(p) AS hi
+    FROM (SELECT UNNEST(ST_Dump({geom_expr})).geom AS p FROM {relation} WHERE {qcol} IS NOT NULL)
+), merged AS (
+    SELECT lo, max(hi) OVER (ORDER BY lo ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS prev
+    FROM parts
+)
+SELECT lo, prev FROM merged WHERE prev IS NOT NULL AND lo > prev ORDER BY lo - prev DESC LIMIT 1
+"""
+
+
+def antimeridian_aware_bbox(con, relation: str, geometry_column: str) -> list[float] | None:
+    """The ``geo`` bbox for a lon/lat relation, in RFC 7946 wrap form when it crosses.
+
+    Returns ``[xmin, ymin, xmax, ymax]`` with ``xmin > xmax`` when the data
+    leaves a longitude gap wider than the one the plain extent implies -- the
+    shape of a dataset that sits astride the antimeridian rather than spanning
+    the globe. Returns the plain extent otherwise, and None when the relation
+    holds no geometry (the caller then leaves the bbox to the writer).
+
+    ``relation`` must already be a FROM-able expression and ``geometry_column``
+    a column of it holding WKB or GEOMETRY. Longitudes are assumed: the caller
+    establishes a geographic CRS, since ``xmin > xmax`` cannot mean a crossing
+    in a projected one.
+    """
+    qcol = quote_identifier(geometry_column)
+    geom_expr = geometry_to_geom_expr(con, relation, geometry_column)
+    params = {"relation": relation, "qcol": qcol, "geom_expr": geom_expr}
+    xmin, xmax, ymin, ymax = con.execute(_PLAIN_EXTENT_SQL.format(**params)).fetchone()
+    if xmin is None:
+        return None
+    plain = [xmin, ymin, xmax, ymax]
+    # Only data reaching both edges can be hiding a crossing; anything else is
+    # already reported tightly and must not pay for the part-level scan.
+    if xmin > -180.0 + _ANTIMERIDIAN_EPS or xmax < 180.0 - _ANTIMERIDIAN_EPS:
+        return plain
+    gap = con.execute(_WIDEST_LON_GAP_SQL.format(**params)).fetchone()
+    if gap is None or (gap[0] - gap[1]) <= (xmin + 360.0) - xmax:
+        return plain
+    return [gap[0], ymin, gap[1], ymax]

--- a/geoparquet_io/core/process/aggregate/grid_common.py
+++ b/geoparquet_io/core/process/aggregate/grid_common.py
@@ -40,6 +40,7 @@ from geoparquet_io.core.logging_config import configure_verbose, debug, info, su
 from geoparquet_io.core.process.aggregate.common import (
     VALID_OUT_GEOMETRY,
     aggregate_source_relation,
+    antimeridian_aware_bbox,
     build_breakdown_column_names,
     build_breakdown_select,
     build_metric_select,
@@ -59,9 +60,10 @@ class GridScheme:
     Templates use ``str.format`` placeholders:
 
     - ``key_template``: ``{pt}`` (a POINT GEOMETRY expression), ``{res}`` -> cell id
-    - ``boundary_template``: ``{cell}`` -> per-row boundary intermediate
+    - ``boundary_template``: ``{cell}`` -> the cell's GEOMETRY polygon, with the
+      longitudes exactly as the grid library reports them (see
+      :data:`_NEEDS_SEAM_REPAIR`); the shared builder owns everything after that
     - ``latlng_template``: ``{cell}`` -> per-row centroid intermediate
-    - ``poly_wkb_template``: ``{bnd}`` (boundary intermediate alias) -> WKB polygon
     - ``centroid_wkb_template``: ``{ll}`` (centroid intermediate alias) -> WKB point
 
     ``name`` doubles as the ``calculate_auto_resolution`` index type and the noun
@@ -76,15 +78,110 @@ class GridScheme:
     key_template: str
     boundary_template: str
     latlng_template: str
-    poly_wkb_template: str
     centroid_wkb_template: str
 
+
+# Cell rings and the antimeridian
+# -------------------------------
+# A cell ring is a closed curve on the sphere; drawing it in the plane forces a
+# choice of where to cut. The two grid libraries make opposite ones, and both
+# need repairing:
+#
+# - ``h3_cell_to_boundary_wkb`` wraps every vertex into [-180, 180], so a cell
+#   straddling the antimeridian comes back with vertices at both +179.x and
+#   -179.x. Read as a planar ring that is a cell spanning 359 degrees, which a
+#   renderer draws as a band across the whole map.
+# - ``a5_cell_to_boundary`` keeps the ring contiguous but lets longitudes run
+#   past the valid range (267.0 is a real value it returns), which fails
+#   GeoParquet's coordinate-range check for a geographic CRS.
+#
+# The repair below is shared by every scheme so the invariant is stated once:
+# **the polygon written for a cell is contiguous, simple, and lies inside
+# [-180, 180]**, as a MultiPolygon cut at the antimeridian when it has to be
+# (RFC 7946 section 3.1.9).
+#
+# It is skipped entirely for the rings that are already fine -- the overwhelming
+# majority -- because a torn ring necessarily has a segment jumping more than
+# 180 degrees of longitude, which forces the planar width past 180. So a ring no
+# wider than 180 degrees and inside the valid range needs nothing done to it.
+_NEEDS_SEAM_REPAIR = (
+    "(ST_XMax({g}) - ST_XMin({g}) > 180.0 OR ST_XMin({g}) < -180.0 OR ST_XMax({g}) > 180.0)"
+)
+
+# The exterior ring as an open DOUBLE[2][] (the closing repeat is sliced off).
+_CELL_RING = (
+    "list_slice(list_transform(ST_Dump(ST_Points(ST_ExteriorRing({g}))), "
+    "p -> [ST_X(p.geom), ST_Y(p.geom)]), 1, -2)"
+)
+
+# Cumulative unwrapping: each vertex is placed relative to the PREVIOUS one, and
+# the 360-degree steps accumulate along the ring. Unwrapping relative to the
+# first vertex instead is only correct while every vertex stays within 180
+# degrees of it, which polar rings do not -- there the `> 180` test fires on
+# vertices that were never wrapped and tears a ring that was intact.
+_UNWRAP_STEPS = (
+    "list_transform({r}, (p, i) -> CASE WHEN i = 1 THEN 0.0 "
+    "WHEN p[1] - {r}[i - 1][1] > 180.0 THEN -360.0 "
+    "WHEN p[1] - {r}[i - 1][1] < -180.0 THEN 360.0 ELSE 0.0 END)"
+)
+_UNWRAP_RING = "list_transform({r}, (p, i) -> [p[1] + list_sum(list_slice({s}, 1, i)), p[2]])"
+
+# Longitude winding of the closed ring, as a multiple of 360. Zero for an
+# ordinary cell -- the unwrapped ring closes on itself. Plus or minus 360 for a
+# ring that encircles a pole: it genuinely spans every longitude, so no amount
+# of unwrapping closes it and it needs an explicit seam instead.
+_RING_WINDING = "(360.0 * round((({u})[-1][1] - ({u})[1][1]) / 360.0))"
+
+_RING_LONS = "list_transform({r}, p -> p[1])"
+_RING_LON_SPAN = "(list_max(" + _RING_LONS + ") - list_min(" + _RING_LONS + "))"
+
+# The pole a ring encircles is the one its vertices sit next to.
+_RING_POLE = "CASE WHEN list_avg(list_transform({r}, p -> p[2])) > 0 THEN 90.0 ELSE -90.0 END"
+
+# Explicit seam for a pole-enclosing ring: carry on past the last vertex to
+# where the first one comes round again, run up to the pole, back along it, and
+# down to the first vertex. That closes the ring in the plane with the polar cap
+# included, and the cut below then splits it at the antimeridian.
+_POLE_SEAM_RING = (
+    "list_concat({u}, [[{u}[1][1] + {w}, {u}[1][2]], "
+    "[{u}[1][1] + {w}, " + _RING_POLE.format(r="{u}") + "], "
+    "[{u}[1][1], " + _RING_POLE.format(r="{u}") + "], {u}[1]])"
+)
+
+# Slide the finished ring by whole turns so its westmost vertex lands in
+# [-180, 180). Everything east of it is then below +540, which is what lets the
+# cut below need only the one eastern box.
+_NORMALIZE_RING = (
+    "list_transform({r}, p -> "
+    "[p[1] - 360.0 * floor((list_min(" + _RING_LONS + ") + 180.0) / 360.0), p[2]])"
+)
+
+_MAKE_RING_POLYGON = "ST_MakePolygon(ST_MakeLine(list_transform({r}, p -> ST_Point(p[1], p[2]))))"
+
+# RFC 7946 section 3.1.9: a polygon crossing the antimeridian is cut at it and
+# written as a MultiPolygon. ST_CollectionExtract(..., 3) drops the degenerate
+# line/point pieces a cut can leave when a ring only grazes the seam.
+_CUT_AT_ANTIMERIDIAN = (
+    "ST_CollectionExtract(ST_Union("
+    "ST_Intersection({g}, ST_MakeEnvelope(-180.0, -90.0, 180.0, 90.0)), "
+    "ST_Translate(ST_Intersection({g}, ST_MakeEnvelope(180.0, -90.0, 540.0, 90.0)), -360.0, 0.0)"
+    "), 3)"
+)
 
 # Internal column aliases used while building the aggregation. Any input column
 # with one of these names is dropped from the SELECT * passthrough so a generated
 # column can never be shadowed by a same-named user column. ("__geom" is kept
 # reserved for inputs that carry a stale column from earlier gpio versions.)
-_RESERVED_INTERNAL = ("__geom", "__pt", "__key", "__bnd", "__ll")
+_RESERVED_INTERNAL = (
+    "__geom",
+    "__pt",
+    "__key",
+    "__bnd",
+    "__ll",
+    "__ring",
+    "__uring",
+    "__fring",
+)
 
 # --bucket-point mode keywords; any other value names an existing point column.
 BUCKET_POINT_GEOMETRY = "geometry"
@@ -325,42 +422,103 @@ def build_grid_query(
     return wrap_grid_geometry(agg_sql, scheme, cell_column, out_geometry)
 
 
+def _cell_boundary_sql(inner_sql: str, scheme: GridScheme, qcol: str) -> str:
+    """Attach the per-cell boundary polygon ``__bnd``, NULL-guarded so a scheme's
+    cell function is never called on the NULL cell id of the unassigned bucket."""
+    boundary = scheme.boundary_template.format(cell=qcol)
+    return (
+        f"SELECT *, CASE WHEN {qcol} IS NULL THEN NULL ELSE {boundary} END AS __bnd "
+        f"FROM ({inner_sql})"
+    )
+
+
+def _seam_repair_sql(base_sql: str) -> str:
+    """Add the seam-repair intermediates for the rings that need one.
+
+    Three nested projections rather than one expression, so each step is named
+    and DuckDB evaluates it only for the rows the previous CASE selected: cells
+    whose ring is already contiguous and in range keep a NULL ``__ring`` and
+    never pay for any of this. See the module comment above
+    :data:`_NEEDS_SEAM_REPAIR` for what the steps mean.
+    """
+    ring = (
+        f"SELECT *, CASE WHEN {_NEEDS_SEAM_REPAIR.format(g='__bnd')} "
+        f"THEN {_CELL_RING.format(g='__bnd')} END AS __ring FROM ({base_sql})"
+    )
+    unwrapped = (
+        f"SELECT *, {_UNWRAP_RING.format(r='__ring', s=_UNWRAP_STEPS.format(r='__ring'))} "
+        f"AS __uring FROM ({ring})"
+    )
+    # Unwrapping is applied only when it narrows the ring. A polar ring spans
+    # more than 180 degrees for real, and shifting its vertices would widen it
+    # towards 360 -- there the original ring was right all along.
+    guarded = (
+        f"CASE WHEN {_RING_LON_SPAN.format(r='__uring')} < {_RING_LON_SPAN.format(r='__ring')} "
+        f"THEN __uring ELSE __ring END"
+    )
+    winding = _RING_WINDING.format(u="__uring")
+    closed = (
+        f"CASE WHEN __ring IS NULL THEN NULL "
+        f"WHEN {winding} <> 0.0 THEN {_POLE_SEAM_RING.format(u='__uring', w=winding)} "
+        f"ELSE list_append({guarded}, ({guarded})[1]) END"
+    )
+    return (
+        f"SELECT * EXCLUDE (__uring), {_NORMALIZE_RING.format(r=closed)} AS __fring "
+        f"FROM ({unwrapped})"
+    )
+
+
+def _repaired_poly_wkb() -> str:
+    """WKB of the cell polygon: the raw boundary, or the repaired ring, cut at
+    the antimeridian into a MultiPolygon when it still crosses."""
+    poly = _MAKE_RING_POLYGON.format(r="__fring")
+    return (
+        "CASE WHEN __bnd IS NULL THEN NULL "
+        "WHEN __ring IS NULL THEN ST_AsWKB(__bnd) "
+        f"WHEN list_max({_RING_LONS.format(r='__fring')}) > 180.0 "
+        f"THEN ST_AsWKB({_CUT_AT_ANTIMERIDIAN.format(g=poly)}) "
+        f"ELSE ST_AsWKB({poly}) END"
+    )
+
+
 def wrap_grid_geometry(
     agg_sql: str, scheme: GridScheme, cell_column: str, out_geometry: str
 ) -> str:
     """Add geometry/centroid columns derived from the grid cell id.
 
     Rows whose cell id is NULL (features with empty/NULL geometry that could not be
-    assigned a cell) get NULL geometry. The boundary/centroid intermediates are
-    NULL-guarded (so a scheme's cell function is never called on a NULL cell), and
-    the output is guarded again so DuckDB short-circuits the geometry constructor
-    for NULL-cell rows.
+    assigned a cell) get NULL geometry throughout.
+
+    The polygon is antimeridian-safe: contiguous, simple, and inside [-180, 180],
+    as a MultiPolygon where the cell crosses the seam. The centroid comes from the
+    scheme's own cell-centre function, which reports lon/lat in range, so polygon
+    and centroid share one frame -- see the module comment above
+    :data:`_NEEDS_SEAM_REPAIR`.
     """
     if out_geometry == "none":
         return agg_sql
 
     qcol = quote_identifier(cell_column)
-    poly_expr = scheme.poly_wkb_template.format(bnd="__bnd")
-    centroid_expr = scheme.centroid_wkb_template.format(ll="__ll")
-    poly = f"CASE WHEN {qcol} IS NULL THEN NULL ELSE {poly_expr} END"
-    centroid = f"CASE WHEN {qcol} IS NULL THEN NULL ELSE {centroid_expr} END"
-
-    if out_geometry == "polygon":
-        geom_cols = f"{poly} AS geometry"
-    elif out_geometry == "centroid":
-        geom_cols = f"{centroid} AS geometry"
-    else:  # both
-        geom_cols = f"{poly} AS geometry, {centroid} AS centroid"
-
-    boundary = scheme.boundary_template.format(cell=qcol)
     latlng = scheme.latlng_template.format(cell=qcol)
-    return (
-        f"SELECT a.* EXCLUDE (__bnd, __ll), {geom_cols} "
-        f"FROM (SELECT *, "
-        f"CASE WHEN {qcol} IS NULL THEN NULL ELSE {boundary} END AS __bnd, "
-        f"CASE WHEN {qcol} IS NULL THEN NULL ELSE {latlng} END AS __ll "
-        f"FROM ({agg_sql})) a"
+    centroid = (
+        f"CASE WHEN {qcol} IS NULL THEN NULL "
+        f"ELSE {scheme.centroid_wkb_template.format(ll='__ll')} END"
     )
+    ll_sql = (
+        f"SELECT *, CASE WHEN {qcol} IS NULL THEN NULL ELSE {latlng} END AS __ll FROM ({agg_sql})"
+    )
+    if out_geometry == "centroid":
+        # No polygon is written, so the cell boundary is never built.
+        return f"SELECT a.* EXCLUDE (__ll), {centroid} AS geometry FROM ({ll_sql}) a"
+
+    poly = _repaired_poly_wkb()
+    geom_cols = (
+        f"{poly} AS geometry"
+        if out_geometry == "polygon"
+        else f"{poly} AS geometry, {centroid} AS centroid"
+    )
+    repaired = _seam_repair_sql(_cell_boundary_sql(ll_sql, scheme, qcol))
+    return f"SELECT a.* EXCLUDE (__bnd, __ll, __ring, __fring), {geom_cols} FROM ({repaired}) a"
 
 
 def _resolve_resolution(
@@ -538,6 +696,23 @@ def _validate_out_geometry(out_geometry: str) -> None:
         )
 
 
+def _result_geo_bbox(con, result) -> list[float] | None:
+    """RFC 7946 bbox for a finished grid result, or None if it cannot be taken.
+
+    A cell cut at the antimeridian puts parts at both -180 and +180, and a plain
+    min/max over that reads as global coverage. Best-effort: a bbox is metadata,
+    so a failure here leaves it to the writer rather than losing the output.
+    """
+    con.register("__agg_result", result)
+    try:
+        return antimeridian_aware_bbox(con, "__agg_result", "geometry")
+    except duckdb.Error as exc:  # pragma: no cover - defensive
+        debug(f"Could not compute an antimeridian-aware bbox: {exc}")
+        return None
+    finally:
+        con.unregister("__agg_result")
+
+
 def aggregate_grid_file(
     scheme: GridScheme,
     input_parquet: str,
@@ -612,6 +787,10 @@ def aggregate_grid_file(
         if show_sql or verbose:
             debug(final_sql)
         result = con.execute(final_sql).arrow().read_all()
+        # The cells are keyed in lon/lat, so the output is always geographic --
+        # whatever the input CRS was -- which is what makes the wrap form
+        # readable (see `antimeridian_aware_bbox`).
+        geo_bbox = None if out_geometry == "none" else _result_geo_bbox(con, result)
     finally:
         con.close()
         # Release GDAL/spatial native handles before the next spatial connection
@@ -646,6 +825,7 @@ def aggregate_grid_file(
             compression_level=compression_level,
             geoparquet_version=geoparquet_version,
             verbose=verbose,
+            geo_bbox=geo_bbox,
         )
     success(f"Aggregated to {result.num_rows} {scheme.name} cells -> {output_parquet}")
 

--- a/geoparquet_io/core/process/overview/run.py
+++ b/geoparquet_io/core/process/overview/run.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 
@@ -21,7 +22,10 @@ from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.logging_config import configure_verbose, debug, success
 from geoparquet_io.core.logging_config import info as log_info
 from geoparquet_io.core.partition.auto_resolution import _register_quadkey_udf
-from geoparquet_io.core.process.aggregate.common import geometry_to_geom_expr
+from geoparquet_io.core.process.aggregate.common import (
+    antimeridian_aware_bbox,
+    geometry_to_geom_expr,
+)
 from geoparquet_io.core.process.overview.detect import (
     AggregateInfo,
     aggregate_connection,
@@ -200,6 +204,7 @@ def _write_overview(
     compression_level: int | None,
     gpq_version: str | None,
     verbose: bool,
+    geo_bbox: list[float] | None = None,
 ) -> None:
     if info.out_geometry == "none":
         kwargs: dict[str, Any] = {"compression": compression}
@@ -215,7 +220,29 @@ def _write_overview(
         compression_level=compression_level,
         geoparquet_version=gpq_version,
         verbose=verbose,
+        geo_bbox=geo_bbox,
     )
+
+
+def _overview_geo_bbox(con, table: pa.Table, info: AggregateInfo) -> list[float] | None:
+    """RFC 7946 bbox for one rolled-up level, wrap form included.
+
+    A grid rollup regenerates parent geometry through the same seam-repairing
+    builder the aggregate uses, so a parent cell can be a MultiPolygon cut at
+    the antimeridian and needs the same bbox treatment (see
+    ``antimeridian_aware_bbox``). Best-effort: a bbox is metadata, so a failure
+    leaves it to the writer rather than losing the level.
+    """
+    if info.out_geometry == "none":
+        return None
+    con.register("__overview_result", table)
+    try:
+        return antimeridian_aware_bbox(con, "__overview_result", "geometry")
+    except duckdb.Error as exc:  # pragma: no cover - defensive
+        debug(f"Could not compute an antimeridian-aware bbox: {exc}")
+        return None
+    finally:
+        con.unregister("__overview_result")
 
 
 def create_overviews(
@@ -304,6 +331,7 @@ def create_overviews(
                 compression_level,
                 geoparquet_version,
                 verbose,
+                geo_bbox=_overview_geo_bbox(con, table, info),
             )
             success(f"Wrote level {level} overview ({table.num_rows} rows) -> {out_path}")
             results.append((level, out_path))

--- a/tests/test_process_aggregate_antimeridian.py
+++ b/tests/test_process_aggregate_antimeridian.py
@@ -1,0 +1,498 @@
+"""Grid-cell output must be antimeridian-safe.
+
+A cell ring is a closed curve on the sphere, and the two grid libraries disagree
+about how to flatten it: `h3_cell_to_boundary_wkb` wraps every vertex into
+[-180, 180] (so a cell straddling the antimeridian tears into a band across the
+whole map), while `a5_cell_to_boundary` keeps the ring contiguous but lets
+longitudes run past the valid range. Both are repaired in one shared builder,
+which cuts a crossing cell into a MultiPolygon at +/-180 (RFC 7946 3.1.9) and
+closes a pole-enclosing ring through an explicit seam.
+
+The invariant these tests hold every scheme to: **every cell polygon is valid,
+contiguous, and inside [-180, 180]**, and the centroid the same row carries
+falls inside it.
+"""
+
+import json
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.process.aggregate.by_a5 import A5_SCHEME, aggregate_by_a5
+from geoparquet_io.core.process.aggregate.by_h3 import H3_SCHEME, aggregate_by_h3
+from geoparquet_io.core.process.aggregate.common import (
+    antimeridian_aware_bbox,
+    geometry_to_geom_expr,
+)
+from geoparquet_io.core.process.aggregate.grid_common import GridScheme, wrap_grid_geometry
+
+# Fiji sits on the antimeridian, so cells here straddle it at low resolutions.
+ANTIMERIDIAN_POINTS = [
+    (179.95, -16.2),
+    (179.80, -16.4),
+    (-179.90, -16.1),
+    (-179.75, -16.3),
+    (179.60, -16.0),
+    (-179.60, -16.5),
+]
+# Both poles, so the pole-enclosing cells are exercised too.
+POLE_POINTS = [(0.0, 89.9), (120.0, 89.5), (-120.0, 88.5), (0.0, -89.9), (60.0, -88.5)]
+
+
+def _spatial_connection():
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial; SET geometry_always_xy = true")
+    return con
+
+
+def _write_points(path, points):
+    con = _spatial_connection()
+    values = ", ".join(f"(ST_Point({x}, {y}), 1)" for x, y in points)
+    con.execute(
+        f"COPY (SELECT * FROM (VALUES {values}) AS t(geometry, n)) TO '{path}' (FORMAT PARQUET)"
+    )
+    con.close()
+    return str(path)
+
+
+@pytest.fixture
+def antimeridian_parquet(tmp_path):
+    return _write_points(tmp_path / "antimeridian.parquet", ANTIMERIDIAN_POINTS)
+
+
+@pytest.fixture
+def pole_parquet(tmp_path):
+    return _write_points(tmp_path / "poles.parquet", POLE_POINTS)
+
+
+# ---------------------------------------------------------------------------
+# Fast lane: no community extension, so these run where diff-cover reads.
+# ---------------------------------------------------------------------------
+
+# Real rings, taken from the grid libraries, keyed by what is wrong with them.
+# "plain" needs nothing done; the rest are what the repair exists for.
+_RING_CASES = {
+    "plain": "POLYGON ((10 10, 11 10, 11 11, 10 11, 10 10))",
+    # h3 819b7ffffffffff near Fiji: vertices on both sides of the seam.
+    "torn": (
+        "POLYGON ((-178.00242433 -22.06717569, -175.76570558 -18.09884526, "
+        "-178.00946172 -14.54728283, 177.80629501 -14.86964530, "
+        "176.70743517 -16.71898041, 175.52711991 -18.29733290, "
+        "177.51613499 -22.19754139, -178.00242433 -22.06717569))"
+    ),
+    # a5-style: contiguous, but running past +180.
+    "beyond_180": "POLYGON ((175 10, 185 10, 185 20, 175 20, 175 10))",
+    # h3 81033ffffffffff, which contains the north pole.
+    "north_pole": (
+        "POLYGON ((8.38436067 87.82361750, 145.55819769 87.36469532, "
+        "-161.89171801 84.22628942, -125.29445893 82.48154131, "
+        "-90.38109747 82.85349004, -51.70487752 84.93555635, "
+        "8.38436067 87.82361750))"
+    ),
+    # The same ring reflected, so it contains the south pole instead.
+    "south_pole": (
+        "POLYGON ((8.38436067 -87.82361750, 145.55819769 -87.36469532, "
+        "-161.89171801 -84.22628942, -125.29445893 -82.48154131, "
+        "-90.38109747 -82.85349004, -51.70487752 -84.93555635, "
+        "8.38436067 -87.82361750))"
+    ),
+}
+
+
+# The cell centres the grid libraries report for those rings -- h3_cell_to_latlng
+# for the two real cells, the obvious centre for the synthetic ones. They stand
+# in for the scheme's own centre function, which reports lon/lat in range.
+_RING_CENTRES = {
+    "plain": (10.5, 10.5),
+    "torn": (179.80304066, -18.38547805),
+    "beyond_180": (180.0, 15.0),
+    "north_pole": (-110.58483359, 86.88988502),
+    "south_pole": (-110.58483359, -86.88988502),
+}
+
+
+def _ring_case_scheme():
+    """A scheme whose boundary is a literal WKT ring picked by the cell id.
+
+    Keeps the whole repair testable on a plain DuckDB + spatial connection, with
+    no h3/a5 community extension and no network.
+    """
+    cases = " ".join(f"WHEN '{name}' THEN '{wkt}'" for name, wkt in _RING_CASES.items())
+    centres = " ".join(
+        f"WHEN '{name}' THEN [{lon}, {lat}]" for name, (lon, lat) in _RING_CENTRES.items()
+    )
+    return GridScheme(
+        name="ringcase",
+        extension="",
+        min_resolution=0,
+        max_resolution=0,
+        default_column="cell",
+        key_template="{pt}",
+        boundary_template=f"ST_GeomFromText(CASE {{cell}} {cases} END)",
+        latlng_template=f"CASE {{cell}} {centres} END",
+        centroid_wkb_template="ST_AsWKB(ST_Point({ll}[1], {ll}[2]))",
+    )
+
+
+@pytest.fixture
+def repaired_rings():
+    """{case name: row} for every ring case, put through the shared builder."""
+    scheme = _ring_case_scheme()
+    names = ", ".join(f"('{name}')" for name in _RING_CASES)
+    sql = wrap_grid_geometry(f"SELECT * FROM (VALUES {names}) AS t(cell)", scheme, "cell", "both")
+    con = _spatial_connection()
+    try:
+        rows = con.execute(
+            f"""
+            SELECT cell,
+                   ST_GeometryType(g) AS type,
+                   ST_IsValid(g) AS is_valid,
+                   ST_XMin(g) AS xmin, ST_XMax(g) AS xmax,
+                   ST_YMin(g) AS ymin, ST_YMax(g) AS ymax,
+                   ST_Area(g) AS area,
+                   ST_Intersects(g, ST_GeomFromWKB(centroid)) AS holds_centroid
+            FROM (SELECT cell, ST_GeomFromWKB(geometry) AS g, centroid FROM ({sql}))
+            """
+        ).fetchall()
+    finally:
+        con.close()
+    cols = (
+        "type",
+        "is_valid",
+        "xmin",
+        "xmax",
+        "ymin",
+        "ymax",
+        "area",
+        "holds_centroid",
+    )
+    return {row[0]: dict(zip(cols, row[1:], strict=True)) for row in rows}
+
+
+@pytest.mark.parametrize("case", sorted(_RING_CASES))
+def test_repaired_ring_is_valid_and_in_range(repaired_rings, case):
+    row = repaired_rings[case]
+    assert row["is_valid"], f"{case}: repaired ring is not a valid polygon"
+    assert row["xmin"] >= -180.0, f"{case}: xmin {row['xmin']} is west of -180"
+    assert row["xmax"] <= 180.0, f"{case}: xmax {row['xmax']} is east of 180"
+    assert -90.0 <= row["ymin"] <= row["ymax"] <= 90.0
+
+
+def test_untouched_ring_stays_a_single_polygon(repaired_rings):
+    """A ring that is already contiguous and in range must not be rewritten."""
+    row = repaired_rings["plain"]
+    assert row["type"] == "POLYGON"
+    assert row["area"] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("case", ["torn", "beyond_180", "north_pole", "south_pole"])
+def test_crossing_ring_becomes_a_multipolygon(repaired_rings, case):
+    assert repaired_rings[case]["type"] == "MULTIPOLYGON"
+
+
+def test_cut_preserves_the_ring_area(repaired_rings):
+    """Cutting at the seam moves vertices, it does not lose area: the 10x10 box
+    at 175..185 keeps its 100 square degrees on both sides of the line."""
+    assert repaired_rings["beyond_180"]["area"] == pytest.approx(100.0)
+
+
+@pytest.mark.parametrize("case,pole", [("north_pole", 90.0), ("south_pole", -90.0)])
+def test_pole_enclosing_ring_gets_a_seam_to_the_pole(repaired_rings, case, pole):
+    """A ring that encircles a pole spans every longitude, so it is closed
+    through the pole rather than unwrapped."""
+    row = repaired_rings[case]
+    assert row["ymax" if pole > 0 else "ymin"] == pytest.approx(pole)
+    # Both halves of the cut are present, so the cap covers the full sweep.
+    assert row["xmin"] == pytest.approx(-180.0)
+    assert row["xmax"] == pytest.approx(180.0)
+
+
+@pytest.mark.parametrize("case", sorted(_RING_CASES))
+def test_polygon_and_centroid_share_one_frame(repaired_rings, case):
+    """--out-geometry both must not put the centroid outside its own cell."""
+    assert repaired_rings[case]["holds_centroid"], (
+        f"{case}: the centroid falls outside the polygon written for the same cell"
+    )
+
+
+def test_polygon_sql_carries_the_seam_repair():
+    """The generated SQL keeps its shape: guard, cut, and no leaked internals."""
+    sql = wrap_grid_geometry("SELECT * FROM t", H3_SCHEME, "h3_cell", "polygon")
+    assert "EXCLUDE (__bnd, __ll, __ring, __fring)" in sql
+    # The repair is skipped for rings that are already contiguous and in range.
+    assert "ST_XMax(__bnd) - ST_XMin(__bnd) > 180.0" in sql
+    assert "WHEN __ring IS NULL THEN ST_AsWKB(__bnd)" in sql
+    # ... and cuts at the antimeridian for the ones that are not.
+    assert "ST_MakeEnvelope(-180.0, -90.0, 180.0, 90.0)" in sql
+    assert "ST_MakeEnvelope(180.0, -90.0, 540.0, 90.0)" in sql
+    assert "ST_CollectionExtract(" in sql
+    # The scheme's cell function is evaluated once, not once per repair layer.
+    assert sql.count("h3_cell_to_boundary_wkb") == 1
+
+
+def test_centroid_only_sql_builds_no_boundary():
+    """--out-geometry centroid needs no polygon, so it must not pay for one."""
+    sql = wrap_grid_geometry("SELECT * FROM t", A5_SCHEME, "a5_cell", "centroid")
+    assert "a5_cell_to_boundary" not in sql
+    assert "__ring" not in sql
+    assert "ST_Intersection" not in sql
+
+
+def test_both_sql_repairs_the_polygon_and_keeps_the_centroid():
+    sql = wrap_grid_geometry("SELECT * FROM t", A5_SCHEME, "a5_cell", "both")
+    assert "AS geometry, " in sql and " AS centroid " in sql
+    assert "ST_CollectionExtract(" in sql
+
+
+# ---------------------------------------------------------------------------
+# geo bbox: RFC 7946 5.2 wrap form
+# ---------------------------------------------------------------------------
+
+
+def _bbox_of(wkts):
+    con = _spatial_connection()
+    try:
+        values = ", ".join(f"(ST_AsWKB(ST_GeomFromText('{w}')))" for w in wkts)
+        con.execute(f"CREATE TEMP TABLE g AS SELECT * FROM (VALUES {values}) t(geometry)")
+        return antimeridian_aware_bbox(con, "g", "geometry")
+    finally:
+        con.close()
+
+
+def test_bbox_stays_plain_for_data_that_does_not_cross():
+    bbox = _bbox_of(["POLYGON ((-100 30, -90 30, -90 40, -100 40, -100 30))"])
+    assert bbox == pytest.approx([-100.0, 30.0, -90.0, 40.0])
+
+
+def test_bbox_uses_the_wrap_form_for_data_astride_the_seam():
+    """Parts at both -180 and 180 with nothing in between: a plain min/max would
+    claim the whole globe, so the extent is written xmin > xmax instead."""
+    bbox = _bbox_of(
+        [
+            "MULTIPOLYGON (((179 -17, 180 -17, 180 -16, 179 -16, 179 -17)), "
+            "((-180 -17, -179 -17, -179 -16, -180 -16, -180 -17)))"
+        ]
+    )
+    assert bbox[0] > bbox[2], f"expected an antimeridian wrap form, got {bbox}"
+    assert bbox == pytest.approx([179.0, -17.0, -179.0, -16.0])
+
+
+def test_bbox_stays_plain_for_genuinely_global_data():
+    bbox = _bbox_of(
+        [
+            "POLYGON ((-180 -10, 0 -10, 0 10, -180 10, -180 -10))",
+            "POLYGON ((0 -10, 180 -10, 180 10, 0 10, 0 -10))",
+        ]
+    )
+    assert bbox == pytest.approx([-180.0, -10.0, 180.0, 10.0])
+
+
+def test_result_bbox_reads_an_arrow_table():
+    """The aggregate writer takes its bbox off the finished Arrow result."""
+    from geoparquet_io.core.process.aggregate.grid_common import _result_geo_bbox
+
+    con = _spatial_connection()
+    try:
+        result = (
+            con.execute(
+                """
+            SELECT ST_AsWKB(ST_GeomFromText(w)) AS geometry FROM (VALUES
+              ('POLYGON ((179 -17, 180 -17, 180 -16, 179 -16, 179 -17))'),
+              ('POLYGON ((-180 -17, -179 -17, -179 -16, -180 -16, -180 -17))')
+            ) t(w)
+            """
+            )
+            .arrow()
+            .read_all()
+        )
+        assert _result_geo_bbox(con, result) == pytest.approx([179.0, -17.0, -179.0, -16.0])
+        # The registration is cleaned up, so a second result can reuse the name.
+        assert _result_geo_bbox(con, result) is not None
+    finally:
+        con.close()
+
+
+def test_bbox_is_none_without_geometry():
+    con = _spatial_connection()
+    try:
+        con.execute("CREATE TEMP TABLE g AS SELECT NULL::BLOB AS geometry WHERE false")
+        assert antimeridian_aware_bbox(con, "g", "geometry") is None
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# The real grids. These need the h3 / a5 community extensions.
+# ---------------------------------------------------------------------------
+
+
+def _cell_report(parquet_file):
+    """Validity, longitude range and widest part over every cell in an output.
+
+    The widest *part*, not the widest geometry: a cell cut at the seam has parts
+    at both -180 and 180, so its own envelope spans the globe by construction. A
+    torn ring is the case where one part does.
+    """
+    con = _spatial_connection()
+    relation = f"read_parquet('{parquet_file}')"
+    try:
+        geom = geometry_to_geom_expr(con, relation, "geometry")
+        cells = f"SELECT {geom} AS g FROM {relation} WHERE geometry IS NOT NULL"
+        return con.execute(
+            f"""
+            SELECT count(*),
+                   count(*) FILTER (WHERE NOT ST_IsValid(g)),
+                   count(*) FILTER (WHERE ST_XMin(g) < -180.0 OR ST_XMax(g) > 180.0),
+                   count(*) FILTER (WHERE ST_GeometryType(g) = 'MULTIPOLYGON'),
+                   (SELECT max(ST_XMax(p) - ST_XMin(p))
+                    FROM (SELECT UNNEST(ST_Dump(g)).geom AS p FROM ({cells})))
+            FROM ({cells})
+            """
+        ).fetchone()
+    finally:
+        con.close()
+
+
+def _assert_cells_are_antimeridian_safe(out, expect_multipolygon=True, max_part_width=None):
+    from geoparquet_io.core.validate import validate_geoparquet
+
+    total, invalid, out_of_range, multi, widest = _cell_report(out)
+    assert total > 0
+    assert invalid == 0, f"{invalid} of {total} cell polygons are invalid"
+    assert out_of_range == 0, f"{out_of_range} of {total} cells leave [-180, 180]"
+    if expect_multipolygon:
+        assert multi > 0, "no cell was cut at the antimeridian"
+    if max_part_width is not None:
+        assert widest < max_part_width, (
+            f"a cell part spans {widest:.3f} degrees of longitude, so its ring tore"
+        )
+    result = validate_geoparquet(str(out), validate_data=True)
+    assert result.failed_count == 0, [c.name for c in result.checks if c.status.value == "failed"]
+
+
+def _pole_cells(parquet_file):
+    """Cells reaching a pole: (ymin, ymax, xmin, xmax) for each."""
+    con = _spatial_connection()
+    relation = f"read_parquet('{parquet_file}')"
+    try:
+        geom = geometry_to_geom_expr(con, relation, "geometry")
+        return con.execute(
+            f"""
+            SELECT ST_YMin(g), ST_YMax(g), ST_XMin(g), ST_XMax(g)
+            FROM (SELECT {geom} AS g FROM {relation} WHERE geometry IS NOT NULL)
+            WHERE ST_YMax(g) >= 89.999999 OR ST_YMin(g) <= -89.999999
+            """
+        ).fetchall()
+    finally:
+        con.close()
+
+
+def _assert_pole_cells_reach_the_pole(out, full_width):
+    """Cells at a pole must reach it -- the seam runs the boundary up to +/-90.
+
+    ``full_width`` says whether the grid's polar cell *encloses* the pole, as
+    H3's does: such a ring spans every longitude, so its seamed polygon runs the
+    whole [-180, 180]. A5's polar cells only touch the pole at a vertex and keep
+    their own longitude wedge.
+    """
+    cells = _pole_cells(out)
+    assert cells, "no cell reached a pole"
+    for ymin, ymax, xmin, xmax in cells:
+        assert ymax == pytest.approx(90.0) or ymin == pytest.approx(-90.0)
+        assert -180.0 <= xmin <= xmax <= 180.0
+        if full_width:
+            assert xmin == pytest.approx(-180.0), f"pole cell starts at {xmin}, not -180"
+            assert xmax == pytest.approx(180.0), f"pole cell ends at {xmax}, not 180"
+
+
+@pytest.mark.slow
+@pytest.mark.network
+@pytest.mark.parametrize("resolution", [1, 3])
+def test_h3_cells_are_antimeridian_safe(antimeridian_parquet, tmp_path, resolution):
+    out = tmp_path / f"h3_{resolution}.parquet"
+    aggregate_by_h3(antimeridian_parquet, str(out), resolution=resolution)
+    _assert_cells_are_antimeridian_safe(out, max_part_width=180.0)
+
+
+@pytest.mark.slow
+@pytest.mark.network
+@pytest.mark.parametrize("resolution", [1, 3])
+def test_a5_cells_are_antimeridian_safe(antimeridian_parquet, tmp_path, resolution):
+    """a5_cell_to_boundary reports longitudes outside [-180, 180] (267.0 is a
+    real value), so this fails before the fix on the range check alone."""
+    out = tmp_path / f"a5_{resolution}.parquet"
+    aggregate_by_a5(antimeridian_parquet, str(out), resolution=resolution)
+    _assert_cells_are_antimeridian_safe(out, max_part_width=180.0)
+
+
+@pytest.mark.slow
+@pytest.mark.network
+@pytest.mark.parametrize("resolution", [0, 1, 2])
+def test_a5_polar_cells_stay_valid_and_in_range(pole_parquet, tmp_path, resolution):
+    """The two pole-touching A5 cells are the ones a naive unwrap ruins: their
+    rings span far more than 180 degrees for real, so shifting vertices relative
+    to the first tears them."""
+    out = tmp_path / f"a5_pole_{resolution}.parquet"
+    aggregate_by_a5(pole_parquet, str(out), resolution=resolution)
+    _assert_cells_are_antimeridian_safe(out, expect_multipolygon=False)
+    _assert_pole_cells_reach_the_pole(out, full_width=False)
+
+
+@pytest.mark.slow
+@pytest.mark.network
+@pytest.mark.parametrize("resolution", [1, 3, 5])
+def test_h3_pole_cells_stay_valid_and_in_range(pole_parquet, tmp_path, resolution):
+    """The cells that contain a pole span every longitude, so they need a seam
+    rather than an unwrap."""
+    out = tmp_path / f"h3_pole_{resolution}.parquet"
+    aggregate_by_h3(pole_parquet, str(out), resolution=resolution)
+    _assert_cells_are_antimeridian_safe(out, expect_multipolygon=False)
+    _assert_pole_cells_reach_the_pole(out, full_width=True)
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_aggregate_writes_the_wrap_form_bbox(antimeridian_parquet, tmp_path):
+    """A Fiji-only aggregate must not claim the whole globe in its geo bbox."""
+    out = tmp_path / "h3_bbox.parquet"
+    aggregate_by_h3(antimeridian_parquet, str(out), resolution=1)
+    col = json.loads(pq.read_schema(out).metadata[b"geo"])["columns"]["geometry"]
+    assert col["bbox"][0] > col["bbox"][2], f"expected the wrap form, got {col['bbox']}"
+    assert "MultiPolygon" in col["geometry_types"]
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_out_geometry_both_keeps_one_frame(antimeridian_parquet, tmp_path):
+    out = tmp_path / "h3_both.parquet"
+    aggregate_by_h3(antimeridian_parquet, str(out), resolution=3, out_geometry="both")
+    con = _spatial_connection()
+    relation = f"read_parquet('{out}')"
+    try:
+        geom = geometry_to_geom_expr(con, relation, "geometry")
+        centroid = geometry_to_geom_expr(con, relation, "centroid")
+        outside = con.execute(
+            f"""
+            SELECT count(*) FROM {relation}
+            WHERE geometry IS NOT NULL AND NOT ST_Intersects({geom}, {centroid})
+            """
+        ).fetchone()[0]
+    finally:
+        con.close()
+    assert outside == 0, f"{outside} centroids fall outside their own cell polygon"
+
+
+@pytest.mark.slow
+@pytest.mark.network
+def test_overview_rollup_is_antimeridian_safe(antimeridian_parquet, tmp_path):
+    """`process overview` regenerates parent geometry through the same builder,
+    so a rolled-up parent cell must be seam-safe too."""
+    from geoparquet_io.core.process.overview.run import create_overviews
+
+    base = tmp_path / "h3_base.parquet"
+    aggregate_by_h3(antimeridian_parquet, str(base), resolution=4)
+    written = create_overviews(str(base), levels=[1, 2])
+    assert len(written) == 2
+    for _level, path in written:
+        _assert_cells_are_antimeridian_safe(path, max_part_width=180.0)

--- a/tests/test_process_aggregate_bucket_point.py
+++ b/tests/test_process_aggregate_bucket_point.py
@@ -843,9 +843,8 @@ def test_build_grid_query_with_metric_and_breakdown(tmp_path):
         max_resolution=5,
         default_column="cell",
         key_template="CAST(floor(ST_X({pt})) AS INTEGER)",
-        boundary_template="{cell}",
+        boundary_template="ST_MakeEnvelope(CAST({cell} AS DOUBLE), 0.0, CAST({cell} AS DOUBLE) + 1.0, 1.0)",
         latlng_template="{cell}",
-        poly_wkb_template="ST_AsWKB(ST_Point(CAST({bnd} AS DOUBLE), 0.0))",
         centroid_wkb_template="ST_AsWKB(ST_Point(CAST({ll} AS DOUBLE), 0.0))",
     )
     src = tmp_path / "f.parquet"

--- a/tests/test_process_aggregate_metric_nodata.py
+++ b/tests/test_process_aggregate_metric_nodata.py
@@ -32,9 +32,8 @@ _DUMMY_SCHEME = GridScheme(
     max_resolution=10,
     default_column="cell",
     key_template="{res}",
-    boundary_template="{cell}",
+    boundary_template="ST_MakeEnvelope(0.0, 0.0, 1.0, 1.0)",
     latlng_template="{cell}",
-    poly_wkb_template="{bnd}",
     centroid_wkb_template="{ll}",
 )
 

--- a/tests/test_process_aggregate_where.py
+++ b/tests/test_process_aggregate_where.py
@@ -381,9 +381,8 @@ def test_grid_aggregation_output_has_no_hive_partition_column(tmp_path):
         max_resolution=10,
         default_column="test_cell",
         key_template="CAST(floor(ST_X({pt}) * {res}) AS VARCHAR)",
-        boundary_template="{cell}",
+        boundary_template="ST_MakeEnvelope(0.0, 0.0, 1.0, 1.0)",
         latlng_template="{cell}",
-        poly_wkb_template="ST_AsWKB(ST_Point(0, 0))",
         centroid_wkb_template="ST_AsWKB(ST_Point(0, 0))",
     )
     glob = _write_hive_points(tmp_path / "hive")

--- a/tests/test_process_overview.py
+++ b/tests/test_process_overview.py
@@ -645,8 +645,11 @@ class TestRollupSqlBuilders:
 
         sql = build_grid_rollup_sql(_grid_info("h3", out_geometry="both"), "SELECT * FROM s", 4)
         assert 'h3_cell_to_parent("h3_cell", 4)' in sql
-        assert "h3_cell_to_boundary_wkt" in sql
+        assert "h3_cell_to_boundary_wkb" in sql
         assert "AS centroid" in sql
+        # A rolled-up parent cell straddles the antimeridian as readily as a base
+        # cell, so it goes through the same seam repair.
+        assert "ST_CollectionExtract(" in sql
 
     def test_grid_rollup_sql_none_geometry(self):
         from geoparquet_io.core.process.overview.rollup import build_grid_rollup_sql


### PR DESCRIPTION
## What changed

Reworked to **Option B**: a cell ring that crosses the antimeridian is **cut at ±180 into a `MultiPolygon`** (RFC 7946 §3.1.9), so the output is spec-clean rather than carrying coordinates outside the valid range. The earlier approach in this PR — unwrapping each vertex relative to the ring's first vertex — is gone; review found it fixed the common case and broke two others.

One invariant, stated once in the shared builder for every grid scheme:

> the polygon written for a cell is **valid, contiguous, and inside `[-180, 180]`**.

Getting there takes four steps, all in `core/process/aggregate/grid_common.py`:

1. **Cumulative unwrapping.** Each vertex is placed relative to the *previous* one, with the 360° steps accumulating along the ring. Relative-to-first is only correct while every vertex stays within 180° of the first, which a polar ring does not — there the `> 180` test fires on vertices that were never wrapped and tears a ring that was intact.
2. **Span guard.** The shift is kept only when it *narrows* the ring's longitude span, so a ring that legitimately spans more than 180° is left alone.
3. **Explicit pole seam.** A ring whose longitude winding comes to ±360 encircles a pole; it spans every longitude, so no unwrapping closes it. It is closed through a seam that runs up to ±90 and back, covering the polar cap instead of self-intersecting.
4. **Cut at ±180.** Whatever still crosses the line is intersected with the two half-world boxes and reassembled, giving a MultiPolygon with one part either side.

Consequences worth calling out for reviewers:

- **`geometry_types` now reads `["Polygon", "MultiPolygon"]`** (or just `["MultiPolygon"]`) for any dataset reaching the antimeridian. It is computed from the data, so no code change was needed — but downstream consumers have to expect both. Documented in `docs/guide/process-aggregate.md`.
- **The `geo` bbox uses the RFC 7946 §5.2 wrap form (`xmin > xmax`)** for a dataset astride the seam. A plain min/max over cut geometry reads `[-180, …, 180, …]`, claiming the whole globe for a Fiji-sized dataset; the parts, not the whole geometries, are what make the crossing visible, so `write_geoparquet_table` grew an optional `geo_bbox` and the aggregate/overview writers compute one. gpio's own validator already reads this form (#876/#930). Data that does not reach both edges never pays for the part-level scan and is reported exactly as before.
- **`process overview` inherits all of it** — grid rollups regenerate parent geometry through the same builder, and a coarser parent cell straddles the seam more readily than its children.
- The scheme descriptors now hand the builder a **GEOMETRY** rather than a vertex list. That lets H3 read `h3_cell_to_boundary_wkb` instead of parsing WKT, and `--out-geometry centroid` build no boundary at all.

## Why

Found on a global aggregate of NASA FIRMS fire detections: one cell near Fiji covered 359.413° of longitude and rendered as a stripe across the map at 16°S. Review of the first fix then turned up three more problems it did not solve, and one it caused.

## Verification

### Global sweep — 50,000 scattered points, h3 and a5, resolutions 0/1/3/5/7/9

| | `main` | this PR |
|---|---:|---:|
| invalid cell polygons | **82** | **0** |
| cells outside `[-180, 180]` | **305** | **0** |
| cell ids and row counts | — | identical in all 12 runs |

Per-scheme, cells with `ST_IsValid = false` / outside `[-180, 180]`:

| | h3 r0 | r1 | r3 | r5 | r7 | r9 | a5 r0 | r1 | r3 | r5 | r7 | r9 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| `main` invalid | 11 | 10 | 46 | 18 | 2 | 1 | 2 | 0 | 0 | 0 | 0 | 0 |
| `main` out of range | 0 | 0 | 0 | 0 | 0 | 0 | 4 | 9 | 32 | 126 | 104 | 30 |
| this PR, both | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

Total spheroid area recovers the whole sphere wherever the cells cover it — a5 r0 goes **448.6M km² → 510.07M km²**, which is 4πR² to six figures.

### The A5 polar cells

These are the ones the relative-to-first unwrap regressed valid → invalid, and the ones `main` has always written out of range. At a5 r1 the 9 cells that leave `[-180, 180]` on `main` all become in-range MultiPolygons, with per-cell area held to within 0.03%:

```
cell                   main xmin/xmax   this PR              main area   this PR area
360287970189639680      87.0 / 267.0    MULTIPOLYGON ±180    8501090     8503440
14195346025471803392   123.0 / 267.0    MULTIPOLYGON ±180    8501090     8497008
72057594037927936     -201.0 /  -93.0   MULTIPOLYGON ±180    8501090     8498755
… 6 more, all in range
total                                                      510065622   510065622   km²
```

### The fixtures the new tests use, run against `main` and against this PR

`widest_part` is the widest *part* after `ST_Dump`, so a seam cut cannot hide a tear behind a globe-spanning envelope.

```
                              cells  invalid  out_of_range  widest_part  validate_failed  bbox_wrap
main    fiji   h3 r1              1        0             0       355.82                0      False
main    fiji   h3 r3              2        0             0       359.41                0      False
main    fiji   a5 r1              1        0             1        36.00                1      False
main    fiji   a5 r3              1        0             1         7.24                1      False
main    poles  h3 r1              3        2             0       321.18                0      False
main    poles  h3 r3              4        1             0       315.60                0      False
main    poles  a5 r0              2        2             2       358.74                1      False
main    poles  a5 r1              5        0             1       216.00                1      False
main    poles  a5 r2              5        0             1       189.65                1      False

this PR fiji   h3 r1              1        0             0         4.47                0      True
this PR fiji   h3 r3              2        0             0         1.23                0      True
this PR fiji   a5 r1              1        0             0        21.00                0      True
this PR fiji   a5 r3              1        0             0         4.77                0      True
this PR poles  h3 r1              3        0             0       360.00                0      False
this PR poles  h3 r3              4        0             0       360.00                0      False
this PR poles  a5 r0              2        0             0       360.00                0      False
this PR poles  a5 r1              5        0             0       273.00                0      False
this PR poles  a5 r2              5        0             0       273.00                0      False
```

Every new extension-backed test fails on `main`. `widest_part = 360.00` on the pole rows is the seam doing its job: a cell that holds a pole spans every longitude, so its polygon runs the full width and reaches ±90.

### `--out-geometry both`

The centroid comes from the grid's own cell-centre function, which reports lon/lat in range; the polygon is now in range too, so it holds its own centroid. Zero centroids outside their polygon over 15,738 h3 and 11,198 a5 cells (was: e.g. `839b5dfffffffff` with polygon lon `[-180.76, -179.55]` and centroid `179.84`).

### Performance

The 15× regression the review measured is gone — this is at parity or better, because reading the WKB boundary instead of parsing WKT offsets a repair that only the crossing cells pay for. Warm, 50,000 points, whole `aggregate_by_*` call:

| | h3 r5 | h3 r7 | h3 r9 | a5 r5 | a5 r7 | a5 r9 |
|---|---|---|---|---|---|---|
| `main` | 0.44s | 0.45s | 0.47s | 0.26s | 0.35s | 0.38s |
| this PR | 0.32s | 0.35s | 0.39s | 0.39s | 0.46s | 0.47s |

Isolated to the geometry SQL over 200k res-6 cells: `main` 0.58s, the previous approach in this PR 0.75s, now **0.14s**.

## Tests

`tests/test_process_aggregate_antimeridian.py` is rewritten. The tests it replaces asserted only `max(ST_XMax − ST_XMin) < 180` on a Fiji fixture, were marked `slow` **and** `network` (so the slow lane deselects them and the fast lane excludes them — only the non-blocking network job ever ran them), and the A5 one passed byte-identically on `main`.

**Fast lane, no community extension, no network** — 25 tests where diff-cover reads. A scheme whose boundary is a literal WKT ring drives the whole builder on plain DuckDB + spatial: real h3 rings for the torn and pole-enclosing cases, synthetic ones for the rest. Plus assertions on the generated SQL's shape (the guard, the cut, the one-evaluation-per-cell property, and that `--out-geometry centroid` builds no boundary) and on the wrap-form bbox.

**Extension lane** — 13 tests over both grids: validity, `ST_XMin >= -180 AND ST_XMax <= 180`, part width, `validate_geoparquet(..., validate_data=True)`, pole fixtures for both schemes, the `--out-geometry both` frame, the wrap-form bbox, and a `process overview` case (`rollup.py` inherits this through `GRID_SCHEMES` and had no coverage of it at all).

```
$ uv run pytest tests/test_process_aggregate_antimeridian.py -q
38 passed in 3.98s

$ uv run pytest tests/test_process_aggregate*.py tests/test_process_overview.py \
    tests/test_validate*.py tests/test_overview_levels.py -q -m "not network and not slow"
599 passed, 5 skipped, 57 deselected

$ uv run pytest -n auto -q -m "not slow and not network and not meta"
6478 passed, 75 skipped, 9 xfailed in 165.74s

$ uv run pytest -q -m meta
203 passed in 167.55s

$ uv run lint-imports
Contracts: 4 kept, 0 broken.

$ uv run xenon --max-absolute=E --max-modules=D --max-average=C geoparquet_io tests
$ uv run ruff check . && uv run vulture && uv run deptry .
```

Rebased onto `main` (the branch was ~10 commits behind and its CI predated #916, which is why it reported 2 import-linter contracts rather than 4).
