### PR TITLE
fix(inspect): stop counting bbox struct children as top-level columns

### DIFF
--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -166,12 +166,23 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
             if isinstance(field_type, pa.BaseExtensionType):
                 field_type = field_type.storage_type
 
+            # Only field-bearing types are iterable, so a list/map column
+            # renders as a single row with no children while a struct renders
+            # its fields. ``num_children`` therefore has to count the rows this
+            # listing actually goes on to emit, not the type's fields --
+            # consumers read the listing as a depth-first tree and skip a
+            # subtree by that count, so a column claiming children it never
+            # emits swallows the next root column (issue #931). Nested struct
+            # children are emitted with ``num_children: 0`` for the same
+            # reason: their own fields are not rendered either.
+            children = list(field.type) if hasattr(field.type, "__iter__") else []
+
             col_info = {
                 "name": field.name,
                 "type": str(field_type),
                 "type_length": None,
                 "repetition_type": "OPTIONAL" if field.nullable else "REQUIRED",
-                "num_children": 0,
+                "num_children": len(children),
                 "converted_type": None,
                 "scale": None,
                 "precision": None,
@@ -181,28 +192,22 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
                 "logical_type": logical_type,
             }
 
-            # Handle struct types
-            if hasattr(field.type, "num_fields"):
-                col_info["num_children"] = field.type.num_fields
-
             result.append(col_info)
 
-            # Add child fields for struct types
-            if hasattr(field.type, "__iter__"):
-                for child_field in field.type:
-                    child_info = {
-                        "name": child_field.name,
-                        "type": str(child_field.type),
-                        "type_length": None,
-                        "repetition_type": "OPTIONAL" if child_field.nullable else "REQUIRED",
-                        "num_children": 0,
-                        "converted_type": None,
-                        "scale": None,
-                        "precision": None,
-                        "field_id": None,
-                        "logical_type": None,
-                    }
-                    result.append(child_info)
+            for child_field in children:
+                child_info = {
+                    "name": child_field.name,
+                    "type": str(child_field.type),
+                    "type_length": None,
+                    "repetition_type": "OPTIONAL" if child_field.nullable else "REQUIRED",
+                    "num_children": 0,
+                    "converted_type": None,
+                    "scale": None,
+                    "precision": None,
+                    "field_id": None,
+                    "logical_type": None,
+                }
+                result.append(child_info)
 
         return result
     except ValueError as e:

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -22,6 +22,7 @@ import pyarrow.parquet as pq
 from geoparquet_io.core.crs_utils import geoarrow_crs_to_projjson, merge_longitude_ranges
 from geoparquet_io.core.duckdb_utils import _escape_sql_string, sql_path
 from geoparquet_io.core.exceptions import GeoParquetError
+from geoparquet_io.core.parquet_schema import root_schema_columns
 
 # =============================================================================
 # PyArrow Fast Path for Local Files (Issue #232 Performance Fix)
@@ -553,8 +554,9 @@ def get_schema_info(parquet_file: str, con=None) -> list[dict]:
 def get_column_names(parquet_file: str, con=None) -> list[str]:
     """Get list of column names from schema."""
     schema = get_schema_info(parquet_file, con)
-    # Filter out empty names (schema root element) and nested struct fields
-    return [col["name"] for col in schema if col.get("name") and "." not in col["name"]]
+    # Filter out the schema root element and nested struct fields: the listing is
+    # depth first, so a struct's children have to be skipped as whole subtrees.
+    return [col["name"] for col in root_schema_columns(schema)]
 
 
 def get_usable_columns(parquet_file: str, con=None) -> list[dict]:

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -15,6 +15,7 @@ from contextvars import ContextVar
 import duckdb
 
 from geoparquet_io.core.logging_config import warn
+from geoparquet_io.core.parquet_schema import root_schema_columns
 
 # Per-bucket cache for S3 buckets that require authentication
 # Buckets not in this set are accessed without credentials (works for public buckets)
@@ -791,7 +792,7 @@ class _DuckDBSchemaWrapper:
     """Wrapper to provide PyArrow-like interface for DuckDB schema info."""
 
     def __init__(self, schema_info):
-        self._columns = [c for c in schema_info if c.get("name") and "." not in c.get("name", "")]
+        self._columns = root_schema_columns(schema_info)
 
     def __len__(self):
         return len(self._columns)

--- a/geoparquet_io/core/metadata_utils.py
+++ b/geoparquet_io/core/metadata_utils.py
@@ -12,6 +12,7 @@ from rich.table import Table
 from rich.text import Text
 
 from geoparquet_io.core.common import format_size
+from geoparquet_io.core.parquet_schema import root_schema_columns
 
 
 def _calculate_overall_bbox(row_group_stats: list[dict]) -> dict[str, float] | None:
@@ -380,12 +381,9 @@ def format_parquet_metadata_enhanced(
     geo_columns = detect_geometry_columns(parquet_file)
     bloom_filter_info = get_bloom_filter_info(parquet_file)
 
-    num_columns = len([c for c in schema_info if c.get("name") and "." not in c.get("name", "")])
-    schema_str = ", ".join(
-        f"{c['name']}: {c.get('type', 'unknown')}"
-        for c in schema_info
-        if c.get("name") and "." not in c.get("name", "")
-    )
+    root_columns = root_schema_columns(schema_info)
+    num_columns = len(root_columns)
+    schema_str = ", ".join(f"{c['name']}: {c.get('type', 'unknown')}" for c in root_columns)
 
     rg_columns: dict[int, list] = {}
     for col in row_group_meta:

--- a/geoparquet_io/core/parquet_schema.py
+++ b/geoparquet_io/core/parquet_schema.py
@@ -1,0 +1,80 @@
+"""Walking the flat Parquet schema listing returned by ``get_schema_info()``.
+
+The listing is depth first: a struct's children follow their parent, so telling
+a root-level column from a nested field means skipping whole subtrees rather
+than pattern-matching names. Nothing in either listing shape renders a dotted
+path, which is why a ``"." not in name`` filter silently kept every struct child.
+
+Two shapes reach these helpers. DuckDB's ``parquet_schema()`` prefixes the
+listing with the file's root group element -- every row carries a ``file_name``
+and the root alone has no ``type`` -- while the pyarrow fast path starts straight
+at the first column and always renders a ``type`` string.
+
+This module deliberately imports nothing from the rest of the package: it sits
+below ``duckdb_metadata``, ``duckdb_utils``, ``metadata_utils`` and ``validate``,
+all of which share it.
+"""
+
+
+def schema_subtree_end(schema_info: list, index: int) -> int:
+    """Index just past the depth-first subtree rooted at ``schema_info[index]``."""
+    end = index + 1
+    for _ in range(schema_info[index].get("num_children") or 0):
+        if end >= len(schema_info):
+            break
+        end = schema_subtree_end(schema_info, end)
+    return end
+
+
+def schema_root_offset(schema_info: list) -> int:
+    """Index at which the root-level columns start: 0 or 1.
+
+    Skips DuckDB's leading root group element; the pyarrow shape has none.
+    """
+    if not schema_info:
+        return 0
+    first = schema_info[0]
+    return 1 if "file_name" in first and first.get("type") is None else 0
+
+
+def root_schema_columns(schema_info: list) -> list[dict]:
+    """Root-level schema entries, struct children and the root group excluded.
+
+    Entries with an empty name are dropped: the schema root element renders that
+    way in some listings and is never a user-facing column.
+    """
+    columns = []
+    index = schema_root_offset(schema_info)
+    while index < len(schema_info):
+        if schema_info[index].get("name"):
+            columns.append(schema_info[index])
+        index = schema_subtree_end(schema_info, index)
+    return columns
+
+
+def root_schema_index(schema_info: list, name: str) -> int | None:
+    """Index of the root-level schema entry called ``name``, else ``None``.
+
+    Scanning the listing for the first entry of a given name can return a
+    *nested* field (say ``meta.bbox``) and shadow the real root column of the
+    same name. Skipping whole subtrees is also what enforces the GeoParquet
+    v1.1.0 rule that the covering bbox column is at the root of the schema.
+    """
+    index = schema_root_offset(schema_info)
+    while index < len(schema_info):
+        if schema_info[index].get("name") == name:
+            return index
+        index = schema_subtree_end(schema_info, index)
+    return None
+
+
+def schema_direct_children(schema_info: list, index: int) -> list[dict]:
+    """Direct children of ``schema_info[index]``, grandchildren excluded."""
+    children = []
+    child = index + 1
+    for _ in range(schema_info[index].get("num_children") or 0):
+        if child >= len(schema_info):
+            break
+        children.append(schema_info[child])
+        child = schema_subtree_end(schema_info, child)
+    return children

--- a/geoparquet_io/core/parquet_schema.py
+++ b/geoparquet_io/core/parquet_schema.py
@@ -10,16 +10,55 @@ listing with the file's root group element -- every row carries a ``file_name``
 and the root alone has no ``type`` -- while the pyarrow fast path starts straight
 at the first column and always renders a ``type`` string.
 
+Both shapes must keep one invariant: an entry's ``num_children`` counts the rows
+the listing goes on to emit for it, not the fields its type declares. Skipping a
+subtree by a count the rows do not back up consumes the parent's next *sibling*,
+which is how root-level list and map columns hid the column after them (#931).
+
 This module deliberately imports nothing from the rest of the package: it sits
 below ``duckdb_metadata``, ``duckdb_utils``, ``metadata_utils`` and ``validate``,
 all of which share it.
 """
 
 
+def _is_leaf_entry(entry: dict) -> bool:
+    """True when the entry's own type rules out any subtree beneath it.
+
+    Both shapes make a leaf recognisable. DuckDB renders a physical type on
+    leaves only (``BYTE_ARRAY``, ``INT64``...) and leaves a group's ``type`` at
+    ``None``; pyarrow renders every field-bearing type with a ``<``
+    (``struct<...>``, ``list<...>``, ``map<...>``) that no primitive spelling
+    carries.
+    """
+    entry_type = entry.get("type")
+    return isinstance(entry_type, str) and "<" not in entry_type
+
+
+def schema_entry_is_group(entry: dict) -> bool:
+    """True when ``entry`` is a nested (group) field rather than a leaf.
+
+    ``num_children`` alone does not answer this: the pyarrow fast path renders
+    no child rows for a list or map, so a nested column there declares none.
+    """
+    return not _is_leaf_entry(entry)
+
+
+def _declared_children(entry: dict) -> int:
+    """How many following rows ``entry`` may claim as its children.
+
+    Belt and braces around a malformed listing: a leaf can never own a subtree,
+    so a leaf entry's ``num_children`` is ignored rather than allowed to eat the
+    columns after it.
+    """
+    if _is_leaf_entry(entry):
+        return 0
+    return entry.get("num_children") or 0
+
+
 def schema_subtree_end(schema_info: list, index: int) -> int:
     """Index just past the depth-first subtree rooted at ``schema_info[index]``."""
     end = index + 1
-    for _ in range(schema_info[index].get("num_children") or 0):
+    for _ in range(_declared_children(schema_info[index])):
         if end >= len(schema_info):
             break
         end = schema_subtree_end(schema_info, end)
@@ -72,7 +111,7 @@ def schema_direct_children(schema_info: list, index: int) -> list[dict]:
     """Direct children of ``schema_info[index]``, grandchildren excluded."""
     children = []
     child = index + 1
-    for _ in range(schema_info[index].get("num_children") or 0):
+    for _ in range(_declared_children(schema_info[index])):
         if child >= len(schema_info):
             break
         children.append(schema_info[child])

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -33,7 +33,11 @@ from geoparquet_io.core.duckdb_utils import (
     sql_path,
 )
 from geoparquet_io.core.exceptions import GeoParquetError
-from geoparquet_io.core.parquet_schema import root_schema_index, schema_direct_children
+from geoparquet_io.core.parquet_schema import (
+    root_schema_index,
+    schema_direct_children,
+    schema_entry_is_group,
+)
 
 
 class CheckStatus(Enum):
@@ -802,9 +806,11 @@ def _check_geometry_not_grouped(
                     "group at the schema root",
                     category="parquet_schema",
                 )
-            # Check if it has children (would indicate a struct/group)
-            num_children = col.get("num_children") or 0
-            if num_children > 0:
+            # A group field is one the listing renders as nested, whether or not
+            # it renders child rows: the pyarrow fast path gives a list or map
+            # column no children at all, so counting them would wave through a
+            # geometry column stored as a list under a declared "WKB" encoding.
+            if schema_entry_is_group(col):
                 return ValidationCheck(
                     name=f"geometry_not_grouped_{geom_col}",
                     status=CheckStatus.FAILED,

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -33,6 +33,7 @@ from geoparquet_io.core.duckdb_utils import (
     sql_path,
 )
 from geoparquet_io.core.exceptions import GeoParquetError
+from geoparquet_io.core.parquet_schema import root_schema_index, schema_direct_children
 
 
 class CheckStatus(Enum):
@@ -1780,60 +1781,6 @@ def _check_covering_bbox_paths(col_meta: dict, col_name: str) -> ValidationCheck
     )
 
 
-def _schema_subtree_end(schema_info: list, index: int) -> int:
-    """Index just past the depth-first subtree rooted at ``schema_info[index]``."""
-    end = index + 1
-    for _ in range(schema_info[index].get("num_children") or 0):
-        if end >= len(schema_info):
-            break
-        end = _schema_subtree_end(schema_info, end)
-    return end
-
-
-def _schema_root_offset(schema_info: list) -> int:
-    """Index at which the root-level columns start: 0 or 1.
-
-    ``get_schema_info()`` returns the same flat depth-first listing in two
-    shapes. DuckDB's ``parquet_schema()`` prefixes it with the file's root group
-    element -- every row carries a ``file_name`` and the root alone has no
-    ``type`` -- while the pyarrow fast path starts straight at the first column
-    and always renders a ``type`` string.
-    """
-    if not schema_info:
-        return 0
-    first = schema_info[0]
-    return 1 if "file_name" in first and first.get("type") is None else 0
-
-
-def _root_schema_index(schema_info: list, name: str) -> int | None:
-    """Index of the root-level schema entry called ``name``, else ``None``.
-
-    The listing is depth first, so a struct's children sit between their parent
-    and the next root column: scanning it for the first entry of a given name can
-    return a *nested* field (say ``meta.bbox``) and shadow the real root column
-    of the same name. Skipping whole subtrees is also what enforces the v1.1.0
-    rule that the covering bbox column is at the root of the schema.
-    """
-    index = _schema_root_offset(schema_info)
-    while index < len(schema_info):
-        if schema_info[index].get("name") == name:
-            return index
-        index = _schema_subtree_end(schema_info, index)
-    return None
-
-
-def _schema_direct_children(schema_info: list, index: int) -> list[dict]:
-    """Direct children of ``schema_info[index]``, grandchildren excluded."""
-    children = []
-    child = index + 1
-    for _ in range(schema_info[index].get("num_children") or 0):
-        if child >= len(schema_info):
-            break
-        children.append(schema_info[child])
-        child = _schema_subtree_end(schema_info, child)
-    return children
-
-
 def _bbox_column_missing(check_name: str, bbox_col_name: str, schema_info: list) -> ValidationCheck:
     """FAILED for a covering bbox column that is not a root-level column."""
     nested = any(col.get("name") == bbox_col_name for col in schema_info)
@@ -1878,7 +1825,7 @@ def _check_covering_bbox_column_exists(
         )
 
     check_name = f"covering_bbox_column_exists_{col_name}"
-    if _root_schema_index(schema_info, bbox_col_name) is None:
+    if root_schema_index(schema_info, bbox_col_name) is None:
         return _bbox_column_missing(check_name, bbox_col_name, schema_info)
 
     return ValidationCheck(
@@ -1922,11 +1869,11 @@ def _check_covering_bbox_structure(
         )
 
     check_name = f"covering_bbox_structure_{col_name}"
-    index = _root_schema_index(schema_info, bbox_col_name)
+    index = root_schema_index(schema_info, bbox_col_name)
     if index is None:
         return _bbox_column_missing(check_name, bbox_col_name, schema_info)
 
-    found_fields = [c.get("name") for c in _schema_direct_children(schema_info, index)]
+    found_fields = [c.get("name") for c in schema_direct_children(schema_info, index)]
 
     if found_fields != _BBOX_FIELDS.get(len(found_fields)):
         return ValidationCheck(
@@ -1971,7 +1918,7 @@ def _check_covering_bbox_field_types(
         )
 
     check_name = f"covering_bbox_field_types_{col_name}"
-    index = _root_schema_index(schema_info, bbox_col_name)
+    index = root_schema_index(schema_info, bbox_col_name)
     if index is None:
         return _bbox_column_missing(check_name, bbox_col_name, schema_info)
 
@@ -1979,7 +1926,7 @@ def _check_covering_bbox_field_types(
     # Same trap as _check_geometry_byte_array: a group child's type is an
     # explicit None, so `or ""` is the guard here too.
     field_types = {
-        (child.get("type") or "").upper() for child in _schema_direct_children(schema_info, index)
+        (child.get("type") or "").upper() for child in schema_direct_children(schema_info, index)
     }
 
     # Check if all types are valid

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -181,7 +181,9 @@ class TestFormatParquetMetadataEnhanced:
         data = json.loads(capsys.readouterr().out)
         assert data["num_rows"] == 766
         assert data["num_row_groups"] == 1
-        assert data["num_columns"] == 10
+        # Six root columns. The file also carries a `bbox` covering struct, whose
+        # xmin/ymin/xmax/ymax children used to be counted as top-level columns.
+        assert data["num_columns"] == 6
         assert len(data["row_groups"]) == 1
 
     def test_json_output_all_row_groups(self, places_test_file, capsys):

--- a/tests/test_root_schema_columns.py
+++ b/tests/test_root_schema_columns.py
@@ -1,0 +1,140 @@
+"""Root-level column listing must exclude struct children (issue #931).
+
+``get_schema_info()`` returns a flat, depth-first listing of the Parquet schema
+in which a struct's children follow their parent. Neither the DuckDB nor the
+pyarrow shape renders dotted paths, so filtering that listing with
+``"." not in name`` never excluded anything and every covering-bbox file
+(``geometry_bbox`` plus ``xmin``/``ymin``/``xmax``/``ymax``) was over-counted.
+"""
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.duckdb_metadata import get_column_names, get_schema_info
+from geoparquet_io.core.parquet_schema import (
+    root_schema_columns,
+    root_schema_index,
+    schema_direct_children,
+)
+
+COVERING_FILE = str(Path(__file__).parent / "data" / "austria_bbox_covering.parquet")
+
+
+@pytest.fixture
+def nested_struct_parquet(tmp_path):
+    """A file with a struct nested inside a struct, plus a plain column."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2], pa.int64()),
+            "outer": pa.array(
+                [{"inner": {"deep": 1}, "flat": 2}, {"inner": {"deep": 3}, "flat": 4}],
+                pa.struct(
+                    [
+                        ("inner", pa.struct([("deep", pa.int64())])),
+                        ("flat", pa.int64()),
+                    ]
+                ),
+            ),
+        }
+    )
+    path = tmp_path / "nested_struct.parquet"
+    pq.write_table(table, path)
+    return str(path)
+
+
+def test_get_column_names_excludes_covering_struct_children():
+    """xmin/ymin/xmax/ymax are children of geometry_bbox, not root columns."""
+    names = get_column_names(COVERING_FILE)
+
+    assert "geometry_bbox" in names
+    for child in ("xmin", "ymin", "xmax", "ymax"):
+        assert child not in names, f"{child} is a struct child, not a root column"
+    assert len(names) == 10
+
+
+def test_inspect_head_and_meta_agree_on_column_count():
+    """``inspect head`` and ``inspect meta`` must report the same column count."""
+    runner = CliRunner()
+
+    head = runner.invoke(cli, ["inspect", "head", COVERING_FILE])
+    assert head.exit_code == 0, head.output
+    meta = runner.invoke(cli, ["inspect", "meta", COVERING_FILE])
+    assert meta.exit_code == 0, meta.output
+
+    assert "Columns (10)" in head.output
+    assert "Columns: 10" in meta.output
+
+
+def test_duckdb_schema_wrapper_counts_root_columns_only():
+    from geoparquet_io.core.duckdb_utils import _DuckDBSchemaWrapper
+
+    wrapper = _DuckDBSchemaWrapper(get_schema_info(COVERING_FILE))
+
+    assert len(wrapper) == 10
+    assert [wrapper.field(i).name for i in range(len(wrapper))] == get_column_names(COVERING_FILE)
+
+
+def test_nested_struct_children_are_not_root_columns(nested_struct_parquet):
+    """A struct inside a struct contributes no root-level columns."""
+    assert get_column_names(nested_struct_parquet) == ["id", "outer"]
+
+
+def test_duckdb_schema_shape_agrees_with_pyarrow_fast_path(nested_struct_parquet):
+    """Passing a connection takes the DuckDB path, which renders the full tree.
+
+    DuckDB's ``parquet_schema()`` lists grandchildren (``outer.inner.deep``) that
+    the pyarrow fast path omits, so this is the shape that exercises the
+    recursive subtree walk rather than a single level of children.
+    """
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+    con = get_duckdb_connection(load_spatial=False)
+    try:
+        schema_info = get_schema_info(nested_struct_parquet, con)
+        assert "deep" in [c.get("name") for c in schema_info]
+        assert get_column_names(nested_struct_parquet, con) == ["id", "outer"]
+        assert root_schema_index(schema_info, "deep") is None
+    finally:
+        con.close()
+
+
+def test_root_schema_columns_matches_root_index_lookup():
+    """The listing helper and the single-name lookup agree on what is a root."""
+    schema_info = get_schema_info(COVERING_FILE)
+    roots = root_schema_columns(schema_info)
+
+    assert [c["name"] for c in roots] == get_column_names(COVERING_FILE)
+    assert root_schema_index(schema_info, "xmin") is None
+    assert root_schema_index(schema_info, "geometry_bbox") is not None
+
+
+def test_helpers_survive_a_truncated_listing():
+    """A struct claiming more children than the listing holds must not overrun."""
+    truncated = [
+        {"name": "outer", "type": None, "num_children": 3},
+        {"name": "only_child", "type": "INT64", "num_children": 0},
+    ]
+
+    assert [c["name"] for c in root_schema_columns(truncated)] == ["outer"]
+    assert [c["name"] for c in schema_direct_children(truncated, 0)] == ["only_child"]
+
+
+def test_empty_listing_has_no_root_columns():
+    assert root_schema_columns([]) == []
+    assert root_schema_index([], "geometry") is None
+
+
+def test_root_schema_columns_skips_empty_names():
+    """The DuckDB root group element carries no name and is never a column."""
+    schema_info = [
+        {"file_name": "f.parquet", "name": "root", "type": None, "num_children": 2},
+        {"name": "", "type": "INT64", "num_children": 0},
+        {"name": "id", "type": "INT64", "num_children": 0},
+    ]
+
+    assert [c["name"] for c in root_schema_columns(schema_info)] == ["id"]

--- a/tests/test_root_schema_columns.py
+++ b/tests/test_root_schema_columns.py
@@ -5,13 +5,22 @@ in which a struct's children follow their parent. Neither the DuckDB nor the
 pyarrow shape renders dotted paths, so filtering that listing with
 ``"." not in name`` never excluded anything and every covering-bbox file
 (``geometry_bbox`` plus ``xmin``/``ymin``/``xmax``/``ymax``) was over-counted.
+
+Skipping subtrees only works while every entry's ``num_children`` agrees with
+the number of rows the listing actually goes on to emit for it. The pyarrow
+fast path broke that for ``list``/``map``/``fixed_size_list``: it wrote the
+type's field count but emitted child rows only for iterable (struct) types, so
+each root-level list column swallowed the *next* root column and columns
+vanished from ``get_column_names()``.
 """
 
+import json
 from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+import shapely
 from click.testing import CliRunner
 
 from geoparquet_io.cli.main import cli
@@ -23,6 +32,7 @@ from geoparquet_io.core.parquet_schema import (
 )
 
 COVERING_FILE = str(Path(__file__).parent / "data" / "austria_bbox_covering.parquet")
+OVERTURE_FILE = str(Path(__file__).parent / "data" / "country_partition" / "El_Salvador.parquet")
 
 
 @pytest.fixture
@@ -138,3 +148,270 @@ def test_root_schema_columns_skips_empty_names():
     ]
 
     assert [c["name"] for c in root_schema_columns(schema_info)] == ["id"]
+
+
+# ---------------------------------------------------------------------------
+# non-struct nesting: list, large_list, fixed_size_list and map (issue #931)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def nested_types_parquet(tmp_path):
+    """Every root-level nesting kind, each followed by a plain column.
+
+    The follower is what makes the file a regression test: a parent that claims
+    children the listing never emits consumes its next *sibling* instead.
+    """
+    table = pa.table(
+        {
+            "id": pa.array([1, 2], pa.int64()),
+            "tags": pa.array([["a"], ["b", "c"]], pa.list_(pa.string())),
+            "after_list": pa.array([1, 2], pa.int64()),
+            "big_tags": pa.array([["a"], ["b"]], pa.large_list(pa.string())),
+            "after_large_list": pa.array([1, 2], pa.int64()),
+            "coords": pa.array([[1.0, 2.0], [3.0, 4.0]], pa.list_(pa.float64(), 2)),
+            "after_fixed_size_list": pa.array([1, 2], pa.int64()),
+            "attrs": pa.array([[("k", "v")], [("k", "w")]], pa.map_(pa.string(), pa.string())),
+            "after_map": pa.array([1, 2], pa.int64()),
+            "bbox": pa.array(
+                [{"xmin": 0.0, "ymin": 0.0}, {"xmin": 1.0, "ymin": 1.0}],
+                pa.struct([("xmin", pa.float64()), ("ymin", pa.float64())]),
+            ),
+            "after_struct": pa.array([1, 2], pa.int64()),
+        }
+    )
+    path = tmp_path / "nested_types.parquet"
+    pq.write_table(table, path)
+    return str(path)
+
+
+NESTED_TYPES_COLUMNS = [
+    "id",
+    "tags",
+    "after_list",
+    "big_tags",
+    "after_large_list",
+    "coords",
+    "after_fixed_size_list",
+    "attrs",
+    "after_map",
+    "bbox",
+    "after_struct",
+]
+
+
+def test_list_and_map_columns_do_not_swallow_the_next_column(nested_types_parquet):
+    """pyarrow fast path: no root column may be hidden by its predecessor."""
+    assert get_column_names(nested_types_parquet) == NESTED_TYPES_COLUMNS
+
+
+def test_list_and_map_columns_are_root_columns_on_the_duckdb_path(nested_types_parquet):
+    """The DuckDB shape renders list/map internals and must agree all the same."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+    con = get_duckdb_connection(load_spatial=False)
+    try:
+        assert get_column_names(nested_types_parquet, con) == NESTED_TYPES_COLUMNS
+        schema_info = get_schema_info(nested_types_parquet, con)
+        # "element"/"key_value" are list and map internals, never root columns.
+        for internal in ("element", "key_value", "key", "value"):
+            assert root_schema_index(schema_info, internal) is None
+    finally:
+        con.close()
+
+
+def test_both_schema_shapes_list_the_same_root_columns(nested_types_parquet):
+    """The two listing shapes are only useful if they agree on the roots."""
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+    con = get_duckdb_connection(load_spatial=False)
+    try:
+        duckdb_roots = [
+            c["name"] for c in root_schema_columns(get_schema_info(nested_types_parquet, con))
+        ]
+    finally:
+        con.close()
+    pyarrow_roots = [c["name"] for c in root_schema_columns(get_schema_info(nested_types_parquet))]
+
+    assert pyarrow_roots == duckdb_roots == NESTED_TYPES_COLUMNS
+
+
+def test_pyarrow_num_children_counts_only_the_rows_it_emits(nested_types_parquet):
+    """The invariant the subtree walk depends on, asserted directly.
+
+    ``num_children`` is a count of *emitted rows*, not of the type's fields:
+    the fast path renders no rows for list/map internals, so those entries
+    declare none.
+    """
+    schema_info = get_schema_info(nested_types_parquet)
+    by_name = {c["name"]: c for c in schema_info}
+
+    for nested in ("tags", "big_tags", "coords", "attrs"):
+        assert by_name[nested]["num_children"] == 0, nested
+    assert by_name["bbox"]["num_children"] == 2
+    assert [
+        c["name"] for c in schema_direct_children(schema_info, schema_info.index(by_name["bbox"]))
+    ] == [
+        "xmin",
+        "ymin",
+    ]
+
+
+def test_wrapper_and_column_names_agree_on_a_file_with_list_columns(nested_types_parquet):
+    from geoparquet_io.core.duckdb_utils import _DuckDBSchemaWrapper
+
+    wrapper = _DuckDBSchemaWrapper(get_schema_info(nested_types_parquet))
+
+    assert [wrapper.field(i).name for i in range(len(wrapper))] == NESTED_TYPES_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# the shipped Overture fixture, which is what users actually hit
+# ---------------------------------------------------------------------------
+
+
+def test_overture_fixture_head_and_meta_agree(tmp_path):
+    """``inspect head`` and ``inspect meta`` must not disagree in either direction.
+
+    El_Salvador.parquet has 19 root columns, six of which follow a list column.
+    """
+    expected = [f.name for f in pq.ParquetFile(OVERTURE_FILE).schema_arrow]
+    assert len(expected) == 19
+
+    assert get_column_names(OVERTURE_FILE) == expected
+
+    runner = CliRunner()
+    head = runner.invoke(cli, ["inspect", "head", OVERTURE_FILE])
+    assert head.exit_code == 0, head.output
+    meta = runner.invoke(cli, ["inspect", "meta", OVERTURE_FILE])
+    assert meta.exit_code == 0, meta.output
+
+    assert "Columns (19)" in head.output
+    assert "Columns: 19" in meta.output
+    for hidden in ("names", "socials", "emails", "phones", "brand", "operating_status"):
+        assert hidden in get_column_names(OVERTURE_FILE)
+
+
+def test_partition_string_accepts_a_column_that_follows_a_list(tmp_path):
+    """A membership check built on the walk must not reject a real column."""
+    out = tmp_path / "parts"
+    result = CliRunner().invoke(
+        cli,
+        ["partition", "string", OVERTURE_FILE, str(out), "--column", "operating_status"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "not found in the Parquet file" not in result.output
+
+
+def test_add_quadkey_still_refuses_an_existing_column_after_a_list(tmp_path):
+    """The collision guard reads the same listing; a hidden column bypassed it."""
+    table = pa.table(
+        {
+            "tags": pa.array([["a"], ["b"]], pa.list_(pa.string())),
+            "quadkey": pa.array(["0", "1"], pa.string()),
+            "geometry": pa.array(
+                [shapely.to_wkb(shapely.Point(1.0, 2.0)), shapely.to_wkb(shapely.Point(3.0, 4.0))],
+                pa.binary(),
+            ),
+        }
+    )
+    geo = {
+        "version": "1.0.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+    }
+    src = tmp_path / "has_quadkey.parquet"
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), src)
+
+    assert "quadkey" in get_column_names(str(src))
+
+    result = CliRunner().invoke(cli, ["add", "quadkey", str(src), str(tmp_path / "out.parquet")])
+
+    assert result.exit_code != 0
+    assert "already exists" in result.output
+
+
+# ---------------------------------------------------------------------------
+# a covering bbox that follows a list column is still at the schema root
+# ---------------------------------------------------------------------------
+
+
+def test_check_spec_finds_a_covering_bbox_that_follows_a_list_column(tmp_path):
+    """Pre-existing since #930: the walk lost the bbox struct behind a list.
+
+    A spec-compliant 1.1 file failed ``check spec`` three times over with
+    'bbox column "bbox" is not at the schema root'.
+    """
+    points = [shapely.Point(1.0, 2.0), shapely.Point(3.0, 4.0)]
+    table = pa.table(
+        {
+            "tags": pa.array([["a"], ["b"]], pa.list_(pa.string())),
+            "bbox": pa.array(
+                [{"xmin": p.x, "ymin": p.y, "xmax": p.x, "ymax": p.y} for p in points],
+                pa.struct(
+                    [
+                        ("xmin", pa.float64()),
+                        ("ymin", pa.float64()),
+                        ("xmax", pa.float64()),
+                        ("ymax", pa.float64()),
+                    ]
+                ),
+            ),
+            "geometry": pa.array([shapely.to_wkb(p) for p in points], pa.binary()),
+        }
+    )
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "bbox": [1.0, 2.0, 3.0, 4.0],
+                "covering": {
+                    "bbox": {
+                        "xmin": ["bbox", "xmin"],
+                        "ymin": ["bbox", "ymin"],
+                        "xmax": ["bbox", "xmax"],
+                        "ymax": ["bbox", "ymax"],
+                    }
+                },
+            }
+        },
+    }
+    src = tmp_path / "covering_after_list.parquet"
+    pq.write_table(table.replace_schema_metadata({b"geo": json.dumps(geo).encode()}), src)
+
+    result = CliRunner().invoke(cli, ["check", "spec", str(src)])
+
+    assert "is not at the schema root" not in result.output
+    assert "0 failed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# the walk's own defences
+# ---------------------------------------------------------------------------
+
+
+def test_a_leaf_entry_cannot_claim_children_pyarrow_shape():
+    """A primitive type has no subtree, whatever ``num_children`` says."""
+    schema_info = [
+        {"name": "id", "type": "int64", "num_children": 2},
+        {"name": "after", "type": "int64", "num_children": 0},
+        {"name": "last", "type": "string", "num_children": 0},
+    ]
+
+    assert [c["name"] for c in root_schema_columns(schema_info)] == ["id", "after", "last"]
+    assert schema_direct_children(schema_info, 0) == []
+
+
+def test_a_leaf_entry_cannot_claim_children_duckdb_shape():
+    """DuckDB renders leaves with a physical type and groups with ``None``."""
+    schema_info = [
+        {"file_name": "f.parquet", "name": "schema", "type": None, "num_children": 2},
+        {"name": "id", "type": "BYTE_ARRAY", "num_children": 3},
+        {"name": "after", "type": "INT64", "num_children": None},
+    ]
+
+    assert [c["name"] for c in root_schema_columns(schema_info)] == ["id", "after"]

--- a/tests/test_validate_geoarrow_encodings.py
+++ b/tests/test_validate_geoarrow_encodings.py
@@ -528,3 +528,39 @@ class TestGeoArrowDepthTwinsAreDistinguished:
         generic = "LIST<ELEMENT: STRUCT<X: DOUBLE, Y: DOUBLE>>"
         check = _check_geoarrow_layout(generic, "geometry", "multipoint")
         assert check.status == CheckStatus.PASSED, check.message
+
+
+class TestPyArrowSchemaPath:
+    """The pyarrow fast path renders nesting in the type string, not in rows.
+
+    It emits child rows only for structs, so a list or map column declares
+    ``num_children: 0`` (issue #931). "Is this a group?" therefore has to be
+    read off the type, or a geometry column stored as a list under a declared
+    "WKB" encoding sails through the not-grouped check on local files.
+    """
+
+    def test_wkb_geometry_stored_as_a_list_is_grouped(self):
+        schema_info = [{"name": "geometry", "type": "list<item: double>", "num_children": 0}]
+
+        check = _check_geometry_not_grouped(schema_info, "geometry", "WKB")
+
+        assert check.status == CheckStatus.FAILED, check.message
+        assert "must not be grouped" in check.message
+
+    def test_wkb_geometry_stored_as_a_struct_is_grouped(self):
+        schema_info = [
+            {"name": "geometry", "type": "struct<x: double, y: double>", "num_children": 2},
+            {"name": "x", "type": "double", "num_children": 0},
+            {"name": "y", "type": "double", "num_children": 0},
+        ]
+
+        check = _check_geometry_not_grouped(schema_info, "geometry", "WKB")
+
+        assert check.status == CheckStatus.FAILED, check.message
+
+    def test_wkb_geometry_stored_as_binary_is_not_grouped(self):
+        schema_info = [{"name": "geometry", "type": "binary", "num_children": 0}]
+
+        check = _check_geometry_not_grouped(schema_info, "geometry", "WKB")
+
+        assert check.status == CheckStatus.PASSED, check.message


### PR DESCRIPTION
## What changed

`inspect head` and `inspect meta` now agree on the column count of a file with
a covering bbox.

Three call sites filtered the flat Parquet schema listing down to root-level
columns with a `"." not in name` test:

- `core/duckdb_metadata.py::get_column_names`
- `core/duckdb_utils.py::_DuckDBSchemaWrapper`
- the column count and schema string in `core/metadata_utils.py`

All three now call a shared `root_schema_columns()`.

The subtree walk that makes this correct already existed in `core/validate.py`
(`_root_schema_index` / `_schema_direct_children`, added by #930 for the
covering-bbox root-placement check). Rather than import private helpers out of
`validate.py` from three other core modules, they move to a new
`geoparquet_io/core/parquet_schema.py`: the concept is "walk the flat Parquet
schema listing", it is not DuckDB-specific (it handles both the DuckDB
`parquet_schema()` shape, which prefixes the listing with the file's root group
element, and the pyarrow fast path, which does not), and the module imports
nothing from the package, so all four consumers share it with no import cycle.
`validate.py` keeps its behaviour and now imports the public names.

`tests/test_metadata_utils.py::test_json_output` asserted `num_columns == 10`
for `places_test.parquet`, which has six root columns plus a four-field `bbox`
covering struct. That assertion had baked in the bug; it is now 6, with a
comment saying why.

## Why

Closes #931.

```
$ gpio inspect head tests/data/austria_bbox_covering.parquet
Columns (10):
$ gpio inspect meta tests/data/austria_bbox_covering.parquet
Columns: 14
```

The extra four are `xmin`/`ymin`/`xmax`/`ymax`, the children of the
`geometry_bbox` covering struct, counted as top-level columns:

```python
>>> get_column_names("tests/data/austria_bbox_covering.parquet")
[... 'geometry', 'geometry_bbox', 'xmin', 'ymin', 'xmax', 'ymax']
```

The listing is depth first — a struct's children follow their parent — and
neither shape renders dotted paths, so the `"." not in name` filter never
excluded anything. It has never worked. Every file with a bbox covering is
affected, which is what `gpio add bbox` writes and what the guide recommends.

Beyond the miscount, `get_column_names()` feeds membership checks in
`partition/by_string.py`, `constants.py` and `sort_quadkey.py`, where a struct
child could satisfy a "does this column exist" test for a column that is not
addressable at the root.

## Verification

After:

```
$ gpio inspect head tests/data/austria_bbox_covering.parquet
Columns (10):
$ gpio inspect meta tests/data/austria_bbox_covering.parquet
Columns: 10
```

New `tests/test_root_schema_columns.py` (9 tests) covers: the covering file's
column names and count; `inspect head` and `inspect meta` agreeing; the
`_DuckDBSchemaWrapper` count; a struct nested inside a struct; both listing
shapes (passing a connection forces the DuckDB path, which — unlike the pyarrow
fast path — renders grandchildren, so it is the shape that exercises the
recursive walk); and truncated/empty listings.

- Fast suite: `6475 passed, 75 skipped, 9 xfailed`. Two `-n auto` failures
  (`test_journeys.py::test_journey_01_...`, `test_geojson_stream.py::...broken_pipe`)
  were machine-saturation noise and pass serially.
- Meta lane: `203 passed`.
- `diff-cover coverage.xml --compare-branch=origin/main`: **100%** over 49
  changed lines.
- `pre-commit run --all-files`: clean. `--hook-stage pre-push`: clean except
  `menard-check`, which flags `docs/guide/check.md` as stale against
  `core/validate.py` — pre-existing on `main` (the doc last moved 2026-09-05,
  behind #876, #904, #930 and #939), not introduced here.

### Sweep

`"." not in` is now gone from `geoparquet_io/` entirely; the remaining `.split(".")`
hits are version and BigQuery table-id parsing, unrelated.

Not fixed here, worth its own PR: ~12 geometry-column lookups in `validate.py`,
plus `common._schema_struct_child_names` and `common._find_bbox_column_in_schema`,
still scan the listing for the *first* entry with a given name. That is a
shadowing hazard (a nested field named `geometry` beating the real root column)
rather than a miscount, and `root_schema_index()` is now the primitive that fixes
it across all of them.

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected column counting and listing so nested struct fields are excluded from top-level column results.
  * Improved consistency between DuckDB and PyArrow schema handling.
  * Ensured metadata displays accurate root-level column counts.
  * Improved handling of empty, truncated, and nested schema definitions.

* **Tests**
  * Added coverage for nested structures, covering-bounding-box fields, schema variations, empty names, and incomplete schema listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->