### PR TITLE
fix(geo-metadata): keep a projected CRS through extract and sort, and stop 'check' crashing on the file it diagnoses

### DIFF
--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -473,7 +473,13 @@ def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, 
     from geoparquet_io.core.geo_metadata import covering_supported
 
     geo_meta = get_geo_metadata(parquet_file)
-    version = geo_meta.get("version", "0.0.0") if geo_meta else "0.0.0"
+    # `get_geo_metadata` is a read-only reader: it hands the block back exactly
+    # as the file holds it, so a block that is not a JSON object arrives here
+    # verbatim and used to crash with `'list' object has no attribute 'get'`
+    # (#968). A validation reader guards and reports the truth rather than
+    # sanitizing: a block that declares no version has none, which is what
+    # "0.0.0" says and what the outdated-version issue below reports.
+    version = geo_meta.get("version", "0.0.0") if isinstance(geo_meta, dict) else "0.0.0"
     bbox_info = check_bbox_structure(parquet_file, verbose)
 
     # Build results

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -864,12 +864,11 @@ def _prune_geo_dict_to_columns(geo_dict: dict, columns: set[str], repoint_primar
     """
     # Sanitizing drops a non-string `primary_column` and repairs it from a lone
     # surviving column, which is the recovery this function needs and #883/#945
-    # already shared out. A block it cannot make usable is an absent one.
-    declared_primary = isinstance(geo_dict, dict) and "primary_column" in geo_dict
-    sanitized = sanitize_geo_metadata(geo_dict)
-    if not isinstance(sanitized, dict):
-        return _DROP_GEO
-    geo_dict = sanitized
+    # already shared out. `_rewrite_geo_metadata` only calls this with a decoded
+    # object -- a block that is not one never gets here -- so sanitizing a dict
+    # hands back a dict.
+    declared_primary = "primary_column" in geo_dict
+    geo_dict = sanitize_geo_metadata(geo_dict)
 
     col_entries = geo_dict.get("columns")
     if not isinstance(col_entries, dict):

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -854,7 +854,23 @@ def _prune_geo_dict_to_columns(geo_dict: dict, columns: set[str], repoint_primar
     itself is gone but another declared geometry column remains,
     ``repoint_primary`` decides between naming that survivor as the new primary
     and dropping the whole block.
+
+    This is a write path -- whatever survives is re-encoded into the output's
+    ``geo`` key -- so the carried block goes through the shared shape check
+    first. It used to compare the *raw* ``primary_column`` against the surviving
+    keys, and ``123`` is neither ``None`` nor a key, so the whole block was
+    dropped: the file lost its ``crs`` too, and an absent ``crs`` is spec-defined
+    as OGC:CRS84, silently relabelling a projected file lon/lat (#968).
     """
+    # Sanitizing drops a non-string `primary_column` and repairs it from a lone
+    # surviving column, which is the recovery this function needs and #883/#945
+    # already shared out. A block it cannot make usable is an absent one.
+    declared_primary = isinstance(geo_dict, dict) and "primary_column" in geo_dict
+    sanitized = sanitize_geo_metadata(geo_dict)
+    if not isinstance(sanitized, dict):
+        return _DROP_GEO
+    geo_dict = sanitized
+
     col_entries = geo_dict.get("columns")
     if not isinstance(col_entries, dict):
         return geo_dict
@@ -863,6 +879,13 @@ def _prune_geo_dict_to_columns(geo_dict: dict, columns: set[str], repoint_primar
         del col_entries[name]
 
     primary = geo_dict.get("primary_column")
+    if primary is None and declared_primary:
+        # Sanitizing dropped a malformed `primary_column` and could not repair
+        # it, because `columns` held more than one entry at the time. Pruning
+        # may just have left exactly one, which is an unambiguous primary.
+        _repair_primary_column(geo_dict)
+        primary = geo_dict.get("primary_column")
+
     if primary is not None and primary not in col_entries:
         if not (repoint_primary and col_entries):
             return _DROP_GEO

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -312,10 +312,17 @@ def sanitize_geo_metadata(geo_meta):
     cleaned = geo_meta
 
     primary = geo_meta.get("primary_column")
-    dropped_primary = "primary_column" in geo_meta and not isinstance(primary, str)
+    # An empty string is a string, but it is not a column name -- and it lands in
+    # the same place a non-string does: `"" not in col_entries`, so pruning drops
+    # the whole block and the CRS with it. `carried_column_name` and the spec
+    # check in `validate` both already reject it; this is the third reader and
+    # has to agree, or the write paths corrupt what the check correctly flags.
+    dropped_primary = "primary_column" in geo_meta and not (isinstance(primary, str) and primary)
     if dropped_primary:
         problems.append(
-            f"'primary_column' is {_article(_json_type_name(primary))}, expected a string"
+            "'primary_column' is an empty string, expected a column name"
+            if isinstance(primary, str)
+            else f"'primary_column' is {_article(_json_type_name(primary))}, expected a string"
         )
         cleaned = dict(cleaned)
         cleaned.pop("primary_column")

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -207,21 +207,33 @@ def find_geometry_column_from_metadata(metadata: dict | None) -> str | None:
     """
     Find the primary geometry column name from metadata.
 
+    A column-name reader shared with read-only callers (``Table.geometry_column``),
+    so it takes the line #945 drew: it guards rather than sanitizes, and refuses
+    to hand back the one thing that cannot be a column name. A carried
+    ``primary_column: 123`` used to travel from here through ``extract`` into
+    ``quote_identifier`` and fail with ``TypeError: argument of type 'int' is
+    not iterable``, four frames from anything a user can act on (#968).
+
+    It also no longer falls back to the literal ``"geometry"``: on a file whose
+    column is called ``geom`` that default names a column that does not exist,
+    which is the silently-wrong-coordinates bug #945's review identified. Every
+    caller asks the file's schema when this reader says nothing, which is the
+    answer a block-less file already gets.
+
     Args:
         metadata: Schema metadata dict (with bytes keys)
 
     Returns:
-        Geometry column name or None if not found
+        Geometry column name or None if the block does not name a usable one
     """
+    from geoparquet_io.core.geo_metadata import carried_column_name, decode_carried_geo
+
     if not metadata or b"geo" not in metadata:
         return None
-    try:
-        geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
-        if isinstance(geo_meta, dict):
-            return geo_meta.get("primary_column", "geometry")
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        pass
-    return None
+    geo_meta = decode_carried_geo(metadata[b"geo"])
+    if not isinstance(geo_meta, dict):
+        return None
+    return carried_column_name(geo_meta.get("primary_column"))
 
 
 def find_geometry_column_from_table(table: pa.Table) -> str | None:
@@ -572,7 +584,10 @@ def extract_crs_from_table(
     if table.schema.metadata and b"geo" in table.schema.metadata:
         try:
             from geoparquet_io.core.crs_utils import crs_is_explicitly_null, warn_null_crs_once
-            from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
+            from geoparquet_io.core.geo_metadata import (
+                carried_geometry_column,
+                sanitize_geo_metadata,
+            )
 
             geo_bytes = table.schema.metadata[b"geo"]
             # `Table.write()` resolves the CRS through here before it builds any
@@ -581,7 +596,13 @@ def extract_crs_from_table(
             geo_meta = sanitize_geo_metadata(json.loads(geo_bytes.decode("utf-8")))
             if isinstance(geo_meta, dict):
                 columns = geo_meta.get("columns", {})
-                geom_col_name = geometry_column or geo_meta.get("primary_column", "geometry")
+                # The literal `"geometry"` default named a column that does not
+                # exist on a file whose column is `geom`, and reported its CRS
+                # as absent (#887 review). Ask the table's schema instead — the
+                # shared recovery #960 shared out (#968).
+                geom_col_name = geometry_column or carried_geometry_column(
+                    geo_meta, table.column_names
+                )
                 if geom_col_name in columns:
                     if crs_is_explicitly_null(columns[geom_col_name]):
                         warn_null_crs_once(

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -227,16 +227,51 @@ def _check_primary_column_present(geo_meta: dict) -> ValidationCheck:
     )
 
 
-def _check_columns_present(geo_meta: dict) -> ValidationCheck:
-    """Check 5: metadata must include a 'columns' object."""
+def _checkable_column_entries(geo_meta: dict) -> dict:
+    """The ``columns`` entries the per-column checks can actually read.
+
+    A ``geo`` block is arbitrary JSON written by some other tool, and every
+    per-column check indexes its entry as an object. The shapes that are not one
+    are reported by :func:`_check_columns_present` and then left out here, so a
+    malformed block gets diagnosed instead of crashing the diagnosis (#968).
+    """
     columns = geo_meta.get("columns")
-    valid = isinstance(columns, dict)
+    if not isinstance(columns, dict):
+        return {}
+    return {name: col for name, col in columns.items() if isinstance(col, dict)}
+
+
+def _check_columns_present(geo_meta: dict) -> ValidationCheck:
+    """Check 5: metadata must include a 'columns' object of per-column objects.
+
+    The spec requires each value in ``columns`` to be an object too, and every
+    per-column check below reads it as one. Reporting a non-object entry here
+    is what lets those checks skip it instead of crashing ``check spec`` with
+    ``'str' object has no attribute 'get'`` (#968).
+    """
+    columns = geo_meta.get("columns")
+    if not isinstance(columns, dict):
+        return ValidationCheck(
+            name="columns_present",
+            status=CheckStatus.FAILED,
+            message='metadata must include a "columns" object',
+            category="core_metadata",
+        )
+
+    not_objects = sorted(str(name) for name, col in columns.items() if not isinstance(col, dict))
+    if not_objects:
+        return ValidationCheck(
+            name="columns_present",
+            status=CheckStatus.FAILED,
+            message=f'"columns" entries must be objects: {", ".join(not_objects)}',
+            details="Each key in 'columns' maps to an object describing that column",
+            category="core_metadata",
+        )
+
     return ValidationCheck(
         name="columns_present",
-        status=CheckStatus.PASSED if valid else CheckStatus.FAILED,
-        message='metadata includes a "columns" object'
-        if valid
-        else 'metadata must include a "columns" object',
+        status=CheckStatus.PASSED,
+        message='metadata includes a "columns" object',
         category="core_metadata",
     )
 
@@ -724,11 +759,19 @@ def _check_version_known(geo_meta: dict) -> ValidationCheck:
 
 
 def _columns_declaring_covering(geo_meta: dict) -> list[str]:
-    """Names of geometry columns whose metadata declares the 'covering' key (added in 1.1)."""
+    """Names of geometry columns whose metadata declares the 'covering' key (added in 1.1).
+
+    A ``columns`` that is not an object declares no columns, so it declares no
+    ``covering`` either — the truthful answer, and the one ``columns_present``
+    is already reporting as a failure beside this check. ``or {}`` only covered
+    the falsy shapes; an array or a string reached ``.items()`` and crashed the
+    one command a user runs to be *told* their file is malformed (#968).
+    """
+    columns = geo_meta.get("columns")
+    if not isinstance(columns, dict):
+        return []
     return sorted(
-        name
-        for name, col in (geo_meta.get("columns") or {}).items()
-        if isinstance(col, dict) and "covering" in col
+        name for name, col in columns.items() if isinstance(col, dict) and "covering" in col
     )
 
 
@@ -3917,7 +3960,14 @@ def _run_geoparquet_checks(
     checks.append(_check_columns_present(geo_meta))
     checks.append(_check_primary_column_in_columns(geo_meta))
 
-    columns = geo_meta.get("columns", {})
+    # `_check_columns_present` above already FAILs both a `columns` that is not
+    # an object and an entry inside it that is not one, naming each. The
+    # per-column loops below read every entry as an object, so they run on the
+    # entries that are: iterating the raw value crashed `check spec` with
+    # `'list' object has no attribute 'items'`, and reading a string entry with
+    # `'str' object has no attribute 'get'` (#968). A validation reader guards
+    # and reports — it does not sanitize, and nothing usable is hidden.
+    columns = _checkable_column_entries(geo_meta)
 
     # A missing version is reported by _check_version_present above; guard the
     # string comparisons below against None so validation never crashes on it.

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -1551,3 +1551,118 @@ def test_api_table_metadata_still_reports_a_well_formed_block(tmp_path):
     assert meta["geo_metadata"] == block
     assert meta["geometry_types"] == ["Point"]
     assert meta["edges"] == "planar"
+
+
+# =============================================================================
+# The column pruner: a malformed `primary_column` must not cost the file its CRS
+# =============================================================================
+#
+# `_prune_geo_dict_to_columns` compared the *raw* `primary_column` against the
+# surviving `columns` keys. `123` is not None and is not a key, so the whole
+# `geo` block was dropped -- CRS included -- and an absent `crs` is spec-defined
+# as OGC:CRS84. A projected file came out of `gpio extract geoparquet` and
+# `gpio sort hilbert` silently relabelled lon/lat: corruption, not a crash
+# (#968). This is a write path -- what survives here is written to the output --
+# so it goes through the shared `sanitize_geo_metadata`, which drops the
+# malformed key and repairs it from the one surviving column.
+
+
+def _projected_file(tmp_path, name: str, primary, col: str = "geometry") -> str:
+    """A one-row EPSG:5070 file whose block declares ``primary`` as its primary."""
+    block = {
+        "version": "1.1.0",
+        "primary_column": primary,
+        "columns": {col: {"encoding": "WKB", "crs": _crs_5070(), "geometry_types": ["Point"]}},
+    }
+    return _file_with_geo(tmp_path, name, block, col=col)
+
+
+def _crs_epsg_of(path) -> int | None:
+    """The EPSG code the written file declares for its primary column, if any."""
+    geo = _geo_of_file(path)
+    if not geo:
+        return None
+    entry = (geo.get("columns") or {}).get(geo.get("primary_column"))
+    crs = entry.get("crs") if isinstance(entry, dict) else None
+    if not isinstance(crs, dict):
+        return None
+    return (crs.get("id") or {}).get("code")
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_prune_keeps_the_block_when_the_primary_column_is_malformed(col):
+    """The pruner must not read `primary_column` raw (#968)."""
+    from geoparquet_io.core.geo_metadata import prune_geo_metadata_to_columns
+
+    reset_malformed_geo_warnings()
+    block = {
+        "version": "1.1.0",
+        "primary_column": 123,
+        "columns": {col: {"encoding": "WKB", "crs": _crs_5070()}},
+    }
+    pruned = prune_geo_metadata_to_columns({b"geo": json.dumps(block).encode("utf-8")}, ["id", col])
+
+    assert b"geo" in pruned, "the whole block was dropped, taking the CRS with it"
+    geo = json.loads(pruned[b"geo"])
+    assert geo["primary_column"] == col
+    assert geo["columns"][col]["crs"]["id"]["code"] == 5070
+
+
+def test_prune_still_drops_a_block_whose_primary_column_is_gone():
+    """The pruner's real job is untouched: no surviving geometry column, no block."""
+    from geoparquet_io.core.geo_metadata import prune_geo_metadata_to_columns
+
+    reset_malformed_geo_warnings()
+    block = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB"}},
+    }
+    pruned = prune_geo_metadata_to_columns({b"geo": json.dumps(block).encode("utf-8")}, ["id"])
+    assert b"geo" not in pruned
+
+
+def test_prune_leaves_no_primary_when_two_columns_could_be_meant():
+    """Two survivors is a guess; the block keeps its columns and names no primary."""
+    from geoparquet_io.core.geo_metadata import prune_geo_metadata_to_columns
+
+    reset_malformed_geo_warnings()
+    block = {
+        "version": "1.1.0",
+        "primary_column": 123,
+        "columns": {"geom_a": {"encoding": "WKB"}, "geom_b": {"encoding": "WKB"}},
+    }
+    pruned = prune_geo_metadata_to_columns(
+        {b"geo": json.dumps(block).encode("utf-8")}, ["geom_a", "geom_b"]
+    )
+    geo = json.loads(pruned[b"geo"])
+    assert "primary_column" not in geo
+    assert set(geo["columns"]) == {"geom_a", "geom_b"}
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+@pytest.mark.parametrize("command", [["extract", "geoparquet"], ["sort", "hilbert"]])
+def test_projected_crs_survives_a_malformed_primary_column(command, col, tmp_path):
+    """A projected file must not come out of gpio relabelled lon/lat (#968).
+
+    The control run pins what the command does with a well-formed block; the
+    malformed run has to match it. Comparing the two is the point: an assertion
+    on the malformed run alone would pass just as well if the command had
+    stopped writing a CRS at all.
+    """
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    reset_malformed_geo_warnings()
+    runner = CliRunner()
+    codes = {}
+    for label, primary in (("control", col), ("malformed", 123)):
+        src = _projected_file(tmp_path, f"{label}_{col}_{command[0]}", primary, col=col)
+        out = tmp_path / f"{label}_{col}_{command[0]}_out.parquet"
+        result = runner.invoke(cli, [*command, src, str(out)])
+        assert result.exit_code == 0, result.output
+        codes[label] = _crs_epsg_of(out)
+
+    assert codes["control"] == 5070, "the control lost the CRS; the fixture is wrong"
+    assert codes["malformed"] == codes["control"]

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -1742,3 +1742,36 @@ def test_check_spec_still_catches_a_covering_declared_by_a_1_0_file(tmp_path):
     )
     reported = {c.name: c.status.value for c in validate_geoparquet(path).checks}
     assert reported["version_features_match"] == "failed"
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_check_bbox_reports_a_malformed_block_instead_of_crashing(col, case, block, tmp_path):
+    """`gpio check bbox` died at `_check_geoparquet_v1` on a non-object block."""
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(tmp_path, f"ckbbox_{col}_{case}", block, col=col)
+    result = CliRunner().invoke(cli, ["check", "bbox", path])
+
+    assert "Traceback" not in result.output, result.output
+    assert not isinstance(result.exception, (AttributeError, TypeError)), result.exception
+
+
+def test_check_bbox_still_reads_the_version_of_a_well_formed_file(tmp_path):
+    """The guard must not cost a real 1.0 file its "outdated version" report."""
+    from geoparquet_io.core.check_parquet_structure import check_metadata_and_bbox
+
+    path = _file_with_geo(
+        tmp_path,
+        "ckbbox_ok",
+        {
+            "version": "1.0.0",
+            "primary_column": "geometry",
+            "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["Point"]}},
+        },
+    )
+    results = check_metadata_and_bbox(path, verbose=False, return_results=True, quiet=True)
+    assert results["version"] == "1.0.0"
+    assert any("outdated" in issue for issue in results["issues"])

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -1622,6 +1622,40 @@ def test_prune_still_drops_a_block_whose_primary_column_is_gone():
     assert b"geo" not in pruned
 
 
+@pytest.mark.parametrize("block", [["geometry"], "geometry", 7])
+def test_prune_passes_a_block_that_is_not_an_object_through_untouched(block):
+    """`_rewrite_geo_metadata` never hands the pruner a block that is not decoded.
+
+    Pinned because the pruner now sanitizes, and sanitizing *would* drop such a
+    block: the guarantee is what makes the shape check inside it a dict-to-dict
+    one. `check spec` is what reports these shapes; a write on one is refused by
+    DuckDB's own reader first.
+    """
+    from geoparquet_io.core.geo_metadata import prune_geo_metadata_to_columns
+
+    reset_malformed_geo_warnings()
+    raw = json.dumps(block).encode("utf-8")
+    assert prune_geo_metadata_to_columns({b"geo": raw}, ["id", "geometry"])[b"geo"] == raw
+
+
+def test_prune_repairs_the_primary_from_the_column_pruning_leaves():
+    """Two entries at sanitize time, one after pruning: an unambiguous primary."""
+    from geoparquet_io.core.geo_metadata import prune_geo_metadata_to_columns
+
+    reset_malformed_geo_warnings()
+    block = {
+        "version": "1.1.0",
+        "primary_column": 123,
+        "columns": {"geom_a": {"encoding": "WKB", "crs": _crs_5070()}, "geom_b": {}},
+    }
+    pruned = prune_geo_metadata_to_columns(
+        {b"geo": json.dumps(block).encode("utf-8")}, ["id", "geom_a"]
+    )
+    geo = json.loads(pruned[b"geo"])
+    assert geo["primary_column"] == "geom_a"
+    assert geo["columns"]["geom_a"]["crs"]["id"]["code"] == 5070
+
+
 def test_prune_leaves_no_primary_when_two_columns_could_be_meant():
     """Two survivors is a guess; the block keeps its columns and names no primary."""
     from geoparquet_io.core.geo_metadata import prune_geo_metadata_to_columns

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -346,6 +346,18 @@ def _malformed_blocks(col: str):
             },
         ),
         (
+            # An empty string passes an `isinstance(..., str)` check but is not a
+            # column name, so it reaches `"" not in col_entries` and takes the
+            # whole block -- CRS included -- with it. Same symptom as the number
+            # above, from the shape most likely to survive a naive guard.
+            "primary_column_is_empty",
+            {
+                "version": "1.1.0",
+                "primary_column": "",
+                "columns": {col: {"encoding": "WKB", "geometry_types": ["Point"]}},
+            },
+        ),
+        (
             "encoding_is_a_number",
             {
                 "version": "1.1.0",
@@ -1063,6 +1075,43 @@ def test_extract_crs_from_parquet_finds_a_projected_crs_after_recovery(col, tmp_
         tmp_path, "proj_bad_primary", col, {"encoding": "WKB", "crs": _crs_5070()}
     )
     assert extract_crs_from_parquet(src) is not None
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_an_empty_primary_column_keeps_the_projected_crs_through_a_write(col, tmp_path):
+    """The shape most likely to survive a naive guard: `""` IS a string.
+
+    An `isinstance(..., str)` check passes it, so it reaches
+    `"" not in col_entries` and takes the whole block -- CRS included -- exactly
+    as a number does. `carried_column_name` and `validate`'s spec check both
+    already reject it, so a sanitizer that accepts it makes the write paths
+    corrupt precisely what `gpio check spec` correctly flags.
+    """
+    import json
+
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(
+        tmp_path,
+        "empty_primary_projected",
+        {
+            "version": "1.1.0",
+            "primary_column": "",
+            "columns": {col: {"encoding": "WKB", "geometry_types": ["Point"], "crs": _crs_5070()}},
+        },
+        col=col,
+    )
+    out = tmp_path / "out.parquet"
+    result = CliRunner().invoke(cli, ["extract", "geoparquet", src, str(out)])
+    assert result.exit_code == 0, result.output
+
+    written = json.loads(pq.read_schema(str(out)).metadata[b"geo"])
+    # Absent would mean OGC:CRS84 per spec -- a projected file relabelled lon/lat.
+    assert written["columns"][col]["crs"] is not None
+    assert written["primary_column"] == col
 
 
 @pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -1666,3 +1666,79 @@ def test_projected_crs_survives_a_malformed_primary_column(command, col, tmp_pat
 
     assert codes["control"] == 5070, "the control lost the CRS; the fixture is wrong"
     assert codes["malformed"] == codes["control"]
+
+
+# =============================================================================
+# `gpio check`: the commands that exist to *diagnose* a malformed file
+# =============================================================================
+#
+# These are validation readers, so they follow the line #883 drew and #945/#960
+# upheld: they do NOT sanitize, because `gpio check` has to see the file as it
+# really is. They guard and report the truth instead -- a `columns` that is not
+# an object declares no geometry columns, and a block that is not an object
+# declares no version (#968).
+
+
+@pytest.mark.parametrize(("col", "case", "block"), MALFORMED_BLOCKS, ids=MALFORMED_BLOCK_IDS)
+def test_check_spec_reports_a_malformed_block_instead_of_crashing(col, case, block, tmp_path):
+    """`check spec` is the command run to be *told* the file is malformed."""
+    from geoparquet_io.core.validate import validate_geoparquet
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(tmp_path, f"spec_{col}_{case}", block, col=col)
+    result = validate_geoparquet(path)
+
+    reported = {c.name: c.status.value for c in result.checks}
+    if not isinstance(block, dict):
+        # A block that is not a JSON object cannot be checked key by key; one
+        # honest failure says so.
+        assert reported.get("geo_metadata_parse") == "failed"
+        return
+    if not isinstance(block.get("columns"), dict):
+        assert reported.get("columns_present") == "failed"
+
+
+@pytest.mark.parametrize("bad", [["geometry"], None, "geometry", 5])
+def test_check_spec_columns_guard_does_not_hide_a_declared_covering(bad, tmp_path):
+    """The 1.1-only 'covering' check must survive a non-object `columns` (#968).
+
+    It crashed at `_columns_declaring_covering` with
+    `'list' object has no attribute 'items'` before reaching any of the checks
+    that would have told the user what was wrong.
+    """
+    from geoparquet_io.core.validate import validate_geoparquet
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(
+        tmp_path,
+        f"covering_{type(bad).__name__}",
+        {"version": "1.0.0", "primary_column": "geometry", "columns": bad},
+    )
+    reported = {c.name: c.status.value for c in validate_geoparquet(path).checks}
+    assert reported["columns_present"] == "failed"
+    # No columns can be read, so none can declare a 1.1-only key: not a failure
+    # to pin on the version.
+    assert reported["version_features_match"] == "passed"
+
+
+def test_check_spec_still_catches_a_covering_declared_by_a_1_0_file(tmp_path):
+    """The guard must not cost a real 1.0-with-covering file its failure."""
+    from geoparquet_io.core.validate import validate_geoparquet
+
+    path = _file_with_geo(
+        tmp_path,
+        "covering_on_1_0",
+        {
+            "version": "1.0.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": ["Point"],
+                    "covering": {"bbox": {"xmin": ["bbox", "xmin"]}},
+                }
+            },
+        },
+    )
+    reported = {c.name: c.status.value for c in validate_geoparquet(path).checks}
+    assert reported["version_features_match"] == "failed"

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -1775,3 +1775,97 @@ def test_check_bbox_still_reads_the_version_of_a_well_formed_file(tmp_path):
     results = check_metadata_and_bbox(path, verbose=False, return_results=True, quiet=True)
     assert results["version"] == "1.0.0"
     assert any("outdated" in issue for issue in results["issues"])
+
+
+# =============================================================================
+# The metadata-only column-name reader
+# =============================================================================
+#
+# `find_geometry_column_from_metadata` returned `primary_column` with no type
+# check, so `123` travelled through `extract` into `quote_identifier` and failed
+# there with `TypeError: argument of type 'int' is not iterable`, four frames
+# from anything a user can act on (#968). It is a column-name reader shared with
+# read-only callers (`Table.geometry_column`), so it takes #945's line: guard,
+# do not sanitize, and hand back nothing rather than a name that cannot be one.
+#
+# The same line carried the literal `"geometry"` default #945's review named as
+# the cause of its silently-wrong-coordinates bug: on a file whose column is
+# `geom`, that default names a column that does not exist. Every caller already
+# asks the schema when this reader says nothing, which is the right answer.
+
+
+@pytest.mark.parametrize("bad", [123, ["geometry"], {"name": "geometry"}, None, ""])
+def test_find_geometry_column_from_metadata_never_returns_a_non_name(bad):
+    from geoparquet_io.core.streaming import find_geometry_column_from_metadata
+
+    reset_malformed_geo_warnings()
+    block = {"version": "1.1.0", "primary_column": bad, "columns": {"geom": {"encoding": "WKB"}}}
+    assert find_geometry_column_from_metadata({b"geo": json.dumps(block).encode("utf-8")}) is None
+
+
+def test_find_geometry_column_from_metadata_still_reads_a_real_name():
+    from geoparquet_io.core.streaming import find_geometry_column_from_metadata
+
+    block = {"version": "1.1.0", "primary_column": "geom", "columns": {"geom": {}}}
+    assert find_geometry_column_from_metadata({b"geo": json.dumps(block).encode("utf-8")}) == "geom"
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_find_geometry_column_from_table_recovers_from_a_non_string_primary(col):
+    """The table-level reader asks the schema, and must find the real column."""
+    from geoparquet_io.core.streaming import find_geometry_column_from_table
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {"version": "1.1.0", "primary_column": 123, "columns": {col: {"encoding": "WKB"}}}, col=col
+    )
+    assert find_geometry_column_from_table(table) == col
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_extract_to_stdout_survives_a_non_string_primary_column(col, tmp_path):
+    """`gpio extract geoparquet <file> -` reached `quote_identifier` with an int."""
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(
+        tmp_path,
+        f"stdout_{col}",
+        {
+            "version": "1.1.0",
+            "primary_column": 123,
+            # A complete entry otherwise: DuckDB's own reader refuses a 1.1
+            # column with no `geometry_types`, and that domain error is outside
+            # gpio's reach (#945). The `primary_column` is the only thing wrong.
+            "columns": {col: {"encoding": "WKB", "geometry_types": ["Point"]}},
+        },
+        col=col,
+    )
+    result = CliRunner().invoke(cli, ["extract", "geoparquet", src, "-"])
+    assert not isinstance(result.exception, TypeError), result.exception
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_extract_crs_from_table_reads_the_named_column_not_the_literal_one(col):
+    """`streaming.extract_crs_from_table` carried the same `"geometry"` default.
+
+    Reached only when the caller passes no `geometry_column`, which no caller
+    does today -- but the default is wrong for a `geom` file either way, and
+    #960 called the one it fixed "the one place still open to it".
+    """
+    from geoparquet_io.core.streaming import extract_crs_from_table
+
+    reset_malformed_geo_warnings()
+    table = _table_with_geo(
+        {
+            "version": "1.1.0",
+            "primary_column": col,
+            "columns": {col: {"encoding": "WKB", "crs": _crs_5070()}},
+        },
+        col=col,
+    )
+    crs = extract_crs_from_table(table)
+    assert isinstance(crs, dict) and crs["id"]["code"] == 5070

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -280,10 +280,18 @@ class TestGeometryColumnDetection:
         metadata = {b"geo": json.dumps({"primary_column": "geom"}).encode("utf-8")}
         assert find_geometry_column_from_metadata(metadata) == "geom"
 
-    def test_find_geometry_column_from_metadata_default(self):
-        """Test default geometry column when not specified."""
-        metadata = {b"geo": json.dumps({}).encode("utf-8")}
-        assert find_geometry_column_from_metadata(metadata) == "geometry"
+    def test_find_geometry_column_from_metadata_names_nothing_it_cannot_read(self):
+        """A block that names no usable primary column names none (#968).
+
+        This used to answer with the literal ``"geometry"``, which is a guess:
+        on a file whose column is ``geom`` it names a column that does not
+        exist, and #945's review traced silently-wrong coordinates to exactly
+        that default. Every caller asks the file's schema when this reader says
+        nothing -- see ``test_find_geometry_column_from_table_common_names``.
+        """
+        assert find_geometry_column_from_metadata({b"geo": json.dumps({}).encode("utf-8")}) is None
+        malformed = {b"geo": json.dumps({"primary_column": 123}).encode("utf-8")}
+        assert find_geometry_column_from_metadata(malformed) is None
 
     def test_find_geometry_column_from_metadata_missing(self):
         """Test None when no geo metadata."""


### PR DESCRIPTION
## What changed

The fourth instalment of #883's class, and the first one whose lead item is
**silent data corruption** rather than a crash. Each site is classified the way
#883, #945 and #960 classified theirs, and the classification decides the fix.

| # | Site | Class | Symptom on `origin/main` |
|---|---|---|---|
| 1 | `geo_metadata._prune_geo_dict_to_columns` | write path → **sanitize** | a projected file silently relabelled OGC:CRS84 |
| 2 | `validate._columns_declaring_covering` + both per-column loops in `_run_geoparquet_checks` | validation → **guard** | `AttributeError: 'list' object has no attribute 'items'` |
| 3 | `check_parquet_structure._check_geoparquet_v1` | validation → **guard** | `AttributeError: 'list' object has no attribute 'get'` |
| 4 | `streaming.find_geometry_column_from_metadata` | column name → **guard** | `TypeError: argument of type 'int' is not iterable` |

**1 — the lead.** `_prune_geo_dict_to_columns` compared the *raw* carried
`primary_column` against the surviving `columns` keys. `123` is neither `None`
nor a key, so the whole `geo` block was dropped — `crs` included. An absent
`crs` is spec-defined as OGC:CRS84, so a projected EPSG:5070 file came out of
`gpio extract geoparquet` and `gpio sort hilbert` relabelled lon/lat, silently.

It is a write path — whatever survives is re-encoded into the output's `geo` key
— so it now goes through the shared `sanitize_geo_metadata`. `_repair_primary_column`
**was** reusable and does the whole job for the single-column case; the one thing
it could not do is the case where `columns` still held two entries at sanitize
time and pruning then left one, so the repair is retried after pruning.

**2 and 3 are validation readers and do not sanitize** — `gpio check` has to see
the file as it really is. `columns_present` now FAILs a non-object *entry*,
naming it, and the per-column loops run over the entries that can be read;
`_check_geoparquet_v1` reads a version only from a block that is an object.
Nothing usable is hidden: a 1.0 file that really does declare a 1.1-only
`covering` still fails `version_features_match`, and a well-formed 1.0 file still
gets its outdated-version report.

**4** is a column-name reader shared with read-only callers
(`Table.geometry_column`), so it takes #945's line: guard, hand back nothing
rather than a name that cannot be one, and let the caller ask the file's schema —
which every caller already does. That also retires the literal `"geometry"`
fallback this line carried (on a `geom` file it names a column that does not
exist — #945's review's silently-wrong-coordinates bug), here and at the second
site `streaming.extract_crs_from_table` still had, which the issue flagged as
contradicting #960's "the one place still open to it".

## Why

### The lead, reproduced

One row, `crs` = EPSG:5070 PROJJSON, the only difference between the two inputs
being `primary_column`. The control run pins what the command does with a
well-formed block; the malformed run has to match it.

**Before (`origin/main`):**

```
input  control  (primary_column: "geometry") : crs EPSG:5070 (NAD83 / Conus Albers)
input  malformed (primary_column: 123)       : crs ABSENT on primary 123

gpio extract geoparquet   control   -> crs EPSG:5070 (NAD83 / Conus Albers)
gpio extract geoparquet   malformed -> crs ABSENT on primary 'geometry'   <-- OGC:CRS84
gpio sort hilbert         control   -> crs EPSG:5070 (NAD83 / Conus Albers)
gpio sort hilbert         malformed -> crs ABSENT on primary 'geometry'   <-- OGC:CRS84
```

**After:**

```
gpio extract geoparquet   control   -> crs EPSG:5070 (NAD83 / Conus Albers)
gpio extract geoparquet   malformed -> crs EPSG:5070 (NAD83 / Conus Albers)
gpio sort hilbert         control   -> crs EPSG:5070 (NAD83 / Conus Albers)
gpio sort hilbert         malformed -> crs EPSG:5070 (NAD83 / Conus Albers)
```

### The three tracebacks

```
# 2. gpio check spec, columns: ["geom"] — the command run to be *told* the file is malformed
  File "geoparquet_io/core/validate.py", line 754, in _check_version_features
    covering_cols = _columns_declaring_covering(geo_meta)
  File "geoparquet_io/core/validate.py", line 730, in _columns_declaring_covering
    for name, col in (geo_meta.get("columns") or {}).items()
AttributeError: 'list' object has no attribute 'items'

# and one layer on, for columns: null / a string / an entry that is not an object
  File "geoparquet_io/core/validate.py", line 3927, in _run_geoparquet_checks
    for col_name, col_meta in columns.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

```
# 3. gpio check bbox, geo block = ["geometry"]
  File "geoparquet_io/core/check_parquet_structure.py", line 476, in _check_geoparquet_v1
    version = geo_meta.get("version", "0.0.0") if geo_meta else "0.0.0"
AttributeError: 'list' object has no attribute 'get'
```

```
# 4. gpio extract geoparquet <file> -, primary_column: 123
  File "geoparquet_io/core/duckdb_utils.py", line 239, in quote_identifier
    if "\x00" in name:
TypeError: argument of type 'int' is not iterable
```

All four are pre-existing on `origin/main` and untouched by #960, so none of them
blocked that merge.

## Verification

Every site was reproduced on `origin/main` first and re-run after the fix.

**A sweep, not a claim.** 8 malformed shapes (`columns` null/array/string, an
entry that is not an object, a non-string `primary_column`, a non-string
`version`, a block that is an array, a block that is a string) x 26 CLI commands,
run against a pristine `git archive origin/main` tree and against this branch
with the same script:

| | raw `TypeError`/`AttributeError` |
|---|---|
| `origin/main` | **12** |
| this branch | **6** |

The 6 that remain are all one shape — see below. They are pre-existing and not
members of the batch this PR fixes.

- `uv run pytest -n auto -m "not slow and not network and not meta" -q` — **7080 passed**, 76 skipped, 9 xfailed
- `uv run pytest -m meta -q` — **205 passed**
- `uv run pre-commit run --all-files` clean; `--hook-stage pre-push` clean, `menard-check` and `xenon` included
- `diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` — **28 changed lines, 0 missing, 100%**
- 41 new tests in `tests/test_malformed_geo_metadata.py`, parametrized over both
  `geometry` and `geom` as #945 established, with a **control run** beside each
  end-to-end assertion so a fix that merely stopped writing a CRS could not pass,
  and a positive test per site so no guard costs a well-formed file its report.

One flake, named rather than hidden: `test_pipe_integration.py::test_add_bbox_to_sort_hilbert`
fails only in the full ~7,100-test `-n auto --cov` run on this shared machine. It
passes serially, in isolation under `-n auto --cov`, and in the uninstrumented
full suite — the saturation noise CLAUDE.md documents, not this change.

## There is a fifth batch — 2 sites, 6 live command paths

Three PRs have each called themselves the last one, so this one will not. The
sweep found a batch that all four PRs missed because they all read the same two
keys. It is a **third key**: a non-string `version`.

| Site | Reached by |
|---|---|
| `core/common.py:197` `detect_geoparquet_file_type` — `version.startswith("2.")` | `check spec`, `check bbox`, `check optimization`, `add bbox` |
| `core/streaming.py:645` `extract_version_from_metadata` — `version.split(".")` | `sort hilbert` (via `hilbert_order._resolve_output_version`), `add quadkey` |

```
$ gpio check spec <file with "version": 2>
  File "geoparquet_io/core/common.py", line 197, in detect_geoparquet_file_type
    if version and version.startswith("2."):
AttributeError: 'int' object has no attribute 'startswith'
```

Both are byte-identical on `origin/main`. `common.py` is outside this PR's scope
and accounts for 4 of the 6 paths, so fixing only the `streaming.py` half would
leave `check spec` still crashing on the same file — a worse state than a clean
report. Per the repo's separate-PRs-for-cross-cutting-fixes convention, this
belongs in its own change.

Two more findings from the sweep, both **pre-existing and verified identical on
`origin/main`** (checked against a `git archive` of it, not assumed):

- `sort hilbert` on a file with two *non-standard-named* geometry columns and no
  usable `primary_column` exits 1 with `BinderException: Referenced column
  "geometry" not found`. `find_primary_geometry_column` ends in
  `return detected if detected else "geometry"`, and `detect_geometry_column_from_names`
  knows only five standard names — the issue's `footprint` item. The
  single-column half of that item is already handled by `_repair_primary_column`;
  only the 2+-column case is live, where naming one would be a guess anyway.
- The remaining `_check_v2_*` raw `geo_meta.get("columns", {}).get(...)` reads in
  `validate.py` are **not** reachable: they run inside `for col_name in columns.keys()`,
  which this PR's normalization makes empty for every malformed `columns`.

The issue's own conclusion still stands and this PR does not deliver it: the
reliable fix is a `meta`-lane grep guard that fails on any *new* raw
`geo_meta["columns"]` / `.get("primary_column")` / `.get("version")` outside the
shared helpers. That would have caught this batch and the fifth one at once.

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or incomplete GeoParquet metadata without unexpected errors.
  * Validation now reports invalid metadata structures clearly instead of failing during checks.
  * Preserved CRS information when repairing metadata during column extraction and sorting.
  * Geometry-column detection no longer assumes a default column when metadata is missing or unusable.
  * Empty or invalid primary-column values are safely corrected or ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->