### PR TITLE
fix(core): report a non-string geo.version in check spec and check bbox instead of crashing

### DIFF
--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -556,7 +556,10 @@ def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, 
     # make (#979). That crash sat behind the `detect_geoparquet_file_type` one
     # `check bbox` hit a frame earlier, so it only becomes reachable once that
     # is guarded -- fix one without the other and the traceback just moves.
-    version = carried_version(geo_meta.get("version") if isinstance(geo_meta, dict) else None)
+    version = carried_version(
+        geo_meta.get("version") if isinstance(geo_meta, dict) else None,
+        source=str(parquet_file),
+    )
     version = version or "0.0.0"
     bbox_info = check_bbox_structure(parquet_file, verbose)
 

--- a/geoparquet_io/core/check_parquet_structure.py
+++ b/geoparquet_io/core/check_parquet_structure.py
@@ -541,7 +541,7 @@ def _check_geoparquet_v2(parquet_file, file_type_info, verbose, return_results, 
 def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, quiet=False):
     """Check GeoParquet 1.x file (existing logic, bbox IS recommended)."""
     from geoparquet_io.core.duckdb_metadata import get_geo_metadata
-    from geoparquet_io.core.geo_metadata import covering_supported
+    from geoparquet_io.core.geo_metadata import carried_version, covering_supported
 
     geo_meta = get_geo_metadata(parquet_file)
     # `get_geo_metadata` is a read-only reader: it hands the block back exactly
@@ -550,7 +550,14 @@ def _check_geoparquet_v1(parquet_file, file_type_info, verbose, return_results, 
     # (#968). A validation reader guards and reports the truth rather than
     # sanitizing: a block that declares no version has none, which is what
     # "0.0.0" says and what the outdated-version issue below reports.
-    version = geo_meta.get("version", "0.0.0") if isinstance(geo_meta, dict) else "0.0.0"
+    #
+    # A version that is not a *string* is the same answer, and has to be: the
+    # comparison two lines down is `version < "1.1.0"`, which a number cannot
+    # make (#979). That crash sat behind the `detect_geoparquet_file_type` one
+    # `check bbox` hit a frame earlier, so it only becomes reachable once that
+    # is guarded -- fix one without the other and the traceback just moves.
+    version = carried_version(geo_meta.get("version") if isinstance(geo_meta, dict) else None)
+    version = version or "0.0.0"
     bbox_info = check_bbox_structure(parquet_file, verbose)
 
     # Build results

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -45,6 +45,7 @@ from geoparquet_io.core.geo_metadata import (
     GEOPARQUET_VERSIONS,
     build_bbox_covering,
     carried_geometry_column,
+    carried_version,
     create_geo_metadata,
     detect_bbox_column_from_schema,
     geoarrow_wkb_codes,
@@ -184,7 +185,12 @@ def detect_geoparquet_file_type(parquet_file, verbose=False, con=None):
     if geo_meta:
         result["has_geo_metadata"] = True
         if isinstance(geo_meta, dict) and "version" in geo_meta:
-            result["geo_version"] = geo_meta["version"]
+            # A version that is not a string is no version this can report:
+            # `2` reached `.startswith` below and took `check spec`,
+            # `check bbox`, `check optimization` and `add bbox` down with a bare
+            # `AttributeError` (#979). `geo_version` is documented as the
+            # version *or None*, and every consumer already handles None.
+            result["geo_version"] = carried_version(geo_meta["version"], source=str(parquet_file))
 
     # Check for native Parquet geo types using schema
     geo_columns = detect_geometry_columns(parquet_file, con=con)
@@ -1020,7 +1026,10 @@ def _detect_version_from_table(table, verbose: bool = False) -> str | None:
     try:
         geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
         if isinstance(geo_meta, dict):
-            version = geo_meta.get("version")
+            # Guarded, not truthiness-checked: a non-string version crashed
+            # `.split` here on the write path too -- `write_geoparquet_table`
+            # resolves auto-mode through this function (#979).
+            version = carried_version(geo_meta.get("version"))
             if version:
                 parts = version.split(".")
                 if len(parts) >= 2:

--- a/geoparquet_io/core/geo_metadata.py
+++ b/geoparquet_io/core/geo_metadata.py
@@ -168,6 +168,39 @@ def carried_column_name(
     return None
 
 
+def carried_version(value, source: str | None = None) -> str | None:
+    """A carried ``geo.version`` *string*, or ``None`` when the block does not give one.
+
+    Every reader of this key parses it -- ``version.startswith("2.")``,
+    ``version.split(".")`` -- and each of them guarded truthiness only, so a
+    ``version`` that is ``2``, ``2.0``, ``["2.0"]``, ``{"major": 2}`` or ``true``
+    walked past the guard and raised ``AttributeError`` several frames from
+    anything a user can act on (#979). In ``streaming`` the ``except`` beside
+    the call named ``json.JSONDecodeError`` and ``UnicodeDecodeError``
+    specifically, so it did not even catch it.
+
+    Version readers are shared between the write paths and ``gpio check``, so
+    this takes the same line as :func:`carried_column_name`: guard rather than
+    sanitize, hand back nothing rather than a value that cannot be a version,
+    name the ignored key once, and let each caller fall through to the default
+    it already has for a file that declares no version. Degrading to "unknown
+    version" is the whole point -- ``gpio check`` is the command a user runs to
+    be *told* their file is malformed, so crashing on the malformed input is the
+    one thing it must not do.
+
+    An *absent* version is not malformed and says nothing; an empty string is
+    not a version either, and ``validate`` already FAILs it as one.
+    """
+    if isinstance(value, str):
+        return value or None
+    if value is None:
+        return None
+    _emit_malformed_geo_warning(
+        f"'version' is {_article(_json_type_name(value))}, expected a string", source
+    )
+    return None
+
+
 def decode_carried_geo(raw):
     """Decode a raw carried ``geo`` value (bytes or str) to JSON, or None.
 

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -637,10 +637,16 @@ def extract_version_from_metadata(metadata: dict | None) -> str | None:
     """
     if not metadata or b"geo" not in metadata:
         return None
+    from geoparquet_io.core.geo_metadata import carried_version
+
     try:
         geo_meta = json.loads(metadata[b"geo"].decode("utf-8"))
         if isinstance(geo_meta, dict):
-            version = geo_meta.get("version")
+            # A truthiness guard let `2`, `2.0`, `["2.0"]` and `true` through to
+            # `.split`, and the `except` below names the two decoder errors
+            # specifically, so the `AttributeError` passed straight through it
+            # and out of `gpio sort hilbert` as a traceback (#979).
+            version = carried_version(geo_meta.get("version"))
             if version:
                 parts = version.split(".")
                 if len(parts) >= 2:

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -326,6 +326,30 @@ def test_extract_crs_from_table_survives_a_malformed_block():
 #: geometry ``geometry``" is exactly the assumption these readers must not make:
 #: a recovery that falls back to the literal ``"geometry"`` looks correct on a
 #: ``geometry`` file and silently reports no CRS on a ``geom`` one (#887 review).
+#: A ``version`` that is not a string (#979). Every *other* key on these blocks
+#: is well formed, which is the point: the keys the four earlier batches
+#: hardened all read cleanly, so a reader that guards those still walks straight
+#: into ``version.startswith`` / ``version.split``. ``true`` is here because it
+#: is the shape a truthiness guard is least likely to be written for, and
+#: ``2.0`` because an unquoted version in a YAML-ish config comes out a float.
+NON_STRING_VERSIONS = [
+    ("a_number", 2),
+    ("an_object", {"major": 2}),
+    ("a_float", 2.0),
+    ("a_list", ["2.0"]),
+    ("true", True),
+]
+
+
+def _version_block(version, col: str = "geometry") -> dict:
+    """A block that is well formed except for ``version``."""
+    return {
+        "version": version,
+        "primary_column": col,
+        "columns": {col: {"encoding": "WKB", "geometry_types": ["Point"]}},
+    }
+
+
 def _malformed_blocks(col: str):
     return [
         ("columns_null", {"version": "1.1.0", "primary_column": col, "columns": None}),
@@ -364,6 +388,10 @@ def _malformed_blocks(col: str):
                 "primary_column": col,
                 "columns": {col: {"encoding": 123, "geometry_types": ["Point"]}},
             },
+        ),
+        *(
+            (f"version_is_{case}", _version_block(bad_version, col))
+            for case, bad_version in NON_STRING_VERSIONS[:2]
         ),
     ]
 
@@ -1952,3 +1980,278 @@ def test_extract_crs_from_table_reads_the_named_column_not_the_literal_one(col):
     )
     crs = extract_crs_from_table(table)
     assert isinstance(crs, dict) and crs["id"]["code"] == 5070
+
+
+# =============================================================================
+# A `version` that is not a string (#979)
+# =============================================================================
+#
+# The fifth batch, and the one all four earlier PRs walked past because they all
+# read the same two keys. `version` is a *third* key, and the readers that reach
+# it guarded truthiness only:
+#
+#     version = geo_meta.get("version")
+#     if version and version.startswith("2."):     # common.py
+#     if version: parts = version.split(".")       # streaming.py
+#
+# so `2`, `2.0`, `["2.0"]`, `{"major": 2}` and `true` all sail past the guard and
+# raise `AttributeError` several frames from anything a user can act on. In
+# `streaming.py` the `except` beside it catches `json.JSONDecodeError` and
+# `UnicodeDecodeError` specifically, so the `AttributeError` passes straight
+# through it.
+#
+# These are version *readers*, shared between `gpio check` and the write paths,
+# so they take #945's line the way `carried_column_name` does: guard, hand back
+# nothing rather than a value that cannot be one, name the ignored key once, and
+# let the caller fall through to its own default. "Unknown version", not a
+# traceback -- `gpio check` exists to *report* that a file is malformed.
+
+
+@pytest.mark.parametrize(("case", "bad"), NON_STRING_VERSIONS)
+def test_carried_version_refuses_a_non_string(case, bad, caplog):
+    from geoparquet_io.core.geo_metadata import carried_version
+
+    reset_malformed_geo_warnings()
+    with caplog.at_level(logging.WARNING):
+        assert carried_version(bad) is None
+    assert any("'version'" in message for message in _malformed_warnings(caplog.records))
+
+
+@pytest.mark.parametrize("good", ["1.0.0", "1.1.0", "2.0.0", "1.1.0-dev"])
+def test_carried_version_passes_a_real_version_through(good, caplog):
+    from geoparquet_io.core.geo_metadata import carried_version
+
+    reset_malformed_geo_warnings()
+    with caplog.at_level(logging.WARNING):
+        assert carried_version(good) == good
+    assert not _malformed_warnings(caplog.records)
+
+
+@pytest.mark.parametrize("absent", [None, ""])
+def test_carried_version_is_quiet_about_an_absent_version(absent, caplog):
+    """An absent key is not malformed; an empty string is not a version either."""
+    from geoparquet_io.core.geo_metadata import carried_version
+
+    reset_malformed_geo_warnings()
+    with caplog.at_level(logging.WARNING):
+        assert carried_version(absent) is None
+    assert not _malformed_warnings(caplog.records)
+
+
+@pytest.mark.parametrize(("case", "bad"), NON_STRING_VERSIONS)
+@pytest.mark.parametrize("col", GEOMETRY_COLUMN_NAMES)
+def test_detect_file_type_survives_a_non_string_version(case, bad, col, tmp_path):
+    """`check spec`, `check bbox`, `check optimization` and `add bbox` all land here."""
+    from geoparquet_io.core.common import (
+        detect_geoparquet_file_type,
+        detect_geoparquet_file_type_cache_clear,
+    )
+
+    reset_malformed_geo_warnings()
+    detect_geoparquet_file_type_cache_clear()
+    path = _file_with_geo(tmp_path, f"ftype_{col}_{case}", _version_block(bad, col), col=col)
+
+    info = detect_geoparquet_file_type(path)
+
+    # The block is there, so the file is GeoParquet; it just does not say which
+    # version, and a version nobody can read is not a 2.x claim.
+    assert info["has_geo_metadata"] is True
+    assert info["geo_version"] is None
+    assert info["file_type"] == "geoparquet_v1"
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"), [("2.0.0", "geoparquet_v2"), ("1.1.0", "geoparquet_v1")]
+)
+def test_detect_file_type_still_reads_a_real_version(version, expected, tmp_path):
+    """The guard must not cost a well-formed file its version."""
+    from geoparquet_io.core.common import (
+        detect_geoparquet_file_type,
+        detect_geoparquet_file_type_cache_clear,
+    )
+
+    detect_geoparquet_file_type_cache_clear()
+    path = _file_with_geo(tmp_path, f"ftype_ok_{version}", _version_block(version))
+
+    info = detect_geoparquet_file_type(path)
+    assert info["geo_version"] == version
+    assert info["file_type"] == expected
+
+
+@pytest.mark.parametrize(("case", "bad"), NON_STRING_VERSIONS)
+def test_extract_version_from_metadata_survives_a_non_string_version(case, bad):
+    """`sort hilbert` resolves its output version through here (#979)."""
+    from geoparquet_io.core.streaming import extract_version_from_metadata
+
+    reset_malformed_geo_warnings()
+    metadata = {b"geo": json.dumps(_version_block(bad)).encode("utf-8")}
+    assert extract_version_from_metadata(metadata) is None
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"), [("1.0.0", "1.1"), ("1.1.0", "1.1"), ("2.0.0", "2.0")]
+)
+def test_extract_version_from_metadata_still_reads_a_real_version(version, expected):
+    from geoparquet_io.core.streaming import extract_version_from_metadata
+
+    metadata = {b"geo": json.dumps(_version_block(version)).encode("utf-8")}
+    assert extract_version_from_metadata(metadata) == expected
+
+
+@pytest.mark.parametrize(("case", "bad"), NON_STRING_VERSIONS)
+def test_detect_version_from_table_survives_a_non_string_version(case, bad):
+    """The API-side twin: `gpio.read(f).write(out)` resolves auto-mode through here."""
+    from geoparquet_io.core.common import resolve_geoparquet_version_from_table
+
+    reset_malformed_geo_warnings()
+    assert resolve_geoparquet_version_from_table(_table_with_geo(_version_block(bad))) is None
+
+
+@pytest.mark.parametrize(("version", "expected"), [("1.0.0", "1.1"), ("2.0.0", "2.0")])
+def test_detect_version_from_table_still_reads_a_real_version(version, expected):
+    from geoparquet_io.core.common import resolve_geoparquet_version_from_table
+
+    assert (
+        resolve_geoparquet_version_from_table(_table_with_geo(_version_block(version))) == expected
+    )
+
+
+@pytest.mark.parametrize(("case", "bad"), NON_STRING_VERSIONS)
+def test_check_bbox_survives_a_non_string_version(case, bad, tmp_path):
+    """`_check_geoparquet_v1` compares `version < "1.1.0"`, which a number cannot do.
+
+    Masked on `origin/main` behind the `detect_geoparquet_file_type` crash one
+    frame earlier, so it becomes reachable the moment that one is fixed -- the
+    half-fix this issue warns about, one file further on.
+    """
+    from geoparquet_io.core.check_parquet_structure import check_metadata_and_bbox
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(tmp_path, f"ckbboxver_{case}", _version_block(bad))
+    results = check_metadata_and_bbox(path, verbose=False, return_results=True, quiet=True)
+
+    # A version nobody can read is no version, which is what "0.0.0" says here
+    # and what the outdated-version issue reports.
+    assert results["version"] == "0.0.0"
+    assert any("outdated" in issue for issue in results["issues"])
+
+
+@pytest.mark.parametrize(("case", "bad"), NON_STRING_VERSIONS)
+def test_check_spec_reports_a_non_string_version_as_a_finding(case, bad, tmp_path):
+    """The whole point of the fix: a validation *finding*, not a traceback."""
+    from geoparquet_io.core.validate import validate_geoparquet
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(tmp_path, f"specver_{case}", _version_block(bad))
+    reported = {c.name: c.status.value for c in validate_geoparquet(path).checks}
+
+    assert reported["version_present"] == "failed"
+    assert reported["version_known"] == "failed"
+
+
+@pytest.mark.parametrize(("case", "bad"), NON_STRING_VERSIONS)
+def test_check_fix_version_resolution_survives_a_non_string_version(case, bad, tmp_path):
+    """`check bbox --fix` picks the rewrite version off the check results."""
+    from geoparquet_io.core.check_fixes import get_geoparquet_version_from_check_results
+    from geoparquet_io.core.check_parquet_structure import check_metadata_and_bbox
+
+    reset_malformed_geo_warnings()
+    path = _file_with_geo(tmp_path, f"fixver_{case}", _version_block(bad))
+    bbox = check_metadata_and_bbox(path, verbose=False, return_results=True, quiet=True)
+    assert get_geoparquet_version_from_check_results({"bbox": bbox}) in {"1.0", "1.1", "2.0", None}
+
+
+# =============================================================================
+# The sweep: every malformed shape against the command surface
+# =============================================================================
+#
+# The per-site tests above each pin one reader. None of them would have found
+# #979, because the crash was in a *third* key that no per-site test was written
+# for -- the sweep is what found it, so the sweep is what gets committed.
+#
+# Every shape is run against every command that reads a carried `geo` block, and
+# the set of commands that die with a raw `TypeError`/`AttributeError` is
+# asserted against `KNOWN_UNGUARDED` below. Both directions matter: a new
+# unguarded reader fails this, and so does fixing one of the known ones without
+# striking it off the list.
+
+SWEEP_COMMANDS: list[tuple[str, list[str]]] = [
+    ("check all", ["check", "all", "{in}"]),
+    ("check bbox", ["check", "bbox", "{in}"]),
+    ("check compression", ["check", "compression", "{in}"]),
+    ("check optimization", ["check", "optimization", "{in}"]),
+    ("check row-group", ["check", "row-group", "{in}"]),
+    ("check spatial", ["check", "spatial", "{in}"]),
+    ("check spec", ["check", "spec", "{in}"]),
+    ("check stac", ["check", "stac", "{in}"]),
+    ("inspect head", ["inspect", "head", "{in}"]),
+    ("inspect meta", ["inspect", "meta", "{in}"]),
+    ("inspect stats", ["inspect", "stats", "{in}"]),
+    ("inspect summary", ["inspect", "summary", "{in}"]),
+    ("inspect tail", ["inspect", "tail", "{in}"]),
+    ("add bbox", ["add", "bbox", "{in}", "{out}"]),
+    ("add bbox-metadata", ["add", "bbox-metadata", "{in}", "{out}"]),
+    ("add geometry-metrics", ["add", "geometry-metrics", "{in}", "{out}"]),
+    ("add quadkey", ["add", "quadkey", "{in}", "{out}"]),
+    ("sort hilbert", ["sort", "hilbert", "{in}", "{out}"]),
+    ("sort quadkey", ["sort", "quadkey", "{in}", "{out}"]),
+    ("sort column", ["sort", "column", "{in}", "{out}", "--column", "id"]),
+    ("sort str", ["sort", "str", "{in}", "{out}"]),
+    ("convert geojson", ["convert", "geojson", "{in}", "{out_geojson}"]),
+    ("convert csv", ["convert", "csv", "{in}", "{out_csv}"]),
+    ("convert geoparquet", ["convert", "geoparquet", "{in}", "{out}"]),
+    ("extract geoparquet", ["extract", "geoparquet", "{in}", "{out}"]),
+    ("publish stac", ["publish", "stac", "{in}", "--output", "{out_json}"]),
+]
+
+#: Readers that still die on a raw block, with the issue that owns each. Not a
+#: waiver: the sweep fails if one of these stops crashing and the entry is left
+#: behind, so a fix cannot land without this list being updated.
+KNOWN_UNGUARDED: dict[str, set[str]] = {
+    # #982: `add quadkey._validate_crs_from_geo_metadata` reads
+    # `geo_meta.get("columns", {})[col].get("crs")` with no shape check at all.
+    # A write path, so the fix is `sanitized_carried_geo`, not another guard --
+    # a different batch from #979's, and out of its scope.
+    "columns_null": {"add quadkey"},
+    "columns_list": {"add quadkey"},
+    "columns_string": {"add quadkey"},
+    "entry_not_an_object": {"add quadkey"},
+    "block_is_a_list": {"add quadkey"},
+    "block_is_a_string": {"add quadkey"},
+}
+
+#: One column name only: the sweep's job is breadth across *commands*, and the
+#: `geometry`-versus-`geom` axis is covered per reader above.
+SWEEP_SHAPES = [(case, block) for col, case, block in MALFORMED_BLOCKS if col == "geometry"] + [
+    (f"version_is_{case}", _version_block(bad)) for case, bad in NON_STRING_VERSIONS[2:]
+]
+
+
+@pytest.mark.parametrize(("case", "block"), SWEEP_SHAPES, ids=[c for c, _ in SWEEP_SHAPES])
+def test_no_command_dies_with_a_raw_type_error_on_a_malformed_block(case, block, tmp_path):
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    reset_malformed_geo_warnings()
+    src = _file_with_geo(tmp_path, f"sweep_{case}", block)
+
+    crashed: dict[str, str] = {}
+    for i, (name, argv) in enumerate(SWEEP_COMMANDS):
+        args = [
+            arg.format(
+                **{
+                    "in": src,
+                    "out": str(tmp_path / f"{case}_{i}.parquet"),
+                    "out_geojson": str(tmp_path / f"{case}_{i}.geojson"),
+                    "out_csv": str(tmp_path / f"{case}_{i}.csv"),
+                    "out_json": str(tmp_path / f"{case}_{i}.json"),
+                }
+            )
+            for arg in argv
+        ]
+        exc = CliRunner().invoke(cli, args).exception
+        if isinstance(exc, (TypeError, AttributeError)):
+            crashed[name] = f"{type(exc).__name__}: {exc}"
+
+    assert set(crashed) == KNOWN_UNGUARDED.get(case, set()), crashed


### PR DESCRIPTION
## What changed

The fifth instalment of #883's class, and the one all four earlier PRs walked
past because they all read the same two keys. This is a **third** key: a
`version` that is not a string.

Every reader of `geo.version` parses it — `version.startswith("2.")`,
`version.split(".")` — and each guarded truthiness only:

```python
version = geo_meta.get("version")
if version and version.startswith("2."):     # common.py
if version: parts = version.split(".")       # streaming.py
```

so `2`, `2.0`, `["2.0"]`, `{"major": 2}` and `true` all sail past the guard. In
`streaming.py` the `except` beside the call names `json.JSONDecodeError` and
`UnicodeDecodeError` specifically, so the `AttributeError` passed straight
through it.

One shared guard, `geo_metadata.carried_version`, sitting next to
`carried_column_name` and taking the same line #945 drew for it: hand back
nothing rather than a value that cannot be a version, name the ignored key once,
and let each caller fall through to the default it already has for a file that
declares no version. Version readers are shared between the write paths and
`gpio check`, so they **guard, they do not sanitize** — `gpio check` has to see
the file as it really is. Degrading to "unknown version" is the whole point:
`check` is the command a user runs to be *told* their file is malformed.

| # | Site | Reached by |
|---|---|---|
| 1 | `common.py` `detect_geoparquet_file_type` | `check spec`, `check bbox`, `check optimization`, `add bbox` |
| 2 | `streaming.py` `extract_version_from_metadata` | `sort hilbert`, `sort str`, `add quadkey` |
| 3 | `common.py` `_detect_version_from_table` | `write_geoparquet_table`, `gpio.read(f).write(out)` |
| 4 | `check_parquet_structure.py` `_check_geoparquet_v1` | `check bbox`, `check bbox --fix` |

**3 and 4 are not in the issue, and both are load-bearing.** #979 named two
sites; the sweep found two more, and skipping either would have reproduced
exactly the half-fix the issue warns about:

- **3** is the API-side twin of 1, and it is a *write* path — `write_geoparquet_table`
  resolves auto-mode through it. Adding the shape to the shared `MALFORMED_BLOCKS`
  list the earlier PRs built found it immediately, in an existing test.
- **4** was *masked*. `check bbox` crashed in `detect_geoparquet_file_type` one
  frame earlier, so it never reached `version < "1.1.0"` — a comparison a number
  cannot make. Fixing site 1 alone would have moved `check bbox`'s traceback one
  file along rather than removing it. That, one layer down, is the issue's own
  argument for why this is one change.

## Why

### The six paths, reproduced

Same one-row file throughout, `"version": 2`, everything else well formed. On
`origin/main`, 6 of 6 die:

```
$ gpio check spec / check bbox / check optimization / add bbox  <file>
  File ".../core/common.py", line 197, in detect_geoparquet_file_type
    if version and version.startswith("2."):
AttributeError: 'int' object has no attribute 'startswith'

$ gpio sort hilbert <file> out.parquet
  File ".../core/hilbert_order.py", line 83, in _resolve_output_version
    return extract_version_from_metadata(metadata) or DEFAULT_GEOPARQUET_VERSION
  File ".../core/streaming.py", line 645, in extract_version_from_metadata
    parts = version.split(".")
AttributeError: 'int' object has no attribute 'split'

$ gpio add quadkey <file> out.parquet
  File ".../core/common.py", line 3604, in get_bbox_advice
    file_info = detect_geoparquet_file_type(parquet_file, verbose)
AttributeError: 'int' object has no attribute 'startswith'
```

After: **0 of 6 `AttributeError`s** -- which is what this PR set out to remove,
but it is not the same as 0 of 6 tracebacks. Measured on the branch, the same
file, the same six commands:

| command | before | after |
|---|---|---|
| `check spec` | `AttributeError` traceback | **clean report, rc 1** |
| `check bbox` | `AttributeError` traceback | **clean, rc 0** |
| `add bbox` | `AttributeError` traceback | `_duckdb.InvalidInputException` traceback |
| `sort hilbert` | `AttributeError` traceback | `_duckdb.InvalidInputException` traceback |
| `add quadkey` | `AttributeError` traceback | `_duckdb.InvalidInputException` traceback |
| `check optimization` | `AttributeError` traceback | `_duckdb.InvalidInputException` traceback |

DuckDB's own Parquet reader rejects **any** non-string `geo.version`
(`Geoparquet metadata does not have a version`), so the four DuckDB-backed paths
cannot read the file at all whatever gpio's guards do. They trade one traceback
for another; the user-visible fix is `check spec` and `check bbox`. Turning those
four into an error line is **#983**, which this PR does not do -- land it with
this and the sentence becomes true for all six.

`gpio check spec` now answers with the finding the command exists to produce, and
names the key it ignored:

```
Ignoring malformed 'geo' metadata on the input of file.parquet: 'version' is a number, expected a string
  ✗ metadata must include a "version" string
  ✗ version must be a string (got int: 2)
      Known versions are 1.x and 2.x
  ○ version is not a string; feature check not applicable
```

and `gpio check bbox` reports `⚠️ Version 0.0.0 (upgrade to 1.1.0+ recommended)`
— a version nobody can read is no version, which is what `0.0.0` already says
here for a block that declares none.

### Reusing what #978 built

Checked before writing anything: `sanitize_geo_metadata` does **not** touch
`version`, and should not. It is the write-path sanitizer, and every write path
*overwrites* `version` from `_initialize_geo_metadata` — a carried version never
reaches an output file. The reusable thing was the shape one layer down:
`carried_column_name`'s guard-and-name-the-key idiom, `_json_type_name` and
`_article` for the message, and `_emit_malformed_geo_warning`'s warn-once-per-
`(detail, source)` cache. `carried_version` is 8 lines because all of that was
already there.

## Verification

**A sweep, not a claim.** The measure #978 reported, re-run on this tree: 12
malformed shapes x 28 CLI commands (its 26 plus `add quadkey` and `sort str`),
against a pristine `origin/main` worktree and against this branch with the same
script.

| | 8 shapes x 28 commands | 4 extra `version` shapes x 28 |
|---|---|---|
| `origin/main` | **13** | **28** |
| this branch | **6** | **0** |

Every one of the 41 that go is a `version` crash. **The 6 that remain are all
one command and none of them are `version`** — see below; they are pre-existing,
filed, and pinned by the new sweep test rather than left implicit.

The sweep is now **committed**, in `tests/test_malformed_geo_metadata.py`, which
is the part that matters: none of the ~40 per-site tests the four earlier PRs
wrote would have found #979, because the crash was in a key none of them was
written for. It asserts the *set* of commands that die per shape against a
`KNOWN_UNGUARDED` table, so it fails in both directions — a new unguarded reader
fails it, and so does fixing a known one without striking it off the list. The
non-string `version` shape also joins the shared `MALFORMED_BLOCKS` list, so
every existing per-site test now runs against it (that is what found site 3).

- `uv run pytest -n auto -m "not slow and not network and not meta"` — **7431 passed**, 76 skipped, 9 xfailed
- `uv run pytest -m meta` — **205 passed**
- `uv run pre-commit run --all-files` clean; `--hook-stage pre-push` clean, `xenon`, `mypy`, `import-linter` and `menard-check` included
- `diff-cover coverage.xml --compare-branch=origin/main` — **14 changed lines, 0 missing, 100%**
- 63 new tests

One flake, named rather than hidden: `tests/e2e/test_journeys.py::test_journey_01_geojson_to_geoparquet_and_back`
failed once in the ~7,500-test `-n auto --cov` run on this shared machine. It
passes serially, passes under `-n auto --cov` in isolation on `origin/main` too,
and the identical instrumented full run immediately after was 7431/7431 — the
saturation noise CLAUDE.md documents, not this change.

## What the sweep found that this PR does not fix

Reported rather than quietly bundled, per the repo's separate-PR convention.
Both were verified on a clean `origin/main` worktree before filing, and neither
is touched by this change.

- **#982** — the 6 remaining sweep crashes, all `gpio add quadkey`.
  `_validate_crs_from_geo_metadata` reads `geo_meta.get("columns", {})[col].get("crs")`
  with no shape check at all, so every shape #978 fixed elsewhere still crashes
  there. Invisible to #978's sweep only because its command list did not carry
  `add quadkey`; invisible on the `version` shape because `add quadkey` used to
  crash a frame earlier, in `common.py`. It is a write path, so its fix is
  `sanitized_carried_geo`, not another guard — a different batch. The sweep test
  pins all six against this issue number.
- **#983** — `check optimization`, `add bbox`, `sort hilbert` and `add quadkey`
  answer any input DuckDB's Parquet reader refuses with a raw
  `_duckdb.InvalidInputException` traceback instead of an error line, while
  `inspect head` and `convert geoparquet` on the same file print
  `Error: Invalid Input Error: ...` and exit 1. Reproduced on `origin/main` with
  a block DuckDB rejects for an unrelated reason (`{"version": "1.1.0"}`), so it
  is not caused by this change — but with #979's `AttributeError` gone, DuckDB's
  refusal is what shows underneath on those four paths.

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or non-string GeoParquet version metadata.
  * Prevented crashes during file inspection, validation, version detection, rewriting, and command execution.
  * Invalid version values now use existing default-version behavior and produce a clear metadata warning.

* **Tests**
  * Expanded coverage for malformed version values across GeoParquet operations and command-line workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
