### PR TITLE
fix(duckdb): spill to a private temp directory instead of ".tmp" under the working directory

### DIFF
--- a/docs/guide/write-strategies.md
+++ b/docs/guide/write-strategies.md
@@ -117,10 +117,10 @@ Override the default strategy when needed:
 A memory limit only helps if DuckDB has somewhere to put the data that does not
 fit. gpio gives every DuckDB connection its own scratch directory under the
 system temp directory — `$TMPDIR` on macOS and Linux, `%TEMP%` on Windows — and
-DuckDB removes it again when the connection closes. A run that never exceeds its
+DuckDB removes it again when the query finishes. A run that never exceeds its
 memory limit writes nothing there.
 
-This matters in two situations:
+This matters in three situations:
 
 - **A read-only working directory.** DuckDB's own default spill location is the
   relative path `.tmp`, so out of the box a large sort fails with
@@ -135,6 +135,22 @@ This matters in two situations:
     TMPDIR=/mnt/scratch gpio sort hilbert huge.parquet sorted.parquet
     ```
 
+- **A RAM-backed `/tmp`.** systemd mounts `/tmp` as a tmpfs sized at half of RAM
+  by default on Fedora, Arch and openSUSE, and so do Kubernetes'
+  `emptyDir: {medium: Memory}` and `docker run --tmpfs /tmp`. Spilling onto a
+  tmpfs spends the very memory the spill was meant to save, so on those systems
+  `TMPDIR` should name real storage — `df -h /tmp` and `findmnt /tmp` say which
+  you have.
+
+!!! warning "\"Out of Memory Error\" can mean out of *disk*"
+    DuckDB caps its own spill at `max_temp_directory_size` (90% of the spill
+    volume by default), so a small or RAM-backed temp volume fails cleanly
+    rather than filling the disk. The message it raises, though, says
+    `Out of Memory Error: failed to offload data block of size 256.0 KiB` and
+    suggests only memory-side remedies. gpio appends a line naming `TMPDIR`
+    whenever DuckDB's error mentions `max_temp_directory_size`, because that is
+    the knob that actually fixes it.
+
 !!! warning "Do not point two runs at one spill directory"
     DuckDB names its spill files after the block size alone
     (`duckdb_temp_storage_S192K-0.tmp`), with nothing in the name identifying
@@ -143,6 +159,37 @@ This matters in two situations:
     `IO Error: Could not read enough bytes from file`. `TMPDIR` is safe because
     gpio still gives each connection a private subdirectory beneath it; a fixed
     `temp_directory` passed straight to DuckDB is not.
+
+### Cleaning Up After an Interrupted Run
+
+DuckDB removes its scratch directory when the query finishes — including when it
+fails. A run **killed** mid-spill (Ctrl-C, `SIGTERM`, the OOM killer) is the
+exception: the process is gone before that cleanup can run, and a directory
+holding gigabytes stays on disk.
+
+gpio names those directories `gpio-spill-<pid>-<random>` and sweeps them at the
+start of every run: any leftover whose owning process has exited is removed
+before a new one is created, so interrupted runs do not accumulate. A directory
+belonging to a process that is still running is never touched. (Pids are the
+test, so give each container its own `TMPDIR` rather than bind-mounting one
+spill volume into several — across pid namespaces the test cannot tell a live
+run from a dead one.)
+
+The one place an OS temp reaper would never help is the admin cache, because the
+admin-boundary commands spill onto the cache volume rather than into `/tmp`.
+`--clear-cache` prices and deletes those leftovers too:
+
+<!-- doctest: skip="deletes the user's real admin cache" -->
+```bash
+gpio add admin-divisions in.parquet out.parquet --clear-cache
+```
+
+```
+Cache directory: /home/you/.geoparquet-io/cache/admin
+Files to delete: 1
+Total size: 3.00 MB
+Leftover spill directories: 1 (250.00 MB)
+```
 
 ### Automatic Detection
 

--- a/docs/guide/write-strategies.md
+++ b/docs/guide/write-strategies.md
@@ -112,6 +112,38 @@ Override the default strategy when needed:
 
 ## Memory Configuration
 
+### Where Spilled Data Goes
+
+A memory limit only helps if DuckDB has somewhere to put the data that does not
+fit. gpio gives every DuckDB connection its own scratch directory under the
+system temp directory — `$TMPDIR` on macOS and Linux, `%TEMP%` on Windows — and
+DuckDB removes it again when the connection closes. A run that never exceeds its
+memory limit writes nothing there.
+
+This matters in two situations:
+
+- **A read-only working directory.** DuckDB's own default spill location is the
+  relative path `.tmp`, so out of the box a large sort fails with
+  `IO Error: Failed to create directory ".tmp"` even when the input and output
+  volumes are perfectly writable. gpio never spills into the working directory.
+- **A small root volume.** A sort of a very large file can spill more bytes than
+  the output itself. If `/tmp` is too small, point `TMPDIR` at a volume that is
+  not:
+
+    <!-- doctest: skip="names /mnt/scratch and huge.parquet, neither of which the harness seeds" -->
+    ```bash
+    TMPDIR=/mnt/scratch gpio sort hilbert huge.parquet sorted.parquet
+    ```
+
+!!! warning "Do not point two runs at one spill directory"
+    DuckDB names its spill files after the block size alone
+    (`duckdb_temp_storage_S192K-0.tmp`), with nothing in the name identifying
+    the connection or the process. Two DuckDB connections sharing one temp
+    directory therefore overwrite each other's blocks, and the loser fails with
+    `IO Error: Could not read enough bytes from file`. `TMPDIR` is safe because
+    gpio still gives each connection a private subdirectory beneath it; a fixed
+    `temp_directory` passed straight to DuckDB is not.
+
 ### Automatic Detection
 
 gpio automatically detects available memory and configures DuckDB to use 50% of it. This detection is container-aware:
@@ -155,10 +187,9 @@ Override auto-detection when needed:
 
         It is **not** a cap on the command's peak memory. The whole result set
         is materialized as an Arrow table before the write, and that copy is
-        allocated by PyArrow, outside DuckDB's `memory_limit` accounting; the
-        scan connection is also built without a `temp_directory`, so DuckDB has
-        no spill path. Size a BigQuery extract against the result set, not
-        against `--write-memory`.
+        allocated by PyArrow, outside DuckDB's `memory_limit` accounting — so
+        the scan spills but the Arrow table it produces does not. Size a
+        BigQuery extract against the result set, not against `--write-memory`.
 
         The flag keeps its name here — it is the same knob, spelled the same way
         — but `gpio extract bigquery --help` describes it accurately: "Memory

--- a/geoparquet_io/cli/commands/add.py
+++ b/geoparquet_io/cli/commands/add.py
@@ -35,6 +35,57 @@ from geoparquet_io.core.add.s2 import add_s2_column as add_s2_column_impl
 from geoparquet_io.core.file_utils import validate_parquet_extension
 from geoparquet_io.core.streaming import StreamingError
 
+ONE_MB = 1024 * 1024
+
+
+def _clear_admin_cache_interactively(cache_dir, clear_admin_cache):
+    """Price the admin cache, confirm, then delete: datasets *and* spill leftovers.
+
+    The leftovers are listed on their own line because they are not cached data.
+    ``gpio add admin-divisions`` spills onto the cache volume, so a run killed
+    mid-spill orphans a directory that can hold gigabytes -- in ``$HOME``, where
+    no OS tmp reaper will ever collect it. Reporting only ``*.parquet`` told the
+    user there was nothing there and then deleted nothing (#977).
+    """
+    from geoparquet_io.core.admin_datasets import cache_spill_dirs, spill_dir_bytes
+    from geoparquet_io.core.logging_config import info, success
+
+    if not cache_dir.exists():
+        click.echo("No cache directory found.")
+        return
+
+    parquet_files = list(cache_dir.glob("*.parquet"))
+    spill_dirs = cache_spill_dirs()
+    if not parquet_files and not spill_dirs:
+        click.echo("No cached datasets found.")
+        return
+
+    click.echo(f"Cache directory: {cache_dir}")
+    click.echo(f"Files to delete: {len(parquet_files)}")
+    click.echo(f"Total size: {sum(f.stat().st_size for f in parquet_files) / ONE_MB:.2f} MB")
+    if spill_dirs:
+        click.echo(
+            f"Leftover spill directories: {len(spill_dirs)} "
+            f"({spill_dir_bytes(spill_dirs) / ONE_MB:.2f} MB)"
+        )
+
+    if not click.confirm("Delete all cached admin datasets?"):
+        info("Cache clear cancelled.")
+        return
+
+    result = clear_admin_cache(confirm=True)
+    success(
+        f"Cleared cache: {result['files_deleted']} files, "
+        f"{result['bytes_freed'] / ONE_MB:.2f} MB freed"
+    )
+    swept = result["spill_dirs_deleted"]
+    if swept:
+        noun = "directory" if swept == 1 else "directories"
+        success(
+            f"plus {swept} leftover spill {noun}, "
+            f"{result['spill_bytes_freed'] / ONE_MB:.2f} MB freed"
+        )
+
 
 @click.group()
 @click.pass_context
@@ -190,34 +241,11 @@ def add_country_codes(
         default_admin_levels,
         get_cache_dir,
     )
-    from geoparquet_io.core.logging_config import info, success
     from geoparquet_io.core.streaming import is_stdin, should_stream_output
 
     # Handle --clear-cache flag first
     if clear_cache:
-        cache_dir = get_cache_dir()
-        if cache_dir.exists():
-            # Get list of files to show size
-            parquet_files = list(cache_dir.glob("*.parquet"))
-            if parquet_files:
-                total_size = sum(f.stat().st_size for f in parquet_files)
-                size_mb = total_size / (1024 * 1024)
-                click.echo(f"Cache directory: {cache_dir}")
-                click.echo(f"Files to delete: {len(parquet_files)}")
-                click.echo(f"Total size: {size_mb:.2f} MB")
-
-                if click.confirm("Delete all cached admin datasets?"):
-                    result = clear_admin_cache(confirm=True)
-                    success(
-                        f"Cleared cache: {result['files_deleted']} files, "
-                        f"{result['bytes_freed'] / (1024 * 1024):.2f} MB freed"
-                    )
-                else:
-                    info("Cache clear cancelled.")
-            else:
-                click.echo("No cached datasets found.")
-        else:
-            click.echo("No cache directory found.")
+        _clear_admin_cache_interactively(get_cache_dir(), clear_admin_cache)
 
     # Check for streaming mode - not supported yet for admin-divisions
     if is_stdin(input_parquet) or should_stream_output(output_parquet):

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -11,6 +11,36 @@ import math
 import click
 
 
+class SpillAwareGroup(click.Group):
+    """Root group that names ``TMPDIR`` when DuckDB runs out of room to spill.
+
+    DuckDB caps its spill at ``max_temp_directory_size`` (90% of the volume by
+    default), so a small or RAM-backed temp volume fails cleanly rather than
+    filling the disk -- but it fails saying "Out of Memory Error", and its list
+    of "possible solutions" is entirely about memory. It never mentions the one
+    knob that fixes a disk shortage. This adds that line.
+
+    It belongs on the *root* group rather than on a decorator because every
+    command spills: ``handle_geoparquet_errors`` is applied to four command
+    modules, and ``gpio sort hilbert`` -- the worked example in the docs -- is
+    not one of them. ``Group.invoke`` is the single funnel every subcommand
+    passes through.
+
+    Anything that is not this specific failure is re-raised untouched.
+    """
+
+    def invoke(self, ctx):
+        from geoparquet_io.core.duckdb_utils import spill_space_hint
+
+        try:
+            return super().invoke(ctx)
+        except Exception as exc:
+            hint = spill_space_hint(exc)
+            if hint is None:
+                raise
+            raise click.ClickException(f"{exc}\n\n{hint}") from exc
+
+
 def handle_geoparquet_errors(func):
     """
     Decorator to convert GeoParquetError exceptions to user-friendly Click errors.

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -17,6 +17,7 @@ from geoparquet_io.cli.commands.publish import publish
 from geoparquet_io.cli.commands.sort import sort
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
+    SpillAwareGroup,
     handle_geoparquet_errors,
 )
 from geoparquet_io.core.logging_config import setup_cli_logging
@@ -57,7 +58,7 @@ class OptionalIntCommand(GlobAwareCommand):
 
 
 @with_plugins(entry_points(group="gpio.plugins"))
-@click.group()
+@click.group(cls=SpillAwareGroup)
 @click.version_option(prog_name="geoparquet-io")
 @click.option("--timestamps", is_flag=True, help="Show timestamps in output messages")
 @click.option(

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -447,7 +447,11 @@ def _setup_duckdb_connection():
     Overture) are run under the same memory discipline DuckDB needs to reliably
     spill rather than OOM (see todo 013):
 
-    - ``temp_directory`` (the admin cache dir) enables spill-to-disk.
+    - ``temp_directory`` enables spill-to-disk, onto the admin cache volume
+      (which already holds the multi-GB cached dataset, so it has the room) in a
+      private leaf per connection -- DuckDB's spill filenames carry no
+      connection identity, so two runs sharing the cache dir itself would
+      overwrite each other's blocks.
     - ``threads = 1`` is required for memory control: parallel spatial-join /
       window operators each grab memory and cannot coordinate spilling, so they
       OOM even with a temp directory set (DuckDB #8270). Single-threaded
@@ -459,12 +463,15 @@ def _setup_duckdb_connection():
       is not contractual anyway.
     """
     from geoparquet_io.core.admin_datasets import get_cache_dir
-    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection, spill_directory
 
     temp_dir = get_cache_dir()
     temp_dir.mkdir(parents=True, exist_ok=True)
     con = get_duckdb_connection(
-        load_spatial=True, load_httpfs=True, temp_directory=str(temp_dir), threads=1
+        load_spatial=True,
+        load_httpfs=True,
+        temp_directory=spill_directory(temp_dir),
+        threads=1,
     )
     con.execute("SET preserve_insertion_order = false")
     # Reproject (CRS-aware admin join, #525) emits lon/lat order to match CRS84.

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -11,6 +11,7 @@ or remote URLs, with automatic caching and error handling.
 import os
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from pathlib import Path
 
 import duckdb
@@ -18,8 +19,10 @@ import duckdb
 from geoparquet_io.core.duckdb_utils import (
     _escape_sql_string,
     get_duckdb_connection,
+    orphaned_spill_dirs,
     spill_directory,
     sql_path,
+    sweep_orphaned_spill_dirs,
 )
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
@@ -254,15 +257,49 @@ def check_cache_age(cache_file: Path) -> str | None:
     return None
 
 
+def spill_dir_bytes(paths: Iterable[Path]) -> int:
+    """Total size of the files under each of ``paths``.
+
+    Unreadable entries count as zero rather than raising: this only ever prices
+    a directory that is about to be deleted anyway.
+    """
+    total = 0
+    for path in paths:
+        for entry in Path(path).rglob("*"):
+            try:
+                if entry.is_file():
+                    total += entry.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def cache_spill_dirs() -> list[Path]:
+    """Leftover spill directories in the admin cache, priced before deletion.
+
+    ``gpio add admin-divisions`` and ``gpio partition admin`` spill onto the
+    admin cache volume, so a run killed mid-spill orphans a directory that can
+    hold gigabytes -- in ``~/.geoparquet-io/cache/admin/``, where no OS tmp
+    reaper will ever collect it. Only directories whose owning process has
+    exited are listed; a concurrent run's scratch space is not ours to price or
+    delete.
+    """
+    return [Path(p) for p in orphaned_spill_dirs(get_cache_dir())]
+
+
 def clear_cache(confirm: bool = False) -> dict | None:
     """
-    Clear all cached admin datasets.
+    Clear all cached admin datasets, and any spill directories left in the cache.
 
     Args:
         confirm: If True, actually delete files. If False, return without action.
 
     Returns:
-        Dictionary with deletion stats: {"files_deleted": int, "bytes_freed": int}
+        Dictionary with deletion stats: ``files_deleted``/``bytes_freed`` for the
+        cached datasets, ``spill_dirs_deleted``/``spill_bytes_freed`` for the
+        leftovers of interrupted runs. The two are counted apart because a spill
+        directory is not a cached dataset: it is a bug's residue, and saying so
+        is the point of reporting it at all.
         Returns None or {"cancelled": True} if confirm is False.
     """
     if not confirm:
@@ -270,8 +307,14 @@ def clear_cache(confirm: bool = False) -> dict | None:
 
     cache_dir = get_cache_dir()
 
+    empty = {
+        "files_deleted": 0,
+        "bytes_freed": 0,
+        "spill_dirs_deleted": 0,
+        "spill_bytes_freed": 0,
+    }
     if not cache_dir.exists():
-        return {"files_deleted": 0, "bytes_freed": 0}
+        return empty
 
     files_deleted = 0
     bytes_freed = 0
@@ -285,7 +328,19 @@ def clear_cache(confirm: bool = False) -> dict | None:
         except OSError:
             pass  # Ignore deletion errors
 
-    return {"files_deleted": files_deleted, "bytes_freed": bytes_freed}
+    # ...and the spill directories an interrupted run left behind, which the
+    # ``*.parquet`` glob above reported as nothing and deleted nothing of. Price
+    # them first: after the sweep there is nothing left to measure, and only
+    # what the sweep actually removed is counted as freed.
+    sizes = {path: spill_dir_bytes([path]) for path in cache_spill_dirs()}
+    removed = sweep_orphaned_spill_dirs(cache_dir)
+
+    return {
+        "files_deleted": files_deleted,
+        "bytes_freed": bytes_freed,
+        "spill_dirs_deleted": len(removed),
+        "spill_bytes_freed": sum(sizes.get(Path(path), 0) for path in removed),
+    }
 
 
 def get_or_cache_dataset(

--- a/geoparquet_io/core/admin_datasets.py
+++ b/geoparquet_io/core/admin_datasets.py
@@ -15,7 +15,12 @@ from pathlib import Path
 
 import duckdb
 
-from geoparquet_io.core.duckdb_utils import _escape_sql_string, get_duckdb_connection, sql_path
+from geoparquet_io.core.duckdb_utils import (
+    _escape_sql_string,
+    get_duckdb_connection,
+    spill_directory,
+    sql_path,
+)
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
     InvalidParameterError,
@@ -415,9 +420,14 @@ class AdminDataset(ABC):
         cache_path.parent.mkdir(parents=True, exist_ok=True)
 
         with s3_config_scope(self.get_s3_config()):
-            # Spill to the cache dir to bound memory on the remote scan (todo 013).
+            # Spill onto the cache volume to bound memory on the remote scan
+            # (todo 013). A private leaf under it, never the cache dir itself:
+            # DuckDB's spill filenames carry no connection identity, so two runs
+            # sharing this well-known directory overwrite each other's blocks.
             con = get_duckdb_connection(
-                load_spatial=True, load_httpfs=True, temp_directory=str(cache_path.parent)
+                load_spatial=True,
+                load_httpfs=True,
+                temp_directory=spill_directory(cache_path.parent),
             )
             try:
                 # Get read options
@@ -1038,10 +1048,11 @@ class OvertureAdminDataset(AdminDataset):
         info("This is a one-time download. Future runs will use the cached version.")
 
         with s3_config_scope(self.get_s3_config()):
-            # Spill to the cache dir so the remote scan + simplification of the
-            # ~4.5GB dataset bounds peak memory rather than OOM-ing (todo 013).
+            # Spill onto the cache volume so the remote scan + simplification of
+            # the ~4.5GB dataset bounds peak memory rather than OOM-ing (todo
+            # 013), into a leaf of its own so concurrent runs cannot collide.
             con = get_duckdb_connection(
-                load_spatial=True, load_httpfs=True, temp_directory=str(cache_dir)
+                load_spatial=True, load_httpfs=True, temp_directory=spill_directory(cache_dir)
             )
             version = self.get_version()
             try:

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -7,7 +7,9 @@ with appropriate extensions loaded for GeoParquet operations.
 
 import os
 import re
+import tempfile
 import threading
+import uuid
 from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -548,6 +550,41 @@ def _install_and_load_extension(con, name: str) -> None:
         raise
 
 
+#: Marks the scratch directories gpio hands to DuckDB, so a stray one left by a
+#: killed process is recognisable in a temp directory listing.
+_SPILL_DIR_PREFIX = "gpio-spill-"
+
+
+def spill_directory(base_dir: str | os.PathLike | None = None) -> str:
+    """Path to a private directory DuckDB may spill intermediate results into.
+
+    The path is *not* created. DuckDB creates its temp directory the first time
+    a query exceeds ``memory_limit``, and removes it again when the connection
+    closes -- so a connection that never spills leaves nothing behind, and one
+    that does cleans up after itself.
+
+    Every call returns a fresh path, and that uniqueness is a correctness
+    requirement rather than tidiness. DuckDB names its spill files after the
+    block size alone (``duckdb_temp_storage_S192K-0.tmp``): nothing in the name
+    identifies the connection, the database or the process. Two connections
+    pointed at one directory therefore write over each other's blocks, and the
+    loser fails with ``IO Error: Could not read enough bytes from file`` or, worse,
+    reads back another query's bytes as its own. That applies to two gpio
+    processes as much as to two connections inside one, so a shared constant --
+    ``/tmp/gpio-spill``, an admin cache directory -- is never a safe answer.
+
+    Args:
+        base_dir: Volume to spill onto. Defaults to the OS temp directory, which
+            follows ``TMPDIR``: that is the knob for a machine whose root volume
+            is too small to hold a large sort's spill.
+
+    Returns:
+        An absolute path, safe to hand to ``SET temp_directory``.
+    """
+    base = os.fspath(base_dir) if base_dir is not None else tempfile.gettempdir()
+    return os.path.join(base, f"{_SPILL_DIR_PREFIX}{os.getpid()}-{uuid.uuid4().hex[:12]}")
+
+
 def get_duckdb_connection(
     load_spatial=True,
     load_httpfs=None,
@@ -577,11 +614,16 @@ def get_duckdb_connection(
         threads: Number of threads for DuckDB to use (default: None = all cores).
                 Limiting threads is useful for parallel test execution to prevent
                 CPU saturation when multiple pytest workers create connections.
-        temp_directory: Directory for DuckDB to spill intermediate results to disk.
-                    Bounds peak memory on large spatial joins (e.g. admin-divisions
-                    against a 400k-feature input) so they don't OOM.
-        memory_limit: DuckDB memory limit (e.g. "8GB"). When set, DuckDB spills to
-                    temp_directory once this is exceeded rather than crashing.
+        temp_directory: Volume for DuckDB to spill intermediate results onto.
+                    Defaults to a private directory under the OS temp directory
+                    (see :func:`spill_directory`); pass a path to put the spill on
+                    another volume, e.g. beside a very large output. Never share
+                    one path between connections -- ``spill_directory(that_path)``
+                    gives each its own leaf under the volume you chose.
+        memory_limit: DuckDB memory limit (e.g. "8GB"). Opt-in: DuckDB's own
+                    default (roughly 80% of RAM) is the right cap for most work,
+                    and a lower one only pushes queries to disk that fit in RAM.
+                    Once set, DuckDB spills to temp_directory rather than crashing.
 
     Returns:
         duckdb.DuckDBPyConnection: Configured connection with extensions loaded
@@ -597,10 +639,18 @@ def get_duckdb_connection(
     # regular string buffers is 2147483647" errors.
     con.execute("SET arrow_large_buffer_size = true;")
 
-    # Spill-to-disk: bound peak memory on large joins/aggregations.
-    if temp_directory is not None:
-        safe_temp_dir = _escape_sql_string(str(temp_directory))
-        con.execute(f"SET temp_directory = '{safe_temp_dir}';")
+    # Spill-to-disk. DuckDB's own default is the *relative* path ".tmp", so a
+    # spill lands wherever the process happens to be running: a read-only working
+    # directory turns a large sort into a hard failure, and a small root volume
+    # into a mid-sort ENOSPC, however much room the input and output volumes have.
+    # Decide it here, once, for all connections -- and decide it now, because
+    # DuckDB refuses to move a temp directory that has already been used
+    # ("Cannot switch temporary directory after the current one has been used"),
+    # so a per-write override cannot be applied to the connections gpio shares
+    # across writes (a partition loop finalizes N files on one connection).
+    effective_temp_dir = temp_directory if temp_directory is not None else spill_directory()
+    safe_temp_dir = _escape_sql_string(str(effective_temp_dir))
+    con.execute(f"SET temp_directory = '{safe_temp_dir}';")
     if memory_limit is not None:
         safe_memory_limit = _escape_sql_string(str(memory_limit))
         con.execute(f"SET memory_limit = '{safe_memory_limit}';")

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -7,6 +7,7 @@ with appropriate extensions loaded for GeoParquet operations.
 
 import os
 import re
+import shutil
 import tempfile
 import threading
 import uuid
@@ -550,18 +551,106 @@ def _install_and_load_extension(con, name: str) -> None:
         raise
 
 
-#: Marks the scratch directories gpio hands to DuckDB, so a stray one left by a
-#: killed process is recognisable in a temp directory listing.
+#: Marks the scratch directories gpio hands to DuckDB. The prefix is not
+#: decoration: :func:`sweep_orphaned_spill_dirs` matches on it, so only a
+#: directory gpio minted itself is ever a candidate for removal.
 _SPILL_DIR_PREFIX = "gpio-spill-"
+
+#: The exact shape :func:`spill_directory` mints, with the owning pid captured.
+#: Anything else under the base -- a cached dataset, another tool's scratch, a
+#: hand-made directory that merely starts with the prefix -- does not match and
+#: is never touched.
+_SPILL_DIR_RE = re.compile(rf"^{re.escape(_SPILL_DIR_PREFIX)}(\d+)-[0-9a-f]{{12}}$")
+
+
+def _process_is_alive(pid: int) -> bool:
+    """Whether ``pid`` is still running. Answers True whenever it cannot tell.
+
+    Only ever used to decide *not* to delete something, so the unsure answer has
+    to be "alive": a false "dead" would take a running sibling's scratch space
+    away mid-query, while a false "alive" merely leaves one more directory for
+    the next run (or the OS tmp reaper) to collect.
+    """
+    try:
+        import psutil
+
+        return psutil.pid_exists(pid)
+    except Exception:  # pragma: no cover - psutil is a hard dependency
+        return True
+
+
+def orphaned_spill_dirs(base_dir: str | os.PathLike) -> list[str]:
+    """Spill directories under ``base_dir`` whose owning process has exited.
+
+    Ownership is decided by the pid in the name, never by age: a gpio run that
+    takes six hours must not have its scratch space swept out from under it.
+    Pid reuse can only make this *more* conservative -- a recycled pid reads as
+    alive, so the leftover simply survives another round.
+
+    The one case pids cannot decide is two *pid namespaces* sharing one spill
+    volume: point ``TMPDIR`` at the same bind-mounted directory from two
+    containers and each sees the other's pids as absent. Give each container its
+    own ``TMPDIR`` (the default already does) if you share a volume between them.
+    """
+    found: list[str] = []
+    try:
+        entries = list(os.scandir(base_dir))
+    except OSError:
+        return found
+    for entry in entries:
+        match = _SPILL_DIR_RE.match(entry.name)
+        if match is None:
+            continue
+        try:
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+        except OSError:  # pragma: no cover - raced with another sweeper
+            continue
+        if _process_is_alive(int(match.group(1))):
+            continue
+        found.append(entry.path)
+    return found
+
+
+def sweep_orphaned_spill_dirs(base_dir: str | os.PathLike) -> list[str]:
+    """Remove the spill directories under ``base_dir`` that nobody owns any more.
+
+    DuckDB removes its temp directory when the *query* completes, not when the
+    process dies. A run killed mid-spill (SIGINT, SIGTERM, SIGKILL) therefore
+    orphans a directory that can hold gigabytes, however carefully the caller
+    closes the connection in a ``finally``. DuckDB's own fixed ``.tmp`` made
+    that self-limiting by accident -- the next run reuses the same path and the
+    same ``duckdb_temp_storage_*.tmp`` filenames -- so the unique names gpio
+    needs for correctness would otherwise turn a bounded leak into a growing
+    one. This is the other half of that trade.
+
+    Best effort by design: a leftover owned by another user, or on a read-only
+    volume, is skipped rather than raised, because failing to tidy up must never
+    fail the run that was only trying to start.
+
+    Returns:
+        The paths actually removed, for callers that report what they freed.
+    """
+    removed: list[str] = []
+    for path in orphaned_spill_dirs(base_dir):
+        try:
+            shutil.rmtree(path)
+        except OSError:
+            continue
+        removed.append(path)
+    return removed
 
 
 def spill_directory(base_dir: str | os.PathLike | None = None) -> str:
     """Path to a private directory DuckDB may spill intermediate results into.
 
     The path is *not* created. DuckDB creates its temp directory the first time
-    a query exceeds ``memory_limit``, and removes it again when the connection
-    closes -- so a connection that never spills leaves nothing behind, and one
-    that does cleans up after itself.
+    a query exceeds ``memory_limit``, and removes it again once the query
+    completes -- so a connection that never spills leaves nothing behind, and an
+    ordinary run, error or not, cleans up after itself. A run *killed* mid-spill
+    does not, which is why every call first sweeps ``base_dir`` for the leavings
+    of processes that are gone (see :func:`sweep_orphaned_spill_dirs`). The
+    sweep is best effort and never raises.
 
     Every call returns a fresh path, and that uniqueness is a correctness
     requirement rather than tidiness. DuckDB names its spill files after the
@@ -576,13 +665,66 @@ def spill_directory(base_dir: str | os.PathLike | None = None) -> str:
     Args:
         base_dir: Volume to spill onto. Defaults to the OS temp directory, which
             follows ``TMPDIR``: that is the knob for a machine whose root volume
-            is too small to hold a large sort's spill.
+            is too small to hold a large sort's spill. Not validated here --
+            DuckDB creates the leaf lazily, so a base that is missing, read-only
+            or not a directory surfaces as an ``IO Error`` naming the path at
+            the first spill rather than at this call. Callers that name a base
+            create it first.
 
     Returns:
         An absolute path, safe to hand to ``SET temp_directory``.
     """
     base = os.fspath(base_dir) if base_dir is not None else tempfile.gettempdir()
+    sweep_orphaned_spill_dirs(base)
     return os.path.join(base, f"{_SPILL_DIR_PREFIX}{os.getpid()}-{uuid.uuid4().hex[:12]}")
+
+
+#: DuckDB's own words when the *spill volume* fills up. The message it prints is
+#: an "Out of Memory Error" that never mentions ``TMPDIR``, so it sends users
+#: after the one knob that cannot help them; this is the phrase that tells the
+#: disk shortage apart from a real memory one.
+_SPILL_EXHAUSTED_SIGNATURE = "max_temp_directory_size"
+
+
+def spill_space_hint(exc: BaseException | str | None) -> str | None:
+    """gpio's guidance for DuckDB's "ran out of spill space" error, or ``None``.
+
+    Accepts an exception (whose ``__cause__``/``__context__`` chain is walked)
+    or the raw error text, mirroring
+    :func:`~geoparquet_io.core.exceptions.is_unpublished_extension_error`.
+    """
+    if exc is None:
+        return None
+    if isinstance(exc, str):
+        blob = exc
+    else:
+        parts: list[str] = []
+        seen: set[int] = set()
+        cur: BaseException | None = exc
+        while cur is not None and id(cur) not in seen:
+            seen.add(id(cur))
+            parts.append(str(cur))
+            cur = cur.__cause__ or cur.__context__
+        blob = " ".join(parts)
+    if _SPILL_EXHAUSTED_SIGNATURE not in blob:
+        return None
+    return (
+        "This is a disk shortage, not a memory one, whatever the wording says: "
+        "DuckDB spills intermediate results to a scratch directory and that "
+        f"volume ran out of room. gpio spills under the system temp directory "
+        f"(currently {tempfile.gettempdir()}); the admin-boundary commands spill "
+        "onto the admin cache volume instead.\n"
+        "\n"
+        "Point TMPDIR (%TEMP% on Windows) at a volume with room to spare:\n"
+        "\n"
+        "    TMPDIR=/path/with/space gpio ...\n"
+        "\n"
+        "Check first whether /tmp is RAM-backed: systemd mounts a tmpfs there by "
+        "default on Fedora, Arch and openSUSE, as do Kubernetes' "
+        "'emptyDir: {medium: Memory}' and 'docker run --tmpfs /tmp'. Spilling "
+        "onto a tmpfs spends the very memory the spill was meant to save, so "
+        "TMPDIR needs to name real storage."
+    )
 
 
 def get_duckdb_connection(

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -273,18 +273,27 @@ def _setup_admin_join_connection(dataset, get_duckdb_connection):
 
     Per-level datasets (Overture) can join multi-million-feature inputs and need
     the same memory discipline as ``gpio add admin-divisions`` to spill rather
-    than OOM (see add_divisions todo 013): a temp directory for spill,
+    than OOM (see add_divisions todo 013): spill onto the admin cache volume,
     single-threaded execution (parallel spatial-join operators each grab memory
     and cannot coordinate spilling, so they OOM even with a temp dir), and no
-    insertion-order buffering. Other datasets keep the simple default connection.
+    insertion-order buffering. Other datasets keep the simple default connection,
+    which spills under the OS temp directory.
+
+    The spill goes in a private leaf of the cache dir, never the cache dir
+    itself: DuckDB's spill filenames carry no connection identity, so two runs
+    sharing that well-known path would overwrite each other's blocks.
     """
     if dataset.supports_per_level_sources():
         from geoparquet_io.core.admin_datasets import get_cache_dir
+        from geoparquet_io.core.duckdb_utils import spill_directory
 
         temp_dir = get_cache_dir()
         temp_dir.mkdir(parents=True, exist_ok=True)
         con = get_duckdb_connection(
-            load_spatial=True, load_httpfs=True, temp_directory=str(temp_dir), threads=1
+            load_spatial=True,
+            load_httpfs=True,
+            temp_directory=spill_directory(temp_dir),
+            threads=1,
         )
         con.execute("SET preserve_insertion_order = false")
         # Reproject (CRS-aware admin join, #525) emits lon/lat order to match CRS84.

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -1,5 +1,5 @@
 {
- "class": "Group",
+ "class": "SpillAwareGroup",
  "commands": {
   "add": {
    "class": "Group",

--- a/tests/test_add_partition_cli_guards.py
+++ b/tests/test_add_partition_cli_guards.py
@@ -53,6 +53,16 @@ def _write_mb(path):
     return path
 
 
+def _dead_pid():
+    """A pid that has certainly exited, so its spill leaf counts as orphaned."""
+    import subprocess
+    import sys
+
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
+
+
 class TestAddAdminDivisionsClearCache:
     """``gpio add admin-divisions --clear-cache`` reports, prompts, then deletes."""
 
@@ -155,6 +165,68 @@ class TestAddAdminDivisionsClearCache:
 
         assert result.exit_code == 0, result.output
         assert "No cache directory found." in result.output
+
+    def test_leftover_spill_directories_are_priced_and_deleted(
+        self, admin_cache_dir, places_test_file, tmp_path
+    ):
+        """An interrupted admin run leaves a spill directory *in the cache dir*.
+
+        It is the worst orphan gpio can leave -- multi-GB, in ``$HOME``, where
+        no OS tmp-reaper will ever touch it -- and globbing ``*.parquet`` made
+        ``--clear-cache`` report it as nothing and delete nothing.
+        """
+        admin_cache_dir.mkdir(parents=True)
+        gaul = _write_mb(admin_cache_dir / "gaul.parquet")
+        orphan = admin_cache_dir / f"gpio-spill-{_dead_pid()}-abcdef123456"
+        orphan.mkdir()
+        _write_mb(orphan / "duckdb_temp_storage_S192K-0.tmp")
+
+        runner = CliRunner()
+        with patch.object(admin_divisions, "add_admin_divisions_multi"):
+            result = runner.invoke(
+                add,
+                [
+                    "admin-divisions",
+                    places_test_file,
+                    str(tmp_path / "out.parquet"),
+                    "--clear-cache",
+                ],
+                input="y\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Leftover spill directories: 1 (1.00 MB)" in result.output
+        assert "Cleared cache: 1 files, 1.00 MB freed" in result.output
+        assert "plus 1 leftover spill directory, 1.00 MB freed" in result.output
+        assert not orphan.exists()
+        assert not gaul.exists()
+
+    def test_a_spill_directory_alone_is_still_worth_clearing(
+        self, admin_cache_dir, places_test_file, tmp_path
+    ):
+        """No cached datasets but a multi-GB orphan is not "nothing to delete"."""
+        admin_cache_dir.mkdir(parents=True)
+        orphan = admin_cache_dir / f"gpio-spill-{_dead_pid()}-abcdef123456"
+        orphan.mkdir()
+        _write_mb(orphan / "duckdb_temp_storage_S192K-0.tmp")
+
+        runner = CliRunner()
+        with patch.object(admin_divisions, "add_admin_divisions_multi"):
+            result = runner.invoke(
+                add,
+                [
+                    "admin-divisions",
+                    places_test_file,
+                    str(tmp_path / "out.parquet"),
+                    "--clear-cache",
+                ],
+                input="y\n",
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "No cached datasets found." not in result.output
+        assert "Leftover spill directories: 1 (1.00 MB)" in result.output
+        assert not orphan.exists()
 
 
 class TestAddAdminDivisionsArgumentGuards:

--- a/tests/test_admin_datasets.py
+++ b/tests/test_admin_datasets.py
@@ -26,6 +26,16 @@ from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
 TEST_DATA_DIR = Path(__file__).parent / "data"
 
 
+def _dead_pid() -> int:
+    """A pid that has certainly exited and been reaped."""
+    import subprocess
+    import sys
+
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
+
+
 def _spatial_connection(duckdb):
     """An in-memory DuckDB with spatial loaded, configured as gpio configures it."""
     con = duckdb.connect()
@@ -1161,6 +1171,60 @@ class TestClearCache:
                 # Non-parquet files should remain
                 assert (cache_dir / "readme.txt").exists()
                 assert (cache_dir / ".gitkeep").exists()
+
+    def test_clear_cache_removes_orphaned_spill_directories(self):
+        """The worst orphan lands here, in ``$HOME``, where no tmp-reaper runs.
+
+        ``gpio add admin-divisions`` spills onto the admin cache volume, so an
+        interrupted Overture run leaves a multi-GB ``gpio-spill-*`` directory in
+        ``~/.geoparquet-io/cache/admin/``. Globbing ``*.parquet`` reported it as
+        nothing and deleted nothing.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            orphan = cache_dir / f"gpio-spill-{_dead_pid()}-abcdef123456"
+            orphan.mkdir()
+            (orphan / "duckdb_temp_storage_S192K-0.tmp").write_bytes(b"x" * 2048)
+
+            with patch("geoparquet_io.core.admin_datasets.get_cache_dir") as mock_get_cache:
+                mock_get_cache.return_value = cache_dir
+                result = clear_cache(confirm=True)
+
+            assert not orphan.exists()
+            assert result["spill_dirs_deleted"] == 1
+            assert result["spill_bytes_freed"] == 2048
+            # Cached-dataset accounting is unchanged: a spill directory is not a file.
+            assert result["files_deleted"] == 0
+            assert result["bytes_freed"] == 0
+
+    def test_clear_cache_on_an_absent_directory_reports_the_same_shape(self):
+        """Callers read four keys off the result; a no-op must still carry them."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = Path(tmpdir) / "never-created"
+            with patch("geoparquet_io.core.admin_datasets.get_cache_dir") as mock_get_cache:
+                mock_get_cache.return_value = missing
+                result = clear_cache(confirm=True)
+
+            assert result == {
+                "files_deleted": 0,
+                "bytes_freed": 0,
+                "spill_dirs_deleted": 0,
+                "spill_bytes_freed": 0,
+            }
+
+    def test_clear_cache_leaves_a_running_process_spill_directory(self):
+        """A concurrent run's scratch space is not ours to delete."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            live = cache_dir / f"gpio-spill-{os.getpid()}-abcdef123456"
+            live.mkdir()
+
+            with patch("geoparquet_io.core.admin_datasets.get_cache_dir") as mock_get_cache:
+                mock_get_cache.return_value = cache_dir
+                result = clear_cache(confirm=True)
+
+            assert live.is_dir()
+            assert result["spill_dirs_deleted"] == 0
 
 
 class TestGetOrCacheDataset:

--- a/tests/test_duckdb_utils.py
+++ b/tests/test_duckdb_utils.py
@@ -209,7 +209,7 @@ class TestGetDuckdbConnection:
         con.close()
 
     def test_temp_directory_is_set(self, tmp_path):
-        """temp_directory enables spill-to-disk (OOM guard, todo 013)."""
+        """An explicit temp_directory is used verbatim (OOM guard, todo 013)."""
         spill = str(tmp_path / "spill")
         con = get_duckdb_connection(load_spatial=False, load_httpfs=False, temp_directory=spill)
         try:
@@ -228,11 +228,19 @@ class TestGetDuckdbConnection:
         finally:
             con.close()
 
-    def test_no_temp_directory_by_default(self):
-        """Default connection is unchanged (no behavior change on small inputs)."""
+    def test_default_temp_directory_is_private_and_off_the_cwd(self):
+        """No caller named one, so gpio picks one (see tests/test_spill_strategy.py).
+
+        DuckDB's own default is the relative path ".tmp", which puts every spill
+        under the working directory. Nothing is created unless a query actually
+        spills, so small inputs behave exactly as before.
+        """
         con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
         try:
-            # Default temp_directory is empty/unset; the connection still works.
+            value = con.execute("SELECT current_setting('temp_directory')").fetchone()[0]
+            assert value != ".tmp"
+            assert os.path.isabs(value)
+            assert not os.path.exists(value)
             assert con.execute("SELECT 1").fetchone() == (1,)
         finally:
             con.close()

--- a/tests/test_spill_strategy.py
+++ b/tests/test_spill_strategy.py
@@ -15,21 +15,42 @@ in. Two things follow, and both are pinned here:
 The fix is central: :func:`get_duckdb_connection` gives every connection its
 own private spill directory under the OS temp directory unless the caller names
 one.
+
+A private *unique* directory has a cost the fixed ``.tmp`` did not, and it is
+pinned here too. DuckDB removes its temp directory when the **query** finishes,
+so a run killed mid-spill (SIGINT, SIGTERM, SIGKILL) leaves the leaf behind
+however carefully the caller closes the connection. With a fixed name that leak
+is self-limiting -- the next run reuses the same path and the same
+``duckdb_temp_storage_*.tmp`` filenames -- while unique names would let three
+killed runs leave three multi-GB directories. So ``spill_directory()`` sweeps
+the base it is about to write into, removing leaves whose owning process is
+gone, and ``--clear-cache`` does the same for the admin cache directory.
 """
 
 from __future__ import annotations
 
 import os
+import re
+import shutil
 import stat
 import subprocess
 import sys
 import tempfile
 import threading
+import uuid
 from pathlib import Path
 
+import click
+import duckdb
 import pytest
+from click.testing import CliRunner
 
-from geoparquet_io.core.duckdb_utils import get_duckdb_connection, spill_directory
+from geoparquet_io.core.duckdb_utils import (
+    get_duckdb_connection,
+    spill_directory,
+    spill_space_hint,
+    sweep_orphaned_spill_dirs,
+)
 
 # A sort that comfortably exceeds the memory limit below, and still runs in
 # well under a second.
@@ -186,8 +207,14 @@ class TestSpillsActuallyLandThere:
             assert list(spill_dir.glob("duckdb_temp_storage*"))
         finally:
             con.close()
-        # DuckDB removes a temp directory it created itself.
-        assert not spill_dir.exists()
+        # DuckDB removes a temp directory it created itself -- when the query
+        # finished, which it did here. On Windows a still-open handle can defeat
+        # that removal (this repo has a long history of WinError 32 on
+        # unlink/replace), and a leftover is not the thing this test is about:
+        # what bounds leftovers is the sweep in ``spill_directory()``, pinned in
+        # TestOrphanedSpillDirectoriesAreReaped below.
+        if os.name != "nt":
+            assert not spill_dir.exists()
 
     def test_concurrent_connections_do_not_corrupt_each_other(self):
         """Regression guard for the shared-directory hazard in the docstring."""
@@ -301,3 +328,263 @@ def test_spilling_write_survives_a_read_only_working_directory(tmp_path):
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "OK" in result.stdout
+
+
+ONE_MB = 1024 * 1024
+
+
+def _dead_pid() -> int:
+    """A pid that has certainly exited and been reaped."""
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    return proc.pid
+
+
+def _plant_leaf(base: Path, pid: int, payload: int = ONE_MB) -> Path:
+    """A spill leaf shaped exactly like one gpio would leave behind."""
+    leaf = base / f"gpio-spill-{pid}-{uuid.uuid4().hex[:12]}"
+    leaf.mkdir(parents=True)
+    (leaf / "duckdb_temp_storage_S192K-0.tmp").write_bytes(b"\0" * payload)
+    return leaf
+
+
+def _bytes_under(base: Path) -> int:
+    return sum(p.stat().st_size for p in base.rglob("*") if p.is_file())
+
+
+class TestOrphanedSpillDirectoriesAreReaped:
+    """A killed run leaves its leaf behind; the next run takes it away.
+
+    DuckDB removes a temp directory when the *query* completes, not when the
+    process dies, so an interrupted spill orphans it no matter what the caller
+    does in a ``finally``. Unique names remove the accidental self-healing the
+    fixed ``.tmp`` had, which is why the sweep exists.
+    """
+
+    def test_a_leaf_whose_owner_is_gone_is_removed(self, tmp_path):
+        leaf = _plant_leaf(tmp_path, _dead_pid())
+
+        spill_directory(tmp_path)
+
+        assert not leaf.exists()
+
+    def test_a_leaf_belonging_to_a_live_process_survives(self, tmp_path):
+        """Never take a *sibling's* scratch space away mid-query."""
+        leaf = _plant_leaf(tmp_path, os.getpid())
+
+        spill_directory(tmp_path)
+
+        assert leaf.is_dir()
+
+    def test_an_unparseable_pid_is_left_alone(self, tmp_path):
+        """When ownership cannot be decided, keep the directory."""
+        odd = tmp_path / "gpio-spill-notapid-abcdef123456"
+        odd.mkdir()
+
+        spill_directory(tmp_path)
+
+        assert odd.is_dir()
+
+    def test_neighbours_are_never_touched(self, tmp_path):
+        cached = tmp_path / "overture-2025-10-22.0.parquet"
+        cached.write_bytes(b"cached dataset")
+        unrelated = tmp_path / "someone-elses-scratch"
+        unrelated.mkdir()
+        # A *file* whose name happens to match: gpio only ever makes directories.
+        decoy = tmp_path / f"gpio-spill-{_dead_pid()}-abcdef123456"
+        decoy.write_bytes(b"not a directory")
+
+        spill_directory(tmp_path)
+
+        assert cached.exists()
+        assert unrelated.is_dir()
+        assert decoy.exists()
+
+    def test_the_sweep_recognises_the_names_gpio_actually_mints(self, tmp_path):
+        """Couples the minting and the matching so they cannot drift apart."""
+        minted = Path(spill_directory(tmp_path)).name
+        prefix, pid, suffix = minted.rsplit("-", 2)[0], os.getpid(), minted.rsplit("-", 1)[1]
+        assert f"{prefix}-{pid}-{suffix}" == minted
+
+        orphan = tmp_path / f"{prefix}-{_dead_pid()}-{suffix}"
+        orphan.mkdir()
+
+        spill_directory(tmp_path)
+
+        assert not orphan.exists()
+
+    def test_repeated_interrupted_runs_do_not_accumulate(self, tmp_path):
+        """The accumulation the reviewer measured: 28MB -> 133MB -> 202MB.
+
+        Each iteration is one gpio run that picks a spill path, spills, and is
+        killed before DuckDB can clean up. Without a sweep the base grows by a
+        leaf per run; with one it plateaus at the single leaf the *last* run
+        left, because every run reaps its dead predecessors first.
+        """
+        sizes = []
+        for _ in range(3):
+            leaf = Path(spill_directory(tmp_path))
+            # Pretend this run is a separate process, since the sweep -- rightly
+            # -- refuses to delete a live process's directory.
+            leaf = leaf.parent / leaf.name.replace(f"-{os.getpid()}-", f"-{_dead_pid()}-")
+            leaf.mkdir()
+            (leaf / "duckdb_temp_storage_S192K-0.tmp").write_bytes(b"\0" * ONE_MB)
+            sizes.append(_bytes_under(tmp_path))
+
+        assert sizes == [ONE_MB, ONE_MB, ONE_MB]
+
+    def test_an_unremovable_leaf_does_not_fail_the_connection(self, tmp_path, monkeypatch):
+        """Best effort: a permission error on someone else's leftovers is not fatal."""
+        leaf = _plant_leaf(tmp_path, _dead_pid())
+
+        def refuse(*args, **kwargs):
+            raise PermissionError(13, "Permission denied", str(leaf))
+
+        monkeypatch.setattr(shutil, "rmtree", refuse)
+
+        con = get_duckdb_connection(
+            load_spatial=False, load_httpfs=False, temp_directory=spill_directory(tmp_path)
+        )
+        try:
+            assert con.execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            con.close()
+        assert leaf.is_dir()
+
+    def test_a_missing_base_directory_is_not_an_error(self, tmp_path):
+        """The default base always exists; an explicit one need not yet."""
+        assert spill_directory(tmp_path / "not-created-yet")
+
+    def test_opening_a_default_connection_reaps_the_temp_directory(self, tmp_path, monkeypatch):
+        """The sweep is on the path every gpio connection already takes."""
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+        leaf = _plant_leaf(tmp_path, _dead_pid())
+
+        con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+        try:
+            assert Path(_temp_directory(con)).parent == tmp_path
+        finally:
+            con.close()
+
+        assert not leaf.exists()
+
+    def test_sweep_reports_what_it_removed(self, tmp_path):
+        dead = _plant_leaf(tmp_path, _dead_pid())
+        alive = _plant_leaf(tmp_path, os.getpid())
+
+        removed = sweep_orphaned_spill_dirs(tmp_path)
+
+        assert [Path(p) for p in removed] == [dead]
+        assert alive.is_dir()
+
+
+#: The real DuckDB error, provoked with a tiny ``max_temp_directory_size``
+#: rather than a tiny volume: the message is byte-for-byte what a user on a
+#: 64MB or RAM-backed ``/tmp`` sees.
+def _out_of_spill_space_error(tmp_path) -> duckdb.Error:
+    con = duckdb.connect()
+    try:
+        con.execute(f"SET temp_directory = '{tmp_path.as_posix()}'")
+        con.execute("SET max_temp_directory_size = '16MB'")
+        con.execute("SET threads = 1")
+        con.execute(f"SET memory_limit = '{SPILL_MEMORY_LIMIT}'")
+        with pytest.raises(duckdb.Error) as excinfo:
+            con.execute(SPILL_QUERY)
+        return excinfo.value
+    finally:
+        con.close()
+
+
+class TestOutOfSpillSpaceIsExplained:
+    """DuckDB says "Out of Memory Error" for a *disk* shortage, and never says TMPDIR."""
+
+    def test_duckdbs_own_message_says_memory_and_never_says_tmpdir(self, tmp_path):
+        text = str(_out_of_spill_space_error(tmp_path))
+        assert "Out of Memory Error" in text
+        assert "TMPDIR" not in text
+
+    def test_the_real_error_is_recognised(self, tmp_path):
+        hint = spill_space_hint(_out_of_spill_space_error(tmp_path))
+        assert hint is not None
+        assert "TMPDIR" in hint
+        assert "tmpfs" in hint
+
+    def test_an_ordinary_memory_error_is_not_claimed(self):
+        con = duckdb.connect()
+        try:
+            con.execute("SET memory_limit = '10MB'")
+            con.execute("SET temp_directory = ''")
+            with pytest.raises(duckdb.Error) as excinfo:
+                con.execute(SPILL_QUERY)
+        finally:
+            con.close()
+        assert "max_temp_directory_size" not in str(excinfo.value)
+        assert spill_space_hint(excinfo.value) is None
+
+    def test_nothing_and_unrelated_errors_return_none(self):
+        assert spill_space_hint(None) is None
+        assert spill_space_hint(ValueError("no such file")) is None
+
+    def test_raw_error_text_is_accepted_too(self):
+        assert spill_space_hint("... the 'max_temp_directory_size' setting.") is not None
+        assert spill_space_hint("IO Error: no such file") is None
+
+    def test_a_wrapped_error_is_found_through_the_cause_chain(self):
+        inner = duckdb.Error("Out of Memory Error: ... the 'max_temp_directory_size' setting.")
+        outer = RuntimeError("write failed")
+        outer.__cause__ = inner
+        assert spill_space_hint(outer) is not None
+
+
+class TestTheCliNamesTmpdir:
+    """The hint has to reach the user, on every command, not just the ones with a decorator."""
+
+    def test_the_group_replaces_an_out_of_spill_space_message(self):
+        from geoparquet_io.cli.decorators import SpillAwareGroup
+
+        @click.group(cls=SpillAwareGroup)
+        def root():
+            pass
+
+        @root.command()
+        def boom():
+            raise duckdb.OutOfMemoryException(
+                "Out of Memory Error: failed to offload data block of size 256.0 KiB.\n"
+                "This limit was set by the 'max_temp_directory_size' setting."
+            )
+
+        result = CliRunner().invoke(root, ["boom"])
+
+        assert result.exit_code != 0
+        assert "TMPDIR" in result.output
+        # The original text is kept: it names the sizes involved.
+        assert "failed to offload data block" in result.output
+
+    def test_other_errors_pass_through_untouched(self):
+        from geoparquet_io.cli.decorators import SpillAwareGroup
+
+        @click.group(cls=SpillAwareGroup)
+        def root():
+            pass
+
+        @root.command()
+        def boom():
+            raise duckdb.IOException("IO Error: No files found that match the pattern")
+
+        result = CliRunner().invoke(root, ["boom"])
+
+        assert isinstance(result.exception, duckdb.IOException)
+
+    def test_the_real_cli_group_uses_it(self):
+        from geoparquet_io.cli.decorators import SpillAwareGroup
+        from geoparquet_io.cli.main import cli
+
+        assert isinstance(cli, SpillAwareGroup)
+
+
+def test_the_reaper_pattern_is_not_hand_written_twice():
+    """One regex owns the naming convention; ``--clear-cache`` reuses it."""
+    from geoparquet_io.core import admin_datasets, duckdb_utils
+
+    assert isinstance(duckdb_utils._SPILL_DIR_RE, re.Pattern)
+    assert admin_datasets.sweep_orphaned_spill_dirs is duckdb_utils.sweep_orphaned_spill_dirs

--- a/tests/test_spill_strategy.py
+++ b/tests/test_spill_strategy.py
@@ -1,0 +1,303 @@
+"""Where DuckDB spills intermediate results (Deep Review 2.1).
+
+DuckDB's out-of-the-box ``temp_directory`` is the relative path ``.tmp``, so
+every spill lands under whatever directory the process happens to be running
+in. Two things follow, and both are pinned here:
+
+* a read-only (or full) working directory turns a large sort into a hard
+  failure even when the input and output volumes are perfectly writable;
+* a *shared* spill directory is not safe. DuckDB names its spill files after
+  the block size alone (``duckdb_temp_storage_S192K-0.tmp``), with nothing
+  identifying the connection or the process, so two connections pointed at one
+  directory overwrite each other's blocks and fail with ``IO Error: Could not
+  read enough bytes`` or corrupt statistics.
+
+The fix is central: :func:`get_duckdb_connection` gives every connection its
+own private spill directory under the OS temp directory unless the caller names
+one.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection, spill_directory
+
+# A sort that comfortably exceeds the memory limit below, and still runs in
+# well under a second.
+SPILL_ROWS = 400_000
+SPILL_MEMORY_LIMIT = "128MB"
+SPILL_QUERY = (
+    "CREATE TABLE spilled AS "
+    f"SELECT i, repeat('x', 400) s FROM range({SPILL_ROWS}) t(i) ORDER BY hash(i)"
+)
+
+
+def _force_spill(con) -> None:
+    """Run a query that cannot finish without writing to temp_directory."""
+    con.execute("SET threads = 1")
+    con.execute(f"SET memory_limit = '{SPILL_MEMORY_LIMIT}'")
+    con.execute(SPILL_QUERY)
+
+
+def _temp_directory(con) -> str:
+    return con.execute("SELECT current_setting('temp_directory')").fetchone()[0]
+
+
+#: Rows in the fixture below: ~300MB of payload, so a sort of it cannot fit in
+#: WRITE_MEMORY_LIMIT, yet it builds and writes in about a second. The limit has
+#: headroom over the payload because duckdb-kv's COPY needs working space of its
+#: own beyond the sort it is draining.
+WIDE_ROWS = 200_000
+WRITE_MEMORY_LIMIT = "320MB"
+
+
+def _wide_geoparquet(path: Path) -> str:
+    """A GeoParquet file whose sort does not fit in ``SPILL_MEMORY_LIMIT``."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    import shapely
+    import shapely.wkb
+
+    point = shapely.wkb.dumps(shapely.Point(1.0, 2.0))
+    table = pa.table(
+        {
+            "geometry": pa.array([point] * WIDE_ROWS, pa.binary()),
+            "sort_key": pa.array([(i * 2654435761) % WIDE_ROWS for i in range(WIDE_ROWS)]),
+            "padding": pa.array(["x" * 1500] * WIDE_ROWS),
+        }
+    )
+    pq.write_table(table, path)
+    return str(path)
+
+
+requires_unprivileged_posix = pytest.mark.skipif(
+    sys.platform == "win32" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="needs POSIX permission bits and a non-root user to make a directory read-only",
+)
+
+
+class TestSpillDirectoryHelper:
+    """``spill_directory()`` picks the location; it never creates it."""
+
+    def test_defaults_under_the_os_temp_directory(self):
+        path = Path(spill_directory())
+        assert path.parent == Path(tempfile.gettempdir())
+
+    def test_honours_an_explicit_base(self, tmp_path):
+        path = Path(spill_directory(tmp_path))
+        assert path.parent == tmp_path
+
+    def test_is_not_created_eagerly(self, tmp_path):
+        # Nothing is written unless DuckDB actually spills, and DuckDB removes
+        # a directory it created itself when the connection closes.
+        assert not Path(spill_directory(tmp_path)).exists()
+        assert list(tmp_path.iterdir()) == []
+
+    def test_is_unique_per_call(self, tmp_path):
+        paths = {spill_directory(tmp_path) for _ in range(50)}
+        assert len(paths) == 50
+
+
+class TestConnectionDefaults:
+    """Every connection gets a private spill directory, named or not."""
+
+    def test_default_is_absolute_and_outside_the_working_directory(self):
+        con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+        try:
+            value = _temp_directory(con)
+            assert value != ".tmp"
+            assert Path(value).is_absolute()
+            assert Path(tempfile.gettempdir()) in Path(value).parents
+        finally:
+            con.close()
+
+    def test_two_connections_never_share_a_spill_directory(self):
+        first = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+        second = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+        try:
+            assert _temp_directory(first) != _temp_directory(second)
+        finally:
+            first.close()
+            second.close()
+
+    def test_an_explicit_temp_directory_is_used_verbatim(self, tmp_path):
+        chosen = str(tmp_path / "chosen")
+        con = get_duckdb_connection(load_spatial=False, load_httpfs=False, temp_directory=chosen)
+        try:
+            assert _temp_directory(con) == chosen
+        finally:
+            con.close()
+
+    def test_memory_limit_stays_opt_in(self):
+        """No default cap: DuckDB's own 80%-of-RAM limit is the right one.
+
+        A limit only helps when spilling works, and forcing a lower one would
+        push queries to disk that fit in RAM today.
+        """
+        configured = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+        bare = get_duckdb_connection(load_spatial=False, load_httpfs=False, memory_limit=None)
+        try:
+            assert _temp_directory(configured) != ".tmp"  # spill dir was set
+            assert (
+                configured.execute("SELECT current_setting('memory_limit')").fetchone()[0]
+                == bare.execute("SELECT current_setting('memory_limit')").fetchone()[0]
+            )
+        finally:
+            configured.close()
+            bare.close()
+
+    def test_threads_and_insertion_order_stay_at_duckdb_defaults(self):
+        """``threads=1`` + ``preserve_insertion_order=false`` are write-time knobs.
+
+        They are what makes a *COPY* spill reliably (duckdb-kv clamps both for
+        the duration of a write), but as a global default they would serialise
+        every read gpio does and change result ordering for callers that never
+        write a file.
+        """
+        con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+        try:
+            assert int(con.execute("SELECT current_setting('threads')").fetchone()[0]) > 0
+            assert (
+                con.execute("SELECT current_setting('preserve_insertion_order')").fetchone()[0]
+                is True
+            )
+        finally:
+            con.close()
+
+
+class TestSpillsActuallyLandThere:
+    """The setting is not the point; surviving the spill is."""
+
+    def test_spill_files_land_in_the_private_directory(self):
+        con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+        spill_dir = Path(_temp_directory(con))
+        try:
+            _force_spill(con)
+            assert spill_dir.is_dir()
+            assert list(spill_dir.glob("duckdb_temp_storage*"))
+        finally:
+            con.close()
+        # DuckDB removes a temp directory it created itself.
+        assert not spill_dir.exists()
+
+    def test_concurrent_connections_do_not_corrupt_each_other(self):
+        """Regression guard for the shared-directory hazard in the docstring."""
+        errors: list[BaseException] = []
+
+        def run() -> None:
+            con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+            try:
+                _force_spill(con)
+                assert con.execute("SELECT count(*) FROM spilled").fetchone()[0] == SPILL_ROWS
+            except BaseException as exc:  # pragma: no cover - only on regression
+                errors.append(exc)
+            finally:
+                con.close()
+
+        threads = [threading.Thread(target=run) for _ in range(3)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        assert not errors
+
+
+#: Body of the subprocess below. Run from a read-only working directory, it
+#: proves the failure Deep Review 2.1 names and then proves gpio's default
+#: clears it, on one interpreter start.
+_READ_ONLY_CWD_SCRIPT = f"""
+import os, pathlib, sys
+import duckdb
+import pyarrow.parquet as pq
+from geoparquet_io.core.common import write_parquet_with_metadata
+from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+source, output = sys.argv[1], sys.argv[2]
+assert not os.access(os.getcwd(), os.W_OK), "working directory is still writable"
+
+def force_spill(con):
+    con.execute("SET threads = 1")
+    con.execute("SET memory_limit = '{SPILL_MEMORY_LIMIT}'")
+    con.execute({SPILL_QUERY!r})
+
+# 1. Stock DuckDB spills into ".tmp" under the working directory, and dies here.
+bare = duckdb.connect()
+try:
+    force_spill(bare)
+    raise AssertionError("expected stock DuckDB to fail on a read-only CWD")
+except duckdb.IOException as exc:
+    assert ".tmp" in str(exc), exc
+finally:
+    bare.close()
+
+# 2. A gpio connection spills somewhere writable instead.
+con = get_duckdb_connection(load_spatial=False, load_httpfs=False)
+try:
+    force_spill(con)
+    assert con.execute("SELECT count(*) FROM spilled").fetchone()[0] == {SPILL_ROWS}
+finally:
+    con.close()
+
+# 3. And so does a real GeoParquet write whose sort does not fit in memory.
+con = get_duckdb_connection(load_httpfs=False)
+spill_dir = pathlib.Path(con.execute("SELECT current_setting('temp_directory')").fetchone()[0])
+try:
+    write_parquet_with_metadata(
+        con=con,
+        query=(
+            "SELECT * REPLACE (ST_GeomFromWKB(geometry) AS geometry) "
+            "FROM read_parquet('" + source + "') ORDER BY sort_key"
+        ),
+        output_file=output,
+        compression="ZSTD",
+        compression_level=1,
+        geoparquet_version="1.1",
+        memory_limit="{WRITE_MEMORY_LIMIT}",
+    )
+    # The payload is larger than the limit, so the sort must have gone to disk
+    # -- and it went to gpio's private directory, not to ".tmp".
+    assert spill_dir.is_dir(), "the write never spilled; the test proves nothing"
+finally:
+    con.close()
+
+assert pq.ParquetFile(output).metadata.num_rows == {WIDE_ROWS}
+assert os.listdir(".") == [], os.listdir(".")
+print("OK")
+"""
+
+
+@requires_unprivileged_posix
+def test_spilling_write_survives_a_read_only_working_directory(tmp_path):
+    """The failure Deep Review 2.1 names, reproduced and then fixed.
+
+    Runs in a subprocess because the working directory is the whole point and
+    this suite may not move its own (see the ``no-cwd-change-in-tests`` hook).
+    """
+    cwd = tmp_path / "read-only-cwd"
+    cwd.mkdir()
+    source = _wide_geoparquet(tmp_path / "in.parquet")
+    output = str(tmp_path / "out.parquet")
+
+    cwd.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", _READ_ONLY_CWD_SCRIPT, source, output],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    finally:
+        cwd.chmod(stat.S_IRWXU)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout


### PR DESCRIPTION
This is **Deep Review item 2.1 (central spill strategy)**. There is no tracking
issue for it — the item lives only in the Deep Review — so there is nothing to
reference here beyond #761, which this unblocks.

## What changed

`get_duckdb_connection` now gives every connection its own spill directory
under the OS temp directory when the caller does not name one. That is the
whole mechanism; the rest is fallout.

- `spill_directory(base_dir=None)` in `core/duckdb_utils.py` returns a fresh,
  **not-yet-created** path under `base_dir` (default: the OS temp directory,
  i.e. `TMPDIR`). DuckDB creates the directory the first time a query spills
  and removes it when the connection closes, so a run that never spills writes
  nothing and leaves nothing behind.
- The four call sites that already passed a `temp_directory` all passed the
  *same* well-known path — the admin cache dir — so they now take a private
  leaf under that same volume (`spill_directory(cache_dir)`). See the hazard
  under "Why" below.
- `temp_directory=` keeps its exact meaning: the path is used verbatim.
- `docs/guide/write-strategies.md` gains a "Where Spilled Data Goes" section,
  and its `extract bigquery` note is corrected — that connection is built
  through `get_duckdb_connection`, so it now has a spill path.

Four source files, 12 changed lines. No call site had to name the setting.

## Why

DuckDB's default `temp_directory` is the **relative** path `.tmp`, and 98 of
gpio's 102 `get_duckdb_connection` call sites left it there, so every spill
landed under whatever directory the user happened to run gpio from. Reproduced
below: a read-only working directory turns a sort into a hard failure even
though the input and output volumes are both writable.

### Why the default lives in the connection factory, not the write path

"Beside the output" was the review's stated intent, and it is not reachable.
DuckDB refuses to relocate a temp directory once it has been used:

```
NotImplementedException: Cannot switch temporary directory after the current one has been used
```

So a per-write override cannot be applied to a connection gpio shares across
writes — a partition loop finalizes N files on one connection, and file 2 would
throw. The location has to be fixed when the connection is opened, which is
exactly one place. `TMPDIR` is then the user's knob for a machine whose root
volume is too small to hold a large sort's spill, and it is also the answer for
an output path on a network or object-store mount, where spilling beside the
output would be pathological.

### Why the directory must be private per connection

This is correctness, not tidiness. DuckDB names its spill files after the block
size alone — `duckdb_temp_storage_S192K-0.tmp` — with nothing in the name
identifying the connection, the database or the process. Three connections
pointed at one directory, each sorting:

```
IOException: Could not read enough bytes from file ".../duckdb_temp_storage_S192K-0.tmp"
InvalidInputException: Invalid unicode (byte sequence mismatch) detected in segment statistics update
```

They overwrite each other's blocks. That is why the admin callers, which all
shared the cache directory, changed: two concurrent `gpio add admin-divisions`
runs (or one plus a `gpio partition admin`) could corrupt each other's spill.

### What did *not* get a default

- **`memory_limit` stays opt-in.** A limit only helps once spilling works, and
  a default below DuckDB's own (~80% of RAM) would push queries to disk that
  fit in RAM today.
- **`threads=1` and `preserve_insertion_order=false` stay where they are.**
  The repo's operational experience is that reliable spilling on large joins
  needed all three together, and `duckdb-kv` already clamps these two for the
  duration of a write (`_configure_duckdb_memory`) — it was only missing the
  temp directory, which it now inherits. As *global* defaults they would
  serialise every read gpio does and change result ordering for callers that
  never write a file.

## Verification

**The reproduction.** From a read-only CWD, with input and output on writable
volumes, a 600MB sort through `duckdb-kv`:

```
cwd writable: False
RESULT: FAILED -> IOException IO Error: Failed to create directory ".tmp": Permission denied
```

After the change the same write succeeds. It is pinned as
`test_spilling_write_survives_a_read_only_working_directory`, which runs in a
subprocess (the `no-cwd-change-in-tests` hook forbids moving this suite's own
CWD) and asserts all three steps in order: stock DuckDB fails on `.tmp`; a gpio
connection spills anyway; and a `write_parquet_with_metadata` sort larger than
its memory limit lands its spill in gpio's private directory and writes every
row, leaving the working directory empty.

`tests/test_spill_strategy.py` — 12 tests, 3.7s — also covers: the helper is
unique per call and creates nothing; the default is absolute and under
`gettempdir()`; two connections never share; an explicit `temp_directory` is
used verbatim; spill files really land there and are cleaned up on close; three
concurrent spilling connections do not corrupt each other (the regression guard
for the hazard above); and `memory_limit`/`threads`/`preserve_insertion_order`
are left at DuckDB's defaults.

| Check | Result |
|---|---|
| `pytest -n auto -m "not slow and not network and not meta"` | 7034 passed, 76 skipped, 9 xfailed (179s) |
| `pytest -m meta` | 204 passed (one `cz check` subprocess timeout under `-n auto`; passes serially, 29/29) |
| `pre-commit run --all-files` | clean |
| `pre-commit run --all-files --hook-stage pre-push` | clean (incl. menard-check, xenon, import-linter, vulture, mypy) |
| `diff-cover --compare-branch=origin/main` | **100%** — 12 changed lines, 0 missing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DuckDB temporary storage now uses private, per-run directories to improve concurrent reliability.
  * CLI errors caused by insufficient temporary disk space now include actionable guidance.
  * Cache cleanup now identifies and removes leftover temporary spill data, with deletion and storage totals reported.

* **Documentation**
  * Added guidance on temporary storage, cleanup, read-only workspaces, limited volumes, concurrent runs, and interrupted processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->