### PR TITLE
fix(common,stac,stream): stop the last malformed-'geo' readers crashing the write

### DIFF
--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -2558,12 +2558,23 @@ class Table:
         if schema_metadata and b"geo" in schema_metadata:
             try:
                 geo_meta = json.loads(schema_metadata[b"geo"].decode("utf-8"))
+                # A read-only reader, the Python API's `gpio inspect meta`:
+                # `geo_metadata` is documented as the file's full `geo` block,
+                # so it is handed back exactly as the file holds it and is NOT
+                # sanitized -- the same line #883 drew around `parse_geo_metadata`
+                # and `check`. Only the derived keys below need guarding: they
+                # indexed the raw block and crashed on a `columns` that is not
+                # an object, or an entry that is not one (#947).
                 result["geo_metadata"] = geo_meta
 
                 # Extract geometry_types from geo metadata
-                columns_meta = geo_meta.get("columns", {})
-                if self._geometry_column and self._geometry_column in columns_meta:
-                    col_meta = columns_meta[self._geometry_column]
+                columns_meta = geo_meta.get("columns") if isinstance(geo_meta, dict) else None
+                col_meta = (
+                    columns_meta.get(self._geometry_column)
+                    if isinstance(columns_meta, dict) and self._geometry_column
+                    else None
+                )
+                if isinstance(col_meta, dict):
                     result["geometry_types"] = col_meta.get("geometry_types")
                     result["edges"] = col_meta.get("edges")
                     result["orientation"] = col_meta.get("orientation")

--- a/geoparquet_io/core/add/bbox_metadata.py
+++ b/geoparquet_io/core/add/bbox_metadata.py
@@ -32,7 +32,12 @@ from geoparquet_io.core.duckdb_utils import (
 )
 from geoparquet_io.core.exceptions import GeoParquetError
 from geoparquet_io.core.file_utils import resolve_file_url
-from geoparquet_io.core.geo_metadata import covering_supported, parse_geo_metadata
+from geoparquet_io.core.geo_metadata import (
+    covering_supported,
+    parse_geo_metadata,
+    sanitize_geo_metadata,
+    sanitized_carried_geo,
+)
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, success
 
@@ -218,12 +223,12 @@ def add_bbox_metadata_table(
 
     schema_metadata = dict(table.schema.metadata) if table.schema.metadata else {}
 
-    geo_meta: object = None
-    if b"geo" in schema_metadata:
-        try:
-            geo_meta = json.loads(schema_metadata[b"geo"].decode("utf-8"))
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            geo_meta = None
+    # A write path: this block is re-serialized onto the returned table, so a
+    # malformed carried one goes through the shared shape check first (#947).
+    # Without it a `columns` mapping to a non-object let the covering be
+    # assigned into a string, and a wrong-typed `crs` was carried straight into
+    # the output.
+    geo_meta: object = sanitized_carried_geo(schema_metadata)
 
     # Same refusal as the file path: a table with no usable `geo` block has
     # nothing describing the geometry column, and the skeleton this used to
@@ -311,7 +316,12 @@ def add_bbox_metadata(
 
     # Get existing metadata
     metadata, _ = get_parquet_metadata(parquet_file)
-    geo_meta = parse_geo_metadata(metadata, False)
+    # `parse_geo_metadata` is the read-only reader and hands the block back as
+    # the file holds it; this command rewrites the file from it, so the
+    # malformed parts are dropped here the way every other write path drops
+    # them (#947). A `columns` entry that is not an object used to fail with
+    # `'str' object does not support item assignment` at the assignment below.
+    geo_meta = sanitize_geo_metadata(parse_geo_metadata(metadata, False))
 
     geo_meta = require_geo_metadata_for_covering(geo_meta, parquet_file)
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -44,11 +44,13 @@ from geoparquet_io.core.geo_metadata import (
     DEFAULT_GEOPARQUET_VERSION,
     GEOPARQUET_VERSIONS,
     build_bbox_covering,
+    carried_geometry_column,
     create_geo_metadata,
     detect_bbox_column_from_schema,
     geoarrow_wkb_codes,
     prune_geo_metadata_to_columns,
     sanitize_geo_metadata,
+    sanitized_carried_geo,
     strip_derived_stats,
     strip_nonplanar_edges,
 )
@@ -57,7 +59,6 @@ from geoparquet_io.core.geoarrow_encoding import (
     is_wkb_extension_field,
 )
 from geoparquet_io.core.geometry_detection import (
-    STANDARD_GEOMETRY_NAMES,
     _detect_geometry_from_query,
     find_primary_geometry_column,
 )
@@ -2759,7 +2760,7 @@ def _geo_block_to_carry_on_fast_path(
     would not write itself — the caller then keeps its existing behaviour.
     """
     from geoparquet_io.core.crs_utils import apply_output_crs
-    from geoparquet_io.core.geo_metadata import _decode_geo_value, declare_carried_bbox_column
+    from geoparquet_io.core.geo_metadata import declare_carried_bbox_column
 
     if effective_version != "2.0" or not geometry_column or not original_metadata:
         return None
@@ -2777,35 +2778,35 @@ def _geo_block_to_carry_on_fast_path(
             )
         return None
 
-    for geo_key in ("geo", b"geo"):
-        if geo_key not in original_metadata:
-            continue
-        geo_dict = _decode_geo_value(original_metadata[geo_key])
-        if not geo_dict:
-            return None
-        col_meta = (geo_dict.get("columns") or {}).get(geometry_column)
-        if not isinstance(col_meta, dict):
-            return None
-        if any(field not in col_meta for field in _REQUIRED_CARRIED_GEO_FIELDS):
-            return None
-        carried = copy.deepcopy(geo_dict)
-        carried["version"] = "2.0.0"
-        # Before the gate: a block whose only extra key was a default or null
-        # `crs` says nothing DuckDB would not write once that key is stripped.
-        apply_output_crs(carried["columns"][geometry_column], input_crs)
-        if con is not None and query is not None:
-            declare_carried_bbox_column(
-                con,
-                query,
-                carried["columns"][geometry_column],
-                verbose,
-                effective_version,
-                output_columns=output_columns,
-            )
-        if not _carries_more_than_duckdb_generates(carried):
-            return None
-        return carried
-    return None
+    # A write-path reader in the strongest sense: whatever comes back is written
+    # to the output file verbatim, so the block goes through the shared shape
+    # check first. `columns` as a list or a string used to abort the write with
+    # `'list' object has no attribute 'get'` on the next line (#947).
+    geo_dict = sanitized_carried_geo(original_metadata)
+    if not geo_dict:
+        return None
+    col_meta = (geo_dict.get("columns") or {}).get(geometry_column)
+    if not isinstance(col_meta, dict):
+        return None
+    if any(field not in col_meta for field in _REQUIRED_CARRIED_GEO_FIELDS):
+        return None
+    carried = copy.deepcopy(geo_dict)
+    carried["version"] = "2.0.0"
+    # Before the gate: a block whose only extra key was a default or null
+    # `crs` says nothing DuckDB would not write once that key is stripped.
+    apply_output_crs(carried["columns"][geometry_column], input_crs)
+    if con is not None and query is not None:
+        declare_carried_bbox_column(
+            con,
+            query,
+            carried["columns"][geometry_column],
+            verbose,
+            effective_version,
+            output_columns=output_columns,
+        )
+    if not _carries_more_than_duckdb_generates(carried):
+        return None
+    return carried
 
 
 def write_parquet_with_metadata(
@@ -3241,24 +3242,15 @@ def write_geoparquet_table(
                Pass the RFC 7946 5.2 wrap form (xmin > xmax) for data that
                crosses the antimeridian; None computes a plain extent.
     """
-    # Auto-detect geometry column if not provided
+    # A write path: the column name is quoted into the output's metadata and the
+    # CRS is written to the output file, so the carried block goes through the
+    # shared shape check rather than being indexed raw. `columns: null` used to
+    # raise `argument of type 'NoneType' is not iterable` here, and a list-,
+    # string- or non-object-entry `columns` a `TypeError` one line later (#947).
+    geo_meta = sanitized_carried_geo(table.schema.metadata)
+
     if geometry_column is None:
-        # Try to detect from table metadata
-        metadata = table.schema.metadata or {}
-        if b"geo" in metadata:
-            try:
-                geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-                geometry_column = geo_meta.get("primary_column", "geometry")
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                geometry_column = "geometry"
-        else:
-            # Check for common geometry column names
-            for name in STANDARD_GEOMETRY_NAMES:
-                if name in table.column_names:
-                    geometry_column = name
-                    break
-            if geometry_column is None:
-                geometry_column = "geometry"
+        geometry_column = carried_geometry_column(geo_meta, table.column_names) or "geometry"
 
     # Check if geometry column exists
     has_geometry = geometry_column in table.column_names
@@ -3267,15 +3259,8 @@ def write_geoparquet_table(
     original_metadata = table.schema.metadata
 
     # Extract CRS from original metadata if available
-    input_crs = None
-    if original_metadata and b"geo" in original_metadata:
-        try:
-            geo_meta = json.loads(original_metadata[b"geo"].decode("utf-8"))
-            columns = geo_meta.get("columns", {})
-            if geometry_column in columns:
-                input_crs = columns[geometry_column].get("crs")
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            pass
+    col_meta = (geo_meta.get("columns") or {}).get(geometry_column)
+    input_crs = col_meta.get("crs") if isinstance(col_meta, dict) else None
 
     # Validate and normalize compression settings
     validated_compression, validated_level, _ = validate_compression_settings(
@@ -3455,11 +3440,18 @@ def _check_bbox_metadata_covering(geo_meta, has_bbox_column, verbose, bbox_colum
         debug("\nParsed geo metadata:")
         debug(json.dumps(geo_meta, indent=2))
 
-    if isinstance(geo_meta, dict) and "columns" in geo_meta:
-        columns = geo_meta["columns"]
+    # Validation-shared, so the block stays as the file really holds it (#883's
+    # line) and this guards instead of sanitizing: `gpio check bbox` and `check
+    # all` report through here. A `columns` that is not an object, or a
+    # `covering` that is not one, simply declares no covering -- the truthful
+    # answer, where iterating it raised an `AttributeError` from someone else's
+    # file (#947).
+    columns = geo_meta.get("columns") if isinstance(geo_meta, dict) else None
+    if isinstance(columns, dict):
         for _col_name, col_info in columns.items():
-            if isinstance(col_info, dict) and col_info.get("covering", {}).get("bbox"):
-                bbox_refs = col_info["covering"]["bbox"]
+            covering = col_info.get("covering") if isinstance(col_info, dict) else None
+            if isinstance(covering, dict) and covering.get("bbox"):
+                bbox_refs = covering["bbox"]
                 # Check if the bbox covering has the required structure
                 if (
                     isinstance(bbox_refs, dict)

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -365,6 +365,46 @@ def _repair_primary_column(cleaned: dict) -> None:
         cleaned["primary_column"] = next(iter(columns))
 
 
+def sanitized_carried_geo(metadata) -> dict:
+    """The ``geo`` block on a Parquet/Arrow metadata mapping, sanitized, or ``{}``.
+
+    The three steps every write-path reader of a carried block repeats -- find
+    the key, decode it, check its shape -- in one place, so a reader is one call
+    away from the rule rather than three lines of its own (#947). Both key
+    spellings are accepted: PyArrow hands back ``bytes`` keys and DuckDB's KV
+    metadata ``str`` ones, and several callers see both.
+
+    Returns ``{}``, never ``None``, so callers can index the result directly;
+    a block that sanitizing leaves unusable is indistinguishable from an absent
+    one, which is exactly how #883 decided a malformed block should read.
+    """
+    if not metadata:
+        return {}
+    for key in (b"geo", "geo"):
+        if key in metadata:
+            cleaned = sanitize_geo_metadata(decode_carried_geo(metadata[key]))
+            return cleaned if isinstance(cleaned, dict) else {}
+    return {}
+
+
+def carried_geometry_column(geo_meta, column_names) -> str | None:
+    """The column a *sanitized* block names as primary, else the one the schema shows.
+
+    Sanitizing *drops* a malformed ``primary_column`` (and repairs it only from
+    a single surviving column), so a block reaches a reader without one.
+    Defaulting to the literal string ``"geometry"`` there is silently wrong on a
+    file whose column is called ``geom`` -- the write then names a column that
+    is not in the table (#887 review). ``column_names`` is the schema to ask
+    instead; the caller supplies the last-resort default, if it wants one.
+    """
+    from geoparquet_io.core.geometry_detection import detect_geometry_column_from_names
+
+    primary = geo_meta.get("primary_column") if isinstance(geo_meta, dict) else None
+    if isinstance(primary, str) and primary:
+        return primary
+    return detect_geometry_column_from_names(column_names)
+
+
 def _article(type_name: str) -> str:
     """``"a list"`` / ``"an object"`` -- correct article for a JSON type name."""
     if type_name == "null":

--- a/geoparquet_io/core/reproject.py
+++ b/geoparquet_io/core/reproject.py
@@ -74,12 +74,9 @@ def _carried_geo(metadata) -> dict:
     ``TypeError`` and a string-, list- or null-shaped block crashed the CRS
     lookups with a bare ``AttributeError``.
     """
-    from geoparquet_io.core.geo_metadata import decode_carried_geo, sanitize_geo_metadata
+    from geoparquet_io.core.geo_metadata import sanitized_carried_geo
 
-    if not metadata or b"geo" not in metadata:
-        return {}
-    geo_meta = sanitize_geo_metadata(decode_carried_geo(metadata[b"geo"]))
-    return geo_meta if isinstance(geo_meta, dict) else {}
+    return sanitized_carried_geo(metadata)
 
 
 def _detect_geometry_column_from_table(table: pa.Table) -> str:
@@ -92,15 +89,14 @@ def _detect_geometry_column_from_table(table: pa.Table) -> str:
         Geometry column name — the block's primary column, else the standard
         name the table's own schema carries, else 'geometry'.
     """
-    from geoparquet_io.core.geometry_detection import detect_geometry_column_from_names
+    from geoparquet_io.core.geo_metadata import carried_geometry_column
 
-    primary = _carried_geo(table.schema.metadata).get("primary_column")
-    if isinstance(primary, str) and primary:
-        return primary
-    # Sanitizing dropped a malformed `primary_column` and could not repair it
-    # from a single column. Falling back to the literal "geometry" would name a
-    # column the table may not have (#887 review).
-    return detect_geometry_column_from_names(table.schema.names) or "geometry"
+    # Sanitizing may have dropped a malformed `primary_column` without being
+    # able to repair it from a single column; `carried_geometry_column` then
+    # asks the schema, because falling back to the literal "geometry" would
+    # name a column the table may not have (#887 review).
+    geo_meta = _carried_geo(table.schema.metadata)
+    return carried_geometry_column(geo_meta, table.schema.names) or "geometry"
 
 
 def _resolve_crs_to_string(crs_info) -> str | None:

--- a/geoparquet_io/core/stac.py
+++ b/geoparquet_io/core/stac.py
@@ -16,7 +16,7 @@ from geoparquet_io.core.exceptions import (
     GeoParquetError,
     InvalidParameterError,
 )
-from geoparquet_io.core.geo_metadata import parse_geo_metadata
+from geoparquet_io.core.geo_metadata import parse_geo_metadata, sanitize_geo_metadata
 from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import debug, warn
 from geoparquet_io.core.remote import is_remote_url
@@ -208,15 +208,29 @@ def construct_asset_href(filename: str, bucket_prefix: str, public_url: str | No
 
 
 def _add_projection_properties(item: pystac.Item, geo_meta: dict | None, parquet_file: str) -> None:
-    """Add projection info to STAC Item properties if available."""
+    """Add projection info to STAC Item properties if available.
+
+    A write-path reader despite reading nothing but metadata: the CRS and
+    geometry types it lifts out leave gpio inside a *published* STAC Item, so
+    the block goes through the shared shape check rather than being copied out
+    of somebody else's file as-is (#947). ``parse_geo_metadata``, which the two
+    callers read with, is the read-only reader and stays untouched -- ``gpio
+    check`` needs it to show the file as it really is.
+
+    Before the check, a ``columns: null`` block aborted ``gpio publish stac``
+    with ``argument of type 'NoneType' is not iterable``, and a list- or
+    string-shaped ``columns`` with a ``TypeError`` one line later.
+    """
+    geo_meta = sanitize_geo_metadata(geo_meta)
     if not geo_meta:
         return
 
     geom_col = find_primary_geometry_column(parquet_file, verbose=False)
-    if "columns" not in geo_meta or geom_col not in geo_meta["columns"]:
+    columns = geo_meta.get("columns")
+    if not isinstance(columns, dict) or geom_col not in columns:
         return
 
-    col_info = geo_meta["columns"][geom_col]
+    col_info = columns[geom_col]
 
     # Add CRS if available
     if "crs" in col_info:

--- a/geoparquet_io/core/stream_io.py
+++ b/geoparquet_io/core/stream_io.py
@@ -24,7 +24,11 @@ import pyarrow as pa
 from geoparquet_io.core.common import get_parquet_metadata, write_parquet_with_metadata
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, quote_identifier, sql_path
 from geoparquet_io.core.file_utils import resolve_file_url
-from geoparquet_io.core.geo_metadata import backfill_derived_stats, prune_geo_metadata_to_columns
+from geoparquet_io.core.geo_metadata import (
+    backfill_derived_stats,
+    prune_geo_metadata_to_columns,
+    sanitized_carried_geo,
+)
 from geoparquet_io.core.logging_config import warn
 from geoparquet_io.core.remote import needs_httpfs
 from geoparquet_io.core.streaming import (
@@ -276,22 +280,31 @@ def write_output(
         return None
 
 
-def _extract_crs_from_metadata(metadata: dict | None) -> dict | str | None:
-    """Extract CRS from GeoParquet metadata."""
-    if not metadata or b"geo" not in metadata:
-        return None
-    try:
-        import json
+def _extract_crs_from_metadata(
+    metadata: dict | None, geometry_column: str | None = None
+) -> dict | str | None:
+    """Extract CRS from GeoParquet metadata.
 
-        geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-        if isinstance(geo_meta, dict):
-            columns = geo_meta.get("columns", {})
-            primary_col = geo_meta.get("primary_column", "geometry")
-            if primary_col in columns:
-                return columns[primary_col].get("crs")
-    except (json.JSONDecodeError, UnicodeDecodeError, KeyError):
-        pass
-    return None
+    A write-path reader: the answer becomes the geoarrow extension type's CRS on
+    the Arrow stream this process writes to stdout, so a malformed carried block
+    goes through the shared shape check (#947). It used to be indexed raw, and
+    the ``except`` beside it caught only the JSON errors -- ``columns: null``
+    escaped as ``argument of type 'NoneType' is not iterable``, and a list- or
+    string-shaped ``columns`` as a ``TypeError`` from the line after it.
+
+    ``geometry_column`` names the column the CRS is about to be attached to.
+    The caller knows it, and reading some other column's CRS onto it is the
+    silent half of #887: a block whose ``primary_column`` sanitizing had to
+    drop would otherwise fall back to the literal ``"geometry"`` and stream a
+    ``geom`` column as if its CRS were absent.
+    """
+    geo_meta = sanitized_carried_geo(metadata)
+    columns = geo_meta.get("columns")
+    if not isinstance(columns, dict):
+        return None
+    col = geometry_column or geo_meta.get("primary_column", "geometry")
+    col_meta = columns.get(col)
+    return col_meta.get("crs") if isinstance(col_meta, dict) else None
 
 
 def _write_stream_output(
@@ -320,7 +333,7 @@ def _write_stream_output(
     # Convert WKB binary to geoarrow extension type for streaming
     # This enables native geometry performance in downstream operations
     if geometry_column:
-        crs = _extract_crs_from_metadata(original_metadata)
+        crs = _extract_crs_from_metadata(original_metadata, geometry_column)
         table = apply_geoarrow_extension_type(table, geometry_column, crs)
 
     # Apply metadata to output table, the way the file path does (#722):

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -1217,3 +1217,337 @@ def test_detect_all_geometry_columns_on_a_non_parquet_input(tmp_path):
     assert info["primary"] == "geom"
     assert info["metadata"] == {"geom": {"encoding": "WKB"}}
     assert info["secondary"] == []
+
+
+# =============================================================================
+# The readers #883 and #887 left behind (#947)
+# =============================================================================
+
+# The third and last instalment. Every reader below indexed the raw block, and
+# each is classified the way #883 and #887 classified theirs:
+#
+#   write path -- the block it reads becomes an output file, a transform or a
+#     published artifact, so it goes through `sanitize_geo_metadata`:
+#       common._geo_block_to_carry_on_fast_path   (written to the output verbatim)
+#       common.write_geoparquet_table             (names the column, reads the CRS)
+#       add.bbox_metadata (table and file paths)  (rewrites the block)
+#       stac._add_projection_properties           (emits proj:* on a STAC Item)
+#       stream_io._extract_crs_from_metadata      (CRS of the streamed output)
+#
+#   validation-shared -- `gpio check bbox` reads through it and has to see the
+#     file as it really is, so it guards rather than sanitizes:
+#       common._check_bbox_metadata_covering
+#
+#   read-only -- documented as handing the caller the file's own `geo` block:
+#       api.Table.metadata
+
+
+def _bbox_struct_column() -> pa.Array:
+    return pa.array(
+        [{"xmin": 1.0, "ymin": 2.0, "xmax": 1.0, "ymax": 2.0}],
+        type=pa.struct(
+            [
+                ("xmin", pa.float64()),
+                ("ymin", pa.float64()),
+                ("xmax", pa.float64()),
+                ("ymax", pa.float64()),
+            ]
+        ),
+    )
+
+
+def _table_with_geo_and_bbox(geo_block, col: str = "geometry") -> pa.Table:
+    return _table_with_geo(geo_block, col=col).append_column("bbox", _bbox_struct_column())
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_fast_path_carry_survives_a_malformed_block(col, case, block):
+    """The 2.0 fast path decides what to write from the carried block (#947).
+
+    ``columns`` as a list or a string crashed it with
+    ``'list' object has no attribute 'get'`` -- and this block would then have
+    been written to the output verbatim.
+    """
+    from geoparquet_io.core.common import _geo_block_to_carry_on_fast_path
+
+    reset_malformed_geo_warnings()
+    metadata = {"geo": json.dumps(block)}
+    carried = _geo_block_to_carry_on_fast_path(metadata, col, "2.0")
+    assert carried is None or isinstance(carried["columns"], dict)
+
+
+def test_fast_path_carry_drops_a_wrong_typed_value_before_writing_it():
+    """A carried ``crs: 42`` must not reach the output through the fast path."""
+    from geoparquet_io.core.common import _geo_block_to_carry_on_fast_path
+
+    reset_malformed_geo_warnings()
+    block = {
+        "version": "2.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "crs": 42,
+                "orientation": "counterclockwise",
+            }
+        },
+    }
+    carried = _geo_block_to_carry_on_fast_path({"geo": json.dumps(block)}, "geometry", "2.0")
+    assert carried is not None
+    assert "crs" not in carried["columns"]["geometry"]
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_write_geoparquet_table_survives_a_malformed_block(col, case, block, tmp_path):
+    """``write_geoparquet_table`` named the column and read the CRS from the raw block.
+
+    ``columns: null`` raised ``argument of type 'NoneType' is not iterable`` and
+    a list-, string- or non-object-entry ``columns`` raised a ``TypeError`` or
+    ``AttributeError`` one line later (#947).
+    """
+    from geoparquet_io.core.common import write_geoparquet_table
+
+    reset_malformed_geo_warnings()
+    out = tmp_path / f"wgt_{col}_{case}.parquet"
+    write_geoparquet_table(_table_with_geo(block, col=col), str(out))
+
+    geo = _geo_of_file(out)
+    _assert_fresh_and_valid(geo, col=col)
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_check_bbox_structure_survives_a_malformed_block(col, case, block, tmp_path):
+    """``gpio check bbox`` reads the covering out of the block (#947).
+
+    Validation-shared: it reports on the file, so the block stays as the file
+    holds it and the reader guards instead. A ``columns`` that is not an object
+    declares no covering, which is the truthful answer, not a crash.
+    """
+    from geoparquet_io.core.common import check_bbox_structure
+
+    reset_malformed_geo_warnings()
+    path = tmp_path / f"checkbbox_{col}_{case}.parquet"
+    pq.write_table(_table_with_geo_and_bbox(block, col=col), path)
+
+    info = check_bbox_structure(str(path))
+    assert info["has_bbox_column"] is True
+    assert info["has_bbox_metadata"] is False
+
+
+def test_check_bbox_structure_survives_a_non_object_covering(tmp_path):
+    """``covering`` itself can be the wrong type; ``.get('bbox')`` crashed on it."""
+    from geoparquet_io.core.common import check_bbox_structure
+
+    reset_malformed_geo_warnings()
+    block = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "covering": "bbox"}},
+    }
+    path = tmp_path / "covering_not_an_object.parquet"
+    pq.write_table(_table_with_geo_and_bbox(block), path)
+
+    assert check_bbox_structure(str(path))["has_bbox_metadata"] is False
+
+
+def test_check_bbox_structure_still_finds_a_real_covering(tmp_path):
+    """The guard must not cost a well-formed file its covering."""
+    from geoparquet_io.core.common import check_bbox_structure
+
+    covering = {
+        "bbox": {
+            "xmin": ["bbox", "xmin"],
+            "ymin": ["bbox", "ymin"],
+            "xmax": ["bbox", "xmax"],
+            "ymax": ["bbox", "ymax"],
+        }
+    }
+    block = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "covering": covering}},
+    }
+    path = tmp_path / "real_covering.parquet"
+    pq.write_table(_table_with_geo_and_bbox(block), path)
+
+    assert check_bbox_structure(str(path))["has_bbox_metadata"] is True
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_add_bbox_metadata_table_survives_a_malformed_block(col, case, block):
+    """``Table.add_bbox_metadata`` rewrites the carried block, so it sanitizes (#947)."""
+    from geoparquet_io.core.add.bbox_metadata import add_bbox_metadata_table
+    from geoparquet_io.core.exceptions import GeoParquetError
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo_and_bbox(block, col=col)
+    try:
+        result = add_bbox_metadata_table(table, geometry_column=col)
+    except (GeoParquetError, ValueError):
+        pass  # a domain error naming the real cause is the contract
+    else:
+        geo = _geo_of(result)
+        assert geo["columns"][col]["covering"]["bbox"]["xmin"] == ["bbox", "xmin"]
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_add_bbox_metadata_file_survives_a_malformed_block(col, case, block, tmp_path):
+    """The file path crashed with ``'str' object does not support item assignment``."""
+    from geoparquet_io.core.add.bbox_metadata import add_bbox_metadata
+    from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.exceptions import GeoParquetError
+
+    reset_malformed_geo_warnings()
+    path = tmp_path / f"addbboxmeta_{col}_{case}.parquet"
+    pq.write_table(_table_with_geo_and_bbox(block, col=col), path)
+    try:
+        add_bbox_metadata(str(path))
+    except (GeoParquetError, ValueError, duckdb.Error):
+        pass  # a domain error naming the real cause is the contract
+    else:
+        # Read the Parquet key-value block, not the Arrow schema: a fixture
+        # written by pyarrow also carries an `ARROW:schema` key holding the
+        # *original* metadata, and pyarrow prefers it on the way back in.
+        columns = get_geo_metadata(str(path))["columns"]
+        assert isinstance(columns, dict)
+        assert columns[col]["covering"]["bbox"]["xmin"] == ["bbox", "xmin"]
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_stream_crs_reader_survives_a_malformed_block(col, case, block):
+    """The Arrow-stream write reads the output's CRS through here (#947).
+
+    ``columns: null`` raised ``argument of type 'NoneType' is not iterable``;
+    the ``except`` beside it caught only the JSON errors.
+    """
+    from geoparquet_io.core.stream_io import _extract_crs_from_metadata
+
+    reset_malformed_geo_warnings()
+    metadata = {b"geo": json.dumps(block).encode("utf-8")}
+    assert _extract_crs_from_metadata(metadata) is None
+
+
+def test_stream_crs_reader_still_finds_a_real_crs():
+    """The sanitizing must not cost a well-formed file its CRS."""
+    from geoparquet_io.core.stream_io import _extract_crs_from_metadata
+
+    crs = _crs_5070()
+    block = {
+        "version": "1.1.0",
+        "primary_column": "geom",
+        "columns": {"geom": {"encoding": "WKB", "crs": crs}},
+    }
+    metadata = {b"geo": json.dumps(block).encode("utf-8")}
+    assert _extract_crs_from_metadata(metadata) == crs
+    # And for the column the stream is actually attaching it to, named by the
+    # caller rather than guessed from a `primary_column` sanitizing may have
+    # dropped.
+    assert _extract_crs_from_metadata(metadata, "geom") == crs
+    assert _extract_crs_from_metadata(metadata, "id") is None
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_stac_projection_properties_survive_a_malformed_block(col, case, block, tmp_path):
+    """``gpio publish stac`` writes proj:* out of the carried block (#947).
+
+    A write path in the sense that matters here: the values leave gpio inside a
+    published STAC Item, so a malformed block is sanitized rather than copied.
+    ``columns: null`` raised ``argument of type 'NoneType' is not iterable``.
+    """
+    import datetime as dt
+
+    import pystac
+
+    from geoparquet_io.core.stac import _add_projection_properties
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(tmp_path, f"stac_{col}_{case}", block, col=col)
+    item = pystac.Item(
+        id="x",
+        geometry=None,
+        bbox=None,
+        datetime=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
+        properties={},
+    )
+    _add_projection_properties(item, block, path)
+    assert "proj:epsg" not in item.properties
+
+
+def test_stac_projection_properties_still_read_a_real_crs(tmp_path):
+    """The sanitizing must not cost a well-formed file its ``proj:*`` properties."""
+    import datetime as dt
+
+    import pystac
+
+    from geoparquet_io.core.stac import _add_projection_properties
+
+    block = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "crs": _crs_5070(),
+                "geometry_types": ["Point"],
+            }
+        },
+    }
+    path = _file_with_geo(tmp_path, "stac_ok", block)
+    item = pystac.Item(
+        id="x",
+        geometry=None,
+        bbox=None,
+        datetime=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
+        properties={},
+    )
+    _add_projection_properties(item, block, path)
+    assert item.properties["proj:epsg"] == 5070
+    assert item.properties["geoparquet:geometry_types"] == ["Point"]
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_api_table_metadata_survives_a_malformed_block(col, case, block, tmp_path):
+    """``Table.metadata()`` is a read-only reader: it guards, it does not sanitize.
+
+    It is the Python API's ``gpio inspect meta``, and its ``geo_metadata`` key is
+    documented as the file's full ``geo`` block, so the caller must get the block
+    the file really holds -- while the *derived* keys beside it stop crashing
+    with ``'list' object has no attribute 'get'`` (#947).
+    """
+    from geoparquet_io.api import read as gpio_read
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(tmp_path, f"apimeta_{col}_{case}", block, col=col)
+    meta = gpio_read(path).metadata()
+
+    # The block comes back exactly as the file holds it -- that is the contract
+    # of a read-only reader, and the whole reason this one guards rather than
+    # sanitizes. Only a block whose `columns` is usable yields derived keys.
+    assert meta["geo_metadata"] == block
+    usable = isinstance(block, dict) and isinstance(block.get("columns"), dict)
+    if not (usable and isinstance(block["columns"].get(col), dict)):
+        assert meta.get("geometry_types") is None
+
+
+def test_api_table_metadata_still_reports_a_well_formed_block(tmp_path):
+    """The guard must not cost a well-formed file its derived keys."""
+    from geoparquet_io.api import read as gpio_read
+
+    block = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "edges": "planar",
+            }
+        },
+    }
+    path = _file_with_geo(tmp_path, "apimeta_ok", block)
+    meta = gpio_read(path).metadata()
+
+    assert meta["geo_metadata"] == block
+    assert meta["geometry_types"] == ["Point"]
+    assert meta["edges"] == "planar"


### PR DESCRIPTION
## What changed

The third instalment of #883's class: the eight readers of a carried `geo`
block that indexed it without a shape check. Each site is classified the way
#883 and #887 classified theirs, and the classification decides the fix.

**Write path** — the block becomes an output file, a transform or a published
artifact, so it goes through the shared `sanitize_geo_metadata`:

| Site | Traceback on `origin/main` |
|---|---|
| `common._geo_block_to_carry_on_fast_path` | `AttributeError: 'list' object has no attribute 'get'` (and `'str'`) at `common.py:2786` |
| `common.write_geoparquet_table` | `TypeError: argument of type 'NoneType' is not iterable` at `common.py:3275`; `list indices must be integers`, `string indices must be integers` and `'str' object has no attribute 'get'` at `:3276` |
| `add_bbox_metadata` (file) | `TypeError: 'str' object does not support item assignment` at `bbox_metadata.py:344` |
| `add_bbox_metadata_table` | no crash, but a wrong-typed `crs` was carried into the returned table |
| `stac._add_projection_properties` | `TypeError: argument of type 'NoneType' is not iterable` at `stac.py:216`; `list/string indices must be integers` at `:219` |
| `stream_io._extract_crs_from_metadata` | `TypeError: argument of type 'NoneType' is not iterable` at `stream_io.py:290`; `list/string indices…` and `'str' object has no attribute 'get'` at `:291` |

`_geo_block_to_carry_on_fast_path` is the strongest case in the set: whatever it
returns is written to the output *verbatim*, so a carried `"crs": 42` reached the
file. `stac` is the judgement call the issue flagged — it reads metadata and
writes no Parquet, but the CRS and geometry types it lifts leave gpio inside a
**published** STAC Item, which is what makes it a write path.

**Validation-shared** — `gpio check bbox` and `check all` report through it, so it
must keep seeing the file as it really is and guards instead of sanitizing:

- `common._check_bbox_metadata_covering` — `AttributeError` from
  `columns.items()` at `common.py:3460`, reached by `gpio check bbox` *and* by
  `add bbox-metadata`, which is how the file path above crashed early. A
  `columns` that is not an object, or a `covering` that is not one, declares no
  covering; that is the truthful answer, not a crash.

**Read-only** — the other judgement call:

- `api.Table.metadata` — `AttributeError: 'list' object has no attribute 'get'`
  / `TypeError` at `table.py:2565-2567`. It is the Python API's
  `gpio inspect meta`, and its `geo_metadata` key is documented as *the file's
  full `geo` block*, so the block comes back exactly as the file holds it and
  only the derived keys beside it are guarded. Asserted by the tests: the block
  round-trips unchanged for every malformed shape.

**Already fine, no change:**

- `add/bbox.py:210-227` (`_passthrough_version`) type-checks both the block and
  the `version` string it reads.
- `reproject.py` 76-124, 289-295 and 825-831 were fixed by #945. Its one
  remaining raw read (`_sanitize_null_crs_file`) sits behind
  `geoparquet_crs_is_null`, which #945 sanitized, so no malformed shape reaches
  it — verified rather than assumed.

**Shared, not duplicated.** The three steps every one of these readers repeated —
find the key, decode it, check the shape — become `sanitized_carried_geo`, and
#945's "the named primary column, else the schema, never the literal
`geometry`" recovery becomes `carried_geometry_column`. `reproject`'s two local
helpers now delegate to both. `stream_io` also reads the CRS for the column it
is about to attach it to rather than for whatever `primary_column` survived
sanitizing — the silent half of #887 at this site.

## Why

A carried `geo` block is arbitrary JSON written by some other tool. Indexing it
without a shape check turns a malformed *input* into a Python type error several
frames from anything the user can act on. #883 fixed four such readers and
#887/#945 six more; these are the remainder, all pre-existing on `main` and all
reproduced before being fixed.

The line both predecessors upheld and this one upholds: **read-only and
validation readers do not sanitize**, because `gpio check` has to see the file as
it really is. `parse_geo_metadata`, `crs_utils.parse_geo_metadata_from_schema`
and `duckdb_metadata.get_geo_metadata` stay untouched.

## Verification

Reproduced every site on `origin/main` first with the shapes #883's tests already
use (`columns` null / list / string, an entry that is not an object, a non-string
`primary_column`), then re-ran the same script after the fix: no crashes, and the
only remaining failures are DuckDB's own reader refusing an unreadable file
(`Invalid Input Error: Geoparquet column 'geometry' is not an object`) — a domain
error naming the real cause, which is outside gpio's reach and is exactly what
#945 documented.

- `tests/test_malformed_geo_metadata.py`: +18 tests (329 lines), parametrized
  over both `geometry` and `geom` column names as #945 established, plus a
  positive test per site so the guards cannot cost a well-formed file its
  covering, its CRS, its `proj:*` properties or its derived metadata keys.
- `uv run pytest -n auto -m "not slow and not network and not meta" -q` —
  **6849 passed, 75 skipped, 9 xfailed**.
- `uv run pytest -m meta -q` — 205 passed (three `test_commitizen.py`
  subprocess timeouts on the first parallel run; all 29 pass serially — machine
  saturation, not the change).
- `uv run pre-commit run --all-files` clean; `--hook-stage pre-push` clean,
  `menard-check` included.
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` —
  **66 changed lines, 0 missing, 100%**.

One incidental finding worth recording: a fixture written by `pq.write_table`
carries an `ARROW:schema` key holding the *original* metadata, and pyarrow
prefers it over the Parquet key-value block on the way back in — so a test that
checks what `add bbox-metadata` wrote has to read the KV block, not
`schema_arrow.metadata`. Noted in the test.

**Not fixed, and deliberately so.** The issue's second item — a `primary_column`
naming a column the file does not have surfacing as a raw `BinderException` from
`sort` and `add` — is confirmed (`Binder Error: Referenced column "nope" not
found in FROM clause!` from `hilbert_order.py:520` and from `duckdb_kv.py:737`),
but it is not a one-liner. Naming the metadata as the cause means a schema probe
inside `find_primary_geometry_column`, which `check spatial` and `check
row-group` also call — new I/O in a validation-shared reader, on a file `#945`
drew a careful line around. It wants its own issue.

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when reading, writing, reprojecting, and validating files with malformed GeoParquet metadata.
  * Prevented crashes caused by invalid geometry columns, bounding-box information, CRS values, or other metadata structures.
  * Ensured CRS information is selected from the relevant geometry column.
  * Preserved raw metadata where appropriate while omitting invalid derived values.

* **Tests**
  * Added coverage for malformed and well-formed metadata across table, streaming, bounding-box, CRS, and projection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Correction: this is not the last instalment

An adversarial review found **four more live members of the same class**, all
reproducing on `main` and all untouched by this PR, so none of them block it.
They are filed as **#968**. The lead one is higher severity than anything the
three instalments have fixed:

- `geo_metadata.py:826` (`_prune_geo_dict_to_columns`) reads `primary_column`
  raw, so a non-string value makes it drop the **entire `geo` block, CRS
  included**. An absent `crs` is spec-defined as OGC:CRS84, so `gpio extract`
  and `gpio sort hilbert` silently relabel a projected file as lon/lat.
  Measured: an EPSG:5070 file on column `geom` with `primary_column: 123` comes
  out with no CRS, where the well-formed control keeps 5070. That is the same
  corruption shape #945's review caught, still live.
- `validate.py:730` — `gpio check spec`, the command you run to be *told* a file
  is malformed, dies with `AttributeError: 'list' object has no attribute
  'items'`.
- `check_parquet_structure.py:463` — `gpio check bbox` crashes on a non-object
  block, one layer above the guard this PR added.
- `streaming.py:206-224` — a non-string `primary_column` still reaches
  `quote_identifier` (#887 item 3, verbatim).

Also inaccurate above: `streaming.py:584` carries the identical
`geo_meta.get("primary_column", "geometry")` pattern, so this is not "the one
place still open to it". It is dead today (both callers pass `geometry_column`
explicitly), but it is a second site.

#968 also argues for the mechanical fix: a `meta`-lane guard that fails on any
new raw `geo_meta["columns"]` / `.get("primary_column")` read outside the shared
helpers, so there is no fourth instalment.