### PR TITLE
fix(validate,inspect): enforce root placement for covering bbox and handle 6-element bboxes and antimeridian wrap

### DIFF
--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -850,6 +850,47 @@ def is_geographic_crs(crs: dict | str | None) -> bool:
     return False
 
 
+def merge_longitude_ranges(ranges: list[tuple[float, float]]) -> tuple[float, float]:
+    """Union of ``(xmin, xmax)`` longitude ranges, antimeridian-aware.
+
+    ``xmin > xmax`` marks a range that wraps the antimeridian -- the convention
+    of RFC 7946 5.2, which GeoParquet's ``bbox`` and Parquet's own geospatial
+    statistics both follow. Plain ``min``/``max`` over such a pair yields the
+    *complement* of the real extent, so the union is taken on the circle: the
+    arcs are merged and the result is the complement of the widest gap left
+    between them.
+
+    With no wrapping input the result is exactly ``(min(xmin), max(xmax))``, so
+    data from a producer that never wraps is reported as before.
+    """
+    if not ranges:
+        raise ValueError("merge_longitude_ranges() needs at least one range")
+    if all(xmin <= xmax for xmin, xmax in ranges):
+        return min(r[0] for r in ranges), max(r[1] for r in ranges)
+
+    arcs: list[list[float]] = []
+    for xmin, xmax in ranges:
+        arcs.extend([[xmin, xmax]] if xmin <= xmax else [[xmin, 180.0], [-180.0, xmax]])
+    arcs.sort()
+
+    merged = [arcs[0]]
+    for start, end in arcs[1:]:
+        if start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+
+    if len(merged) == 1:
+        return merged[0][0], merged[0][1]
+
+    # The widest gap is the part of the circle the data does not cover, so the
+    # answer is everything else. Reaching here means some range wrapped, which
+    # put arcs on both sides of the antimeridian: the -180/180 seam is covered
+    # and the gaps between the merged arcs are the only candidates.
+    _, at = max((merged[i + 1][0] - merged[i][1], i) for i in range(len(merged) - 1))
+    return merged[at + 1][0], merged[at][1]
+
+
 def parse_crs_string_to_projjson(crs_string, con=None):
     """Convert a CRS string (like "EPSG:5070") to full PROJJSON dict."""
     identifier = _extract_crs_identifier(crs_string)

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -862,6 +862,11 @@ def merge_longitude_ranges(ranges: list[tuple[float, float]]) -> tuple[float, fl
 
     With no wrapping input the result is exactly ``(min(xmin), max(xmax))``, so
     data from a producer that never wraps is reported as before.
+
+    The ranges must be **longitudes**: the split of a wrapping range happens at
+    +/-180, so callers have to establish a geographic CRS first (see
+    :func:`is_geographic_crs`). For a projected CRS the spec gives a bbox as
+    minima then maxima with no wrap-around, and the caller takes plain min/max.
     """
     if not ranges:
         raise ValueError("merge_longitude_ranges() needs at least one range")

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -19,7 +19,7 @@ import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from geoparquet_io.core.crs_utils import geoarrow_crs_to_projjson
+from geoparquet_io.core.crs_utils import geoarrow_crs_to_projjson, merge_longitude_ranges
 from geoparquet_io.core.duckdb_utils import _escape_sql_string, sql_path
 from geoparquet_io.core.exceptions import GeoParquetError
 
@@ -1355,6 +1355,10 @@ def get_aggregated_native_geo_stats(parquet_file: str, geometry_column: str, con
 def aggregate_native_geo_stats(chunks: list[dict]) -> dict:
     """Combine per-column-chunk statistics into one bbox and type list.
 
+    A chunk whose ``xmin`` exceeds its ``xmax`` wraps the antimeridian, which
+    the Parquet geospatial statistics permit; ``merge_longitude_ranges`` unions
+    the X ranges on the circle so the wrap is not inverted into its complement.
+
     Args:
         chunks: Output of :func:`get_native_geo_stats_by_row_group`
 
@@ -1365,10 +1369,11 @@ def aggregate_native_geo_stats(chunks: list[dict]) -> dict:
 
     with_bbox = [c for c in chunks if c["xmin"] is not None]
     if with_bbox:
+        xmin, xmax = merge_longitude_ranges([(c["xmin"], c["xmax"]) for c in with_bbox])
         stats["bbox"] = [
-            min(c["xmin"] for c in with_bbox),
+            xmin,
             min(c["ymin"] for c in with_bbox),
-            max(c["xmax"] for c in with_bbox),
+            xmax,
             max(c["ymax"] for c in with_bbox),
         ]
         with_z = [c for c in with_bbox if c["zmin"] is not None]

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -22,6 +22,7 @@ from geoparquet_io.core.crs_utils import (
     _is_crs84_equivalent,
     is_crs84_identifier,
     is_default_crs,
+    merge_longitude_ranges,
 )
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
 from geoparquet_io.core.file_utils import resolve_file_url
@@ -1215,9 +1216,11 @@ def extract_partition_summary(files: list[str], verbose: bool = False) -> dict[s
             - per_file_info: List of per-file details
     """
     from geoparquet_io.core.logging_config import debug
+    from geoparquet_io.core.validate import _bbox_xy
 
     total_rows = 0
     total_size_bytes = 0
+    x_ranges: list[tuple[float, float]] = []
     combined_bbox = None  # [xmin, ymin, xmax, ymax]
     compressions = set()
     geoparquet_versions = set()
@@ -1251,16 +1254,18 @@ def extract_partition_summary(files: list[str], verbose: bool = False) -> dict[s
         if geo_info.get("version"):
             geoparquet_versions.add(geo_info["version"])
 
-        # Merge bbox
-        bbox = geo_info.get("bbox")
-        if bbox and len(bbox) >= 4:
+        # Merge bbox. A GeoParquet bbox interleaves its dimensions -- the 6- and
+        # 8-element forms read [xmin, ymin, zmin, ...], so indices 2 and 3 are
+        # not xmax/ymax; _bbox_xy pulls the X/Y bounds out of any of the three.
+        xy = _bbox_xy(geo_info.get("bbox") or [])
+        if xy:
+            xmin, ymin, xmax, ymax = xy
+            x_ranges.append((xmin, xmax))
             if combined_bbox is None:
-                combined_bbox = list(bbox[:4])
+                combined_bbox = [xmin, ymin, xmax, ymax]
             else:
-                combined_bbox[0] = min(combined_bbox[0], bbox[0])  # xmin
-                combined_bbox[1] = min(combined_bbox[1], bbox[1])  # ymin
-                combined_bbox[2] = max(combined_bbox[2], bbox[2])  # xmax
-                combined_bbox[3] = max(combined_bbox[3], bbox[3])  # ymax
+                combined_bbox[1] = min(combined_bbox[1], ymin)
+                combined_bbox[3] = max(combined_bbox[3], ymax)
 
         # Check schema consistency
         from geoparquet_io.core.duckdb_metadata import get_usable_columns
@@ -1285,6 +1290,11 @@ def extract_partition_summary(files: list[str], verbose: bool = False) -> dict[s
                 "size_human": file_info.get("size_human", "N/A"),
             }
         )
+
+    if combined_bbox is not None:
+        # xmin > xmax in any file means an antimeridian-crossing extent, which
+        # min/max would turn into its complement (RFC 7946, 5.2).
+        combined_bbox[0], combined_bbox[2] = merge_longitude_ranges(x_ranges)
 
     return {
         "file_count": len(per_file_info),

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -1321,6 +1321,16 @@ def extract_partition_summary(files: list[str], verbose: bool = False) -> dict[s
     }
 
 
+def _combined_bbox_wrap_note(bbox: list) -> str:
+    """Trailing note for a combined bbox whose X range wraps the antimeridian.
+
+    ``extract_partition_summary`` can now emit ``xmin > xmax`` (#886). Printed
+    bare, that is indistinguishable from corrupt metadata, so every path that
+    shows the numbers to a person says how they are meant to be read.
+    """
+    return " (antimeridian-crossing, RFC 7946 5.2)" if bbox[0] > bbox[2] else ""
+
+
 def format_partition_terminal_output(
     partition_summary: dict[str, Any],
     geo_info: dict[str, Any],
@@ -1351,6 +1361,7 @@ def format_partition_terminal_output(
         console.print(
             f"Combined bounds: [cyan][{bbox[0]:.6f}, {bbox[1]:.6f}, "
             f"{bbox[2]:.6f}, {bbox[3]:.6f}][/cyan]"
+            f"[dim]{_combined_bbox_wrap_note(bbox)}[/dim]"
         )
 
     console.print()
@@ -1490,7 +1501,8 @@ def format_partition_markdown_output(
     if partition_summary["combined_bbox"]:
         bbox = partition_summary["combined_bbox"]
         lines.append(
-            f"- **Combined bounds:** [{bbox[0]:.6f}, {bbox[1]:.6f}, {bbox[2]:.6f}, {bbox[3]:.6f}]"
+            f"- **Combined bounds:** [{bbox[0]:.6f}, {bbox[1]:.6f}, "
+            f"{bbox[2]:.6f}, {bbox[3]:.6f}]{_combined_bbox_wrap_note(bbox)}"
         )
 
     lines.append("")

--- a/geoparquet_io/core/inspect_utils.py
+++ b/geoparquet_io/core/inspect_utils.py
@@ -22,6 +22,7 @@ from geoparquet_io.core.crs_utils import (
     _is_crs84_equivalent,
     is_crs84_identifier,
     is_default_crs,
+    is_geographic_crs,
     merge_longitude_ranges,
 )
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
@@ -1221,6 +1222,9 @@ def extract_partition_summary(files: list[str], verbose: bool = False) -> dict[s
     total_rows = 0
     total_size_bytes = 0
     x_ranges: list[tuple[float, float]] = []
+    # The antimeridian reading of xmin > xmax belongs to geographic CRS only, so
+    # one projected member is enough to disqualify it for the whole partition.
+    all_geographic = True
     combined_bbox = None  # [xmin, ymin, xmax, ymax]
     compressions = set()
     geoparquet_versions = set()
@@ -1261,6 +1265,7 @@ def extract_partition_summary(files: list[str], verbose: bool = False) -> dict[s
         if xy:
             xmin, ymin, xmax, ymax = xy
             x_ranges.append((xmin, xmax))
+            all_geographic = all_geographic and is_geographic_crs(geo_info.get("crs"))
             if combined_bbox is None:
                 combined_bbox = [xmin, ymin, xmax, ymax]
             else:
@@ -1292,9 +1297,16 @@ def extract_partition_summary(files: list[str], verbose: bool = False) -> dict[s
         )
 
     if combined_bbox is not None:
-        # xmin > xmax in any file means an antimeridian-crossing extent, which
-        # min/max would turn into its complement (RFC 7946, 5.2).
-        combined_bbox[0], combined_bbox[2] = merge_longitude_ranges(x_ranges)
+        if all_geographic:
+            # xmin > xmax in any file means an antimeridian-crossing extent, which
+            # min/max would turn into its complement (RFC 7946, 5.2).
+            combined_bbox[0], combined_bbox[2] = merge_longitude_ranges(x_ranges)
+        else:
+            # merge_longitude_ranges splits a wrapping range at +/-180, which is
+            # meaningless in projected units: for a non-geographic CRS the spec
+            # gives the bbox as plain minima then maxima, so union them plainly.
+            combined_bbox[0] = min(r[0] for r in x_ranges)
+            combined_bbox[2] = max(r[1] for r in x_ranges)
 
     return {
         "file_count": len(per_file_info),

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -1773,6 +1773,77 @@ def _check_covering_bbox_paths(col_meta: dict, col_name: str) -> ValidationCheck
     )
 
 
+def _schema_subtree_end(schema_info: list, index: int) -> int:
+    """Index just past the depth-first subtree rooted at ``schema_info[index]``."""
+    end = index + 1
+    for _ in range(schema_info[index].get("num_children") or 0):
+        if end >= len(schema_info):
+            break
+        end = _schema_subtree_end(schema_info, end)
+    return end
+
+
+def _schema_root_offset(schema_info: list) -> int:
+    """Index at which the root-level columns start: 0 or 1.
+
+    ``get_schema_info()`` returns the same flat depth-first listing in two
+    shapes. DuckDB's ``parquet_schema()`` prefixes it with the file's root group
+    element -- every row carries a ``file_name`` and the root alone has no
+    ``type`` -- while the pyarrow fast path starts straight at the first column
+    and always renders a ``type`` string.
+    """
+    if not schema_info:
+        return 0
+    first = schema_info[0]
+    return 1 if "file_name" in first and first.get("type") is None else 0
+
+
+def _root_schema_index(schema_info: list, name: str) -> int | None:
+    """Index of the root-level schema entry called ``name``, else ``None``.
+
+    The listing is depth first, so a struct's children sit between their parent
+    and the next root column: scanning it for the first entry of a given name can
+    return a *nested* field (say ``meta.bbox``) and shadow the real root column
+    of the same name. Skipping whole subtrees is also what enforces the v1.1.0
+    rule that the covering bbox column is at the root of the schema.
+    """
+    index = _schema_root_offset(schema_info)
+    while index < len(schema_info):
+        if schema_info[index].get("name") == name:
+            return index
+        index = _schema_subtree_end(schema_info, index)
+    return None
+
+
+def _schema_direct_children(schema_info: list, index: int) -> list[dict]:
+    """Direct children of ``schema_info[index]``, grandchildren excluded."""
+    children = []
+    child = index + 1
+    for _ in range(schema_info[index].get("num_children") or 0):
+        if child >= len(schema_info):
+            break
+        children.append(schema_info[child])
+        child = _schema_subtree_end(schema_info, child)
+    return children
+
+
+def _bbox_column_missing(check_name: str, bbox_col_name: str, schema_info: list) -> ValidationCheck:
+    """FAILED for a covering bbox column that is not a root-level column."""
+    nested = any(col.get("name") == bbox_col_name for col in schema_info)
+    detail = (
+        "it exists only as a nested field; GeoParquet 1.1 requires the bounding "
+        "box column at the root of the schema"
+        if nested
+        else "no root-level column of that name exists"
+    )
+    return ValidationCheck(
+        name=check_name,
+        status=CheckStatus.FAILED,
+        message=f'bbox column "{bbox_col_name}" is not at the schema root ({detail})',
+        category="geoparquet_1_1",
+    )
+
+
 def _check_covering_bbox_column_exists(
     col_meta: dict, col_name: str, schema_info: list
 ) -> ValidationCheck:
@@ -1799,21 +1870,14 @@ def _check_covering_bbox_column_exists(
             category="geoparquet_1_1",
         )
 
-    # Check if column exists at root (no dots in name indicating nesting)
-    for col in schema_info:
-        name = col.get("name", "")
-        if name == bbox_col_name:
-            return ValidationCheck(
-                name=f"covering_bbox_column_exists_{col_name}",
-                status=CheckStatus.PASSED,
-                message=f'bbox column "{bbox_col_name}" exists at schema root',
-                category="geoparquet_1_1",
-            )
+    check_name = f"covering_bbox_column_exists_{col_name}"
+    if _root_schema_index(schema_info, bbox_col_name) is None:
+        return _bbox_column_missing(check_name, bbox_col_name, schema_info)
 
     return ValidationCheck(
-        name=f"covering_bbox_column_exists_{col_name}",
-        status=CheckStatus.FAILED,
-        message=f'bbox column "{bbox_col_name}" not found at schema root',
+        name=check_name,
+        status=CheckStatus.PASSED,
+        message=f'bbox column "{bbox_col_name}" exists at schema root',
         category="geoparquet_1_1",
     )
 
@@ -1850,12 +1914,12 @@ def _check_covering_bbox_structure(
             category="geoparquet_1_1",
         )
 
-    found_fields = []
-    for i, col in enumerate(schema_info):
-        if col.get("name") == bbox_col_name:
-            num_children = col.get("num_children") or 0
-            found_fields = [c.get("name") for c in schema_info[i + 1 : i + 1 + num_children]]
-            break
+    check_name = f"covering_bbox_structure_{col_name}"
+    index = _root_schema_index(schema_info, bbox_col_name)
+    if index is None:
+        return _bbox_column_missing(check_name, bbox_col_name, schema_info)
+
+    found_fields = [c.get("name") for c in _schema_direct_children(schema_info, index)]
 
     if found_fields != _BBOX_FIELDS.get(len(found_fields)):
         return ValidationCheck(
@@ -1899,20 +1963,17 @@ def _check_covering_bbox_field_types(
             category="geoparquet_1_1",
         )
 
-    # Find field types
-    field_types = set()
-    valid_types = {"FLOAT", "DOUBLE", "FLOAT32", "FLOAT64"}
+    check_name = f"covering_bbox_field_types_{col_name}"
+    index = _root_schema_index(schema_info, bbox_col_name)
+    if index is None:
+        return _bbox_column_missing(check_name, bbox_col_name, schema_info)
 
-    for i, col in enumerate(schema_info):
-        if col.get("name") == bbox_col_name:
-            num_children = col.get("num_children") or 0
-            for j in range(1, num_children + 1):
-                if i + j < len(schema_info):
-                    # Same trap as _check_geometry_byte_array: a group child's
-                    # type is an explicit None, so `or ""` is the guard here too.
-                    child_type = (schema_info[i + j].get("type") or "").upper()
-                    field_types.add(child_type)
-            break
+    valid_types = {"FLOAT", "DOUBLE", "FLOAT32", "FLOAT64"}
+    # Same trap as _check_geometry_byte_array: a group child's type is an
+    # explicit None, so `or ""` is the guard here too.
+    field_types = {
+        (child.get("type") or "").upper() for child in _schema_direct_children(schema_info, index)
+    }
 
     # Check if all types are valid
     invalid_types = field_types - valid_types

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2422,10 +2422,17 @@ def _check_native_geo_statistics(parquet_file: str, geom_col: str) -> Validation
                 f"[{geo_bbox['xmin']:.2f}, {geo_bbox['ymin']:.2f}, "
                 f"{geo_bbox['xmax']:.2f}, {geo_bbox['ymax']:.2f}]"
             )
+            # These values may now wrap the antimeridian (#886), and a bare
+            # xmin > xmax reads as corrupt metadata; say which it is.
+            wrap_note = (
+                " (statistics interpreted as antimeridian-crossing, RFC 7946 5.2)"
+                if geo_bbox["xmin"] > geo_bbox["xmax"]
+                else ""
+            )
             return ValidationCheck(
                 name=f"native_geo_stats_{geom_col}",
                 status=CheckStatus.PASSED,
-                message=f"geometry column has geospatial statistics: {bbox_str}",
+                message=f"geometry column has geospatial statistics: {bbox_str}{wrap_note}",
                 category="parquet_geo_types",
             )
         else:

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2489,6 +2489,9 @@ def _check_native_geo_stats_contains_data(
                 category="parquet_geo_types",
             )
 
+        # Native statistics order Z after XY ([xmin, ymin, xmax, ymax, zmin,
+        # zmax]), unlike GeoParquet's interleaved metadata bbox -- so the first
+        # four values are the X/Y bounds here and _bbox_xy does not apply.
         geo_bbox = dict(zip(("xmin", "ymin", "xmax", "ymax"), bbox[:4], strict=True))
 
         # Validate that bbox values are reasonable (not garbage from parsing errors)
@@ -2506,6 +2509,9 @@ def _check_native_geo_stats_contains_data(
         ymin = geo_bbox["ymin"]
         xmax = geo_bbox["xmax"]
         ymax = geo_bbox["ymax"]
+        # Parquet's geospatial statistics may legally wrap the antimeridian
+        # (xmin > xmax), the same reading _check_bbox_contains_data applies.
+        wrapped = xmin > xmax
 
         limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
@@ -2513,9 +2519,8 @@ def _check_native_geo_stats_contains_data(
         query = f"""
             SELECT COUNT(*) as total,
                    COUNT(CASE WHEN
-                       ST_XMin({quote_identifier(geom_col)}) >= {xmin} AND
+                       {_x_within_sql(quote_identifier(geom_col), xmin, xmax)} AND
                        ST_YMin({quote_identifier(geom_col)}) >= {ymin} AND
-                       ST_XMax({quote_identifier(geom_col)}) <= {xmax} AND
                        ST_YMax({quote_identifier(geom_col)}) <= {ymax}
                    THEN 1 END) as within_bbox
             FROM (
@@ -2539,17 +2544,25 @@ def _check_native_geo_stats_contains_data(
                     message="no non-empty geometries to check against geospatial statistics",
                     category="parquet_geo_types",
                 )
+            # The wrap reading must never be invisible in the check output.
+            wrap_note = (
+                " (statistics interpreted as antimeridian-crossing, RFC 7946 5.2)"
+                if wrapped
+                else ""
+            )
             if total == within:
                 return ValidationCheck(
                     name=f"native_geo_stats_contains_data_{geom_col}",
                     status=CheckStatus.PASSED,
-                    message=f"all geometries fall within geospatial statistics ({total} checked)",
+                    message=f"all geometries fall within geospatial statistics "
+                    f"({total} checked){wrap_note}",
                     category="parquet_geo_types",
                 )
             return ValidationCheck(
                 name=f"native_geo_stats_contains_data_{geom_col}",
                 status=CheckStatus.FAILED,
-                message=f"{total - within} of {total} geometries fall outside geospatial statistics",
+                message=f"{total - within} of {total} geometries fall outside "
+                f"geospatial statistics{wrap_note}",
                 category="parquet_geo_types",
             )
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2448,9 +2448,18 @@ def _check_native_geo_statistics(parquet_file: str, geom_col: str) -> Validation
 
 
 def _check_native_geo_stats_contains_data(
-    parquet_file: str, geom_col: str, con, sample_size: int
+    parquet_file: str, geom_col: str, con, sample_size: int, crs: Any = None
 ) -> ValidationCheck:
-    """Check that sampled geometries fall within declared geospatial statistics (geo_bbox)."""
+    """Check that sampled geometries fall within declared geospatial statistics (geo_bbox).
+
+    ``crs`` is the column's declared crs value (None means the CRS84 default), read
+    the same way :func:`_check_bbox_contains_data` reads it: xmin > xmax is an
+    antimeridian-crossing extent (RFC 7946, 5.2) only for a geographic CRS. The
+    gate is the CRS and not the GEOGRAPHY logical type -- a GEOMETRY column in a
+    geographic CRS wraps just as legally, and parquet-format's own rule is that
+    "this wraparound occurs only when the corresponding bounding box crosses the
+    antimeridian line".
+    """
     from geoparquet_io.core.duckdb_metadata import get_aggregated_native_geo_stats
     from geoparquet_io.core.file_utils import resolve_file_url
     from geoparquet_io.core.remote import is_remote_url
@@ -2510,8 +2519,20 @@ def _check_native_geo_stats_contains_data(
         xmax = geo_bbox["xmax"]
         ymax = geo_bbox["ymax"]
         # Parquet's geospatial statistics may legally wrap the antimeridian
-        # (xmin > xmax), the same reading _check_bbox_contains_data applies.
+        # (xmin > xmax), the same reading _check_bbox_contains_data applies --
+        # and, like there, only for a geographic CRS.
         wrapped = xmin > xmax
+        if wrapped and not is_geographic_crs(crs):
+            return ValidationCheck(
+                name=f"native_geo_stats_contains_data_{geom_col}",
+                status=CheckStatus.FAILED,
+                message=(
+                    "geospatial statistics have xmin > xmax; the antimeridian wrap-around "
+                    "reading (RFC 7946, 5.2) applies only to geographic CRS, so these "
+                    "statistics are invalid for the declared projected CRS"
+                ),
+                category="parquet_geo_types",
+            )
 
         limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
 
@@ -3872,9 +3893,13 @@ def _run_parquet_geo_only_checks(
 
         # Data validation if requested
         if validate_data and con:
+            # The declared CRS decides whether xmin > xmax in the statistics is
+            # an antimeridian wrap or broken metadata; here it comes from the
+            # Parquet logical type, the only place a geo-only file declares it.
+            crs = _get_crs_from_schema(schema_info, geom_col)
             checks.append(_check_native_geo_types_match(parquet_file, geom_col, sample_size, con))
             checks.append(
-                _check_native_geo_stats_contains_data(parquet_file, geom_col, con, sample_size)
+                _check_native_geo_stats_contains_data(parquet_file, geom_col, con, sample_size, crs)
             )
             checks.append(
                 _check_geography_coordinate_bounds(
@@ -3883,8 +3908,6 @@ def _run_parquet_geo_only_checks(
             )
 
             # Check coordinates are valid for declared CRS
-            # Get CRS from schema logical type for parquet-geo-only files
-            crs = _get_crs_from_schema(schema_info, geom_col)
             checks.append(
                 _check_coordinates_valid_for_crs(parquet_file, geom_col, crs, con, sample_size)
             )
@@ -4047,8 +4070,14 @@ def _run_geoparquet_checks(
                 checks.append(
                     _check_native_geo_types_match(parquet_file, col_name, sample_size, con)
                 )
+                # A 2.0 column may declare its CRS in the GeoParquet metadata,
+                # in the Parquet logical type, or both; either one rules out
+                # reading xmin > xmax as an antimeridian wrap when it is projected.
+                stats_crs = col_meta.get("crs") or _get_crs_from_schema(schema_info, col_name)
                 checks.append(
-                    _check_native_geo_stats_contains_data(parquet_file, col_name, con, sample_size)
+                    _check_native_geo_stats_contains_data(
+                        parquet_file, col_name, con, sample_size, stats_crs
+                    )
                 )
                 checks.append(
                     _check_geography_coordinate_bounds(

--- a/tests/test_covering_v2.py
+++ b/tests/test_covering_v2.py
@@ -372,7 +372,7 @@ def test_check_spec_validates_coverings_at_v2(tmp_path):
 
     result = CliRunner().invoke(cli, ["check", "spec", src])
 
-    assert 'bbox column "ghost" not found at schema root' in result.output
+    assert 'bbox column "ghost" is not at the schema root' in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_bbox_dimensions.py
+++ b/tests/test_validate_bbox_dimensions.py
@@ -13,11 +13,16 @@ import pytest
 from geoparquet_io.core.common import get_duckdb_connection
 from geoparquet_io.core.crs_utils import merge_longitude_ranges
 from geoparquet_io.core.duckdb_metadata import aggregate_native_geo_stats
-from geoparquet_io.core.inspect_utils import extract_partition_summary
+from geoparquet_io.core.inspect_utils import (
+    extract_partition_summary,
+    format_partition_markdown_output,
+    format_partition_terminal_output,
+)
 from geoparquet_io.core.validate import (
     CheckStatus,
     _check_bbox_contains_data,
     _check_bbox_valid,
+    _check_native_geo_statistics,
     _check_native_geo_stats_contains_data,
     validate_geoparquet,
 )
@@ -476,3 +481,55 @@ class TestPartitionSummaryWrapNeedsGeographicCrs:
         )
         summary = extract_partition_summary([str(geographic), str(projected)])
         assert summary["combined_bbox"] == [0.0, -10.0, 10.0, 10.0]
+
+
+def _summary(bbox):
+    return {
+        "file_count": 1,
+        "total_rows": 2,
+        "total_size_bytes": 100,
+        "total_size_human": "100 B",
+        "combined_bbox": bbox,
+        "schema_consistent": True,
+        "compressions": ["SNAPPY"],
+        "geoparquet_versions": ["1.1.0"],
+        "per_file_info": [
+            {"file": "a.parquet", "file_name": "a.parquet", "rows": 2, "size_human": "100 B"}
+        ],
+    }
+
+
+class TestWrapIsVisibleWhereTheValuesArePrinted:
+    """A wrapped range printed bare is indistinguishable from corrupt metadata (#886)."""
+
+    def test_terminal_output_notes_a_wrapping_combined_bbox(self, capsys):
+        format_partition_terminal_output(_summary(WRAPPING_BBOX), {}, [])
+        assert "antimeridian" in capsys.readouterr().out
+
+    def test_terminal_output_leaves_a_plain_bbox_unannotated(self, capsys):
+        format_partition_terminal_output(_summary([0.0, 0.0, 10.0, 5.0]), {}, [])
+        assert "antimeridian" not in capsys.readouterr().out
+
+    def test_markdown_output_notes_a_wrapping_combined_bbox(self):
+        out = format_partition_markdown_output(_summary(WRAPPING_BBOX), {}, [])
+        line = next(ln for ln in out.splitlines() if "Combined bounds" in ln)
+        assert "antimeridian-crossing, RFC 7946 5.2" in line
+
+    def test_markdown_output_leaves_a_plain_bbox_unannotated(self):
+        out = format_partition_markdown_output(_summary([0.0, 0.0, 10.0, 5.0]), {}, [])
+        line = next(ln for ln in out.splitlines() if "Combined bounds" in ln)
+        assert "antimeridian" not in line
+
+    def test_native_geo_statistics_message_notes_the_wrap(self, antimeridian_file, monkeypatch):
+        monkeypatch.setattr(
+            "geoparquet_io.core.duckdb_metadata.get_native_geo_stats_by_row_group",
+            lambda *a, **k: [_chunk(175.0, 0.0, -175.0, 5.0)],
+        )
+        check = _check_native_geo_statistics(str(antimeridian_file), "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+        assert "antimeridian" in check.message
+
+    def test_native_geo_statistics_message_is_unannotated_without_a_wrap(self, antimeridian_file):
+        check = _check_native_geo_statistics(str(antimeridian_file), "geometry")
+        assert check.status == CheckStatus.PASSED, check.message
+        assert "antimeridian" not in check.message

--- a/tests/test_validate_bbox_dimensions.py
+++ b/tests/test_validate_bbox_dimensions.py
@@ -58,6 +58,15 @@ UTM_33N = {
     "id": {"authority": "EPSG", "code": 32633},
 }
 
+CRS84 = {
+    "type": "GeographicCRS",
+    "name": "WGS 84 longitude-latitude",
+    "id": {"authority": "OGC", "code": "CRS84"},
+}
+
+#: A wrapping extent: legal for a geographic CRS, corrupt for a projected one.
+WRAPPING_BBOX = [170.0, -10.0, -170.0, 10.0]
+
 
 @pytest.fixture
 def xyz_file(tmp_path):
@@ -342,3 +351,128 @@ class TestPartitionSummaryBbox:
         broken = _rewrite_geo(xyz_file, tmp_path / "broken.parquet", bbox=[0.0, 0.0, 1.0])
         summary = extract_partition_summary([str(broken)])
         assert summary["combined_bbox"] is None
+
+
+def _stats(monkeypatch, bbox):
+    """Force the aggregated native geospatial statistics to ``bbox``."""
+    monkeypatch.setattr(
+        "geoparquet_io.core.duckdb_metadata.get_aggregated_native_geo_stats",
+        lambda *a, **k: {"bbox": bbox},
+    )
+
+
+class TestNativeGeoStatsWrapNeedsGeographicCrs:
+    """xmin > xmax is a wrap only for a geographic CRS (GeoParquet 1.1.0, #876)."""
+
+    def test_projected_crs_rejects_wrapping_statistics(self, antimeridian_file, con, monkeypatch):
+        _stats(monkeypatch, WRAPPING_BBOX)
+        check = _check_native_geo_stats_contains_data(
+            str(antimeridian_file), "geometry", con, 0, crs=UTM_33N
+        )
+        assert check.status == CheckStatus.FAILED, check.message
+        assert "projected" in check.message.lower()
+        assert "geographic" in check.message.lower()
+
+    def test_geographic_crs_still_reads_the_wrap(self, antimeridian_file, con, monkeypatch):
+        _stats(monkeypatch, WRAPPING_BBOX)
+        check = _check_native_geo_stats_contains_data(
+            str(antimeridian_file), "geometry", con, 0, crs=CRS84
+        )
+        assert check.status == CheckStatus.PASSED, check.message
+        assert "antimeridian" in check.message
+
+    def test_absent_crs_is_the_geographic_crs84_default(self, antimeridian_file, con, monkeypatch):
+        _stats(monkeypatch, WRAPPING_BBOX)
+        check = _check_native_geo_stats_contains_data(str(antimeridian_file), "geometry", con, 0)
+        assert check.status == CheckStatus.PASSED, check.message
+        assert "antimeridian" in check.message
+
+    def test_the_two_wrap_checks_agree_on_a_projected_crs(
+        self, antimeridian_file, con, monkeypatch
+    ):
+        # The bug: these two functions, on the same numbers and the same CRS,
+        # returned PASSED and FAILED respectively.
+        _stats(monkeypatch, WRAPPING_BBOX)
+        stats_check = _check_native_geo_stats_contains_data(
+            str(antimeridian_file), "geometry", con, 0, crs=UTM_33N
+        )
+        bbox_check = _check_bbox_contains_data(
+            str(antimeridian_file), "geometry", WRAPPING_BBOX, con, 0, "WKB", UTM_33N
+        )
+        assert stats_check.status == bbox_check.status == CheckStatus.FAILED, (
+            stats_check.message,
+            bbox_check.message,
+        )
+
+    def _stats_check(self, path):
+        result = validate_geoparquet(str(path))
+        return next(c for c in result.checks if c.name == "native_geo_stats_contains_data_geometry")
+
+    def test_projected_crs_reaches_the_check_end_to_end(
+        self, tmp_path, antimeridian_file, monkeypatch
+    ):
+        # The column's crs has to travel from the metadata to the check; without
+        # the wiring the file validates clean on statistics it contradicts. Same
+        # data and same statistics as the test below -- only the CRS differs.
+        path = _rewrite_geo(antimeridian_file, tmp_path / "proj.parquet", crs=UTM_33N)
+        _stats(monkeypatch, WRAPPING_BBOX)
+        check = self._stats_check(path)
+        assert check.status == CheckStatus.FAILED, check.message
+        assert "projected" in check.message.lower()
+
+    def test_default_crs_file_reads_the_wrap_end_to_end(
+        self, tmp_path, antimeridian_file, monkeypatch
+    ):
+        path = _rewrite_geo(antimeridian_file, tmp_path / "default_crs.parquet")
+        _stats(monkeypatch, WRAPPING_BBOX)
+        check = self._stats_check(path)
+        assert check.status == CheckStatus.PASSED, check.message
+        assert "antimeridian" in check.message
+
+
+class TestPartitionSummaryWrapNeedsGeographicCrs:
+    """merge_longitude_ranges splits at +/-180, which is meaningless in metres (#886)."""
+
+    def _projected_pair(self, tmp_path, xyz_file):
+        a = _rewrite_geo(
+            xyz_file, tmp_path / "m_a.parquet", bbox=[1000.0, 0.0, 2000.0, 100.0], crs=UTM_33N
+        )
+        b = _rewrite_geo(
+            xyz_file, tmp_path / "m_b.parquet", bbox=[5000.0, 0.0, 3000.0, 100.0], crs=UTM_33N
+        )
+        return [str(a), str(b)]
+
+    def test_projected_crs_takes_plain_min_max(self, tmp_path, xyz_file):
+        summary = extract_partition_summary(self._projected_pair(tmp_path, xyz_file))
+        assert summary["combined_bbox"] == [1000.0, 0.0, 3000.0, 100.0]
+
+    def test_projected_crs_never_yields_the_wrap_merge(self, tmp_path, xyz_file):
+        summary = extract_partition_summary(self._projected_pair(tmp_path, xyz_file))
+        xmin, xmax = summary["combined_bbox"][0], summary["combined_bbox"][2]
+        assert (xmin, xmax) != (5000.0, 3000.0)
+        assert xmin <= xmax
+
+    def test_a_single_projected_crs_file_is_not_reinterpreted(self, tmp_path, xyz_file):
+        one = _rewrite_geo(
+            xyz_file,
+            tmp_path / "m_one.parquet",
+            bbox=[-500000.0, 0.0, 500000.0, 100.0],
+            crs=UTM_33N,
+        )
+        other = _rewrite_geo(
+            xyz_file,
+            tmp_path / "m_two.parquet",
+            bbox=[900000.0, 0.0, 800000.0, 100.0],
+            crs=UTM_33N,
+        )
+        summary = extract_partition_summary([str(one), str(other)])
+        assert summary["combined_bbox"] == [-500000.0, 0.0, 800000.0, 100.0]
+
+    def test_a_projected_file_disables_the_wrap_for_the_whole_partition(self, tmp_path, xyz_file):
+        # One projected member is enough to make the wrap reading unsafe.
+        geographic = _rewrite_geo(xyz_file, tmp_path / "geo.parquet", bbox=WRAPPING_BBOX)
+        projected = _rewrite_geo(
+            xyz_file, tmp_path / "proj_member.parquet", bbox=[0.0, 0.0, 10.0, 5.0], crs=UTM_33N
+        )
+        summary = extract_partition_summary([str(geographic), str(projected)])
+        assert summary["combined_bbox"] == [0.0, -10.0, 10.0, 10.0]

--- a/tests/test_validate_bbox_dimensions.py
+++ b/tests/test_validate_bbox_dimensions.py
@@ -1,4 +1,9 @@
-"""bbox checks for 6-element (XYZ) and 8-element (XYZM) bboxes and antimeridian extents (#603)."""
+"""bbox checks for 6-element (XYZ) and 8-element (XYZM) bboxes and antimeridian extents.
+
+Covers the validate checks (#603) and the same two bug classes where they survived
+outside them: the partition summary's bbox merge and the native geospatial
+statistics aggregate (#886).
+"""
 
 import json
 
@@ -6,10 +11,14 @@ import pyarrow.parquet as pq
 import pytest
 
 from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.crs_utils import merge_longitude_ranges
+from geoparquet_io.core.duckdb_metadata import aggregate_native_geo_stats
+from geoparquet_io.core.inspect_utils import extract_partition_summary
 from geoparquet_io.core.validate import (
     CheckStatus,
     _check_bbox_contains_data,
     _check_bbox_valid,
+    _check_native_geo_stats_contains_data,
     validate_geoparquet,
 )
 
@@ -228,3 +237,108 @@ class TestBboxContainsData:
         assert all(c.status == CheckStatus.PASSED for c in bbox_checks.values()), [
             (c.name, c.message) for c in bbox_checks.values()
         ]
+
+
+def _chunk(xmin, ymin, xmax, ymax, **extra):
+    return {
+        "row_group_id": 0,
+        "xmin": xmin,
+        "ymin": ymin,
+        "xmax": xmax,
+        "ymax": ymax,
+        "zmin": None,
+        "zmax": None,
+        "geometry_types": [],
+        **extra,
+    }
+
+
+class TestMergeLongitudeRanges:
+    """The union is taken on the circle, so a wrapping range is not inverted (#886)."""
+
+    def test_plain_ranges_are_min_max(self):
+        assert merge_longitude_ranges([(0.0, 10.0), (-5.0, 4.0)]) == (-5.0, 10.0)
+
+    def test_wrapping_range_survives(self):
+        assert merge_longitude_ranges([(170.0, -170.0)]) == (170.0, -170.0)
+
+    def test_union_with_a_wrapping_range_keeps_the_short_way_round(self):
+        assert merge_longitude_ranges([(170.0, -170.0), (-179.0, -175.0)]) == (170.0, -170.0)
+
+    def test_union_widens_the_wrapping_range(self):
+        # 170 east to -90 spans 100 degrees; -100 west to -170 would span 290.
+        assert merge_longitude_ranges([(170.0, -170.0), (-100.0, -90.0)]) == (170.0, -90.0)
+
+    def test_plain_ranges_that_meet_at_the_antimeridian_stay_min_max(self):
+        # Deliberate: with nothing declaring a wrap, the producer's own reading
+        # of its two extents is kept rather than guessed at.
+        assert merge_longitude_ranges([(170.0, 180.0), (-180.0, -170.0)]) == (-180.0, 180.0)
+
+    def test_no_ranges_is_a_programming_error(self):
+        with pytest.raises(ValueError):
+            merge_longitude_ranges([])
+
+    def test_full_circle_collapses_to_the_whole_world(self):
+        xmin, xmax = merge_longitude_ranges([(170.0, -170.0), (-175.0, 175.0)])
+        assert (xmin, xmax) == (-180.0, 180.0)
+
+
+class TestNativeGeoStatsWrap:
+    """Parquet's own geospatial statistics may wrap the antimeridian (#886)."""
+
+    def test_aggregate_keeps_a_wrapping_extent(self):
+        stats = aggregate_native_geo_stats(
+            [_chunk(175.0, 0.0, -175.0, 5.0), _chunk(178.0, 1.0, 179.0, 2.0)]
+        )
+        assert stats["bbox"] == [175.0, 0.0, -175.0, 5.0]
+
+    def test_aggregate_without_wrap_is_unchanged(self):
+        stats = aggregate_native_geo_stats(
+            [_chunk(0.0, 0.0, 10.0, 5.0), _chunk(-5.0, 1.0, 4.0, 20.0)]
+        )
+        assert stats["bbox"] == [-5.0, 0.0, 10.0, 20.0]
+
+    def test_check_accepts_data_inside_a_wrapping_stat(self, antimeridian_file, con, monkeypatch):
+        monkeypatch.setattr(
+            "geoparquet_io.core.duckdb_metadata.get_aggregated_native_geo_stats",
+            lambda *a, **k: {"bbox": [170.0, -10.0, -170.0, 10.0]},
+        )
+        check = _check_native_geo_stats_contains_data(str(antimeridian_file), "geometry", con, 0)
+        assert check.status == CheckStatus.PASSED, check.message
+        assert "antimeridian" in check.message
+
+    def test_check_still_fails_geometry_in_the_wrap_gap(self, tmp_path, con, monkeypatch):
+        path = _write_v2(tmp_path / "gap_stats.parquet", ["POINT (175 0)", "POINT (0 0)"])
+        monkeypatch.setattr(
+            "geoparquet_io.core.duckdb_metadata.get_aggregated_native_geo_stats",
+            lambda *a, **k: {"bbox": [170.0, -10.0, -170.0, 10.0]},
+        )
+        check = _check_native_geo_stats_contains_data(str(path), "geometry", con, 0)
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 2" in check.message
+
+
+class TestPartitionSummaryBbox:
+    """extract_partition_summary read indices 2/3 as xmax/ymax (#886)."""
+
+    def test_six_element_bboxes_merge_on_x_and_y(self, tmp_path, xyz_file):
+        other = _write_v2(
+            tmp_path / "xyz2.parquet",
+            ["POLYGON Z ((10 10 5, 12 10 5, 12 12 5, 10 12 5, 10 10 5))"],
+        )
+        assert len(_declared_bbox(xyz_file)) == 6
+        summary = extract_partition_summary([str(xyz_file), str(other)])
+        assert summary["combined_bbox"] == [0.0, 0.0, 12.0, 12.0]
+
+    def test_wrapping_bboxes_merge_on_the_circle(self, tmp_path, xyz_file):
+        wrapped = _rewrite_geo(
+            xyz_file, tmp_path / "wrap.parquet", bbox=[170.0, -10.0, -170.0, 10.0]
+        )
+        near = _rewrite_geo(xyz_file, tmp_path / "near.parquet", bbox=[-179.0, -5.0, -175.0, 5.0])
+        summary = extract_partition_summary([str(wrapped), str(near)])
+        assert summary["combined_bbox"] == [170.0, -10.0, -170.0, 10.0]
+
+    def test_short_bbox_is_ignored(self, tmp_path, xyz_file):
+        broken = _rewrite_geo(xyz_file, tmp_path / "broken.parquet", bbox=[0.0, 0.0, 1.0])
+        summary = extract_partition_summary([str(broken)])
+        assert summary["combined_bbox"] is None

--- a/tests/test_validate_covering_strictness.py
+++ b/tests/test_validate_covering_strictness.py
@@ -6,9 +6,11 @@ import json
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from geoparquet_io.core.common import get_duckdb_connection
 from geoparquet_io.core.duckdb_metadata import get_schema_info
 from geoparquet_io.core.validate import (
     CheckStatus,
+    _check_covering_bbox_column_exists,
     _check_covering_bbox_field_types,
     _check_covering_bbox_paths,
     _check_covering_bbox_structure,
@@ -40,11 +42,12 @@ def _write(path, children, paths=PATHS_4):
     return str(path)
 
 
-def _covering_checks(path):
+def _covering_checks(path, con=None):
     col_meta = json.loads(pq.read_metadata(path).metadata[b"geo"])["columns"]["geometry"]
-    schema_info = get_schema_info(path)
+    schema_info = get_schema_info(path, con=con)
     return {
         "paths": _check_covering_bbox_paths(col_meta, "geometry"),
+        "exists": _check_covering_bbox_column_exists(col_meta, "geometry", schema_info),
         "structure": _check_covering_bbox_structure(col_meta, "geometry", schema_info),
         "types": _check_covering_bbox_field_types(col_meta, "geometry", schema_info),
     }
@@ -107,6 +110,82 @@ class TestFieldTypes:
             _covering_checks(_write(tmp_path / "f.parquet", children))["types"].status
             == CheckStatus.PASSED
         )
+
+
+def _write_with_decoy(path, children=None, bbox_column="bbox"):
+    """A file whose first column is a struct carrying a child field named ``bbox``.
+
+    The real root ``bbox`` column comes after it, so a flat schema scan that stops
+    at the first name match lands on the nested field instead of the column.
+    ``bbox_column=None`` drops the real column, leaving only the nested field.
+    """
+    children = children or XY
+    decoy = pa.StructArray.from_arrays(
+        [pa.array(["shadow", "shadow"]), pa.array([0, 1], type=pa.int32())],
+        names=["bbox", "other"],
+    )
+    columns = {"meta": decoy, "geometry": pa.array([WKB_POINT] * 2, pa.binary())}
+    if bbox_column is not None:
+        columns[bbox_column] = pa.StructArray.from_arrays(
+            [pa.array([0, 1], type=t) for _, t in children], names=[n for n, _ in children]
+        )
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "covering": {"bbox": PATHS_4},
+            }
+        },
+    }
+    table = pa.table(columns)
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), path)
+    return str(path)
+
+
+class TestRootPlacement:
+    """v1.1.0: "The bounding box column MUST be at the root of the schema"."""
+
+    def _both_schema_paths(self, path):
+        con = get_duckdb_connection()
+        try:
+            return {"pyarrow": _covering_checks(path), "duckdb": _covering_checks(path, con=con)}
+        finally:
+            con.close()
+
+    def test_nested_bbox_field_does_not_shadow_the_root_column(self, tmp_path):
+        path = _write_with_decoy(tmp_path / "shadowed.parquet")
+        for source, checks in self._both_schema_paths(path).items():
+            assert all(c.status == CheckStatus.PASSED for c in checks.values()), (
+                source,
+                {k: c.message for k, c in checks.items()},
+            )
+
+    def test_nested_bbox_field_does_not_shadow_a_6_field_root_column(self, tmp_path):
+        path = _write_with_decoy(tmp_path / "shadowed_xyz.parquet", children=XYZ)
+        for source, checks in self._both_schema_paths(path).items():
+            assert checks["structure"].status == CheckStatus.PASSED, (
+                source,
+                checks["structure"].message,
+            )
+
+    def test_bbox_column_only_nested_is_not_at_the_root(self, tmp_path):
+        path = _write_with_decoy(tmp_path / "nested_only.parquet", bbox_column=None)
+        for source, checks in self._both_schema_paths(path).items():
+            exists = checks["exists"]
+            assert exists.status == CheckStatus.FAILED, (source, exists.message)
+            assert "root" in exists.message
+            assert checks["structure"].status == CheckStatus.FAILED, source
+            assert "found: []" not in checks["structure"].message, source
+
+    def test_missing_bbox_column_says_so(self, tmp_path):
+        path = _write(tmp_path / "f.parquet", XY, {k: ["nope", k] for k in PATHS_4})
+        checks = _covering_checks(path)
+        assert checks["exists"].status == CheckStatus.FAILED
+        assert checks["structure"].status == CheckStatus.FAILED
+        assert "nope" in checks["structure"].message
 
 
 class TestRealFiles:


### PR DESCRIPTION
## What changed

Two correctness fixes in the validate/inspect bbox paths, one commit each.

**#885 — the covering bbox column is matched at the schema root only.** The flat
parquet schema listing is depth first, so `_check_covering_bbox_column_exists`,
`_check_covering_bbox_structure` and `_check_covering_bbox_field_types` could all
match a *nested* field before the real root column of the same name. A new
`_root_schema_index()` walks the listing subtree by subtree; `_schema_direct_children()`
reads a struct's own children rather than the next N entries. The column-exists
check now actually enforces the v1.1.0 rule it claimed ("The bounding box column
MUST be at the root of the schema") and says which failure happened, and the other
two report a missing column as a missing column.

**#886 — 6-element bboxes and antimeridian wrap outside `_check_bbox_valid`.**
`extract_partition_summary` merged per-file bboxes by index; it now takes X/Y
through #876's `_bbox_xy`. `_check_native_geo_stats_contains_data` now builds its
X predicate with #876's `_x_within_sql` and names the wrap reading in its message.
`aggregate_native_geo_stats` unions the X ranges through a new
`merge_longitude_ranges()` in `crs_utils`, which is a no-op for input that never
wraps.

`stac_check.py:135`'s "4 or 6" rule was considered and deliberately left alone:
STAC and GeoJSON bboxes have no 8-element form, so it is correct as written.

## Why

Both reproduce on `main` and neither is a regression from #876/#877 — those PRs'
rules check out against the merged v1.1.0 spec text; these are the same bug
classes surviving in the code around them.

**#885, on a file whose first column is a struct with a child field named `bbox`,
followed by a perfectly valid root `bbox` covering column:**

```
before:  ✗ bbox column fields must be ['xmin', 'ymin', 'xmax', 'ymax'] or
           ['xmin', 'ymin', 'zmin', 'xmax', 'ymax', 'zmax'], in that order (found: [])
         ✓ bbox column "bbox" exists at schema root   # matched the nested field
after:   ✓ bbox column "bbox" exists at schema root
         ✓ bbox column has valid structure with xmin/ymin/xmax/ymax
```

Reproduced on both the pyarrow and the DuckDB schema path. The same scan meant a
covering naming a column that exists *only* as a nested field passed the
root-placement check; it now fails with
`bbox column "bbox" is not at the schema root (it exists only as a nested field; ...)`.

**#886, merging two XYZ files whose declared bboxes are
`[0, 0, 10, 4, 4, 15]` and `[10, 10, 5, 12, 12, 5]`:**

```
before:  combined_bbox = [0.0, 0.0, 10.0, 12.0]   # index 2 is zmin, not xmax
after :  combined_bbox = [0.0, 0.0, 12.0, 12.0]
```

**#886, on a file whose native geospatial statistics wrap the antimeridian
(`[170, -10, -170, 10]`, which Parquet permits):**

```
before:  ✗ 2 of 2 geometries fall outside geospatial statistics
after :  ✓ all geometries fall within geospatial statistics (2 checked)
           (statistics interpreted as antimeridian-crossing, RFC 7946 5.2)

aggregate before: [175.0, 0.0, 179.0, 5.0]     # complement of the real extent
aggregate after : [175.0, 0.0, -175.0, 5.0]
```

## Verification

- `uv run pytest -n auto -m "not slow and not network and not meta" -q`:
  6361 passed, 75 skipped, 9 xfailed. One failure,
  `test_pipe_integration.py::TestTwoStagePipelines::test_add_bbox_to_sort_hilbert`,
  is the known xdist subprocess flake and passes on a serial re-run.
- `uv run pytest -m meta -q`: 203 passed.
- diff-cover against `origin/main`: **96%** of 79 changed lines (gate is 90);
  the three uncovered lines are defensive guards for a truncated or empty schema
  listing.
- `uv run pre-commit run --all-files` and `--hook-stage pre-push`: clean.
- New tests: `TestRootPlacement` in `tests/test_validate_covering_strictness.py`
  (shadowing fixture exercised through both schema paths) and
  `TestMergeLongitudeRanges` / `TestNativeGeoStatsWrap` / `TestPartitionSummaryBbox`
  in `tests/test_validate_bbox_dimensions.py`. All were written failing first.

One existing assertion in `tests/test_covering_v2.py` moved to the new
column-exists wording.

### Same bug classes found in the sweep, reported rather than fixed here

- The `"." not in name` filter used to pick root columns out of a schema listing
  (`duckdb_metadata.get_column_names`, `duckdb_utils._DuckDBSchemaWrapper`,
  `metadata_utils`'s column count) does not work for either schema shape: neither
  renders dotted paths, so struct children are counted as top-level columns.
  `get_column_names("tests/data/austria_bbox_covering.parquet")` returns
  `xmin`/`ymin`/`xmax`/`ymax` alongside the ten real columns. Cross-cutting, needs
  its own issue and PR.
- ~12 checks in `validate.py` locate the geometry column with the same
  first-name-match scan (`_check_native_geo_type_present`, `_check_native_crs_format`,
  `_is_geography_column`, `_get_crs_from_schema`, …), as do
  `common._schema_struct_child_names` and `common._find_bbox_column_in_schema`.
  Same shadowing exposure, and `_root_schema_index()` is now there to fix them —
  but it is a dozen call sites, so its own issue.
- `common.py`'s row-group bbox merge (~line 2185) already carries a comment
  noting its antimeridian limitation, and is over-wide rather than wrong.
- `stac.py`'s overall-bounds merge indexes 2/3, but `get_dataset_bounds()` always
  returns four elements, so it is correct.

Closes #885
Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of antimeridian-crossing longitude ranges in geospatial statistics, partition summaries, and bounding-box validation.
  - Added clear annotations when combined bounds cross the antimeridian.
  - Ensured covering bounding-box columns are correctly identified at the schema root.

- **Bug Fixes**
  - Prevented projected coordinate reference systems from incorrectly declaring wrapped longitude extents.
  - Improved validation of nested, missing, and shadowed bounding-box columns.

- **Tests**
  - Expanded coverage for longitude merging, CRS validation, bounding-box dimensions, metadata, and schema handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->