### PR TITLE
fix(extract): match carto --exclude-cols case-insensitively, and reject a blank entry in a columns list

### DIFF
--- a/docs/api/python-api.md
+++ b/docs/api/python-api.md
@@ -1643,7 +1643,7 @@ The return value is a dict with `processed`, `skipped`, `errors`, `candidates`
 | `ops.sort_quadkey(table, column_name='quadkey', resolution=13, use_centroid=False, remove_column=False)` | Sort by quadkey |
 | `ops.reproject(table, target_crs='EPSG:4326', source_crs=None, geometry_column=None, assume_crs84=False)` | Reproject geometry (`assume_crs84` treats an unknown/null CRS as OGC:CRS84) |
 | `ops.extract(table, columns=None, exclude_columns=None, bbox=None, where=None, limit=None, geometry_column=None)` | Filter columns/rows |
-| `ops.read_bigquery(table_id, project=None, credentials_file=None, where=None, bbox=None, bbox_mode='auto', bbox_threshold=500000, limit=None, columns=None, exclude_columns=None)` | Read BigQuery table |
+| `ops.read_bigquery(table_id, project=None, credentials_file=None, where=None, bbox=None, bbox_mode='auto', bbox_threshold=500000, limit=None, columns=None, exclude_columns=None)` | Read BigQuery table (`None`/`[]` selects every column; a blank entry in the list raises) |
 | `ops.from_arcgis(service_url, token=None, where='1=1', bbox=None, include_cols=None, exclude_cols=None, limit=None)` | Fetch ArcGIS Feature Service |
 | `ops.convert_to_geojson(table, output, precision=7, write_bbox=False, id_field=None)` | Convert to GeoJSON |
 | `ops.convert_to_geopackage(table, output, layer_name='features', overwrite=False)` | Convert to GeoPackage |

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1953,10 +1953,11 @@ Names are matched case-insensitively and resolved to the source's own spelling,
 so `--exclude-cols OWNER` drops a column named `Owner` rather than silently
 dropping nothing.
 
-`--exclude-cols` names columns of the *fetched* table, so `geometry` is always
-an accepted name there even where the source calls it something else (Carto's
-`the_geom`, an ArcGIS layer's shape). Excluding it from GeoParquet output is
-still refused, with a warning — the column is required.
+On `carto` and `arcgis`, `--exclude-cols` names columns of the *fetched* table
+rather than of the service, so `geometry` is an accepted name there even though
+the source calls it something else (Carto's `the_geom`, an ArcGIS layer's
+shape). On `carto` it is then refused with a warning, since GeoParquet output
+requires the column — including when you spell it `GEOMETRY`.
 
 On `carto`, passing `--geometry` or `--no-geometry` skips the shape probe that
 normally supplies that schema; if you also pass a column option, one bounded

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1945,20 +1945,23 @@ gpio extract data.parquet output.parquet --include-cols invalid_column
 # Available columns: id, name, geometry, bbox, ...
 ```
 
-The same check runs on `gpio extract bigquery`, `carto` and `arcgis`, against
-the schema each already reads to plan the extraction — so an unknown name fails
-locally instead of becoming a backend error or, for ArcGIS, an `outFields`
-entry the server quietly ignores. Names are matched case-insensitively and
-resolved to the source's own spelling.
+The same check runs on `gpio extract bigquery`, `carto` and `arcgis`, for both
+`--include-cols` and `--exclude-cols`, against the schema each already reads to
+plan the extraction — so an unknown name fails locally instead of becoming a
+backend error or, for ArcGIS, an `outFields` entry the server quietly ignores.
+Names are matched case-insensitively and resolved to the source's own spelling,
+so `--exclude-cols OWNER` drops a column named `Owner` rather than silently
+dropping nothing.
 
-Two limits on that, both because the check can only use a schema the command
-already had in hand:
+`--exclude-cols` names columns of the *fetched* table, so `geometry` is always
+an accepted name there even where the source calls it something else (Carto's
+`the_geom`, an ArcGIS layer's shape). Excluding it from GeoParquet output is
+still refused, with a warning — the column is required.
 
-- On `carto` it applies to `--include-cols` only. `--exclude-cols` names
-  columns of the *fetched* table and is still matched exactly, so
-  `--exclude-cols OWNER` does not drop a column named `Owner`.
-- On `carto`, passing `--geometry` or `--no-geometry` skips the schema probe
-  that the check reads, so neither list is checked against the table.
+On `carto`, passing `--geometry` or `--no-geometry` skips the shape probe that
+normally supplies that schema; if you also pass a column option, one bounded
+`SELECT * … LIMIT 0` is issued so the check still runs. If it cannot be reached,
+extraction proceeds unchecked rather than failing.
 
 A **blank entry** in the list — `--include-cols id,,name`, or `--include-cols '   '` —
 is a usage error and is rejected before anything is opened or contacted. That
@@ -1967,6 +1970,12 @@ holds for the Python API too (`ops.from_carto`, `ops.from_arcgis`,
 through the CLI's option parsing. A **wholly empty** value is not a blank entry:
 `--include-cols ""` means "option not given", so `--include-cols "$COLS"` keeps
 working when `COLS` is unset.
+
+That last rule is about the *string* option. The Python API's list arguments —
+`ops.read_bigquery(columns=[...])` and `gpio.Table.from_bigquery(columns=[...])`
+— have their own "unset", which is `None` or `[]`. A list holding a blank entry,
+including `[""]` on its own, is a mistake and raises rather than quietly
+selecting every column.
 
 ### Invalid WHERE Clause
 

--- a/docs/guide/extract.md
+++ b/docs/guide/extract.md
@@ -1946,23 +1946,28 @@ gpio extract data.parquet output.parquet --include-cols invalid_column
 ```
 
 The same check runs on `gpio extract bigquery`, `carto` and `arcgis`, for both
-`--include-cols` and `--exclude-cols`, against the schema each already reads to
-plan the extraction — so an unknown name fails locally instead of becoming a
-backend error or, for ArcGIS, an `outFields` entry the server quietly ignores.
-Names are matched case-insensitively and resolved to the source's own spelling,
-so `--exclude-cols OWNER` drops a column named `Owner` rather than silently
+`--include-cols` and `--exclude-cols`, against a column list each command
+already has — so an unknown name fails locally instead of becoming a backend
+error or, for ArcGIS, an `outFields` entry the server quietly ignores. Names are
+matched case-insensitively and resolved to that list's own spelling, so
+`--exclude-cols OWNER` drops a column named `Owner` rather than silently
 dropping nothing.
 
-On `carto` and `arcgis`, `--exclude-cols` names columns of the *fetched* table
-rather than of the service, so `geometry` is an accepted name there even though
-the source calls it something else (Carto's `the_geom`, an ArcGIS layer's
-shape). On `carto` it is then refused with a warning, since GeoParquet output
-requires the column — including when you spell it `GEOMETRY`.
+`--exclude-cols` names columns of the table you get back, not of the source. On
+`carto` it is therefore checked against that table once it is fetched, so the
+name to use is `geometry` — the post-fetch name of the geometry column — and not
+the source's `the_geom`. Excluding `geometry` from a spatial extraction is
+refused with a warning, since GeoParquet output requires the column; on a
+geometry-less (tabular) table there is no such column, so naming it is an
+unknown-column error like any other.
 
-On `carto`, passing `--geometry` or `--no-geometry` skips the shape probe that
-normally supplies that schema; if you also pass a column option, one bounded
-`SELECT * … LIMIT 0` is issued so the check still runs. If it cannot be reached,
-extraction proceeds unchecked rather than failing.
+Because that check reads the fetched table, it needs no extra request and holds
+whatever else you pass — including `--geometry`/`--no-geometry`, which skip the
+shape probe. It does report after the fetch rather than before it. `--include-cols`
+is checked *before* the fetch instead, since it becomes the SELECT list: under
+`--geometry`/`--no-geometry` it issues one bounded `SELECT * … LIMIT 0` of its
+own to do so, and if that cannot be reached, extraction proceeds unchecked
+rather than failing.
 
 A **blank entry** in the list — `--include-cols id,,name`, or `--include-cols '   '` —
 is a usage error and is rejected before anything is opened or contacted. That

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1782,8 +1782,8 @@ def read_bigquery(
         bbox_mode: Filtering mode - "auto" (default), "server", or "local"
         bbox_threshold: Row count threshold for auto mode (default: 500000)
         limit: Maximum rows to extract
-        columns: Columns to include (None = all)
-        exclude_columns: Columns to exclude
+        columns: Columns to include (None or [] = all; a blank entry raises)
+        exclude_columns: Columns to exclude (a blank entry raises)
         geography_column: Column containing geometry data. Auto-detected
             for native GEOGRAPHY columns. Specify to parse VARCHAR columns.
         geometry_format: Format of VARCHAR geometry ("wkt" or "geojson")
@@ -1814,7 +1814,15 @@ def read_bigquery(
         ...     geometry_format='wkt'
         ... )
     """
+    from geoparquet_io.core.column_selection import reject_blank_column_entries
     from geoparquet_io.core.extract_bigquery import extract_bigquery
+
+    # A blank entry is a mistake in a *list* argument, and must be caught before
+    # the join: [""] joins to "", which the core reads as "option not given" and
+    # so widens the request to every column -- the widest possible answer to a
+    # caller's typo (#992). A wholly absent list (None or []) is the unset one.
+    reject_blank_column_entries(columns, "columns")
+    reject_blank_column_entries(exclude_columns, "exclude_columns")
 
     # Convert columns list to comma-separated string for the core function
     include_cols = ",".join(columns) if columns else None

--- a/geoparquet_io/api/ops.py
+++ b/geoparquet_io/api/ops.py
@@ -1814,19 +1814,16 @@ def read_bigquery(
         ...     geometry_format='wkt'
         ... )
     """
-    from geoparquet_io.core.column_selection import reject_blank_column_entries
+    from geoparquet_io.core.column_selection import join_column_list
     from geoparquet_io.core.extract_bigquery import extract_bigquery
 
-    # A blank entry is a mistake in a *list* argument, and must be caught before
-    # the join: [""] joins to "", which the core reads as "option not given" and
-    # so widens the request to every column -- the widest possible answer to a
-    # caller's typo (#992). A wholly absent list (None or []) is the unset one.
-    reject_blank_column_entries(columns, "columns")
-    reject_blank_column_entries(exclude_columns, "exclude_columns")
-
-    # Convert columns list to comma-separated string for the core function
-    include_cols = ",".join(columns) if columns else None
-    exclude_cols = ",".join(exclude_columns) if exclude_columns else None
+    # Convert the list arguments to the comma-separated options the core takes.
+    # join_column_list checks and joins in one call because the gap between the
+    # two steps *is* #992: [""] joins to "", which the core reads as "option not
+    # given" and so widens the request to every column. None or [] is the unset
+    # a list argument has.
+    include_cols = join_column_list(columns, "columns")
+    exclude_cols = join_column_list(exclude_columns, "exclude_columns")
 
     # Validate bbox_mode
     valid_bbox_modes = {"auto", "server", "local"}

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -642,8 +642,8 @@ class Table:
             bbox_mode: Filtering mode - "auto" (default), "server", or "local"
             bbox_threshold: Row count threshold for auto mode (default: 500000)
             limit: Maximum rows to extract
-            columns: Columns to include (None = all)
-            exclude_columns: Columns to exclude
+            columns: Columns to include (None or [] = all; a blank entry raises)
+            exclude_columns: Columns to exclude (a blank entry raises)
             geography_column: Column containing geometry data. Auto-detected
                 for native GEOGRAPHY columns. Specify to parse VARCHAR columns.
             geometry_format: Format of VARCHAR geometry ("wkt" or "geojson")
@@ -681,7 +681,14 @@ class Table:
             ...     geometry_format='wkt'
             ... )
         """
+        from geoparquet_io.core.column_selection import reject_blank_column_entries
         from geoparquet_io.core.extract_bigquery import extract_bigquery
+
+        # See ops.read_bigquery: [""] joins to "", which the core reads as
+        # "option not given", silently widening the request to every column
+        # (#992). Checked before the join, where the list shape still exists.
+        reject_blank_column_entries(columns, "columns")
+        reject_blank_column_entries(exclude_columns, "exclude_columns")
 
         # Convert columns list to comma-separated string for the core function
         include_cols = ",".join(columns) if columns else None

--- a/geoparquet_io/api/table.py
+++ b/geoparquet_io/api/table.py
@@ -681,18 +681,14 @@ class Table:
             ...     geometry_format='wkt'
             ... )
         """
-        from geoparquet_io.core.column_selection import reject_blank_column_entries
+        from geoparquet_io.core.column_selection import join_column_list
         from geoparquet_io.core.extract_bigquery import extract_bigquery
 
-        # See ops.read_bigquery: [""] joins to "", which the core reads as
-        # "option not given", silently widening the request to every column
-        # (#992). Checked before the join, where the list shape still exists.
-        reject_blank_column_entries(columns, "columns")
-        reject_blank_column_entries(exclude_columns, "exclude_columns")
-
-        # Convert columns list to comma-separated string for the core function
-        include_cols = ",".join(columns) if columns else None
-        exclude_cols = ",".join(exclude_columns) if exclude_columns else None
+        # Convert the list arguments to the comma-separated options the core
+        # takes. See ops.read_bigquery: the check belongs inside the join, not
+        # beside it, because [""] joining to "" is exactly #992.
+        include_cols = join_column_list(columns, "columns")
+        exclude_cols = join_column_list(exclude_columns, "exclude_columns")
 
         # Get PyArrow table (don't write to file)
         arrow_table = extract_bigquery(

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -446,6 +446,62 @@ def _detect_table_shape(
     return False, columns
 
 
+def _probe_schema_columns(
+    url: str,
+    table_name: str,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> list[str] | None:
+    """Read a table's column names for the column check, tolerating a failure.
+
+    :func:`_detect_table_shape` gets these for free from the probe it already
+    runs. ``--geometry``/``--no-geometry`` skips that probe, so this pays for the
+    one bounded ``SELECT * ... LIMIT 0`` itself -- and only when a column option
+    was actually given, so the flags stay a single-request path otherwise (#991).
+
+    Returns:
+        The column names, or None when there is no schema to check against --
+        never an extraction failure, matching how every other call site treats
+        a probe that could not answer.
+    """
+    try:
+        return _column_names_from_fields(_probe_table_schema(url, table_name, api_key, timeout))
+    except CartoError as e:
+        debug(f"Schema probe for the column check failed ({e}); skipping it")
+        return None
+
+
+def _resolve_carto_columns(
+    include_list: list[str] | None,
+    exclude_list: list[str] | None,
+    schema_columns: list[str] | None,
+) -> tuple[list[str] | None, list[str] | None]:
+    """Check both column lists against the table's schema, in its own spelling.
+
+    ``include_list`` becomes the SELECT list and so names *source* columns.
+    ``exclude_list`` is applied to the fetched table, whose columns are the
+    source ones with the geometry column renamed to ``geometry`` (geometry path)
+    or exactly the source ones (tabular path, which fetches CSV and renames
+    nothing) -- hence the extra allowed name, exactly as
+    :func:`geoparquet_io.core.arcgis._resolve_field_selection` does it.
+
+    That allowed set is a deliberate superset: ``geometry`` is tolerated on the
+    tabular path, and the source geometry column on the geometry path, because
+    both are the user naming the geometry, which is refused with a warning
+    rather than treated as a typo.
+
+    Returns:
+        Both lists in the schema's spelling, unchanged when there is no schema.
+    """
+    if schema_columns is None:
+        return include_list, exclude_list
+    include_list = resolve_columns_against_schema(include_list, schema_columns, "--include-cols")
+    exclude_list = resolve_columns_against_schema(
+        exclude_list, ["geometry", *schema_columns], "--exclude-cols"
+    )
+    return include_list, exclude_list
+
+
 def _create_empty_geoparquet_table(geoparquet_version: str | None = None) -> pa.Table:
     """Create an empty table with proper GeoParquet metadata.
 
@@ -658,31 +714,25 @@ def carto_to_table(
     # callback: the Python API never goes through Click, and `` `` reached
     # quote_identifier() through _build_carto_query as a raw ValueError (#980).
     include_list = split_column_list(include_cols, "--include-cols")
-    exclude_set = set(split_column_list(exclude_cols, "--exclude-cols") or ())
+    exclude_list = split_column_list(exclude_cols, "--exclude-cols")
 
-    # Decide between geometry and plain/tabular extraction.
+    # Decide between geometry and plain/tabular extraction. The shape probe
+    # carries the schema, so on the default path the column check is free.
     schema_columns: list[str] | None = None
     if geometry is None:
         has_geometry, schema_columns = _detect_table_shape(
             url, table_name, effective_api_key, timeout
         )
     else:
+        # Forcing the mode skips that probe. A column option then buys its own
+        # schema rather than losing the check to an unrelated flag (#991); with
+        # no column option there is nothing to check and no request is made.
         has_geometry = geometry
+        if include_list or exclude_list:
+            schema_columns = _probe_schema_columns(url, table_name, effective_api_key, timeout)
 
-    # --include-cols becomes the SELECT list, so it is checked against the
-    # schema the probe above already read -- for free, and only when it ran.
-    #
-    # --exclude-cols is not checked, and that is a gap rather than a decision:
-    # it names columns of the *fetched* table, where ``the_geom`` has become
-    # ``geometry``, so the set to check against is ``["geometry",
-    # *schema_columns]`` -- which is exactly what arcgis.py does. (``geometry``
-    # itself is not the obstacle: it is warned about and dropped below, before
-    # any filtering.) Until that lands, ``--exclude-cols OWNER`` silently fails
-    # to drop a column named ``Owner``. Tracked separately.
-    if schema_columns is not None:
-        include_list = resolve_columns_against_schema(
-            include_list, schema_columns, "--include-cols"
-        )
+    include_list, exclude_list = _resolve_carto_columns(include_list, exclude_list, schema_columns)
+    exclude_set = set(exclude_list or ())
 
     if not has_geometry:
         if bbox:

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -452,12 +452,15 @@ def _probe_schema_columns(
     api_key: str | None = None,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> list[str] | None:
-    """Read a table's column names for the column check, tolerating a failure.
+    """Read a table's column names for the ``--include-cols`` check, tolerating a failure.
 
     :func:`_detect_table_shape` gets these for free from the probe it already
     runs. ``--geometry``/``--no-geometry`` skips that probe, so this pays for the
-    one bounded ``SELECT * ... LIMIT 0`` itself -- and only when a column option
-    was actually given, so the flags stay a single-request path otherwise (#991).
+    one bounded ``SELECT * ... LIMIT 0`` itself -- and only for ``--include-cols``,
+    where the round-trip earns itself: that list becomes the SELECT list, so an
+    unresolved name comes back as an opaque ``ST_Read`` failure on an HTTP error
+    body *and* burns the retry budget first. ``--exclude-cols`` needs no probe at
+    all; :func:`_apply_column_exclusions` checks it against the fetched table.
 
     Returns:
         The column names, or None when there is no schema to check against --
@@ -471,35 +474,48 @@ def _probe_schema_columns(
         return None
 
 
-def _resolve_carto_columns(
-    include_list: list[str] | None,
+def _apply_column_exclusions(
+    table: pa.Table,
     exclude_list: list[str] | None,
-    schema_columns: list[str] | None,
-) -> tuple[list[str] | None, list[str] | None]:
-    """Check both column lists against the table's schema, in its own spelling.
+    *,
+    protect_geometry: bool,
+) -> pa.Table:
+    """Drop the ``--exclude-cols`` columns from the table that was actually fetched.
 
-    ``include_list`` becomes the SELECT list and so names *source* columns.
-    ``exclude_list`` is applied to the fetched table, whose columns are the
-    source ones with the geometry column renamed to ``geometry`` (geometry path)
-    or exactly the source ones (tabular path, which fetches CSV and renames
-    nothing) -- hence the extra allowed name, exactly as
-    :func:`geoparquet_io.core.arcgis._resolve_field_selection` does it.
+    The names are resolved against ``table.column_names`` -- the exact post-fetch
+    set, after Carto's ``the_geom`` has become ``geometry`` -- so a case mismatch
+    or a typo is an error rather than a filter that silently matches nothing
+    (#991). Resolving here rather than against the source schema also costs
+    nothing and needs nothing: no probe is involved, so the check holds under
+    ``--geometry``/``--no-geometry`` too.
 
-    That allowed set is a deliberate superset: ``geometry`` is tolerated on the
-    tabular path, and the source geometry column on the geometry path, because
-    both are the user naming the geometry, which is refused with a warning
-    rather than treated as a typo.
+    Args:
+        table: The fetched table, after any rename
+        exclude_list: Column names to drop, or None
+        protect_geometry: Refuse to drop ``geometry``, which GeoParquet output
+            requires. Only the geometry path has such a column; on the tabular
+            path ``geometry`` is not a column at all, so naming it is an error
+            like any other name the table does not carry.
 
     Returns:
-        Both lists in the schema's spelling, unchanged when there is no schema.
+        The table without the excluded columns.
+
+    Raises:
+        InvalidParameterError: If a name is absent from the fetched table.
     """
-    if schema_columns is None:
-        return include_list, exclude_list
-    include_list = resolve_columns_against_schema(include_list, schema_columns, "--include-cols")
     exclude_list = resolve_columns_against_schema(
-        exclude_list, ["geometry", *schema_columns], "--exclude-cols"
+        exclude_list, table.column_names, "--exclude-cols"
     )
-    return include_list, exclude_list
+    if exclude_list and protect_geometry and "geometry" in exclude_list:
+        exclude_list = [col for col in exclude_list if col != "geometry"]
+        warn("Cannot exclude 'geometry' column - it is required for GeoParquet output")
+    if not exclude_list:
+        return table
+
+    exclude_set = set(exclude_list)
+    table = table.select([col for col in table.column_names if col not in exclude_set])
+    debug(f"Excluded columns: {exclude_set}")
+    return table
 
 
 def _create_empty_geoparquet_table(geoparquet_version: str | None = None) -> pa.Table:
@@ -717,22 +733,26 @@ def carto_to_table(
     exclude_list = split_column_list(exclude_cols, "--exclude-cols")
 
     # Decide between geometry and plain/tabular extraction. The shape probe
-    # carries the schema, so on the default path the column check is free.
+    # carries the schema, so on the default path the --include-cols check is free.
     schema_columns: list[str] | None = None
     if geometry is None:
         has_geometry, schema_columns = _detect_table_shape(
             url, table_name, effective_api_key, timeout
         )
     else:
-        # Forcing the mode skips that probe. A column option then buys its own
-        # schema rather than losing the check to an unrelated flag (#991); with
-        # no column option there is nothing to check and no request is made.
+        # Forcing the mode skips that probe. --include-cols buys its own rather
+        # than losing the check to an unrelated flag (#991); --exclude-cols needs
+        # no schema here, since it is checked against the fetched table below.
         has_geometry = geometry
-        if include_list or exclude_list:
+        if include_list:
             schema_columns = _probe_schema_columns(url, table_name, effective_api_key, timeout)
 
-    include_list, exclude_list = _resolve_carto_columns(include_list, exclude_list, schema_columns)
-    exclude_set = set(exclude_list or ())
+    # --include-cols becomes the SELECT list, so it names *source* columns and is
+    # the only list a schema can answer for ahead of the fetch.
+    if schema_columns is not None:
+        include_list = resolve_columns_against_schema(
+            include_list, schema_columns, "--include-cols"
+        )
 
     if not has_geometry:
         if bbox:
@@ -743,7 +763,7 @@ def carto_to_table(
             where=where,
             limit=limit,
             include_list=include_list,
-            exclude_set=exclude_set,
+            exclude_list=exclude_list,
             api_key=effective_api_key,
             timeout=timeout,
             max_retries=max_retries,
@@ -756,7 +776,7 @@ def carto_to_table(
         bbox=bbox,
         limit=limit,
         include_list=include_list,
-        exclude_set=exclude_set,
+        exclude_list=exclude_list,
         api_key=effective_api_key,
         timeout=timeout,
         max_retries=max_retries,
@@ -773,7 +793,7 @@ def _carto_geo_table(
     bbox: tuple[float, float, float, float] | None,
     limit: int | None,
     include_list: list[str] | None,
-    exclude_set: set[str],
+    exclude_list: list[str] | None,
     api_key: str | None,
     timeout: float,
     max_retries: int,
@@ -835,16 +855,9 @@ def _carto_geo_table(
         cols_to_keep = [c for c in table.column_names if c != "OGC_FID"]
         table = table.select(cols_to_keep)
 
-    # Apply column exclusions (but never exclude geometry)
-    if exclude_set:
-        # Prevent excluding the geometry column - it's required for GeoParquet
-        if "geometry" in exclude_set:
-            exclude_set = exclude_set - {"geometry"}
-            warn("Cannot exclude 'geometry' column - it is required for GeoParquet output")
-        if exclude_set:
-            cols_to_keep = [c for c in table.column_names if c not in exclude_set]
-            table = table.select(cols_to_keep)
-            debug(f"Excluded columns: {exclude_set}")
+    # Apply column exclusions, resolved against the table just fetched -- the
+    # rename above is why that is the only set that answers exactly (#991).
+    table = _apply_column_exclusions(table, exclude_list, protect_geometry=True)
 
     # Add CRS metadata (Carto uses WGS84)
     version = geoparquet_version or "1.1.0"
@@ -881,7 +894,7 @@ def _carto_plain_table(
     where: str | None,
     limit: int | None,
     include_list: list[str] | None,
-    exclude_set: set[str],
+    exclude_list: list[str] | None,
     api_key: str | None,
     timeout: float,
     max_retries: int,
@@ -926,11 +939,10 @@ def _carto_plain_table(
 
     debug(f"Received {table.num_rows:,} rows")
 
-    # Apply column exclusions (no geometry to protect here)
-    if exclude_set:
-        cols_to_keep = [c for c in table.column_names if c not in exclude_set]
-        table = table.select(cols_to_keep)
-        debug(f"Excluded columns: {exclude_set}")
+    # Apply column exclusions. Nothing was renamed on this path, so the fetched
+    # columns are the source ones -- and 'geometry' is not among them, so naming
+    # it is an error here rather than something to protect.
+    table = _apply_column_exclusions(table, exclude_list, protect_geometry=False)
 
     success(f"Extracted {table.num_rows:,} rows (plain table, no geometry)")
     return table

--- a/geoparquet_io/core/column_selection.py
+++ b/geoparquet_io/core/column_selection.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from geoparquet_io.core.exceptions import InvalidParameterError
 
 __all__ = [
+    "join_column_list",
     "reject_blank_column_entries",
     "resolve_columns_against_schema",
     "split_column_list",
@@ -83,6 +84,41 @@ def split_column_list(value: str | None, option_name: str) -> list[str] | None:
     return entries
 
 
+def join_column_list(columns: list[str] | None, argument_name: str) -> str | None:
+    """Join a list argument into the comma-separated option the core backends take.
+
+    The inverse of :func:`split_column_list`, and it exists because of the seam
+    *between* the two. The Python API's BigQuery entry points take ``columns`` as
+    a **list** and join it for a core function that takes a string, and ``[""]``
+    joins to ``""`` -- which the splitting side correctly reads as "option not
+    given", silently widening the request to every column (#992). Validating and
+    joining in one call closes that seam so the next list argument cannot reopen
+    it by spelling the two steps out again.
+
+    The two shapes have different "unset" values, and that is the whole point:
+
+    - a **string** option is unset when it is wholly empty, so
+      ``--include-cols "$COLS"`` keeps working when ``COLS`` is (#973);
+    - a **list** argument is unset when it is None or ``[]``. A list holding a
+      blank entry is a caller's mistake, never an absent argument.
+
+    Args:
+        columns: The column names, or None
+        argument_name: The *argument* to name in the error message, e.g.
+            "columns" -- these callers have no CLI option to point at
+
+    Returns:
+        The comma-separated value, or None when the argument was not given
+
+    Raises:
+        InvalidParameterError: If any entry is empty or whitespace-only
+    """
+    reject_blank_column_entries(columns, argument_name)
+    if not columns:
+        return None
+    return ",".join(columns)
+
+
 def resolve_columns_against_schema(
     requested_cols: list[str] | None,
     all_columns: list[str],
@@ -106,8 +142,13 @@ def resolve_columns_against_schema(
     ``--exclude-cols ID`` against a column ``id`` silently excluded nothing.
 
     An **exact** match is preferred to a folded one, because folding is not
-    injective: DuckDB permits a local table carrying both ``id`` and ``ID``, and
-    a ``{col.lower(): col}`` map keeps only the last of those.
+    injective: DuckDB permits a local table carrying both ``id`` and ``ID``.
+
+    Where folding is genuinely ambiguous -- a third spelling like ``Id`` against
+    a schema holding both ``id`` and ``ID`` -- this **raises** rather than
+    picking one. A ``{col.lower(): col}`` map silently kept the last, which is
+    an arbitrary choice; on ``--exclude-cols`` that arbitrary choice deletes a
+    column, so the caller is asked to disambiguate instead.
 
     Args:
         requested_cols: Column names the caller asked for (or None)
@@ -126,15 +167,27 @@ def resolve_columns_against_schema(
     reject_blank_column_entries(requested_cols, option_name)
 
     exact = set(all_columns)
-    folded = {col.lower(): col for col in all_columns}
+    folded: dict[str, list[str]] = {}
+    for col in all_columns:
+        folded.setdefault(col.lower(), []).append(col)
 
-    def _resolve(col: str) -> str | None:
-        if col in exact:
-            return col
-        return folded.get(col.lower())
+    def _candidates(col: str) -> list[str]:
+        """Every schema spelling this name could mean: the exact one, else the folds."""
+        return [col] if col in exact else folded.get(col.lower(), [])
 
-    resolved = [(col, _resolve(col)) for col in requested_cols]
-    missing = [col for col, match in resolved if match is None]
+    matches = [(col, _candidates(col)) for col in requested_cols]
+
+    ambiguous = {col: cands for col, cands in matches if len(cands) > 1}
+    if ambiguous:
+        detail = "; ".join(
+            f"{col} matches {', '.join(sorted(cands))}" for col, cands in sorted(ambiguous.items())
+        )
+        raise InvalidParameterError(
+            option_name,
+            f"Ambiguous column names: {detail}. Use the exact spelling.",
+        )
+
+    missing = [col for col, cands in matches if not cands]
     if missing:
         raise InvalidParameterError(
             option_name,
@@ -142,4 +195,4 @@ def resolve_columns_against_schema(
             f"Available columns: {', '.join(all_columns)}",
         )
 
-    return [match for _, match in resolved if match is not None]
+    return [cands[0] for _, cands in matches]

--- a/tests/test_core_column_list_guard.py
+++ b/tests/test_core_column_list_guard.py
@@ -26,8 +26,11 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
+import geoparquet_io as gpio
 from geoparquet_io.api import ops
 from geoparquet_io.core import arcgis, carto, pmtiles
+from geoparquet_io.core import extract_bigquery as extract_bigquery_module
+from geoparquet_io.core.carto import CartoError
 from geoparquet_io.core.column_selection import reject_blank_column_entries, split_column_list
 from geoparquet_io.core.exceptions import InvalidParameterError
 
@@ -40,22 +43,51 @@ CARTO_FIELDS = {
     "the_geom": {"type": "geometry"},
 }
 
+# The same table with no geometry-typed column, i.e. the tabular path. Its
+# fetched CSV columns *are* the schema columns -- there is no rename at all.
+CARTO_TABULAR_FIELDS = {
+    "cartodb_id": {"type": "number"},
+    "Owner": {"type": "string"},
+}
 
-def _carto_payload(sql: str) -> dict:
+
+def _carto_payload(sql: str, fields: dict | None = None) -> dict:
     """Stand in for :func:`carto._carto_sql_json` for the two probe queries."""
     if "IS NOT NULL" in sql:
         return {"rows": [{"has_geom": 1}]}
-    return {"fields": CARTO_FIELDS, "rows": []}
+    return {"fields": CARTO_FIELDS if fields is None else fields, "rows": []}
 
 
-def _patch_carto_probes(**kwargs):
+def _patch_carto_probes(fields: dict | None = None, **kwargs):
     """Answer Carto's schema/geometry probes; fail loudly on a data fetch."""
     return mock.patch.object(
         carto,
         "_carto_sql_json",
-        side_effect=lambda url, sql, *a, **kw: _carto_payload(sql),
+        side_effect=lambda url, sql, *a, **kw: _carto_payload(sql, fields),
         **kwargs,
     )
+
+
+def _run_carto(fetched: pa.Table, fields: dict | None = None, **kwargs) -> pa.Table:
+    """Run ``ops.from_carto`` end to end with every request mocked out.
+
+    ``--exclude-cols`` is applied to the *fetched* table, so only a full run
+    shows whether a name actually dropped a column or silently did nothing.
+    """
+    with (
+        _patch_carto_probes(fields),
+        mock.patch.object(carto, "_fetch_with_retry", return_value=fetched),
+        mock.patch.object(carto, "_get_row_count", return_value=fetched.num_rows),
+        mock.patch.object(
+            carto, "repair_arrow_table_geometry", side_effect=lambda t, col, repair: (t, 0)
+        ),
+    ):
+        return ops.from_carto(CARTO_URL, "tbl", **kwargs)
+
+
+def _geo_fetch() -> pa.Table:
+    """What ST_Read hands back for :data:`CARTO_FIELDS`: ``the_geom`` is ``geom``."""
+    return pa.table({"cartodb_id": [1], "Owner": ["acme"], "geom": [b"\x00"]})
 
 
 def _layer_info() -> arcgis.ArcGISLayerInfo:
@@ -177,9 +209,96 @@ class TestCartoSchemaCheck:
             with pytest.raises(SystemExit):
                 ops.from_carto(CARTO_URL, "tbl", exclude_cols="geometry")
 
-    def test_no_schema_check_when_the_probe_is_skipped(self):
-        """``geometry=True`` runs no probe, so there is no schema to check against."""
+
+class TestCartoExcludeSchemaCheck:
+    """``--exclude-cols`` is checked and resolved too (#991).
+
+    #989 left it matched exactly, on the grounds that the post-fetch rename made
+    the fetched column set unknowable. It is knowable: ``geometry`` plus the
+    schema the probe already read, which is exactly what ``arcgis.py`` checks
+    ``--exclude-cols`` against.
+    """
+
+    def test_a_typo_is_an_error_not_a_silent_no_op(self):
+        with _patch_carto_probes():
+            with pytest.raises(InvalidParameterError) as exc:
+                ops.from_carto(CARTO_URL, "tbl", exclude_cols="Ownre")
+        assert "--exclude-cols" in str(exc.value)
+        assert "Ownre" in str(exc.value)
+        assert "cartodb_id" in str(exc.value)
+
+    @pytest.mark.parametrize("exclude_cols", ["Owner", "owner", "OWNER"])
+    def test_a_case_mismatch_drops_the_column_it_names(self, exclude_cols):
+        """Postgres is case-sensitive through a quoted identifier; the user is not."""
+        table = _run_carto(_geo_fetch(), exclude_cols=exclude_cols)
+        assert table.column_names == ["cartodb_id", "geometry"]
+
+    def test_the_tabular_path_is_checked_too(self):
+        """``_carto_plain_table`` has no rename at all, so the excuse never applied."""
+        with _patch_carto_probes(CARTO_TABULAR_FIELDS):
+            with pytest.raises(InvalidParameterError) as exc:
+                ops.from_carto(CARTO_URL, "tbl", exclude_cols="Ownre")
+        assert "Ownre" in str(exc.value)
+
+    def test_the_tabular_path_resolves_the_spelling_too(self):
+        table = _run_carto(
+            pa.table({"cartodb_id": [1], "Owner": ["acme"]}),
+            CARTO_TABULAR_FIELDS,
+            exclude_cols="owner",
+        )
+        assert table.column_names == ["cartodb_id"]
+
+    def test_excluding_geometry_in_any_spelling_is_refused_not_obeyed(self):
+        """``geometry`` is required for GeoParquet output, so it is warned about.
+
+        On main ``GEOMETRY`` missed that guard by exact match and then silently
+        dropped nothing; now it resolves to ``geometry`` and is refused out loud.
+        """
+        with mock.patch.object(carto, "warn") as warn:
+            table = _run_carto(_geo_fetch(), exclude_cols="GEOMETRY")
+        assert table.column_names == ["cartodb_id", "Owner", "geometry"]
+        assert any("Cannot exclude" in str(call.args[0]) for call in warn.call_args_list)
+
+
+class TestCartoForcedModeStillChecks:
+    """``--geometry``/``--no-geometry`` no longer skips the check (#991).
+
+    #989 pinned the skip as deliberate: the shape probe is what supplies the
+    schema, and forcing the mode skips it. But the guarantee "a typo is an
+    error" should not hinge on an unrelated flag, so the column options now pay
+    for their own ``SELECT * ... LIMIT 0`` -- and only when one is given.
+    """
+
+    @pytest.mark.parametrize("geometry", [True, False])
+    def test_an_unknown_include_column_is_still_rejected(self, geometry):
+        with _patch_carto_probes():
+            with pytest.raises(InvalidParameterError) as exc:
+                ops.from_carto(CARTO_URL, "tbl", include_cols="nope", geometry=geometry)
+        assert "nope" in str(exc.value)
+
+    def test_an_unknown_exclude_column_is_still_rejected(self):
+        with _patch_carto_probes():
+            with pytest.raises(InvalidParameterError) as exc:
+                ops.from_carto(CARTO_URL, "tbl", exclude_cols="Ownre", geometry=True)
+        assert "Ownre" in str(exc.value)
+
+    def test_no_column_option_means_no_probe(self):
+        """The flags' whole point is to skip the probe, so nothing else pays for it."""
         with (
+            mock.patch.object(carto, "_carto_sql_json", side_effect=AssertionError("probed Carto")),
+            mock.patch.object(
+                carto, "_build_carto_query", side_effect=SystemExit("query built")
+            ) as build,
+            mock.patch.object(carto, "_get_row_count", return_value=1),
+        ):
+            with pytest.raises(SystemExit):
+                ops.from_carto(CARTO_URL, "tbl", geometry=True)
+        assert build.call_args.kwargs["columns"] is None
+
+    def test_a_failed_probe_does_not_fail_the_extraction(self):
+        """No schema in hand is "nothing to check against", as everywhere else."""
+        with (
+            mock.patch.object(carto, "_carto_sql_json", side_effect=CartoError("boom")),
             mock.patch.object(
                 carto, "_build_carto_query", side_effect=SystemExit("query built")
             ) as build,
@@ -188,6 +307,14 @@ class TestCartoSchemaCheck:
             with pytest.raises(SystemExit):
                 ops.from_carto(CARTO_URL, "tbl", include_cols="whatever", geometry=True)
         assert build.call_args.kwargs["columns"] == ["whatever"]
+
+    def test_a_blank_entry_is_still_rejected_before_the_probe(self):
+        with mock.patch.object(
+            carto, "_carto_sql_json", side_effect=AssertionError("probed Carto")
+        ):
+            with pytest.raises(InvalidParameterError) as exc:
+                ops.from_carto(CARTO_URL, "tbl", include_cols="id,,name", geometry=True)
+        assert "empty or whitespace-only" in str(exc.value)
 
 
 class TestArcGISBlankEntries:
@@ -296,6 +423,75 @@ class TestParquetBackendSaysWhatIsWrong:
         with pytest.raises(InvalidParameterError) as exc:
             ops.extract(self._table(), columns=["nope"])
         assert "Columns not found in schema: nope" in str(exc.value)
+
+
+class TestBigQueryListArguments:
+    """A blank entry in a *list* argument is a mistake, not an unset option (#992).
+
+    ``ops.read_bigquery``/``Table.from_bigquery`` take ``columns`` as a list and
+    join it into the string option the core takes. ``[""]`` joined to ``""``,
+    which :func:`split_column_list` reads as "option not given" -- correctly, for
+    a string (``--include-cols "$COLS"`` with ``COLS`` unset, #973). For a list
+    it silently widened the request to **every column**, the widest possible
+    answer to a caller mistake. ``["id", ""]`` and ``["", ""]`` were already
+    caught only because they join to ``"id,"`` and ``","``.
+    """
+
+    @staticmethod
+    def _forbid_extract():
+        return mock.patch.object(
+            extract_bigquery_module,
+            "extract_bigquery",
+            side_effect=AssertionError("reached extract_bigquery"),
+        )
+
+    @staticmethod
+    def _spy_on_extract():
+        return mock.patch.object(
+            extract_bigquery_module, "extract_bigquery", side_effect=SystemExit("extracting")
+        )
+
+    @pytest.mark.parametrize("columns", [[""], ["  "], ["id", ""], ["", ""]])
+    def test_a_blank_entry_in_columns_is_rejected(self, columns):
+        with self._forbid_extract():
+            with pytest.raises(InvalidParameterError) as exc:
+                ops.read_bigquery("p.d.t", columns=columns)
+        assert "columns" in str(exc.value)
+        assert "empty or whitespace-only" in str(exc.value)
+
+    def test_a_blank_entry_in_exclude_columns_is_rejected(self):
+        with self._forbid_extract():
+            with pytest.raises(InvalidParameterError) as exc:
+                ops.read_bigquery("p.d.t", exclude_columns=[""])
+        assert "exclude_columns" in str(exc.value)
+
+    @pytest.mark.parametrize("columns", [[""], ["id", ""]])
+    def test_the_table_constructor_rejects_it_too(self, columns):
+        with self._forbid_extract():
+            with pytest.raises(InvalidParameterError):
+                gpio.Table.from_bigquery("p.d.t", columns=columns)
+
+    def test_the_table_constructor_rejects_a_blank_exclusion(self):
+        with self._forbid_extract():
+            with pytest.raises(InvalidParameterError) as exc:
+                gpio.Table.from_bigquery("p.d.t", exclude_columns=["  "])
+        assert "exclude_columns" in str(exc.value)
+
+    @pytest.mark.parametrize("columns", [None, []])
+    def test_an_absent_list_still_means_every_column(self, columns):
+        """The list argument's own "unset": None or empty, never a blank entry."""
+        with self._spy_on_extract() as extract:
+            with pytest.raises(SystemExit):
+                ops.read_bigquery("p.d.t", columns=columns, exclude_columns=columns)
+        assert extract.call_args.kwargs["include_cols"] is None
+        assert extract.call_args.kwargs["exclude_cols"] is None
+
+    def test_a_real_list_is_still_joined(self):
+        with self._spy_on_extract() as extract:
+            with pytest.raises(SystemExit):
+                ops.read_bigquery("p.d.t", columns=["id", "name"], exclude_columns=["junk"])
+        assert extract.call_args.kwargs["include_cols"] == "id,name"
+        assert extract.call_args.kwargs["exclude_cols"] == "junk"
 
 
 class TestPMTilesBlankEntries:

--- a/tests/test_core_column_list_guard.py
+++ b/tests/test_core_column_list_guard.py
@@ -20,6 +20,7 @@ stands in for a request is reached, since fast failure is half the point.
 
 from __future__ import annotations
 
+import contextlib
 from unittest import mock
 
 import pyarrow as pa
@@ -31,7 +32,11 @@ from geoparquet_io.api import ops
 from geoparquet_io.core import arcgis, carto, pmtiles
 from geoparquet_io.core import extract_bigquery as extract_bigquery_module
 from geoparquet_io.core.carto import CartoError
-from geoparquet_io.core.column_selection import reject_blank_column_entries, split_column_list
+from geoparquet_io.core.column_selection import (
+    join_column_list,
+    reject_blank_column_entries,
+    split_column_list,
+)
 from geoparquet_io.core.exceptions import InvalidParameterError
 
 CARTO_URL = "https://example.carto.com/api/v2/sql"
@@ -68,26 +73,39 @@ def _patch_carto_probes(fields: dict | None = None, **kwargs):
     )
 
 
-def _run_carto(fetched: pa.Table, fields: dict | None = None, **kwargs) -> pa.Table:
+def _run_carto(
+    fetched: pa.Table, fields: dict | None = None, *, probes: bool = True, **kwargs
+) -> pa.Table:
     """Run ``ops.from_carto`` end to end with every request mocked out.
 
-    ``--exclude-cols`` is applied to the *fetched* table, so only a full run
-    shows whether a name actually dropped a column or silently did nothing.
+    ``--exclude-cols`` is resolved and applied against the *fetched* table, so
+    only a full run shows whether a name dropped a column or silently did
+    nothing. ``probes=False`` leaves ``_carto_sql_json`` to the caller, which is
+    how the no-probe claims are asserted rather than argued.
     """
-    with (
-        _patch_carto_probes(fields),
-        mock.patch.object(carto, "_fetch_with_retry", return_value=fetched),
-        mock.patch.object(carto, "_get_row_count", return_value=fetched.num_rows),
-        mock.patch.object(
-            carto, "repair_arrow_table_geometry", side_effect=lambda t, col, repair: (t, 0)
-        ),
-    ):
+    with contextlib.ExitStack() as stack:
+        if probes:
+            stack.enter_context(_patch_carto_probes(fields))
+        stack.enter_context(mock.patch.object(carto, "_fetch_with_retry", return_value=fetched))
+        stack.enter_context(
+            mock.patch.object(carto, "_get_row_count", return_value=fetched.num_rows)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                carto, "repair_arrow_table_geometry", side_effect=lambda t, col, repair: (t, 0)
+            )
+        )
         return ops.from_carto(CARTO_URL, "tbl", **kwargs)
 
 
 def _geo_fetch() -> pa.Table:
     """What ST_Read hands back for :data:`CARTO_FIELDS`: ``the_geom`` is ``geom``."""
     return pa.table({"cartodb_id": [1], "Owner": ["acme"], "geom": [b"\x00"]})
+
+
+def _plain_fetch() -> pa.Table:
+    """What the CSV fetch hands back for :data:`CARTO_TABULAR_FIELDS`: no rename."""
+    return pa.table({"cartodb_id": [1], "Owner": ["acme"]})
 
 
 def _layer_info() -> arcgis.ArcGISLayerInfo:
@@ -200,29 +218,30 @@ class TestCartoSchemaCheck:
                 ops.from_carto(CARTO_URL, "tbl", include_cols="owner,CARTODB_ID")
         assert build.call_args.kwargs["columns"] == ["Owner", "cartodb_id"]
 
-    def test_exclude_geometry_is_not_a_schema_error(self):
-        """``exclude_cols`` names post-fetch columns, where ``the_geom`` is ``geometry``."""
-        with (
-            _patch_carto_probes(),
-            mock.patch.object(carto, "_build_carto_query", side_effect=SystemExit("query built")),
-        ):
-            with pytest.raises(SystemExit):
-                ops.from_carto(CARTO_URL, "tbl", exclude_cols="geometry")
+    def test_exclude_is_not_checked_against_the_source_schema(self):
+        """``the_geom`` is a source column but not a fetched one, so it is an error.
+
+        The fetched table is what ``--exclude-cols`` filters, and the probe's
+        schema is a different set. Checking against the probe would have made
+        ``the_geom`` a tolerated no-op; checking against the fetch does not.
+        """
+        with pytest.raises(InvalidParameterError) as exc:
+            _run_carto(_geo_fetch(), exclude_cols="the_geom")
+        assert "the_geom" in str(exc.value)
 
 
-class TestCartoExcludeSchemaCheck:
-    """``--exclude-cols`` is checked and resolved too (#991).
+class TestCartoExcludeIsCheckedAgainstTheFetchedTable:
+    """``--exclude-cols`` is resolved against the table it actually filters (#991).
 
     #989 left it matched exactly, on the grounds that the post-fetch rename made
-    the fetched column set unknowable. It is knowable: ``geometry`` plus the
-    schema the probe already read, which is exactly what ``arcgis.py`` checks
-    ``--exclude-cols`` against.
+    the fetched column set unknowable. The fetched table knows it exactly, and
+    is already in hand where the exclusion is applied -- so the check is free,
+    needs no probe, and is exact rather than a superset of the source schema.
     """
 
     def test_a_typo_is_an_error_not_a_silent_no_op(self):
-        with _patch_carto_probes():
-            with pytest.raises(InvalidParameterError) as exc:
-                ops.from_carto(CARTO_URL, "tbl", exclude_cols="Ownre")
+        with pytest.raises(InvalidParameterError) as exc:
+            _run_carto(_geo_fetch(), exclude_cols="Ownre")
         assert "--exclude-cols" in str(exc.value)
         assert "Ownre" in str(exc.value)
         assert "cartodb_id" in str(exc.value)
@@ -235,38 +254,53 @@ class TestCartoExcludeSchemaCheck:
 
     def test_the_tabular_path_is_checked_too(self):
         """``_carto_plain_table`` has no rename at all, so the excuse never applied."""
-        with _patch_carto_probes(CARTO_TABULAR_FIELDS):
-            with pytest.raises(InvalidParameterError) as exc:
-                ops.from_carto(CARTO_URL, "tbl", exclude_cols="Ownre")
+        with pytest.raises(InvalidParameterError) as exc:
+            _run_carto(_plain_fetch(), CARTO_TABULAR_FIELDS, exclude_cols="Ownre")
         assert "Ownre" in str(exc.value)
 
     def test_the_tabular_path_resolves_the_spelling_too(self):
-        table = _run_carto(
-            pa.table({"cartodb_id": [1], "Owner": ["acme"]}),
-            CARTO_TABULAR_FIELDS,
-            exclude_cols="owner",
-        )
+        table = _run_carto(_plain_fetch(), CARTO_TABULAR_FIELDS, exclude_cols="owner")
         assert table.column_names == ["cartodb_id"]
 
-    def test_excluding_geometry_in_any_spelling_is_refused_not_obeyed(self):
-        """``geometry`` is required for GeoParquet output, so it is warned about.
+    def test_geometry_is_not_a_column_on_the_tabular_path(self):
+        """The path whose own comment said "no geometry to protect here".
 
-        On main ``GEOMETRY`` missed that guard by exact match and then silently
-        dropped nothing; now it resolves to ``geometry`` and is refused out loud.
+        It had no guard at all, so ``--exclude-cols geometry`` was a silent
+        no-op there. The fetched table simply has no such column, so it is now
+        an error like any other name the table does not carry.
+        """
+        with pytest.raises(InvalidParameterError) as exc:
+            _run_carto(_plain_fetch(), CARTO_TABULAR_FIELDS, exclude_cols="geometry")
+        assert "geometry" in str(exc.value)
+
+    @pytest.mark.parametrize("exclude_cols", ["geometry", "GEOMETRY"])
+    def test_excluding_geometry_is_refused_out_loud_on_the_geometry_path(self, exclude_cols):
+        """``geometry`` is a real fetched column there, and GeoParquet requires it.
+
+        ``GEOMETRY`` used to miss the guard by exact match and then silently drop
+        nothing; it now folds to ``geometry`` and reaches the refusal.
         """
         with mock.patch.object(carto, "warn") as warn:
-            table = _run_carto(_geo_fetch(), exclude_cols="GEOMETRY")
+            table = _run_carto(_geo_fetch(), exclude_cols=exclude_cols)
         assert table.column_names == ["cartodb_id", "Owner", "geometry"]
         assert any("Cannot exclude" in str(call.args[0]) for call in warn.call_args_list)
+
+    def test_a_second_name_still_applies_when_geometry_is_dropped_from_the_list(self):
+        """Refusing ``geometry`` must not swallow the rest of the list."""
+        with mock.patch.object(carto, "warn"):
+            table = _run_carto(_geo_fetch(), exclude_cols="geometry,owner")
+        assert table.column_names == ["cartodb_id", "geometry"]
 
 
 class TestCartoForcedModeStillChecks:
     """``--geometry``/``--no-geometry`` no longer skips the check (#991).
 
     #989 pinned the skip as deliberate: the shape probe is what supplies the
-    schema, and forcing the mode skips it. But the guarantee "a typo is an
-    error" should not hinge on an unrelated flag, so the column options now pay
-    for their own ``SELECT * ... LIMIT 0`` -- and only when one is given.
+    schema, and forcing the mode skips it. The guarantee "a typo is an error"
+    should not hinge on an unrelated flag, so ``--include-cols`` buys its own
+    ``SELECT * ... LIMIT 0`` -- that list becomes the SELECT list, where an
+    unresolved name costs a retry budget and an opaque ST_Read failure.
+    ``--exclude-cols`` needs no probe at all: it is checked against the fetch.
     """
 
     @pytest.mark.parametrize("geometry", [True, False])
@@ -276,11 +310,22 @@ class TestCartoForcedModeStillChecks:
                 ops.from_carto(CARTO_URL, "tbl", include_cols="nope", geometry=geometry)
         assert "nope" in str(exc.value)
 
-    def test_an_unknown_exclude_column_is_still_rejected(self):
-        with _patch_carto_probes():
+    def test_an_unknown_exclude_column_is_still_rejected_without_a_probe(self):
+        """No schema probe runs, yet the typo is still caught -- after the fetch."""
+        with mock.patch.object(
+            carto, "_carto_sql_json", side_effect=AssertionError("probed Carto")
+        ):
             with pytest.raises(InvalidParameterError) as exc:
-                ops.from_carto(CARTO_URL, "tbl", exclude_cols="Ownre", geometry=True)
+                _run_carto(_geo_fetch(), exclude_cols="Ownre", geometry=True, probes=False)
         assert "Ownre" in str(exc.value)
+
+    def test_exclude_alone_buys_no_probe(self):
+        """The cost of the check for --exclude-cols is zero requests, not one."""
+        with mock.patch.object(
+            carto, "_carto_sql_json", side_effect=AssertionError("probed Carto")
+        ):
+            table = _run_carto(_geo_fetch(), exclude_cols="owner", geometry=True, probes=False)
+        assert table.column_names == ["cartodb_id", "geometry"]
 
     def test_no_column_option_means_no_probe(self):
         """The flags' whole point is to skip the probe, so nothing else pays for it."""
@@ -317,112 +362,38 @@ class TestCartoForcedModeStillChecks:
         assert "empty or whitespace-only" in str(exc.value)
 
 
-class TestArcGISBlankEntries:
-    """``ops.from_arcgis`` rejects a blank entry instead of sending it."""
+class TestJoinColumnList:
+    """The joiner: the list side's "unset", and why it is not the string side's.
 
-    def test_blank_include_entry_rejected_before_any_request(self):
-        """The #980 misbehavior: ``outFields=name,,pop`` went to the server."""
-        with mock.patch.object(
-            arcgis, "get_layer_info", side_effect=AssertionError("contacted the service")
-        ):
-            with pytest.raises(InvalidParameterError) as exc:
-                ops.from_arcgis(ARCGIS_URL, include_cols="name,,pop")
-        assert "--include-cols" in str(exc.value)
-        assert "empty or whitespace-only" in str(exc.value)
+    ``split_column_list`` and this are inverses, and #992 lived in the gap
+    between them -- so the check belongs *inside* the join, not beside it at
+    each call site.
+    """
 
-    def test_blank_exclude_entry_rejected_before_any_request(self):
-        with mock.patch.object(
-            arcgis, "get_layer_info", side_effect=AssertionError("contacted the service")
-        ):
-            with pytest.raises(InvalidParameterError) as exc:
-                ops.from_arcgis(ARCGIS_URL, exclude_cols="name,,pop")
-        assert "--exclude-cols" in str(exc.value)
+    @pytest.mark.parametrize("columns", [None, []])
+    def test_an_absent_list_is_an_unset_option(self, columns):
+        assert join_column_list(columns, "columns") is None
 
+    def test_a_list_is_joined(self):
+        assert join_column_list(["id", "name"], "columns") == "id,name"
 
-class TestArcGISSchemaCheck:
-    """Non-blank names are checked against the layer metadata already fetched."""
+    @pytest.mark.parametrize("columns", [[""], ["  "], ["id", ""], ["", ""]])
+    def test_a_blank_entry_is_rejected(self, columns):
+        """``[""]`` is the one that used to join to ``""`` and read as unset."""
+        with pytest.raises(InvalidParameterError, match="empty or whitespace-only"):
+            join_column_list(columns, "columns")
 
-    def test_unknown_include_field_rejected(self):
-        with mock.patch.object(arcgis, "get_layer_info", return_value=_layer_info()):
-            with pytest.raises(InvalidParameterError) as exc:
-                ops.from_arcgis(ARCGIS_URL, include_cols="name,nope")
-        assert "nope" in str(exc.value)
-        assert "OBJECTID" in str(exc.value)
-
-    def test_unknown_exclude_field_rejected(self):
-        with mock.patch.object(arcgis, "get_layer_info", return_value=_layer_info()):
-            with pytest.raises(InvalidParameterError) as exc:
-                ops.from_arcgis(ARCGIS_URL, exclude_cols="nope")
-        assert "nope" in str(exc.value)
-
-    def test_exclude_geometry_is_accepted(self):
-        """``geometry`` is not a layer field but is the table's first column."""
-        with (
-            mock.patch.object(arcgis, "get_layer_info", return_value=_layer_info()),
-            mock.patch.object(
-                arcgis, "_stream_features_to_parquet", side_effect=SystemExit("streamed")
-            ),
-        ):
-            with pytest.raises(SystemExit):
-                ops.from_arcgis(ARCGIS_URL, exclude_cols="geometry")
-
-    def test_include_field_resolved_to_layer_spelling(self):
-        with (
-            mock.patch.object(arcgis, "get_layer_info", return_value=_layer_info()),
-            mock.patch.object(
-                arcgis, "_stream_features_to_parquet", side_effect=SystemExit("streamed")
-            ) as stream,
-        ):
-            with pytest.raises(SystemExit):
-                ops.from_arcgis(ARCGIS_URL, include_cols="objectid,Name")
-        assert stream.call_args.kwargs["out_fields"] == "OBJECTID,name"
-
-    def test_wholly_empty_value_still_means_unset(self):
-        """``--include-cols "$COLS"`` with COLS unset must keep working (#973)."""
-        with (
-            mock.patch.object(arcgis, "get_layer_info", return_value=_layer_info()),
-            mock.patch.object(
-                arcgis, "_stream_features_to_parquet", side_effect=SystemExit("streamed")
-            ) as stream,
-        ):
-            with pytest.raises(SystemExit):
-                ops.from_arcgis(ARCGIS_URL, include_cols="", exclude_cols="")
-        assert stream.call_args.kwargs["out_fields"] == "*"
-
-    def test_star_is_still_the_all_fields_wildcard(self):
-        """``outFields=*`` is ArcGIS's own spelling for "every field"."""
-        with (
-            mock.patch.object(arcgis, "get_layer_info", return_value=_layer_info()),
-            mock.patch.object(
-                arcgis, "_stream_features_to_parquet", side_effect=SystemExit("streamed")
-            ) as stream,
-        ):
-            with pytest.raises(SystemExit):
-                ops.from_arcgis(ARCGIS_URL, include_cols="*")
-        assert stream.call_args.kwargs["out_fields"] == "*"
-
-
-class TestParquetBackendSaysWhatIsWrong:
-    """``ops.extract`` already raised; the message now names the real problem."""
-
-    @staticmethod
-    def _table() -> pa.Table:
-        return pa.table({"id": [1], "name": ["a"]})
-
-    def test_blank_column_entry_message(self):
+    def test_the_argument_is_named_in_the_message(self):
+        """These callers have a Python argument to point at, not a CLI option."""
         with pytest.raises(InvalidParameterError) as exc:
-            ops.extract(self._table(), columns=["id", ""])
-        assert "empty or whitespace-only" in str(exc.value)
+            join_column_list([""], "exclude_columns")
+        assert "exclude_columns" in str(exc.value)
 
-    def test_blank_exclude_entry_message(self):
-        with pytest.raises(InvalidParameterError) as exc:
-            ops.extract(self._table(), exclude_columns=["   "])
-        assert "empty or whitespace-only" in str(exc.value)
-
-    def test_unknown_column_still_reports_the_schema(self):
-        with pytest.raises(InvalidParameterError) as exc:
-            ops.extract(self._table(), columns=["nope"])
-        assert "Columns not found in schema: nope" in str(exc.value)
+    def test_it_round_trips_with_the_splitter(self):
+        assert split_column_list(join_column_list(["id", "name"], "columns"), "--include-cols") == [
+            "id",
+            "name",
+        ]
 
 
 class TestBigQueryListArguments:

--- a/tests/test_extract_bigquery.py
+++ b/tests/test_extract_bigquery.py
@@ -824,6 +824,32 @@ class TestColumnValidation:
         # A spelling that matches neither exactly still folds, as before.
         assert resolve_columns_against_schema(["GeoM"], schema, "--include-cols") == ["geom"]
 
+    @pytest.mark.parametrize("requested", ["Id", "iD"])
+    def test_an_ambiguous_fold_raises_instead_of_picking_one(self, requested):
+        """A third spelling could mean either column, so the caller is asked which.
+
+        ``{col.lower(): col}`` silently kept the last, which is arbitrary -- and
+        on ``--exclude-cols`` an arbitrary choice deletes a column the caller did
+        not name.
+        """
+        from geoparquet_io.core.column_selection import resolve_columns_against_schema
+        from geoparquet_io.core.exceptions import InvalidParameterError
+
+        with pytest.raises(InvalidParameterError) as exc_info:
+            resolve_columns_against_schema([requested], ["id", "ID", "geom"], "--exclude-cols")
+
+        message = str(exc_info.value)
+        assert "Ambiguous" in message
+        assert "ID" in message and "id" in message
+
+    def test_an_unambiguous_schema_never_reports_ambiguity(self):
+        """The check must not fire on ordinary schemas, which is every real one."""
+        from geoparquet_io.core.column_selection import resolve_columns_against_schema
+
+        assert resolve_columns_against_schema(
+            ["ID", "GeoM"], ["id", "name", "geom"], "--exclude-cols"
+        ) == ["id", "geom"]
+
     def test_missing_column_is_an_invalid_parameter(self):
         from geoparquet_io.core.column_selection import resolve_columns_against_schema
         from geoparquet_io.core.exceptions import InvalidParameterError


### PR DESCRIPTION
## What changed

Two holes an adversarial review found in #989 — the same defect class, in the
same subsystem, so one PR.

### #991 — carto `--exclude-cols` is checked against the table it filters

`carto.py` split `--exclude-cols` into a `set[str]` and filtered the fetched
table by **exact string**, so a case mismatch or a typo silently dropped
nothing. `_apply_column_exclusions` now resolves the names against
`table.column_names` — the table that was actually fetched, at the point the
exclusion is applied — so they are matched case-insensitively and resolved to
that table's own spelling before anything is filtered.

#989 declined to check it at all, on the grounds that the post-fetch rename made
the fetched column set unknowable. The fetched table knows it exactly, and both
paths already had it in hand where they apply the exclusion. Resolving there is
exact rather than approximate, costs **no extra request**, and therefore holds
under `--geometry`/`--no-geometry` too.

Consequences, each pinned by a test:

- `--exclude-cols OWNER` drops a column named `Owner`; `--exclude-cols Ownre` is
  an error naming the available columns.
- `--exclude-cols GEOMETRY` now folds to `geometry` and reaches the existing
  "cannot exclude 'geometry'" warning, which it used to miss by case.
- `--exclude-cols the_geom` on the geometry path and `--exclude-cols geometry`
  on the tabular path are errors, not no-ops — those columns do not exist in the
  respective fetched tables.
- `--include-cols Owner --exclude-cols Notes` is an error too: `Notes` is not in
  the table the include list produced.

The **tabular** path (`_carto_plain_table`) fetches CSV and renames nothing at
all, so #989's justification never applied there even in principle — and its own
comment ("no geometry to protect here") marked a path with no guard whatsoever.

### #991, also in scope — the probe-skipped gap

`--geometry`/`--no-geometry` skips the shape probe that supplies the schema, so
neither list was checked. #989 pinned that as deliberate
(`test_no_schema_check_when_the_probe_is_skipped`).

**Decision: closed for both lists, but only `--include-cols` pays for it.**
`--exclude-cols` needs no probe at all now that it reads the fetched table.
`--include-cols` buys one bounded `SELECT * … LIMIT 0` when a forced mode
skipped the probe, and that round-trip earns itself: that list becomes the
SELECT list, so an unresolved name comes back as an opaque `ST_Read` failure on
an HTTP error body *after* burning the retry budget.

- The guarantee "a typo is an error" should not hinge on a flag about geometry
  detection.
- With no `--include-cols`, nothing is probed — asserted, not assumed
  (`test_no_column_option_means_no_probe`, `test_exclude_alone_buys_no_probe`).
- A probe that cannot be reached means "no schema to check against", never an
  extraction failure.

**Honest cost:** under a forced mode, an `--exclude-cols` typo surfaces *after*
the fetch rather than before it. That is the only thing a probe bought for
exclude, and it is not worth a round-trip on every run.

### #992 — a blank entry in a list argument is a mistake, not an unset option

`ops.read_bigquery(columns=[""])` joined to `""`, which `split_column_list`
correctly reads as "option not given" — so the request silently widened to
**every column**, the widest possible answer to a caller's typo.

`core/column_selection.py` gains **`join_column_list`**, the inverse of
`split_column_list`, and both BigQuery API sites use it. The check lives *inside*
the join rather than beside it, because the gap between the two steps is exactly
where #992 lived; leaving two adjacent statements duplicated in two files would
re-open the seam the module exists to close.

The distinction that had to survive is intact and pinned: wholly-empty-means-unset
is right for the **string** option (`--include-cols "$COLS"` with `COLS` unset,
#973) and wrong for a **list** argument, whose own unset is `None` or `[]`.

`exclude_columns=[""]` had the identical silent no-op and is fixed by the same
call.

### An ambiguous case fold now raises

`{col.lower(): col}` silently kept the *last* of a schema carrying both `id` and
`ID`, so `Id` resolved arbitrarily. An exact match still wins and an unambiguous
fold still resolves, but a genuinely ambiguous one now asks the caller to
disambiguate — because on `--exclude-cols` an arbitrary choice **deletes** a
column the caller did not name. (Low severity, pre-existing on `main`; fixed
here because this PR routes carto's exclude through that resolver.)

## Reproductions

All on `origin/main` @ `a9394e2` (the branch is now rebased onto `1473251`;
no file overlap). Network mocked; the probe returns a table
carrying `cartodb_id`, `Owner`, `the_geom`.

**#991 — geometry path:**

```
--exclude-cols 'Owner'    -> kept ['cartodb_id', 'geometry']            # works
--exclude-cols 'owner'    -> kept ['cartodb_id', 'Owner', 'geometry']   # silent no-op
--exclude-cols 'OWNER'    -> kept ['cartodb_id', 'Owner', 'geometry']   # silent no-op
--exclude-cols 'Ownre'    -> kept ['cartodb_id', 'Owner', 'geometry']   # typo, silent
```

**#991 — tabular path** (`_carto_plain_table`, where no rename happens at all):

```
--exclude-cols 'owner'    -> kept ['cartodb_id', 'Owner']               # silent no-op
--exclude-cols 'Ownre'    -> kept ['cartodb_id', 'Owner']               # typo, silent
```

**#991 — the two no-ops the first round of this PR would have left** (verified
against that intermediate commit, not just `main`):

```
geometry path,  --exclude-cols the_geom   -> kept [...], warnings: []
tabular path,   --exclude-cols geometry   -> kept [...], warnings: []
```

**#991 — probe skipped:**

```
ops.from_carto(..., include_cols='nope', geometry=True)
# -> columns forwarded to _build_carto_query: ['nope']
```

**#992:**

```
ops.read_bigquery('p.d.t', columns=[''])         -> include_cols='' exclude_cols=None   # -> every column
ops.read_bigquery('p.d.t', exclude_columns=['']) -> include_cols=None exclude_cols=''   # -> excludes nothing
ops.read_bigquery('p.d.t', columns=['id', ''])   -> include_cols='id,'                  # already caught
gpio.Table.from_bigquery('p.d.t', columns=[''])  -> include_cols=''                     # same hole
```

**After**, on this branch:

```
geometry path,  --exclude-cols owner     -> kept ['cartodb_id', 'geometry'], warnings: []
geometry path,  --exclude-cols GEOMETRY  -> kept [...], warnings: ["Cannot exclude 'geometry' column …"]
geometry path,  --exclude-cols the_geom  -> InvalidParameterError: Columns not found in schema: the_geom.
                                            Available columns: cartodb_id, Owner, geometry
tabular path,   --exclude-cols geometry  -> InvalidParameterError: Columns not found in schema: geometry.
                                            Available columns: cartodb_id, Owner
geometry=True,  --exclude-cols Ownre     -> InvalidParameterError (and no probe was issued)
columns=['']                             -> InvalidParameterError: Invalid parameter 'columns':
                                            column names cannot be empty or whitespace-only
exclude_columns=['']                     -> InvalidParameterError: Invalid parameter 'exclude_columns': …
```

## The list-vs-string distinction elsewhere in the API

Audited every API entry point that takes column names, since #992 is really
"one shape of argument got the other shape's rule":

- **The four joining call sites are the only ones**, and all four are BigQuery
  (`ops.py`, `table.py`). Nothing else in `api/` joins a list into a string
  option, so there is no third instance of this bug to find. All four now go
  through `join_column_list`.
- `ops.extract` / `Table.extract` take real lists and reach
  `core.extract.validate_columns`, which #989 already routed through
  `reject_blank_column_entries` — `columns=[""]` raises there today.
- Carto and ArcGIS take `include_cols`/`exclude_cols` as *strings* in the Python
  API too, so they are the string rule's territory and behave correctly.
- Two other list arguments were checked and are **not** affected:
  `ops.add_admin_divisions(levels=[""])` raises (a membership check catches it,
  though the message reads `Invalid levels …: .` — the same wrong-diagnosis shape
  #989 fixed for `extract geoparquet`; cosmetic, not a widening, left alone);
  `ops.from_wfs_layers(typenames=[""])` has no "unset" reinterpretation — every
  entry is requested from the service.

## Tests

`tests/test_core_column_list_guard.py` grows four classes, all driving the
**Python API** rather than Click, since a Click-only guard is exactly what left
these holes:

- `TestCartoExcludeIsCheckedAgainstTheFetchedTable` — the typo, all three
  casings, both paths, `the_geom` and tabular `geometry` as honest errors,
  `geometry`/`GEOMETRY` reaching the warning, and a second name still applying
  when `geometry` is dropped from the list. These run `ops.from_carto` end to
  end with the fetch mocked, because only a full run shows whether a name
  actually dropped a column.
- `TestCartoForcedModeStillChecks` — the check survives `geometry=True/False`;
  exclude buys no probe (`_carto_sql_json` raises `AssertionError` if touched);
  no column option means no probe; a failed probe does not fail the extraction;
  a blank entry is still rejected before the probe. This replaces #989's
  `test_no_schema_check_when_the_probe_is_skipped`, which pinned the behaviour
  this PR deliberately changes.
- `TestJoinColumnList` — the joiner's own unset (`None`/`[]`), blank entries,
  the argument name in the message, and a round-trip with `split_column_list`.
- `TestBigQueryListArguments` — `[""]`, `["  "]`, `["id", ""]`, `["", ""]` for
  both `columns` and `exclude_columns`, on `ops.read_bigquery` and
  `Table.from_bigquery`, each asserting the failure lands before the mock
  standing in for `extract_bigquery`; plus `None`/`[]` still meaning every
  column, and a real list still joining.

`tests/test_extract_bigquery.py` gains the ambiguous-fold cases, against the
local-table schema carrying both `id` and `ID` that module already produces.

## Verification

- `uv run pytest -n auto -m "not slow and not network and not meta"` — **7601 passed, 76 skipped, 7 xfailed**, zero failures, measured on the rebased branch.
- `uv run pytest -m meta` — **205 passed**
- `uv run pytest docs/guide/extract.md -n 4 -m "not network"` — **27 passed, 71 skipped**
- `uv run pre-commit run --all-files` and `--hook-stage pre-push` — **all green**, including `mypy`, `vulture`, `xenon`, `import-linter`, `deptry` and `menard-check`. (`menard-check` flagged `docs/api/python-api.md#Standalone Functions` while the work was uncommitted; it was proven green on a clean detached `origin/main` worktree first, so the flag was this PR's own `api/ops.py` change. That doc target was re-read, corrected for the new behaviour, and passes.)
- `diff-cover` vs `origin/main` — **100%** (45 changed lines, 0 missing)

Closes #991. Closes #992. Refs #969, #973, #980, #989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
