### PR TITLE
fix(extract,carto,validate,convert): quote the last bare SQL identifiers and escape paths once

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,8 +123,16 @@ repos:
             # string literals; both live in core/duckdb_utils.py, which implements
             # them and is therefore exempt. Justify a rare, deliberate exception with
             # a trailing "# allow-manual-quote" comment.
-            if grep -rnE 'f'"'"'"\{|f"\\"\{|\.replace\('"'"'"'"'"', '"'"'""'"'"'\)' geoparquet_io/ --include="*.py" \
+            # The \" arm is deliberately NOT anchored to the start of the
+            # f-string: extract.py's `f"ST_Intersects(\"{geometry_col}\", ...)"`
+            # (#936) was the same bug mid-string and slipped straight past the
+            # anchored version of this rule.
+            # core/extract_bigquery.py is exempt by path, not because it is
+            # clean: BigQuery reads "..." as a STRING literal, so its sites need
+            # backticks rather than quote_identifier and are tracked in #932.
+            if grep -rnE 'f'"'"'"\{|\\"\{|\.replace\('"'"'"'"'"', '"'"'""'"'"'\)' geoparquet_io/ --include="*.py" \
                 | grep -v '^geoparquet_io/core/duckdb_utils.py:' \
+                | grep -v '^geoparquet_io/core/extract_bigquery.py:' \
                 | grep -v 'allow-manual-quote' \
                 | awk -F: '$3 !~ /^[[:space:]]*#/' | grep .; then
               echo "ERROR: Do not hand-roll SQL identifier quoting."

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -464,7 +464,7 @@ def _fetch_with_retry(
 
     # GeoJSON is parsed with ST_Read; CSV (geometry-less) with read_csv_auto.
     if fmt == "GeoJSON":
-        read_expr = f'ST_Read("{full_url}")'
+        read_expr = f"ST_Read({sql_path(full_url)})"
     else:
         read_expr = f"read_csv_auto({sql_path(full_url)})"
 

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -372,13 +372,15 @@ def _build_csv_read_expr(input_url, delimiter):
     Args:
         input_url: A RAW path or URL. ``sql_path()`` quotes and escapes it
             here, so callers must not pre-escape it (#802).
-        delimiter: CSV delimiter, or None to auto-detect.
+        delimiter: A RAW CSV delimiter, or None to auto-detect. It goes into a
+            SQL string literal, so it is escaped here -- exactly once, at the
+            boundary -- rather than by the caller (#937).
     """
     max_line_size = get_csv_max_line_size()
     if delimiter:
         return (
-            f"read_csv({sql_path(input_url)}, delim='{delimiter}', header=true, "
-            f"AUTO_DETECT=TRUE, max_line_size={max_line_size})"
+            f"read_csv({sql_path(input_url)}, delim='{_escape_sql_string(delimiter)}', "
+            f"header=true, AUTO_DETECT=TRUE, max_line_size={max_line_size})"
         )
     return f"read_csv_auto({sql_path(input_url)}, max_line_size={max_line_size})"
 

--- a/geoparquet_io/core/extract.py
+++ b/geoparquet_io/core/extract.py
@@ -557,7 +557,9 @@ def build_spatial_filter(
 
     if geometry_wkt:
         escaped_wkt = _escape_sql_string(geometry_wkt)
-        conditions.append(f"ST_Intersects(\"{geometry_col}\", ST_GeomFromText('{escaped_wkt}'))")
+        conditions.append(
+            f"ST_Intersects({quote_identifier(geometry_col)}, ST_GeomFromText('{escaped_wkt}'))"
+        )
 
     return " AND ".join(conditions) if conditions else None
 

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -141,7 +141,7 @@ def _target_crs_is_projected(target_crs: str, con=None) -> bool:
 
 def _warn_edges_dropped(col_name: str, edges: str, target_crs: str) -> None:
     warn(
-        f"Dropped 'edges: {edges}' on column \"{col_name}\": the reprojected "
+        f"Dropped 'edges: {edges}' on column '{col_name}': the reprojected "
         f"edges are straight lines in {target_crs}. Densify before reprojecting "
         "if great-circle edges must be preserved."
     )

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -1427,12 +1427,19 @@ def _check_orientation_matches_data(
         )
 
     from geoparquet_io.core.duckdb_utils import sql_path
-    from geoparquet_io.core.file_utils import safe_file_url
+    from geoparquet_io.core.file_utils import resolve_file_url
 
     limit_clause = f"LIMIT {sample_size}" if sample_size > 0 else ""
     quoted_geom = quote_identifier(geom_col)
     try:
-        col_type = _describe_geom_type(con, safe_file_url(parquet_file, verbose=False), geom_col)
+        # RAW, like every sibling caller: _describe_geom_type and sql_path each
+        # escape their own argument, so handing them a pre-escaped
+        # safe_file_url() value escaped it twice and failed this check on any
+        # valid file whose path contains an apostrophe (#937, the #718 class).
+        # Resolved inside the try so an unreadable path stays a FAILED check
+        # rather than an exception, as it was before.
+        raw_url = resolve_file_url(parquet_file, verbose=False)
+        col_type = _describe_geom_type(con, raw_url, geom_col)
         geom_expr = (
             quoted_geom if "GEOMETRY" in col_type.upper() else f"ST_GeomFromWKB({quoted_geom})"
         )
@@ -1440,7 +1447,7 @@ def _check_orientation_matches_data(
             SELECT ST_AsWKB(ST_Force2D(part.geom))
             FROM (
                 SELECT {geom_expr} AS g
-                FROM read_parquet({sql_path(parquet_file)})
+                FROM read_parquet({sql_path(raw_url)})
                 WHERE {quoted_geom} IS NOT NULL
                 {limit_clause}
             ) t, UNNEST(ST_Dump(t.g)) AS u(part)

--- a/geoparquet_io/core/wfs.py
+++ b/geoparquet_io/core/wfs.py
@@ -1304,7 +1304,13 @@ def _build_local_bbox_filter(
     wkt = f"POLYGON(({xmin} {ymin}, {xmax} {ymin}, {xmax} {ymax}, {xmin} {ymax}, {xmin} {ymin}))"
     # Fetched features carry geometry as WKB (BLOB), so decode it before the
     # spatial predicate — ST_Intersects has no BLOB overload.
-    return f"ST_Intersects(ST_GeomFromWKB(\"{safe_column}\"), ST_GeomFromText('{wkt}'))"
+    # _validate_identifier already rejects `"`, so quote_identifier is a no-op
+    # for every name that reaches here -- it is used anyway so the quoting rule
+    # is enforced at the interpolation site rather than by a distant allowlist
+    # that a later edit could loosen (#936).
+    return (
+        f"ST_Intersects(ST_GeomFromWKB({quote_identifier(safe_column)}), ST_GeomFromText('{wkt}'))"
+    )
 
 
 def _reproject_bbox_for_local_filter(

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -721,3 +721,70 @@ class TestCartoCli:
             )
             assert result.exit_code != 0
             assert "Invalid table name" in result.output
+
+
+class TestCartoReadExpressionEscaping:
+    """core/carto.py: `_fetch_with_retry`'s read expression (#936).
+
+    The CSV branch already wrapped the URL with ``sql_path``; the GeoJSON
+    branch one line above hand-rolled ``f'ST_Read("{full_url}")'``. DuckDB
+    tolerates a double-quoted string in that position, so the bug was silent
+    until a URL contained a ``"`` -- which ``_validate_carto_url`` does not
+    reject -- at which point the quoting broke apart. ``--url`` is
+    operator-supplied, so this is primarily a correctness bug, but it is the
+    same "quote at the boundary, exactly once" rule as everywhere else, and a
+    URL that arrives from config or automation makes it an injection.
+    """
+
+    # Passes _validate_carto_url (https scheme, /api/v2/sql suffix) and
+    # carries the one character the old spelling could not survive.
+    HOSTILE_URL = 'https://ex"ample.carto.com/api/v2/sql'
+
+    def _captured_read_sql(self, monkeypatch, fmt):
+        """Run _fetch_with_retry against a connection that only records SQL."""
+        from geoparquet_io.core import carto as carto_module
+
+        seen: list[str] = []
+
+        class _RecordingConnection:
+            def execute(self, sql, *args, **kwargs):
+                seen.append(sql)
+                if sql.lstrip().upper().startswith("SELECT"):
+                    # Non-retryable, so the helper gives up after one attempt.
+                    raise RuntimeError("404 not found")
+                return self
+
+        monkeypatch.setattr(
+            carto_module, "get_duckdb_connection", lambda *a, **k: _RecordingConnection()
+        )
+        with pytest.raises(CartoError):
+            carto_module._fetch_with_retry(
+                url=self.HOSTILE_URL, table_name="t", sql="SELECT * FROM t", fmt=fmt
+            )
+        return next(s for s in seen if s.lstrip().upper().startswith("SELECT"))
+
+    @pytest.mark.parametrize(("fmt", "reader"), [("GeoJSON", "ST_Read"), ("csv", "read_csv_auto")])
+    def test_url_becomes_one_well_formed_string_literal(self, monkeypatch, fmt, reader):
+        from urllib.parse import quote
+
+        from geoparquet_io.core.duckdb_utils import sql_path
+
+        sql = self._captured_read_sql(monkeypatch, fmt)
+
+        fmt_param = "GeoJSON" if fmt == "GeoJSON" else "csv"
+        full_url = f"{self.HOSTILE_URL}?q={quote('SELECT * FROM t')}&format={fmt_param}"
+        assert sql == f"SELECT * FROM {reader}({sql_path(full_url)})"
+
+    def test_geojson_expression_parses(self, monkeypatch):
+        """The generated statement must be parseable SQL, not two half-tokens."""
+        import duckdb
+
+        sql = self._captured_read_sql(monkeypatch, "GeoJSON")
+
+        con = duckdb.connect()
+        try:
+            # json_serialize_sql parses without binding or opening anything.
+            (payload,) = con.execute("SELECT json_serialize_sql(?)", [sql]).fetchone()
+        finally:
+            con.close()
+        assert '"error":true' not in payload.replace(" ", ""), payload

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -675,6 +675,47 @@ class TestConvertCSVCore:
         assert result[1] > 100_000
         con.close()
 
+    def test_delimiter_is_escaped_for_the_sql_literal(self):
+        """#937: `--delimiter` went into `delim='{...}'` unescaped.
+
+        The path beside it was already routed through ``sql_path``; the
+        delimiter was not, so a value containing ``'`` closed the literal early
+        and produced a ParserException. ``_escape_sql_string`` takes a RAW
+        value and adds no quotes of its own, so the surrounding ``'...'`` stays.
+        """
+        from geoparquet_io.core.convert import _build_csv_read_expr
+
+        expr = _build_csv_read_expr("/tmp/x.csv", "'")
+
+        assert "delim=''''" in expr
+        # Escape exactly once: a doubled escape would read as an empty string
+        # followed by a stray quote pair.
+        assert "delim=''''''" not in expr
+
+    def test_quote_in_delimiter_produces_parseable_sql(self):
+        """The generated statement must parse; before the fix it did not."""
+        from geoparquet_io.core.convert import _build_csv_read_expr
+
+        expr = _build_csv_read_expr("/tmp/x.csv", "'")
+
+        con = duckdb.connect()
+        try:
+            (payload,) = con.execute(
+                "SELECT json_serialize_sql(?)", [f"SELECT * FROM {expr}"]
+            ).fetchone()
+        finally:
+            con.close()
+        assert '"error":true' not in payload.replace(" ", ""), payload
+
+    def test_convert_csv_with_quote_delimiter_end_to_end(self, tmp_path, temp_output_file):
+        """A `'`-delimited CSV converts instead of dying in the parser."""
+        csv_path = tmp_path / "quote_delim.csv"
+        csv_path.write_text("id'wkt\n1'POINT (1 2)\n2'POINT (3 4)\n")
+
+        convert_to_geoparquet(str(csv_path), temp_output_file, delimiter="'", verbose=False)
+
+        assert pq.read_table(temp_output_file).num_rows == 2
+
     def test_convert_csv_custom_max_line_size_env_var(
         self, tmp_path, temp_output_file, monkeypatch
     ):

--- a/tests/test_geometry_identifier_quoting.py
+++ b/tests/test_geometry_identifier_quoting.py
@@ -622,6 +622,110 @@ class TestExtractGeoparquetQuoting:
         assert column_name in pq.read_schema(out).names
 
 
+class TestExtractSpatialFilterQuoting:
+    """geoparquet_io/core/extract.py: build_spatial_filter's `--geometry` branch.
+
+    The `--bbox` branch five lines above already used ``quote_identifier``; the
+    `--geometry` branch hand-rolled ``f'"{col}"'`` (#936). The name it
+    interpolates is the file's own ``geo.primary_column``, so a published
+    GeoParquet file chose the text -- the #918/#923 threat model, and the one
+    site of that family that lands in a ``WHERE`` clause, where an injected
+    disjunct silently disables the filter instead of crashing.
+    """
+
+    #: A `geo.primary_column` that closes ST_Intersects, ORs in an
+    #: always-true scalar subquery, and reopens ST_Intersects so the template's
+    #: own tail still parses. Unquoted it is a *valid* predicate that matches
+    #: every row; quoted it is one (nonexistent) identifier.
+    BYPASS_COL = (
+        "geometry\", ST_GeomFromText('POINT (0 0)')) "
+        "OR ((SELECT 42) = 42) "
+        'OR ST_Intersects("geometry'
+    )
+
+    @pytest.mark.parametrize("column_name", [*ADVERSARIAL_COLUMNS, INJECTION_COL, BYPASS_COL])
+    def test_geometry_filter_quotes_the_identifier(self, column_name):
+        """The predicate must contain the name as ONE quoted identifier.
+
+        Asserted as an exact string rather than a substring: every hostile name
+        here contains its own payload text, so `"payload" in sql` would pass
+        even on the vulnerable spelling.
+        """
+        from geoparquet_io.core.extract import build_spatial_filter
+
+        wkt = "POINT (999 999)"
+        sql = build_spatial_filter(None, wkt, {}, column_name)
+
+        assert sql == f"ST_Intersects({quote_identifier(column_name)}, ST_GeomFromText('{wkt}'))"
+
+    @adversarial_column
+    def test_cli_geometry_filter_returns_the_right_rows(self, tmp_path, column_name):
+        """A hostile-but-honest column name must still filter correctly."""
+        path = _points_fixture(tmp_path, column_name, "geom_filter_input.parquet")
+        out = str(tmp_path / "geom_filter_output.parquet")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            extract,
+            [
+                "geoparquet",
+                path,
+                out,
+                "--geometry",
+                "POLYGON ((-1 -1, -1 3, 3 3, 3 -1, -1 -1))",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # Points march along the diagonal (0 0)..(9 9); four fall in the box.
+        assert pq.read_table(out).num_rows == 4
+
+    def test_cli_geometry_filter_injection_cannot_bypass_the_filter(self, tmp_path):
+        """End-to-end: a crafted file must not turn `--geometry` into a no-op.
+
+        The fixture declares BOTH the real ``geometry`` column and the payload
+        in ``geo.columns`` -- DuckDB only hands back a GEOMETRY (rather than a
+        BLOB) for a column the `geo` metadata names, and the injected predicate
+        has to bind for the bypass to be observable at all.
+
+        Before the fix this exits 0 having written all ten rows, none of which
+        intersect the requested point.
+        """
+        con = duckdb.connect()
+        con.execute("INSTALL spatial; LOAD spatial;")
+        values_sql = ", ".join(
+            f"({i + 1}, ST_AsWKB(ST_GeomFromText('POINT ({i} {i})')))" for i in range(10)
+        )
+        table = (
+            con.execute(f"SELECT * FROM (VALUES {values_sql}) AS t(id, geometry)")
+            .arrow()
+            .read_all()
+        )
+        con.close()
+
+        col_meta = {"encoding": "WKB", "geometry_types": ["Point"], "bbox": [0.0, 0.0, 9.0, 9.0]}
+        geo = {
+            "version": "1.0.0",
+            "primary_column": self.BYPASS_COL,
+            "columns": {"geometry": col_meta, self.BYPASS_COL: col_meta},
+        }
+        path = str(tmp_path / "bypass_input.parquet")
+        pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), path)
+        out = tmp_path / "bypass_output.parquet"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            extract, ["geoparquet", path, str(out), "--geometry", "POINT (999 999)"]
+        )
+
+        # Nothing in the file intersects (999 999), so no row may be written.
+        # Quoting turns the payload into a column name that does not exist, so
+        # the run fails cleanly instead of silently returning the whole file.
+        leaked = pq.read_table(out).num_rows if out.exists() else 0
+        assert leaked == 0, f"spatial filter bypassed: {leaked} non-intersecting rows written"
+        assert result.exit_code != 0
+
+
 class TestAddCommandsQuoting:
     """Every `gpio add` subcommand builds its own geometry expression."""
 

--- a/tests/test_reproject_spherical_edges.py
+++ b/tests/test_reproject_spherical_edges.py
@@ -85,7 +85,7 @@ class TestReprojectToProjectedCrs:
 
         warnings = [r for r in caplog.records if DROP_WARNING in r.message]
         assert len(warnings) == 1, caplog.text
-        assert '"geometry"' in warnings[0].message
+        assert "column 'geometry'" in warnings[0].message
         assert "spherical" in warnings[0].message
         assert "EPSG:3857" in warnings[0].message
 
@@ -167,7 +167,7 @@ class TestMultiGeometryColumns:
 
         warnings = [r for r in caplog.records if DROP_WARNING in r.message]
         assert len(warnings) == 1, caplog.text
-        assert '"geometry"' in warnings[0].message
+        assert "column 'geometry'" in warnings[0].message
         assert "centerline" not in caplog.text
 
     def test_python_api_table_scopes_drop_to_transformed_column(

--- a/tests/test_validate_orientation.py
+++ b/tests/test_validate_orientation.py
@@ -1,10 +1,13 @@
 """orientation_matches_data: exterior rings CCW and holes CW when orientation is declared (#586)."""
 
+import json
 from pathlib import Path
 
+import pyarrow.parquet as pq
 import pytest
 
 from geoparquet_io.core.common import get_duckdb_connection
+from geoparquet_io.core.duckdb_utils import sql_path
 from geoparquet_io.core.validate import (
     CheckStatus,
     _check_orientation_matches_data,
@@ -23,9 +26,35 @@ def _write_v2(path, wkts):
     values = ", ".join("(NULL)" if w is None else f"(ST_GeomFromText('{w}'))" for w in wkts)
     con.execute(
         f"COPY (SELECT * FROM (VALUES {values}) t(geometry)) "
-        f"TO '{path.as_posix()}' (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')"
+        f"TO {sql_path(path.as_posix())} (FORMAT PARQUET, GEOPARQUET_VERSION 'V2')"
     )
     con.close()
+    return str(path)
+
+
+def _write_wkb_with_orientation(path, wkts, orientation="counterclockwise"):
+    """A plain-WKB GeoParquet file that *declares* an orientation.
+
+    ``_write_v2`` leaves the field unset, which makes the orientation check
+    short-circuit to SKIPPED -- useless for an end-to-end assertion.
+    """
+    con = get_duckdb_connection(load_spatial=True)
+    values = ", ".join(f"(ST_AsWKB(ST_GeomFromText('{w}')))" for w in wkts)
+    table = con.execute(f"SELECT * FROM (VALUES {values}) t(geometry)").arrow().read_all()
+    con.close()
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Polygon"],
+                "orientation": orientation,
+            }
+        },
+    }
+    table = table.replace_schema_metadata({b"geo": json.dumps(geo).encode()})
+    pq.write_table(table, path)
     return str(path)
 
 
@@ -136,3 +165,50 @@ class TestEdges:
         check = _check(str(tmp_path / "missing.parquet"), con)
         assert check.status == CheckStatus.FAILED
         assert "failed to validate orientation" in check.message
+
+
+class TestPathEscapedExactlyOnce:
+    """#937: the check escaped its own path twice.
+
+    ``_describe_geom_type(con, raw_url, ...)`` escapes its argument itself (it
+    builds ``read_parquet({sql_path(raw_url)})``), so passing the already
+    escaped ``safe_file_url()`` result turned ``o'brien`` into ``o''''brien``
+    inside the literal. The read then failed, the broad ``except`` caught it,
+    and a perfectly valid file was reported as *failing* the orientation
+    check -- the #718 failure mode, in a check whose verdict users act on.
+    """
+
+    def test_apostrophe_in_path_does_not_fail_a_valid_file(self, tmp_path, con):
+        directory = tmp_path / "o'brien"
+        directory.mkdir()
+        path = _write_v2(directory / "f.parquet", [CCW])
+
+        check = _check(path, con)
+
+        assert check.status == CheckStatus.PASSED, check.message
+
+    def test_apostrophe_in_path_still_detects_a_real_violation(self, tmp_path, con):
+        """The path fix must not make the check vacuously pass."""
+        directory = tmp_path / "o'brien"
+        directory.mkdir()
+        path = _write_v2(directory / "bad.parquet", [CW])
+
+        check = _check(path, con)
+
+        assert check.status == CheckStatus.FAILED
+        assert "1 of 1" in check.message
+
+    def test_reported_through_validate_geoparquet(self, tmp_path):
+        """The whole `check spec` run, not just the helper.
+
+        Needs a file that actually *declares* an orientation, or the check
+        short-circuits to SKIPPED before it ever builds the query.
+        """
+        directory = tmp_path / "o'brien"
+        directory.mkdir()
+        path = _write_wkb_with_orientation(directory / "f.parquet", [CCW])
+
+        result = validate_geoparquet(path)
+        (check,) = [c for c in result.checks if c.name == "orientation_matches_data_geometry"]
+
+        assert check.status == CheckStatus.PASSED, check.message


### PR DESCRIPTION
## What changed

Four SQL identifier/escaping defects, plus the guard that should have caught two of them.

| # | Site | Class | Fix |
|---|------|-------|-----|
| 1 | `core/extract.py:560` | file-borne injection | `quote_identifier(geometry_col)` |
| 2 | `core/carto.py:467` | hand-rolled quotes | `sql_path(full_url)` |
| 3 | `core/validate.py:1435` | double escape (#718 class) | pass a raw `resolve_file_url()` |
| 4 | `core/convert.py:380` | unescaped SQL string literal | `_escape_sql_string(delimiter)` |

Plus: the `duckdb-antipatterns` hook's `\"{` arm was anchored to the *start* of the
f-string, so #1 and the `wfs.py` site below sat mid-string and went unseen. It is now
unanchored, `core/extract_bigquery.py` is exempt by path (BigQuery dialect, tracked in
#932), `wfs.py`'s allowlist-validated site is routed through `quote_identifier` anyway,
and `reproject.py`'s edges warning uses the codebase's usual `'{col}'` message style so
the unanchored rule has no false positive to excuse.

## Why

### Attacker model for FIX 1

```python
# before
conditions.append(f"ST_Intersects(\"{geometry_col}\", ST_GeomFromText('{escaped_wkt}'))")
```

`geometry_col` is `find_primary_geometry_column(input_parquet)` — the file's own
`geo.primary_column`, copied verbatim with no existence or shape check. **Whoever
published the file chose that text**, which is the #918/#923 threat model. The WKT beside
it was already escaped; only the identifier was not — and the `--bbox` branch five lines
above already did it right with `quote_identifier`.

What makes this one worse than its siblings is *where* it lands. Every earlier site of
this family injected into a projection, where a broken identifier is a parse error you
notice. This one injects into a `WHERE` clause, so a crafted name is a **silent spatial
filter bypass**: the command exits 0 and writes rows the user's filter excluded.

Demonstrated end to end. A file whose `geo.primary_column` is

```
geometry", ST_GeomFromText('POINT (0 0)')) OR ((SELECT 42) = 42) OR ST_Intersects("geometry
```

produces this `WHERE` clause (`--dry-run` on main):

```sql
COPY (SELECT "id", "geometry" FROM read_parquet('in.parquet')
      WHERE (ST_Intersects("geometry", ST_GeomFromText('POINT (0 0)'))
             OR ((SELECT 42) = 42)
             OR ST_Intersects("geometry", ST_GeomFromText('POINT (999 999)'))))
```

— a scalar subquery evaluated inside the predicate, and the user's filter reduced to a
dead disjunct:

```
$ gpio extract geoparquet in.parquet out.parquet --geometry 'POINT (999 999)'   # on main
Extracted 10 rows (out of 10 total) to out.parquet     # nothing intersects (999 999)
```

Reachable from any `gpio extract ... --geometry <WKT>` (and `ops.extract` /
`Table.extract`). With the fix the payload is one quoted identifier that names no column,
so the run fails cleanly and writes nothing.

FIX 2 is operator-supplied (`--url`), so primarily a correctness bug — but the CSV branch
on the very next line already used `sql_path`, and a URL that arrives from config or
automation makes it an injection. `full_url` was traced and confirmed **raw** at that
point: nothing upstream escapes it, and `_validate_carto_url` accepts a `"`. (A #904
review reported this migrated; the change is not on main, so it was lost — the fix stands
as issued.)

FIX 3 and FIX 4 are escaping-discipline bugs, not injections. #3 escaped a path twice and
so reported a **spurious failure** on a valid file whose path contains an apostrophe —
`check spec` output users act on. Its four sibling callers all pass a raw
`resolve_file_url()`; line 1435 was the lone outlier and the last `safe_file_url` caller
left in the package. The resolve stays inside the `try` so an unreadable path is still a
FAILED check rather than an exception.

## Sweep

Re-grepped the whole package for the same shapes so this PR closes the class.

| Pattern | Hits | Verdict |
|---|---|---|
| `f'"{` | `duckdb_utils.py:244` | safe — `quote_identifier`'s own implementation |
| `\"{` (unanchored) | `extract.py:560` | **fixed** |
| | `carto.py:467` (`f'"{url}"'` form) | **fixed** |
| | `wfs.py:1307` | safe (allowlist-validated) → routed through `quote_identifier` anyway |
| | `reproject.py:144` | safe — a log message, not SQL; restyled to `'{col}'` |
| | `extract_bigquery.py:739,743,748` | **deferred, #932** — BigQuery reads `"..."` as a *string literal*, so these need backticks, not `quote_identifier`. The only deferral. |
| `AS {` | 92 hits | all safe: `quote_identifier(...)`/`quoted_*` (86), a SQL subquery fragment in `CREATE TEMP TABLE x AS {query}` (5), and `partition/common.py:729`'s `{alias}`, a gpio-generated `__gpio_part*` constant |
| `'{var}'` string literals in SQL | `convert.py:380` | **fixed** |
| | `duckdb_metadata.py` ×11, `validate.py:2525`, `bbox_metadata.py:67`, `geojson_stream.py:239`, `duckdb_utils.py:602/605/638/645` | safe — `_escape_sql_string` applied |
| | `convert.py:114` | safe — `_validate_layer_name` allowlist |
| | `extract_bigquery.py` `bigquery_scan('{table_id}')` | safe — `_validate_bigquery_table_id` allowlist |
| | everything else | not SQL (log/error messages, docstrings, `repr`) |
| `safe_file_url(...)` into a `raw_*` parameter | `validate.py:1435` | **fixed** — and it was the only `safe_file_url` caller left in `geoparquet_io/` |
| `sql_path(safe_file_url(...))` | none | — |

`core/partition/admin_hierarchical.py` was left alone (PR #926 in flight).

## Verification

Each new test was confirmed failing on `main` before the fix.

**FIX 1** — `tests/test_geometry_identifier_quoting.py::TestExtractSpatialFilterQuoting`

```
FAILED ...::test_geometry_filter_quotes_the_identifier[geo"m]
FAILED ...::test_geometry_filter_quotes_the_identifier[g") AS x, (SELECT 1) AS pwned --]
FAILED ...::test_geometry_filter_quotes_the_identifier[geometry", ST_GeomFromText('POINT (0 0)')) OR ...]
FAILED ...::test_cli_geometry_filter_returns_the_right_rows[geo"m]
FAILED ...::test_cli_geometry_filter_injection_cannot_bypass_the_filter
E   AssertionError: spatial filter bypassed: 10 non-intersecting rows written
5 failed, 4 passed
```
→ `9 passed` after the fix. The identifier is asserted as an **exact** string, not a
substring: every hostile name contains its own payload text, so `"payload" in sql` would
pass on the vulnerable spelling too.

**FIX 2** — `tests/test_carto.py::TestCartoReadExpressionEscaping`

```
FAILED ...::test_url_becomes_one_well_formed_string_literal[GeoJSON-ST_Read]
E   - SELECT * FROM ST_Read('https://ex"ample.carto.com/api/v2/sql?q=...')
E   + SELECT * FROM ST_Read("https://ex"ample.carto.com/api/v2/sql?q=...")
FAILED ...::test_geojson_expression_parses
E   {"error":true,"error_type":"parser","error_message":"syntax error at or near \"ample\""}
2 failed, 1 passed
```
The CSV parametrisation passing on main is the control — only the GeoJSON branch was
broken. → `3 passed` after the fix.

**FIX 3** — `tests/test_validate_orientation.py::TestPathEscapedExactlyOnce`

```
FAILED ...::test_apostrophe_in_path_does_not_fail_a_valid_file
FAILED ...::test_apostrophe_in_path_still_detects_a_real_violation
FAILED ...::test_reported_through_validate_geoparquet
E   AssertionError: failed to validate orientation: IO Error: No files found that match
E     the pattern ".../o''brien/f.parquet"
E   LINE 1: DESCRIBE SELECT "geometry" FROM read_parquet('.../o''''brien/f.parquet')
3 failed
```
→ `15 passed` after the fix. A CW-ring case is included so the fix cannot make the check
vacuously pass.

**FIX 4** — `tests/test_convert.py::TestConvertCSVCore`

```
FAILED ...::test_delimiter_is_escaped_for_the_sql_literal
FAILED ...::test_quote_in_delimiter_produces_parseable_sql
FAILED ...::test_convert_csv_with_quote_delimiter_end_to_end
E   ParserException: Parser Error: unterminated quoted string at or near
E     "''', header=true, AUTO_DETECT=TRUE, max_line_size=52428800) LIMIT 0"
3 failed
```
→ `6 passed` after the fix (escape asserted to happen exactly once).

### Gates

```
pytest tests/test_extract*.py tests/test_carto*.py tests/test_validate*.py \
       tests/test_convert*.py tests/test_sql_path_escaping.py \
       tests/test_geometry_identifier_quoting.py tests/test_wfs.py \
       tests/test_reproject_spherical_edges.py -m "not network and not slow"
                                              1197 passed, 7 skipped
pytest -n auto -m "not slow and not network and not meta"
                                              6391 passed  (4 known -n auto subprocess
                                                            flakes; all pass serially)
pytest -m meta                                203 passed
python scripts/check_sql_path_literals.py     exit 0
bandit -r geoparquet_io/ -c pyproject.toml -q exit 0
ruff check / ruff format --check              clean
lint-imports                                  4 kept, 0 broken
vulture / deptry / xenon                      clean
duckdb-antipatterns (broadened)               exit 0
```

Closes #936
Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS
