### PR TITLE
fix(partition): quote bbox column identifiers from the input file in the admin join

### DIFF
--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -81,11 +81,18 @@ def _build_enrichment_query(
     input_ref = input_source if input_is_table_ref else sql_path(input_source)
 
     q_input_geom = quote_identifier(input_geom_col)
+    q_admin_geom = quote_identifier(admin_geom_col)
+    # Struct-field access ``a.<col>.xmin``: quote the column segment only, so the
+    # ``a.`` alias and the ``.xmin`` accessor stay bare. ``input_bbox_col`` comes
+    # from the input file's own schema and ``admin_bbox_col`` from the dataset;
+    # both reach here RAW, so quote exactly once (#926).
+    q_input_bbox = quote_identifier(input_bbox_col) if input_bbox_col else None
+    q_admin_bbox = quote_identifier(admin_bbox_col) if admin_bbox_col else None
     bbox_filter = f"""
-            (a.{input_bbox_col}.xmin <= b.{admin_bbox_col}.xmax AND
-             a.{input_bbox_col}.xmax >= b.{admin_bbox_col}.xmin AND
-             a.{input_bbox_col}.ymin <= b.{admin_bbox_col}.ymax AND
-             a.{input_bbox_col}.ymax >= b.{admin_bbox_col}.ymin)
+            (a.{q_input_bbox}.xmin <= b.{q_admin_bbox}.xmax AND
+             a.{q_input_bbox}.xmax >= b.{q_admin_bbox}.xmin AND
+             a.{q_input_bbox}.ymin <= b.{q_admin_bbox}.ymax AND
+             a.{q_input_bbox}.ymax >= b.{q_admin_bbox}.ymin)
         """
 
     if source_crs and input_bbox_col and admin_bbox_col:
@@ -94,10 +101,10 @@ def _build_enrichment_query(
         # join runs in one CRS and keeps the cheap bbox pre-filter — instead of
         # transforming the (large) input per row and degrading to a nested-loop
         # ST_Intersects (#525, preserving the #460 pre-filter).
-        radmin = reproject_to_source_sql(quote_identifier(admin_geom_col), source_crs)
+        radmin = reproject_to_source_sql(q_admin_geom, source_crs)
         bbox_struct = (
             f"struct_pack(xmin := ST_XMin({radmin}), xmax := ST_XMax({radmin}), "
-            f"ymin := ST_YMin({radmin}), ymax := ST_YMax({radmin})) AS {admin_bbox_col}"
+            f"ymin := ST_YMin({radmin}), ymax := ST_YMax({radmin})) AS {q_admin_bbox}"
         )
         return f"""
             CREATE TEMP TABLE {enriched_table} AS
@@ -106,12 +113,12 @@ def _build_enrichment_query(
                 {admin_select_clause}
             FROM {input_ref} a
             LEFT JOIN (
-                SELECT {radmin} AS {admin_geom_col}, {bbox_struct}, {subquery_cols_str}
+                SELECT {radmin} AS {q_admin_geom}, {bbox_struct}, {subquery_cols_str}
                 FROM {admin_table_ref}
                 {admin_where_clause}
             ) b
             ON {bbox_filter}
-                AND ST_Intersects(b.{admin_geom_col}, a.{q_input_geom})
+                AND ST_Intersects(b.{q_admin_geom}, a.{q_input_geom})
         """
 
     if input_bbox_col and admin_bbox_col and not source_crs:
@@ -122,12 +129,12 @@ def _build_enrichment_query(
                 {admin_select_clause}
             FROM {input_ref} a
             LEFT JOIN (
-                SELECT {admin_geom_col}, {admin_bbox_col}, {subquery_cols_str}
+                SELECT {q_admin_geom}, {q_admin_bbox}, {subquery_cols_str}
                 FROM {admin_table_ref}
                 {admin_where_clause}
             ) b
             ON {bbox_filter}
-                AND ST_Intersects(b.{admin_geom_col}, a.{q_input_geom})
+                AND ST_Intersects(b.{q_admin_geom}, a.{q_input_geom})
         """
 
     # No bbox on one side: reproject the input geometry inline (no pre-filter to
@@ -140,11 +147,11 @@ def _build_enrichment_query(
                 {admin_select_clause}
             FROM {input_ref} a
             LEFT JOIN (
-                SELECT {admin_geom_col}, {subquery_cols_str}
+                SELECT {q_admin_geom}, {subquery_cols_str}
                 FROM {admin_table_ref}
                 {admin_where_clause}
             ) b
-            ON ST_Intersects(b.{admin_geom_col}, {input_geom_sql})
+            ON ST_Intersects(b.{q_admin_geom}, {input_geom_sql})
         """
 
 
@@ -163,12 +170,15 @@ def _compute_input_extent(con, input_path, input_bbox_col, input_geom_col, sourc
     CRS) so the admin extent filter is in the right units (#525).
     """
     if input_bbox_col and not source_crs:
+        # ``input_bbox_col`` is read from the input file's schema; quote the
+        # column segment of the struct-field access, leaving ``.xmin`` bare (#926).
+        q_input_bbox = quote_identifier(input_bbox_col)
         extent_query = f"""
             SELECT
-                MIN({input_bbox_col}.xmin) as xmin,
-                MAX({input_bbox_col}.xmax) as xmax,
-                MIN({input_bbox_col}.ymin) as ymin,
-                MAX({input_bbox_col}.ymax) as ymax
+                MIN({q_input_bbox}.xmin) as xmin,
+                MAX({q_input_bbox}.xmax) as xmax,
+                MIN({q_input_bbox}.ymin) as ymin,
+                MAX({q_input_bbox}.ymax) as ymax
             FROM {sql_path(input_path)}
         """
     else:
@@ -208,11 +218,13 @@ def _build_admin_where_clause(dataset, levels, admin_bbox_col, extent, verbose, 
     # Add bbox extent filter
     if admin_bbox_col and extent:
         xmin, xmax, ymin, ymax = extent
+        # Quote the column segment of the struct-field access (#926).
+        q_admin_bbox = quote_identifier(admin_bbox_col)
         extent_filter = f"""
-            ({admin_bbox_col}.xmin <= {xmax} AND
-             {admin_bbox_col}.xmax >= {xmin} AND
-             {admin_bbox_col}.ymin <= {ymax} AND
-             {admin_bbox_col}.ymax >= {ymin})
+            ({q_admin_bbox}.xmin <= {xmax} AND
+             {q_admin_bbox}.xmax >= {xmin} AND
+             {q_admin_bbox}.ymin <= {ymax} AND
+             {q_admin_bbox}.ymax >= {ymin})
         """
         admin_where_clauses.append(extent_filter)
         if verbose:
@@ -872,7 +884,7 @@ def _get_preview_partitions(con, table_name, partition_columns, level_names):
     group_by_cols = ", ".join([quote_identifier(col) for col in partition_columns])
     select_cols = ", ".join(
         [
-            f"{quote_identifier(col)} as {name}"
+            f"{quote_identifier(col)} as {quote_identifier(name)}"
             for col, name in zip(partition_columns, level_names, strict=True)
         ]
     )

--- a/tests/test_crs_normalize.py
+++ b/tests/test_crs_normalize.py
@@ -541,8 +541,9 @@ class TestAdminReprojectsAdminSideWithBbox:
             source_crs="EPSG:5070",
         )
         assert "ST_Transform" in sql  # admin reprojected
-        assert 'ST_Intersects(b.geom, a."geometry")' in sql  # input untransformed
-        assert "a.bbox.xmin <= b.bbox.xmax" in sql  # bbox pre-filter restored
+        # Identifiers are quoted (#926); the input geom is still untransformed.
+        assert 'ST_Intersects(b."geom", a."geometry")' in sql
+        assert 'a."bbox".xmin <= b."bbox".xmax' in sql  # bbox pre-filter restored
         assert "struct_pack" in sql
 
     def test_enrichment_reproject_path_runs_and_assigns(self, fields_5070_file):

--- a/tests/test_partition_admin_bbox_quoting.py
+++ b/tests/test_partition_admin_bbox_quoting.py
@@ -1,0 +1,201 @@
+"""Regression guard for #926: bbox column identifiers from the input file's own
+schema are interpolated bare into the ``partition admin`` enrichment join.
+
+``input_bbox_col`` is read from the input file's GeoParquet schema
+(``check_bbox_structure`` -> ``bbox_column_name``), so the attacker is whoever
+wrote the file (the #918 / #923 threat model), not the person running the
+command. A hostile bbox column name breaks out of the unquoted
+``MIN({col}.xmin)`` / ``a.{col}.xmin`` struct-field accesses and runs
+attacker-chosen SQL in the user's DuckDB session; a legitimate name that merely
+needs quoting (a space) raises a ParserException instead of partitioning.
+
+The struct-field subtlety: the fix quotes only the column segment
+(``a."col".xmin``); the ``a.`` alias and the ``.xmin`` accessor stay bare.
+"""
+
+import json
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.partition.admin_hierarchical import (
+    _build_enrichment_query,
+    partition_by_admin_hierarchical,
+)
+
+# A bbox column name that breaks out of an unquoted struct-field access. Doubling
+# the embedded double-quote (quote_identifier) neutralises it; leaving it bare
+# lets the `AS pwn` and the scalar subquery execute.
+MALICIOUS_BBOX_NAME = 'bb") AS pwn, (SELECT 1) AS injected, struct_pack(xmin := 0.0'
+
+
+def _write_bbox_input(con, path, bbox_name):
+    """Write a 2-point GeoParquet whose bbox struct column is named ``bbox_name``.
+
+    The covering metadata points at that column so ``check_bbox_structure``
+    returns it as ``bbox_column_name`` -- exactly the value that reaches the
+    bare interpolation sites.
+    """
+    con.execute(
+        f"""
+        COPY (
+            SELECT id, geometry,
+                   struct_pack(xmin := ST_XMin(geometry), xmax := ST_XMax(geometry),
+                               ymin := ST_YMin(geometry), ymax := ST_YMax(geometry)) AS bbox_tmp
+            FROM (VALUES
+                (1, ST_GeomFromText('POINT(17 46)')),
+                (2, ST_GeomFromText('POINT(19 47)'))
+            ) AS t(id, geometry)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+    table = pq.read_table(path)
+    table = table.rename_columns([bbox_name if n == "bbox_tmp" else n for n in table.column_names])
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "covering": {
+                    "bbox": {
+                        "xmin": [bbox_name, "xmin"],
+                        "ymin": [bbox_name, "ymin"],
+                        "xmax": [bbox_name, "xmax"],
+                        "ymax": [bbox_name, "ymax"],
+                    }
+                },
+            }
+        },
+    }
+    md = dict(table.schema.metadata or {})
+    md[b"geo"] = json.dumps(geo).encode()
+    pq.write_table(table.replace_schema_metadata(md), path)
+
+
+@pytest.fixture
+def _covering_admin(tmp_path):
+    """A single CRS84 polygon (with bbox covering) over the test points."""
+    from geoparquet_io.core.common import add_bbox
+
+    admin = str(tmp_path / "admin.parquet")
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial")
+    con.execute(
+        f"""
+        COPY (
+            SELECT 'XX' AS country,
+                   ST_GeomFromText('POLYGON((16 45, 20 45, 20 49, 16 49, 16 45))') AS geometry
+        ) TO '{admin}' (FORMAT PARQUET)
+        """
+    )
+    con.close()
+    add_bbox(admin, "bbox", False)
+    return admin
+
+
+def _patch_dataset(monkeypatch, admin_path):
+    from geoparquet_io.core.admin_datasets import CurrentAdminDataset
+
+    def fake_create(dataset_name, source_path=None, verbose=False):
+        return CurrentAdminDataset(source_path=admin_path, verbose=verbose)
+
+    monkeypatch.setattr(
+        "geoparquet_io.core.partition.admin_hierarchical.AdminDatasetFactory.create",
+        staticmethod(fake_create),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Unit: query builder must quote the bbox column segment only
+# --------------------------------------------------------------------------- #
+
+
+def test_enrichment_query_quotes_hostile_bbox_column():
+    """`_build_enrichment_query` quotes the input bbox column in the pre-filter."""
+    query = _build_enrichment_query(
+        "input.parquet",
+        "'admin.parquet'",
+        "",
+        "b.iso as _admin_c",
+        "geometry",
+        "bbox",
+        ["iso"],
+        "geometry",
+        MALICIOUS_BBOX_NAME,
+        "_enriched",
+    )
+    # Embedded double-quote doubled inside a quoted identifier; the raw breakout
+    # never appears as executable SQL.
+    assert 'bb"") AS pwn' in query
+    assert 'bb") AS pwn' not in query
+    # Struct-field subtlety: the alias and accessor stay bare around the quoted
+    # column segment.
+    assert 'a."' + MALICIOUS_BBOX_NAME.replace('"', '""') + '".xmin' in query
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: a legitimate name round-trips; a hostile name cannot inject
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+def test_partition_admin_bbox_name_with_space_round_trips(tmp_path, monkeypatch, _covering_admin):
+    """A bbox column named ``my bbox`` must partition, not raise a ParserException."""
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial")
+    src = str(tmp_path / "in_space.parquet")
+    _write_bbox_input(con, src, "my bbox")
+    con.close()
+
+    _patch_dataset(monkeypatch, _covering_admin)
+    out_dir = str(tmp_path / "out_space")
+    count = partition_by_admin_hierarchical(
+        src, out_dir, dataset_name="current", levels=["country"], hive=True
+    )
+    assert count == 1
+    from pathlib import Path
+
+    files = list(Path(out_dir).rglob("*.parquet"))
+    assert len(files) == 1
+    assert sum(pq.ParquetFile(str(f)).metadata.num_rows for f in files) == 2
+
+
+@pytest.mark.integration
+def test_partition_admin_hostile_bbox_name_does_not_inject(tmp_path, monkeypatch, _covering_admin):
+    """A hostile bbox column name is treated as a literal identifier, not SQL.
+
+    The attacker names their (real, numeric) bbox struct column with a
+    ``struct_pack(...)`` payload whose first field is an ``error()`` over a file
+    the user never named. Before the fix the bare interpolation re-parses the
+    name as SQL and the payload runs; after the fix the name is a quoted
+    identifier referencing the real (benign) struct, so the partition just
+    succeeds.
+    """
+    secret = tmp_path / "victim_secret.txt"
+    secret.write_text("aws_secret_access_key=hunter2\n")
+    payload = (
+        "struct_pack(xmin := (SELECT error('INJECTED926 ' || any_value(l)) "
+        f"FROM read_csv('{secret}', header=false, columns={{'l': 'VARCHAR'}})), "
+        "xmax := 0.0, ymin := 0.0, ymax := 0.0)"
+    )
+
+    con = duckdb.connect()
+    con.execute("INSTALL spatial; LOAD spatial")
+    src = str(tmp_path / "in_hostile.parquet")
+    _write_bbox_input(con, src, payload)
+    con.close()
+
+    _patch_dataset(monkeypatch, _covering_admin)
+    out_dir = str(tmp_path / "out_hostile")
+    # Must not raise the injected error, and must partition the two real points.
+    count = partition_by_admin_hierarchical(
+        src, out_dir, dataset_name="current", levels=["country"], hive=True
+    )
+    assert count == 1
+    from pathlib import Path
+
+    files = list(Path(out_dir).rglob("*.parquet"))
+    assert sum(pq.ParquetFile(str(f)).metadata.num_rows for f in files) == 2


### PR DESCRIPTION
## What changed

`geoparquet_io/core/partition/admin_hierarchical.py` interpolated bbox column identifiers **bare** into the `gpio partition admin` enrichment join. This quotes every struct-field access at the source with `quote_identifier`, quoting only the column segment and leaving the `a.` alias and `.xmin`/`.xmax`/`.ymin`/`.ymax` accessors bare:

- `_build_enrichment_query` — the bbox pre-filter (`a.{col}.xmin`), the reproject-path `struct_pack(...) AS {admin_bbox_col}` / `AS {admin_geom_col}` aliases, and the subquery/`ST_Intersects` column references
- `_compute_input_extent` — `MIN({input_bbox_col}.xmin)` … in the extent scan
- `_build_admin_where_clause` — the admin extent filter `{admin_bbox_col}.xmin <= …`
- `_get_preview_partitions` — the level-name alias (same-shape one-liner)

New regression test `tests/test_partition_admin_bbox_quoting.py`: a builder-level unit test proving the hostile name is doubled/quoted (not a bare breakout), plus two end-to-end tests through `partition_by_admin_hierarchical` — a legitimate `my bbox` round-trips, and a hostile name cannot inject. `tests/test_crs_normalize.py` updated to the now-quoted SQL.

## Why

`input_bbox_col` is not user-supplied: it comes from `_get_input_file_info` → `check_bbox_structure()` → `bbox_column_name`, read from **the input file's own Parquet schema/covering metadata**. So the attacker is whoever wrote the file — the #918/#923 threat model, not #924's weaker "user injects their own session".

Reproduction (via `partition_by_admin_hierarchical` with a local admin dataset):

- **Legitimate name (DoS).** A file whose bbox column is `my bbox` crashes every run:
  ```
  _duckdb.ParserException: Parser Error: syntax error at or near "bbox"
  LINE 3:  MIN(my bbox.xmin) as xmin,
  ```
- **Hostile name (arbitrary SQL execution).** The attacker names their (real, numeric) bbox struct column
  ```
  struct_pack(xmin := (SELECT error('…leaked…: ' || any_value(l))
              FROM read_csv('victim_secret.txt', header=false, columns={'l':'VARCHAR'})),
              xmax := 0.0, ymin := 0.0, ymax := 0.0)
  ```
  Bare interpolation into `MIN({col}.xmin)` re-parses the name as SQL, so `read_csv()` runs against a file the user never named and its contents are exfiltrated:
  ```
  _duckdb.InvalidInputException: Invalid Input Error: [#926] injected SQL ran;
  leaked a file the user never named: aws_secret_access_key=hunter2
  ```
  After the fix both files partition normally; the hostile name is a quoted identifier referencing the real (benign) struct, and the payload never executes.

The struct-field-access subtlety needed nothing beyond `quote_identifier` on the column segment — the `a.` alias and `.xmin` accessor are left outside the quotes.

**Module sweep.** The remaining bare interpolations in the module are safe: `enriched_table` / `_admin_step_{i}` are internal constants; `admin_table_ref` is `sql_path`-escaped; the `{col} as _col_{i}` case is a deliberate dataset-controlled struct/function expression from hardcoded per-dataset mappings (not file- or user-derived); filenames go through `sanitize_filename`. `input_geom_col` was already quoted. Level names (validated against a fixed allowlist) were the only other same-shape one-liner and are now quoted for defense in depth. No larger issue found.

## Verification

- New tests fail on the pre-fix code for the right reasons (ParserException / injected `error()` executes) and pass after.
- `tests/test_partition_admin_bbox_quoting.py`: 3 passed.
- Related suites (crs_normalize, crs_aware_operations, partition_admin_vecorel, admin_datasets, admin_sql_injection, partition, single_pass, hive): all pass.
- Fast suite `-n auto -m "not slow and not network and not meta"`: 6339 passed; the 8 reported failures were the known xdist saturation flakes (pipe/e2e/geojson_stream/geometry_repair) plus the one crs_normalize assertion updated here — all 8 pass serially.
- `uv run pytest -m meta -q`: 203 passed.
- `uv run pre-commit run --all-files` and `--hook-stage pre-push`: clean.
- diff-cover vs origin/main: 100% (6/6 changed source lines covered).

Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of geometry and bounding-box column names containing spaces or special characters.
  - Prevented specially crafted column names from being interpreted as SQL, improving partitioning safety.
  - Preserved bounding-box pre-filtering and geometry intersection behavior during administrative partitioning.

- **Tests**
  - Added coverage for quoted identifiers, unusual column names, and SQL-injection regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->