### PR TITLE
fix(extract): stop arcgis guessing geometry_types when the data does not say

### DIFF
--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -49,15 +49,6 @@ WKID_TO_EPSG = {
     102113: 3785,  # Legacy Web Mercator
 }
 
-# Map ArcGIS geometry types to GeoJSON types
-ARCGIS_GEOM_TYPES = {
-    "esriGeometryPoint": "Point",
-    "esriGeometryMultipoint": "MultiPoint",
-    "esriGeometryPolyline": "MultiLineString",
-    "esriGeometryPolygon": "MultiPolygon",
-    "esriGeometryEnvelope": "Polygon",
-}
-
 
 @dataclass
 class ArcGISAuth:
@@ -1199,25 +1190,48 @@ def _stream_features_to_parquet(
 def _resolve_geometry_types(table: pa.Table, esri_geometry_type: str, verbose: bool) -> list[str]:
     """Geometry types for the geo block, read from the fetched WKB (#928).
 
-    The layer's advertised ``geometryType`` is only a fallback. It is coarser
-    than the data (Esri's ``esriGeometryPolyline`` covers both LineString and
-    MultiLineString, and says nothing about Z/M), it does not cover every Esri
-    type, and it used to fall back to the literal ``"Geometry"`` -- which the
+    The layer's advertised ``geometryType`` does not describe the file. It is
+    coarser than the data (Esri's ``esriGeometryPolyline`` covers both
+    LineString and MultiLineString, and says nothing about Z/M), it does not
+    cover every Esri type, and it used to fall back to ``"Geometry"`` -- which the
     GeoParquet schema does not allow, so unmapped layers wrote files that
     failed validation on their own metadata.
 
     Computing from the data instead is what every gpio write path does, gives
     the spec's " Z"/" M"/" ZM" suffixes for free, and keeps the declaration
-    consistent with the statistics a reader checks it against. When the WKB
-    cannot be read the mapping table still serves as a fallback, and an Esri
-    type outside it yields ``[]`` -- the spec's way of saying the types are
-    not known.
+    consistent with the statistics a reader checks it against.
+
+    The declared type is no longer a fallback either (#962). Falling back
+    whenever the compute came back empty put the invented value straight back on
+    three reachable paths, because an empty result does not mean "the data was
+    fine and said nothing": ``unique_geometry_types`` is all-or-nothing, so one
+    malformed row empties the answer for a whole column of good geometry; an
+    all-NULL column has nothing to describe; and ``--exclude-cols geometry``
+    leaves no column to read. In each case the layer's coarse advertisement
+    (``esriGeometryPolygon`` -> MultiPolygon, over data holding a single
+    Polygon or no geometry at all) named a type the file does not contain.
+    ``[]`` -- the spec's way of saying the types are not known -- is the honest
+    answer wherever the data does not supply one, and gpio's own
+    geometry_types-vs-statistics check would flag the guess anyway.
+
+    The two ways of arriving at ``[]`` are still worth telling apart for the
+    user: unreadable geometry is a data-quality problem worth chasing, an empty
+    column is not. They cannot be told apart by catching, because
+    ``_compute_geometry_types`` swallows the geoarrow error itself, so the
+    non-NULL geometries are counted first.
     """
+    geometry = table.column("geometry") if "geometry" in table.column_names else None
+    if geometry is None or geometry.null_count == len(geometry):
+        warn("Fetched data holds no geometries; declaring geometry_types as [] (types not known).")
+        return []
+
     computed = _compute_geometry_types(table, "geometry", verbose)
-    if computed:
-        return computed
-    declared = ARCGIS_GEOM_TYPES.get(esri_geometry_type)
-    return [declared] if declared else []
+    if not computed:
+        warn(
+            "Fetched geometry could not be read, so geometry_types is declared as [] "
+            f"rather than guessed from the layer's {esri_geometry_type}."
+        )
+    return computed
 
 
 def arcgis_to_table(

--- a/geoparquet_io/core/arcgis.py
+++ b/geoparquet_io/core/arcgis.py
@@ -1221,7 +1221,16 @@ def _resolve_geometry_types(table: pa.Table, esri_geometry_type: str, verbose: b
     non-NULL geometries are counted first.
     """
     geometry = table.column("geometry") if "geometry" in table.column_names else None
-    if geometry is None or geometry.null_count == len(geometry):
+    if geometry is None:
+        # The user dropped the column with --exclude-cols; the service may well
+        # have returned geometry. Blaming the fetch here would point at the
+        # wrong thing and give the user nothing to act on.
+        warn(
+            "The geometry column was excluded, so there is nothing to describe; "
+            "declaring geometry_types as [] (types not known)."
+        )
+        return []
+    if geometry.null_count == len(geometry):
         warn("Fetched data holds no geometries; declaring geometry_types as [] (types not known).")
         return []
 

--- a/tests/test_arcgis_geometry_types.py
+++ b/tests/test_arcgis_geometry_types.py
@@ -12,9 +12,17 @@ longer than five — wrote a file that failed validation on its own metadata.
 The types are now computed from the fetched WKB with the same helper the write
 paths use, so they carry the spec's " Z"/" M"/" ZM" suffixes and match the data
 rather than the layer's advertisement.
+
+That fix kept the table as a fallback for whenever the compute came back empty,
+which put the guess straight back on three reachable paths (#962): one malformed
+row makes the all-or-nothing compute return nothing for the whole column, an
+all-NULL geometry column has nothing to describe, and ``--exclude-cols geometry``
+leaves no geometry column at all. The fallback is gone: when the data does not
+say, the file says ``[]``.
 """
 
 import json
+import logging
 import re
 
 import pyarrow as pa
@@ -93,9 +101,15 @@ def test_unknown_esri_geometry_type_is_computed_not_invented(run_extract):
         assert GEOMETRY_TYPE_PATTERN.match(name), f"{name!r} is not a valid geometry_types entry"
 
 
-def test_unknown_esri_geometry_type_falls_back_to_empty_not_invalid(run_extract):
-    """When the WKB cannot be read, an unknown Esri type declares nothing."""
-    column = run_extract("esriGeometryMultiPatch", [b"not wkb at all"])
+@pytest.mark.parametrize("esri_type", ["esriGeometryMultiPatch", "esriGeometryPolygon"])
+def test_unreadable_wkb_declares_nothing_whatever_the_layer_says(run_extract, esri_type):
+    """Unreadable WKB declares nothing — including for a type the table covered.
+
+    The mapped half is the regression: ``esriGeometryPolygon`` used to reach the
+    five-entry table here and write ``["MultiPolygon"]`` over bytes nobody could
+    read, which is the invented declaration #928 exists to stop.
+    """
+    column = run_extract(esri_type, [b"not wkb at all"])
 
     # An empty array is the spec's way to say the types are not known.
     assert column["geometry_types"] == []
@@ -167,6 +181,89 @@ def test_declaration_follows_the_data_when_repair_is_off(run_extract):
 
     assert column["geometry_types"] == ["Polygon"]
     assert _actual_types(run_extract.table) == ["Polygon"]
+
+
+# ---------------------------------------------------------------------------
+# #962: the compute coming back empty is not a licence to guess
+# ---------------------------------------------------------------------------
+
+VALID_POLYGON = shapely_wkb.dumps(Polygon([(0, 0), (1, 0), (1, 1), (0, 0)]))
+
+
+def test_one_malformed_row_does_not_resurrect_the_declared_guess(run_extract):
+    """A single unreadable row must not turn the whole column into a guess.
+
+    ``unique_geometry_types`` is all-or-nothing: it raises on the bad row rather
+    than reporting the types it managed to read, so the compute returns nothing
+    for a column that is almost entirely fine. Testing that emptiness for
+    truthiness sent an ``esriGeometryPolygon`` layer back to the table, which
+    declared ``["MultiPolygon"]`` over data whose only readable geometry is a
+    single ``Polygon`` — a type that is not in the file at all.
+    """
+    column = run_extract("esriGeometryPolygon", [VALID_POLYGON, b"junk"])
+
+    assert column["geometry_types"] == []
+    # The guess is not merely different from the data, it names a type the file
+    # does not contain -- which is why [] is the honest answer and not a cop-out.
+    readable = []
+    for value in run_extract.table.column("geometry"):
+        try:
+            readable.append(shapely_wkb.loads(bytes(value.as_py())).geom_type)
+        except Exception:  # the malformed row, which is the whole point
+            pass
+    assert readable == ["Polygon"]
+
+
+def test_all_null_geometry_column_declares_nothing(run_extract):
+    """Zero geometries means zero types, not the layer's advertised one.
+
+    FeatureServer records can carry ``"geometry": null``, and a ``--where`` can
+    select only those. NULLs are filtered by the compute by design, so this is
+    the "nothing to describe" case landing in the "compute failed" branch.
+    """
+    column = run_extract("esriGeometryPolygon", [None, None])
+
+    assert column["geometry_types"] == []
+
+
+def test_excluding_the_geometry_column_declares_nothing(run_extract):
+    """``--exclude-cols geometry`` leaves nothing to read, so nothing is declared.
+
+    The repair helper passes a table with no geometry column straight through,
+    so this reaches the geo block, where the fallback used to describe a column
+    that is not in the file.
+
+    Only the declaration is asserted here. The block still names ``geometry`` as
+    the primary_column when that column was excluded, which ``gpio check spec``
+    fails -- a separate bug from this one, left for its own change.
+    """
+    column = run_extract("esriGeometryPolygon", [VALID_POLYGON], exclude_cols="geometry")
+
+    assert "geometry" not in run_extract.table.column_names
+    assert column["geometry_types"] == []
+
+
+def test_could_not_read_and_nothing_to_read_are_told_apart(run_extract, caplog):
+    """Both declare ``[]``, but the user is told which of the two happened.
+
+    ``_compute_geometry_types`` swallows the geoarrow error and returns ``[]``,
+    so the two outcomes are indistinguishable at the call site unless the
+    non-NULL geometries are counted first. They are worth telling apart: one is
+    a data-quality problem worth chasing, the other is just an empty column.
+    """
+    with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+        assert run_extract("esriGeometryPolygon", [VALID_POLYGON, b"junk"])
+        unreadable = caplog.text
+        caplog.clear()
+        assert run_extract("esriGeometryPolygon", [None, None])
+        empty = caplog.text
+
+    assert "could not be read" in unreadable
+    # The layer's declared type survives as context for the warning, not as a
+    # value written to the file.
+    assert "esriGeometryPolygon" in unreadable
+    assert "could not be read" not in empty
+    assert "no geometries" in empty
 
 
 def test_written_file_validates_for_an_unknown_esri_type(tmp_path, monkeypatch):

--- a/tests/test_arcgis_geometry_types.py
+++ b/tests/test_arcgis_geometry_types.py
@@ -243,6 +243,21 @@ def test_excluding_the_geometry_column_declares_nothing(run_extract):
     assert column["geometry_types"] == []
 
 
+def test_an_excluded_column_is_not_blamed_on_the_fetch(run_extract, caplog):
+    """The warning must name the cause the user can act on.
+
+    The fetch here returned a perfectly good polygon; the column is missing
+    because the user passed ``--exclude-cols geometry``. Reporting "fetched data
+    holds no geometries" points at the service and leaves the user nothing to
+    do, so the excluded case gets its own message.
+    """
+    with caplog.at_level(logging.WARNING, logger="geoparquet_io"):
+        run_extract("esriGeometryPolygon", [VALID_POLYGON], exclude_cols="geometry")
+
+    assert "was excluded" in caplog.text
+    assert "Fetched data holds no geometries" not in caplog.text
+
+
 def test_could_not_read_and_nothing_to_read_are_told_apart(run_extract, caplog):
     """Both declare ``[]``, but the user is told which of the two happened.
 


### PR DESCRIPTION
## What changed

`_resolve_geometry_types` no longer falls back to the five-entry `ARCGIS_GEOM_TYPES`
table when the computed types come back empty. The table is deleted; the layer's
declared type now appears only as context in a warning, never in the file.

The two ways of arriving at `[]` are told apart by counting the non-NULL
geometries before computing, because `_compute_geometry_types` swallows the
geoarrow error itself and returns `[]` — so catching cannot distinguish them one
level up, as #962 suspected. Both still declare `[]`; the distinction drives the
message, not the value:

- **nothing to describe** — no geometry column, or every value NULL →
  `Fetched data holds no geometries; declaring geometry_types as [] (types not known).`
- **could not read** — non-NULL geometry the compute could not parse →
  `Fetched geometry could not be read, so geometry_types is declared as [] rather than guessed from the layer's esriGeometryPolygon.`

## Why

#956 stopped the geo block inventing `"Geometry"`, but `if computed:` put the
guess straight back wherever the compute returned nothing. Three reachable paths,
all measured against `esriGeometryPolygon`:

| input | declared before | declared after | readable in the file |
|---|---|---|---|
| `[Polygon, b"junk"]` | `["MultiPolygon"]` | `[]` | `Polygon` |
| `[NULL, NULL]` | `["MultiPolygon"]` | `[]` | none |
| `--exclude-cols geometry` | `["MultiPolygon"]` | `[]` | no geometry column |

`ga.unique_geometry_types` is all-or-nothing, so one malformed row empties the
answer for a whole column of good geometry. An all-NULL column has nothing to
describe — the compute filters NULLs by design, so it lands in the "compute
failed" branch. And `repair_arrow_table_geometry` passes a table with no geometry
column straight through, so `--exclude-cols geometry` reaches the geo block too.
In each case the layer's advertisement named a type the file does not contain.

**What the mapping table is still for: nothing.** It is not merely wrong in the
three cases above, it has no remaining case to serve.

- The one scenario where the declared type is the only information available —
  an empty result set — never reaches the geo block: `arcgis_to_table` returns a
  bare table at `total_count == 0` and raises at `total_rows == 0`, so the block
  is only ever built over at least one row.
- The unreadable-WKB case it was kept for is unreachable in practice: this
  geometry is always DuckDB `ST_AsWKB` output (`arcgis.py:991`), which is
  readable by construction.
- Even where it did fire, it is coarser than what it describes
  (`esriGeometryPolyline` → `MultiLineString` over LineString data, no Z/M) and
  covers five of Esri's types.

**Why not the partial answer.** #962 allows "the types that could be read" for
the malformed-row case. Declaring those claims the unreadable rows are among
them, which is exactly the unverifiable claim this PR removes — and a conformant
reader skips rows whose type is not declared, so under-declaring is data loss,
not a cosmetic mismatch. `[]` makes no claim.

**All-NULL vs could-not-read.** Both declare `[]`, and deliberately so: a column
holding zero geometries has zero types present, which is the same empty array the
spec uses for "not known". Declaring the layer's type over it would be vacuously
true and unverifiable. What differs is the warning — one is a data-quality
problem worth chasing, the other is just an empty column.

This adds a producer of `[]`, which #952 documents as sticky.

**Noticed, not fixed:** `extract arcgis --exclude-cols geometry` writes a geo
block whose `primary_column` names a column that is not in the file, which
`gpio check spec` fails with `geometry column "geometry" not found in schema`.
`extract geoparquet` handles the same case by writing plain Parquet with no `geo`
metadata. That is a separate bug and wants its own change; this PR only stops the
`geometry_types` inside that block from being invented.

## Verification

- Fast suite: `uv run pytest -n auto -m "not slow and not network and not meta" -q`
  → **6758 passed, 75 skipped, 9 xfailed** in 171s.
- Meta lane: `uv run pytest -m meta -q` → **205 passed**, 7585 deselected.
- Diff coverage: `uv run diff-cover coverage.xml --compare-branch origin/main --fail-under=90`
  → **100%** (7/7 changed lines).
- `uv run pre-commit run --all-files` clean; `--hook-stage pre-push` clean
  (vulture included, which is what confirms the deleted table had no other user).
- Five tests written failing first, against the shipped code, then made to pass:
  the malformed row, the all-NULL column, the excluded column, the mapped Esri
  type with unreadable WKB, and one that pins the two warnings apart.

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ArcGIS geometry type detection for exported GeoParquet files.
  * Files now correctly indicate unknown geometry types when geometry data is missing, empty, malformed, or unreadable.
  * Added clearer warnings distinguishing unavailable geometry data from empty geometry columns.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->