### PR TITLE
fix(crs,reproject): recover the real geometry column from malformed 'geo' metadata

### DIFF
--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -179,6 +179,15 @@ def _detect_geometry_column(con, input_file, verbose, is_parquet=False, layer=No
     return None
 
 
+def _schema_geometry_column(input_file: str, verbose: bool, is_parquet: bool = True) -> str | None:
+    """``_detect_geometry_column`` on a connection of its own, closed either way."""
+    con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_file))
+    try:
+        return _detect_geometry_column(con, input_file, verbose, is_parquet=is_parquet)
+    finally:
+        con.close()
+
+
 def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
     """Detect all geometry columns from a GeoParquet file.
 
@@ -206,14 +215,10 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
     # Only GeoParquet files can have multiple geometry columns with metadata
     if not _is_parquet_file(input_file):
         # For non-parquet, detect single geometry column the standard way
-        con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_file))
-        try:
-            geom_col = _detect_geometry_column(con, input_file, verbose, is_parquet=False)
-            if geom_col:
-                result["primary"] = geom_col
-                result["metadata"][geom_col] = {"encoding": "WKB"}
-        finally:
-            con.close()
+        geom_col = _schema_geometry_column(input_file, verbose, is_parquet=False)
+        if geom_col:
+            result["primary"] = geom_col
+            result["metadata"][geom_col] = {"encoding": "WKB"}
         return result
 
     # A write-path reader: the column names and encodings this returns are
@@ -227,18 +232,19 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
     if not geo_meta or not geo_meta.get("columns"):
         # No GeoParquet metadata -- or nothing left of it once the malformed
         # parts were dropped. Either way, detect the column from the schema.
-        con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_file))
-        try:
-            geom_col = _detect_geometry_column(con, input_file, verbose, is_parquet=True)
-            if geom_col:
-                result["primary"] = geom_col
-                result["metadata"][geom_col] = {"encoding": "WKB"}
-        finally:
-            con.close()
+        geom_col = _schema_geometry_column(input_file, verbose)
+        if geom_col:
+            result["primary"] = geom_col
+            result["metadata"][geom_col] = {"encoding": "WKB"}
         return result
 
     # Extract from GeoParquet metadata
-    primary_col = geo_meta.get("primary_column", "geometry")
+    primary_col = geo_meta.get("primary_column")
+    if not isinstance(primary_col, str):
+        # Sanitizing dropped a malformed `primary_column` and could not repair
+        # it from a single column. The literal "geometry" would name a column
+        # this file may not have, so ask the schema (#887 review).
+        primary_col = _schema_geometry_column(input_file, verbose)
     columns = geo_meta.get("columns", {})
 
     result["primary"] = primary_col

--- a/geoparquet_io/core/convert.py
+++ b/geoparquet_io/core/convert.py
@@ -199,6 +199,7 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
             - "metadata": dict - per-column metadata from input (crs, encoding, etc.)
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
 
     result = {"primary": None, "secondary": [], "metadata": {}}
 
@@ -215,10 +216,17 @@ def detect_all_geometry_columns(input_file: str, verbose: bool = False) -> dict:
             con.close()
         return result
 
-    geo_meta = get_geo_metadata(input_file)
+    # A write-path reader: the column names and encodings this returns are
+    # quoted into the conversion query and copied into the output block, so a
+    # malformed carried block is sanitized rather than indexed as-is (#887).
+    # Without it `columns: null` crashed on `.items()`, a non-string
+    # `primary_column` reached `quote_identifier`, and a non-string `encoding`
+    # reached `_calculate_bounds`'s `encoding.lower()`.
+    geo_meta = sanitize_geo_metadata(get_geo_metadata(input_file))
 
-    if not geo_meta:
-        # No GeoParquet metadata - detect single column from schema
+    if not geo_meta or not geo_meta.get("columns"):
+        # No GeoParquet metadata -- or nothing left of it once the malformed
+        # parts were dropped. Either way, detect the column from the schema.
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(input_file))
         try:
             geom_col = _detect_geometry_column(con, input_file, verbose, is_parquet=True)

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -324,9 +324,29 @@ def geoparquet_crs_is_null(parquet_file) -> bool:
     geo_meta = sanitize_geo_metadata(get_geo_metadata(str(parquet_file)))
     if not geo_meta:
         return False
-    primary_col = geo_meta.get("primary_column", "geometry")
+    primary_col = _primary_column_of_file(geo_meta, parquet_file)
+    if primary_col is None:
+        return False
     col_meta = geo_meta.get("columns", {}).get(primary_col, {})
     return crs_is_explicitly_null(col_meta)
+
+
+def _primary_column_of_file(geo_meta: dict, parquet_file) -> str | None:
+    """The column a sanitized block names as primary, or the one the schema shows.
+
+    Sanitizing *drops* a malformed ``primary_column``, so a block can reach a
+    reader without one. Defaulting to the literal string ``"geometry"`` there is
+    silently wrong on a file whose column is called ``geom``: the lookup misses,
+    the CRS reads as absent, and ``reproject`` then transforms unknown or
+    projected coordinates as if they were lon/lat -- where the raw block used to
+    raise (#887 review). Ask the file instead.
+    """
+    from geoparquet_io.core.geometry_detection import detect_parquet_geometry_column
+
+    primary_col = geo_meta.get("primary_column")
+    if isinstance(primary_col, str):
+        return primary_col
+    return detect_parquet_geometry_column(str(parquet_file))
 
 
 @lru_cache(maxsize=256)
@@ -610,6 +630,7 @@ def extract_crs_from_table(table, geometry_column: str | None = None):
     treated the way an absent one is (#887).
     """
     from geoparquet_io.core.geo_metadata import decode_carried_geo, sanitize_geo_metadata
+    from geoparquet_io.core.geometry_detection import detect_geometry_column_from_names
 
     metadata = table.schema.metadata
     if not metadata or b"geo" not in metadata:
@@ -618,7 +639,14 @@ def extract_crs_from_table(table, geometry_column: str | None = None):
     if not isinstance(geo_meta, dict):
         return None
     columns = geo_meta.get("columns", {})
-    col = geometry_column or geo_meta.get("primary_column", "geometry")
+    col = geometry_column or geo_meta.get("primary_column")
+    if not isinstance(col, str):
+        # Sanitizing dropped a malformed `primary_column`; the table's own
+        # schema names the column, where the literal "geometry" would miss a
+        # `geom` one and report a projected CRS as absent (#887 review).
+        col = detect_geometry_column_from_names(table.schema.names)
+    if col is None:
+        return None
     crs = columns.get(col, {}).get("crs")
     if crs and not is_default_crs(crs):
         return crs
@@ -655,7 +683,7 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
 
     geo_meta = sanitize_geo_metadata(get_geo_metadata(parquet_file))
     if geo_meta:
-        primary_col = geo_meta.get("primary_column", "geometry")
+        primary_col = _primary_column_of_file(geo_meta, parquet_file)
         columns = geo_meta.get("columns", {})
         if primary_col in columns:
             if crs_is_explicitly_null(columns[primary_col]):

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -316,8 +316,12 @@ def geoparquet_crs_is_null(parquet_file) -> bool:
     it internally, so passing an already-escaped URL double-escapes it.
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
 
-    geo_meta = get_geo_metadata(str(parquet_file))
+    # `get_geo_metadata` is the read-only reader and hands the block back as the
+    # file really holds it; the reproject paths that ask this question then act
+    # on the answer, so the malformed parts get dropped here (#887).
+    geo_meta = sanitize_geo_metadata(get_geo_metadata(str(parquet_file)))
     if not geo_meta:
         return False
     primary_col = geo_meta.get("primary_column", "geometry")
@@ -600,17 +604,20 @@ def extract_crs_from_table(table, geometry_column: str | None = None):
     else ``None``. ``geometry_column`` defaults to the geo metadata's declared
     primary column. Used by the table-centric (Python API) operations to detect
     a projected input before grid keying.
+
+    A write-path reader: the CRS it returns decides how the output is keyed, so
+    a malformed carried block goes through :func:`sanitize_geo_metadata` and is
+    treated the way an absent one is (#887).
     """
+    from geoparquet_io.core.geo_metadata import decode_carried_geo, sanitize_geo_metadata
+
     metadata = table.schema.metadata
     if not metadata or b"geo" not in metadata:
         return None
-    try:
-        geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    geo_meta = sanitize_geo_metadata(decode_carried_geo(metadata[b"geo"]))
+    if not isinstance(geo_meta, dict):
         return None
     columns = geo_meta.get("columns", {})
-    if not isinstance(columns, dict):
-        return None
     col = geometry_column or geo_meta.get("primary_column", "geometry")
     crs = columns.get(col, {}).get("crs")
     if crs and not is_default_crs(crs):
@@ -630,6 +637,13 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
     Checks in order:
     1. GeoParquet metadata (columns.<geom_col>.crs)
     2. Parquet native geo type (from schema logical_type)
+
+    A write-path reader: ``convert``, ``reproject``, the format writers and
+    ``process aggregate`` all turn this answer into a transform or an output
+    file, so a malformed carried block goes through
+    :func:`sanitize_geo_metadata` rather than being indexed as-is (#887).
+    ``get_geo_metadata`` itself stays unsanitized -- ``gpio check`` reads
+    through it and has to see the file as it really is.
     """
     from geoparquet_io.core.duckdb_metadata import (
         get_geo_metadata,
@@ -637,8 +651,9 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
         parse_geometry_logical_type,
         resolve_crs_reference,
     )
+    from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
 
-    geo_meta = get_geo_metadata(parquet_file)
+    geo_meta = sanitize_geo_metadata(get_geo_metadata(parquet_file))
     if geo_meta:
         primary_col = geo_meta.get("primary_column", "geometry")
         columns = geo_meta.get("columns", {})
@@ -1030,7 +1045,16 @@ def crs_string_from_geo_meta(geo_meta: dict | None, geom_col: str) -> str | None
     schema for the table-centric Python API). Returns ``None`` when no transform
     is needed — the CRS is absent, the default (OGC:CRS84 / EPSG:4326), explicitly
     null (unknown), or not identifiable as an authority code.
+
+    A write-path reader: the string it returns is spliced into an
+    ``ST_Transform`` call, so the block is sanitized first (#887). Sanitizing
+    here rather than in the callers keeps the single check in one place --
+    ``parse_geo_metadata_from_schema``, which both callers parse with, is a
+    read-only reader and deliberately hands the block over untouched.
     """
+    from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
+
+    geo_meta = sanitize_geo_metadata(geo_meta)
     if not geo_meta:
         return None
     columns = geo_meta.get("columns", {})

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -124,14 +124,48 @@ def _json_type_name(value) -> str:
 
 
 @lru_cache(maxsize=256)
-def _emit_malformed_geo_warning(detail: str) -> None:
-    """Emit the malformed-block warning once per distinct ``detail`` (LRU-bounded)."""
-    warn(f"Ignoring malformed 'geo' metadata on the input: {detail}")
+def _emit_malformed_geo_warning(detail: str, source: str | None = None) -> None:
+    """Emit the malformed-block warning once per ``(detail, source)`` (LRU-bounded).
+
+    ``source`` names the file the block came from where the caller knows it. It
+    is part of the dedup key as well as the message: without it two different
+    malformed inputs in one process (a Python API loop, a shell ``for``) share
+    one cache entry and the second file is ignored in silence.
+    """
+    where = f" of {source}" if source else ""
+    warn(f"Ignoring malformed 'geo' metadata on the input{where}: {detail}")
 
 
 def reset_malformed_geo_warnings() -> None:
     """Clear the malformed-``geo`` warn-once cache. Intended for tests."""
     _emit_malformed_geo_warning.cache_clear()
+
+
+def carried_column_name(
+    value, key: str = "primary_column", source: str | None = None
+) -> str | None:
+    """A carried geometry-column *name*, or ``None`` when the block does not give one.
+
+    A column name is a string. A carried ``primary_column: 123`` handed on
+    reaches ``quote_identifier`` and fails there with a bare ``TypeError``
+    several frames later (#887), so the readers that must keep seeing the file
+    as it really is -- the column-name readers are shared with ``gpio check``
+    and so guard rather than sanitize -- come through here instead of repeating
+    the check, and their caller falls through to schema detection.
+
+    An ignored key gets named in a warning, the rule #883 established: without
+    it ``gpio sort hilbert``, ``gpio check spatial`` and ``gpio add bbox`` all
+    exit 0 with nothing said, while ``gpio convert geoparquet`` on the same file
+    warns. An *absent* key is not malformed and says nothing.
+    """
+    if isinstance(value, str):
+        return value or None
+    if value is None:
+        return None
+    _emit_malformed_geo_warning(
+        f"'{key}' is {_article(_json_type_name(value))}, expected a string", source
+    )
+    return None
 
 
 def decode_carried_geo(raw):
@@ -278,7 +312,8 @@ def sanitize_geo_metadata(geo_meta):
     cleaned = geo_meta
 
     primary = geo_meta.get("primary_column")
-    if "primary_column" in geo_meta and not isinstance(primary, str):
+    dropped_primary = "primary_column" in geo_meta and not isinstance(primary, str)
+    if dropped_primary:
         problems.append(
             f"'primary_column' is {_article(_json_type_name(primary))}, expected a string"
         )
@@ -301,9 +336,33 @@ def sanitize_geo_metadata(geo_meta):
                 cleaned = dict(cleaned)
                 cleaned["columns"] = kept
 
+    if dropped_primary:
+        _repair_primary_column(cleaned)
+
     for problem in problems:
         _emit_malformed_geo_warning(problem)
     return cleaned
+
+
+def _repair_primary_column(cleaned: dict) -> None:
+    """Name the primary column again when exactly one candidate survives sanitizing.
+
+    Dropping a malformed ``primary_column`` and stopping there is not a safe
+    recovery: the readers downstream then fall back to the literal string
+    ``"geometry"``, which *misses* a file whose column is called ``geom`` (or
+    ``wkb_geometry``, ``shape``, ``the_geom``) and reports its CRS as absent.
+    That is worse than the crash it replaced -- ``convert reproject`` bypasses
+    the explicit-null-CRS guard and a projected file is aggregated as lon/lat,
+    silently, where the raw block used to raise (#887 review).
+
+    One surviving column is an unambiguous primary: the spec requires
+    ``primary_column`` to name a key of ``columns``, and there is only one. Two
+    or more is a guess, so the block is left without one and the callers ask the
+    file's schema instead.
+    """
+    columns = cleaned.get("columns")
+    if isinstance(columns, dict) and len(columns) == 1:
+        cleaned["primary_column"] = next(iter(columns))
 
 
 def _article(type_name: str) -> str:

--- a/geoparquet_io/core/geometry_detection.py
+++ b/geoparquet_io/core/geometry_detection.py
@@ -39,7 +39,11 @@ def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> 
     geo_meta = get_geo_metadata(parquet_file)
     if geo_meta and isinstance(geo_meta, dict):
         primary = geo_meta.get("primary_column")
-        if primary:
+        # A carried `primary_column` that is not a string is somebody else's
+        # malformed block; returning it hands a non-string column name to
+        # `quote_identifier`, which fails with a bare TypeError several frames
+        # later (#887). Fall through to schema detection instead.
+        if primary and isinstance(primary, str):
             if verbose:
                 debug(f"Detected geometry column from metadata: {primary}")
             return primary
@@ -130,13 +134,16 @@ def find_primary_geometry_column(parquet_file: str, verbose: bool = False) -> st
     if geo_meta:
         if isinstance(geo_meta, dict):
             primary = geo_meta.get("primary_column")
-            if primary:
+            # Only a string is a column name. A non-string one reaches
+            # `quote_identifier` and fails with a bare TypeError (#887); the
+            # schema fallback below gives the answer the file's data supports.
+            if primary and isinstance(primary, str):
                 return primary
         elif isinstance(geo_meta, list):
             for col in geo_meta:
                 if isinstance(col, dict) and col.get("primary", False):
                     name = col.get("name")
-                    if name:
+                    if name and isinstance(name, str):
                         return name
 
     # No geo metadata or no primary_column specified - use schema-based detection

--- a/geoparquet_io/core/geometry_detection.py
+++ b/geoparquet_io/core/geometry_detection.py
@@ -13,6 +13,23 @@ from geoparquet_io.core.logging_config import debug
 STANDARD_GEOMETRY_NAMES = ["geometry", "geom", "wkb_geometry", "shape", "the_geom"]
 
 
+def detect_geometry_column_from_names(column_names) -> str | None:
+    """First standard geometry name present in ``column_names``, matched case-insensitively.
+
+    The name-based half of detection, split out so the callers that already
+    hold a schema -- an in-memory ``pa.Table`` in ``reproject``, a CRS reader
+    that has to answer "which column did the block mean?" -- do not fall back
+    to the literal string ``"geometry"`` and miss a ``geom`` file (#887 review).
+    """
+    by_lowered: dict[str, str] = {}
+    for name in column_names:
+        by_lowered.setdefault(str(name).lower(), name)
+    for std_name in STANDARD_GEOMETRY_NAMES:
+        if std_name in by_lowered:
+            return by_lowered[std_name]
+    return None
+
+
 def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> str | None:
     """
     Detect the geometry column in a Parquet file.
@@ -30,20 +47,20 @@ def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> 
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
     from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
     from geoparquet_io.core.file_utils import resolve_file_url
+    from geoparquet_io.core.geo_metadata import carried_column_name
     from geoparquet_io.core.remote import needs_httpfs
 
     # Normalize path for consistent handling of URLs and local files
     raw_url = resolve_file_url(parquet_file, verbose=False)
 
-    # 1. Check GeoParquet metadata first
+    # 1. Check GeoParquet metadata first. A carried `primary_column` that is not
+    # a string is somebody else's malformed block: `carried_column_name` names
+    # the ignored key in a warning and answers None, so detection falls through
+    # to the schema rather than handing `quote_identifier` a number (#887).
     geo_meta = get_geo_metadata(parquet_file)
     if geo_meta and isinstance(geo_meta, dict):
-        primary = geo_meta.get("primary_column")
-        # A carried `primary_column` that is not a string is somebody else's
-        # malformed block; returning it hands a non-string column name to
-        # `quote_identifier`, which fails with a bare TypeError several frames
-        # later (#887). Fall through to schema detection instead.
-        if primary and isinstance(primary, str):
+        primary = carried_column_name(geo_meta.get("primary_column"), source=str(parquet_file))
+        if primary:
             if verbose:
                 debug(f"Detected geometry column from metadata: {primary}")
             return primary
@@ -53,13 +70,11 @@ def detect_parquet_geometry_column(parquet_file: str, verbose: bool = False) -> 
     try:
         con = get_duckdb_connection(load_httpfs=needs_httpfs(raw_url))
         result = con.execute(f"DESCRIBE SELECT * FROM read_parquet({sql_path(raw_url)})").fetchall()
-        column_names = [row[0] for row in result]
-        for std_name in STANDARD_GEOMETRY_NAMES:
-            for col in column_names:
-                if col.lower() == std_name.lower():
-                    if verbose:
-                        debug(f"Detected geometry column from schema: {col}")
-                    return col
+        col = detect_geometry_column_from_names(row[0] for row in result)
+        if col:
+            if verbose:
+                debug(f"Detected geometry column from schema: {col}")
+            return col
     except (OSError, duckdb.InvalidInputException) as e:
         # OSError for file access issues
         # InvalidInputException for DuckDB rejecting invalid GeoParquet metadata
@@ -125,25 +140,28 @@ def find_primary_geometry_column(parquet_file: str, verbose: bool = False) -> st
         str: Name of the primary geometry column (defaults to 'geometry')
     """
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.geo_metadata import carried_column_name
 
     geo_meta = get_geo_metadata(parquet_file)
 
     if verbose and geo_meta:
         debug(f"Geo metadata: {_summarize_geo_metadata(geo_meta)}")
 
+    # Only a string is a column name. A non-string one reaches
+    # `quote_identifier` and fails with a bare TypeError (#887), so
+    # `carried_column_name` warns that the key was ignored and the schema
+    # fallback below gives the answer the file's data supports.
+    source = str(parquet_file)
     if geo_meta:
         if isinstance(geo_meta, dict):
-            primary = geo_meta.get("primary_column")
-            # Only a string is a column name. A non-string one reaches
-            # `quote_identifier` and fails with a bare TypeError (#887); the
-            # schema fallback below gives the answer the file's data supports.
-            if primary and isinstance(primary, str):
+            primary = carried_column_name(geo_meta.get("primary_column"), source=source)
+            if primary:
                 return primary
         elif isinstance(geo_meta, list):
             for col in geo_meta:
                 if isinstance(col, dict) and col.get("primary", False):
-                    name = col.get("name")
-                    if name and isinstance(name, str):
+                    name = carried_column_name(col.get("name"), key="name", source=source)
+                    if name:
                         return name
 
     # No geo metadata or no primary_column specified - use schema-based detection

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -64,6 +64,24 @@ class ReprojectResult:
     feature_count: int
 
 
+def _carried_geo(metadata) -> dict:
+    """The carried ``geo`` block on ``metadata``, sanitized, or ``{}``.
+
+    ``reproject`` is a write path: the column name it reads is quoted into SQL
+    and the CRS it reads decides the transform, so the block it indexes goes
+    through the same shape check every other write-path reader uses (#887).
+    Without it a ``primary_column: 123`` reached ``quote_identifier`` as a bare
+    ``TypeError`` and a string-, list- or null-shaped block crashed the CRS
+    lookups with a bare ``AttributeError``.
+    """
+    from geoparquet_io.core.geo_metadata import decode_carried_geo, sanitize_geo_metadata
+
+    if not metadata or b"geo" not in metadata:
+        return {}
+    geo_meta = sanitize_geo_metadata(decode_carried_geo(metadata[b"geo"]))
+    return geo_meta if isinstance(geo_meta, dict) else {}
+
+
 def _detect_geometry_column_from_table(table: pa.Table) -> str:
     """Detect geometry column from table metadata.
 
@@ -71,16 +89,18 @@ def _detect_geometry_column_from_table(table: pa.Table) -> str:
         table: PyArrow Table with geo metadata
 
     Returns:
-        Geometry column name, defaults to 'geometry'
+        Geometry column name — the block's primary column, else the standard
+        name the table's own schema carries, else 'geometry'.
     """
-    if table.schema.metadata and b"geo" in table.schema.metadata:
-        try:
-            geo_meta = json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
-            if "primary_column" in geo_meta:
-                return geo_meta["primary_column"]
-        except (json.JSONDecodeError, KeyError):
-            pass
-    return "geometry"
+    from geoparquet_io.core.geometry_detection import detect_geometry_column_from_names
+
+    primary = _carried_geo(table.schema.metadata).get("primary_column")
+    if isinstance(primary, str) and primary:
+        return primary
+    # Sanitizing dropped a malformed `primary_column` and could not repair it
+    # from a single column. Falling back to the literal "geometry" would name a
+    # column the table may not have (#887 review).
+    return detect_geometry_column_from_names(table.schema.names) or "geometry"
 
 
 def _resolve_crs_to_string(crs_info) -> str | None:
@@ -102,30 +122,16 @@ def _detect_crs_from_table(table: pa.Table, geom_col: str) -> str:
     Returns:
         CRS string like "EPSG:4326" or PROJJSON string for ST_Transform
     """
-    if table.schema.metadata and b"geo" in table.schema.metadata:
-        try:
-            geo_meta = json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
-            columns = geo_meta.get("columns", {})
-            if geom_col in columns:
-                crs_info = columns[geom_col].get("crs")
-                resolved = _resolve_crs_to_string(crs_info)
-                if resolved:
-                    return resolved
-        except (json.JSONDecodeError, KeyError):
-            pass
+    resolved = _resolve_crs_to_string(_table_geo_column_meta(table, geom_col).get("crs"))
     # Default to WGS84 per GeoParquet spec
-    return "EPSG:4326"
+    return resolved or "EPSG:4326"
 
 
 def _table_geo_column_meta(table: pa.Table, geom_col: str) -> dict:
     """Return the geo-metadata dict for ``geom_col``, or ``{}`` if unavailable."""
-    if table.schema.metadata and b"geo" in table.schema.metadata:
-        try:
-            geo_meta = json.loads(table.schema.metadata[b"geo"].decode("utf-8"))
-            return geo_meta.get("columns", {}).get(geom_col, {})
-        except (json.JSONDecodeError, KeyError):
-            return {}
-    return {}
+    columns = _carried_geo(table.schema.metadata).get("columns", {})
+    entry = columns.get(geom_col) if isinstance(columns, dict) else None
+    return entry if isinstance(entry, dict) else {}
 
 
 def _target_crs_is_projected(target_crs: str, con=None) -> bool:
@@ -183,6 +189,25 @@ def _drop_nonplanar_edges_from_geo_meta(geo_meta: dict, target_crs: str, geom_co
     if edges and edges != "planar":
         del col_meta["edges"]
         _warn_edges_dropped(geom_col, edges, target_crs)
+
+
+def _retarget_carried_geo(metadata: dict, geom_col: str, target_crs: str, con) -> bool:
+    """Rewrite ``metadata[b"geo"]`` for ``target_crs``; False when there is nothing to rewrite.
+
+    The single place the Arrow and streaming paths update the carried block, so
+    the same sanitizing applies to both: the block written back out is the
+    cleaned one, and ``apply_target_crs_to_geo_meta`` -- which indexes
+    ``columns`` -- is never handed a list-, string- or null-shaped block (#887).
+    """
+    geo_meta = _carried_geo(metadata)
+    if not geo_meta:
+        debug("Could not update CRS in geo metadata, leaving as-is")
+        return False
+    apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
+    if _target_crs_is_projected(target_crs, con):
+        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs, geom_col)
+    metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
+    return True
 
 
 #: Raised by the Arrow/Python-API path on an explicit ``crs: null`` input.
@@ -287,15 +312,8 @@ def reproject_table(
         if table.schema.metadata:
             new_metadata = dict(table.schema.metadata)
             if b"geo" in new_metadata:
-                try:
-                    geo_meta = json.loads(new_metadata[b"geo"].decode("utf-8"))
-                    apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
-                    if _target_crs_is_projected(target_crs, con):
-                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs, geom_col)
-                    new_metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
+                if _retarget_carried_geo(new_metadata, geom_col, target_crs, con):
                     result = result.replace_schema_metadata(new_metadata)
-                except (json.JSONDecodeError, KeyError) as e:
-                    debug(f"Could not update CRS in geo metadata, leaving as-is: {e}")
             else:
                 result = result.replace_schema_metadata(table.schema.metadata)
 
@@ -823,14 +841,7 @@ def _reproject_streaming(
 
             # Update metadata with target CRS
             if metadata and b"geo" in metadata:
-                try:
-                    geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-                    apply_target_crs_to_geo_meta(geo_meta, geom_col, target_crs, con)
-                    if _target_crs_is_projected(target_crs, con):
-                        _drop_nonplanar_edges_from_geo_meta(geo_meta, target_crs, geom_col)
-                    metadata[b"geo"] = json.dumps(geo_meta).encode("utf-8")
-                except (json.JSONDecodeError, KeyError) as e:
-                    debug(f"Could not update CRS in geo metadata, leaving as-is: {e}")
+                _retarget_carried_geo(metadata, geom_col, target_crs, con)
 
             # Reprojection moves coordinates, so the carried bbox (and, for a
             # geometry-repairing transform, geometry_types) no longer describes

--- a/tests/test_crs_conversion.py
+++ b/tests/test_crs_conversion.py
@@ -699,14 +699,20 @@ class TestCRSDetectionHelpers:
         assert geom_col == "geometry"
 
     def test_detect_geometry_column_from_table_handles_invalid_json(self):
-        """Test geometry column detection handles invalid JSON gracefully."""
+        """Undecodable metadata falls back to the schema, not to the literal 'geometry'.
+
+        This asserted ``"geometry"`` until #887's review: the table's only
+        column is ``geom``, so answering ``"geometry"`` names a column that is
+        not there, and every reader downstream then reports the CRS as absent
+        and reprojects or grid-keys the data as if it were lon/lat.
+        """
         import pyarrow as pa
 
         schema = pa.schema([pa.field("geom", pa.binary())]).with_metadata({b"geo": b"invalid json"})
         table = pa.table({"geom": [b""]}, schema=schema)
 
         geom_col = _detect_geometry_column_from_table(table)
-        assert geom_col == "geometry"
+        assert geom_col == "geom"
 
     def test_detect_crs_from_table_with_epsg_code(self):
         """Test CRS detection from table metadata with EPSG code."""

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -18,6 +18,7 @@ import json
 import logging
 import struct
 
+import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -33,6 +34,12 @@ POINT_WKB = struct.pack("<BI2d", 1, 1, 1.0, 2.0)
 
 WRITE_STRATEGIES = ["in-memory", "streaming", "disk-rewrite", "duckdb-kv"]
 
+#: gpio's own detection list holds five standard names; ``geom`` stands for
+#: every one of them that is not ``geometry``. A recovery that falls back to
+#: the literal ``"geometry"`` looks correct on the first and silently reports
+#: no CRS on the second, so every reader test is run against both (#887 review).
+GEOMETRY_COLUMN_NAMES = ["geometry", "geom"]
+
 # (id, the value carried as geo["columns"], the substring the warning must name)
 MALFORMED_COLUMNS = [
     ("null", None, "'columns'"),
@@ -42,8 +49,8 @@ MALFORMED_COLUMNS = [
 ]
 
 
-def _table_with_geo(geo_block) -> pa.Table:
-    table = pa.table({"id": [1], "geometry": pa.array([POINT_WKB], type=pa.binary())})
+def _table_with_geo(geo_block, col: str = "geometry") -> pa.Table:
+    table = pa.table({"id": [1], col: pa.array([POINT_WKB], type=pa.binary())})
     return table.replace_schema_metadata({b"geo": json.dumps(geo_block).encode("utf-8")})
 
 
@@ -59,12 +66,12 @@ def _malformed_warnings(records) -> list[str]:
     return [r.getMessage() for r in records if "malformed" in r.getMessage().lower()]
 
 
-def _assert_fresh_and_valid(geo: dict) -> None:
+def _assert_fresh_and_valid(geo: dict, col: str = "geometry") -> None:
     """The rebuilt block must be the one gpio would have written with no input block."""
-    assert geo["primary_column"] == "geometry"
+    assert geo["primary_column"] == col
     assert isinstance(geo["columns"], dict)
-    assert isinstance(geo["columns"]["geometry"], dict)
-    assert geo["columns"]["geometry"]["encoding"]
+    assert isinstance(geo["columns"][col], dict)
+    assert geo["columns"][col]["encoding"]
 
 
 # =============================================================================
@@ -93,6 +100,40 @@ class TestSanitizeGeoMetadata:
         reset_malformed_geo_warnings()
         cleaned = sanitize_geo_metadata({"primary_column": 123, "columns": {}})
         assert "primary_column" not in cleaned
+
+    @pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+    def test_repairs_a_dropped_primary_column_from_the_only_column(self, col):
+        """One column is an unambiguous primary: name it rather than leave a hole.
+
+        Dropping ``primary_column`` and stopping there is what turned #887's
+        loud crash into silently wrong coordinates: the readers then fell back
+        to the literal ``"geometry"``, missed a ``geom`` column, and reported
+        the file's CRS as absent (#887 review).
+        """
+        reset_malformed_geo_warnings()
+        cleaned = sanitize_geo_metadata(
+            {"version": "1.1.0", "primary_column": 123, "columns": {col: {"encoding": "WKB"}}}
+        )
+        assert cleaned["primary_column"] == col
+
+    def test_does_not_invent_a_primary_column_when_two_could_be_meant(self):
+        """Two columns and no declared primary is a guess; the callers ask the schema."""
+        reset_malformed_geo_warnings()
+        cleaned = sanitize_geo_metadata(
+            {
+                "primary_column": 123,
+                "columns": {"geom": {"encoding": "WKB"}, "other": {"encoding": "WKB"}},
+            }
+        )
+        assert "primary_column" not in cleaned
+
+    def test_repairs_from_the_kept_columns_not_the_dropped_ones(self):
+        """A column entry that is itself malformed is not a candidate primary."""
+        reset_malformed_geo_warnings()
+        cleaned = sanitize_geo_metadata(
+            {"primary_column": 123, "columns": {"geom": {"encoding": "WKB"}, "bogus": "WKB"}}
+        )
+        assert cleaned["primary_column"] == "geom"
 
     def test_a_block_that_is_not_an_object_is_dropped_entirely(self):
         reset_malformed_geo_warnings()
@@ -276,82 +317,96 @@ def test_extract_crs_from_table_survives_a_malformed_block():
 # feeds the answer into a transform or an output file, and none of them is
 # `gpio check` -- so they sanitize rather than report.
 
+
 #: Every malformed shape these readers can be handed, block-level included.
 #: The entries are otherwise complete 1.1 blocks, so the shape named in the id
 #: is the only thing wrong with each one.
+#:
+#: Spelled for an arbitrary geometry column name, because "the file calls its
+#: geometry ``geometry``" is exactly the assumption these readers must not make:
+#: a recovery that falls back to the literal ``"geometry"`` looks correct on a
+#: ``geometry`` file and silently reports no CRS on a ``geom`` one (#887 review).
+def _malformed_blocks(col: str):
+    return [
+        ("columns_null", {"version": "1.1.0", "primary_column": col, "columns": None}),
+        ("columns_list", {"version": "1.1.0", "primary_column": col, "columns": [col]}),
+        ("columns_string", {"version": "1.1.0", "primary_column": col, "columns": col}),
+        (
+            "entry_not_an_object",
+            {"version": "1.1.0", "primary_column": col, "columns": {col: "WKB"}},
+        ),
+        ("block_is_a_list", [col]),
+        ("block_is_a_string", col),
+        (
+            "primary_column_is_a_number",
+            {
+                "version": "1.1.0",
+                "primary_column": 123,
+                "columns": {col: {"encoding": "WKB", "geometry_types": ["Point"]}},
+            },
+        ),
+        (
+            "encoding_is_a_number",
+            {
+                "version": "1.1.0",
+                "primary_column": col,
+                "columns": {col: {"encoding": 123, "geometry_types": ["Point"]}},
+            },
+        ),
+    ]
+
+
 MALFORMED_BLOCKS = [
-    ("columns_null", {"version": "1.1.0", "primary_column": "geometry", "columns": None}),
-    ("columns_list", {"version": "1.1.0", "primary_column": "geometry", "columns": ["geometry"]}),
-    ("columns_string", {"version": "1.1.0", "primary_column": "geometry", "columns": "geometry"}),
-    (
-        "entry_not_an_object",
-        {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": "WKB"}},
-    ),
-    ("block_is_a_list", ["geometry"]),
-    ("block_is_a_string", "geometry"),
-    (
-        "primary_column_is_a_number",
-        {
-            "version": "1.1.0",
-            "primary_column": 123,
-            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
-        },
-    ),
-    (
-        "encoding_is_a_number",
-        {
-            "version": "1.1.0",
-            "primary_column": "geometry",
-            "columns": {"geometry": {"encoding": 123, "geometry_types": ["Point"]}},
-        },
-    ),
+    (col, case, block) for col in GEOMETRY_COLUMN_NAMES for case, block in _malformed_blocks(col)
 ]
+MALFORMED_BLOCK_IDS = [f"{col}-{case}" for col, case, _ in MALFORMED_BLOCKS]
 
 
-def _file_with_geo(tmp_path, name: str, geo_block) -> str:
+def _file_with_geo(tmp_path, name: str, geo_block, col: str = "geometry") -> str:
     """A real Parquet file carrying ``geo_block`` verbatim as its ``geo`` key."""
     path = tmp_path / f"{name}.parquet"
-    pq.write_table(_table_with_geo(geo_block), path)
+    pq.write_table(_table_with_geo(geo_block, col=col), path)
     return str(path)
 
 
-@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
-def test_crs_utils_extract_crs_from_parquet_survives_a_malformed_block(case, block, tmp_path):
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_crs_utils_extract_crs_from_parquet_survives_a_malformed_block(col, case, block, tmp_path):
     """``convert``/``reproject``/``aggregate`` resolve the input CRS through here."""
     from geoparquet_io.core.crs_utils import extract_crs_from_parquet
 
     reset_malformed_geo_warnings()
-    assert extract_crs_from_parquet(_file_with_geo(tmp_path, case, block)) is None
+    assert extract_crs_from_parquet(_file_with_geo(tmp_path, case, block, col=col)) is None
 
 
-@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
-def test_crs_utils_extract_crs_from_table_survives_a_malformed_block(case, block):
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_crs_utils_extract_crs_from_table_survives_a_malformed_block(col, case, block):
     """The aggregate grid-keying reader (distinct from ``streaming``'s)."""
     from geoparquet_io.core.crs_utils import extract_crs_from_table
 
     reset_malformed_geo_warnings()
-    assert extract_crs_from_table(_table_with_geo(block), "geometry") is None
+    assert extract_crs_from_table(_table_with_geo(block, col=col), col) is None
 
 
-@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
-def test_geoparquet_crs_is_null_survives_a_malformed_block(case, block, tmp_path):
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_geoparquet_crs_is_null_survives_a_malformed_block(col, case, block, tmp_path):
     """``convert reproject`` asks this before it decides how to read the input."""
     from geoparquet_io.core.crs_utils import geoparquet_crs_is_null
 
     reset_malformed_geo_warnings()
-    assert geoparquet_crs_is_null(_file_with_geo(tmp_path, case, block)) is False
+    assert geoparquet_crs_is_null(_file_with_geo(tmp_path, case, block, col=col)) is False
 
 
-@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
-def test_crs_string_from_table_survives_a_malformed_block(case, block):
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_crs_string_from_table_survives_a_malformed_block(col, case, block):
     """The table-centric transform-string reader, via ``crs_string_from_geo_meta``."""
     from geoparquet_io.core.crs_utils import crs_string_from_table
 
     reset_malformed_geo_warnings()
-    assert crs_string_from_table(_table_with_geo(block), "geometry") is None
+    assert crs_string_from_table(_table_with_geo(block, col=col), col) is None
 
 
-def test_geoparquet_crs_is_null_still_sees_an_explicit_null_crs(tmp_path):
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_geoparquet_crs_is_null_still_sees_an_explicit_null_crs(col, tmp_path):
     """Sanitizing must not swallow ``crs: null`` -- it is the spec's "unknown"."""
     reset_malformed_geo_warnings()
     from geoparquet_io.core.crs_utils import geoparquet_crs_is_null
@@ -359,12 +414,14 @@ def test_geoparquet_crs_is_null_still_sees_an_explicit_null_crs(tmp_path):
     path = _file_with_geo(
         tmp_path,
         "null_crs",
-        {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"crs": None}}},
+        {"version": "1.1.0", "primary_column": col, "columns": {col: {"crs": None}}},
+        col=col,
     )
     assert geoparquet_crs_is_null(path) is True
 
 
-def test_geometry_detection_never_returns_a_non_string_column_name(tmp_path):
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_geometry_detection_never_returns_a_non_string_column_name(col, tmp_path):
     """The column-name readers are shared with ``gpio check``, so they guard, not sanitize.
 
     ``check spatial`` and ``check row-group`` ask ``find_primary_geometry_column``
@@ -387,19 +444,73 @@ def test_geometry_detection_never_returns_a_non_string_column_name(tmp_path):
         {
             "version": "1.1.0",
             "primary_column": 123,
-            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+            "columns": {col: {"encoding": "WKB", "geometry_types": ["Point"]}},
         },
+        col=col,
     )
-    assert detect_parquet_geometry_column(readable) == "geometry"
-    assert find_primary_geometry_column(readable) == "geometry"
+    assert detect_parquet_geometry_column(readable) == col
+    assert find_primary_geometry_column(readable) == col
 
     unreadable = _file_with_geo(
         tmp_path,
         "pc_number_cols_null",
         {"version": "1.1.0", "primary_column": 123, "columns": None},
+        col=col,
     )
     assert detect_parquet_geometry_column(unreadable) is None
     assert find_primary_geometry_column(unreadable) == "geometry"
+
+
+def test_geometry_detection_names_the_ignored_primary_column_key(tmp_path, caplog):
+    """An ignored metadata key gets named in a warning -- #883's rule (#887 review).
+
+    Without it ``gpio sort hilbert`` / ``check spatial`` / ``add bbox`` exit 0
+    with nothing said, while ``gpio convert geoparquet`` on the same file warns.
+    """
+    from geoparquet_io.core.geometry_detection import find_primary_geometry_column
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(
+        tmp_path,
+        "pc_number_warn",
+        {
+            "version": "1.1.0",
+            "primary_column": 123,
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+        },
+    )
+    with caplog.at_level(logging.WARNING):
+        assert find_primary_geometry_column(src) == "geometry"
+
+    messages = _malformed_warnings(caplog.records)
+    assert any("'primary_column'" in m and "number" in m for m in messages), messages
+
+
+def test_geometry_detection_warns_once_per_file_not_once_per_process(tmp_path, caplog):
+    """The warn-once cache keys on the message, so the message has to name the file.
+
+    Two different malformed inputs in one process (a Python API loop, a shell
+    ``for``) otherwise share one cache entry and the second file is ignored in
+    silence (#887 review).
+    """
+    from geoparquet_io.core.geometry_detection import find_primary_geometry_column
+
+    reset_malformed_geo_warnings()
+    block = {
+        "version": "1.1.0",
+        "primary_column": 123,
+        "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+    }
+    first = _file_with_geo(tmp_path, "first", block)
+    second = _file_with_geo(tmp_path, "second", block)
+
+    with caplog.at_level(logging.WARNING):
+        find_primary_geometry_column(first)
+        find_primary_geometry_column(second)
+
+    messages = _malformed_warnings(caplog.records)
+    assert any("first.parquet" in m for m in messages), messages
+    assert any("second.parquet" in m for m in messages), messages
 
 
 @pytest.mark.parametrize(
@@ -416,8 +527,8 @@ def test_find_primary_geometry_column_guards_the_legacy_list_block(case, name, e
     assert find_primary_geometry_column(src) == expected
 
 
-@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
-def test_detect_all_geometry_columns_survives_a_malformed_block(case, block, tmp_path):
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_detect_all_geometry_columns_survives_a_malformed_block(col, case, block, tmp_path):
     """``convert`` resolves the geometry columns here, before it builds any query.
 
     Every name and encoding this returns is spliced into SQL or copied into the
@@ -427,7 +538,7 @@ def test_detect_all_geometry_columns_survives_a_malformed_block(case, block, tmp
     from geoparquet_io.core.convert import detect_all_geometry_columns
 
     reset_malformed_geo_warnings()
-    info = detect_all_geometry_columns(_file_with_geo(tmp_path, case, block))
+    info = detect_all_geometry_columns(_file_with_geo(tmp_path, case, block, col=col))
 
     assert info["primary"] is None or isinstance(info["primary"], str)
     assert all(isinstance(name, str) for name in info["metadata"])
@@ -436,19 +547,54 @@ def test_detect_all_geometry_columns_survives_a_malformed_block(case, block, tmp
         assert isinstance(col_meta.get("encoding", "WKB"), str)
 
 
-def test_detect_all_geometry_columns_falls_back_when_the_columns_are_unusable(tmp_path):
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_detect_all_geometry_columns_falls_back_when_the_columns_are_unusable(col, tmp_path):
     """Nothing left of ``columns`` means the block-less answer: detect from the schema."""
     from geoparquet_io.core.convert import detect_all_geometry_columns
 
     reset_malformed_geo_warnings()
     src = _file_with_geo(
-        tmp_path, "cols_null", {"version": "1.1.0", "primary_column": "geometry", "columns": None}
+        tmp_path,
+        "cols_null",
+        {"version": "1.1.0", "primary_column": col, "columns": None},
+        col=col,
     )
     assert detect_all_geometry_columns(src) == {
-        "primary": "geometry",
+        "primary": col,
         "secondary": [],
-        "metadata": {"geometry": {"encoding": "WKB"}},
+        "metadata": {col: {"encoding": "WKB"}},
     }
+
+
+def test_detect_all_geometry_columns_asks_the_schema_when_no_primary_is_left(tmp_path):
+    """Two columns and no usable ``primary_column``: the schema decides, not ``"geometry"``.
+
+    The single-column case is repaired by the sanitizer; this is the one it
+    cannot repair, and falling back to the literal name would pick a column the
+    file does not have (#887 review).
+    """
+    from geoparquet_io.core.convert import detect_all_geometry_columns
+
+    reset_malformed_geo_warnings()
+    table = pa.table(
+        {
+            "id": [1],
+            "geom": pa.array([POINT_WKB], type=pa.binary()),
+            "other_geom": pa.array([POINT_WKB], type=pa.binary()),
+        }
+    )
+    entry = {"encoding": "WKB", "geometry_types": ["Point"]}
+    block = {
+        "version": "1.1.0",
+        "primary_column": 123,
+        "columns": {"geom": dict(entry), "other_geom": dict(entry)},
+    }
+    src = tmp_path / "two_cols.parquet"
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(block).encode("utf-8")}), src)
+
+    info = detect_all_geometry_columns(str(src))
+    assert info["primary"] == "geom"
+    assert info["secondary"] == ["other_geom"]
 
 
 def test_convert_geoparquet_recovers_from_a_non_string_primary_column(tmp_path, caplog):
@@ -480,8 +626,8 @@ def test_convert_geoparquet_recovers_from_a_non_string_primary_column(tmp_path, 
     assert any("'primary_column'" in m and "number" in m for m in messages), messages
 
 
-@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
-def test_convert_geoparquet_never_fails_with_a_bare_type_error(case, block, tmp_path, caplog):
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_convert_geoparquet_never_fails_with_a_bare_type_error(col, case, block, tmp_path, caplog):
     """``gpio convert geoparquet`` on somebody else's file: no ``TypeError`` escapes.
 
     Some of these files cannot be converted at all -- DuckDB's own GeoParquet
@@ -499,7 +645,7 @@ def test_convert_geoparquet_never_fails_with_a_bare_type_error(case, block, tmp_
     with caplog.at_level(logging.WARNING):
         try:
             convert_to_geoparquet(
-                _file_with_geo(tmp_path, case, block), str(out), compression="SNAPPY"
+                _file_with_geo(tmp_path, case, block, col=col), str(out), compression="SNAPPY"
             )
         except GeoParquetError as exc:
             chain, seen = [], exc.__cause__
@@ -508,7 +654,7 @@ def test_convert_geoparquet_never_fails_with_a_bare_type_error(case, block, tmp_
                 seen = seen.__cause__
             assert not any(isinstance(c, (TypeError, AttributeError)) for c in chain), chain
         else:
-            _assert_fresh_and_valid(_geo_of_file(out))
+            _assert_fresh_and_valid(_geo_of_file(out), col=col)
             assert pq.ParquetFile(out).metadata.num_rows == 1
 
 
@@ -794,3 +940,280 @@ def test_table_write_drops_a_wrong_typed_crs(strategy, tmp_path, caplog):
 
     con = get_duckdb_connection(load_spatial=True)
     assert con.execute(f"SELECT count(*) FROM read_parquet({sql_path(out)})").fetchone()[0] == 1
+
+
+# =============================================================================
+# The recovery must not answer with the wrong column (#887 review)
+# =============================================================================
+
+# Dropping a malformed `primary_column` and then falling back to the literal
+# string "geometry" turns a loud crash into silently wrong output: on a file
+# whose geometry column is `geom` (or `wkb_geometry`, `shape`, `the_geom` --
+# all in gpio's own detection list) the lookup misses and the file's CRS is
+# reported as absent. Two consequences, both verified below:
+#   (a) `convert reproject` bypasses the explicit-null-CRS guard and transforms
+#       unknown coordinates as if they were lon/lat;
+#   (b) `process aggregate h3` keys a projected file as if it were lon/lat.
+# The fix is the sanitizer *repairing* `primary_column` from the only column
+# there is, plus schema detection (never the literal name) where it cannot.
+
+
+def _crs_5070() -> dict:
+    from pyproj import CRS
+
+    return CRS.from_epsg(5070).to_json_dict()
+
+
+def _malformed_primary_file(tmp_path, name: str, col: str, col_meta: dict) -> str:
+    """A one-row file on column ``col`` whose ``primary_column`` is unusable."""
+    return _file_with_geo(
+        tmp_path,
+        name,
+        {"version": "1.1.0", "primary_column": 123, "columns": {col: col_meta}},
+        col=col,
+    )
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_reproject_still_refuses_an_explicit_null_crs_after_recovery(col, tmp_path):
+    """(a) The null-CRS guard must survive the recovery, whatever the column is called.
+
+    ``crs: null`` means *unknown*. Reprojecting it as if it were CRS84 writes
+    coordinates that are simply wrong, and says "Source CRS: EPSG:4326" while
+    doing it -- worse than the ``TypeError`` this recovery replaced.
+    """
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    reset_malformed_geo_warnings()
+    src = _malformed_primary_file(
+        tmp_path, "null_crs_bad_primary", col, {"encoding": "WKB", "crs": None}
+    )
+    result = CliRunner().invoke(
+        cli,
+        ["convert", "reproject", src, str(tmp_path / "out.parquet"), "--dst-crs", "EPSG:3857"],
+    )
+    assert result.exit_code != 0, result.output
+    assert "explicit null CRS" in result.output
+    assert "--assume-crs84" in result.output
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_reproject_table_still_refuses_an_explicit_null_crs_after_recovery(col):
+    """The same guard on the table-centric API (``ops.reproject`` / ``Table.reproject``)."""
+    from geoparquet_io.core.reproject import reproject_table
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {
+            "version": "1.1.0",
+            "primary_column": 123,
+            "columns": {col: {"encoding": "WKB", "crs": None}},
+        },
+        col=col,
+    )
+    with pytest.raises(ValueError, match="null CRS"):
+        reproject_table(table, target_crs="EPSG:3857")
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_aggregate_h3_keys_a_projected_file_the_same_way_with_or_without_the_block(col, tmp_path):
+    """(b) A projected file must not be aggregated as lon/lat because of a bad key.
+
+    The control is the identical file with a well-formed ``primary_column``:
+    the recovered run has to land in the same H3 cell, not somewhere off the
+    coast of Africa.
+    """
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    crs = _crs_5070()
+    cells = {}
+    for label, primary in (("control", col), ("recovered", 7)):
+        src = _file_with_geo(
+            tmp_path,
+            f"h3_{label}",
+            {
+                "version": "1.1.0",
+                "primary_column": primary,
+                "columns": {col: {"encoding": "WKB", "crs": crs, "geometry_types": ["Point"]}},
+            },
+            col=col,
+        )
+        out = tmp_path / f"h3_{label}_out.parquet"
+        reset_malformed_geo_warnings()
+        result = CliRunner().invoke(
+            cli, ["process", "aggregate", "h3", src, str(out), "--resolution", "5"]
+        )
+        assert result.exit_code == 0, result.output
+        cells[label] = pq.read_table(out).column("h3_cell").to_pylist()
+
+    assert cells["recovered"] == cells["control"]
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_extract_crs_from_parquet_finds_a_projected_crs_after_recovery(col, tmp_path):
+    """The unit under (b): the CRS is still found once ``primary_column`` is repaired."""
+    from geoparquet_io.core.crs_utils import extract_crs_from_parquet
+
+    reset_malformed_geo_warnings()
+    src = _malformed_primary_file(
+        tmp_path, "proj_bad_primary", col, {"encoding": "WKB", "crs": _crs_5070()}
+    )
+    assert extract_crs_from_parquet(src) is not None
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_extract_crs_from_table_finds_a_projected_crs_after_recovery(col):
+    """The table-centric sibling, used by ``process aggregate`` before grid keying."""
+    from geoparquet_io.core.crs_utils import extract_crs_from_table
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {
+            "version": "1.1.0",
+            "primary_column": 123,
+            "columns": {col: {"encoding": "WKB", "crs": _crs_5070()}},
+        },
+        col=col,
+    )
+    assert extract_crs_from_table(table) is not None
+
+
+# =============================================================================
+# `reproject` reads the carried block too (#887 bullet 3, still live on the API)
+# =============================================================================
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_ops_reproject_survives_a_non_string_primary_column(col):
+    """``ops.reproject`` / ``Table.reproject`` raised the exact ``TypeError`` from #887.
+
+    ``reproject._detect_geometry_column_from_table`` handed ``primary_column:
+    123`` straight to ``quote_identifier``, which fails with
+    ``argument of type 'int' is not iterable``.
+    """
+    from geoparquet_io.api import Table, ops
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {"version": "1.1.0", "primary_column": 123, "columns": {col: {"encoding": "WKB"}}},
+        col=col,
+    )
+    assert col in ops.reproject(table, target_crs="EPSG:3857").column_names
+    assert col in Table(table).reproject("EPSG:3857").table.column_names
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_reproject_table_readers_survive_a_malformed_block(col, case, block):
+    """The three ``reproject`` readers of the raw block: no ``TypeError``/``AttributeError``.
+
+    A string- or list-shaped block, ``columns: null`` and a non-object column
+    entry each crashed one of them with a bare ``AttributeError`` (#887 review).
+    """
+    from geoparquet_io.core.reproject import (
+        _detect_crs_from_table,
+        _detect_geometry_column_from_table,
+        _table_geo_column_meta,
+    )
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(block, col=col)
+
+    detected = _detect_geometry_column_from_table(table)
+    assert isinstance(detected, str)
+    assert isinstance(_detect_crs_from_table(table, detected), str)
+    assert isinstance(_table_geo_column_meta(table, detected), dict)
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_reproject_table_never_fails_with_a_bare_type_error(col, case, block, tmp_path):
+    """``Table.reproject`` end to end: a domain error is fine, a bare TypeError is not."""
+    from geoparquet_io.core.reproject import reproject_table
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(block, col=col)
+    try:
+        result = reproject_table(table, target_crs="EPSG:3857")
+    except (ValueError, duckdb.Error):
+        pass  # a domain error naming the real cause is the contract
+    else:
+        assert result.num_rows == 1
+
+
+def test_carried_column_name_says_nothing_about_an_absent_key(caplog):
+    """An absent ``primary_column`` is not malformed -- only a wrong-typed one warns."""
+    from geoparquet_io.core.geo_metadata import carried_column_name
+
+    reset_malformed_geo_warnings()
+    with caplog.at_level(logging.WARNING):
+        assert carried_column_name(None) is None
+        assert carried_column_name("") is None
+        assert carried_column_name("geom") == "geom"
+    assert _malformed_warnings(caplog.records) == []
+
+
+def test_geoparquet_crs_is_null_says_false_when_no_column_can_be_named(tmp_path):
+    """Nothing names a column and DuckDB will not describe the file: not a null CRS.
+
+    ``columns: null`` leaves the block with no ``columns`` to repair a
+    ``primary_column`` from, and the same malformed block stops DuckDB opening
+    the file to detect one, so there is no column to ask about (#887 review).
+    """
+    from geoparquet_io.core.crs_utils import geoparquet_crs_is_null
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(
+        tmp_path,
+        "no_primary_no_columns",
+        {"version": "1.1.0", "primary_column": 123, "columns": None},
+    )
+    assert geoparquet_crs_is_null(src) is False
+
+
+def test_extract_crs_from_table_says_none_when_no_column_can_be_named():
+    """No usable ``primary_column`` and no standard name in the schema: no CRS."""
+    from geoparquet_io.core.crs_utils import extract_crs_from_table
+
+    reset_malformed_geo_warnings()
+    table = pa.table({"id": [1], "footprint": pa.array([POINT_WKB], type=pa.binary())})
+    table = table.replace_schema_metadata(
+        {
+            b"geo": json.dumps(
+                {
+                    "version": "1.1.0",
+                    "primary_column": 123,
+                    "columns": {"a": {"encoding": "WKB"}, "b": {"encoding": "WKB"}},
+                }
+            ).encode("utf-8")
+        }
+    )
+    assert extract_crs_from_table(table) is None
+
+
+def test_detect_all_geometry_columns_on_a_non_parquet_input(tmp_path):
+    """The non-GeoParquet arm answers with the one column ``ST_Read`` shows."""
+    from geoparquet_io.core.convert import detect_all_geometry_columns
+
+    src = tmp_path / "one.geojson"
+    src.write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"id": 1},
+                        "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    info = detect_all_geometry_columns(str(src))
+    assert info["primary"] == "geom"
+    assert info["metadata"] == {"geom": {"encoding": "WKB"}}
+    assert info["secondary"] == []

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -265,6 +265,270 @@ def test_extract_crs_from_table_survives_a_malformed_block():
 
 
 # =============================================================================
+# The CRS and geometry-column readers reached before a write (#887)
+# =============================================================================
+
+# #883 routed four write-path readers through the shared check. These are the
+# rest: `crs_utils` resolves the input's CRS and `convert` resolves its geometry
+# columns *before* any metadata is built, and both indexed the raw block. They
+# are write-path readers too -- every caller (`convert geoparquet`, `convert
+# reproject`, `format_writers`, `process aggregate`, and the table-centric API)
+# feeds the answer into a transform or an output file, and none of them is
+# `gpio check` -- so they sanitize rather than report.
+
+#: Every malformed shape these readers can be handed, block-level included.
+#: The entries are otherwise complete 1.1 blocks, so the shape named in the id
+#: is the only thing wrong with each one.
+MALFORMED_BLOCKS = [
+    ("columns_null", {"version": "1.1.0", "primary_column": "geometry", "columns": None}),
+    ("columns_list", {"version": "1.1.0", "primary_column": "geometry", "columns": ["geometry"]}),
+    ("columns_string", {"version": "1.1.0", "primary_column": "geometry", "columns": "geometry"}),
+    (
+        "entry_not_an_object",
+        {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": "WKB"}},
+    ),
+    ("block_is_a_list", ["geometry"]),
+    ("block_is_a_string", "geometry"),
+    (
+        "primary_column_is_a_number",
+        {
+            "version": "1.1.0",
+            "primary_column": 123,
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+        },
+    ),
+    (
+        "encoding_is_a_number",
+        {
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": 123, "geometry_types": ["Point"]}},
+        },
+    ),
+]
+
+
+def _file_with_geo(tmp_path, name: str, geo_block) -> str:
+    """A real Parquet file carrying ``geo_block`` verbatim as its ``geo`` key."""
+    path = tmp_path / f"{name}.parquet"
+    pq.write_table(_table_with_geo(geo_block), path)
+    return str(path)
+
+
+@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
+def test_crs_utils_extract_crs_from_parquet_survives_a_malformed_block(case, block, tmp_path):
+    """``convert``/``reproject``/``aggregate`` resolve the input CRS through here."""
+    from geoparquet_io.core.crs_utils import extract_crs_from_parquet
+
+    reset_malformed_geo_warnings()
+    assert extract_crs_from_parquet(_file_with_geo(tmp_path, case, block)) is None
+
+
+@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
+def test_crs_utils_extract_crs_from_table_survives_a_malformed_block(case, block):
+    """The aggregate grid-keying reader (distinct from ``streaming``'s)."""
+    from geoparquet_io.core.crs_utils import extract_crs_from_table
+
+    reset_malformed_geo_warnings()
+    assert extract_crs_from_table(_table_with_geo(block), "geometry") is None
+
+
+@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
+def test_geoparquet_crs_is_null_survives_a_malformed_block(case, block, tmp_path):
+    """``convert reproject`` asks this before it decides how to read the input."""
+    from geoparquet_io.core.crs_utils import geoparquet_crs_is_null
+
+    reset_malformed_geo_warnings()
+    assert geoparquet_crs_is_null(_file_with_geo(tmp_path, case, block)) is False
+
+
+@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
+def test_crs_string_from_table_survives_a_malformed_block(case, block):
+    """The table-centric transform-string reader, via ``crs_string_from_geo_meta``."""
+    from geoparquet_io.core.crs_utils import crs_string_from_table
+
+    reset_malformed_geo_warnings()
+    assert crs_string_from_table(_table_with_geo(block), "geometry") is None
+
+
+def test_geoparquet_crs_is_null_still_sees_an_explicit_null_crs(tmp_path):
+    """Sanitizing must not swallow ``crs: null`` -- it is the spec's "unknown"."""
+    reset_malformed_geo_warnings()
+    from geoparquet_io.core.crs_utils import geoparquet_crs_is_null
+
+    path = _file_with_geo(
+        tmp_path,
+        "null_crs",
+        {"version": "1.1.0", "primary_column": "geometry", "columns": {"geometry": {"crs": None}}},
+    )
+    assert geoparquet_crs_is_null(path) is True
+
+
+def test_geometry_detection_never_returns_a_non_string_column_name(tmp_path):
+    """The column-name readers are shared with ``gpio check``, so they guard, not sanitize.
+
+    ``check spatial`` and ``check row-group`` ask ``find_primary_geometry_column``
+    what the file calls its geometry -- they must keep seeing the file as it is.
+    But a name is a string: a carried ``primary_column: 123`` handed back here
+    reaches ``quote_identifier`` and fails there with a bare ``TypeError``
+    (#887). Falling through to schema detection answers with the real column --
+    or, when DuckDB will not open the file to describe it either, with ``None``,
+    which the callers already turn into "No geometry column detected".
+    """
+    from geoparquet_io.core.geometry_detection import (
+        detect_parquet_geometry_column,
+        find_primary_geometry_column,
+    )
+
+    reset_malformed_geo_warnings()
+    readable = _file_with_geo(
+        tmp_path,
+        "pc_number_only",
+        {
+            "version": "1.1.0",
+            "primary_column": 123,
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+        },
+    )
+    assert detect_parquet_geometry_column(readable) == "geometry"
+    assert find_primary_geometry_column(readable) == "geometry"
+
+    unreadable = _file_with_geo(
+        tmp_path,
+        "pc_number_cols_null",
+        {"version": "1.1.0", "primary_column": 123, "columns": None},
+    )
+    assert detect_parquet_geometry_column(unreadable) is None
+    assert find_primary_geometry_column(unreadable) == "geometry"
+
+
+@pytest.mark.parametrize(
+    ("case", "name", "expected"),
+    [("string", "geom", "geom"), ("number", 123, "geometry")],
+    ids=["a_string_name_is_used", "a_number_name_falls_back"],
+)
+def test_find_primary_geometry_column_guards_the_legacy_list_block(case, name, expected, tmp_path):
+    """The pre-1.0 list-shaped ``geo`` block needs the same string guard (#887)."""
+    from geoparquet_io.core.geometry_detection import find_primary_geometry_column
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(tmp_path, f"legacy_{case}", [{"name": name, "primary": True}])
+    assert find_primary_geometry_column(src) == expected
+
+
+@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
+def test_detect_all_geometry_columns_survives_a_malformed_block(case, block, tmp_path):
+    """``convert`` resolves the geometry columns here, before it builds any query.
+
+    Every name and encoding this returns is spliced into SQL or copied into the
+    output block, so each one has to be a string -- never the ``123`` a carried
+    ``primary_column`` or ``encoding`` can hold.
+    """
+    from geoparquet_io.core.convert import detect_all_geometry_columns
+
+    reset_malformed_geo_warnings()
+    info = detect_all_geometry_columns(_file_with_geo(tmp_path, case, block))
+
+    assert info["primary"] is None or isinstance(info["primary"], str)
+    assert all(isinstance(name, str) for name in info["metadata"])
+    for col_meta in info["metadata"].values():
+        assert isinstance(col_meta, dict)
+        assert isinstance(col_meta.get("encoding", "WKB"), str)
+
+
+def test_detect_all_geometry_columns_falls_back_when_the_columns_are_unusable(tmp_path):
+    """Nothing left of ``columns`` means the block-less answer: detect from the schema."""
+    from geoparquet_io.core.convert import detect_all_geometry_columns
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(
+        tmp_path, "cols_null", {"version": "1.1.0", "primary_column": "geometry", "columns": None}
+    )
+    assert detect_all_geometry_columns(src) == {
+        "primary": "geometry",
+        "secondary": [],
+        "metadata": {"geometry": {"encoding": "WKB"}},
+    }
+
+
+def test_convert_geoparquet_recovers_from_a_non_string_primary_column(tmp_path, caplog):
+    """``primary_column: 123`` used to reach ``quote_identifier`` as a bare TypeError.
+
+    Nothing else about this file is wrong, so the conversion now runs to
+    completion and the output names the geometry column found in the schema.
+    """
+    from geoparquet_io.core.convert import convert_to_geoparquet
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(
+        tmp_path,
+        "pc_number",
+        {
+            "version": "1.1.0",
+            "primary_column": 123,
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+        },
+    )
+    out = tmp_path / "pc_number_out.parquet"
+    with caplog.at_level(logging.WARNING):
+        convert_to_geoparquet(src, str(out), compression="SNAPPY")
+
+    _assert_fresh_and_valid(_geo_of_file(out))
+    assert pq.ParquetFile(out).metadata.num_rows == 1
+
+    messages = _malformed_warnings(caplog.records)
+    assert any("'primary_column'" in m and "number" in m for m in messages), messages
+
+
+@pytest.mark.parametrize(("case", "block"), MALFORMED_BLOCKS)
+def test_convert_geoparquet_never_fails_with_a_bare_type_error(case, block, tmp_path, caplog):
+    """``gpio convert geoparquet`` on somebody else's file: no ``TypeError`` escapes.
+
+    Some of these files cannot be converted at all -- DuckDB's own GeoParquet
+    reader refuses to open a block whose ``columns`` or ``encoding`` is the
+    wrong type, which is outside gpio's reach (#887, #771). What gpio owes the
+    user either way is a domain error naming the real cause, plus the warning
+    that says which key was malformed -- not a ``TypeError`` from indexing the
+    block three frames deep.
+    """
+    from geoparquet_io.core.convert import convert_to_geoparquet
+    from geoparquet_io.core.exceptions import GeoParquetError
+
+    reset_malformed_geo_warnings()
+    out = tmp_path / f"{case}_out.parquet"
+    with caplog.at_level(logging.WARNING):
+        try:
+            convert_to_geoparquet(
+                _file_with_geo(tmp_path, case, block), str(out), compression="SNAPPY"
+            )
+        except GeoParquetError as exc:
+            chain, seen = [], exc.__cause__
+            while seen is not None and seen not in chain:
+                chain.append(seen)
+                seen = seen.__cause__
+            assert not any(isinstance(c, (TypeError, AttributeError)) for c in chain), chain
+        else:
+            _assert_fresh_and_valid(_geo_of_file(out))
+            assert pq.ParquetFile(out).metadata.num_rows == 1
+
+
+def test_convert_geoparquet_names_the_malformed_key(tmp_path, caplog):
+    """One warning, naming the offending key and the JSON type actually found."""
+    from geoparquet_io.core.convert import convert_to_geoparquet
+    from geoparquet_io.core.exceptions import GeoParquetError
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(
+        tmp_path, "warn", {"version": "1.1.0", "primary_column": "geometry", "columns": None}
+    )
+    with caplog.at_level(logging.WARNING), pytest.raises(GeoParquetError):
+        convert_to_geoparquet(src, str(tmp_path / "warn_out.parquet"), compression="SNAPPY")
+
+    messages = _malformed_warnings(caplog.records)
+    assert any("'columns'" in m and "null" in m for m in messages), messages
+
+
+# =============================================================================
 # The public API boundary -- every write strategy
 # =============================================================================
 


### PR DESCRIPTION
## What changed

Five more readers of a carried `geo` block now go through the shared
`sanitize_geo_metadata` check that #883 established:

| Site | Category | Before |
|---|---|---|
| `crs_utils.extract_crs_from_parquet` | write-path → sanitize | `argument of type 'NoneType' is not iterable` (`columns: null`), `list indices must be integers` (`columns` an array), `'str' object has no attribute 'get'` (entry not an object), `'list'/'str' object has no attribute 'get'` (block not an object) |
| `crs_utils.extract_crs_from_table` (the aggregate grid-keying one, distinct from `streaming`'s) | write-path → sanitize | `AttributeError` on a non-object block and on an entry that is not an object |
| `crs_utils.geoparquet_crs_is_null` | write-path → sanitize | `AttributeError` on every non-object `columns` and every non-object block |
| `crs_utils.crs_string_from_geo_meta` (so `crs_string_from_table` and `stream_io` too) | write-path → sanitize | same |
| `convert.detect_all_geometry_columns` | write-path → sanitize | `'NoneType'/'list'/'str' object has no attribute 'items'`; and it passed a non-string `primary_column` to `quote_identifier` and a non-string `encoding` to `_calculate_bounds`'s `encoding.lower()` |
| `geometry_detection.detect_parquet_geometry_column` / `find_primary_geometry_column` | **validation-shared → guard, not sanitize** | returned `primary_column: 123` verbatim, which failed in `quote_identifier` |

The read-only readers keep the line #883 drew. `get_geo_metadata` and
`parse_geo_metadata_from_schema` still hand the block back exactly as the file
holds it, because `gpio check` reads through them. `geometry_detection` is the
one site that is shared between the two worlds — `check spatial` and
`check row-group` ask it what the file calls its geometry — so it does not
sanitize either; it only refuses to hand back the one thing that cannot be a
column name, a non-string `primary_column`, and falls through to schema
detection instead. The pre-1.0 list-shaped block gets the same guard.

`convert.detect_all_geometry_columns` also falls back to schema detection when
nothing usable is left of `columns`, which is the answer a block-less file
already gives.

## Why

The `geo` key on an input file is arbitrary JSON written by somebody else's
tool. #883 fixed the four readers on the write path proper; these run *earlier*
— `crs_utils` resolves the input CRS and `convert` resolves the geometry columns
before any output metadata exists — and still indexed the raw block. Every
crash above was reproduced on a real file before the fix and is pre-existing on
`main`; per repo convention the cross-cutting fix gets its own PR.

One honest limit, already recorded in #887: a file whose `columns` or `encoding`
is the wrong type still cannot be converted, because DuckDB's own GeoParquet
reader refuses to open it (`Invalid Input Error: Geoparquet metadata does not
have a columns object`). That is outside gpio's reach. What changed is that the
failure is now a domain error naming the real cause, alongside gpio's warning
saying which key was malformed — not a `TypeError` raised from indexing the
block three frames deep. `primary_column: 123`, whose file DuckDB *can* read,
now converts to completion.

Sweep of the remaining unguarded raw-block readers, reported not fixed (other
agents hold those files, and each is larger than a one-liner): `common.py`
(2774–2794, 3435), `add/bbox_metadata.py` (222–253, 338–344), `add/bbox.py`
(210–216), `reproject.py` (76–124, 289–295, 383, 825–831), `stac.py` (216–219),
`stream_io.py` (281–286), `api/table.py` (2558). The `primary_column`-names-a-
nonexistent-column case in `sort`/`add`, which surfaces a raw DuckDB
`BinderException`, is also left for a separate change.

## Verification

- `uv run pytest -n auto -m "not slow and not network and not meta" -q` — 6503 passed, 75 skipped, 9 xfailed
- `uv run pytest -m meta -q` — 203 passed
- `uv run pre-commit run --all-files` and `--hook-stage pre-push` — clean
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` — **100%** (15/15 changed lines)
- 30 new tests in `tests/test_malformed_geo_metadata.py`, each of the eight
  malformed shapes against each of the five readers, plus the end-to-end
  `convert` contract: never a `TypeError`/`AttributeError` anywhere in the
  cause chain

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed GeoParquet metadata across CRS extraction, geometry detection, conversion, and write operations.
  * Falls back to schema-based geometry detection when metadata is missing or invalid.
  * Prevents crashes caused by malformed metadata while preserving valid CRS and geometry information.
  * Provides clearer warnings and domain-specific errors for invalid metadata.

* **Tests**
  * Added regression coverage for malformed metadata scenarios across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->