### PR TITLE
fix(extract): reject blank --include-cols/--exclude-cols entries and check BigQuery names against the table

### DIFF
--- a/geoparquet_io/cli/commands/extract.py
+++ b/geoparquet_io/cli/commands/extract.py
@@ -18,6 +18,7 @@ from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     any_extension_option,
     aws_profile_option,
+    column_list_option,
     compression_options,
     dry_run_option,
     geoparquet_version_option,
@@ -69,11 +70,11 @@ def extract(ctx):
 @extract.command(name="geoparquet", cls=GlobAwareCommand)
 @click.argument("input_file")
 @click.argument("output_file", type=click.Path(), required=False, default=None)
-@click.option(
+@column_list_option(
     "--include-cols",
     help="Comma-separated columns to include (geometry and bbox auto-added unless in --exclude-cols)",
 )
-@click.option(
+@column_list_option(
     "--exclude-cols",
     help="Comma-separated columns to exclude (can be used with --include-cols to exclude geometry/bbox)",
 )
@@ -286,11 +287,11 @@ def extract_geoparquet(
     "--bbox",
     help="Bounding box filter: xmin,ymin,xmax,ymax in WGS84 (pushed to server)",
 )
-@click.option(
+@column_list_option(
     "--include-cols",
     help="Comma-separated columns to include (pushed to server for efficiency)",
 )
-@click.option(
+@column_list_option(
     "--exclude-cols",
     help="Comma-separated columns to exclude (applied after download)",
 )
@@ -508,11 +509,11 @@ def extract_arcgis(
     help="Path to GCP service account JSON file (otherwise uses gcloud auth or "
     "GOOGLE_APPLICATION_CREDENTIALS)",
 )
-@click.option(
+@column_list_option(
     "--include-cols",
     help="Comma-separated columns to include",
 )
-@click.option(
+@column_list_option(
     "--exclude-cols",
     help="Comma-separated columns to exclude",
 )
@@ -1052,11 +1053,11 @@ def extract_wfs_cmd(
     type=click.IntRange(0, None),
     help="Maximum number of rows to extract",
 )
-@click.option(
+@column_list_option(
     "--include-cols",
     help="Comma-separated columns to include (default: all)",
 )
-@click.option(
+@column_list_option(
     "--exclude-cols",
     help="Comma-separated columns to exclude",
 )

--- a/geoparquet_io/cli/commands/pmtiles.py
+++ b/geoparquet_io/cli/commands/pmtiles.py
@@ -10,6 +10,7 @@ import click
 from geoparquet_io.cli.decorators import (
     SingleFileCommand,
     aws_profile_option,
+    column_list_option,
     repair_geometry_option,
     verbose_option,
 )
@@ -42,7 +43,7 @@ def pmtiles(ctx):
 @click.option("--max-zoom", type=int, help="Maximum zoom level (auto-detected if not set)")
 @click.option("--bbox", help="Bounding box filter: minx,miny,maxx,maxy")
 @click.option("--where", help="SQL WHERE clause for filtering")
-@click.option("--include-cols", help="Comma-separated list of columns to include")
+@column_list_option("--include-cols", help="Comma-separated list of columns to include")
 @click.option(
     "--precision",
     type=int,

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -354,8 +354,19 @@ def _validate_column_list(ctx, param, value):
     BigQuery), which reports it as ``InvalidParameterError`` -- also exit 2.
     Catching blanks here matters even so: ``--dry-run`` builds the same SELECT
     without ever opening a connection, so there is no schema to check against.
+
+    A **wholly empty** value is not a blank entry, it is an unset option, and is
+    normalised to ``None``. Every backend reads these options as
+    ``[c.strip() for c in v.split(",")] if v else None``
+    (``core/extract.py``, ``core/extract_bigquery.py``, ``core/carto.py``,
+    ``core/pmtiles.py``), so ``""`` has always meant "not given" -- which is what
+    ``--include-cols "$COLS"`` expands to when ``COLS`` is unset. Rejecting it
+    would break working invocations without catching anything: ``"".split(",")``
+    is ``[""]`` only because there is nothing there to name. ``"   "`` and
+    ``"id,,name"`` are a different case -- both are truthy, so both reach
+    ``quote_identifier()`` on main, and both stay rejected.
     """
-    if value is None:
+    if value is None or value == "":
         return None
     if any(not entry.strip() for entry in value.split(",")):
         raise click.BadParameter(

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -333,6 +333,51 @@ def column_name_option(*param_decls, **kwargs):
     return click.option(*param_decls, **kwargs)
 
 
+def _validate_column_list(ctx, param, value):
+    """Reject a blank entry in an option carrying a comma-separated column list.
+
+    The list-valued sibling of :func:`_validate_column_name`. ``--include-cols``
+    and ``--exclude-cols`` are split on commas by each backend, and the entries
+    become delimited SQL identifiers: ``gpio extract bigquery ... --include-cols
+    '   '`` split to ``['']`` and raised a raw
+    ``ValueError: cannot quote an empty SQL identifier`` traceback out of
+    ``quote_identifier()`` (#969); ``gpio extract carto`` hit the same call one
+    network round-trip later.
+
+    #959 could not cover these with :func:`_validate_column_name` because that
+    callback validates *the value*, and here the value is a list -- ``"id,,name"``
+    is not blank but carries a blank entry.
+
+    This layer owns blank entries only. Whether a non-blank name exists is a
+    schema question, so it stays with whichever backend can see the schema
+    (``validate_columns`` for parquet, ``validate_bigquery_columns`` for
+    BigQuery), which reports it as ``InvalidParameterError`` -- also exit 2.
+    Catching blanks here matters even so: ``--dry-run`` builds the same SELECT
+    without ever opening a connection, so there is no schema to check against.
+    """
+    if value is None:
+        return None
+    if any(not entry.strip() for entry in value.split(",")):
+        raise click.BadParameter(
+            "column list cannot contain an empty or whitespace-only entry",
+            ctx=ctx,
+            param=param,
+        )
+    return value
+
+
+def column_list_option(*param_decls, **kwargs):
+    """``click.option`` for an option whose value is a comma-separated column list.
+
+    Identical to :func:`click.option` except that the shared
+    :func:`_validate_column_list` callback is wired up. Declaring a new
+    list-valued column option with this rather than a bare ``@click.option`` is
+    what ``tests/test_cli_column_list_guard.py`` enforces.
+    """
+    kwargs.setdefault("callback", _validate_column_list)
+    return click.option(*param_decls, **kwargs)
+
+
 def repair_geometry_option(func):
     """
     Add --repair-geometry/--no-repair-geometry option to a command.

--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -405,11 +405,46 @@ def extract_bigquery_table(
     return result
 
 
+def _schema_rows(
+    con: duckdb.DuckDBPyConnection,
+    table_id: str,
+    table_source: str = "bigquery",
+) -> list[tuple[str, str]]:
+    """Return ``(column name, column type)`` for every column, in schema order.
+
+    The module's single ``DESCRIBE``. Every function here that needs a schema
+    goes through this one, and a caller holding the result can pass it on
+    (``schema_rows=``) instead of paying for a second round-trip against
+    BigQuery.
+
+    ``table_id`` is interpolated raw on the BigQuery branch, and that is not an
+    oversight to be fixed with ``sql_path()`` or ``quote_identifier()``:
+    ``bigquery_scan`` takes a ``project.dataset.table`` **string literal**, not
+    a path or an identifier. **The caller must have run the id through**
+    :func:`_normalize_table_id`, whose ``_TABLE_PART_PATTERN`` admits only
+    ``[A-Za-z0-9_-]`` per part and so cannot carry a quote. Consolidating the
+    five copies of this query is what makes that contract statable in one
+    place; ``tests/test_extract_bigquery.py::TestSchemaIsReadOnce`` keeps it
+    there. The local branch takes a real table name and quotes it.
+
+    Args:
+        con: DuckDB connection
+        table_id: Pre-validated BigQuery table ID, or a local table name
+        table_source: "bigquery" for bigquery_scan, "local" for local tables
+    """
+    if table_source == "bigquery":
+        schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
+    else:
+        schema_query = f"DESCRIBE SELECT * FROM {quote_identifier(table_id)} LIMIT 0"
+    return [(row[0], str(row[1])) for row in con.execute(schema_query).fetchall()]
+
+
 def _detect_geometry_column_from_schema(
     con: duckdb.DuckDBPyConnection,
     table_id: str,
     geography_column: str | None = None,
     table_source: str = "bigquery",
+    schema_rows: list[tuple[str, str]] | None = None,
 ) -> str | None:
     """
     Detect native GEOMETRY-typed column from table schema.
@@ -425,23 +460,20 @@ def _detect_geometry_column_from_schema(
         geography_column: If provided and matches a native GEOMETRY column,
             returns it. Otherwise returns None (caller handles VARCHAR columns).
         table_source: "bigquery" for bigquery_scan, "local" for local tables
+        schema_rows: The schema, when the caller has already read it. Saves a
+            DESCRIBE round-trip against BigQuery.
 
     Returns:
         Name of detected GEOMETRY column, or None
     """
-    if table_source == "bigquery":
-        schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
-    else:
-        schema_query = f"DESCRIBE SELECT * FROM {quote_identifier(table_id)} LIMIT 0"
-    schema_result = con.execute(schema_query).fetchall()
+    if schema_rows is None:
+        schema_rows = _schema_rows(con, table_id, table_source)
 
     geometry_cols = []
     all_cols = []
-    for row in schema_result:
-        col_name = row[0]
-        col_type = str(row[1]).upper()
+    for col_name, col_type in schema_rows:
         all_cols.append(col_name)
-        if "GEOMETRY" in col_type:
+        if "GEOMETRY" in col_type.upper():
             geometry_cols.append(col_name)
 
     # If explicit column provided and it's a native GEOMETRY column, use it
@@ -479,11 +511,7 @@ def _schema_column_names(
         table_id: BigQuery table ID or local table name
         table_source: "bigquery" for bigquery_scan, "local" for local tables
     """
-    if table_source == "bigquery":
-        schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
-    else:
-        schema_query = f"DESCRIBE SELECT * FROM {quote_identifier(table_id)} LIMIT 0"
-    return [row[0] for row in con.execute(schema_query).fetchall()]
+    return [name for name, _ in _schema_rows(con, table_id, table_source)]
 
 
 def validate_bigquery_columns(
@@ -511,6 +539,11 @@ def validate_bigquery_columns(
     ``--exclude-cols ID`` silently excluded nothing. Resolving makes the two
     agree.
 
+    An **exact** match is preferred to a folded one, because folding is not
+    injective: ``_schema_column_names`` also serves ``table_source="local"``,
+    where DuckDB permits a table carrying both ``id`` and ``ID``, and a
+    ``{col.lower(): col}`` map keeps only the last of those.
+
     Args:
         requested_cols: Column names the user asked for (or None)
         all_columns: Every column in the table's schema
@@ -528,8 +561,16 @@ def validate_bigquery_columns(
     if any(not col.strip() for col in requested_cols):
         raise InvalidParameterError(option_name, "column names cannot be empty or whitespace-only")
 
-    schema_spelling = {col.lower(): col for col in all_columns}
-    missing = [col for col in requested_cols if col.lower() not in schema_spelling]
+    exact = set(all_columns)
+    folded = {col.lower(): col for col in all_columns}
+
+    def _resolve(col: str) -> str | None:
+        if col in exact:
+            return col
+        return folded.get(col.lower())
+
+    resolved = [(col, _resolve(col)) for col in requested_cols]
+    missing = [col for col, match in resolved if match is None]
     if missing:
         raise InvalidParameterError(
             option_name,
@@ -537,7 +578,7 @@ def validate_bigquery_columns(
             f"Available columns: {', '.join(all_columns)}",
         )
 
-    return [schema_spelling[col.lower()] for col in requested_cols]
+    return [match for _, match in resolved if match is not None]
 
 
 def _get_column_type(
@@ -556,11 +597,9 @@ def _get_column_type(
     Returns:
         Uppercase type string (e.g. "GEOMETRY", "VARCHAR")
     """
-    schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
-    schema_result = con.execute(schema_query).fetchall()
-    for row in schema_result:
-        if row[0].lower() == column_name.lower():
-            return str(row[1]).upper()
+    for name, col_type in _schema_rows(con, table_id):
+        if name.lower() == column_name.lower():
+            return col_type.upper()
     return "VARCHAR"
 
 
@@ -582,14 +621,9 @@ def _resolve_column_name(
     Returns:
         The actual column name from the schema, or the input if not found
     """
-    if table_source == "bigquery":
-        schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
-    else:
-        schema_query = f"DESCRIBE SELECT * FROM {quote_identifier(table_id)} LIMIT 0"
-    schema_result = con.execute(schema_query).fetchall()
-    for row in schema_result:
-        if row[0].lower() == column_name.lower():
-            return row[0]
+    for name in _schema_column_names(con, table_id, table_source):
+        if name.lower() == column_name.lower():
+            return name
     return column_name
 
 
@@ -651,9 +685,7 @@ def _build_select_with_wkb(
     """
     # Get all column names if selecting all
     if columns is None:
-        schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
-        schema_result = con.execute(schema_query).fetchall()
-        columns = [row[0] for row in schema_result]
+        columns = _schema_column_names(con, table_id)
 
     # Detect geometry column type if we have one
     geom_col_type = ""
@@ -749,7 +781,7 @@ def _build_column_list(
 
     Args:
         schema_columns: The table's columns, when the caller has already read
-            them (``validate_bigquery_columns`` does). Saves a DESCRIBE
+            them (``_execute_bigquery_extraction`` always has). Saves a DESCRIBE
             round-trip against BigQuery on the exclude branch.
 
     Returns:
@@ -1049,8 +1081,16 @@ def _execute_bigquery_extraction(
             con.execute(f"SET memory_limit = '{validate_memory_limit(memory_limit)}'")
             debug(f"DuckDB memory limit: {memory_limit}")
 
+        # One DESCRIBE serves everything that needs the schema here: the
+        # geometry detection below and the --include-cols/--exclude-cols check
+        # further down. Validation therefore costs no BigQuery round-trip at
+        # all, on either branch.
+        schema_rows = _schema_rows(con, validated_table_id)
+
         # Detect geometry column from schema (native GEOMETRY type only)
-        geom_col = _detect_geometry_column_from_schema(con, validated_table_id, geography_column)
+        geom_col = _detect_geometry_column_from_schema(
+            con, validated_table_id, geography_column, schema_rows=schema_rows
+        )
         is_native_geometry = geom_col is not None  # Track whether geometry is native GEOGRAPHY type
         if geom_col:
             debug(f"Detected geometry column: {geom_col}")
@@ -1082,13 +1122,10 @@ def _execute_bigquery_extraction(
             final_edges = None  # Planar (no edges metadata)
 
         # Check the requested columns against the table before any of them is
-        # quoted into the SELECT (#969). The schema is read once and handed to
-        # _build_column_list so --exclude-cols costs no extra DESCRIBE.
-        schema_columns: list[str] | None = None
-        if include_list or exclude_list:
-            schema_columns = _schema_column_names(con, validated_table_id)
-            include_list = validate_bigquery_columns(include_list, schema_columns, "--include-cols")
-            exclude_list = validate_bigquery_columns(exclude_list, schema_columns, "--exclude-cols")
+        # quoted into the SELECT (#969), reusing the schema read above.
+        schema_columns = [name for name, _ in schema_rows]
+        include_list = validate_bigquery_columns(include_list, schema_columns, "--include-cols")
+        exclude_list = validate_bigquery_columns(exclude_list, schema_columns, "--exclude-cols")
 
         # Build column list and SELECT clause
         cols_to_select = _build_column_list(

--- a/geoparquet_io/core/extract_bigquery.py
+++ b/geoparquet_io/core/extract_bigquery.py
@@ -21,6 +21,7 @@ from geoparquet_io.core.duckdb_utils import (
     validate_where_clause,
     where_condition_fragment,
 )
+from geoparquet_io.core.exceptions import InvalidParameterError
 from geoparquet_io.core.extract import parse_bbox
 from geoparquet_io.core.file_utils import handle_output_overwrite
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
@@ -466,6 +467,79 @@ def _detect_geometry_column_from_schema(
     return None
 
 
+def _schema_column_names(
+    con: duckdb.DuckDBPyConnection,
+    table_id: str,
+    table_source: str = "bigquery",
+) -> list[str]:
+    """Return the table's column names, in schema order.
+
+    Args:
+        con: DuckDB connection
+        table_id: BigQuery table ID or local table name
+        table_source: "bigquery" for bigquery_scan, "local" for local tables
+    """
+    if table_source == "bigquery":
+        schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
+    else:
+        schema_query = f"DESCRIBE SELECT * FROM {quote_identifier(table_id)} LIMIT 0"
+    return [row[0] for row in con.execute(schema_query).fetchall()]
+
+
+def validate_bigquery_columns(
+    requested_cols: list[str] | None,
+    all_columns: list[str],
+    option_name: str,
+) -> list[str] | None:
+    """Check requested column names against the BigQuery table's schema.
+
+    The BigQuery backend's equivalent of ``core.extract.validate_columns``,
+    which the parquet backend has run since #731. Without it a name the table
+    does not carry was quoted straight into the SELECT and failed as a DuckDB
+    binder error, and a blank entry raised
+    ``ValueError: cannot quote an empty SQL identifier`` (#969).
+
+    Blank entries are also rejected here, not only by the Click callback: the
+    Python API (``ops.read_bigquery``, ``Table.from_bigquery``) never goes
+    through Click.
+
+    Matching is case-insensitive and the **schema spelling is returned**,
+    following the rest of this module (``_resolve_column_name``,
+    ``_get_column_type``). DuckDB resolves a quoted identifier
+    case-insensitively, so ``--include-cols ID`` always worked; but
+    ``_build_column_list`` filters ``--exclude-cols`` by string comparison, so
+    ``--exclude-cols ID`` silently excluded nothing. Resolving makes the two
+    agree.
+
+    Args:
+        requested_cols: Column names the user asked for (or None)
+        all_columns: Every column in the table's schema
+        option_name: Option to name in the error message, e.g. "--include-cols"
+
+    Returns:
+        The requested columns in their schema spelling, or None
+
+    Raises:
+        InvalidParameterError: If any entry is blank or absent from the schema
+    """
+    if not requested_cols:
+        return None
+
+    if any(not col.strip() for col in requested_cols):
+        raise InvalidParameterError(option_name, "column names cannot be empty or whitespace-only")
+
+    schema_spelling = {col.lower(): col for col in all_columns}
+    missing = [col for col in requested_cols if col.lower() not in schema_spelling]
+    if missing:
+        raise InvalidParameterError(
+            option_name,
+            f"Columns not found in schema: {', '.join(sorted(missing))}. "
+            f"Available columns: {', '.join(all_columns)}",
+        )
+
+    return [schema_spelling[col.lower()] for col in requested_cols]
+
+
 def _get_column_type(
     con: duckdb.DuckDBPyConnection,
     table_id: str,
@@ -668,9 +742,15 @@ def _build_column_list(
     include_list: list[str] | None,
     exclude_list: list[str] | None,
     geom_col: str | None,
+    schema_columns: list[str] | None = None,
 ) -> list[str] | None:
     """
     Build the column list for SELECT based on include/exclude lists.
+
+    Args:
+        schema_columns: The table's columns, when the caller has already read
+            them (``validate_bigquery_columns`` does). Saves a DESCRIBE
+            round-trip against BigQuery on the exclude branch.
 
     Returns:
         List of columns to select, or None for all columns
@@ -685,9 +765,9 @@ def _build_column_list(
 
     if exclude_list is not None:
         # Push down exclusions: get all columns, then remove excluded ones
-        schema_query = f"DESCRIBE SELECT * FROM bigquery_scan('{table_id}') LIMIT 0"
-        schema_result = con.execute(schema_query).fetchall()
-        all_schema_cols = [row[0] for row in schema_result]
+        all_schema_cols = (
+            schema_columns if schema_columns is not None else _schema_column_names(con, table_id)
+        )
         return [c for c in all_schema_cols if c not in exclude_list]
 
     return None  # All columns
@@ -1001,9 +1081,18 @@ def _execute_bigquery_extraction(
         else:
             final_edges = None  # Planar (no edges metadata)
 
+        # Check the requested columns against the table before any of them is
+        # quoted into the SELECT (#969). The schema is read once and handed to
+        # _build_column_list so --exclude-cols costs no extra DESCRIBE.
+        schema_columns: list[str] | None = None
+        if include_list or exclude_list:
+            schema_columns = _schema_column_names(con, validated_table_id)
+            include_list = validate_bigquery_columns(include_list, schema_columns, "--include-cols")
+            exclude_list = validate_bigquery_columns(exclude_list, schema_columns, "--exclude-cols")
+
         # Build column list and SELECT clause
         cols_to_select = _build_column_list(
-            con, validated_table_id, include_list, exclude_list, geom_col
+            con, validated_table_id, include_list, exclude_list, geom_col, schema_columns
         )
         select_cols, _ = _build_select_with_wkb(
             cols_to_select, geom_col, con, validated_table_id, geometry_format

--- a/tests/test_cli_column_list_guard.py
+++ b/tests/test_cli_column_list_guard.py
@@ -1,0 +1,163 @@
+"""Every option carrying a comma-separated column list rejects a blank entry.
+
+The sibling of ``tests/test_cli_column_name_guard.py``. #959 closed the #933
+sweep for options carrying **one** column name; the list-valued options were
+left out because a callback validating "the value" is the wrong shape when the
+value is ``"a,b,c"`` -- each *entry* needs checking (#969).
+
+``gpio extract bigquery ... --include-cols '   '`` split to ``['']``, and the
+empty string reached ``quote_identifier()`` in ``_handle_dry_run`` /
+``_build_select_with_wkb``, surfacing as a raw
+``ValueError: cannot quote an empty SQL identifier`` traceback at exit 1.
+``gpio extract carto`` reached the same call through ``_build_carto_query``,
+after a network round-trip. The guard is a shared Click callback wired up by
+:func:`geoparquet_io.cli.decorators.column_list_option`, so it fires during
+parameter processing, before any file is read or any service is contacted.
+
+``test_no_unreviewed_cols_option_appeared`` walks the live command tree, so a
+new list-valued column option declared with a bare ``@click.option`` fails here
+rather than shipping unguarded.
+
+The Click layer owns *blank entries only*. Whether a non-blank name actually
+exists is a schema question, so it belongs to whichever backend can see the
+schema -- ``validate_columns`` for parquet, ``validate_bigquery_columns`` for
+BigQuery -- and is covered in those backends' own tests.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.decorators import _validate_column_list
+from geoparquet_io.cli.main import cli
+
+# Options whose value is a comma-separated list of column names. Keyed by
+# command path, valued by the flags on that command.
+GUARDED_LIST_OPTIONS = {
+    ("extract", "geoparquet"): ["--exclude-cols", "--include-cols"],
+    ("extract", "arcgis"): ["--exclude-cols", "--include-cols"],
+    ("extract", "bigquery"): ["--exclude-cols", "--include-cols"],
+    ("extract", "carto"): ["--exclude-cols", "--include-cols"],
+    # Forwarded verbatim to a `gpio extract` subprocess (core/pmtiles.py), so a
+    # blank entry used to fail there, one process away from the user.
+    ("pmtiles", "create"): ["--include-cols"],
+}
+
+# Options the sweep matches but that deliberately carry no guard. Empty for
+# now: every ``--*-cols`` option in the tree is a column list.
+REVIEWED_UNGUARDED_LISTS: dict[tuple[str, ...], list[str]] = {}
+
+# Leading positional arguments per command, so a *missing* argument is never
+# what makes these assertions pass. The output path is appended per test.
+LEADING_ARGS = {
+    ("extract", "geoparquet"): ["tests/data/places_test.parquet"],
+    ("extract", "arcgis"): ["https://example.com/arcgis/rest/services/x/FeatureServer/0"],
+    ("extract", "bigquery"): ["project-name.dataset.table"],
+    ("extract", "carto"): ["https://gcp-us-east1.api.carto.com", "carto-demo.public.table"],
+    ("pmtiles", "create"): ["tests/data/places_test.parquet"],
+}
+
+OUTPUT_NAME = {("pmtiles", "create"): "out.pmtiles"}
+
+
+def _iter_options(command: click.Command, path: tuple[str, ...]):
+    """Yield ``(path, option)`` for every option in the command tree."""
+    if isinstance(command, click.Group):
+        for name, sub in command.commands.items():
+            yield from _iter_options(sub, (*path, name))
+        return
+    for param in command.params:
+        if isinstance(param, click.Option):
+            yield path, param
+
+
+def _column_list_options():
+    """Every option in the tree whose flag looks like a column list.
+
+    Matches ``--*-cols``, accumulating per command so a second list option on
+    one command cannot hide behind the first.
+    """
+    found: dict[tuple[str, ...], list[str]] = {}
+    for path, option in _iter_options(cli, ()):
+        if option.is_flag:
+            continue
+        flags = [opt for opt in option.opts if opt.startswith("--")]
+        if any(flag.endswith("-cols") for flag in flags):
+            found.setdefault(path, []).extend(flags)
+    return {path: sorted(flags) for path, flags in found.items()}
+
+
+class TestListGuardCoverage:
+    """The declared family matches the live command tree."""
+
+    def test_every_column_list_option_is_guarded(self):
+        for path, flags in GUARDED_LIST_OPTIONS.items():
+            command = cli
+            for part in path:
+                command = command.commands[part]
+            for flag in flags:
+                option = next(opt for opt in command.params if flag in opt.opts)
+                assert option.callback is _validate_column_list, (
+                    f"{' '.join(path)} {flag} must be declared with column_list_option()"
+                )
+
+    def test_no_unreviewed_cols_option_appeared(self):
+        reviewed = {path: list(flags) for path, flags in REVIEWED_UNGUARDED_LISTS.items()}
+        for path, flags in GUARDED_LIST_OPTIONS.items():
+            reviewed.setdefault(path, []).extend(flags)
+        assert _column_list_options() == {path: sorted(f) for path, f in reviewed.items()}
+
+
+class TestBlankEntryIsRejected:
+    """A blank entry is a usage error, and nothing is read or contacted."""
+
+    @pytest.mark.parametrize(
+        ("path", "flag"),
+        sorted((path, flag) for path, flags in GUARDED_LIST_OPTIONS.items() for flag in flags),
+    )
+    @pytest.mark.parametrize("value", ["", "   ", "\t", "id,,name", "id, ,name", "id,"])
+    def test_blank_entry_is_a_usage_error(self, path, flag, value, tmp_path):
+        runner = CliRunner()
+        output = tmp_path / OUTPUT_NAME.get(path, "out.parquet")
+        args = [*path, *LEADING_ARGS[path], str(output), flag, value]
+        result = runner.invoke(cli, args)
+
+        assert result.exit_code == 2, result.output
+        assert flag in result.output
+        assert "empty or whitespace-only" in result.output
+        # Refused during parameter processing: nothing was written.
+        assert not list(tmp_path.iterdir())
+
+    def test_blank_entry_is_refused_even_in_dry_run(self, tmp_path):
+        """``--dry-run`` builds the SELECT too, so it hit the same ValueError."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "extract",
+                "bigquery",
+                "project-name.dataset.table",
+                str(tmp_path / "out.parquet"),
+                "--include-cols",
+                "   ",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        assert "cannot quote an empty SQL identifier" not in result.output
+
+
+class TestValidValuesPassThrough:
+    """The callback is a guard, not a transform."""
+
+    @pytest.mark.parametrize("value", ["id", "id,name", "id, name", "weird name,other"])
+    def test_a_real_list_is_returned_unchanged(self, value):
+        param = click.Option(["--include-cols"])
+        assert _validate_column_list(None, param, value) == value
+
+    def test_none_is_passed_through(self):
+        """An option left unset reaches the command as ``None``."""
+        param = click.Option(["--include-cols"])
+        assert _validate_column_list(None, param, None) is None

--- a/tests/test_cli_column_list_guard.py
+++ b/tests/test_cli_column_list_guard.py
@@ -16,7 +16,21 @@ parameter processing, before any file is read or any service is contacted.
 
 ``test_no_unreviewed_cols_option_appeared`` walks the live command tree, so a
 new list-valued column option declared with a bare ``@click.option`` fails here
-rather than shipping unguarded.
+rather than shipping unguarded. Its sweep matches the **spelling** ``--*-cols``,
+which is a filter on what has to be *classified*, not a claim of coverage: a
+list-valued option spelled some other way is invisible to it. Membership is
+decided by tracing the value, exactly as in the sibling module, and the
+list-shaped values that fall outside the spelling filter are recorded in
+``LIST_VALUED_OUTSIDE_THE_SWEEP`` with the reason each is already safe.
+
+An entirely empty value is **unset**, not a blank entry. Every backend reads
+these options as ``[c.strip() for c in v.split(",")] if v else None``
+(``core/extract.py``, ``core/extract_bigquery.py``, ``core/carto.py``,
+``core/pmtiles.py``), so ``""`` has always meant "option not given" -- which is
+what ``--include-cols "$COLS"`` with an unset variable expands to. The guard
+preserves that and rejects only a value that carries a blank *entry*: ``"   "``
+and ``"id,,name"`` are truthy on main, split to a list containing ``""``, and
+are the actual #969 defect.
 
 The Click layer owns *blank entries only*. Whether a non-blank name actually
 exists is a schema question, so it belongs to whichever backend can see the
@@ -45,9 +59,34 @@ GUARDED_LIST_OPTIONS = {
     ("pmtiles", "create"): ["--include-cols"],
 }
 
-# Options the sweep matches but that deliberately carry no guard. Empty for
-# now: every ``--*-cols`` option in the tree is a column list.
+# Options the sweep matches but that deliberately carry no guard. Empty: every
+# option in the tree spelled ``--*-cols`` is in GUARDED_LIST_OPTIONS above.
+# That is a statement about this dict, not about coverage -- see
+# LIST_VALUED_OUTSIDE_THE_SWEEP for what the spelling filter cannot see.
 REVIEWED_UNGUARDED_LISTS: dict[tuple[str, ...], list[str]] = {}
+
+# List-shaped values the ``--*-cols`` sweep does **not** match, traced and found
+# already validated where the names are used. Recorded so the limit of the
+# spelling filter is written down rather than implied, and pinned by
+# ``test_out_of_sweep_params_still_exist`` so a rename cannot leave the note
+# stale. Keyed by command path, valued by parameter name as Click knows it.
+LIST_VALUED_OUTSIDE_THE_SWEEP = {
+    # Positional COLUMNS, comma-separated. Every one of the three code paths
+    # checks each name against the schema before quoting it: the Arrow path
+    # (core/sort_by_column.py sort_table_by_column), the file path
+    # (_build_sort_query) and the streaming path (_build_streaming_sort_query)
+    # all raise "column '   ' not found" first.
+    ("sort", "column"): ["columns"],
+    # ``--metric`` carries comma-separated ``func:column`` pairs. parse_metrics()
+    # (core/process/aggregate/common.py) skips an entry that strips to empty, so
+    # a blank one is dropped rather than quoted.
+    ("process", "aggregate", "a5"): ["metric"],
+    ("process", "aggregate", "h3"): ["metric"],
+    ("process", "aggregate", "admin"): ["metric"],
+    # Not identifiers, so no exposure to quote_identifier() at all:
+    # ``--levels`` is a list of integers, ``--converters`` names conversion
+    # backends, and ``--metric-nodata`` carries numeric fill values.
+}
 
 # Leading positional arguments per command, so a *missing* argument is never
 # what makes these assertions pass. The output path is appended per test.
@@ -109,6 +148,19 @@ class TestListGuardCoverage:
             reviewed.setdefault(path, []).extend(flags)
         assert _column_list_options() == {path: sorted(f) for path, f in reviewed.items()}
 
+    @pytest.mark.parametrize(
+        ("path", "param_name"),
+        sorted(
+            (path, name) for path, names in LIST_VALUED_OUTSIDE_THE_SWEEP.items() for name in names
+        ),
+    )
+    def test_out_of_sweep_params_still_exist(self, path, param_name):
+        """The recorded reasons name real parameters, so a rename fails here."""
+        command = cli
+        for part in path:
+            command = command.commands[part]
+        assert param_name in {param.name for param in command.params}
+
 
 class TestBlankEntryIsRejected:
     """A blank entry is a usage error, and nothing is read or contacted."""
@@ -117,7 +169,7 @@ class TestBlankEntryIsRejected:
         ("path", "flag"),
         sorted((path, flag) for path, flags in GUARDED_LIST_OPTIONS.items() for flag in flags),
     )
-    @pytest.mark.parametrize("value", ["", "   ", "\t", "id,,name", "id, ,name", "id,"])
+    @pytest.mark.parametrize("value", ["   ", "\t", "id,,name", "id, ,name", "id,", ","])
     def test_blank_entry_is_a_usage_error(self, path, flag, value, tmp_path):
         runner = CliRunner()
         output = tmp_path / OUTPUT_NAME.get(path, "out.parquet")
@@ -147,6 +199,45 @@ class TestBlankEntryIsRejected:
         )
         assert result.exit_code == 2, result.output
         assert "cannot quote an empty SQL identifier" not in result.output
+
+
+class TestWhollyEmptyMeansUnset:
+    """``--include-cols ""`` is "option not given", the way it always was.
+
+    Every backend reads the option as ``... if v else None``, so the empty
+    string was already unset before any guard existed. ``--include-cols
+    "$COLS"`` with an unset ``COLS`` expands to exactly this, so rejecting it
+    would break working invocations for no gain: there is no blank *entry* to
+    protect against, because there is no entry at all.
+    """
+
+    @pytest.mark.parametrize(
+        ("path", "flag"),
+        sorted((path, flag) for path, flags in GUARDED_LIST_OPTIONS.items() for flag in flags),
+    )
+    def test_empty_string_is_accepted_as_unset(self, path, flag):
+        param = click.Option([flag])
+        assert _validate_column_list(None, param, "") is None
+
+    @pytest.mark.parametrize("flag", ["--include-cols", "--exclude-cols"])
+    def test_empty_string_extracts_every_row_and_column(self, flag, tmp_path):
+        """End to end: the option is inert, not an error."""
+        runner = CliRunner()
+        output = tmp_path / "out.parquet"
+        result = runner.invoke(
+            cli,
+            ["extract", "geoparquet", "tests/data/places_test.parquet", str(output), flag, ""],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert output.exists()
+
+        import pyarrow.parquet as pq
+
+        written = pq.read_table(output)
+        source = pq.read_table("tests/data/places_test.parquet")
+        assert written.num_rows == source.num_rows
+        assert set(written.column_names) == set(source.column_names)
 
 
 class TestValidValuesPassThrough:

--- a/tests/test_extract_bigquery.py
+++ b/tests/test_extract_bigquery.py
@@ -838,6 +838,26 @@ class TestColumnValidation:
         finally:
             con.close()
 
+    def test_schema_column_names_scans_the_remote_table(self):
+        """The BigQuery branch reads through ``bigquery_scan``, not a table name."""
+        from geoparquet_io.core.extract_bigquery import _schema_column_names
+
+        con = MagicMock()
+        con.execute.return_value.fetchall.return_value = [("id", "BIGINT"), ("geom", "GEOMETRY")]
+
+        assert _schema_column_names(con, "project.dataset.table") == ["id", "geom"]
+        query = con.execute.call_args[0][0]
+        assert "bigquery_scan('project.dataset.table')" in query
+
+    def test_build_column_list_reuses_the_schema_it_was_given(self):
+        """The exclude branch takes the caller's schema instead of a DESCRIBE."""
+        from geoparquet_io.core.extract_bigquery import _build_column_list
+
+        # con is None: reusing the schema means no query is issued at all.
+        assert _build_column_list(
+            None, "project.dataset.table", None, ["name"], "geom", ["id", "name", "geom"]
+        ) == ["id", "geom"]
+
     def test_extraction_validates_before_building_the_select(self):
         """The wiring: a bad name fails against the schema, not in the binder."""
         from geoparquet_io.core.exceptions import InvalidParameterError
@@ -861,6 +881,13 @@ class TestColumnValidation:
                     table_id="project-name.dataset.table",
                     output_parquet=None,
                     include_cols="id,nope",
+                )
+            # --exclude-cols runs through the same schema read.
+            with pytest.raises(InvalidParameterError, match="--exclude-cols"):
+                extract_bigquery(
+                    table_id="project-name.dataset.table",
+                    output_parquet=None,
+                    exclude_cols="nope",
                 )
         # Failed before any query was executed against the table.
         assert not any("SELECT" in str(call) for call in con.execute.call_args_list)

--- a/tests/test_extract_bigquery.py
+++ b/tests/test_extract_bigquery.py
@@ -800,6 +800,22 @@ class TestColumnValidation:
         result = validate_bigquery_columns(["ID", "GeoM"], ["id", "geom"], "--exclude-cols")
         assert result == ["id", "geom"]
 
+    def test_an_exact_match_wins_over_a_case_fold(self):
+        """Case folding cannot be allowed to collapse two distinct columns.
+
+        ``_schema_column_names`` also serves ``table_source="local"``, and DuckDB
+        lets a local table carry both ``id`` and ``ID``. A ``{col.lower(): col}``
+        map keeps only the last of those, so an exactly-spelled request has to be
+        honoured as itself before any folding is tried.
+        """
+        from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
+
+        schema = ["id", "ID", "geom"]
+        assert validate_bigquery_columns(["id"], schema, "--exclude-cols") == ["id"]
+        assert validate_bigquery_columns(["ID"], schema, "--exclude-cols") == ["ID"]
+        # A spelling that matches neither exactly still folds, as before.
+        assert validate_bigquery_columns(["GeoM"], schema, "--include-cols") == ["geom"]
+
     def test_missing_column_is_an_invalid_parameter(self):
         from geoparquet_io.core.exceptions import InvalidParameterError
         from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
@@ -867,12 +883,8 @@ class TestColumnValidation:
         with (
             patch("geoparquet_io.core.extract_bigquery.BigQueryConnection") as mock_conn,
             patch(
-                "geoparquet_io.core.extract_bigquery._schema_column_names",
-                return_value=["id", "geom"],
-            ),
-            patch(
-                "geoparquet_io.core.extract_bigquery._detect_geometry_column_from_schema",
-                return_value="geom",
+                "geoparquet_io.core.extract_bigquery._schema_rows",
+                return_value=[("id", "BIGINT"), ("geom", "GEOMETRY")],
             ),
         ):
             mock_conn.return_value.__enter__.return_value = con
@@ -899,12 +911,8 @@ class TestColumnValidation:
         with (
             patch("geoparquet_io.core.extract_bigquery.BigQueryConnection") as mock_conn,
             patch(
-                "geoparquet_io.core.extract_bigquery._schema_column_names",
-                return_value=["id", "geom"],
-            ),
-            patch(
-                "geoparquet_io.core.extract_bigquery._detect_geometry_column_from_schema",
-                return_value="geom",
+                "geoparquet_io.core.extract_bigquery._schema_rows",
+                return_value=[("id", "BIGINT"), ("geom", "GEOMETRY")],
             ),
         ):
             mock_conn.return_value.__enter__.return_value = MagicMock()
@@ -922,6 +930,109 @@ class TestColumnValidation:
 
         assert result.exit_code == 2, result.output
         assert "nope" in result.output
+
+
+class TestSchemaIsReadOnce:
+    """Every schema read in this module goes through ``_schema_rows``.
+
+    Five call sites each spelled out their own
+    ``DESCRIBE SELECT * FROM bigquery_scan(...) LIMIT 0``. Consolidating them
+    has two payoffs beyond the duplication: the raw ``{table_id}``
+    interpolation that ``bigquery_scan`` forces (it takes a string literal, so
+    ``sql_path``/``quote_identifier`` do not apply) now exists in exactly one
+    place with the pre-validation contract written next to it; and a caller that
+    already holds the rows can hand them on instead of paying for a second
+    round-trip against BigQuery.
+    """
+
+    def test_describe_is_spelled_in_exactly_one_helper(self):
+        """A new inline DESCRIBE fails here rather than quietly becoming a sixth."""
+        import inspect
+
+        from geoparquet_io.core import extract_bigquery
+
+        module_source = Path(inspect.getsourcefile(extract_bigquery)).read_text(encoding="utf-8")
+        helper_source = inspect.getsource(extract_bigquery._schema_rows)
+
+        # Two: the bigquery_scan branch and the local-table branch.
+        assert helper_source.count("DESCRIBE SELECT") == 2
+        assert module_source.count("DESCRIBE SELECT") == 2
+
+    def test_given_rows_are_used_without_touching_the_connection(self):
+        from geoparquet_io.core.extract_bigquery import _detect_geometry_column_from_schema
+
+        rows = [("id", "BIGINT"), ("geom", "GEOMETRY")]
+        # con is None: reusing the rows means no query can possibly be issued.
+        assert _detect_geometry_column_from_schema(None, "p.d.t", schema_rows=rows) == "geom"
+
+    def test_an_explicit_geography_column_resolves_from_the_given_rows(self):
+        from geoparquet_io.core.extract_bigquery import _detect_geometry_column_from_schema
+
+        rows = [("id", "BIGINT"), ("Geom", "GEOMETRY")]
+        assert (
+            _detect_geometry_column_from_schema(None, "p.d.t", "GEOM", schema_rows=rows) == "Geom"
+        )
+
+    def test_column_type_comes_from_the_shared_read(self):
+        from geoparquet_io.core.extract_bigquery import _get_column_type
+
+        con = MagicMock()
+        con.execute.return_value.fetchall.return_value = [("id", "BIGINT"), ("geom", "GEOMETRY")]
+
+        assert _get_column_type(con, "p.d.t", "GEOM") == "GEOMETRY"
+        assert _get_column_type(con, "p.d.t", "absent") == "VARCHAR"
+
+    def test_selecting_all_columns_reads_them_through_the_helper(self):
+        from geoparquet_io.core.extract_bigquery import _build_select_with_wkb
+
+        con = MagicMock()
+        con.execute.return_value.fetchall.return_value = [("id", "BIGINT"), ("geom", "GEOMETRY")]
+
+        select_cols, _ = _build_select_with_wkb(None, None, con, "p.d.t")
+        assert '"id"' in select_cols and '"geom"' in select_cols
+
+    def test_column_validation_costs_no_extra_schema_read(self):
+        """``--include-cols`` used to add a DESCRIBE the detection already paid for.
+
+        The invariant: by the time ``_build_column_list`` is reached, the schema
+        has been read exactly once, whether or not either column option was
+        given.
+        """
+        import functools
+
+        from geoparquet_io.core.extract_bigquery import extract_bigquery
+
+        class _Stop(Exception):
+            pass
+
+        rows = [("id", "BIGINT"), ("name", "VARCHAR"), ("geom", "GEOMETRY")]
+
+        def _spy(con, table_id, table_source="bigquery", *, _reads):
+            _reads.append(table_id)
+            return rows
+
+        for kwargs in ({}, {"include_cols": "id"}, {"exclude_cols": "name"}):
+            reads: list[str] = []
+            with (
+                patch("geoparquet_io.core.extract_bigquery.BigQueryConnection") as mock_conn,
+                patch(
+                    "geoparquet_io.core.extract_bigquery._schema_rows",
+                    side_effect=functools.partial(_spy, _reads=reads),
+                ),
+                patch(
+                    "geoparquet_io.core.extract_bigquery._build_column_list",
+                    side_effect=_Stop,
+                ),
+            ):
+                mock_conn.return_value.__enter__.return_value = MagicMock()
+                with pytest.raises(_Stop):
+                    extract_bigquery(
+                        table_id="project-name.dataset.table",
+                        output_parquet=None,
+                        **kwargs,
+                    )
+
+            assert reads == ["project-name.dataset.table"], kwargs
 
 
 class TestPythonAPI:

--- a/tests/test_extract_bigquery.py
+++ b/tests/test_extract_bigquery.py
@@ -764,6 +764,139 @@ class TestGeometryIdentifierQuoting:
         )
 
 
+class TestColumnValidation:
+    """``--include-cols``/``--exclude-cols`` are checked against the table (#969).
+
+    The parquet backend has run ``validate_columns`` since #731; the BigQuery
+    backend had no equivalent, so a name the table does not carry was quoted
+    into the SELECT and failed as a DuckDB binder error (or, for
+    ``--exclude-cols``, silently excluded nothing). A blank entry was worse
+    still: it reached ``quote_identifier()`` and raised
+    ``ValueError: cannot quote an empty SQL identifier``.
+
+    The Click layer rejects blank entries before any connection is opened
+    (``tests/test_cli_column_list_guard.py``); this is the schema half, which
+    only the backend can do, and it matches the parquet precedent by raising
+    ``InvalidParameterError`` -- mapped to exit 2 by ``handle_core_exception``.
+    """
+
+    def test_none_is_passed_through(self):
+        from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
+
+        assert validate_bigquery_columns(None, ["id", "geom"], "--include-cols") is None
+
+    def test_known_columns_are_returned(self):
+        from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
+
+        result = validate_bigquery_columns(["id", "geom"], ["id", "name", "geom"], "--include-cols")
+        assert result == ["id", "geom"]
+
+    def test_case_is_resolved_to_the_schema_spelling(self):
+        """DuckDB matches a quoted identifier case-insensitively, but the exclude
+        filter in ``_build_column_list`` compares strings, so ``--exclude-cols
+        ID`` used to exclude nothing at all. Resolving here makes both agree."""
+        from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
+
+        result = validate_bigquery_columns(["ID", "GeoM"], ["id", "geom"], "--exclude-cols")
+        assert result == ["id", "geom"]
+
+    def test_missing_column_is_an_invalid_parameter(self):
+        from geoparquet_io.core.exceptions import InvalidParameterError
+        from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
+
+        with pytest.raises(InvalidParameterError) as exc_info:
+            validate_bigquery_columns(["id", "nope"], ["id", "geom"], "--include-cols")
+
+        message = str(exc_info.value)
+        assert "--include-cols" in message
+        assert "nope" in message
+        # The available columns are listed, as the parquet backend does.
+        assert "id, geom" in message
+
+    def test_blank_entry_is_an_invalid_parameter(self):
+        """The Python API bypasses Click, so core must reject a blank too."""
+        from geoparquet_io.core.exceptions import InvalidParameterError
+        from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
+
+        with pytest.raises(InvalidParameterError, match="empty or whitespace-only"):
+            validate_bigquery_columns(["id", "   "], ["id", "geom"], "--exclude-cols")
+
+    def test_blank_entry_never_reaches_quote_identifier(self):
+        from geoparquet_io.core.exceptions import InvalidParameterError
+        from geoparquet_io.core.extract_bigquery import validate_bigquery_columns
+
+        with pytest.raises(InvalidParameterError):
+            validate_bigquery_columns([""], ["id"], "--include-cols")
+
+    def test_schema_column_names_reads_the_table(self):
+        from geoparquet_io.core.extract_bigquery import _schema_column_names
+
+        con = duckdb.connect()
+        try:
+            con.execute("CREATE TABLE test_cols AS SELECT 1 AS id, 'x' AS Name")
+            assert _schema_column_names(con, "test_cols", table_source="local") == ["id", "Name"]
+        finally:
+            con.close()
+
+    def test_extraction_validates_before_building_the_select(self):
+        """The wiring: a bad name fails against the schema, not in the binder."""
+        from geoparquet_io.core.exceptions import InvalidParameterError
+        from geoparquet_io.core.extract_bigquery import extract_bigquery
+
+        con = MagicMock()
+        with (
+            patch("geoparquet_io.core.extract_bigquery.BigQueryConnection") as mock_conn,
+            patch(
+                "geoparquet_io.core.extract_bigquery._schema_column_names",
+                return_value=["id", "geom"],
+            ),
+            patch(
+                "geoparquet_io.core.extract_bigquery._detect_geometry_column_from_schema",
+                return_value="geom",
+            ),
+        ):
+            mock_conn.return_value.__enter__.return_value = con
+            with pytest.raises(InvalidParameterError, match="--include-cols"):
+                extract_bigquery(
+                    table_id="project-name.dataset.table",
+                    output_parquet=None,
+                    include_cols="id,nope",
+                )
+        # Failed before any query was executed against the table.
+        assert not any("SELECT" in str(call) for call in con.execute.call_args_list)
+
+    def test_cli_reports_a_missing_column_as_a_usage_error(self, tmp_path):
+        """Exit 2, matching ``gpio extract geoparquet --include-cols nope``."""
+        from geoparquet_io.cli.main import cli
+
+        with (
+            patch("geoparquet_io.core.extract_bigquery.BigQueryConnection") as mock_conn,
+            patch(
+                "geoparquet_io.core.extract_bigquery._schema_column_names",
+                return_value=["id", "geom"],
+            ),
+            patch(
+                "geoparquet_io.core.extract_bigquery._detect_geometry_column_from_schema",
+                return_value="geom",
+            ),
+        ):
+            mock_conn.return_value.__enter__.return_value = MagicMock()
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "extract",
+                    "bigquery",
+                    "project-name.dataset.table",
+                    str(tmp_path / "out.parquet"),
+                    "--include-cols",
+                    "nope",
+                ],
+            )
+
+        assert result.exit_code == 2, result.output
+        assert "nope" in result.output
+
+
 class TestPythonAPI:
     """Test the Python API for BigQuery."""
 


### PR DESCRIPTION
## What changed

**The Click layer rejects blank entries; the backend rejects names the table
does not have.**

`cli/decorators.py` gains `_validate_column_list`, a Click callback, and
`column_list_option()`, a thin `click.option` wrapper — the list-valued sibling
of #959's `_validate_column_name` / `column_name_option()`. Nine option
declarations switch from `@click.option` to `@column_list_option`:
`--include-cols` and `--exclude-cols` on all four `gpio extract` subcommands
that have them (`geoparquet`, `arcgis`, `bigquery`, `carto`), plus
`gpio pmtiles create --include-cols`. No default, help text or type changes.

`core/extract_bigquery.py` gains `validate_bigquery_columns()`, the BigQuery
equivalent of the parquet backend's `validate_columns`, run in
`_execute_bigquery_extraction` once the schema is known and before anything is
quoted into the SELECT. `_schema_column_names()` factors out the `DESCRIBE`
that three call sites already duplicated, and `_build_column_list` takes the
schema the validator already read, so `--exclude-cols` costs no extra
round-trip against BigQuery.

`tests/test_cli_column_list_guard.py` walks the live command tree and fails if a
new `--*-cols` option appears without the guard, the way
`test_cli_column_name_guard.py` does for the single-name family.

## Why

**Which layer owns which check.** A blank entry is a *usage* error — nothing
about the data can make `--include-cols '   '` meaningful — and it is catchable
before a file is opened or a service contacted, so it belongs at the CLI.
Whether a non-blank name exists is a *schema* question, so it belongs to
whichever backend can see the schema. They are not redundant:

- `--dry-run` builds the same SELECT without ever opening a connection, so on
  that path there is no schema to check against and only the Click guard can
  fire;
- the Python API (`ops.read_bigquery`, `Table.from_bigquery`) never goes through
  Click, so `validate_bigquery_columns` rejects blanks too.

**Why #959 did not cover this.** #959 closed the #933 sweep for options carrying
*one* column name, with a callback that validates *the value*. Here the value is
`"a,b,c"` and each entry needs checking — `"id,,name"` is not blank but carries
a blank entry. So the fix is a second callback of the same shape, not an
extension of the first.

**Error type and exit code follow the parquet backend.**
`core/extract.py:validate_columns` has raised `InvalidParameterError` since
#731, and `handle_core_exception` maps it to `click.BadParameter` → exit 2; the
new BigQuery validator matches it, message shape included ("Columns not found in
schema: … Available columns: …"). The Click guard raises `click.BadParameter`
directly — also exit 2 — which is what `_validate_column_name` and
`_validate_write_memory` in the same module already do.

**The other extract subcommands shared the gap, so they are fixed here.**
Tracing each `--include-cols`/`--exclude-cols` to where its entries land:

| Subcommand | Where a blank entry went | Fixed by |
|---|---|---|
| `bigquery` | `quote_identifier()` via `_handle_dry_run` / `_build_select_with_wkb` — raw `ValueError`, exit 1 | Click guard + schema check |
| `carto` | `quote_identifier()` via `_build_carto_query` — same `ValueError`, one network round-trip later | Click guard |
| `arcgis` | `outFields` sent to the server as `"name,,pop"` | Click guard |
| `geoparquet` | already clean: `validate_columns` reports it as "not found in schema" | Click guard now catches it earlier, with a message that says what is wrong |
| `pmtiles create` | forwarded verbatim to a `gpio extract` subprocess, so it failed one process away from the user | Click guard |

`extract wfs` has no such option. `--where` on the BigQuery path is already
routed through `validate_where_clause` before any query is built (#612), and
`--geography-column` is already resolved against the schema first
(`Column '   ' not found in table`), which is why both stay in
`REVIEWED_UNGUARDED` in the sibling test; neither needed a change.

**One side effect worth naming.** Names are resolved to their schema spelling,
because DuckDB matches a quoted identifier case-insensitively but
`_build_column_list` filters `--exclude-cols` by string comparison — so
`--exclude-cols ID` against a column named `id` silently excluded nothing.
Resolving makes the two agree.

## Verification

Before, with no credentials needed:

```
$ gpio extract bigquery my-project-x.ds.tbl out.parquet --include-cols '   ' --dry-run
  File ".../extract_bigquery.py", line 611, in <genexpr>
    select_cols = ", ".join(quote_identifier(c) for c in include_list)
ValueError: cannot quote an empty SQL identifier: DuckDB rejects the
zero-length delimited identifier ""                        # exit 1, traceback
```

After:

```
$ gpio extract bigquery my-project-x.ds.tbl out.parquet --include-cols '   ' --dry-run
Error: Invalid value for '--include-cols': column list cannot contain an empty
or whitespace-only entry                                   # exit 2

$ gpio extract bigquery my-project-x.ds.tbl out.parquet --include-cols 'id,,name' --dry-run
Error: Invalid value for '--include-cols': column list cannot contain an empty
or whitespace-only entry                                   # exit 2

$ gpio extract bigquery my-project-x.ds.tbl out.parquet --include-cols 'id,name' --dry-run
SQL: SELECT "id", "name" FROM bigquery_scan('my-project-x.ds.tbl')
                                                           # exit 0, unchanged

$ gpio extract carto https://phl.carto.com tbl out.parquet --include-cols '  '
Error: Invalid value for '--include-cols': column list cannot contain an empty
or whitespace-only entry                     # exit 2, no network round-trip

$ gpio extract geoparquet buildings.parquet out.parquet --include-cols 'id, ,x'
Error: Invalid value for '--include-cols': column list cannot contain an empty
or whitespace-only entry                                   # exit 2

$ gpio extract geoparquet buildings.parquet out.parquet --include-cols id
Extracted 42 rows (out of 42 total) to out.parquet         # exit 0, unchanged
```

- Fast suite: `pytest -n auto -m "not slow and not network and not meta"` —
  **7095 passed, 76 skipped, 9 xfailed**. No reruns needed; green first time.
- Meta lane: `pytest -m meta` — **205 passed**.
- `pre-commit run --all-files` clean; `--hook-stage pre-push` clean (deptry,
  mypy, vulture, xenon, import-linter, menard-check, fast-tests).
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` —
  **40 changed lines, 0 missing, 100%**.

### A note on `menard-check`

Running `pre-commit --all-files --hook-stage pre-push` with everything staged
reports 10 stale doc targets. That is **not** caused by this branch: `menard
check` inspects *staged* files, and staging a one-line no-op comment in
`geoparquet_io/cli/commands/extract.py` on a **clean `origin/main` checkout**
(detached worktree at 5ce725e) reproduces it exactly — four stale targets
attributed to `5ce725e`, `725b1d1` and `d40eca2`, all doc drift those commits
left behind. Against the real commits the hook passes, which is why nothing is
marked reviewed and no hook was bypassed here.

### `tests/data/cli_surface.json`

Unchanged. This branch only adds a `callback=` to existing options, which the
snapshot does not record — the same reason #959 needed no snapshot entry for its
`--*-name` guard.

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for comma-separated column lists across extraction commands.
  * Blank, whitespace-only, and invalid column names now produce clear command-line errors instead of database-related tracebacks.
  * BigQuery column validation now supports case-insensitive matching while preserving schema spelling.
  * Invalid column selections are rejected before queries or external services are accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->