### PR TITLE
refactor(cli): extract the duplicated command prologue, group callback and kdtree option resolution

### DIFF
--- a/geoparquet_io/cli/_shared.py
+++ b/geoparquet_io/cli/_shared.py
@@ -103,9 +103,13 @@ def prepare_output(
        that ``--row-group-size`` and ``--row-group-size-mb`` are mutually
        exclusive and converts the size string to MB.
 
-    The order matters and is part of what this helper pins: a user who typed
-    neither an output nor a ``.parquet`` name should get the streaming hint,
-    which tells them what to do, rather than the extension complaint.
+    The order matters and is part of what this helper pins, though not between
+    steps 1 and 2: those two can never both fire, since ``validate_output``
+    raises only for a missing output and ``validate_parquet_extension`` returns
+    immediately on one. The live constraint is step 1 before step 3 -- a user
+    who piped nothing anywhere and also passed both row-group options should be
+    told how to name an output, which is actionable, rather than which pair of
+    size flags conflict.
 
     Args:
         output_path: The command's output argument. ``None`` means "stream to

--- a/geoparquet_io/cli/_shared.py
+++ b/geoparquet_io/cli/_shared.py
@@ -25,6 +25,25 @@ from contextlib import contextmanager
 
 import click
 
+from geoparquet_io.core.logging_config import setup_cli_logging
+
+
+def init_group_context(ctx: click.Context) -> None:
+    """Prime ``ctx.obj`` and set up CLI logging for a ``gpio`` subgroup.
+
+    Every group callback needs both, for the same two reasons:
+
+    * ``ctx.obj`` is filled by the root ``gpio`` callback, but a group object
+      invoked on its own -- ``CliRunner().invoke(add, [...])``, or any
+      programmatic caller -- never runs it, and reading ``ctx.obj`` then fails
+      on ``None`` (#922).
+    * ``--timestamps`` is a root option, so a group has to read it back out of
+      ``ctx.obj`` and hand it to the logger. ``verbose`` stays ``False`` here;
+      individual commands raise it to DEBUG themselves.
+    """
+    ctx.ensure_object(dict)
+    setup_cli_logging(verbose=False, show_timestamps=ctx.obj.get("timestamps", False))
+
 
 @contextmanager
 def _activate_s3(ctx, aws_profile=None, s3_endpoint=None, s3_region=None, s3_no_ssl=False):

--- a/geoparquet_io/cli/_shared.py
+++ b/geoparquet_io/cli/_shared.py
@@ -13,7 +13,8 @@ The split against the neighbouring modules:
   helpers such as ``parse_row_group_options``. That is still their home;
   nothing was moved out of it.
 * this module - the group-neutral runtime plumbing that is not a decorator and
-  not a Click option: S3 activation, and the default-subcommand group factory.
+  not a Click option: S3 activation, the shared write-command prologue, and the
+  default-subcommand group factory.
 
 Only helpers used by more than one command group belong here. A helper used by a
 single group travels with that group into ``cli/commands/<group>.py``.
@@ -60,6 +61,67 @@ def _activate_s3(ctx, aws_profile=None, s3_endpoint=None, s3_region=None, s3_no_
             os.environ.pop("AWS_PROFILE", None)
         else:
             os.environ["AWS_PROFILE"] = previous_profile
+
+
+def prepare_output(
+    output_path: str | None,
+    any_extension: bool,
+    row_group_size: int | None,
+    row_group_size_mb: str | None,
+) -> float | None:
+    """Run the three checks every write command performs before it does any work.
+
+    In order:
+
+    1. :func:`~geoparquet_io.core.streaming.validate_output` - refuses a missing
+       output when stdout is a terminal, and warns when binary Arrow IPC would
+       be written to one. Its ``StreamingError`` is re-raised as a
+       ``ClickException`` with ``from None``: the message is already written for
+       a user, and the traceback behind it is noise.
+    2. :func:`~geoparquet_io.core.file_utils.validate_parquet_extension` -
+       rejects a non-``.parquet`` output unless ``--any-extension`` was given.
+    3. :func:`~geoparquet_io.cli.decorators.parse_row_group_options` - enforces
+       that ``--row-group-size`` and ``--row-group-size-mb`` are mutually
+       exclusive and converts the size string to MB.
+
+    The order matters and is part of what this helper pins: a user who typed
+    neither an output nor a ``.parquet`` name should get the streaming hint,
+    which tells them what to do, rather than the extension complaint.
+
+    Args:
+        output_path: The command's output argument. ``None`` means "stream to
+            stdout" and ``"-"`` means it explicitly.
+        any_extension: Value of ``--any-extension``.
+        row_group_size: Value of ``--row-group-size`` (rows).
+        row_group_size_mb: Value of ``--row-group-size-mb`` (size string).
+
+    Returns:
+        The row group size in MB, or ``None`` when it was not requested -- pass
+        it to the core writer as ``row_group_size_mb``.
+
+    Raises:
+        click.ClickException: No output was given and stdout is a terminal.
+        click.UsageError: Both row-group options were given, or the size string
+            is invalid.
+        InvalidParameterError: The output has a non-``.parquet`` extension and
+            ``--any-extension`` was not given.
+    """
+    from geoparquet_io.cli.decorators import parse_row_group_options
+    from geoparquet_io.core.file_utils import validate_parquet_extension
+    from geoparquet_io.core.streaming import StreamingError, validate_output
+
+    try:
+        validate_output(output_path)
+    except StreamingError as e:
+        raise click.ClickException(str(e)) from None
+
+    # ``validate_parquet_extension`` returns immediately on ``None``, but is
+    # annotated ``str``. Skipping the call keeps the None-handling visible here
+    # rather than relying on an annotation that does not admit it.
+    if output_path is not None:
+        validate_parquet_extension(output_path, any_extension)
+
+    return parse_row_group_options(row_group_size, row_group_size_mb)
 
 
 def create_default_group(default_subcommand: str, description: str) -> type:

--- a/geoparquet_io/cli/commands/add.py
+++ b/geoparquet_io/cli/commands/add.py
@@ -10,6 +10,8 @@ from click.core import ParameterSource
 
 from geoparquet_io.cli._shared import _activate_s3, init_group_context, prepare_output
 from geoparquet_io.cli.decorators import (
+    DEFAULT_KDTREE_APPROX,
+    DEFAULT_KDTREE_TARGET_ROWS,
     SingleFileCommand,
     any_extension_option,
     bbox_option,
@@ -730,13 +732,13 @@ def add_s2(
     "--auto",
     default=None,
     type=int,
-    help="Auto-select partitions targeting N rows/partition. Default when neither --partitions nor --auto specified: 120,000.",
+    help=f"Auto-select partitions targeting N rows/partition. Default when neither --partitions nor --auto specified: {DEFAULT_KDTREE_TARGET_ROWS:,}.",
 )
 @click.option(
     "--approx",
-    default=100000,
+    default=DEFAULT_KDTREE_APPROX,
     type=int,
-    help="Use approximate computation by sampling N points (default: 100000). Mutually exclusive with --exact.",
+    help=f"Use approximate computation by sampling N points (default: {DEFAULT_KDTREE_APPROX}). Mutually exclusive with --exact.",
 )
 @click.option(
     "--exact",

--- a/geoparquet_io/cli/commands/add.py
+++ b/geoparquet_io/cli/commands/add.py
@@ -8,7 +8,7 @@ dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
 import click
 from click.core import ParameterSource
 
-from geoparquet_io.cli._shared import _activate_s3, prepare_output
+from geoparquet_io.cli._shared import _activate_s3, init_group_context, prepare_output
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     any_extension_option,
@@ -28,7 +28,6 @@ from geoparquet_io.core.add.kdtree import add_kdtree_column as add_kdtree_column
 from geoparquet_io.core.add.quadkey import add_quadkey_column as add_quadkey_column_impl
 from geoparquet_io.core.add.s2 import add_s2_column as add_s2_column_impl
 from geoparquet_io.core.file_utils import validate_parquet_extension
-from geoparquet_io.core.logging_config import setup_cli_logging
 from geoparquet_io.core.streaming import StreamingError
 
 
@@ -36,10 +35,7 @@ from geoparquet_io.core.streaming import StreamingError
 @click.pass_context
 def add(ctx):
     """Commands for enhancing GeoParquet files in various ways."""
-    # Ensure logging is set up (in case this group is invoked directly in tests)
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 @add.command(name="admin-divisions", cls=SingleFileCommand)

--- a/geoparquet_io/cli/commands/add.py
+++ b/geoparquet_io/cli/commands/add.py
@@ -8,7 +8,7 @@ dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
 import click
 from click.core import ParameterSource
 
-from geoparquet_io.cli._shared import _activate_s3
+from geoparquet_io.cli._shared import _activate_s3, prepare_output
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     any_extension_option,
@@ -29,6 +29,7 @@ from geoparquet_io.core.add.quadkey import add_quadkey_column as add_quadkey_col
 from geoparquet_io.core.add.s2 import add_s2_column as add_s2_column_impl
 from geoparquet_io.core.file_utils import validate_parquet_extension
 from geoparquet_io.core.logging_config import setup_cli_logging
+from geoparquet_io.core.streaming import StreamingError
 
 
 @click.group()
@@ -440,19 +441,9 @@ def add_bbox(
         gpio add bbox input.parquet output.parquet --force
     """
     with _activate_s3(ctx):
-        # Validate output early - provides helpful error if no output and not piping
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        row_group_mb = prepare_output(
+            output_parquet, any_extension, row_group_size, row_group_size_mb
+        )
 
         # An input that already has a bbox column is answered with a verbatim copy,
         # which cannot honour a --compression the user actually typed. Pass None
@@ -554,19 +545,9 @@ def add_h3(
     Supports both local and remote (S3, GCS, Azure) inputs and outputs.
     """
     with _activate_s3(ctx):
-        # Validate output early - provides helpful error if no output and not piping
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        row_group_mb = prepare_output(
+            output_parquet, any_extension, row_group_size, row_group_size_mb
+        )
 
         try:
             add_h3_column_impl(
@@ -637,19 +618,9 @@ def add_a5(
     Supports both local and remote (S3, GCS, Azure) inputs and outputs.
     """
     with _activate_s3(ctx):
-        # Validate output early - provides helpful error if no output and not piping
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        row_group_mb = prepare_output(
+            output_parquet, any_extension, row_group_size, row_group_size_mb
+        )
 
         try:
             add_a5_column_impl(
@@ -720,19 +691,9 @@ def add_s2(
     Supports both local and remote (S3, GCS, Azure) inputs and outputs.
     """
     with _activate_s3(ctx):
-        # Validate output early - provides helpful error if no output and not piping
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        row_group_mb = prepare_output(
+            output_parquet, any_extension, row_group_size, row_group_size_mb
+        )
 
         try:
             add_s2_column_impl(
@@ -960,19 +921,9 @@ def add_quadkey(
     Supports both local and remote (S3, GCS, Azure) inputs and outputs.
     """
     with _activate_s3(ctx):
-        # Validate output early - provides helpful error if no output and not piping
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        row_group_mb = prepare_output(
+            output_parquet, any_extension, row_group_size, row_group_size_mb
+        )
 
         try:
             add_quadkey_column_impl(

--- a/geoparquet_io/cli/commands/add.py
+++ b/geoparquet_io/cli/commands/add.py
@@ -18,6 +18,7 @@ from geoparquet_io.cli.decorators import (
     output_format_options,
     overwrite_option,
     parse_row_group_options,
+    resolve_kdtree_options,
     show_sql_option,
     verbose_option,
 )
@@ -793,46 +794,12 @@ def add_kdtree(
     Use --verbose to track progress with iteration-by-iteration updates.
     """
     with _activate_s3(ctx):
-        import math
-
         # Validate .parquet extension
         validate_parquet_extension(output_parquet, any_extension)
 
-        # Validate mutually exclusive options
-        if sum([partitions is not None, auto is not None]) > 1:
-            raise click.UsageError("--partitions and --auto are mutually exclusive")
-
-        # Set defaults
-        if partitions is None and auto is None:
-            auto = 120000  # Default: auto-select targeting 120k rows/partition
-            partitions = None
-        elif auto is not None:
-            # Auto mode: will compute partitions below
-            partitions = None
-
-        # Validate partitions if specified
-        if partitions is not None and (partitions < 2 or (partitions & (partitions - 1)) != 0):
-            raise click.UsageError(
-                f"Partitions must be a power of 2 (2, 4, 8, ...), got {partitions}"
-            )
-
-        # Validate mutually exclusive options for approx/exact
-        if exact and approx != 100000:
-            raise click.UsageError("--approx and --exact are mutually exclusive")
-
-        # Determine sample size
-        sample_size = None if exact else approx
-
-        # If auto mode, compute optimal partitions
-        if auto is not None:
-            # Pass None for iterations, let implementation compute
-            iterations = None
-            target_rows = auto if auto > 0 else 120000
-            auto_target = ("rows", target_rows)
-        else:
-            # Convert partitions to iterations
-            iterations = int(math.log2(partitions))
-            auto_target = None
+        iterations, sample_size, auto_target = resolve_kdtree_options(
+            partitions, auto, approx, exact
+        )
 
         # Parse row group options
         row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)

--- a/geoparquet_io/cli/commands/add.py
+++ b/geoparquet_io/cli/commands/add.py
@@ -12,6 +12,7 @@ from geoparquet_io.cli._shared import _activate_s3, init_group_context, prepare_
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     any_extension_option,
+    bbox_option,
     dry_run_option,
     geoparquet_version_option,
     output_format_options,
@@ -58,9 +59,7 @@ def add(ctx):
     help="Comma-separated hierarchical levels to add as columns (e.g., 'continent,country'). "
     "If not specified, adds all available levels for the dataset.",
 )
-@click.option(
-    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
-)
+@bbox_option
 @click.option(
     "--prefix",
     type=str,

--- a/geoparquet_io/cli/commands/check.py
+++ b/geoparquet_io/cli/commands/check.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3, create_default_group
+from geoparquet_io.cli._shared import _activate_s3, create_default_group, init_group_context
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
     check_partition_options,
@@ -24,7 +24,7 @@ from geoparquet_io.cli.fix_helpers import handle_fix_common
 from geoparquet_io.core.check_parquet_structure import CheckProfile
 from geoparquet_io.core.check_parquet_structure import check_all as check_structure_impl
 from geoparquet_io.core.check_spatial_order import check_spatial_order as check_spatial_impl
-from geoparquet_io.core.logging_config import configure_verbose, setup_cli_logging
+from geoparquet_io.core.logging_config import configure_verbose
 
 # CheckDefaultGroup: defaults to 'all' when no subcommand is provided
 CheckDefaultGroup = create_default_group(
@@ -44,10 +44,7 @@ def check(ctx):
     When run without a subcommand, all checks are performed. Options like --fix
     can be used directly without specifying 'all'.
     """
-    # Ensure logging is set up (in case this group is invoked directly in tests)
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 class MultiFileCheckRunner:

--- a/geoparquet_io/cli/commands/convert.py
+++ b/geoparquet_io/cli/commands/convert.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3, prepare_output
+from geoparquet_io.cli._shared import _activate_s3, init_group_context, prepare_output
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     any_extension_option,
@@ -25,7 +25,7 @@ from geoparquet_io.cli.decorators import (
 )
 from geoparquet_io.core.convert import convert_to_geoparquet
 from geoparquet_io.core.file_utils import validate_parquet_extension
-from geoparquet_io.core.logging_config import configure_verbose, setup_cli_logging
+from geoparquet_io.core.logging_config import configure_verbose
 from geoparquet_io.core.reproject import reproject as reproject_core
 
 
@@ -118,9 +118,7 @@ def convert(ctx):
         gpio convert reproject input.parquet out.parquet -d EPSG:32610
         gpio convert geojson data.parquet | tippecanoe -P -o tiles.pmtiles
     """
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 @convert.command(name="geoparquet", cls=SingleFileCommand)

--- a/geoparquet_io/cli/commands/convert.py
+++ b/geoparquet_io/cli/commands/convert.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3
+from geoparquet_io.cli._shared import _activate_s3, prepare_output
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     any_extension_option,
@@ -228,27 +228,13 @@ def convert_to_geoparquet_cmd(
       gpio convert input.gpkg | gpio add bbox - | gpio upload - s3://bucket/data.parquet
     """
     from geoparquet_io.core.convert import set_csv_max_line_size
-    from geoparquet_io.core.streaming import (
-        StreamingError,
-        should_stream_output,
-        validate_output,
-    )
+    from geoparquet_io.core.streaming import should_stream_output
 
     # Set CSV max line size if specified
     if csv_max_line_size is not None:
         set_csv_max_line_size(csv_max_line_size)
 
-    # Validate output early - provides helpful error if no output and not piping
-    try:
-        validate_output(output_file)
-    except StreamingError as e:
-        raise click.ClickException(str(e)) from None
-
-    # Validate .parquet extension
-    validate_parquet_extension(output_file, any_extension)
-
-    # Parse row group options
-    row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+    row_group_mb = prepare_output(output_file, any_extension, row_group_size, row_group_size_mb)
 
     # Check for streaming output
     with _activate_s3(ctx, aws_profile=aws_profile):

--- a/geoparquet_io/cli/commands/extract.py
+++ b/geoparquet_io/cli/commands/extract.py
@@ -7,7 +7,7 @@ dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3, create_default_group
+from geoparquet_io.cli._shared import _activate_s3, create_default_group, prepare_output
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
     SingleFileCommand,
@@ -220,19 +220,7 @@ def extract_geoparquet(
         # Extract first 1000 rows
         gpio extract data.parquet output.parquet --limit 1000
     """
-    # Validate output early - provides helpful error if no output and not piping
-    from geoparquet_io.core.streaming import StreamingError, validate_output
-
-    try:
-        validate_output(output_file)
-    except StreamingError as e:
-        raise click.ClickException(str(e)) from None
-
-    # Validate .parquet extension
-    validate_parquet_extension(output_file, any_extension)
-
-    # Parse row group options
-    row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+    row_group_mb = prepare_output(output_file, any_extension, row_group_size, row_group_size_mb)
 
     with _activate_s3(ctx, aws_profile=aws_profile):
         extract_impl(
@@ -675,19 +663,7 @@ def extract_bigquery_cmd(
     """
     from geoparquet_io.core.extract_bigquery import extract_bigquery
 
-    # Validate output early
-    from geoparquet_io.core.streaming import StreamingError, validate_output
-
-    try:
-        validate_output(output_file)
-    except StreamingError as e:
-        raise click.ClickException(str(e)) from None
-
-    # Validate .parquet extension
-    validate_parquet_extension(output_file, any_extension)
-
-    # Parse row group options
-    row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+    row_group_mb = prepare_output(output_file, any_extension, row_group_size, row_group_size_mb)
 
     extract_bigquery(
         table_id=table_id,

--- a/geoparquet_io/cli/commands/extract.py
+++ b/geoparquet_io/cli/commands/extract.py
@@ -7,7 +7,12 @@ dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3, create_default_group, prepare_output
+from geoparquet_io.cli._shared import (
+    _activate_s3,
+    create_default_group,
+    init_group_context,
+    prepare_output,
+)
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
     SingleFileCommand,
@@ -29,7 +34,7 @@ from geoparquet_io.cli.decorators import (
 )
 from geoparquet_io.core.extract import extract as extract_impl
 from geoparquet_io.core.file_utils import validate_parquet_extension
-from geoparquet_io.core.logging_config import configure_verbose, setup_cli_logging
+from geoparquet_io.core.logging_config import configure_verbose
 from geoparquet_io.core.wfs import DEFAULT_WFS_PAGE_SIZE
 
 ExtractDefaultGroup = create_default_group(
@@ -58,10 +63,7 @@ def extract(ctx):
         gpio extract arcgis https://services.arcgis.com/.../FeatureServer/0 out.parquet
         gpio extract bigquery project.dataset.table output.parquet
     """
-    # Ensure logging is set up (in case this group is invoked directly in tests)
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 @extract.command(name="geoparquet", cls=GlobAwareCommand)

--- a/geoparquet_io/cli/commands/inspect.py
+++ b/geoparquet_io/cli/commands/inspect.py
@@ -9,7 +9,7 @@ import os
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3, create_default_group
+from geoparquet_io.cli._shared import _activate_s3, create_default_group, init_group_context
 from geoparquet_io.cli.decorators import GlobAwareCommand, verbose_option
 from geoparquet_io.core.inspect import (
     display_metadata,
@@ -26,7 +26,6 @@ from geoparquet_io.core.inspect import (
 from geoparquet_io.core.inspect import (
     inspect_summary as _inspect_summary_core,
 )
-from geoparquet_io.core.logging_config import setup_cli_logging
 
 # InspectDefaultGroup: defaults to 'summary' when no subcommand is provided
 InspectDefaultGroup = create_default_group(
@@ -73,9 +72,7 @@ def inspect(ctx):
         # GeoParquet 'geo' key metadata only
         gpio inspect meta data.parquet --geo
     """
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 def _validate_parquet_input(file_path: str) -> None:

--- a/geoparquet_io/cli/commands/partition.py
+++ b/geoparquet_io/cli/commands/partition.py
@@ -7,7 +7,7 @@ dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3
+from geoparquet_io.cli._shared import _activate_s3, init_group_context
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     geoparquet_version_option,
@@ -19,7 +19,6 @@ from geoparquet_io.cli.decorators import (
     show_sql_option,
     verbose_option,
 )
-from geoparquet_io.core.logging_config import setup_cli_logging
 from geoparquet_io.core.partition.admin_hierarchical import (
     partition_by_admin_hierarchical as partition_admin_hierarchical_impl,
 )
@@ -40,10 +39,7 @@ from geoparquet_io.core.partition.by_string import (
 @click.pass_context
 def partition(ctx):
     """Commands for partitioning GeoParquet files."""
-    # Ensure logging is set up (in case this group is invoked directly in tests)
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 @partition.command(name="admin", cls=SingleFileCommand)

--- a/geoparquet_io/cli/commands/partition.py
+++ b/geoparquet_io/cli/commands/partition.py
@@ -9,6 +9,8 @@ import click
 
 from geoparquet_io.cli._shared import _activate_s3, init_group_context
 from geoparquet_io.cli.decorators import (
+    DEFAULT_KDTREE_APPROX,
+    DEFAULT_KDTREE_TARGET_ROWS,
     SingleFileCommand,
     geoparquet_version_option,
     handle_directory_sub_partition,
@@ -805,13 +807,13 @@ def partition_a5(
     "--auto",
     default=None,
     type=int,
-    help="Auto-select partitions targeting N rows/partition. Default: 120,000.",
+    help=f"Auto-select partitions targeting N rows/partition. Default: {DEFAULT_KDTREE_TARGET_ROWS:,}.",
 )
 @click.option(
     "--approx",
-    default=100000,
+    default=DEFAULT_KDTREE_APPROX,
     type=int,
-    help="Use approximate computation by sampling N points (default: 100000). Mutually exclusive with --exact.",
+    help=f"Use approximate computation by sampling N points (default: {DEFAULT_KDTREE_APPROX}). Mutually exclusive with --exact.",
 )
 @click.option(
     "--exact",

--- a/geoparquet_io/cli/commands/partition.py
+++ b/geoparquet_io/cli/commands/partition.py
@@ -16,6 +16,7 @@ from geoparquet_io.cli.decorators import (
     parse_row_group_options,
     partition_options,
     partition_options_base,
+    resolve_kdtree_options,
     show_sql_option,
     verbose_option,
 )
@@ -882,39 +883,9 @@ def partition_kdtree(
         gpio partition kdtree input.parquet output/ --approx 200000
     """
     with _activate_s3(ctx):
-        # Validate mutually exclusive options
-        import math
-
-        if sum([partitions is not None, auto is not None]) > 1:
-            raise click.UsageError("--partitions and --auto are mutually exclusive")
-
-        # Set defaults
-        if partitions is None and auto is None:
-            auto = 120000  # Default: auto-select targeting 120k rows/partition
-
-        # Validate partitions if specified
-        if partitions is not None:
-            if partitions < 2 or (partitions & (partitions - 1)) != 0:
-                raise click.UsageError(
-                    f"Partitions must be a power of 2 (2, 4, 8, ...), got {partitions}"
-                )
-            iterations = int(math.log2(partitions))
-        else:
-            iterations = None  # Will be computed in auto mode
-
-        # Validate mutually exclusive options for approx/exact
-        if exact and approx != 100000:
-            raise click.UsageError("--approx and --exact are mutually exclusive")
-
-        # Determine sample size
-        sample_size = None if exact else approx
-
-        # Prepare auto_target if in auto mode
-        if auto is not None:
-            target_rows = auto if auto > 0 else 120000
-            auto_target = ("rows", target_rows)
-        else:
-            auto_target = None
+        iterations, sample_size, auto_target = resolve_kdtree_options(
+            partitions, auto, approx, exact
+        )
 
         # If preview mode, output_folder is not required
         if not preview and not output_folder:

--- a/geoparquet_io/cli/commands/publish.py
+++ b/geoparquet_io/cli/commands/publish.py
@@ -9,14 +9,13 @@ from pathlib import Path
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3
+from geoparquet_io.cli._shared import _activate_s3, init_group_context
 from geoparquet_io.cli.decorators import (
     aws_profile_option,
     dry_run_option,
     handle_geoparquet_errors,
     verbose_option,
 )
-from geoparquet_io.core.logging_config import setup_cli_logging
 from geoparquet_io.core.upload import check_credentials
 from geoparquet_io.core.upload import upload as upload_impl
 
@@ -197,9 +196,7 @@ def _stac_impl(input, output, bucket, public_url, collection_id, item_id, overwr
 @click.pass_context
 def publish(ctx):
     """Commands for publishing GeoParquet data (STAC metadata, cloud uploads)."""
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 @publish.command(name="stac")

--- a/geoparquet_io/cli/commands/sort.py
+++ b/geoparquet_io/cli/commands/sort.py
@@ -7,7 +7,7 @@ dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3
+from geoparquet_io.cli._shared import _activate_s3, prepare_output
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     allow_schema_diff_option,
@@ -89,19 +89,9 @@ def hilbert_order(
     Supports both local and remote (S3, GCS, Azure) inputs and outputs.
     """
     with _activate_s3(ctx):
-        # Validate output early - provides helpful error if no output and not piping
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        # Validate .parquet extension
-        validate_parquet_extension(output_parquet, any_extension)
-
-        # Parse row group options
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        row_group_mb = prepare_output(
+            output_parquet, any_extension, row_group_size, row_group_size_mb
+        )
 
         hilbert_impl(
             input_parquet,
@@ -171,15 +161,9 @@ def str_order_command(
     is itself a multiple of 2048.
     """
     with _activate_s3(ctx):
-        from geoparquet_io.core.streaming import StreamingError, validate_output
-
-        try:
-            validate_output(output_parquet)
-        except StreamingError as e:
-            raise click.ClickException(str(e)) from None
-
-        validate_parquet_extension(output_parquet, any_extension)
-        row_group_mb = parse_row_group_options(row_group_size, row_group_size_mb)
+        row_group_mb = prepare_output(
+            output_parquet, any_extension, row_group_size, row_group_size_mb
+        )
         str_impl(
             input_parquet,
             output_parquet,

--- a/geoparquet_io/cli/commands/sort.py
+++ b/geoparquet_io/cli/commands/sort.py
@@ -12,6 +12,7 @@ from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     allow_schema_diff_option,
     any_extension_option,
+    bbox_option,
     geoparquet_version_option,
     output_format_options,
     overwrite_option,
@@ -43,9 +44,7 @@ def sort(ctx):
     default="geometry",
     help="Name of the geometry column (default: geometry)",
 )
-@click.option(
-    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
-)
+@bbox_option
 @output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
 @geoparquet_version_option
 @overwrite_option
@@ -115,9 +114,7 @@ def hilbert_order(
     default="geometry",
     help="Name of the geometry column (default: geometry)",
 )
-@click.option(
-    "--add-bbox", is_flag=True, help="Automatically add bbox column and metadata if missing."
-)
+@bbox_option
 @output_format_options(default_rows=DEFAULT_SORT_ROW_GROUP_ROWS)
 @geoparquet_version_option
 @overwrite_option

--- a/geoparquet_io/cli/commands/sort.py
+++ b/geoparquet_io/cli/commands/sort.py
@@ -7,7 +7,7 @@ dependency runs one way, ``main`` -> ``commands`` -> ``_shared``/``decorators``.
 
 import click
 
-from geoparquet_io.cli._shared import _activate_s3, prepare_output
+from geoparquet_io.cli._shared import _activate_s3, init_group_context, prepare_output
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     allow_schema_diff_option,
@@ -21,7 +21,6 @@ from geoparquet_io.cli.decorators import (
 )
 from geoparquet_io.core.file_utils import validate_parquet_extension
 from geoparquet_io.core.hilbert_order import hilbert_order as hilbert_impl
-from geoparquet_io.core.logging_config import setup_cli_logging
 from geoparquet_io.core.parquet_writer import DEFAULT_SORT_ROW_GROUP_ROWS
 from geoparquet_io.core.sort_by_column import sort_by_column as sort_by_column_impl
 from geoparquet_io.core.sort_quadkey import sort_by_quadkey as sort_by_quadkey_impl
@@ -32,10 +31,7 @@ from geoparquet_io.core.str_order import str_order as str_impl
 @click.pass_context
 def sort(ctx):
     """Commands for sorting GeoParquet files."""
-    # Ensure logging is set up (in case this group is invoked directly in tests)
-    ctx.ensure_object(dict)
-    timestamps = ctx.obj.get("timestamps", False)
-    setup_cli_logging(verbose=False, show_timestamps=timestamps)
+    init_group_context(ctx)
 
 
 @sort.command(name="hilbert", cls=SingleFileCommand)

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -6,6 +6,7 @@ and reduce code duplication.
 """
 
 import functools
+import math
 
 import click
 
@@ -68,6 +69,77 @@ def parse_row_group_options(
         return size_bytes / (1024 * 1024)
     except ValueError as e:
         raise click.UsageError(f"Invalid row group size: {e}") from e
+
+
+# ``--approx``'s declared default, repeated here because exclusivity against
+# ``--exact`` is detected by comparing the received value against it. See the
+# note in ``resolve_kdtree_options``.
+_KDTREE_DEFAULT_APPROX = 100000
+
+# Rows per partition targeted when the user asks for neither ``--partitions``
+# nor ``--auto``, and the floor for a non-positive ``--auto``.
+_KDTREE_DEFAULT_TARGET_ROWS = 120000
+
+
+def resolve_kdtree_options(
+    partitions: int | None,
+    auto: int | None,
+    approx: int,
+    exact: bool,
+) -> tuple[int | None, int | None, tuple[str, int] | None]:
+    """Resolve the four KD-tree sizing options into what the core layer takes.
+
+    ``gpio add kdtree`` and ``gpio partition kdtree`` offer the same
+    ``--partitions``/``--auto``/``--approx``/``--exact`` quartet with the same
+    defaults, and each resolved it with its own copy of these rules. Since the
+    command groups moved into separate modules the two copies no longer sit next
+    to each other, so the shared wording of three ``UsageError`` messages had
+    nothing keeping it in step.
+
+    Args:
+        partitions: ``--partitions``, an explicit power-of-two partition count.
+        auto: ``--auto``, a target row count per partition.
+        approx: ``--approx``, the sample size for approximate medians.
+        exact: ``--exact``, computing medians over the full dataset instead.
+
+    Returns:
+        ``(iterations, sample_size, auto_target)`` -- the recursion depth
+        (``None`` in auto mode, where the core layer derives it), the sample size
+        (``None`` when exact), and the auto target as ``("rows", n)`` (``None``
+        when the partition count was explicit).
+
+    Raises:
+        click.UsageError: ``--partitions`` with ``--auto``, ``--exact`` with a
+            non-default ``--approx``, or a ``--partitions`` value that is not a
+            power of two of at least 2.
+
+    Note:
+        The ``--approx``/``--exact`` check compares ``approx`` against its
+        declared default rather than asking Click whether the user typed it, so
+        ``--exact --approx 100000`` is accepted silently. That is preserved
+        verbatim from both call sites: correcting it with a
+        ``ctx.get_parameter_source`` check would change behaviour, and belongs in
+        its own change (#919).
+    """
+    if sum([partitions is not None, auto is not None]) > 1:
+        raise click.UsageError("--partitions and --auto are mutually exclusive")
+
+    if partitions is None and auto is None:
+        auto = _KDTREE_DEFAULT_TARGET_ROWS
+
+    if partitions is not None and (partitions < 2 or (partitions & (partitions - 1)) != 0):
+        raise click.UsageError(f"Partitions must be a power of 2 (2, 4, 8, ...), got {partitions}")
+
+    if exact and approx != _KDTREE_DEFAULT_APPROX:
+        raise click.UsageError("--approx and --exact are mutually exclusive")
+
+    sample_size = None if exact else approx
+
+    if partitions is not None:
+        return int(math.log2(partitions)), sample_size, None
+
+    target_rows = auto if auto and auto > 0 else _KDTREE_DEFAULT_TARGET_ROWS
+    return None, sample_size, ("rows", target_rows)
 
 
 def compression_options(func):

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -71,14 +71,18 @@ def parse_row_group_options(
         raise click.UsageError(f"Invalid row group size: {e}") from e
 
 
-# ``--approx``'s declared default, repeated here because exclusivity against
-# ``--exact`` is detected by comparing the received value against it. See the
-# note in ``resolve_kdtree_options``.
-_KDTREE_DEFAULT_APPROX = 100000
+# ``--approx``'s default. ``gpio add kdtree`` and ``gpio partition kdtree`` both
+# declare the option with this value, and exclusivity against ``--exact`` is
+# detected by comparing the received value against it (see the note in
+# ``resolve_kdtree_options``), so the declarations import it from here rather
+# than repeating the literal: a second copy that drifted would make a bare
+# ``--exact`` start reporting a conflict with an ``--approx`` nobody typed.
+DEFAULT_KDTREE_APPROX = 100000
 
 # Rows per partition targeted when the user asks for neither ``--partitions``
-# nor ``--auto``, and the floor for a non-positive ``--auto``.
-_KDTREE_DEFAULT_TARGET_ROWS = 120000
+# nor ``--auto``, and the floor for a non-positive ``--auto``. Both commands
+# quote it in ``--auto``'s help text, so they import it too.
+DEFAULT_KDTREE_TARGET_ROWS = 120000
 
 
 def resolve_kdtree_options(
@@ -119,18 +123,18 @@ def resolve_kdtree_options(
         ``--exact --approx 100000`` is accepted silently. That is preserved
         verbatim from both call sites: correcting it with a
         ``ctx.get_parameter_source`` check would change behaviour, and belongs in
-        its own change (#919).
+        its own change (#951).
     """
     if sum([partitions is not None, auto is not None]) > 1:
         raise click.UsageError("--partitions and --auto are mutually exclusive")
 
     if partitions is None and auto is None:
-        auto = _KDTREE_DEFAULT_TARGET_ROWS
+        auto = DEFAULT_KDTREE_TARGET_ROWS
 
     if partitions is not None and (partitions < 2 or (partitions & (partitions - 1)) != 0):
         raise click.UsageError(f"Partitions must be a power of 2 (2, 4, 8, ...), got {partitions}")
 
-    if exact and approx != _KDTREE_DEFAULT_APPROX:
+    if exact and approx != DEFAULT_KDTREE_APPROX:
         raise click.UsageError("--approx and --exact are mutually exclusive")
 
     sample_size = None if exact else approx
@@ -138,7 +142,7 @@ def resolve_kdtree_options(
     if partitions is not None:
         return int(math.log2(partitions)), sample_size, None
 
-    target_rows = auto if auto and auto > 0 else _KDTREE_DEFAULT_TARGET_ROWS
+    target_rows = auto if auto and auto > 0 else DEFAULT_KDTREE_TARGET_ROWS
     return None, sample_size, ("rows", target_rows)
 
 

--- a/tests/cli/test_kdtree_option_resolution.py
+++ b/tests/cli/test_kdtree_option_resolution.py
@@ -1,0 +1,88 @@
+"""Unit tests for :func:`geoparquet_io.cli.decorators.resolve_kdtree_options`.
+
+``gpio add kdtree`` and ``gpio partition kdtree`` accept the same four sampling
+and partition-count options and resolved them with their own copy of the same
+~20 lines, in two different files. These tests pin the resolution -- including
+the one quirk it deliberately preserves -- so the two commands cannot drift.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from geoparquet_io.cli.decorators import resolve_kdtree_options
+
+
+class TestExplicitPartitions:
+    @pytest.mark.parametrize(
+        ("partitions", "iterations"),
+        [(2, 1), (4, 2), (8, 3), (1024, 10)],
+    )
+    def test_partition_count_becomes_log2_iterations(self, partitions, iterations):
+        assert resolve_kdtree_options(partitions, None, 100_000, False) == (
+            iterations,
+            100_000,
+            None,
+        )
+
+    @pytest.mark.parametrize("partitions", [0, 1, 3, 6, 100, -4])
+    def test_rejects_a_count_that_is_not_a_power_of_two(self, partitions):
+        with pytest.raises(click.UsageError) as excinfo:
+            resolve_kdtree_options(partitions, None, 100_000, False)
+        assert str(excinfo.value) == (
+            f"Partitions must be a power of 2 (2, 4, 8, ...), got {partitions}"
+        )
+
+
+class TestAutoMode:
+    def test_defaults_to_120k_rows_when_neither_option_is_given(self):
+        assert resolve_kdtree_options(None, None, 100_000, False) == (
+            None,
+            100_000,
+            ("rows", 120_000),
+        )
+
+    def test_explicit_target_rows(self):
+        assert resolve_kdtree_options(None, 50_000, 100_000, False) == (
+            None,
+            100_000,
+            ("rows", 50_000),
+        )
+
+    @pytest.mark.parametrize("auto", [0, -1])
+    def test_a_non_positive_target_falls_back_to_120k(self, auto):
+        assert resolve_kdtree_options(None, auto, 100_000, False)[2] == ("rows", 120_000)
+
+    def test_partitions_and_auto_are_mutually_exclusive(self):
+        with pytest.raises(click.UsageError) as excinfo:
+            resolve_kdtree_options(8, 50_000, 100_000, False)
+        assert str(excinfo.value) == "--partitions and --auto are mutually exclusive"
+
+
+class TestSampling:
+    def test_exact_disables_sampling(self):
+        assert resolve_kdtree_options(8, None, 100_000, True) == (3, None, None)
+
+    def test_approx_sets_the_sample_size(self):
+        assert resolve_kdtree_options(8, None, 25_000, False) == (3, 25_000, None)
+
+    def test_exact_with_a_non_default_approx_is_rejected(self):
+        with pytest.raises(click.UsageError) as excinfo:
+            resolve_kdtree_options(8, None, 25_000, True)
+        assert str(excinfo.value) == "--approx and --exact are mutually exclusive"
+
+    def test_exact_with_approx_left_at_its_default_is_accepted(self):
+        # Known quirk, preserved verbatim from both call sites: exclusivity is
+        # detected by comparing --approx against its default, so
+        # `--exact --approx 100000` passes silently instead of being rejected.
+        # Fixing it means a ParameterSource check and is a behaviour change; it
+        # is tracked in #919, not made here.
+        assert resolve_kdtree_options(8, None, 100_000, True) == (3, None, None)
+
+
+def test_exclusivity_is_checked_before_the_power_of_two_rule():
+    # Both are wrong; the pair error is the one both commands raise today.
+    with pytest.raises(click.UsageError) as excinfo:
+        resolve_kdtree_options(3, 50_000, 100_000, False)
+    assert str(excinfo.value) == "--partitions and --auto are mutually exclusive"

--- a/tests/cli/test_kdtree_option_resolution.py
+++ b/tests/cli/test_kdtree_option_resolution.py
@@ -77,7 +77,7 @@ class TestSampling:
         # detected by comparing --approx against its default, so
         # `--exact --approx 100000` passes silently instead of being rejected.
         # Fixing it means a ParameterSource check and is a behaviour change; it
-        # is tracked in #919, not made here.
+        # is tracked in #951, not made here.
         assert resolve_kdtree_options(8, None, 100_000, True) == (3, None, None)
 
 

--- a/tests/cli/test_shared_group_context.py
+++ b/tests/cli/test_shared_group_context.py
@@ -1,0 +1,78 @@
+"""Unit tests for :func:`geoparquet_io.cli._shared.init_group_context`.
+
+Every ``gpio`` subgroup opened with the same three lines. The two behaviours
+worth pinning are that ``ctx.obj`` is primed even when the root ``gpio``
+callback never ran -- which is what a ``CliRunner().invoke(add, ...)`` in a test
+does -- and that ``--timestamps``, set by the root callback, reaches
+``setup_cli_logging``.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli._shared import init_group_context
+from geoparquet_io.cli.main import cli
+
+
+@pytest.fixture
+def logging_spy():
+    with mock.patch("geoparquet_io.cli._shared.setup_cli_logging") as spy:
+        yield spy
+
+
+def test_primes_a_missing_context_object(logging_spy):
+    ctx = click.Context(click.Command("x"))
+    assert ctx.obj is None
+
+    init_group_context(ctx)
+
+    assert ctx.obj == {}
+    logging_spy.assert_called_once_with(verbose=False, show_timestamps=False)
+
+
+def test_leaves_an_existing_context_object_alone(logging_spy):
+    ctx = click.Context(click.Command("x"))
+    ctx.obj = {"timestamps": True, "aws_profile": "prod"}
+
+    init_group_context(ctx)
+
+    assert ctx.obj == {"timestamps": True, "aws_profile": "prod"}
+    logging_spy.assert_called_once_with(verbose=False, show_timestamps=True)
+
+
+GROUPS_USING_THE_HELPER = [
+    "add",
+    "check",
+    "convert",
+    "extract",
+    "inspect",
+    "partition",
+    "publish",
+    "sort",
+]
+
+
+@pytest.mark.parametrize("group", GROUPS_USING_THE_HELPER)
+def test_group_invoked_standalone_does_not_crash(group):
+    # A group object reached without the root callback has ctx.obj None, so the
+    # group callback is the first thing that touches it (cf. #922). ``--help``
+    # on a *subcommand* is used rather than on the group, because Click prints
+    # a group's own help during parsing, before the callback ever runs.
+    command = cli.commands[group]
+    subcommand = sorted(command.commands)[0]
+
+    result = CliRunner().invoke(command, [subcommand, "--help"])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_timestamps_flag_reaches_the_logger_through_a_group(logging_spy):
+    result = CliRunner().invoke(cli, ["--timestamps", "add", "bbox", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert logging_spy.call_args_list == [mock.call(verbose=False, show_timestamps=True)]

--- a/tests/cli/test_shared_group_context.py
+++ b/tests/cli/test_shared_group_context.py
@@ -15,13 +15,19 @@ import click
 import pytest
 from click.testing import CliRunner
 
+from geoparquet_io.cli import _shared
 from geoparquet_io.cli._shared import init_group_context
 from geoparquet_io.cli.main import cli
 
 
 @pytest.fixture
 def logging_spy():
-    with mock.patch("geoparquet_io.cli._shared.setup_cli_logging") as spy:
+    # `patch.object`, not the dotted string form: `geoparquet_io/__init__.py`
+    # does `from geoparquet_io.cli.main import cli`, which rebinds the name
+    # `geoparquet_io.cli` to the Click Group. On Python 3.10 mock resolves the
+    # target by walking that name and gets `AttributeError: 'Group' object has
+    # no attribute '_shared'`. The module object imported above is unambiguous.
+    with mock.patch.object(_shared, "setup_cli_logging") as spy:
         yield spy
 
 

--- a/tests/cli/test_shared_prepare_output.py
+++ b/tests/cli/test_shared_prepare_output.py
@@ -66,10 +66,10 @@ class TestMissingOutputGuard:
         with mock.patch.object(sys.stdout, "isatty", return_value=False):
             assert prepare_output(None, False, None, None) is None
 
-    def test_output_guard_runs_before_the_extension_check(self):
+    def test_output_guard_runs_before_the_row_group_parse(self):
         # Both would fail; the streaming hint is the more useful message, so it
-        # must win. Reordering the helper's steps would surface the extension
-        # error instead.
+        # must win. Reordering the helper's steps would surface the row-group
+        # mutual-exclusion error instead.
         with mock.patch.object(sys.stdout, "isatty", return_value=True):
             with pytest.raises(click.ClickException) as excinfo:
                 prepare_output(None, False, 50_000, "256MB")

--- a/tests/cli/test_shared_prepare_output.py
+++ b/tests/cli/test_shared_prepare_output.py
@@ -1,0 +1,76 @@
+"""Unit tests for :func:`geoparquet_io.cli._shared.prepare_output`.
+
+``prepare_output`` is the extracted form of a prologue that ran verbatim at the
+top of nine write commands. These tests pin the three steps it performs, the
+order it performs them in, and the exception type each one surfaces -- that
+ordering is what makes the "missing output" hint reach a user who also typed a
+non-``.parquet`` filename.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import click
+import pytest
+
+from geoparquet_io.cli._shared import prepare_output
+from geoparquet_io.core.exceptions import InvalidParameterError
+
+
+class TestRowGroupResult:
+    """The return value is exactly what ``parse_row_group_options`` produces."""
+
+    def test_returns_none_when_neither_row_group_option_given(self):
+        assert prepare_output("out.parquet", False, None, None) is None
+
+    def test_returns_none_for_row_based_sizing(self):
+        # Row-based sizing is passed through by the caller, not converted to MB.
+        assert prepare_output("out.parquet", False, 50_000, None) is None
+
+    def test_returns_megabytes_for_size_string(self):
+        assert prepare_output("out.parquet", False, None, "256MB") == pytest.approx(256.0)
+
+    def test_rejects_both_row_group_options(self):
+        with pytest.raises(click.UsageError, match="mutually exclusive"):
+            prepare_output("out.parquet", False, 50_000, "256MB")
+
+
+class TestExtensionCheck:
+    """``--any-extension`` is honoured, and the error type is unchanged."""
+
+    def test_rejects_non_parquet_extension(self):
+        with pytest.raises(InvalidParameterError, match="does not have .parquet extension"):
+            prepare_output("out.csv", False, None, None)
+
+    def test_any_extension_allows_anything(self):
+        assert prepare_output("out.csv", True, None, None) is None
+
+    def test_stream_marker_is_not_extension_checked(self):
+        with mock.patch.object(sys.stdout, "isatty", return_value=False):
+            assert prepare_output("-", False, None, None) is None
+
+
+class TestMissingOutputGuard:
+    """A missing output raises ``ClickException``, with the traceback suppressed."""
+
+    def test_missing_output_on_a_terminal_is_a_click_exception(self):
+        with mock.patch.object(sys.stdout, "isatty", return_value=True):
+            with pytest.raises(click.ClickException) as excinfo:
+                prepare_output(None, False, None, None)
+        assert "Missing output" in str(excinfo.value)
+        assert excinfo.value.__cause__ is None
+
+    def test_missing_output_when_piped_is_allowed(self):
+        with mock.patch.object(sys.stdout, "isatty", return_value=False):
+            assert prepare_output(None, False, None, None) is None
+
+    def test_output_guard_runs_before_the_extension_check(self):
+        # Both would fail; the streaming hint is the more useful message, so it
+        # must win. Reordering the helper's steps would surface the extension
+        # error instead.
+        with mock.patch.object(sys.stdout, "isatty", return_value=True):
+            with pytest.raises(click.ClickException) as excinfo:
+                prepare_output(None, False, 50_000, "256MB")
+        assert "Missing output" in str(excinfo.value)

--- a/tests/test_patch_target_shadowing.py
+++ b/tests/test_patch_target_shadowing.py
@@ -1,0 +1,105 @@
+"""Forbid dotted ``mock.patch`` targets that walk through ``geoparquet_io.cli``.
+
+``geoparquet_io/__init__.py`` does ``from geoparquet_io.cli.main import cli``.
+That import binds the *name* ``cli`` inside the ``geoparquet_io`` package to the
+Click ``Group`` object, shadowing the ``geoparquet_io.cli`` **subpackage** as an
+attribute of its own parent::
+
+    >>> import geoparquet_io, geoparquet_io.cli
+    >>> type(geoparquet_io.cli)
+    <class 'click.core.Group'>
+    >>> hasattr(geoparquet_io.cli, "_shared")
+    False
+
+``mock.patch`` resolves a dotted string target by importing the longest prefix
+it can and then walking the rest with ``getattr``. When the walk reaches
+``geoparquet_io.cli`` it finds the ``Group``, and the next step fails::
+
+    AttributeError: 'Group' object has no attribute '_shared'
+
+Whether that happens depends on how much of the target ``mock`` manages to
+import before it starts walking, which differs across Python versions -- so a
+test written this way can pass locally and on most of the CI matrix while
+failing on exactly one interpreter. It has cost this repo three times now
+(``test_write_memory_forwarding.py`` and ``test_check_cli_guards.py`` both
+carry warning comments about it; ``test_shared_group_context.py`` hit it on
+Python 3.10 only, after passing on 3.11, 3.12 and 3.13).
+
+``mock.patch.object(module, "name")`` takes the module object directly, so there
+is no name to walk and no version-dependent behaviour. Import the module and use
+that instead.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.meta
+
+TESTS_DIR = Path(__file__).parent
+
+#: Any patch target starting with this prefix walks through the shadowed name.
+SHADOWED_PREFIX = "geoparquet_io.cli."
+
+_PATCH_FUNCS = {"patch", "patch.object", "mock.patch"}
+
+
+def _patch_string_targets(tree: ast.AST):
+    """Yield ``(lineno, target)`` for every ``patch("...")``-style call."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+
+        func = node.func
+        # `patch(...)`, `mock.patch(...)`, `unittest.mock.patch(...)` -- but NOT
+        # `patch.object(...)`, which takes a module object as its first argument.
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        else:
+            continue
+        if name != "patch":
+            continue
+
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            yield node.lineno, first.value
+
+
+def test_no_dotted_patch_target_walks_through_the_cli_package():
+    offenders = []
+
+    for path in sorted(TESTS_DIR.rglob("test_*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for lineno, target in _patch_string_targets(tree):
+            if target.startswith(SHADOWED_PREFIX):
+                offenders.append(f"{path.relative_to(TESTS_DIR.parent)}:{lineno}: {target}")
+
+    assert not offenders, (
+        "These dotted patch targets walk through `geoparquet_io.cli`, which "
+        "`geoparquet_io/__init__.py` rebinds to a Click Group. They resolve on "
+        "some Python versions and raise `AttributeError: 'Group' object has no "
+        "attribute ...` on others.\n\n"
+        + "\n".join(offenders)
+        + '\n\nImport the module and use `mock.patch.object(module, "name")`.'
+    )
+
+
+def test_the_shadowing_this_guard_exists_for_is_real():
+    """If the shadowing ever goes away, this guard can go with it."""
+    import click
+
+    import geoparquet_io
+    import geoparquet_io.cli  # noqa: F401  -- imported for its side effect
+
+    assert isinstance(geoparquet_io.cli, click.Group), (
+        "`geoparquet_io.cli` no longer resolves to the Click Group, so the "
+        "patch-target hazard this module guards may be gone. Re-check before "
+        "deleting: the guard is cheap and the failure mode is version-specific."
+    )


### PR DESCRIPTION
## What changed

Four extractions, one commit each, in `cli/commands/*.py`, `cli/_shared.py` and
`cli/decorators.py`. Together they remove **257 lines from the command modules**
and add 143 to the two shared modules.

**1. `_shared.prepare_output(...)` — the output-validation prologue** (`-133/+30`)

The same three checks — guard the output against a missing destination, reject a
non-`.parquet` extension, parse the mutually exclusive row-group options — were
spelled out in full at the top of **ten** call sites across nine commands: `add bbox`, `add h3`,
`add a5`, `add s2`, `add quadkey`, `sort hilbert`, `sort str`,
`extract geoparquet`, `extract bigquery` and `convert` (10 sites; `convert`
folded its import in with `should_stream_output`). One helper now does all three
and returns the row-group size in MB. **No `validate_output` call remains in
`cli/`.**

Only the **guard-side** `except StreamingError` is absorbed. The five
**call-side** handlers in `add.py` — the ones wrapping the core `*_impl` call —
stay put: each wraps a different core function and the `from None` there is
deliberate traceback suppression a shared helper would hide.

**2. `_shared.init_group_context(ctx)` — the group callback** (`-45/+24`)

`add`, `check`, `convert`, `extract`, `inspect`, `partition`, `publish` and
`sort` all opened with the same three statements, and eight modules imported
`setup_cli_logging` for nothing else. The root `gpio` callback in `main.py` keeps
its own body — it *writes* `ctx.obj["timestamps"]` rather than reading it.

**3. `bbox_option` adopted for `--add-bbox`** (`-9/+5`)

The decorator had zero production callers while three commands declared its
byte-identical literal inline. Adopted rather than deleted.

**4. `decorators.resolve_kdtree_options(...)`** (`-70/+8`)

`add kdtree` and `partition kdtree` each turned the same
`--partitions`/`--auto`/`--approx`/`--exact` quartet into the same
`(iterations, sample_size, auto_target)` triple with their own ~25-line copy,
including three `UsageError` messages that had to stay worded identically with
nothing enforcing it. The two copies were already written differently, and #916
moved them into separate files, so the next divergence would have been invisible.

Behaviour is preserved exactly, including the quirk that `--exact` is checked
against `--approx`'s *default value* rather than against whether the user typed
it, so `--exact --approx 100000` is still accepted silently. That is now written
down in one place with a pointer to this issue instead of being an unremarked
line in two files — fixing it needs a `ParameterSource` check and is a
user-visible change.

41 new unit tests cover the three new helpers (20 kdtree, 11 group-context, 10 prepare-output).

## Why

The #916 module split did not create any of this duplication; it made it
legible. The counts in #919 were re-measured against `main` before starting —
line numbers had shifted, and the prologue turned out to appear at **ten** sites
rather than seven, with no guard-only residue left over.

### Judged not worth extracting

**Issue item 2, a `standard_write_options` composite decorator** (~120 lines).
Declined. There is no single stack to name: `add` uses a 7-decorator stack (7
sites), `partition` a differently-ordered 4 (7 sites), `sort` a 6 with
`default_rows=` (4 sites), and the one-offs in `convert`/`extract` match none of
them. Naming each group's current accident gives three composites that differ by
one or two options, and the first time a group gains one the composite grows a
boolean parameter — worse than the duplication. It would also only halve the
copy-paste it targets: every option still has to be named in the function
signature. `output_format_options` is the right precedent for a *cohesive* bundle
(five knobs that all describe the output file's physical layout); "everything
`gpio add` happens to accept" is not one.

**A second helper for the extension + row-group pair** (6 adjacent sites).
Declined. Those two statements name exactly what they do; replacing them with one
four-argument call that wraps to three lines is longer *and* less clear. Adding a
`require_output=False` flag to `prepare_output` is worse still: none of these
sites calls the streaming guard today, so adopting the helper would *add*
behaviour rather than preserve it, and passing `-` would newly emit a
"Writing binary Arrow IPC data to terminal" warning.

(An earlier draft of this paragraph said OUTPUT is a required argument at all of
these commands. That is true for some — `add h3`'s OUTPUT is required — but not
for `add admin-divisions`, `add geometry-metrics`, `convert reproject` or
`extract wfs`, which all declare `required=False, default=None`. Each exclusion
still stands; the reason is the one above, that the guard was never there to
begin with, not that it could not apply.)

**Issue item 6, the triplicated bbox parsing in `extract.py`.** Declined, with a
measurement worth recording: the three copies raise **different** inner
`ValueError` messages ("bbox must have exactly 4 values" vs "Expected 4 values"),
and `arcgis` interpolates its one into the user-facing text, so unifying them
changes a user-visible string. More importantly, the issue's claim that this
makes the `pyproject.toml` mypy override "disappear entirely" does not hold: with
the override lifted, `extract.py` emits 5 `arg-type` errors, and only **4** are
the bbox tuple. The fifth is
`row_group_size_mb: float | None` vs `int | None` on
`convert_arcgis_to_geoparquet` — a `core/arcgis.py` annotation, so the override
survives either way. This belongs with a `core/` annotation pass.

**Aligning `sort hilbert`/`sort str` to wrap their impl call in
`except StreamingError`**, as a second reviewer suggested in the issue. That is a
behaviour change (a traceback becomes a `ClickException`), not a refactor.

## Verification

- `git diff --stat origin/main -- tests/data/cli_surface.json` is **empty** — the
  snapshot is byte-identical, and `tests/test_cli_surface.py` was green after
  every one of the four commits. The snapshot was never re-recorded.
- Fast suite: `uv run pytest -n auto -m "not slow and not network and not meta" -q`
  → **6489 passed, 75 skipped, 9 xfailed** in 317s. Two subprocess-pipe tests
  (`test_streaming_handles_broken_pipe`, `test_zero_row_pipe_to_add_bbox`) failed
  on the saturated parallel run and pass both serially and on a re-run under
  `-n auto` — machine saturation, not the change.
- Meta lane: `uv run pytest -m meta -q` → **203 passed**.
- `uv run pre-commit run --all-files` clean; `--hook-stage pre-push` clean
  (deptry, mypy, vulture, xenon, import-linter, menard-check, fast-tests).

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

