### PR TITLE
fix(extract): compute arcgis geometry_types from the data, not a five-entry table

### DIFF
--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -28,6 +28,7 @@ from geoparquet_io.core.exceptions import (
     InvalidParameterError,
     RemoteAccessError,
 )
+from geoparquet_io.core.geo_metadata import _compute_geometry_types
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.http_retry import (
     DEFAULT_TIMEOUT,
@@ -1195,6 +1196,30 @@ def _stream_features_to_parquet(
             writer.close()
 
 
+def _resolve_geometry_types(table: pa.Table, esri_geometry_type: str, verbose: bool) -> list[str]:
+    """Geometry types for the geo block, read from the fetched WKB (#928).
+
+    The layer's advertised ``geometryType`` is only a fallback. It is coarser
+    than the data (Esri's ``esriGeometryPolyline`` covers both LineString and
+    MultiLineString, and says nothing about Z/M), it does not cover every Esri
+    type, and it used to fall back to the literal ``"Geometry"`` -- which the
+    GeoParquet schema does not allow, so unmapped layers wrote files that
+    failed validation on their own metadata.
+
+    Computing from the data instead is what every gpio write path does, gives
+    the spec's " Z"/" M"/" ZM" suffixes for free, and keeps the declaration
+    consistent with the statistics a reader checks it against. When the WKB
+    cannot be read the mapping table still serves as a fallback, and an Esri
+    type outside it yields ``[]`` -- the spec's way of saying the types are
+    not known.
+    """
+    computed = _compute_geometry_types(table, "geometry", verbose)
+    if computed:
+        return computed
+    declared = ARCGIS_GEOM_TYPES.get(esri_geometry_type)
+    return [declared] if declared else []
+
+
 def arcgis_to_table(
     service_url: str,
     auth: ArcGISAuth | None = None,
@@ -1348,6 +1373,14 @@ def arcgis_to_table(
                 table = table.select(cols_to_keep)
                 debug(f"Excluded columns: {cols_to_exclude}")
 
+        # Repair invalid geometry (issue #506) before the geo block is built:
+        # ST_MakeValid can change a geometry's type (a bowtie Polygon comes back
+        # as a MultiPolygon), so the types have to be read off the repaired data
+        # that is actually written. The helper preserves schema metadata, so it
+        # is equally safe on either side of the block.
+        if table.num_rows > 0:
+            table, _ = repair_arrow_table_geometry(table, "geometry", repair=repair_geometry)
+
         # Add CRS to metadata.
         # Default (GeoJSON path): always CRS84 (WGS84 lon/lat) because we request
         # f=geojson, which per RFC 7946 is always WGS84 regardless of the native SR.
@@ -1374,9 +1407,9 @@ def arcgis_to_table(
                     "geometry": {
                         "encoding": "WKB",
                         "crs": crs,
-                        "geometry_types": [
-                            ARCGIS_GEOM_TYPES.get(layer_info.geometry_type, "Geometry")
-                        ],
+                        "geometry_types": _resolve_geometry_types(
+                            table, layer_info.geometry_type, verbose
+                        ),
                     }
                 },
             }
@@ -1385,10 +1418,6 @@ def arcgis_to_table(
             existing_metadata = table.schema.metadata or {}
             new_metadata = {**existing_metadata, b"geo": json.dumps(geo_metadata).encode("utf-8")}
             table = table.replace_schema_metadata(new_metadata)
-
-        # Repair invalid geometry (issue #506). Helper preserves schema metadata.
-        if table.num_rows > 0:
-            table, _ = repair_arrow_table_geometry(table, "geometry", repair=repair_geometry)
 
         success(f"Converted {table.num_rows} features")
         return table

--- a/tests/test_arcgis_geometry_types.py
+++ b/tests/test_arcgis_geometry_types.py
@@ -69,14 +69,15 @@ def _stub_stream(tmp_path, geometries):
 def run_extract(tmp_path, monkeypatch):
     """Run ``arcgis_to_table`` over stubbed network calls, returning its geo block."""
 
-    def _run(geometry_type, geometries):
+    def _run(geometry_type, geometries, **kwargs):
         from geoparquet_io.core import arcgis
 
         monkeypatch.setattr(arcgis, "get_layer_info", lambda *a, **k: _layer(geometry_type))
         monkeypatch.setattr(
             arcgis, "_stream_features_to_parquet", _stub_stream(tmp_path, geometries)
         )
-        table = arcgis_to_table("https://example.com/FeatureServer/0")
+        table = arcgis_to_table("https://example.com/FeatureServer/0", **kwargs)
+        _run.table = table
         return json.loads(table.schema.metadata[b"geo"])["columns"]["geometry"]
 
     return _run
@@ -125,6 +126,47 @@ def test_mixed_geometries_are_all_declared(run_extract):
     column = run_extract("esriGeometryMultiPatch", geometries)
 
     assert sorted(column["geometry_types"]) == ["Point", "Polygon"]
+
+
+#: A self-intersecting "bowtie". ``ST_MakeValid`` splits it into two triangles,
+#: so it comes back a MultiPolygon -- the cheapest geometry whose TYPE changes
+#: under repair, which is what makes it the right probe for the ordering below.
+BOWTIE = Polygon([(0, 0), (2, 2), (2, 0), (0, 2), (0, 0)])
+
+
+def _actual_types(table):
+    """The geometry types really present in a table's WKB, read back independently."""
+    return sorted({shapely_wkb.loads(bytes(v.as_py())).geom_type for v in table.column("geometry")})
+
+
+def test_repair_runs_before_the_geo_block_is_built(run_extract):
+    """The declaration must describe the REPAIRED data that is actually written.
+
+    ``ST_MakeValid`` can change a geometry's type, so building the geo block
+    before the repair declares the input's types over the output's bytes. That
+    is not a cosmetic ordering: it writes a file whose own metadata under-declares
+    it, which ``gpio check spec`` fails and which makes a conformant reader skip
+    rows. Moving the repair back below the block flips this to ``["Polygon"]``
+    over MultiPolygon data, so this test is what pins the order.
+    """
+    column = run_extract("esriGeometryPolygon", [shapely_wkb.dumps(BOWTIE)])
+
+    assert column["geometry_types"] == ["MultiPolygon"]
+    # ...and that is genuinely what landed in the column, not just what was claimed.
+    assert _actual_types(run_extract.table) == ["MultiPolygon"]
+
+
+def test_declaration_follows_the_data_when_repair_is_off(run_extract):
+    """The mirror of the above: no repair, no type change, so ``Polygon`` is right.
+
+    Together the two pin the declaration to the data rather than to a fixed
+    answer -- a hardcoded ``["MultiPolygon"]`` would pass the test above and
+    fail this one.
+    """
+    column = run_extract("esriGeometryPolygon", [shapely_wkb.dumps(BOWTIE)], repair_geometry=False)
+
+    assert column["geometry_types"] == ["Polygon"]
+    assert _actual_types(run_extract.table) == ["Polygon"]
 
 
 def test_written_file_validates_for_an_unknown_esri_type(tmp_path, monkeypatch):

--- a/tests/test_arcgis_geometry_types.py
+++ b/tests/test_arcgis_geometry_types.py
@@ -1,0 +1,152 @@
+"""``gpio extract arcgis`` must declare geometry_types the spec allows (#928).
+
+The geo block used to name the type from a five-entry table of Esri geometry
+types, falling back to the literal ``"Geometry"`` for anything else. That is
+not a value the GeoParquet schema permits::
+
+    ^(GeometryCollection|(Multi)?(Point|LineString|Polygon))( Z| M| ZM)?$
+
+so every layer whose ``geometryType`` was outside the table — Esri's list is
+longer than five — wrote a file that failed validation on its own metadata.
+
+The types are now computed from the fetched WKB with the same helper the write
+paths use, so they carry the spec's " Z"/" M"/" ZM" suffixes and match the data
+rather than the layer's advertisement.
+"""
+
+import json
+import re
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from shapely import wkb as shapely_wkb
+from shapely.geometry import LineString, Point, Polygon
+
+from geoparquet_io.core.arcgis import ArcGISLayerInfo, arcgis_to_table
+
+#: The GeoParquet JSON schema's pattern for one geometry_types entry.
+GEOMETRY_TYPE_PATTERN = re.compile(
+    r"^(GeometryCollection|(Multi)?(Point|LineString|Polygon))( Z| M| ZM)?$"
+)
+
+
+def _layer(geometry_type: str) -> ArcGISLayerInfo:
+    return ArcGISLayerInfo(
+        name="Test",
+        geometry_type=geometry_type,
+        spatial_reference={"wkid": 4326},
+        fields=[{"name": "OBJECTID", "type": "esriFieldTypeOID", "nullable": False}],
+        max_record_count=1000,
+        total_count=1,
+    )
+
+
+def _stub_stream(tmp_path, geometries):
+    """Stand in for ``_stream_features_to_parquet``, yielding ``geometries`` as WKB."""
+    import shutil
+
+    temp_parquet = str(tmp_path / "streamed.parquet")
+    pq.write_table(
+        pa.table(
+            {
+                "geometry": pa.array(geometries, type=pa.binary()),
+                "OBJECTID": list(range(1, len(geometries) + 1)),
+            }
+        ),
+        temp_parquet,
+    )
+
+    def side_effect(*args, **kwargs):
+        output_path = kwargs.get("output_path") or args[2]
+        shutil.copy(temp_parquet, output_path)
+        return len(geometries), None
+
+    return side_effect
+
+
+@pytest.fixture
+def run_extract(tmp_path, monkeypatch):
+    """Run ``arcgis_to_table`` over stubbed network calls, returning its geo block."""
+
+    def _run(geometry_type, geometries):
+        from geoparquet_io.core import arcgis
+
+        monkeypatch.setattr(arcgis, "get_layer_info", lambda *a, **k: _layer(geometry_type))
+        monkeypatch.setattr(
+            arcgis, "_stream_features_to_parquet", _stub_stream(tmp_path, geometries)
+        )
+        table = arcgis_to_table("https://example.com/FeatureServer/0")
+        return json.loads(table.schema.metadata[b"geo"])["columns"]["geometry"]
+
+    return _run
+
+
+def test_unknown_esri_geometry_type_is_computed_not_invented(run_extract):
+    """An Esri type outside the mapping table must not write ``"Geometry"``."""
+    # esriGeometryMultiPatch is a real Esri type the mapping table never covered.
+    column = run_extract("esriGeometryMultiPatch", [shapely_wkb.dumps(Point(1, 2))])
+
+    assert column["geometry_types"] == ["Point"]
+    for name in column["geometry_types"]:
+        assert GEOMETRY_TYPE_PATTERN.match(name), f"{name!r} is not a valid geometry_types entry"
+
+
+def test_unknown_esri_geometry_type_falls_back_to_empty_not_invalid(run_extract):
+    """When the WKB cannot be read, an unknown Esri type declares nothing."""
+    column = run_extract("esriGeometryMultiPatch", [b"not wkb at all"])
+
+    # An empty array is the spec's way to say the types are not known.
+    assert column["geometry_types"] == []
+
+
+def test_computed_types_beat_the_declared_mapping(run_extract):
+    """Single Polygons stay ``Polygon`` even though the layer says polygon->Multi."""
+    polygon = shapely_wkb.dumps(Polygon([(0, 0), (1, 0), (1, 1), (0, 0)]))
+    column = run_extract("esriGeometryPolygon", [polygon])
+
+    assert column["geometry_types"] == ["Polygon"]
+
+
+def test_computed_types_carry_dimension_suffixes(run_extract):
+    """Z data is spelled ``"LineString Z"``, which the old table could never say."""
+    line_z = shapely_wkb.dumps(LineString([(0, 0, 1), (1, 1, 2)]), output_dimension=3)
+    column = run_extract("esriGeometryPolyline", [line_z])
+
+    assert column["geometry_types"] == ["LineString Z"]
+
+
+def test_mixed_geometries_are_all_declared(run_extract):
+    """Every type present in the data is declared, not just the advertised one."""
+    geometries = [
+        shapely_wkb.dumps(Point(0, 0)),
+        shapely_wkb.dumps(Polygon([(0, 0), (1, 0), (1, 1), (0, 0)])),
+    ]
+    column = run_extract("esriGeometryMultiPatch", geometries)
+
+    assert sorted(column["geometry_types"]) == ["Point", "Polygon"]
+
+
+def test_written_file_validates_for_an_unknown_esri_type(tmp_path, monkeypatch):
+    """End to end: the file an unknown Esri type produces passes ``gpio check spec``."""
+    from geoparquet_io.core import arcgis
+    from geoparquet_io.core.validate import CheckStatus, validate_geoparquet
+
+    monkeypatch.setattr(arcgis, "get_layer_info", lambda *a, **k: _layer("esriGeometryMultiPatch"))
+    monkeypatch.setattr(
+        arcgis,
+        "_stream_features_to_parquet",
+        _stub_stream(tmp_path, [shapely_wkb.dumps(Point(1, 2))]),
+    )
+
+    output = tmp_path / "out.parquet"
+    arcgis.convert_arcgis_to_geoparquet(
+        "https://example.com/FeatureServer/0",
+        str(output),
+        skip_hilbert=True,
+        skip_bbox=True,
+    )
+
+    result = validate_geoparquet(str(output))
+    failures = [c for c in result.checks if c.status == CheckStatus.FAILED]
+    assert failures == [], [c.message for c in failures]


### PR DESCRIPTION
## What changed

`gpio extract arcgis` now computes the `geo` block's `geometry_types` from the fetched WKB instead of translating the layer's advertised `geometryType` through a five-entry table.

- New `_resolve_geometry_types()` in `core/arcgis.py` calls `_compute_geometry_types()` from `core/geo_metadata.py` — the same helper the write paths use, fixed in #892/#927 to recombine geoarrow's `geometry_type` and `dimensions` fields.
- `ARCGIS_GEOM_TYPES` survives only as a fallback for WKB that cannot be read. An Esri type outside it now yields `[]` — the spec's own way of saying the types are not known — never an invented name.
- Geometry repair (#506) moved above the geo block. `ST_MakeValid` can change a geometry's type (a bowtie Polygon comes back as a MultiPolygon), so the declaration has to describe the repaired data that actually gets written. The helper preserves schema metadata, so it is equally safe on either side.

**User-visible metadata change.** The table mapped `esriGeometryPolyline` → `MultiLineString` and `esriGeometryPolygon` → `MultiPolygon` unconditionally. Computed types win, so a polygon layer holding single Polygons is now declared `["Polygon"]` rather than `["MultiPolygon"]`, a mixed layer declares every type present, and Z/M layers get the `" Z"` / `" M"` / `" ZM"` suffixes the table could never express. In every case the new value is what the data actually contains.

## Why

`ARCGIS_GEOM_TYPES.get(layer_info.geometry_type, "Geometry")` fell back to the literal `"Geometry"`, which the GeoParquet schema does not permit:

```
^(GeometryCollection|(Multi)?(Point|LineString|Polygon))( Z| M| ZM)?$
```

Esri's geometry-type list is longer than the five entries in the table, so any layer outside it (`esriGeometryMultiPatch`, for one) wrote a file that failed validation on its own metadata. Before this change, `gpio check spec` on such a file reported two failures:

```
column "geometry" has invalid geometry_types: ['Geometry']
found undeclared geometry types: {'Point'} (1 checked)
```

The issue offered an empty-array fallback or computing from the data, and asked for the second if the write path's helper was reusable. It was, directly — the extraction path already materialises the table before writing, so the real types were in hand — and it is the better answer: a declared-but-wrong type is worse than an absent one, and #879's `geometry_types`-vs-statistics check would have flagged the guesses the old table made.

## Verification

- New `tests/test_arcgis_geometry_types.py` (6 tests, all failing before the fix): unknown Esri type computes `["Point"]` and matches the schema pattern; unreadable WKB on an unknown type declares `[]`; single Polygons stay `Polygon` against the `MultiPolygon` mapping; `LineString Z` keeps its suffix; mixed geometries are all declared; and end to end, a file written for `esriGeometryMultiPatch` passes `validate_geoparquet` with zero failed checks.
- Fast suite: `uv run pytest -n auto -m "not slow and not network and not meta" -q` → 6472 passed, 75 skipped, 9 xfailed. Two unrelated `-n auto` saturation failures (`test_journey_01_geojson_to_geoparquet_and_back`, `test_streaming_handles_broken_pipe`) both pass on a serial re-run.
- Meta lane: `uv run pytest -m meta -q` → 203 passed.
- `uv run pre-commit run --all-files` and `--hook-stage pre-push` both clean (mypy, vulture, xenon, import-linter, deptry included).
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` → 9 changed lines, 0 missing, **100%**.

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GeoParquet geometry metadata for ArcGIS extracts by deriving geometry types from the actual written data.
  - Improved handling of repaired, mixed, 3D, and previously unsupported geometry types.
  - Prevented invalid generic geometry labels from appearing in metadata.
  - Ensured files with unknown or unreadable geometry types remain valid with an empty geometry-type list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->