### PR TITLE
fix(cli): quote the kdtree column identifier and stop the process group crashing when invoked directly

### DIFF
--- a/geoparquet_io/cli/_shared.py
+++ b/geoparquet_io/cli/_shared.py
@@ -30,10 +30,19 @@ def _activate_s3(ctx, aws_profile=None, s3_endpoint=None, s3_region=None, s3_no_
     """Resolve and activate S3 config from ctx + per-command overrides.
 
     Properly saves/restores AWS_PROFILE env var to avoid credential leaks.
+
+    ``ctx.obj`` is primed here rather than relied upon. The root ``gpio`` group
+    fills it, so every real CLI path already arrives with a dict -- but a group
+    object invoked on its own (``CliRunner().invoke(process, [...])``, or any
+    programmatic caller) never runs the root callback, and the read below then
+    raised ``AttributeError: 'NoneType' object has no attribute 'get'`` (#922).
+    Enforcing the precondition in the one helper that has it keeps every group
+    correct, instead of depending on each group callback to remember.
     """
     from geoparquet_io.core.duckdb_utils import s3_config_scope
     from geoparquet_io.core.remote import resolve_s3_config
 
+    ctx.ensure_object(dict)
     config = resolve_s3_config(
         s3_endpoint=s3_endpoint or ctx.obj.get("s3_endpoint"),
         s3_region=s3_region or ctx.obj.get("s3_region"),

--- a/geoparquet_io/cli/commands/benchmark.py
+++ b/geoparquet_io/cli/commands/benchmark.py
@@ -13,8 +13,7 @@ from geoparquet_io.core.logging_config import configure_verbose
 
 # Benchmark commands group
 @click.group()
-@click.pass_context
-def benchmark(ctx):
+def benchmark():
     """Benchmark GeoParquet performance.
 
     Commands for measuring and comparing performance of GeoParquet operations.
@@ -26,7 +25,6 @@ def benchmark(ctx):
       explain  Show DuckDB query plan analysis (EXPLAIN ANALYZE)
       report   View and compare benchmark results
     """
-    ctx.ensure_object(dict)
 
 
 @benchmark.command("compare")

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -181,7 +181,9 @@ def _build_sampling_query(
     then applies them to the full dataset using iterative CTEs.
 
     ``input_path`` is a RAW path: ``sql_path`` escapes it at each point of
-    interpolation, so it is never escaped twice (#802).
+    interpolation, so it is never escaped twice (#802). ``kdtree_column_name``
+    is likewise RAW — it comes straight from ``--kdtree-name`` — so the alias is
+    wrapped in ``quote_identifier`` at the one place it reaches SQL (#924).
 
     Strategy:
     1. Sample the data and compute KD-tree to get split boundaries
@@ -318,7 +320,7 @@ def _build_sampling_query(
     full_query = f"""
         WITH {cte_sql}
         SELECT * EXCLUDE(_kdtree_x, _kdtree_y, _kdtree_partition),
-            _kdtree_partition AS {kdtree_column_name}
+            _kdtree_partition AS {quote_identifier(kdtree_column_name)}
         FROM {final_cte}
     """
 
@@ -593,7 +595,8 @@ def add_kdtree_column(
                 SELECT *, ROW_NUMBER() OVER () AS row_id
                 FROM {sql_path(input_path)}
             )
-            SELECT original_with_rownum.* EXCLUDE (row_id), kdtree_final.partition_id AS {kdtree_column_name}
+            SELECT original_with_rownum.* EXCLUDE (row_id),
+                kdtree_final.partition_id AS {quote_identifier(kdtree_column_name)}
             FROM original_with_rownum
             JOIN kdtree_final ON original_with_rownum.row_id = kdtree_final.row_id
         """

--- a/tests/test_cli_s3_options.py
+++ b/tests/test_cli_s3_options.py
@@ -41,3 +41,61 @@ class TestGlobalToCommandWiring:
             ["--s3-endpoint", "data.source.coop", "inspect", "summary", "nonexistent.parquet"],
         )
         assert "No such option" not in result.output
+
+
+class TestGroupInvokedDirectly:
+    """A group object invoked on its own must not need its callback to have
+    primed ``ctx.obj``.
+
+    The root ``cli`` group calls ``ctx.ensure_object(dict)``, so every real CLI
+    path arrives at ``_activate_s3`` with a dict. Invoking a group object
+    directly -- what tests and programmatic callers do -- skips the root, and
+    ``_activate_s3`` then hit ``None.get(...)``: ``process`` was the group with
+    no ``ensure_object`` of its own and four ``_activate_s3`` call sites
+    (#922 item 1). Making the helper enforce its own precondition covers every
+    group, present and future, rather than the ten callbacks each remembering.
+    """
+
+    def test_activate_s3_primes_an_unset_ctx_obj(self):
+        """The helper itself tolerates ``ctx.obj is None``."""
+        import click
+
+        from geoparquet_io.cli._shared import _activate_s3
+
+        ctx = click.Context(click.Command("standalone"))
+        assert ctx.obj is None
+
+        with _activate_s3(ctx):
+            pass
+
+        assert ctx.obj == {}
+
+    def test_process_group_invoked_directly(self, tmp_path):
+        """``process`` has no ``ensure_object`` of its own -- the regression."""
+        from geoparquet_io.cli.commands.process import process
+
+        result = CliRunner().invoke(
+            process,
+            ["aggregate", "h3", str(tmp_path / "missing.parquet"), str(tmp_path / "out.parquet")],
+        )
+        assert not isinstance(result.exception, AttributeError), result.exception
+
+    def test_add_group_invoked_directly(self, buildings_test_file, tmp_path):
+        """A group that does carry ``ensure_object`` keeps working unchanged."""
+        from geoparquet_io.cli.commands.add import add
+
+        result = CliRunner().invoke(
+            add,
+            ["bbox", buildings_test_file, str(tmp_path / "out.parquet")],
+        )
+        assert not isinstance(result.exception, AttributeError), result.exception
+        assert result.exit_code == 0, result.output
+
+    def test_benchmark_group_invoked_directly(self):
+        """``benchmark``'s callback body is only ``ensure_object`` -- removing it
+        must not change how the group behaves on its own."""
+        from geoparquet_io.cli.commands.benchmark import benchmark
+
+        result = CliRunner().invoke(benchmark, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "suite" in result.output

--- a/tests/test_kdtree.py
+++ b/tests/test_kdtree.py
@@ -677,3 +677,66 @@ class TestAddKDTreePythonAPI:
         # because `extract_crs_from_table` stringified the resolved geoarrow CRS
         # object into "ProjJsonCrs(OGC:CRS84)" (issue #816, fixed).
         assert _failed_checks(temp_output_file) == []
+
+
+class TestKDTreeColumnNameQuoting:
+    """``--kdtree-name`` reaches the KD-tree ``SELECT ... AS <name>`` verbatim.
+
+    Both KD-tree query builders alias the computed partition id to the
+    user-supplied column name: ``_build_sampling_query`` (approximate mode, the
+    default) and the exact-mode branch of ``add_kdtree_column``. Interpolating
+    that name bare means any name that is not a bare SQL identifier either
+    breaks the query or, with a crafted value, injects into the projection
+    (#924, the CLI-supplied sibling of #918).
+    """
+
+    # A name that closes the alias and appends an attacker-chosen projection
+    # column. Bare, this yields an extra ``pwn`` column; quoted, it is one
+    # delimited identifier that happens to contain punctuation.
+    _PAYLOAD = "cell, 42 AS pwn"
+
+    @pytest.mark.parametrize("mode", [[], ["--exact"]], ids=["approx", "exact"])
+    def test_a_name_needing_quoting_round_trips(self, buildings_test_file, temp_output_file, mode):
+        """A name with a space and an embedded double quote survives verbatim."""
+        name = 'weird "kd" name'
+        result = CliRunner().invoke(
+            add,
+            [
+                "kdtree",
+                buildings_test_file,
+                temp_output_file,
+                "--partitions",
+                "4",
+                "--kdtree-name",
+                name,
+                *mode,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        table = pq.read_table(temp_output_file)
+        assert name in table.schema.names
+        values = table.column(name).to_pylist()
+        assert values and all(v is None or all(c in "01" for c in v) for v in values)
+
+    @pytest.mark.parametrize("mode", [[], ["--exact"]], ids=["approx", "exact"])
+    def test_an_injection_payload_stays_one_column(
+        self, buildings_test_file, temp_output_file, mode
+    ):
+        """The payload must land as a single column name, not extra SQL."""
+        result = CliRunner().invoke(
+            add,
+            [
+                "kdtree",
+                buildings_test_file,
+                temp_output_file,
+                "--partitions",
+                "4",
+                "--kdtree-name",
+                self._PAYLOAD,
+                *mode,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        names = pq.read_table(temp_output_file).schema.names
+        assert "pwn" not in names
+        assert self._PAYLOAD in names


### PR DESCRIPTION
Two small, unrelated correctness defects the CLI module split (#916) made visible. One commit each.

## What changed

**1. `fix(add)`: quote the kdtree column identifier — closes #924.**
`--kdtree-name` reached the KD-tree `SELECT ... AS <name>` bare. The issue recorded one site (`kdtree.py:596`, exact mode); the sweep below found a **second** in the same file — `_build_sampling_query` at `kdtree.py:321`, which is the *default* (approximate) path. Both now go through `quote_identifier()`. The `covering.kdtree.column` metadata keeps the raw name, which is correct: it names a column, it is not SQL.

**2. `fix(cli)`: `_activate_s3` primes `ctx.obj` — refs #922 (item 1 only).**
`ctx.ensure_object(dict)` moved into `_activate_s3` in `cli/_shared.py`, so the helper enforces its own precondition instead of depending on ten group callbacks to remember. Of the per-callback copies, only `benchmark`'s was purely defensive and it is removed (with the `@click.pass_context` that existed only to supply `ctx`). The other seven **stay**: each reads `ctx.obj.get("timestamps", False)` on the very next line to configure logging, so their `ensure_object` is load-bearing for a second reason and their "invoked directly in tests" comments remain accurate. The issue's expectation that "the six copy-pasted comments go away" does not hold.

## Why

**#924 is a real injection, not just a broken query.** `--kdtree-name 'cell, 42 AS pwn'` wrote an extra `pwn` column into the output on *both* paths (verified in DuckDB, and the new test asserts it). Ordinary names needing quoting — a space, an embedded `"` — failed outright with a parser error rather than round-tripping. The threat model is weaker than #918 (a user injecting into their own session, not a hostile file), but it is the same class and the same one-liner.

**#922 item 1** bit tests and any programmatic group invocation: `CliRunner().invoke(process, ["aggregate", "h3", ...])` raised `AttributeError: 'NoneType' object has no attribute 'get'` at `_shared.py:38`. Real CLI paths were fine because the root `gpio` group calls `ensure_object`.

### Identifier-interpolation sweep

#924 claims `kdtree.py:596` was "the last one outstanding". **That did not hold** — `kdtree.py:321` is a second site, fixed here. Re-running the sweep repo-wide (`AS {`, `EXCLUDE (`, and f-string interpolation of a column name) and tracing each variable to its assignment, everything else is correct:

- Quoted at the source: `geometry_repair.py` (`quote_identifier(geometry_column)`), `str_order.py` (all four temporaries), `convert.py` (`wkt_col`/`lat_col`/`lon_col`/`quoted_bbox`/`exclude_cols`), `reproject.py` (`exclude_clause`), `add/bbox.py`, `add/admin_divisions.py`, `common.py`, `inspect_utils.py`, `duckdb_utils.py`, `stream_io.py`, `geojson_stream.py`, `hilbert_order.py`, `process/aggregate/*`, `process/overview/rollup.py`.
- Not user data: `arcgis.py:991` interpolates a hardcoded `"geom, OGC_FID"`; `partition/common.py:729` interpolates an alias from `make_partition_aliases`; the remaining `AS {…}` hits are `CREATE TEMP TABLE x AS {query}` (a subquery, not an identifier).

One thing the sweep turned up that is **out of scope here and wants its own issue**: `core/partition/admin_hierarchical.py` interpolates `input_bbox_col` and `admin_bbox_col` bare at `:85-88`, `:100`, `:109`, `:125`, `:168-171` and `:212-215`. `input_bbox_col` comes from `check_bbox_structure()` — the input file's own schema — which is exactly the #918 threat model (hostile file), a different module and a different input source from this PR. Filed separately per the cross-cutting-fix convention rather than bolted on here.

## Verification

```
uv run pytest -n auto -m "not slow and not network and not meta" -q
  -> 6351 passed, 75 skipped, 9 xfailed  (1 known xdist flake:
     test_geojson_stream::test_streaming_handles_broken_pipe -- passes serially)

uv run pytest -m meta -q
  -> 203 passed, 7166 deselected

uv run pre-commit run --all-files                     -> all Passed
uv run pre-commit run --all-files --hook-stage pre-push -> all Passed
                                    (deptry, mypy, vulture, xenon, import-linter, menard)

uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
  -> Total 2 lines, Missing 0, Coverage 100%
```

New tests, each failing on `origin/main` before its fix:

- `tests/test_kdtree.py::TestKDTreeColumnNameQuoting` — 4 cases, parametrized over approx/exact. Before: `'weird "kd" name'` gave `ParserException` on both paths, and `'cell, 42 AS pwn'` produced schema `['id', 'geometry', 'cell', 'pwn']` on both paths.
- `tests/test_cli_s3_options.py::TestGroupInvokedDirectly` — 4 cases. `_activate_s3` against a bare `click.Context`, `process` invoked directly (the regression), `add` invoked directly (a group that keeps its `ensure_object`), and `benchmark --help` (the callback whose body was removed).

The 3 failures under `-n auto` during the coverage run (`test_geojson_stream`, `e2e/test_journeys`, `test_pipe_integration`) are the known subprocess xdist flake; all three pass serially.

Closes #924
Refs #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-line groups invoked directly so S3 options and help commands work without errors.
  * Improved handling of custom KD-tree column names, including names with spaces or quotation marks.
  * Prevented special characters in KD-tree names from being interpreted as additional SQL columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->