### PR TITLE
fix(convert): name the row-group size the writer will use when --row-group-size is rounded up

### DIFF
--- a/docs/guide/convert.md
+++ b/docs/guide/convert.md
@@ -29,9 +29,18 @@ The `convert` command transforms between GeoParquet and other vector formats wit
     `gpio check optimization` scores, so `convert` produced files its own
     spatial check marked `[fail]`
     ([#981](https://github.com/geoparquet/geoparquet-io/issues/981)). Pass
-    `--row-group-size` to choose your own; it is snapped to the writer's
-    2,048-row vector the same way the sort commands snap it, so the number you
-    ask for is the number that lands.
+    `--row-group-size` to choose your own; anything above one 2,048-row writer
+    vector is snapped to a whole vector the same way the sort commands snap it,
+    so the number you ask for is the number that lands.
+
+    A request of **2,048 rows or fewer** is the exception: gpio passes it
+    through untouched, because pyarrow honours it exactly while DuckDB's
+    `COPY` rounds it up to 2,048 regardless — so what lands depends on which
+    writer runs, and gpio cannot snap it without overriding the one writer that
+    could have obeyed. `convert` writes through DuckDB, so
+    `--row-group-size 249` really does produce 2,048-row groups; it now prints
+    one line naming both numbers before the footer does
+    ([#986](https://github.com/geoparquet/geoparquet-io/issues/986)).
 
 === "Python"
 

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -1100,7 +1100,10 @@ class Table:
 
         import pyarrow as pa
 
-        from geoparquet_io.core.parquet_writer import resolve_row_group_rows
+        from geoparquet_io.core.parquet_writer import (
+            note_duckdb_copy_rounding,
+            resolve_row_group_rows,
+        )
         from geoparquet_io.core.remote import is_remote_url
         from geoparquet_io.core.upload import upload
         from geoparquet_io.core.write_strategies import WriteStrategy, WriteStrategyFactory
@@ -1167,6 +1170,15 @@ class Table:
             # Get the appropriate write strategy
             strategy_enum = WriteStrategy(write_strategy)
             strategy = WriteStrategyFactory.get_strategy(strategy_enum)
+
+            # duckdb-kv -- the default -- lets DuckDB's COPY have the last word
+            # on row-group size, so a sub-vector request lands at 2,048 rows
+            # whatever was asked for, while the other three strategies write it
+            # exactly. The CLI says so (#986); saying it here too keeps the
+            # Python API and the CLI from disagreeing about what a number means,
+            # which is what #971 was.
+            if strategy_enum == WriteStrategy.DUCKDB_KV:
+                note_duckdb_copy_rounding(row_group_rows)
 
             # Forward the input CRS so a non-default CRS survives the write (otherwise
             # the geometry silently defaults to OGC:CRS84). write_from_table expects a

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -74,6 +74,7 @@ from geoparquet_io.core.logging_config import (
 )
 from geoparquet_io.core.parquet_writer import (
     ParquetWriteSettings,
+    note_duckdb_copy_rounding,
     resolve_output_geoparquet_version,
     resolve_row_group_rows,
 )
@@ -3038,6 +3039,11 @@ def write_parquet_with_metadata(
                 debug(f"Writing GeoParquet version: {effective_version}")
                 debug(f"No metadata rewrite needed for {effective_version} - using plain COPY TO")
 
+            # Nothing but a bare DuckDB COPY writes this file, so a sub-vector
+            # request lands at 2,048 whatever was asked for. Say so here, where
+            # that is certain, rather than let the footer be the first to tell
+            # the user (#986).
+            note_duckdb_copy_rounding(row_group_rows)
             _plain_copy_to(
                 con=con,
                 query=query,
@@ -3135,6 +3141,14 @@ def write_parquet_with_metadata(
             }
             if strategy_enum == WriteStrategy.DUCKDB_KV:
                 write_kwargs["memory_limit"] = memory_limit
+            # duckdb-kv alone lets DuckDB's COPY have the last word on row-group
+            # size, so it alone rounds a sub-vector request up to 2,048 (#986).
+            # Measured with --row-group-size 249 on a 10,000-row input:
+            # duckdb-kv writes 2,048-row groups; in-memory, streaming and
+            # disk-rewrite all write 249-row ones -- disk-rewrite because its
+            # pyarrow pass regroups the COPY output at the requested size.
+            if strategy_enum == WriteStrategy.DUCKDB_KV:
+                note_duckdb_copy_rounding(row_group_rows)
 
             strategy.write_from_query(**write_kwargs)
 

--- a/geoparquet_io/core/parquet_writer.py
+++ b/geoparquet_io/core/parquet_writer.py
@@ -167,6 +167,12 @@ def resolve_row_group_rows(
     ceiling-everywhere rule: it answers "what would the DuckDB writer do", and
     that answer is still 2,048.
 
+    Passing the request through is not the same as pretending it lands. A
+    DuckDB-backed write still produces 2,048-row groups for a request of 249,
+    and used to do it without a word, so the user read 249 in the command and
+    2,048 in the footer (#986). :func:`note_duckdb_copy_rounding` says it, at
+    the funnels that know the write reaches DuckDB's ``COPY``.
+
     A row count below 1 is rejected, not clamped: ``sort str`` raised on
     ``--row-group-size -5`` while the other three quietly wrote 2,048-row groups.
     ``param_name`` is what that rejection blames. One function now serves both
@@ -185,13 +191,55 @@ def resolve_row_group_rows(
 
     aligned = align_to_writer_vector(row_group_rows)
     if aligned != row_group_rows:
-        info(
-            f"Writing {aligned:,} rows per row group rather than the requested "
-            f"{row_group_rows:,}: the Parquet writer emits row groups in whole "
-            f"{WRITER_VECTOR_ROWS:,}-row vectors, so {row_group_rows:,} is not a "
-            "size a row group can have."
-        )
+        info(_rounding_note(row_group_rows, aligned))
     return aligned
+
+
+def _rounding_note(requested: int, landed: int) -> str:
+    """The one sentence gpio says when a row-group request does not land.
+
+    One string, so the note the sort commands print when *gpio* snaps a value
+    and the note the DuckDB funnels print when the *writer* does are the same
+    sentence. They are the same fact about the same file.
+    """
+    return (
+        f"Writing {landed:,} rows per row group rather than the requested "
+        f"{requested:,}: the Parquet writer emits row groups in whole "
+        f"{WRITER_VECTOR_ROWS:,}-row vectors, so {requested:,} is not a "
+        "size a row group can have."
+    )
+
+
+def note_duckdb_copy_rounding(row_group_rows: int | None) -> None:
+    """Say what DuckDB's ``COPY`` will make of an already-resolved row count.
+
+    :func:`resolve_row_group_rows` announces every value *it* moves, so by the
+    time a write funnel calls this the only request still able to surprise
+    anyone is a sub-vector one: resolve passes 1-2,047 through untouched
+    because ``pq.write_table`` honours it exactly, and DuckDB's ``COPY`` then
+    rounds it up to 2,048 regardless. The note therefore fires for exactly that
+    window, and calling it after resolve is silent for everything else --
+    including a resolve that already spoke, whose value is a whole vector by
+    construction.
+
+    Which writer a request reaches is not something the facade can see, so this
+    is deliberately a *funnel* decision rather than part of resolve. Measured on
+    a 10,000-row input with ``--row-group-size 249``: the plain ``COPY`` fast
+    path and the ``duckdb-kv`` strategy both write 2,048-row groups, while
+    ``in-memory``, ``streaming`` and ``disk-rewrite`` write 249-row groups --
+    ``disk-rewrite`` because its pyarrow pass regroups the ``COPY`` output at
+    the requested size afterwards. Call this only where DuckDB's ``COPY`` has
+    the last word on the file the user gets.
+
+    ``None`` -- no row count asked for, or only a ``--row-group-size-mb``
+    target -- says nothing: naming a row count the user never typed would be
+    the inverse of the fix (#986).
+    """
+    if row_group_rows is None:
+        return
+    landed = align_to_writer_vector(row_group_rows)
+    if landed != row_group_rows:
+        info(_rounding_note(row_group_rows, landed))
 
 
 def resolve_output_geoparquet_version(

--- a/tests/test_convert_row_group_note.py
+++ b/tests/test_convert_row_group_note.py
@@ -1,0 +1,134 @@
+"""A DuckDB-backed write says what it will do with a sub-vector request (#986).
+
+The write facade snaps any request above one 2,048-row vector and announces the
+change (``resolve_row_group_rows``, #961/#990). It deliberately passes a request
+of 2,048 rows *or fewer* through untouched, because ``pq.write_table`` honours
+such a request exactly and snapping it would override the only writer that could
+have obeyed.
+
+That passthrough left a hole. DuckDB's ``COPY`` rounds a sub-vector request up
+to 2,048 anyway, so ``gpio convert --row-group-size 249`` wrote 2,048-row groups
+and said nothing: the user read 249 in the command and 2,048 in the footer.
+``note_duckdb_copy_rounding`` closes it, at the funnels that know the write
+reaches ``COPY``, with the same sentence the sort commands print.
+
+The per-strategy divergence the tests below pin is measured, not assumed: on a
+10,000-row input a request of 249 produces 2,048-row groups under ``duckdb-kv``
+and 249-row groups under ``in-memory``, ``streaming`` and ``disk-rewrite``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+import geoparquet_io as gpio
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core.parquet_writer import (
+    WRITER_VECTOR_ROWS,
+    note_duckdb_copy_rounding,
+    resolve_row_group_rows,
+)
+from tests.test_sort_row_group_default import _row_group_rows, _write_points
+
+ROWS = 10_000
+
+# The exact sentence, spelled out once so a change to the wording has to be
+# deliberate and so the two producers of it cannot drift apart.
+NOTE_249 = (
+    "Writing 2,048 rows per row group rather than the requested 249: the Parquet "
+    "writer emits row groups in whole 2,048-row vectors, so 249 is not a size a "
+    "row group can have."
+)
+
+
+@pytest.fixture(scope="module")
+def points_file(tmp_path_factory):
+    return _write_points(tmp_path_factory.mktemp("convert_rg") / "points.parquet", n=ROWS)
+
+
+@pytest.fixture
+def said(monkeypatch):
+    """Capture what the facade prints, without a CLI runner in the way."""
+    from geoparquet_io.core import parquet_writer
+
+    lines: list[str] = []
+    monkeypatch.setattr(parquet_writer, "info", lines.append)
+    return lines
+
+
+@pytest.mark.parametrize("requested", [1, 249, 1_000, 2_047])
+def test_a_sub_vector_request_is_named(said, requested):
+    note_duckdb_copy_rounding(requested)
+    assert said == [
+        f"Writing 2,048 rows per row group rather than the requested {requested:,}: "
+        "the Parquet writer emits row groups in whole 2,048-row vectors, so "
+        f"{requested:,} is not a size a row group can have."
+    ]
+
+
+@pytest.mark.parametrize("requested", [None, WRITER_VECTOR_ROWS, 4_096, 49_152])
+def test_a_whole_vector_or_no_request_says_nothing(said, requested):
+    note_duckdb_copy_rounding(requested)
+    assert said == []
+
+
+@pytest.mark.parametrize("requested", [3_000, 9_000, 50_000, 100_000])
+def test_resolve_speaks_once_and_the_funnel_stays_quiet(said, requested):
+    """Above one vector the facade already snapped and announced; no second note."""
+    resolved = resolve_row_group_rows(requested, None)
+    assert len(said) == 1
+    note_duckdb_copy_rounding(resolved)
+    assert len(said) == 1, "the funnel repeated a note resolve had already printed"
+
+
+def test_convert_names_the_size_duckdb_will_write(points_file, tmp_path):
+    output = tmp_path / "out.parquet"
+    result = CliRunner().invoke(
+        cli,
+        ["convert", "geoparquet", str(points_file), str(output), "--skip-hilbert"]
+        + ["--row-group-size", "249"],
+    )
+    assert result.exit_code == 0, result.output
+    assert NOTE_249 in result.output
+    assert _row_group_rows(output)[0] == WRITER_VECTOR_ROWS
+
+
+def test_convert_says_nothing_for_a_whole_vector(points_file, tmp_path):
+    output = tmp_path / "out.parquet"
+    result = CliRunner().invoke(
+        cli,
+        ["convert", "geoparquet", str(points_file), str(output), "--skip-hilbert"]
+        + ["--row-group-size", "4096"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "rather than the requested" not in result.output
+    assert _row_group_rows(output)[0] == 4_096
+
+
+def test_convert_says_nothing_when_no_size_is_requested(points_file, tmp_path):
+    output = tmp_path / "out.parquet"
+    result = CliRunner().invoke(
+        cli, ["convert", "geoparquet", str(points_file), str(output), "--skip-hilbert"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "rather than the requested" not in result.output
+
+
+def test_the_python_api_says_it_too(points_file, tmp_path, said):
+    """``Table.write`` defaults to duckdb-kv, so it rounds and must say so (#971)."""
+    output = tmp_path / "api.parquet"
+    gpio.read(str(points_file)).write(str(output), row_group_rows=249)
+    assert said == [NOTE_249]
+    assert _row_group_rows(output)[0] == WRITER_VECTOR_ROWS
+
+
+@pytest.mark.parametrize("strategy", ["in-memory", "streaming", "disk-rewrite"])
+def test_a_strategy_that_honours_the_request_is_not_told_otherwise(
+    points_file, tmp_path, said, strategy
+):
+    """Only duckdb-kv rounds; claiming 2,048 for the others would be a lie."""
+    output = tmp_path / f"{strategy}.parquet"
+    gpio.read(str(points_file)).write(str(output), row_group_rows=249, write_strategy=strategy)
+    assert said == []
+    assert _row_group_rows(output)[0] == 249


### PR DESCRIPTION
## PR Title
fix(convert): name the row-group size the writer will use when --row-group-size is rounded up

## Description
Rebased onto `main` after [#990](https://github.com/geoparquet/geoparquet-io/pull/990) landed the write facade. The defect is still live on `main` (`1473251`), just smaller than it was, and the fix is now re-derived against the facade instead of alongside it.

`resolve_row_group_rows` snaps any request **above** one 2,048-row vector and prints a line naming both numbers. It deliberately passes a request of **2,048 rows or fewer** straight through, because `pq.write_table` honours such a request exactly and snapping it would override the only writer that could obey.

That passthrough leaves a hole on the writers that *cannot* obey. Measured on `main`, 10,000-row input:

```
$ gpio convert geoparquet in.parquet out.parquet --row-group-size 249
row groups: [2048, 2048, 2048, 2048, 1808]      # note printed: none
```

The user asks for 249, gets 2,048, and is told nothing — the same shape as #961, in the window the facade left open.

## Technical Details
- `parquet_writer.py`: `note_duckdb_copy_rounding(row_group_rows)`. It reuses `align_to_writer_vector` for the arithmetic and a new `_rounding_note(requested, landed)` for the sentence `resolve_row_group_rows` already prints — **no second rounding rule, no second wording**. Since resolve has already announced anything above one vector, the funnel note fires only for a sub-vector request and can never repeat one (pinned by a test).
- Called from the three funnels that know the write reaches DuckDB's `COPY`: `write_parquet_with_metadata`'s plain-COPY fast path, its `duckdb-kv` strategy branch, and `Table._write`'s `duckdb-kv` branch — the last so the Python API and the CLI do not disagree about what a number means ([#971](https://github.com/geoparquet/geoparquet-io/issues/971)).
- `None` says nothing, so a `--row-group-size-mb` target never gets a row count the user did not type named back at them.

### What lands per write strategy — measured, `--row-group-size 249`, 10,000-row input

| path | landed | note |
|---|---|---|
| plain `COPY` fast path (2.0 / parquet-geo-only output) | 2,048 | ✅ now printed |
| `duckdb-kv` (the default, CLI and `Table.write`) | 2,048 | ✅ now printed |
| `disk-rewrite` | 249 | silent — correct |
| `in-memory` | 249 | silent — correct |
| `streaming` | 249 | silent — correct |

The original version of this PR also noted on `disk-rewrite`, on the reasoning that it writes through `COPY`. Measured, that is wrong: its `COPY` output is a temp file that its pyarrow pass then regroups at the requested size, so `disk-rewrite` really does write 249-row groups. Telling that user "2,048 will land" would have been a new false statement. Scoped to the two writers that round.

### #990's convert doc overclaimed
`docs/guide/convert.md` said `--row-group-size` "is snapped to the writer's 2,048-row vector the same way the sort commands snap it, so the number you ask for is the number that lands." Below one vector that last clause is false on the DuckDB path — and, because the passthrough is deliberate, *what lands genuinely depends on which writer runs*. The guide now states the exception, says why gpio cannot snap it away, and points at this issue.

## Breaking Changes
**Does this PR introduce breaking changes?** No. No written file changes; only the message is new.

## Related Issue(s)
- Closes #986
- Corrects a doc claim from #990

## Verification
After, same input and command:

```
$ gpio convert geoparquet in.parquet out.parquet --row-group-size 249
Writing 2,048 rows per row group rather than the requested 249: the Parquet writer emits row groups in whole 2,048-row vectors, so 249 is not a size a row group can have.
row groups: [2048, 2048, 2048, 2048, 1808]
```

Full sweep on this branch (`note` column = whether the line is printed):

| request | landed | note |
|---|---|---|
| 1 | 2,048 | yes |
| 249 | 2,048 | yes |
| 1,000 | 2,048 | yes |
| 2,048 | 2,048 | **no** |
| 3,000 | 4,096 | yes (from `resolve`, unchanged) |
| 4,096 | 4,096 | **no** |
| 50,000 | 49,152 | yes (from `resolve`, unchanged) |

```
uv run pytest -n auto -m "not slow and not network and not meta"   # 7592 passed, 76 skipped, 7 xfailed
uv run pytest -m meta                                              # 205 passed
uv run pre-commit run --all-files                                  # all passed
uv run pre-commit run --all-files --hook-stage pre-push            # all passed (incl. menard-check, xenon, import-linter, mypy)
uv run diff-cover coverage.xml --compare-branch=origin/main        # 100% (15/15 lines)
```

`tests/data/cli_surface.json` is unchanged.

## Checklist
- [x] Tests added/updated, run against real data where feasible
- [x] Integration tests for changes that cross module/format/service boundaries (the per-strategy tests write real files and read the footers back)
- [x] All tests pass (`uv run pytest`) for the touched suites; the full suite runs in CI
- [ ] At least one adversarial review (AI counts, rubber stamps don't)
- [ ] CodeRabbit comments fixed or answered
- [x] Documentation updated (README, guides, CLI reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `convert` guidance with the default row-group size of 49,152 rows.
  - Documented row-group rounding behavior, including DuckDB’s 2,048-row minimum and related notifications.
  - Clarified curved-geometry handling when skipping Hilbert ordering, including the option to preserve prior errors.

- **Bug Fixes**
  - Row-group requests of 2,048 rows or fewer are preserved where supported.
  - DuckDB-backed conversions and Python API writes now accurately report when requested sizes are rounded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->