### PR TITLE
fix(write): keep geometry_types on carried secondary columns and Z/M/ZM data

### DIFF
--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -46,6 +46,7 @@ from geoparquet_io.core.geo_metadata import (
     build_bbox_covering,
     create_geo_metadata,
     detect_bbox_column_from_schema,
+    geoarrow_wkb_codes,
     prune_geo_metadata_to_columns,
     sanitize_geo_metadata,
     strip_derived_stats,
@@ -1333,8 +1334,11 @@ def _compute_geometry_types(table, geometry_column: str, verbose: bool) -> list[
         wkb_arr = ga.as_wkb(geom_col)
         types_struct = ga.unique_geometry_types(wkb_arr)
 
-        # Extract geometry type codes from struct array
-        type_codes = types_struct.field("geometry_type").to_pylist()
+        # Extract geometry type codes from struct array. geoarrow reports the
+        # base type and the dimensions separately, so the two are recombined
+        # into a WKB code -- reading `geometry_type` alone dropped the " Z" /
+        # " M" / " ZM" the spec makes part of the type name (#892).
+        type_codes = geoarrow_wkb_codes(types_struct)
 
         # Map codes to GeoParquet standard names (avoid duplicates)
         type_names = []

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -2819,6 +2819,7 @@ def write_parquet_with_metadata(
     extra_kv_metadata: dict[str, str] | None = None,
     input_file: str | None = None,
     invalidate_derived_stats: bool = False,
+    invalidate_derived_stats_columns: Collection[str] | None = None,
     drop_nonplanar_edges_columns: Collection[str] | None = None,
 ):
     """
@@ -2870,6 +2871,12 @@ def write_parquet_with_metadata(
             carried metadata came from only the first file: the input's stats no
             longer describe the output, so they must be recomputed from the
             written data or omitted rather than carried.
+        invalidate_derived_stats_columns: Restricts that invalidation to these
+            geometry columns. Set by a caller that changes coordinates in some
+            geometry columns but not others — reproject transforms only the
+            primary column, so a secondary column reaches the output unchanged
+            and its carried stats still describe it (#890). None (the default)
+            invalidates every column, which is right for a row filter or a merge.
         drop_nonplanar_edges_columns: Geometry columns whose non-planar
             ``edges`` declaration must neither be carried through nor
             re-attached to the output. Set by writes that invalidate the edge
@@ -2893,9 +2900,13 @@ def write_parquet_with_metadata(
 
     # Callers that transform geometry, filter rows, or merge multiple inputs
     # invalidate the carried bbox/geometry_types; drop them so the write
-    # strategies recompute (or omit) them instead of describing the input.
+    # strategies recompute (or omit) them instead of describing the input. A
+    # caller that transforms only some geometry columns names them, so an
+    # untouched secondary column keeps the stats that still describe it (#890).
     if invalidate_derived_stats:
-        original_metadata = strip_derived_stats(original_metadata)
+        original_metadata = strip_derived_stats(
+            original_metadata, columns=invalidate_derived_stats_columns
+        )
 
     # A write that invalidates the edge interpretation for the columns it
     # transforms (reprojecting into a projected CRS, #601) must neither carry

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -548,16 +548,9 @@ def _rewrite_geo_metadata(metadata: dict | None, rewrite) -> dict | None:
     return result
 
 
-def _drop_derived_stats(geo_dict: dict) -> dict:
-    """Remove :data:`DERIVED_STAT_KEYS` from every column entry, in place."""
-    for col_meta in (geo_dict.get("columns") or {}).values():
-        if isinstance(col_meta, dict):
-            for key in DERIVED_STAT_KEYS:
-                col_meta.pop(key, None)
-    return geo_dict
-
-
-def strip_derived_stats(metadata: dict | None) -> dict | None:
+def strip_derived_stats(
+    metadata: dict | None, columns: Collection[str] | None = None
+) -> dict | None:
     """Return a copy of Parquet KV ``metadata`` without derived geo stats.
 
     Drops the per-column ``bbox`` and ``geometry_types`` (see
@@ -570,11 +563,30 @@ def strip_derived_stats(metadata: dict | None) -> dict | None:
     per-partition splits, and multi-file merges whose carried metadata came from
     only the first input file.
 
+    ``columns`` limits the strip to those column entries, for a caller that
+    changes coordinates in some geometry columns but not others: reproject
+    transforms only the primary column, so a secondary column's bytes reach the
+    output unchanged and its carried stats still describe them (#890). Dropping
+    them anyway left the output without the ``geometry_types`` GeoParquet 1.1
+    requires — nothing recomputes a secondary column's — and DuckDB then refuses
+    to open the file at all. ``None`` strips every column, which is right for a
+    row filter or a merge: those change every column's rows.
+
     Both ``"geo"`` and ``b"geo"`` keys are handled, and the value is returned in
     the same form (``bytes``/``str``/``dict``) it arrived in. The input is never
     mutated; unparsable ``geo`` values are passed through untouched.
     """
-    return _rewrite_geo_metadata(metadata, _drop_derived_stats)
+
+    def _drop(geo_dict: dict) -> dict:
+        for col_name, col_meta in (geo_dict.get("columns") or {}).items():
+            if columns is not None and col_name not in columns:
+                continue
+            if isinstance(col_meta, dict):
+                for key in DERIVED_STAT_KEYS:
+                    col_meta.pop(key, None)
+        return geo_dict
+
+    return _rewrite_geo_metadata(metadata, _drop)
 
 
 def strip_orientation(metadata: dict | None, column: str) -> dict | None:

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -78,6 +78,28 @@ _DIMENSION_SUFFIXES = {
     3: " ZM",  # ZM dimensions (codes 3001-3007)
 }
 
+# geoarrow's Dimensions enum (XY=1, XYZ=2, XYM=3, XYZM=4) to the WKB type
+# code's dimensional modifier above. UNSPECIFIED (-1) and UNKNOWN (0) have no
+# entry and fall back to 2D, the only reading that claims nothing extra.
+_GEOARROW_DIMENSION_CODES = {1: 0, 2: 1, 3: 2, 4: 3}
+
+
+def geoarrow_wkb_codes(types_struct) -> list[int]:
+    """WKB type codes for a geoarrow ``unique_geometry_types`` result.
+
+    geoarrow reports the base type and the dimensions in two *separate* struct
+    fields, so reading only ``geometry_type`` spells ``Polygon M`` data as
+    ``Polygon`` — dropping a suffix the spec makes part of the type name, and
+    which every other gpio write path emits (#892). Recombining the two fields
+    yields the code :func:`_get_geometry_type_name` already understands.
+    """
+    bases = types_struct.field("geometry_type").to_pylist()
+    dims = types_struct.field("dimensions").to_pylist()
+    return [
+        1000 * _GEOARROW_DIMENSION_CODES.get(dim, 0) + base
+        for base, dim in zip(bases, dims, strict=True)
+    ]
+
 
 # =============================================================================
 # Carried-block shape check
@@ -1237,8 +1259,11 @@ def _compute_geometry_types(table: pa.Table, geometry_column: str, verbose: bool
         wkb_arr = ga.as_wkb(geom_col)
         types_struct = ga.unique_geometry_types(wkb_arr)
 
-        # Extract geometry type codes from struct array
-        type_codes = types_struct.field("geometry_type").to_pylist()
+        # Extract geometry type codes from struct array. geoarrow reports the
+        # base type and the dimensions separately, so the two are recombined
+        # into a WKB code -- reading `geometry_type` alone dropped the " Z" /
+        # " M" / " ZM" the spec makes part of the type name (#892).
+        type_codes = geoarrow_wkb_codes(types_struct)
 
         # Map codes to GeoParquet standard names (avoid duplicates)
         type_names = []

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -649,6 +649,7 @@ def reproject_impl(
                     memory_limit=memory_limit,
                     input_file=read_source,
                     invalidate_derived_stats=True,
+                    invalidate_derived_stats_columns={geom_col},
                     drop_nonplanar_edges_columns=drop_edges_columns,
                 )
                 # Replace original with temp file
@@ -679,6 +680,7 @@ def reproject_impl(
                     memory_limit=memory_limit,
                     input_file=read_source,
                     invalidate_derived_stats=True,
+                    invalidate_derived_stats_columns={geom_col},
                     drop_nonplanar_edges_columns=drop_edges_columns,
                 )
 
@@ -833,7 +835,9 @@ def _reproject_streaming(
             # Reprojection moves coordinates, so the carried bbox (and, for a
             # geometry-repairing transform, geometry_types) no longer describes
             # the output; drop them so they are recomputed from the written data.
-            metadata = strip_derived_stats(metadata)
+            # Only the transformed column, though: a secondary geometry column
+            # is passed through untouched, and its stats must survive (#890).
+            metadata = strip_derived_stats(metadata, columns={geom_col})
 
             # Write output using stream_io
             write_output(

--- a/tests/test_metadata_bbox_invalidation.py
+++ b/tests/test_metadata_bbox_invalidation.py
@@ -121,6 +121,46 @@ class TestStripDerivedStats:
         assert strip_derived_stats(meta)["vecorel"] == '{"a": 1}'
 
 
+class TestStripDerivedStatsColumns:
+    """``columns=`` scopes the strip to the columns a caller actually touched (#890)."""
+
+    def _geo(self):
+        return {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "bbox": [1, 1, 3, 3],
+                    "geometry_types": ["Point"],
+                },
+                "other_geom": {
+                    "encoding": "WKB",
+                    "bbox": [0, 0, 9, 9],
+                    "geometry_types": ["Polygon"],
+                },
+            },
+        }
+
+    def test_scoped_strip_leaves_untouched_column_intact(self):
+        out = strip_derived_stats({"geo": self._geo()}, columns={"geometry"})
+        cols = out["geo"]["columns"]
+        assert "bbox" not in cols["geometry"]
+        assert "geometry_types" not in cols["geometry"]
+        assert cols["other_geom"]["bbox"] == [0, 0, 9, 9]
+        assert cols["other_geom"]["geometry_types"] == ["Polygon"]
+
+    def test_none_still_strips_every_column(self):
+        out = strip_derived_stats({"geo": self._geo()})
+        for col in out["geo"]["columns"].values():
+            assert "bbox" not in col
+            assert "geometry_types" not in col
+
+    def test_unknown_column_name_strips_nothing(self):
+        meta = {"geo": self._geo()}
+        assert strip_derived_stats(meta, columns={"nope"}) == meta
+
+
 def _write_points(path, points, version="1.1"):
     """Write a CRS84 GeoParquet file from ``[(id, wkt), ...]``."""
     from geoparquet_io.core.common import write_parquet_with_metadata

--- a/tests/test_multi_geometry.py
+++ b/tests/test_multi_geometry.py
@@ -623,3 +623,79 @@ class TestWriteStrategiesWithMultiGeometry:
             assert boundary_crs.get("id", {}).get("code") == 3857, (
                 f"Strategy {strategy} did not preserve CRS for secondary column"
             )
+
+
+class TestMultiGeometryReproject:
+    """Reproject must not strip a secondary column's derived stats (#890).
+
+    ``gpio convert reproject`` transforms the PRIMARY geometry column only —
+    the query is ``SELECT * EXCLUDE (geometry), ST_Transform(geometry, ...)``,
+    so a secondary column's bytes reach the output byte-for-byte. Its carried
+    ``geometry_types``/``bbox`` therefore still describe the rows and must
+    survive; blanket-invalidating them left the output without the
+    ``geometry_types`` GeoParquet 1.1 requires, and DuckDB refuses to open such
+    a file at all: "Geoparquet column 'boundary' does not have geometry types".
+    """
+
+    def _reproject(self, tmp_path, name, **kwargs):
+        from geoparquet_io.core.reproject import reproject
+
+        input_file = tmp_path / f"in_{name}.parquet"
+        output_file = tmp_path / f"out_{name}.parquet"
+        create_multi_geometry_geoparquet(str(input_file))
+        reproject(str(input_file), str(output_file), target_crs="EPSG:3857", **kwargs)
+        meta = pq.read_metadata(str(output_file))
+        return output_file, json.loads(meta.metadata[b"geo"].decode("utf-8"))
+
+    def test_secondary_column_keeps_geometry_types(self, tmp_path):
+        _, geo_meta = self._reproject(tmp_path, "types")
+        boundary = geo_meta["columns"]["boundary"]
+        assert boundary["geometry_types"] == ["Polygon"], boundary
+
+    def test_secondary_column_keeps_its_bbox(self, tmp_path):
+        """The untransformed column's coordinates never moved, so its bbox holds."""
+        _, geo_meta = self._reproject(tmp_path, "bbox")
+        assert geo_meta["columns"]["boundary"]["bbox"] == [-0.5, -0.5, 2.5, 2.5]
+
+    def test_primary_column_stats_are_still_recomputed(self, tmp_path):
+        """The transformed column's carried degree-space stats must NOT survive."""
+        _, geo_meta = self._reproject(tmp_path, "primary")
+        geometry = geo_meta["columns"]["geometry"]
+        assert geometry["geometry_types"] == ["Point"]
+        # Reprojected to Web Mercator: meters, not the carried [0, 0, 2, 2].
+        assert geometry["bbox"][2] > 1000, geometry["bbox"]
+
+    def test_streaming_path_also_keeps_secondary_stats(self, tmp_path):
+        """The pipe path strips the same way and needed the same scoping."""
+        from geoparquet_io.core.reproject import _reproject_streaming
+
+        input_file = tmp_path / "in_stream.parquet"
+        output_file = tmp_path / "out_stream.parquet"
+        create_multi_geometry_geoparquet(str(input_file))
+        _reproject_streaming(
+            str(input_file),
+            str(output_file),
+            "EPSG:3857",
+            None,
+            "ZSTD",
+            None,
+            False,
+            None,
+            None,
+        )
+        meta = pq.read_metadata(str(output_file))
+        geo_meta = json.loads(meta.metadata[b"geo"].decode("utf-8"))
+        assert geo_meta["columns"]["boundary"]["geometry_types"] == ["Polygon"]
+
+    def test_duckdb_can_read_the_output(self, tmp_path):
+        """The end-user symptom of #890: the output was unreadable outright."""
+        import duckdb
+
+        output_file, _ = self._reproject(tmp_path, "duckdb")
+        con = duckdb.connect()
+        try:
+            con.execute("INSTALL spatial; LOAD spatial;")
+            rows = con.execute(f"SELECT * FROM read_parquet('{output_file.as_posix()}')").fetchall()
+        finally:
+            con.close()
+        assert len(rows) == 3

--- a/tests/test_write_zm_geometry_types.py
+++ b/tests/test_write_zm_geometry_types.py
@@ -3,11 +3,24 @@
 The GeoParquet spec treats "LineString" and "LineString ZM" as distinct
 geometry_types entries. The write-side SQL scan previously collapsed the
 dimension, so gpio's own converted Z/M output failed gpio's own spec check.
+
+The four write strategies must agree on that spelling. The in-memory strategy
+computes the types from Arrow data rather than by SQL scan, and read only
+geoarrow's base type code — so it alone declared "Polygon" for Polygon M data
+(#892), a disagreement invisible until a reader compared the declaration
+against the file's own statistics.
 """
 
+import json
+
+import pyarrow.parquet as pq
 import pytest
 
-from geoparquet_io.core.common import get_duckdb_connection, split_zm_suffix
+from geoparquet_io.core.common import (
+    get_duckdb_connection,
+    split_zm_suffix,
+    write_parquet_with_metadata,
+)
 from geoparquet_io.core.convert import convert_to_geoparquet
 from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
 from tests.conftest import get_geo_metadata
@@ -17,6 +30,19 @@ WKT_BY_DIM = {
     "M": ("LINESTRING M (0 0 5, 1 1 6)", "LineString M"),
     "ZM": ("LINESTRING ZM (0 0 1 5, 1 1 2 6)", "LineString ZM"),
 }
+
+#: Every dimension, XY included: the suffix-less case is the control.
+POLYGON_BY_DIM = {
+    "XY": ("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", "Polygon"),
+    "Z": ("POLYGON Z ((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1))", "Polygon Z"),
+    "M": ("POLYGON M ((0 0 5, 1 0 5, 1 1 5, 0 1 5, 0 0 5))", "Polygon M"),
+    "ZM": (
+        "POLYGON ZM ((0 0 1 5, 1 0 1 5, 1 1 1 5, 0 1 1 5, 0 0 1 5))",
+        "Polygon ZM",
+    ),
+}
+
+WRITE_STRATEGIES = ["in-memory", "streaming", "disk-rewrite", "duckdb-kv"]
 
 
 def _make_source(tmp_path, wkt):
@@ -75,3 +101,51 @@ def test_convert_emits_suffixed_geometry_types(tmp_path, dim, version):
         c for c in result.checks if "geometry_types" in c.name and c.status == CheckStatus.FAILED
     ]
     assert not failures, [f"{c.name}: {c.message}" for c in failures]
+
+
+@pytest.mark.parametrize("dim", list(POLYGON_BY_DIM))
+@pytest.mark.parametrize("strategy", WRITE_STRATEGIES)
+def test_every_write_strategy_declares_the_same_suffix(tmp_path, strategy, dim):
+    """All four strategies must spell the dimension the same way (#892)."""
+    wkt, expected = POLYGON_BY_DIM[dim]
+    out = tmp_path / f"{strategy}_{dim}.parquet"
+
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        write_parquet_with_metadata(
+            con,
+            f"SELECT 1 AS id, ST_GeomFromText('{wkt}') AS geometry",
+            str(out),
+            geoparquet_version="1.1",
+            write_strategy=strategy,
+        )
+    finally:
+        con.close()
+
+    geo = json.loads(pq.read_metadata(str(out)).metadata[b"geo"].decode("utf-8"))
+    assert geo["columns"]["geometry"]["geometry_types"] == [expected]
+
+
+def test_compute_geometry_types_from_arrow_is_dimension_aware():
+    """The Arrow/geoarrow computation, on both copies, keeps the suffix (#892).
+
+    geoarrow reports the base type and the dimensions in separate struct
+    fields, so reading only ``geometry_type`` spelled every dimension "Polygon".
+    """
+    import pyarrow as pa
+    import shapely
+    from shapely import wkt as shapely_wkt
+
+    from geoparquet_io.core import common, geo_metadata
+
+    for _dim, (wkt, expected) in POLYGON_BY_DIM.items():
+        table = pa.table(
+            {
+                "geometry": pa.array(
+                    [shapely.to_wkb(shapely_wkt.loads(wkt), flavor="iso")],
+                    type=pa.binary(),
+                )
+            }
+        )
+        assert common._compute_geometry_types(table, "geometry", False) == [expected]
+        assert geo_metadata._compute_geometry_types(table, "geometry", False) == [expected]


### PR DESCRIPTION
## What changed

Two independent `geometry_types` correctness bugs, one commit each.

**`fix(reproject)` — #890.** `strip_derived_stats` gains the `columns` scoping
`strip_nonplanar_edges` already has, and both reproject write paths (file and
streaming) pass the single column they transformed. `write_parquet_with_metadata`
gets a matching `invalidate_derived_stats_columns`. Callers that pass nothing —
`extract`'s row filters, partition staging, the multi-file merges in
`sort_by_column` / `sort_quadkey` — keep invalidating every column. That is
semantically warranted for a row filter (it does change every geometry column's
rows) but the *mechanism* is still wrong there: those paths DELETE the key, and
nothing recomputes a secondary column's stats on any file-write path, so the
output is unreadable in exactly the way this PR fixes for reproject. Verified
after this change: `extract geoparquet --where`, `extract geoparquet --bbox` and
`sort quadkey` on a two-geometry-column input all still emit a file DuckDB
refuses and gpio's own validator rejects. `geometry_types: []` (the spec's
"not known" sentinel) is the correct degradation there; tracked separately.

**`fix(write)` — #892.** geoarrow's `unique_geometry_types` reports the base type
and the dimensions in two *separate* struct fields; both copies of
`_compute_geometry_types` read only `geometry_type`. New `geoarrow_wkb_codes`
recombines them into the WKB code the existing name mapping already understands,
so no second spelling of the type names is introduced.

## Why

**#890 — the secondary column was carried, not reprojected.** The reproject query
is `SELECT * EXCLUDE (geometry), ST_Transform(geometry, ...) AS geometry FROM ...`,
so a secondary geometry column's bytes reach the output unchanged; its carried
`bbox` and `geometry_types` still describe its rows exactly. Blanket-invalidating
every column dropped them, and nothing on the write path recomputes a *secondary*
column's — only the primary's are rebuilt. `geometry_types` is REQUIRED by
GeoParquet 1.1, so the output was not merely lossy, it was unreadable:

```
$ gpio convert reproject in.parquet out.parquet --dst-crs EPSG:3857
$ duckdb -c "SELECT * FROM read_parquet('out.parquet')"
Invalid Input Error: Geoparquet column 'other_geom' does not have geometry types
```

Before / after, the same two-geometry-column input:

```
before:  geometry   {'encoding': 'WKB', 'bbox': [0.0, 0.0, 333958.47, 334111.17], 'geometry_types': ['Polygon']}
         other_geom {'encoding': 'WKB'}                                    <- unreadable
after:   geometry   {'encoding': 'WKB', 'bbox': [0.0, 0.0, 333958.47, 334111.17], 'geometry_types': ['Polygon']}
         other_geom {'encoding': 'WKB', 'geometry_types': ['Point'], 'bbox': [0.5, 0.5, 2.5, 2.5]}
```

This is the discipline #884 established on the same file for the `edges` drop:
touch only what you transformed. The transformed column's degree-space stats are
still invalidated and recomputed from the written coordinates; the untouched
column keeps what still holds.

**#892 — one strategy disagreed with three.** The other three strategies compute
the types by SQL scan and spell ` Z` / ` M` / ` ZM` correctly; the in-memory
strategy computes them from Arrow via geoarrow and dropped every suffix, not just
` M`. The same broken helper also feeds `backfill_derived_stats`, which `extract`
and the Arrow-stream writer use.

## Verification

Strategy x dimension matrix (`geometry_types` declared for a single `Polygon`,
all four write strategies x all four dimensions):

```
                XY           Z              M              ZM
before
  in-memory     Polygon      Polygon  X     Polygon  X     Polygon  X
  streaming     Polygon      Polygon Z      Polygon M      Polygon ZM
  disk-rewrite  Polygon      Polygon Z      Polygon M      Polygon ZM
  duckdb-kv     Polygon      Polygon Z      Polygon M      Polygon ZM
after
  all four      Polygon      Polygon Z      Polygon M      Polygon ZM
```

Tests (failing first, then passing):

- `tests/test_multi_geometry.py::TestMultiGeometryReproject` — the secondary
  column keeps its `geometry_types` and its `bbox`, the primary's are still
  recomputed, the streaming path is covered too, and DuckDB reads the output.
- `tests/test_metadata_bbox_invalidation.py::TestStripDerivedStatsColumns` —
  `columns=` scoping, including that `None` still strips everything.
- `tests/test_write_zm_geometry_types.py` — the 16-case strategy x dimension
  matrix plus a direct test of both `_compute_geometry_types` copies.

Suites:

- fast lane: `6367 passed, 75 skipped, 9 xfailed` in 236s. Two failures under
  `-n auto` (`test_geojson_stream::test_streaming_handles_broken_pipe`,
  `test_pipe_integration::test_add_bbox_to_sort_hilbert`) are the known xdist
  cold-run flake; both pass serially.
- meta lane: `203 passed`.
- `pre-commit run --all-files` and `--hook-stage pre-push` (deptry, mypy,
  vulture, xenon, import-linter, menard-check): all pass.
- diff-cover vs `origin/main`: **100%** of 19 changed lines.

Siblings checked, not fixed here (different shape, worth their own issues):
`duckdb_metadata._format_geo_types` is a fourth, *correct* copy of the WKB
code-to-name table on the read side — duplication, not a bug; and
`arcgis.py:1377` declares `geometry_types: ["Geometry"]` from a layer's declared
type when the ArcGIS type is unrecognized, which is not a valid spec value.

Closes #890
Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved Z, M, and ZM geometry dimension information in recorded geometry types.
  - Reprojection now refreshes derived statistics only for transformed geometry columns, preserving statistics for untouched geometry columns.
  - Added support for limiting derived-statistics invalidation to selected columns when writing metadata.

- **Tests**
  - Added coverage for dimension-aware geometry types, multi-geometry reprojection, and selective statistics invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
