### PR TITLE
refactor(cli): split cli/main.py, starting with the shared helpers and the sort group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -233,7 +233,7 @@ repos:
           - -c
           - |
             # This is a reminder hook - it doesn't fail, just warns
-            if git diff --cached --name-only | grep -q "geoparquet_io/cli/main.py"; then
+            if git diff --cached --name-only | grep -qE "geoparquet_io/cli/(main\.py|commands/)"; then
               echo "⚠️  Reminder: If you added new CLI commands, ensure you also:"
               echo "   1. Added corresponding methods to api/table.py"
               echo "   2. Added corresponding functions to api/ops.py"
@@ -249,7 +249,7 @@ repos:
         description: Validate CLAUDE.md against the actual codebase
         entry: uv run python scripts/validate_claude_md.py
         language: system
-        files: ^(CLAUDE\.md|geoparquet_io/cli/main\.py|pyproject\.toml)$
+        files: ^(CLAUDE\.md|geoparquet_io/cli/main\.py|geoparquet_io/cli/commands/.*\.py|pyproject\.toml)$
         pass_filenames: false
 
       - id: doc-sync
@@ -257,7 +257,7 @@ repos:
         description: Auto-update generated doc sections (CLAUDE.md, SKILL.md, contributing.md)
         entry: uv run python scripts/doc_sync.py --update
         language: system
-        files: ^(CHANGELOG\.md|geoparquet_io/cli/main\.py|geoparquet_io/cli/decorators\.py|pyproject\.toml|geoparquet_io/core/.*\.py|scripts/doc_sync\.py|docs/contributing\.md)$
+        files: ^(CHANGELOG\.md|geoparquet_io/cli/main\.py|geoparquet_io/cli/commands/.*\.py|geoparquet_io/cli/decorators\.py|pyproject\.toml|geoparquet_io/core/.*\.py|scripts/doc_sync\.py|docs/contributing\.md)$
         pass_filenames: false
 
       - id: sync-dependencies

--- a/geoparquet_io/cli/_shared.py
+++ b/geoparquet_io/cli/_shared.py
@@ -1,0 +1,81 @@
+"""CLI helpers shared between ``cli/main.py`` and the per-group command modules.
+
+``cli/main.py`` owns the root ``gpio`` group and imports each command group from
+:mod:`geoparquet_io.cli.commands`. Anything a group module also needs therefore
+cannot keep living in ``main.py``: importing it back would make the dependency
+cyclic. It lives here instead, so both sides import downwards.
+
+The split against the neighbouring modules:
+
+* :mod:`geoparquet_io.cli.decorators` - reusable Click *option* decorators and
+  the ``click.Command`` subclasses commands declare with ``cls=``
+  (``GlobAwareCommand``, ``SingleFileCommand``, ``parse_row_group_options``).
+  That is still their home; nothing was moved out of it.
+* this module - the group-neutral runtime plumbing that is not a decorator and
+  not a Click option: S3 activation, and the default-subcommand group factory.
+
+Only helpers used by more than one command group belong here. A helper used by a
+single group travels with that group into ``cli/commands/<group>.py``.
+"""
+
+import os
+from contextlib import contextmanager
+
+import click
+
+
+@contextmanager
+def _activate_s3(ctx, aws_profile=None, s3_endpoint=None, s3_region=None, s3_no_ssl=False):
+    """Resolve and activate S3 config from ctx + per-command overrides.
+
+    Properly saves/restores AWS_PROFILE env var to avoid credential leaks.
+    """
+    from geoparquet_io.core.duckdb_utils import s3_config_scope
+    from geoparquet_io.core.remote import resolve_s3_config
+
+    config = resolve_s3_config(
+        s3_endpoint=s3_endpoint or ctx.obj.get("s3_endpoint"),
+        s3_region=s3_region or ctx.obj.get("s3_region"),
+        s3_no_ssl=s3_no_ssl or ctx.obj.get("s3_no_ssl", False),
+        aws_profile=aws_profile or ctx.obj.get("aws_profile"),
+    )
+    previous_profile = os.environ.get("AWS_PROFILE")
+    try:
+        if config["profile"]:
+            os.environ["AWS_PROFILE"] = config["profile"]
+        with s3_config_scope(config):
+            yield config
+    finally:
+        if previous_profile is None:
+            os.environ.pop("AWS_PROFILE", None)
+        else:
+            os.environ["AWS_PROFILE"] = previous_profile
+
+
+# Check commands group - use custom command class for default subcommand
+def create_default_group(default_subcommand: str, description: str) -> type:
+    """Factory to create a click.Group subclass that defaults to a specific subcommand.
+
+    Args:
+        default_subcommand: The subcommand to invoke when none is provided
+        description: The docstring for the generated class
+
+    Returns:
+        A click.Group subclass with the configured default behavior
+    """
+
+    class _DefaultGroup(click.Group):
+        def parse_args(self, ctx, args):
+            # Handle --help for group
+            if "--help" in args and (not args or args[0] not in self.commands):
+                return super().parse_args(ctx, [a for a in args if a != "--help"] + ["--help"])
+
+            # If first arg is a known subcommand, use it
+            if args and not args[0].startswith("-") and args[0] in self.commands:
+                return super().parse_args(ctx, args)
+
+            # Default to configured subcommand
+            return super().parse_args(ctx, [default_subcommand] + args)
+
+    _DefaultGroup.__doc__ = description
+    return _DefaultGroup

--- a/geoparquet_io/cli/_shared.py
+++ b/geoparquet_io/cli/_shared.py
@@ -7,10 +7,11 @@ cyclic. It lives here instead, so both sides import downwards.
 
 The split against the neighbouring modules:
 
-* :mod:`geoparquet_io.cli.decorators` - reusable Click *option* decorators and
+* :mod:`geoparquet_io.cli.decorators` - reusable Click *option* decorators,
   the ``click.Command`` subclasses commands declare with ``cls=``
-  (``GlobAwareCommand``, ``SingleFileCommand``, ``parse_row_group_options``).
-  That is still their home; nothing was moved out of it.
+  (``GlobAwareCommand``, ``SingleFileCommand``), and small option-parsing
+  helpers such as ``parse_row_group_options``. That is still their home;
+  nothing was moved out of it.
 * this module - the group-neutral runtime plumbing that is not a decorator and
   not a Click option: S3 activation, and the default-subcommand group factory.
 
@@ -52,7 +53,6 @@ def _activate_s3(ctx, aws_profile=None, s3_endpoint=None, s3_region=None, s3_no_
             os.environ["AWS_PROFILE"] = previous_profile
 
 
-# Check commands group - use custom command class for default subcommand
 def create_default_group(default_subcommand: str, description: str) -> type:
     """Factory to create a click.Group subclass that defaults to a specific subcommand.
 

--- a/geoparquet_io/cli/commands/__init__.py
+++ b/geoparquet_io/cli/commands/__init__.py
@@ -1,0 +1,15 @@
+"""Per-group ``gpio`` command modules.
+
+One module per top-level command group. Each module declares its group with a
+plain ``@click.group()`` and its subcommands with ``@<group>.command(...)``;
+``cli/main.py`` imports the group object and attaches it to the root group with
+an explicit ``cli.add_command(<group>)``. Nothing here imports ``cli.main``,
+so the dependency runs one way:
+
+    cli/main.py -> cli/commands/<group>.py -> cli/_shared.py, cli/decorators.py
+
+Shared helpers live in :mod:`geoparquet_io.cli._shared` (group-neutral runtime
+plumbing) and :mod:`geoparquet_io.cli.decorators` (reusable Click options and
+``cls=`` command classes). A helper used by exactly one group belongs in that
+group's module.
+"""

--- a/geoparquet_io/cli/commands/sort.py
+++ b/geoparquet_io/cli/commands/sort.py
@@ -1,0 +1,359 @@
+"""``gpio sort`` - commands for sorting GeoParquet files.
+
+Registered on the root ``gpio`` group by ``cli/main.py`` via
+``cli.add_command(sort)``. This module must not import ``cli.main``: the
+dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
+"""
+
+import click
+
+from geoparquet_io.cli._shared import _activate_s3
+from geoparquet_io.cli.decorators import (
+    SingleFileCommand,
+    allow_schema_diff_option,
+    any_extension_option,
+    geoparquet_version_option,
+    output_format_options,
+    overwrite_option,
+    parse_row_group_options,
+    show_sql_option,
+    verbose_option,
+)
+from geoparquet_io.core.file_utils import validate_parquet_extension
+from geoparquet_io.core.hilbert_order import hilbert_order as hilbert_impl
+from geoparquet_io.core.logging_config import setup_cli_logging
+from geoparquet_io.core.parquet_writer import DEFAULT_SORT_ROW_GROUP_ROWS
+from geoparquet_io.core.sort_by_column import sort_by_column as sort_by_column_impl
+from geoparquet_io.core.sort_quadkey import sort_by_quadkey as sort_by_quadkey_impl
+from geoparquet_io.core.str_order import str_order as str_impl
+
+
+@click.group()
+@click.pass_context
+def sort(ctx):
+    """Commands for sorting GeoParquet files."""
+    # Ensure logging is set up (in case this group is invoked directly in tests)
+    ctx.ensure_object(dict)
+    timestamps = ctx.obj.get("timestamps", False)
+    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+
+
+@sort.command(name="hilbert", cls=SingleFileCommand)
+@click.argument("input_parquet")
+@click.argument("output_parquet", type=click.Path(), required=False, default=None)
+@click.option(
+    "--geometry-column",
+    "-g",
+    default="geometry",
+    help="Name of the geometry column (default: geometry)",
+)
+@click.option(
+    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
+)
+@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
+@geoparquet_version_option
+@overwrite_option
+@verbose_option
+@any_extension_option
+@show_sql_option
+@click.pass_context
+def hilbert_order(
+    ctx,
+    input_parquet,
+    output_parquet,
+    geometry_column,
+    add_bbox,
+    compression,
+    compression_level,
+    row_group_size,
+    row_group_size_mb,
+    write_memory,
+    geoparquet_version,
+    overwrite,
+    verbose,
+    any_extension,
+    show_sql,
+):
+    """
+    Reorder a GeoParquet file using Hilbert curve ordering.
+
+    Takes an input GeoParquet file and creates a new file with rows ordered
+    by their position along a Hilbert space-filling curve.
+
+    Applies optimal formatting (configurable compression, optimized row groups,
+    bbox metadata). A non-default CRS is carried through unchanged; a CRS that
+    spells out the GeoParquet default (OGC:CRS84 / EPSG:4326) is normalized to
+    how the spec writes it, an omitted crs key. Use --verbose to see when that
+    happens.
+
+    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
+    """
+    with _activate_s3(ctx):
+        # Validate output early - provides helpful error if no output and not piping
+        from geoparquet_io.core.streaming import StreamingError, validate_output
+
+        try:
+            validate_output(output_parquet)
+        except StreamingError as e:
+            raise click.ClickException(str(e)) from None
+
+        # Validate .parquet extension
+        validate_parquet_extension(output_parquet, any_extension)
+
+        # Parse row group options
+        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+
+        hilbert_impl(
+            input_parquet,
+            output_parquet,
+            geometry_column,
+            add_bbox,
+            verbose,
+            compression.upper(),
+            compression_level,
+            row_group_mb,
+            row_group_size,
+            None,
+            geoparquet_version,
+            overwrite,
+            memory_limit=write_memory,
+        )
+
+
+@sort.command(name="str", cls=SingleFileCommand)
+@click.argument("input_parquet")
+@click.argument("output_parquet", type=click.Path(), required=False, default=None)
+@click.option(
+    "--geometry-column",
+    "-g",
+    default="geometry",
+    help="Name of the geometry column (default: geometry)",
+)
+@click.option(
+    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
+)
+@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
+@geoparquet_version_option
+@overwrite_option
+@verbose_option
+@any_extension_option
+@show_sql_option
+@click.pass_context
+def str_order_command(
+    ctx,
+    input_parquet,
+    output_parquet,
+    geometry_column,
+    add_bbox,
+    compression,
+    compression_level,
+    row_group_size,
+    row_group_size_mb,
+    write_memory,
+    geoparquet_version,
+    overwrite,
+    verbose,
+    any_extension,
+    show_sql,
+):
+    """Pack GeoParquet rows with Sort-Tile-Recursive ordering.
+
+    STR sorts geometry bounding-box centers into X strips, sorts each strip on
+    Y, and alternates the Y direction between strips. This can produce tighter
+    row-group bounding boxes than a space-filling curve.
+
+    --row-group-size does double duty: it is the writer's row-group target, and
+    it selects how many X strips STR builds, as
+    ceil(sqrt(num_rows / row-group-size)). That makes it a coarse control -
+    nearby values often produce an identical ordering. Rows are not packed into
+    row-group-sized tiles, and because the writer rounds row groups up to a
+    multiple of 2048, tiles and row groups only line up when --row-group-size
+    is itself a multiple of 2048.
+    """
+    with _activate_s3(ctx):
+        from geoparquet_io.core.streaming import StreamingError, validate_output
+
+        try:
+            validate_output(output_parquet)
+        except StreamingError as e:
+            raise click.ClickException(str(e)) from None
+
+        validate_parquet_extension(output_parquet, any_extension)
+        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        str_impl(
+            input_parquet,
+            output_parquet,
+            geometry_column=geometry_column,
+            add_bbox_flag=add_bbox,
+            verbose=verbose,
+            compression=compression.upper(),
+            compression_level=compression_level,
+            row_group_size_mb=row_group_mb,
+            row_group_rows=row_group_size,
+            profile=None,
+            geoparquet_version=geoparquet_version,
+            overwrite=overwrite,
+            memory_limit=write_memory,
+        )
+
+
+@sort.command(name="column", cls=SingleFileCommand)
+@click.argument("input_parquet")
+@click.argument("output_parquet", type=click.Path())
+@click.argument("columns")
+@click.option(
+    "--descending",
+    is_flag=True,
+    help="Sort in descending order (default: ascending)",
+)
+@allow_schema_diff_option
+@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
+@geoparquet_version_option
+@overwrite_option
+@verbose_option
+@any_extension_option
+@show_sql_option
+@click.pass_context
+def sort_column(
+    ctx,
+    input_parquet,
+    output_parquet,
+    columns,
+    descending,
+    allow_schema_diff,
+    compression,
+    compression_level,
+    row_group_size,
+    row_group_size_mb,
+    write_memory,
+    geoparquet_version,
+    overwrite,
+    verbose,
+    any_extension,
+    show_sql,
+):
+    """
+    Sort a GeoParquet file by specified column(s).
+
+    COLUMNS is a comma-separated list of column names to sort by.
+
+    Examples:
+
+        gpio sort column input.parquet output.parquet name
+
+        gpio sort column input.parquet output.parquet name,date --descending
+
+    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
+    """
+    with _activate_s3(ctx):
+        # Validate .parquet extension
+        validate_parquet_extension(output_parquet, any_extension)
+
+        # Parse row group options
+        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+
+        sort_by_column_impl(
+            input_parquet,
+            output_parquet,
+            columns=columns,
+            descending=descending,
+            verbose=verbose,
+            compression=compression.upper(),
+            compression_level=compression_level,
+            row_group_size_mb=row_group_mb,
+            row_group_rows=row_group_size,
+            geoparquet_version=geoparquet_version,
+            overwrite=overwrite,
+            memory_limit=write_memory,
+            allow_schema_diff=allow_schema_diff,
+        )
+
+
+@sort.command(name="quadkey", cls=SingleFileCommand)
+@click.argument("input_parquet")
+@click.argument("output_parquet", type=click.Path())
+@click.option(
+    "--quadkey-name",
+    default="quadkey",
+    help="Name of the quadkey column to sort by (default: quadkey)",
+)
+@click.option(
+    "--resolution",
+    default=13,
+    type=click.IntRange(0, 23),
+    help="Resolution when auto-adding quadkey column (0-23). Default: 13",
+)
+@click.option(
+    "--use-centroid",
+    is_flag=True,
+    help="Use geometry centroid when auto-adding quadkey column",
+)
+@click.option(
+    "--remove-quadkey-column",
+    is_flag=True,
+    help="Exclude quadkey column from output after sorting",
+)
+@allow_schema_diff_option
+@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
+@geoparquet_version_option
+@overwrite_option
+@verbose_option
+@any_extension_option
+@show_sql_option
+@click.pass_context
+def sort_quadkey(
+    ctx,
+    input_parquet,
+    output_parquet,
+    quadkey_name,
+    resolution,
+    use_centroid,
+    remove_quadkey_column,
+    allow_schema_diff,
+    compression,
+    compression_level,
+    row_group_size,
+    row_group_size_mb,
+    write_memory,
+    geoparquet_version,
+    overwrite,
+    verbose,
+    any_extension,
+    show_sql,
+):
+    """
+    Sort a GeoParquet file by quadkey spatial index.
+
+    If the quadkey column doesn't exist and using the default column name,
+    it will be auto-added at the specified resolution. If using --quadkey-name
+    and the column is missing, an error is raised.
+
+    Use --remove-quadkey-column to exclude the quadkey column from output
+    after sorting (useful when you only want the sorted order).
+
+    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
+    """
+    with _activate_s3(ctx):
+        # Validate .parquet extension
+        validate_parquet_extension(output_parquet, any_extension)
+
+        # Parse row group options
+        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+
+        sort_by_quadkey_impl(
+            input_parquet,
+            output_parquet,
+            quadkey_column_name=quadkey_name,
+            resolution=resolution,
+            use_centroid=use_centroid,
+            remove_quadkey_column=remove_quadkey_column,
+            verbose=verbose,
+            compression=compression.upper(),
+            compression_level=compression_level,
+            row_group_size_mb=row_group_mb,
+            row_group_rows=row_group_size,
+            geoparquet_version=geoparquet_version,
+            overwrite=overwrite,
+            memory_limit=write_memory,
+            allow_schema_diff=allow_schema_diff,
+        )

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -9,10 +9,10 @@ from click.core import ParameterSource
 from click_plugins import with_plugins
 
 from geoparquet_io.cli._shared import _activate_s3, create_default_group
+from geoparquet_io.cli.commands.sort import sort
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
     SingleFileCommand,
-    allow_schema_diff_option,
     any_extension_option,
     aws_profile_option,
     bucket_point_options,
@@ -53,7 +53,6 @@ from geoparquet_io.core.convert import convert_to_geoparquet
 from geoparquet_io.core.exceptions import InvalidParameterError, ValidationError
 from geoparquet_io.core.extract import extract as extract_impl
 from geoparquet_io.core.file_utils import validate_parquet_extension
-from geoparquet_io.core.hilbert_order import hilbert_order as hilbert_impl
 from geoparquet_io.core.inspect import (
     display_metadata,
     format_preview_output,
@@ -70,7 +69,6 @@ from geoparquet_io.core.inspect import (
     inspect_summary as _inspect_summary_core,
 )
 from geoparquet_io.core.logging_config import configure_verbose, setup_cli_logging
-from geoparquet_io.core.parquet_writer import DEFAULT_SORT_ROW_GROUP_ROWS
 from geoparquet_io.core.partition.admin_hierarchical import (
     partition_by_admin_hierarchical as partition_admin_hierarchical_impl,
 )
@@ -91,9 +89,6 @@ from geoparquet_io.core.process.aggregate.by_admin import (
 from geoparquet_io.core.process.aggregate.by_h3 import aggregate_by_h3 as aggregate_by_h3_impl
 from geoparquet_io.core.process.overview import create_overviews as create_overviews_impl
 from geoparquet_io.core.reproject import reproject as reproject_core
-from geoparquet_io.core.sort_by_column import sort_by_column as sort_by_column_impl
-from geoparquet_io.core.sort_quadkey import sort_by_quadkey as sort_by_quadkey_impl
-from geoparquet_io.core.str_order import str_order as str_impl
 from geoparquet_io.core.upload import check_credentials
 from geoparquet_io.core.upload import upload as upload_impl
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
@@ -177,6 +172,19 @@ def cli(ctx, timestamps, s3_endpoint, s3_region, s3_no_ssl, aws_profile):
     ctx.obj["aws_profile"] = aws_profile
     # Setup logging for CLI output (default level INFO, verbose commands will set DEBUG)
     setup_cli_logging(verbose=False, show_timestamps=timestamps)
+
+
+# ---------------------------------------------------------------------------
+# Command groups extracted into geoparquet_io/cli/commands/
+#
+# Each of those modules declares a standalone `@click.group()` and is attached
+# here, explicitly, one line per group. Registration is deliberately not done by
+# the group module itself (no `@cli.group()` there, no import-time
+# self-registration): that would need `cli.main`, and `cli.main` imports the
+# group -- a cycle. Keeping it here also means `grep add_command` lists the
+# whole tree.
+# ---------------------------------------------------------------------------
+cli.add_command(sort)
 
 
 # Create default group classes using the factory
@@ -3576,338 +3584,6 @@ def _handle_meta_display(
     display_metadata(
         parquet_file, parquet, geoparquet, parquet_geo, row_groups, json_output, geo_stats
     )
-
-
-# Sort commands group
-@cli.group()
-@click.pass_context
-def sort(ctx):
-    """Commands for sorting GeoParquet files."""
-    # Ensure logging is set up (in case this group is invoked directly in tests)
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
-
-
-@sort.command(name="hilbert", cls=SingleFileCommand)
-@click.argument("input_parquet")
-@click.argument("output_parquet", type=click.Path(), required=False, default=None)
-@click.option(
-    "--geometry-column",
-    "-g",
-    default="geometry",
-    help="Name of the geometry column (default: geometry)",
-)
-@click.option(
-    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
-)
-@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
-@geoparquet_version_option
-@overwrite_option
-@verbose_option
-@any_extension_option
-@show_sql_option
-@click.pass_context
-def hilbert_order(
-    ctx,
-    input_parquet,
-    output_parquet,
-    geometry_column,
-    add_bbox,
-    compression,
-    compression_level,
-    row_group_size,
-    row_group_size_mb,
-    write_memory,
-    geoparquet_version,
-    overwrite,
-    verbose,
-    any_extension,
-    show_sql,
-):
-    """
-    Reorder a GeoParquet file using Hilbert curve ordering.
-
-    Takes an input GeoParquet file and creates a new file with rows ordered
-    by their position along a Hilbert space-filling curve.
-
-    Applies optimal formatting (configurable compression, optimized row groups,
-    bbox metadata). A non-default CRS is carried through unchanged; a CRS that
-    spells out the GeoParquet default (OGC:CRS84 / EPSG:4326) is normalized to
-    how the spec writes it, an omitted crs key. Use --verbose to see when that
-    happens.
-
-    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
-    """
-    with _activate_s3(ctx):
-        # Validate output early - provides helpful error if no output and not piping
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
-
-        hilbert_impl(
-            input_parquet,
-            output_parquet,
-            geometry_column,
-            add_bbox,
-            verbose,
-            compression.upper(),
-            compression_level,
-            row_group_mb,
-            row_group_size,
-            None,
-            geoparquet_version,
-            overwrite,
-            memory_limit=write_memory,
-        )
-
-
-@sort.command(name="str", cls=SingleFileCommand)
-@click.argument("input_parquet")
-@click.argument("output_parquet", type=click.Path(), required=False, default=None)
-@click.option(
-    "--geometry-column",
-    "-g",
-    default="geometry",
-    help="Name of the geometry column (default: geometry)",
-)
-@click.option(
-    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
-)
-@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
-@geoparquet_version_option
-@overwrite_option
-@verbose_option
-@any_extension_option
-@show_sql_option
-@click.pass_context
-def str_order_command(
-    ctx,
-    input_parquet,
-    output_parquet,
-    geometry_column,
-    add_bbox,
-    compression,
-    compression_level,
-    row_group_size,
-    row_group_size_mb,
-    write_memory,
-    geoparquet_version,
-    overwrite,
-    verbose,
-    any_extension,
-    show_sql,
-):
-    """Pack GeoParquet rows with Sort-Tile-Recursive ordering.
-
-    STR sorts geometry bounding-box centers into X strips, sorts each strip on
-    Y, and alternates the Y direction between strips. This can produce tighter
-    row-group bounding boxes than a space-filling curve.
-
-    --row-group-size does double duty: it is the writer's row-group target, and
-    it selects how many X strips STR builds, as
-    ceil(sqrt(num_rows / row-group-size)). That makes it a coarse control -
-    nearby values often produce an identical ordering. Rows are not packed into
-    row-group-sized tiles, and because the writer rounds row groups up to a
-    multiple of 2048, tiles and row groups only line up when --row-group-size
-    is itself a multiple of 2048.
-    """
-    with _activate_s3(ctx):
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        validate_parquet_extension(output_parquet, any_extension)
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
-        str_impl(
-            input_parquet,
-            output_parquet,
-            geometry_column=geometry_column,
-            add_bbox_flag=add_bbox,
-            verbose=verbose,
-            compression=compression.upper(),
-            compression_level=compression_level,
-            row_group_size_mb=row_group_mb,
-            row_group_rows=row_group_size,
-            profile=None,
-            geoparquet_version=geoparquet_version,
-            overwrite=overwrite,
-            memory_limit=write_memory,
-        )
-
-
-@sort.command(name="column", cls=SingleFileCommand)
-@click.argument("input_parquet")
-@click.argument("output_parquet", type=click.Path())
-@click.argument("columns")
-@click.option(
-    "--descending",
-    is_flag=True,
-    help="Sort in descending order (default: ascending)",
-)
-@allow_schema_diff_option
-@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
-@geoparquet_version_option
-@overwrite_option
-@verbose_option
-@any_extension_option
-@show_sql_option
-@click.pass_context
-def sort_column(
-    ctx,
-    input_parquet,
-    output_parquet,
-    columns,
-    descending,
-    allow_schema_diff,
-    compression,
-    compression_level,
-    row_group_size,
-    row_group_size_mb,
-    write_memory,
-    geoparquet_version,
-    overwrite,
-    verbose,
-    any_extension,
-    show_sql,
-):
-    """
-    Sort a GeoParquet file by specified column(s).
-
-    COLUMNS is a comma-separated list of column names to sort by.
-
-    Examples:
-
-        gpio sort column input.parquet output.parquet name
-
-        gpio sort column input.parquet output.parquet name,date --descending
-
-    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
-    """
-    with _activate_s3(ctx):
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
-
-        sort_by_column_impl(
-            input_parquet,
-            output_parquet,
-            columns=columns,
-            descending=descending,
-            verbose=verbose,
-            compression=compression.upper(),
-            compression_level=compression_level,
-            row_group_size_mb=row_group_mb,
-            row_group_rows=row_group_size,
-            geoparquet_version=geoparquet_version,
-            overwrite=overwrite,
-            memory_limit=write_memory,
-            allow_schema_diff=allow_schema_diff,
-        )
-
-
-@sort.command(name="quadkey", cls=SingleFileCommand)
-@click.argument("input_parquet")
-@click.argument("output_parquet", type=click.Path())
-@click.option(
-    "--quadkey-name",
-    default="quadkey",
-    help="Name of the quadkey column to sort by (default: quadkey)",
-)
-@click.option(
-    "--resolution",
-    default=13,
-    type=click.IntRange(0, 23),
-    help="Resolution when auto-adding quadkey column (0-23). Default: 13",
-)
-@click.option(
-    "--use-centroid",
-    is_flag=True,
-    help="Use geometry centroid when auto-adding quadkey column",
-)
-@click.option(
-    "--remove-quadkey-column",
-    is_flag=True,
-    help="Exclude quadkey column from output after sorting",
-)
-@allow_schema_diff_option
-@output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
-@geoparquet_version_option
-@overwrite_option
-@verbose_option
-@any_extension_option
-@show_sql_option
-@click.pass_context
-def sort_quadkey(
-    ctx,
-    input_parquet,
-    output_parquet,
-    quadkey_name,
-    resolution,
-    use_centroid,
-    remove_quadkey_column,
-    allow_schema_diff,
-    compression,
-    compression_level,
-    row_group_size,
-    row_group_size_mb,
-    write_memory,
-    geoparquet_version,
-    overwrite,
-    verbose,
-    any_extension,
-    show_sql,
-):
-    """
-    Sort a GeoParquet file by quadkey spatial index.
-
-    If the quadkey column doesn't exist and using the default column name,
-    it will be auto-added at the specified resolution. If using --quadkey-name
-    and the column is missing, an error is raised.
-
-    Use --remove-quadkey-column to exclude the quadkey column from output
-    after sorting (useful when you only want the sorted order).
-
-    Supports both local and remote (S3, GCS, Azure) inputs and outputs.
-    """
-    with _activate_s3(ctx):
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
-
-        sort_by_quadkey_impl(
-            input_parquet,
-            output_parquet,
-            quadkey_column_name=quadkey_name,
-            resolution=resolution,
-            use_centroid=use_centroid,
-            remove_quadkey_column=remove_quadkey_column,
-            verbose=verbose,
-            compression=compression.upper(),
-            compression_level=compression_level,
-            row_group_size_mb=row_group_mb,
-            row_group_rows=row_group_size,
-            geoparquet_version=geoparquet_version,
-            overwrite=overwrite,
-            memory_limit=write_memory,
-            allow_schema_diff=allow_schema_diff,
-        )
 
 
 @cli.group()

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from contextlib import contextmanager
 from importlib.metadata import entry_points
 from pathlib import Path
 
@@ -9,6 +8,7 @@ import duckdb
 from click.core import ParameterSource
 from click_plugins import with_plugins
 
+from geoparquet_io.cli._shared import _activate_s3, create_default_group
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
     SingleFileCommand,
@@ -133,34 +133,6 @@ class OptionalIntCommand(GlobAwareCommand):
         return super().make_context(info_name, args, parent=parent, **extra)
 
 
-@contextmanager
-def _activate_s3(ctx, aws_profile=None, s3_endpoint=None, s3_region=None, s3_no_ssl=False):
-    """Resolve and activate S3 config from ctx + per-command overrides.
-
-    Properly saves/restores AWS_PROFILE env var to avoid credential leaks.
-    """
-    from geoparquet_io.core.duckdb_utils import s3_config_scope
-    from geoparquet_io.core.remote import resolve_s3_config
-
-    config = resolve_s3_config(
-        s3_endpoint=s3_endpoint or ctx.obj.get("s3_endpoint"),
-        s3_region=s3_region or ctx.obj.get("s3_region"),
-        s3_no_ssl=s3_no_ssl or ctx.obj.get("s3_no_ssl", False),
-        aws_profile=aws_profile or ctx.obj.get("aws_profile"),
-    )
-    previous_profile = os.environ.get("AWS_PROFILE")
-    try:
-        if config["profile"]:
-            os.environ["AWS_PROFILE"] = config["profile"]
-        with s3_config_scope(config):
-            yield config
-    finally:
-        if previous_profile is None:
-            os.environ.pop("AWS_PROFILE", None)
-        else:
-            os.environ["AWS_PROFILE"] = previous_profile
-
-
 @with_plugins(entry_points(group="gpio.plugins"))
 @click.group()
 @click.version_option(prog_name="geoparquet-io")
@@ -205,35 +177,6 @@ def cli(ctx, timestamps, s3_endpoint, s3_region, s3_no_ssl, aws_profile):
     ctx.obj["aws_profile"] = aws_profile
     # Setup logging for CLI output (default level INFO, verbose commands will set DEBUG)
     setup_cli_logging(verbose=False, show_timestamps=timestamps)
-
-
-# Check commands group - use custom command class for default subcommand
-def create_default_group(default_subcommand: str, description: str) -> type:
-    """Factory to create a click.Group subclass that defaults to a specific subcommand.
-
-    Args:
-        default_subcommand: The subcommand to invoke when none is provided
-        description: The docstring for the generated class
-
-    Returns:
-        A click.Group subclass with the configured default behavior
-    """
-
-    class _DefaultGroup(click.Group):
-        def parse_args(self, ctx, args):
-            # Handle --help for group
-            if "--help" in args and (not args or args[0] not in self.commands):
-                return super().parse_args(ctx, [a for a in args if a != "--help"] + ["--help"])
-
-            # If first arg is a known subcommand, use it
-            if args and not args[0].startswith("-") and args[0] in self.commands:
-                return super().parse_args(ctx, args)
-
-            # Default to configured subcommand
-            return super().parse_args(ctx, [default_subcommand] + args)
-
-    _DefaultGroup.__doc__ = description
-    return _DefaultGroup
 
 
 # Create default group classes using the factory

--- a/tests/test_cli_api_call_parity_scaffold.py
+++ b/tests/test_cli_api_call_parity_scaffold.py
@@ -22,7 +22,10 @@ Each `ParityCase` names, per front end:
   into, as a ``(module_or_class, attribute)`` pair. `ops` binds its core imports
   at module import time, so `ops` is patched on `ops`; `Table` imports inside
   each method body, so `Table` is patched on the *core* module; the CLI imports
-  under an ``_impl`` alias, so the CLI is patched on `cli.main`.
+  under an ``_impl`` alias, so the CLI is patched on the module that owns the
+  command. That is `cli.main` for groups still living there, and
+  `cli.commands.<group>` for groups already extracted (#3.2) -- pass
+  ``module=`` to `_cli` for those.
 * the *reference callable* -- the real function, used only for its signature.
   Captured calls are bound through it with ``apply_defaults()``, so a value
   passed positionally by one front end and by keyword (or not at all) by
@@ -83,6 +86,7 @@ from click.testing import CliRunner
 from geoparquet_io.api import ops
 from geoparquet_io.api import table as table_module
 from geoparquet_io.cli import main as cli_main
+from geoparquet_io.cli.commands import sort as cli_sort
 from geoparquet_io.core import extract as core_extract
 from geoparquet_io.core import hilbert_order as core_hilbert
 from geoparquet_io.core import sort_by_column as core_sort_column
@@ -189,9 +193,14 @@ class Ctx:
 # --------------------------------------------------------------------------
 
 
-def _cli(alias: str, reference: Callable, args: Callable[[Ctx], list[str]]) -> Frontend:
+def _cli(
+    alias: str,
+    reference: Callable,
+    args: Callable[[Ctx], list[str]],
+    module: Any = cli_main,
+) -> Frontend:
     return Frontend(
-        patch_site=(cli_main, alias),
+        patch_site=(module, alias),
         reference=reference,
         invoke=lambda ctx: ctx.run_cli(args(ctx)),
     )
@@ -373,6 +382,7 @@ CASES: list[ParityCase] = [
             "hilbert_impl",
             core_hilbert.hilbert_order,
             lambda c: ["sort", "hilbert", c.input_file, c.output_file],
+            module=cli_sort,
         ),
         ops=_ops(
             "hilbert_order_table",
@@ -393,6 +403,7 @@ CASES: list[ParityCase] = [
             "str_impl",
             core_str.str_order,
             lambda c: ["sort", "str", c.input_file, c.output_file],
+            module=cli_sort,
         ),
         ops=_ops(
             "str_order_table",
@@ -416,6 +427,7 @@ CASES: list[ParityCase] = [
             "sort_by_column_impl",
             core_sort_column.sort_by_column,
             lambda c: ["sort", "column", c.input_file, c.output_file, SORT_COLUMN],
+            module=cli_sort,
         ),
         ops=_ops(
             "sort_by_column_table",
@@ -439,6 +451,7 @@ CASES: list[ParityCase] = [
             "sort_by_quadkey_impl",
             core_sort_quadkey.sort_by_quadkey,
             lambda c: ["sort", "quadkey", c.input_file, c.output_file],
+            module=cli_sort,
         ),
         ops=_ops(
             "sort_by_quadkey_table",

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -181,7 +181,7 @@ def _dispatch_target(ctx: click.Context, group: click.Group) -> str | None:
 def _probe_dispatch(group: click.Group, argv: list[str]) -> str | None:
     """Return the subcommand a group rewrites ``argv`` to, or ``None``.
 
-    ``create_default_group`` in ``cli/main.py`` builds its groups from a
+    ``create_default_group`` in ``cli/_shared.py`` builds its groups from a
     factory, so every generated class is named ``_DefaultGroup`` and the
     configured subcommand lives only in a closure. Rather than reaching into
     ``__closure__`` cells, this asks the group what it actually does with an

--- a/tests/test_write_memory_forwarding.py
+++ b/tests/test_write_memory_forwarding.py
@@ -42,6 +42,7 @@ from click.testing import CliRunner
 # `from geoparquet_io.cli import main as cli_main` is the form that works
 # everywhere. Do not "simplify" this back to a dotted patch target.
 from geoparquet_io.cli import main as cli_main
+from geoparquet_io.cli.commands import sort as cli_sort
 from geoparquet_io.cli.main import cli
 from tests.conftest import skip_if_geography_unavailable
 
@@ -108,43 +109,54 @@ class TestEveryCommandForwardsWriteMemory:
 # Layer 1: CLI forwards --write-memory as memory_limit=<value> BY KEYWORD
 # ---------------------------------------------------------------------------
 
+# The module each case patches is the one that owns the command: `cli.main` for
+# groups still defined there, `cli.commands.<group>` for groups already
+# extracted into their own module (Deep Review 3.2).
 CLI_FORWARDING_CASES = [
     pytest.param(
+        cli_main,
         "add_h3_column_impl",
         lambda in_f, out_f, col: ["add", "h3", in_f, out_f],
         id="add-h3",
     ),
     pytest.param(
+        cli_main,
         "add_a5_column_impl",
         lambda in_f, out_f, col: ["add", "a5", in_f, out_f],
         id="add-a5",
     ),
     pytest.param(
+        cli_main,
         "add_s2_column_impl",
         lambda in_f, out_f, col: ["add", "s2", in_f, out_f],
         id="add-s2",
     ),
     pytest.param(
+        cli_main,
         "add_kdtree_column_impl",
         lambda in_f, out_f, col: ["add", "kdtree", in_f, out_f],
         id="add-kdtree",
     ),
     pytest.param(
+        cli_main,
         "add_quadkey_column_impl",
         lambda in_f, out_f, col: ["add", "quadkey", in_f, out_f],
         id="add-quadkey",
     ),
     pytest.param(
+        cli_main,
         "add_bbox_column_impl",
         lambda in_f, out_f, col: ["add", "bbox", in_f, out_f],
         id="add-bbox",
     ),
     pytest.param(
+        cli_sort,
         "sort_by_column_impl",
         lambda in_f, out_f, col: ["sort", "column", in_f, out_f, col],
         id="sort-column",
     ),
     pytest.param(
+        cli_sort,
         "sort_by_quadkey_impl",
         lambda in_f, out_f, col: ["sort", "quadkey", in_f, out_f],
         id="sort-quadkey",
@@ -155,13 +167,13 @@ CLI_FORWARDING_CASES = [
 class TestCliForwardsWriteMemoryByKeyword:
     """The CLI must call the core function with memory_limit=<value> as a kwarg."""
 
-    @pytest.mark.parametrize("impl_name,build_args", CLI_FORWARDING_CASES)
-    def test_write_memory_forwarded_as_keyword(self, impl_name, build_args):
+    @pytest.mark.parametrize("impl_module,impl_name,build_args", CLI_FORWARDING_CASES)
+    def test_write_memory_forwarded_as_keyword(self, impl_module, impl_name, build_args):
         runner = CliRunner()
         args = build_args("input.parquet", "output.parquet", "some_column")
         args = [*args, "--write-memory", "222MB"]
 
-        with mock.patch.object(cli_main, impl_name) as mocked_impl:
+        with mock.patch.object(impl_module, impl_name) as mocked_impl:
             result = runner.invoke(cli, args)
 
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
## What changed

First step of splitting `geoparquet_io/cli/main.py` (7,730 lines) into per-group
modules. Two commits, no behaviour change.

**1. `refactor(cli): give the shared CLI helpers a home outside main.py`**

New `geoparquet_io/cli/_shared.py` holding the two helpers used by more than one
command group:

| helper | why it is shared |
|---|---|
| `_activate_s3` | 48 call sites, spread across most groups |
| `create_default_group` | the factory behind `check`, `extract` and `inspect`'s default-subcommand groups |

Why a new module rather than `decorators.py`: `parse_row_group_options`,
`GlobAwareCommand` and `SingleFileCommand` already live in `decorators.py` and
were **not** moved — that file is the home for reusable Click *option* decorators
and the `cls=` command classes, and it stays that way. `_shared.py` takes the
group-neutral *runtime* plumbing that is neither. Both are things a group module
imports; neither may live in `main.py`, because `main.py` imports the groups.

Helpers used by exactly one group stay in `main.py` for now and will travel with
their group: `OptionalIntCommand`, `ConvertDefaultGroup`, and the three
`create_default_group(...)` instances.

**2. `refactor(cli): move the sort group into its own module`**

New `geoparquet_io/cli/commands/` package, and `sort.py` inside it holding the
`sort` group and its four commands (`column`, `hilbert`, `quadkey`, `str`).

### The registration pattern the next ten PRs copy

```python
# geoparquet_io/cli/commands/<group>.py
@click.group()          # NOT @cli.group()
def <group>(ctx): ...

# geoparquet_io/cli/main.py
from geoparquet_io.cli.commands.<group> import <group>   # with the other imports
cli.add_command(<group>)                                 # in the registration block
```

Explicit, one line per group, all in one block under the root group. Not
self-registration: `@cli.group()` inside the group module would need `cli.main`,
which imports the group — a cycle. And `grep add_command geoparquet_io/cli/main.py`
lists the whole tree, which an import-time side effect would not.

`main.py` re-exports `sort`, so `from geoparquet_io.cli.main import sort` (used by
`tests/test_sort.py` and others) still resolves. The 330 moved lines are
byte-identical to their previous form apart from the group's decorator line —
verified programmatically, not by eye.

Two test files needed the patch site renamed, because they patch the CLI's `*_impl`
alias in the module that resolved it: `test_write_memory_forwarding` and
`test_cli_api_call_parity_scaffold` now carry the owning module per case
(`cli_main` or `cli_sort`), so the next group move is a one-line edit in each.
Three pre-commit hook file patterns (`doc-sync`, `validate-claude-md`,
`check-api-for-cli`) were widened to `geoparquet_io/cli/commands/`, so a change
confined to a group module still triggers them.

## Why

Deep Review item 3.2. A 7,730-line module is the single worst file in the repo to
review, test or navigate; every group PR after this one is mechanical once the
shape is settled. This PR is the pilot: it decides where shared helpers live and
how a group attaches itself, so the shape matters more than the 381 lines removed.

Explicitly **not** in scope (later steps of 3.2): no `@gpio_command` decorator, no
uniform exception mapping, no touching the 48 hand-rolled `_activate_s3` call
sites, and no moving `MultiFileCheckRunner` or the `_*_impl` functions into
`core/` — that belongs with the `check`/`inspect` group PRs.

## Verification

**The CLI surface snapshot is unchanged — not re-recorded.**

```
$ git diff --stat origin/main -- tests/data/cli_surface.json
                                     (no output)
$ uv run pytest tests/test_cli_surface.py
74 passed in 0.45s
```

**Identical output, before and after.** `gpio --help`, `gpio sort --help` and
`gpio sort hilbert --help` all diff clean against captures taken at
`origin/main`. A real run:

```
$ gpio sort hilbert tests/data/unsorted.parquet out.parquet --verbose
before sha256: 1dc5a7f061a751cfeea97e1cc7ebd1c77fc59ace70cf94c4ba3762b3af0434d1
after  sha256: 1dc5a7f061a751cfeea97e1cc7ebd1c77fc59ace70cf94c4ba3762b3af0434d1
```

The verbose *log* differs in exactly three places, all environment noise: a set's
iteration order in one debug line, a memory limit derived from free RAM at the
time (`1.3GB` vs `1.2GB`), and the output filename. The written file is
byte-identical.

**Plugin entry point still works.** `@with_plugins(entry_points(group="gpio.plugins"))`
is untouched, and coexists with `cli.add_command`. Verified by putting a fake
`gpio-probe32a` dist-info with a `gpio.plugins` entry point on `PYTHONPATH`:

```
$ python -c "from geoparquet_io.cli.main import cli; print(sorted(cli.commands))"
['add', 'benchmark', 'check', 'convert', 'extract', 'inspect', 'partition',
 'pmtiles', 'probe32a', 'process', 'publish', 'skills', 'sort']
```

`probe32a` is registered and renders in `gpio --help`.

**Line counts**

| file | before | after |
|---|---|---|
| `geoparquet_io/cli/main.py` | 7,730 | 7,349 |
| `geoparquet_io/cli/_shared.py` | — | 81 |
| `geoparquet_io/cli/commands/__init__.py` | — | 15 |
| `geoparquet_io/cli/commands/sort.py` | — | 359 |

**Suites** (run at both commits; commit 1 passes on its own)

```
uv run pytest -n auto -m "not slow and not network and not meta" -q
  6266 passed, 75 skipped, 9 xfailed in 183.70s
uv run pytest -m meta -q
  203 passed, 7080 deselected
```

The meta lane is deselected by the fast suite and does not run on PRs, so it was
run explicitly — it contains repo-structure checks a file move can break.

**pre-commit, both stages**

```
uv run pre-commit run --all-files              # all Passed
uv run pre-commit run --all-files --hook-stage pre-push
  deptry ......... Passed
  mypy ........... Passed
  vulture ........ Passed
  xenon .......... Passed
  import-linter .. Passed
  menard-check ... Failed  (pre-existing, see below)
  fast-tests ..... Passed
```

`import-linter` specifically:

```
$ uv run lint-imports
Core modules must not import Click KEPT (1 ignored import)
API modules must not import CLI KEPT
Contracts: 2 kept, 0 broken.
```

`menard-check` fails, and **failed identically on `origin/main` before this branch
existed** — it flagged the same three doc targets (`CLAUDE.md#CLI Command Groups`,
`geoparquet_io/skills/geoparquet.md#Command Reference`, `docs/contributing.md`)
attributed to `90038a9` and `f4a4b1d`, both already on main. `doc-sync` reports
nothing to regenerate, because none of the generated content changed. It is a
pre-push-only hook and is not run in CI.

Refs: none — this is Deep Review item 3.2, for which no GitHub issue exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `gpio sort` command group with Hilbert, STR, column, and quadkey sorting subcommands.
  * Added sorting options for compression, row groups, GeoParquet versions, overwriting, memory limits, and S3 configuration.

* **Refactor**
  * Organized CLI commands into dedicated modules while preserving sorting behavior and help handling.

* **Tests**
  * Expanded CLI parity and option-forwarding coverage for the sorting commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->