### PR TITLE
fix(check): quote the bbox column identifier in the check --fix rewrite

### DIFF
--- a/geoparquet_io/core/check_fixes.py
+++ b/geoparquet_io/core/check_fixes.py
@@ -13,7 +13,11 @@ from geoparquet_io.core.common import (
     get_parquet_metadata,
     write_parquet_with_metadata,
 )
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    quote_identifier,
+    sql_path,
+)
 from geoparquet_io.core.exceptions import GeoParquetError, RemoteAccessError
 from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.hilbert_order import hilbert_order
@@ -219,8 +223,12 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
 
     try:
-        # Select all columns EXCEPT the bbox column
-        query = f"SELECT * EXCLUDE ({bbox_column_name}) FROM {sql_path(raw_url)}"
+        # Select all columns EXCEPT the bbox column. The column name is read from
+        # the file's own schema (see ``_detect_bbox_column_from_table``), so it is
+        # attacker-controlled and must be quoted as an identifier -- a bare
+        # interpolation lets a crafted column name inject arbitrary SQL into the
+        # projection (#918).
+        query = f"SELECT * EXCLUDE ({quote_identifier(bbox_column_name)}) FROM {sql_path(raw_url)}"
 
         write_parquet_with_metadata(
             con=con,

--- a/tests/test_check_fixes_core.py
+++ b/tests/test_check_fixes_core.py
@@ -3,11 +3,13 @@
 import os
 import shutil
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 from geoparquet_io.core.check_fixes import (
     fix_bbox_column,
     fix_bbox_metadata,
+    fix_bbox_removal,
     fix_compression,
     fix_spatial_ordering,
 )
@@ -207,6 +209,91 @@ class TestFixBboxRemoval:
         )
 
         assert fix_result["success"] is True
+
+
+class TestFixBboxRemovalSqlInjection:
+    """The bbox column name reaches the ``EXCLUDE`` rewrite from the file's own
+    schema (``_detect_bbox_column_from_table``), so it is attacker-controlled.
+    A bare interpolation let a crafted column name inject arbitrary SQL into the
+    projection of ``gpio check --fix`` (#918)."""
+
+    # A struct column NAME (pyarrow allows any name) that breaks out of the
+    # ``SELECT * EXCLUDE (<name>) FROM ...`` template: it closes the EXCLUDE
+    # list, appends an attacker-chosen projection column, and opens a final
+    # scalar subquery that the template's own trailing ``)`` closes.
+    _PAYLOAD = "filler) , (SELECT 42) AS pwn, (SELECT 1 LIMIT 0"
+
+    def _write_malicious_file(self, path, places_test_file):
+        """A GeoParquet file whose bbox struct column is named with an injection
+        payload, plus a benign ``filler`` column the payload references so the
+        injected SQL is valid on the vulnerable code path."""
+        places = pq.read_table(places_test_file)
+        n = places.num_rows
+        struct_arr = pa.StructArray.from_arrays(
+            [
+                pa.array([0.0] * n),
+                pa.array([0.0] * n),
+                pa.array([1.0] * n),
+                pa.array([1.0] * n),
+            ],
+            names=["xmin", "ymin", "xmax", "ymax"],
+        )
+        table = pa.table(
+            {
+                "geometry": places.column("geometry"),
+                "filler": pa.array(list(range(n))),
+                self._PAYLOAD: struct_arr,
+            }
+        ).replace_schema_metadata(places.schema.metadata or {})
+        pq.write_table(table, path)
+
+    def test_injection_payload_in_bbox_name_does_not_execute(
+        self, places_test_file, temp_output_dir
+    ):
+        src = os.path.join(temp_output_dir, "malicious.parquet")
+        out = os.path.join(temp_output_dir, "fixed.parquet")
+        self._write_malicious_file(src, places_test_file)
+
+        fix_bbox_removal(src, out, bbox_column_name=self._PAYLOAD, verbose=False)
+
+        result_cols = pq.read_table(out).column_names
+        # The injected projection must never materialise.
+        assert "pwn" not in result_cols
+        assert "(SELECT 1 LIMIT 0)" not in result_cols
+        # The named column is treated as a single identifier and removed cleanly;
+        # the legitimate columns survive untouched.
+        assert self._PAYLOAD not in result_cols
+        assert result_cols == ["geometry", "filler"]
+
+    def test_bbox_name_with_embedded_quote_is_escaped(self, places_test_file, temp_output_dir):
+        """A payload carrying a literal double quote must have it doubled, not
+        interpreted as an identifier delimiter."""
+        payload = 'weird") , (SELECT 99) AS pwn2 FROM (SELECT 1) t("x'
+        src = os.path.join(temp_output_dir, "malicious_quote.parquet")
+        out = os.path.join(temp_output_dir, "fixed_quote.parquet")
+
+        places = pq.read_table(places_test_file)
+        n = places.num_rows
+        struct_arr = pa.StructArray.from_arrays(
+            [
+                pa.array([0.0] * n),
+                pa.array([0.0] * n),
+                pa.array([1.0] * n),
+                pa.array([1.0] * n),
+            ],
+            names=["xmin", "ymin", "xmax", "ymax"],
+        )
+        table = pa.table(
+            {"geometry": places.column("geometry"), payload: struct_arr}
+        ).replace_schema_metadata(places.schema.metadata or {})
+        pq.write_table(table, src)
+
+        fix_bbox_removal(src, out, bbox_column_name=payload, verbose=False)
+
+        result_cols = pq.read_table(out).column_names
+        assert "pwn2" not in result_cols
+        assert payload not in result_cols
+        assert result_cols == ["geometry"]
 
 
 class TestGetGeoparquetVersionFromCheckResults:


### PR DESCRIPTION
## What changed

`fix_bbox_removal` in `geoparquet_io/core/check_fixes.py` built its
`SELECT * EXCLUDE (<col>) FROM ...` rewrite by interpolating the bbox column
name **bare**. The name now goes through `quote_identifier()` (from
`core/duckdb_utils.py`), so the whole name is treated as a single delimited SQL
identifier. The file path on that line was already escaped via `sql_path`.

## Why

The `bbox_column_name` is **not** a constant. It is read from the file's own
schema — `check_bbox_structure` / `_detect_bbox_column_from_table` return
whatever a column is named (conventional `*bbox`/`*bounds`/`*extent` struct, or
the covering-metadata pointer). A hostile GeoParquet file therefore fully
controls that string, and `gpio check --fix` executes SQL built from it. This is
exactly the injection surface CLAUDE.md calls out ("Column names arrive from a
file's own `geo.primary_column` and from `--column`/`--bbox-name`").

## Verified exploit shape

A struct column (pyarrow allows any name) named:

```
filler) , (SELECT 42) AS pwn, (SELECT 1 LIMIT 0
```

turns the rewrite into:

```sql
SELECT * EXCLUDE (filler) , (SELECT 42) AS pwn, (SELECT 1 LIMIT 0) FROM <path>
```

The template's own trailing `)` closes the attacker's final subquery, injecting
arbitrary columns into the projection. Swapping `SELECT 42` for a
`read_csv('/etc/passwd')` subquery exfiltrates local file contents into the
"fixed" output. Confirmed executing in DuckDB.

## Verification

New regression tests in `tests/test_check_fixes_core.py`
(`TestFixBboxRemovalSqlInjection`) build a parquet file whose bbox struct
column is named with an injection payload, run `fix_bbox_removal`, and assert
the payload does not execute.

**Fail on unfixed code (`origin/main`):**
```
assert 'pwn' not in ['geometry', 'filler) , (SELECT 42) AS pwn, (SELECT 1 LIMIT 0', 'pwn', '(SELECT 1 LIMIT 0)']
...
_duckdb.ParserException: Parser Error: syntax error at or near "") , (SELECT 99) AS pwn2 FROM (SELECT 1) t(""
2 failed
```

**Pass after the fix** (output is cleanly `['geometry', 'filler']`):
```
tests/test_check_fixes_core.py::TestFixBboxRemovalSqlInjection .. 2 passed
```

Also green:
- `uv run pytest tests/test_check*.py tests/test_sql_path_escaping.py -q -m "not network and not slow"` — 178 + escaping tests pass
- `uv run python scripts/check_sql_path_literals.py` — exit 0
- `uv run bandit -r geoparquet_io/ -c pyproject.toml -q` — clean
- `ruff check` / `ruff format --check` — clean; all pre-commit hooks pass
- Full fast suite (`-n auto -m "not slow and not network and not meta"`) — only unrelated `test_streaming_handles_broken_pipe` flaked under xdist and passes serially

## Sweep

Swept `check_fixes.py` and neighbouring modules for the same bare-identifier
shape. `check_fixes.py:223` was the only reachable SQL-injection site: the other
queries in the module (`:88`, `:347`) interpolate only `sql_path(...)` (a path,
no identifier), and `check_parquet_structure.py` uses `bbox_column_name` only in
log/message f-strings, never in SQL. Every other `EXCLUDE (...)` in the codebase
(`convert.py`, `reproject.py`, `arcgis.py`, `str_order.py`, `add/bbox.py`,
`partition/common.py`) already passes its identifier through `quote_identifier`
or uses a hardcoded constant.

## Checker

`scripts/check_sql_path_literals.py` catches path literals via the unambiguous
`'{` adjacency (the author owns the quote). Bare-identifier interpolation has no
such signal: the **correct** form is also `EXCLUDE ({var})` — where `var` was
quoted elsewhere — so a regex cannot distinguish `{quote_identifier(x)}` /
`{prequoted_var}` (safe) from `{raw_name}` (unsafe) without flagging every
legitimate `EXCLUDE` site. Extending it cleanly is not feasible; left for the
issue.

The bandit B608 skip in `pyproject.toml` is intentionally untouched (separate
decision recorded in #918).

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unusual bounding-box column names during GeoParquet processing.
  * Prevented crafted column names from being interpreted as SQL, ensuring affected columns are handled safely while preserving legitimate data.

* **Tests**
  * Added coverage for malicious and quote-containing column names to verify SQL-injection resistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->