### PR TITLE
fix(cli): answer a DuckDB-rejected file with an error line instead of a traceback

### DIFF
--- a/geoparquet_io/cli/commands/check.py
+++ b/geoparquet_io/cli/commands/check.py
@@ -16,6 +16,7 @@ from geoparquet_io.cli._shared import _activate_s3, create_default_group, init_g
 from geoparquet_io.cli.decorators import (
     GlobAwareCommand,
     check_partition_options,
+    enable_verbose_logging,
     handle_geoparquet_errors,
     overwrite_option,
     verbose_option,
@@ -177,7 +178,13 @@ class MultiFileCheckRunner:
 
 @check.command(name="all", cls=GlobAwareCommand)
 @click.argument("parquet_file")
-@click.option("--verbose", is_flag=True, help="Print detailed diagnostics")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print detailed diagnostics",
+    callback=enable_verbose_logging,
+    is_eager=True,
+)
 @click.option("--fix", is_flag=True, help="Fix detected issues")
 @click.option(
     "--fix-output",
@@ -462,7 +469,13 @@ def check_all(
     show_default=True,
     help="Max rows for spatial order check",
 )
-@click.option("--verbose", is_flag=True, help="Print detailed diagnostics")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print detailed diagnostics",
+    callback=enable_verbose_logging,
+    is_eager=True,
+)
 @click.option("--fix", is_flag=True, help="Fix with Hilbert ordering")
 @click.option(
     "--fix-output",
@@ -606,7 +619,13 @@ def check_spatial(
 
 @check.command(name="compression", cls=GlobAwareCommand)
 @click.argument("parquet_file")
-@click.option("--verbose", is_flag=True, help="Print detailed diagnostics")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print detailed diagnostics",
+    callback=enable_verbose_logging,
+    is_eager=True,
+)
 @click.option("--fix", is_flag=True, help="Recompress geometry with ZSTD")
 @click.option(
     "--fix-output",
@@ -694,7 +713,13 @@ def check_compression_cmd(
 
 @check.command(name="bbox", cls=GlobAwareCommand)
 @click.argument("parquet_file")
-@click.option("--verbose", is_flag=True, help="Print detailed diagnostics")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print detailed diagnostics",
+    callback=enable_verbose_logging,
+    is_eager=True,
+)
 @click.option("--fix", is_flag=True, help="Fix bbox (add for v1.x, remove for v2/parquet-geo)")
 @click.option(
     "--fix-output",
@@ -827,7 +852,13 @@ def check_bbox_cmd(
 
 @check.command(name="row-group", cls=GlobAwareCommand)
 @click.argument("parquet_file")
-@click.option("--verbose", is_flag=True, help="Print detailed diagnostics")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print detailed diagnostics",
+    callback=enable_verbose_logging,
+    is_eager=True,
+)
 @click.option("--fix", is_flag=True, help="Optimize row group size")
 @click.option(
     "--fix-output",
@@ -1075,7 +1106,13 @@ def check_spec(
 
 @check.command(name="optimization", cls=GlobAwareCommand)
 @click.argument("parquet_file")
-@click.option("--verbose", is_flag=True, help="Print detailed diagnostics")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print detailed diagnostics",
+    callback=enable_verbose_logging,
+    is_eager=True,
+)
 @check_partition_options
 @click.pass_context
 def check_optimization_cmd(

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -34,7 +34,9 @@ class ErrorBoundaryGroup(click.Group):
       file, not a gpio bug -- and DuckDB's message already says what is wrong
       with it. Eleven commands answered such a file with a traceback because the
       handling lived in per-site ``except`` blocks that those paths never
-      reached (#983).
+      reached (#983). Only the DuckDB errors the *input* causes are translated;
+      the ones gpio's own generated SQL causes keep their traceback, which is
+      the line ``INPUT_FILE_DUCKDB_ERRORS`` draws.
 
     Both belong on the *root* group rather than on a decorator, because every
     command can hit them: ``handle_geoparquet_errors`` is applied to four

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -20,29 +20,30 @@ from geoparquet_io.core.parquet_writer import (
 class ErrorBoundaryGroup(click.Group):
     """Root group that turns a DuckDB failure into gpio's error line.
 
-    Two failures reach this point with no gpio frame willing to own them, and
-    both used to leave a raw Python traceback on the terminal:
+    Failures reach this point with no gpio frame willing to own them, and used
+    to leave a raw Python traceback on the terminal -- an out-of-spill-space
+    error with no ``TMPDIR`` line (#752), and a ``geo`` block DuckDB's Parquet
+    reader refuses, on eleven commands whose paths never reached a per-site
+    ``except`` (#983). :func:`~geoparquet_io.cli.exception_handler.cli_error_for`
+    decides what is answered and what is not; the reasoning for where that line
+    falls lives once, on
+    :data:`~geoparquet_io.core.duckdb_utils.INPUT_FILE_DUCKDB_ERRORS`.
 
-    * DuckDB runs out of room to spill. It caps its spill at
-      ``max_temp_directory_size`` (90% of the volume by default), so a small or
-      RAM-backed temp volume fails cleanly rather than filling the disk -- but
-      it fails saying "Out of Memory Error", and its list of "possible
-      solutions" is entirely about memory. It never mentions the one knob that
-      fixes a disk shortage, so the boundary adds that line (#752).
-    * DuckDB's Parquet reader refuses the input's ``geo`` block. That block is
-      arbitrary JSON from somebody else's tool, so its refusal is news about the
-      file, not a gpio bug -- and DuckDB's message already says what is wrong
-      with it. Eleven commands answered such a file with a traceback because the
-      handling lived in per-site ``except`` blocks that those paths never
-      reached (#983). Only the DuckDB errors the *input* causes are translated;
-      the ones gpio's own generated SQL causes keep their traceback, which is
-      the line ``INPUT_FILE_DUCKDB_ERRORS`` draws.
+    This belongs on the *root* group rather than on a decorator, because every
+    command can hit those failures: ``handle_geoparquet_errors`` is applied to
+    four command modules, and ``gpio sort hilbert`` -- the worked example in the
+    docs -- is not one of them. ``Group.invoke`` is the single funnel every
+    subcommand passes through, so a command added tomorrow inherits this, and
+    inner handlers are strictly inside it and still run first (#988's
+    curved-geometry retry depends on that).
 
-    Both belong on the *root* group rather than on a decorator, because every
-    command can hit them: ``handle_geoparquet_errors`` is applied to four
-    command modules, and ``gpio sort hilbert`` -- the worked example in the docs
-    -- is not one of them. ``Group.invoke`` is the single funnel every
-    subcommand passes through, so a command added tomorrow inherits this.
+    A caveat worth naming: an ``IOException`` on a scratch file gpio itself
+    minted -- partition staging, an ``add <index>`` intermediate -- is reported
+    with the same line as one on the user's input, because the class is all the
+    exception says. No live case has been constructed (apostrophe and
+    glob-metacharacter paths behave identically with and without this boundary),
+    and the message still names the path that failed, so it is a known,
+    reasoned cost rather than an unnoticed one.
 
     Anything ``cli_error_for`` does not claim is re-raised untouched: a genuine
     gpio bug still gets its traceback.
@@ -58,8 +59,12 @@ class ErrorBoundaryGroup(click.Group):
             error = cli_error_for(exc)
             if error is None:
                 raise
-            # The traceback is hidden, not discarded: --verbose still prints it,
-            # which is what a gpio bug that surfaces as a DuckDB error needs.
+            # The traceback is hidden, not discarded: --verbose prints it, which
+            # is what a gpio bug that surfaces as a DuckDB error needs. That
+            # holds because `verbose_option` raises the package logger to DEBUG
+            # as the flag is parsed -- before the command body runs, so before
+            # anything can fail on the way to a core function's own
+            # `configure_verbose` call.
             get_logger(__name__).debug(
                 "Converted a low-level failure to an error line", exc_info=exc
             )
@@ -309,13 +314,46 @@ def dry_run_option(func):
     )(func)
 
 
+def enable_verbose_logging(ctx, param, value):
+    """Raise the package logger to DEBUG the moment ``--verbose`` is parsed.
+
+    ``configure_verbose`` is also called from ~60 core functions that take a
+    ``verbose`` argument, but always *inside* them -- so a command that fails
+    before reaching one has left the logger at INFO, and everything the run was
+    asked to say at DEBUG is dropped. Measured on a DuckDB-rejected input: of
+    the eleven commands #983 covers, seven had reached a ``configure_verbose``
+    call by the time they failed and four had not, so ``--verbose`` printed the
+    boundary's hidden traceback on seven of them and nothing on the rest.
+
+    A Click option callback runs during ``make_context`` for the subcommand,
+    which is after the root group's ``setup_cli_logging(verbose=False)`` and
+    before the command body -- the only point early enough to be unconditional.
+    ``is_eager`` puts it ahead of any other callback that might log.
+
+    Used as the ``callback`` of every ``--verbose`` flag; see
+    :class:`ErrorBoundaryGroup` for what depends on it.
+    """
+    if value:
+        from geoparquet_io.core.logging_config import configure_verbose
+
+        configure_verbose(True)
+    return value
+
+
 def verbose_option(func):
     """
     Add --verbose/-v option to a command.
 
     Enables detailed logging and information output.
     """
-    return click.option("--verbose", "-v", is_flag=True, help="Print verbose output")(func)
+    return click.option(
+        "--verbose",
+        "-v",
+        is_flag=True,
+        help="Print verbose output",
+        callback=enable_verbose_logging,
+        is_eager=True,
+    )(func)
 
 
 def show_sql_option(func):

--- a/geoparquet_io/cli/decorators.py
+++ b/geoparquet_io/cli/decorators.py
@@ -17,34 +17,51 @@ from geoparquet_io.core.parquet_writer import (
 )
 
 
-class SpillAwareGroup(click.Group):
-    """Root group that names ``TMPDIR`` when DuckDB runs out of room to spill.
+class ErrorBoundaryGroup(click.Group):
+    """Root group that turns a DuckDB failure into gpio's error line.
 
-    DuckDB caps its spill at ``max_temp_directory_size`` (90% of the volume by
-    default), so a small or RAM-backed temp volume fails cleanly rather than
-    filling the disk -- but it fails saying "Out of Memory Error", and its list
-    of "possible solutions" is entirely about memory. It never mentions the one
-    knob that fixes a disk shortage. This adds that line.
+    Two failures reach this point with no gpio frame willing to own them, and
+    both used to leave a raw Python traceback on the terminal:
 
-    It belongs on the *root* group rather than on a decorator because every
-    command spills: ``handle_geoparquet_errors`` is applied to four command
-    modules, and ``gpio sort hilbert`` -- the worked example in the docs -- is
-    not one of them. ``Group.invoke`` is the single funnel every subcommand
-    passes through.
+    * DuckDB runs out of room to spill. It caps its spill at
+      ``max_temp_directory_size`` (90% of the volume by default), so a small or
+      RAM-backed temp volume fails cleanly rather than filling the disk -- but
+      it fails saying "Out of Memory Error", and its list of "possible
+      solutions" is entirely about memory. It never mentions the one knob that
+      fixes a disk shortage, so the boundary adds that line (#752).
+    * DuckDB's Parquet reader refuses the input's ``geo`` block. That block is
+      arbitrary JSON from somebody else's tool, so its refusal is news about the
+      file, not a gpio bug -- and DuckDB's message already says what is wrong
+      with it. Eleven commands answered such a file with a traceback because the
+      handling lived in per-site ``except`` blocks that those paths never
+      reached (#983).
 
-    Anything that is not this specific failure is re-raised untouched.
+    Both belong on the *root* group rather than on a decorator, because every
+    command can hit them: ``handle_geoparquet_errors`` is applied to four
+    command modules, and ``gpio sort hilbert`` -- the worked example in the docs
+    -- is not one of them. ``Group.invoke`` is the single funnel every
+    subcommand passes through, so a command added tomorrow inherits this.
+
+    Anything ``cli_error_for`` does not claim is re-raised untouched: a genuine
+    gpio bug still gets its traceback.
     """
 
     def invoke(self, ctx):
-        from geoparquet_io.core.duckdb_utils import spill_space_hint
+        from geoparquet_io.cli.exception_handler import cli_error_for
+        from geoparquet_io.core.logging_config import get_logger
 
         try:
             return super().invoke(ctx)
         except Exception as exc:
-            hint = spill_space_hint(exc)
-            if hint is None:
+            error = cli_error_for(exc)
+            if error is None:
                 raise
-            raise click.ClickException(f"{exc}\n\n{hint}") from exc
+            # The traceback is hidden, not discarded: --verbose still prints it,
+            # which is what a gpio bug that surfaces as a DuckDB error needs.
+            get_logger(__name__).debug(
+                "Converted a low-level failure to an error line", exc_info=exc
+            )
+            raise error from exc
 
 
 def handle_geoparquet_errors(func):

--- a/geoparquet_io/cli/exception_handler.py
+++ b/geoparquet_io/cli/exception_handler.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from typing import TypeVar
 
 import click
+import duckdb
 
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
@@ -24,6 +25,37 @@ from geoparquet_io.core.exceptions import (
 )
 
 F = TypeVar("F", bound=Callable)
+
+#: The DuckDB failures whose cause is the *input*, not gpio.
+#:
+#: Enumerated one by one rather than written as a base class, because DuckDB's
+#: hierarchy does not split along this line. Measured against duckdb 1.5.5:
+#: ``InvalidInputException`` -- the one #983 is about -- sits under
+#: ``ProgrammingError`` next to ``ParserException``, ``BinderException`` and
+#: ``CatalogException``, which are its exact opposite, and ``duckdb.Error``'s
+#: only direct subclass is ``DatabaseError``, so every shorthand available is
+#: either too wide or splits the wrong set.
+#:
+#: * ``InvalidInputException`` -- the file's own bytes or metadata are
+#:   unreadable. A ``geo`` block with no ``columns`` object raises this, as do
+#:   all four of #983's reproductions.
+#: * ``IOException`` -- missing, unreachable or unreadable. ``HTTPException``
+#:   hangs below it, so a remote URL that will not fetch is covered too; both
+#:   are properties of the path the user named.
+#: * ``ConversionException`` -- a value the file holds will not cast.
+#:
+#: What is deliberately *not* here is everything gpio itself can get wrong.
+#: gpio authors every SQL string it runs, so ``ParserException``,
+#: ``BinderException`` and ``CatalogException`` are never news about the user's
+#: file and always a bug in a query we generated -- the defect class behind
+#: #700, #718 and #944. Those keep their traceback: answering them with the
+#: same ``Error:`` line used for a bad input would tell a user their data is
+#: broken when the broken thing is ours.
+INPUT_FILE_DUCKDB_ERRORS = (
+    duckdb.InvalidInputException,
+    duckdb.IOException,
+    duckdb.ConversionException,
+)
 
 
 def handle_core_exception(exc: GeoParquetError) -> click.ClickException:
@@ -52,29 +84,32 @@ def cli_error_for(exc: BaseException) -> click.ClickException | None:
     the other half: exceptions raised *underneath* gpio, by DuckDB, which reach
     the boundary with nothing in between willing to claim them.
 
-    A ``duckdb.Error`` on a read is almost always a property of the input file.
-    DuckDB's Parquet reader refuses a ``geo`` block it cannot parse -- no
+    One of those is worth answering without a traceback: DuckDB's Parquet reader
+    refusing the input. It refuses a ``geo`` block it cannot parse -- no
     ``columns`` object, a non-string ``version``, a column entry with no
     ``encoding`` -- and that block is arbitrary JSON written by somebody else's
     tool, so the refusal is news about the file rather than a gpio bug (#983).
     DuckDB's message says exactly what is wrong, so it is kept verbatim; only
     the traceback around it was noise.
 
+    That is the whole claim, and ``INPUT_FILE_DUCKDB_ERRORS`` is what makes it
+    literally true rather than merely usual: a DuckDB failure gpio *caused*, by
+    generating SQL that will not parse or bind, is not in the tuple and so keeps
+    its traceback.
+
     ``None`` means "not mine": the caller re-raises, traceback intact, which is
     what a genuine gpio bug deserves.
     """
-    import duckdb
-
     from geoparquet_io.core.duckdb_utils import spill_space_hint
 
     # Running out of room to spill is a DuckDB error too, and it needs the extra
     # line naming TMPDIR that DuckDB's own message never mentions. Ask first, so
-    # the generic translation below cannot swallow it.
+    # the translation below cannot swallow it.
     hint = spill_space_hint(exc)
     if hint is not None:
         return click.ClickException(f"{exc}\n\n{hint}")
 
-    if isinstance(exc, duckdb.Error):
+    if isinstance(exc, INPUT_FILE_DUCKDB_ERRORS):
         return click.ClickException(str(exc))
 
     return None

--- a/geoparquet_io/cli/exception_handler.py
+++ b/geoparquet_io/cli/exception_handler.py
@@ -45,6 +45,41 @@ def handle_core_exception(exc: GeoParquetError) -> click.ClickException:
         return click.ClickException(exc.message)
 
 
+def cli_error_for(exc: BaseException) -> click.ClickException | None:
+    """The CLI's answer to an exception no gpio frame owned, or ``None``.
+
+    ``handle_core_exception`` above translates gpio's own vocabulary. This is
+    the other half: exceptions raised *underneath* gpio, by DuckDB, which reach
+    the boundary with nothing in between willing to claim them.
+
+    A ``duckdb.Error`` on a read is almost always a property of the input file.
+    DuckDB's Parquet reader refuses a ``geo`` block it cannot parse -- no
+    ``columns`` object, a non-string ``version``, a column entry with no
+    ``encoding`` -- and that block is arbitrary JSON written by somebody else's
+    tool, so the refusal is news about the file rather than a gpio bug (#983).
+    DuckDB's message says exactly what is wrong, so it is kept verbatim; only
+    the traceback around it was noise.
+
+    ``None`` means "not mine": the caller re-raises, traceback intact, which is
+    what a genuine gpio bug deserves.
+    """
+    import duckdb
+
+    from geoparquet_io.core.duckdb_utils import spill_space_hint
+
+    # Running out of room to spill is a DuckDB error too, and it needs the extra
+    # line naming TMPDIR that DuckDB's own message never mentions. Ask first, so
+    # the generic translation below cannot swallow it.
+    hint = spill_space_hint(exc)
+    if hint is not None:
+        return click.ClickException(f"{exc}\n\n{hint}")
+
+    if isinstance(exc, duckdb.Error):
+        return click.ClickException(str(exc))
+
+    return None
+
+
 def core_exception_handler(func: F) -> F:
     """
     Decorator to catch core exceptions and convert to click exceptions.

--- a/geoparquet_io/cli/exception_handler.py
+++ b/geoparquet_io/cli/exception_handler.py
@@ -12,7 +12,6 @@ from collections.abc import Callable
 from typing import TypeVar
 
 import click
-import duckdb
 
 from geoparquet_io.core.exceptions import (
     FileNotFoundGeoParquetError,
@@ -25,37 +24,6 @@ from geoparquet_io.core.exceptions import (
 )
 
 F = TypeVar("F", bound=Callable)
-
-#: The DuckDB failures whose cause is the *input*, not gpio.
-#:
-#: Enumerated one by one rather than written as a base class, because DuckDB's
-#: hierarchy does not split along this line. Measured against duckdb 1.5.5:
-#: ``InvalidInputException`` -- the one #983 is about -- sits under
-#: ``ProgrammingError`` next to ``ParserException``, ``BinderException`` and
-#: ``CatalogException``, which are its exact opposite, and ``duckdb.Error``'s
-#: only direct subclass is ``DatabaseError``, so every shorthand available is
-#: either too wide or splits the wrong set.
-#:
-#: * ``InvalidInputException`` -- the file's own bytes or metadata are
-#:   unreadable. A ``geo`` block with no ``columns`` object raises this, as do
-#:   all four of #983's reproductions.
-#: * ``IOException`` -- missing, unreachable or unreadable. ``HTTPException``
-#:   hangs below it, so a remote URL that will not fetch is covered too; both
-#:   are properties of the path the user named.
-#: * ``ConversionException`` -- a value the file holds will not cast.
-#:
-#: What is deliberately *not* here is everything gpio itself can get wrong.
-#: gpio authors every SQL string it runs, so ``ParserException``,
-#: ``BinderException`` and ``CatalogException`` are never news about the user's
-#: file and always a bug in a query we generated -- the defect class behind
-#: #700, #718 and #944. Those keep their traceback: answering them with the
-#: same ``Error:`` line used for a bad input would tell a user their data is
-#: broken when the broken thing is ours.
-INPUT_FILE_DUCKDB_ERRORS = (
-    duckdb.InvalidInputException,
-    duckdb.IOException,
-    duckdb.ConversionException,
-)
 
 
 def handle_core_exception(exc: GeoParquetError) -> click.ClickException:
@@ -84,33 +52,47 @@ def cli_error_for(exc: BaseException) -> click.ClickException | None:
     the other half: exceptions raised *underneath* gpio, by DuckDB, which reach
     the boundary with nothing in between willing to claim them.
 
-    One of those is worth answering without a traceback: DuckDB's Parquet reader
-    refusing the input. It refuses a ``geo`` block it cannot parse -- no
-    ``columns`` object, a non-string ``version``, a column entry with no
-    ``encoding`` -- and that block is arbitrary JSON written by somebody else's
-    tool, so the refusal is news about the file rather than a gpio bug (#983).
-    DuckDB's message says exactly what is wrong, so it is kept verbatim; only
-    the traceback around it was noise.
+    It decides nothing itself. Three questions already have an answer in
+    ``core/`` -- is this a spill-volume shortage, an unpublished community
+    extension, or a failure the *input file* caused
+    (:data:`~geoparquet_io.core.duckdb_utils.INPUT_FILE_DUCKDB_ERRORS`, which
+    carries the reasoning for where that line falls) -- and this asks them in
+    order, most specific first, then wraps. Keeping the taxonomy in ``core/`` is
+    what lets ``api/`` reach the same verdict, which it could never do from
+    here: ``api/`` may not import ``cli/``.
 
-    That is the whole claim, and ``INPUT_FILE_DUCKDB_ERRORS`` is what makes it
-    literally true rather than merely usual: a DuckDB failure gpio *caused*, by
-    generating SQL that will not parse or bind, is not in the tuple and so keeps
-    its traceback.
+    Every message is sanitized before it is shown. DuckDB names the URL it
+    failed on with its query string intact, and quotes offending values back
+    verbatim, so a presigned signature or an ANSI escape can ride in from
+    outside gpio -- see
+    :func:`~geoparquet_io.core.exceptions.sanitize_error_message`.
 
     ``None`` means "not mine": the caller re-raises, traceback intact, which is
     what a genuine gpio bug deserves.
     """
-    from geoparquet_io.core.duckdb_utils import spill_space_hint
+    from geoparquet_io.core.duckdb_utils import is_input_file_duckdb_error, spill_space_hint
+    from geoparquet_io.core.exceptions import (
+        sanitize_error_message,
+        unpublished_extension_hint,
+    )
+
+    message = sanitize_error_message(str(exc))
 
     # Running out of room to spill is a DuckDB error too, and it needs the extra
-    # line naming TMPDIR that DuckDB's own message never mentions. Ask first, so
-    # the translation below cannot swallow it.
+    # line naming TMPDIR that DuckDB's own message never mentions (#752).
     hint = spill_space_hint(exc)
     if hint is not None:
-        return click.ClickException(f"{exc}\n\n{hint}")
+        return click.ClickException(f"{message}\n\n{hint}")
 
-    if isinstance(exc, INPUT_FILE_DUCKDB_ERRORS):
-        return click.ClickException(str(exc))
+    # A community extension the registry has no build of arrives as an
+    # HTTPException, which hangs below IOException -- so without this it would
+    # read as "your input file is unreachable" and lose #778's guidance.
+    hint = unpublished_extension_hint(exc)
+    if hint is not None:
+        return click.ClickException(f"{message}\n\n{hint}")
+
+    if is_input_file_duckdb_error(exc):
+        return click.ClickException(message)
 
     return None
 

--- a/geoparquet_io/cli/main.py
+++ b/geoparquet_io/cli/main.py
@@ -16,8 +16,8 @@ from geoparquet_io.cli.commands.process import process
 from geoparquet_io.cli.commands.publish import publish
 from geoparquet_io.cli.commands.sort import sort
 from geoparquet_io.cli.decorators import (
+    ErrorBoundaryGroup,
     GlobAwareCommand,
-    SpillAwareGroup,
     handle_geoparquet_errors,
 )
 from geoparquet_io.core.logging_config import setup_cli_logging
@@ -58,7 +58,7 @@ class OptionalIntCommand(GlobAwareCommand):
 
 
 @with_plugins(entry_points(group="gpio.plugins"))
-@click.group(cls=SpillAwareGroup)
+@click.group(cls=ErrorBoundaryGroup)
 @click.version_option(prog_name="geoparquet-io")
 @click.option("--timestamps", is_flag=True, help="Show timestamps in output messages")
 @click.option(

--- a/geoparquet_io/core/duckdb_utils.py
+++ b/geoparquet_io/core/duckdb_utils.py
@@ -679,6 +679,65 @@ def spill_directory(base_dir: str | os.PathLike | None = None) -> str:
     return os.path.join(base, f"{_SPILL_DIR_PREFIX}{os.getpid()}-{uuid.uuid4().hex[:12]}")
 
 
+#: The DuckDB failures whose cause is the *input*, not gpio.
+#:
+#: This is gpio's one answer to "is this DuckDB error news about the user's
+#: file, or a bug in something we generated?" -- the question the CLI asks
+#: before it replaces a traceback with an error line (#983), and the same
+#: question ``api/`` has to answer without Click, which is why the taxonomy
+#: lives in ``core/`` rather than at the boundary that happens to consume it.
+#:
+#: Enumerated one by one rather than named by a base class, because DuckDB's
+#: hierarchy does not split along this line. Measured against duckdb 1.5.5:
+#: ``InvalidInputException`` sits under ``ProgrammingError`` next to
+#: ``ParserException``, ``BinderException`` and ``CatalogException``, which are
+#: its exact opposite, and ``duckdb.Error``'s only direct subclass is
+#: ``DatabaseError`` -- so every shorthand available is either too wide or
+#: splits the wrong set.
+#:
+#: * ``InvalidInputException`` -- the file's own bytes or metadata are
+#:   unreadable. A ``geo`` block with no ``columns`` object raises this, as do
+#:   all four of #983's reproductions and DuckDB's curved-WKB refusal (#988).
+#: * ``IOException`` -- missing, unreachable or unreadable. ``HTTPException``
+#:   hangs below it, so a remote URL that will not fetch is covered too; both
+#:   are properties of the path the user named.
+#:
+#: What is deliberately *not* here is everything gpio itself can get wrong.
+#: ``ParserException``, ``BinderException`` and ``CatalogException`` are decided
+#: by the SQL text and the schema before a single row is read: they reproduce on
+#: every file, so they are never news about one of them, and always a bug in a
+#: query we generated -- the defect class behind #700, #718 and #944. Those keep
+#: their traceback.
+#:
+#: ``ConversionException`` is not here either, and that is a decision rather
+#: than an oversight: no reproduction reaches an unowned boundary with one.
+#: ``core/convert.py`` already owns the live conversion site with a better
+#: message, and the one refusal known to carry "Conversion Error" in its *text*
+#: -- #988's curved WKB -- is raised as an ``InvalidInputException`` and so is
+#: covered by the first entry anyway. gpio writes every ``CAST`` it runs, so
+#: whether such a failure is the data's fault or gpio's choice of target type is
+#: not decidable from the exception, and membership here has to be decidable.
+INPUT_FILE_DUCKDB_ERRORS = (
+    duckdb.InvalidInputException,
+    duckdb.IOException,
+)
+
+
+def is_input_file_duckdb_error(exc: BaseException) -> bool:
+    """True when `exc` is a DuckDB failure the *input* caused, not gpio.
+
+    Tests the exception itself and not its ``__cause__`` chain, unlike
+    :func:`spill_space_hint` and
+    :func:`~geoparquet_io.core.exceptions.is_unpublished_extension_error`. Those
+    two match on *text*, which survives being re-raised inside a wrapper, so
+    they have to look down the chain to find it. This matches on *class*, and a
+    class that has been wrapped by a gpio frame is no longer unowned: the
+    wrapper is gpio saying what it thinks happened, and its own class is the
+    answer to use.
+    """
+    return isinstance(exc, INPUT_FILE_DUCKDB_ERRORS)
+
+
 #: DuckDB's own words when the *spill volume* fills up. The message it prints is
 #: an "Out of Memory Error" that never mentions ``TMPDIR``, so it sends users
 #: after the one knob that cannot help them; this is the phrase that tells the

--- a/geoparquet_io/core/exceptions.py
+++ b/geoparquet_io/core/exceptions.py
@@ -17,6 +17,8 @@ Exception Hierarchy:
 
 from __future__ import annotations
 
+import re
+
 
 def sanitize_url_for_logging(url: str) -> str:
     """Remove credentials and query params from URL for safe logging.
@@ -42,6 +44,45 @@ def sanitize_url_for_logging(url: str) -> str:
     if len(parts) > 5:
         return "/".join(parts[:4]) + "/..." + "/" + parts[-1]
     return url
+
+
+#: A URL embedded in free text. Quotes are excluded from the body because
+#: DuckDB writes URLs inside single quotes -- ``HTTP GET error on '<url>'`` --
+#: and the closing quote is not part of the URL.
+_URL_IN_TEXT = re.compile(r"[A-Za-z][A-Za-z0-9+.\-]*://[^\s'\"<>]+")
+
+#: A complete ANSI escape sequence, removed whole so no readable tail is left
+#: behind when the introducing ESC goes.
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+#: C0/C1 control characters, minus tab and newline, which error text legitimately
+#: uses. ``\r`` is not spared: on a terminal it rewinds the line and can hide
+#: what was printed before it.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def sanitize_error_message(text: str) -> str:
+    """Make a low-level error message safe to print as gpio's own error line.
+
+    Two things can ride into an error message from outside gpio, and neither is
+    safe to echo verbatim:
+
+    * **Credentials.** DuckDB names the URL it failed on, query string and all
+      -- ``HTTP GET error on 'https://bucket/x.parquet?X-Amz-Signature=...'``.
+      A presigned URL carries its signature there, which is why
+      :func:`sanitize_url_for_logging` exists and is applied at ~25 sites. Every
+      URL in the text goes through it.
+    * **Control characters.** DuckDB quotes the offending value back in a
+      conversion or parse error, so a value a *file* chose reaches the terminal.
+      ANSI escapes in it can rewrite the line, so an input could author a clean
+      ``Error:`` line of its own choosing. They are stripped; tab and newline
+      stay.
+    """
+    if not text:
+        return text
+    text = _URL_IN_TEXT.sub(lambda m: sanitize_url_for_logging(m.group(0)), text)
+    text = _ANSI_ESCAPE.sub("", text)
+    return _CONTROL_CHARS.sub("", text)
 
 
 class GeoParquetError(Exception):
@@ -175,6 +216,43 @@ _UNPUBLISHED_EXTENSION_HINTS = {
         "meanwhile, use `gpio add a5` or `gpio partition a5`."
     ),
 }
+
+
+#: The extension name inside DuckDB's download failure, e.g. ``Failed to
+#: download extension "geography" at URL "..." (HTTP 404)``.
+_EXTENSION_NAME_IN_ERROR = re.compile(r'extension\s+"([^"]+)"')
+
+
+def unpublished_extension_hint(exc: BaseException | str | None) -> str | None:
+    """gpio's guidance for DuckDB's "not published for this version" 404, or ``None``.
+
+    The same shape as
+    :func:`~geoparquet_io.core.duckdb_utils.spill_space_hint`: a paragraph to
+    append to DuckDB's own message, or ``None`` when this is not that failure.
+
+    It exists because the 404 arrives as an ``HTTPException``, which hangs below
+    ``IOException`` and so is otherwise classified as "the input file is
+    unreachable" -- true of the extension registry, useless to a user who named
+    a perfectly good file. :class:`ExtensionUnavailableError` already says the
+    right thing wherever the ``INSTALL`` is wrapped, but three sites are not
+    (``core/duckdb_utils._install_and_load_extension``,
+    ``core/extract_bigquery``, ``core/partition/admin_hierarchical``), and their
+    failures reach the CLI raw.
+    """
+    if not is_unpublished_extension_error(exc):
+        return None
+    match = _EXTENSION_NAME_IN_ERROR.search(exc if isinstance(exc, str) else str(exc))
+    if match is None:
+        return None
+    name = match.group(1)
+    listing = f"https://community-extensions.duckdb.org/extensions/{name}.html"
+    hint = (
+        f"This is the extension registry answering, not your input file: community "
+        f"extensions are built per DuckDB release, and '{name}' is not published for "
+        f"this one (see {listing})."
+    )
+    extra = _UNPUBLISHED_EXTENSION_HINTS.get(name)
+    return f"{hint} {extra}" if extra else hint
 
 
 class ExtensionUnavailableError(GeoParquetError):

--- a/tests/data/cli_surface.json
+++ b/tests/data/cli_surface.json
@@ -1,5 +1,5 @@
 {
- "class": "SpillAwareGroup",
+ "class": "ErrorBoundaryGroup",
  "commands": {
   "add": {
    "class": "Group",

--- a/tests/test_cli_error_boundary.py
+++ b/tests/test_cli_error_boundary.py
@@ -1,0 +1,193 @@
+"""A DuckDB-rejected input gets an error line, not a traceback (#983).
+
+The ``geo`` key on an input file is arbitrary JSON written by somebody else's
+tool, and DuckDB's Parquet reader refuses several shapes of it outright --
+``{"version": "1.1.0"}`` with no ``columns``, a non-string ``version``, a column
+entry with no ``encoding``. That refusal is a property of the *input*, not a
+gpio bug, and DuckDB's message ("Geoparquet metadata does not have a columns
+object") says exactly what is wrong with the file.
+
+``gpio inspect head`` and ``gpio convert geoparquet`` already answered such a
+file with ``Error: <duckdb's message>`` and exit 1. Eleven other commands
+answered it with a raw Python traceback, because the handling lived in per-site
+``except`` blocks rather than at the boundary every command passes through.
+
+The fix is the boundary: the root group converts a ``duckdb.Error`` that nobody
+underneath owned into a ``ClickException``. One funnel, so a command added
+tomorrow inherits it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+
+import click
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.decorators import ErrorBoundaryGroup
+from geoparquet_io.cli.exception_handler import cli_error_for
+from geoparquet_io.cli.main import cli
+
+# One WKB point (1.0, 2.0), little-endian.
+POINT_WKB = struct.pack("<BI2d", 1, 1, 1.0, 2.0)
+
+#: The reproduction from #983: valid JSON, a string version, nothing gpio's own
+#: guards object to, and nothing DuckDB will read.
+DUCKDB_REJECTED_GEO = {"version": "1.1.0"}
+
+
+@pytest.fixture
+def rejected_file(tmp_path):
+    """A real one-row Parquet file whose ``geo`` block DuckDB refuses."""
+    table = pa.table({"id": pa.array([1]), "geometry": pa.array([POINT_WKB], pa.binary())})
+    table = table.replace_schema_metadata({b"geo": json.dumps(DUCKDB_REJECTED_GEO).encode()})
+    path = tmp_path / "rejected.parquet"
+    pq.write_table(table, path)
+    return str(path)
+
+
+def _group_raising(exc: BaseException):
+    """A throwaway root group whose one subcommand raises ``exc``."""
+
+    @click.group(cls=ErrorBoundaryGroup)
+    def root():
+        pass
+
+    @root.command()
+    def boom():
+        raise exc
+
+    return root
+
+
+# =============================================================================
+# The translation itself
+# =============================================================================
+
+
+class TestCliErrorFor:
+    def test_a_duckdb_error_becomes_a_click_exception(self):
+        error = cli_error_for(duckdb.InvalidInputException("Invalid Input Error: no columns"))
+        assert isinstance(error, click.ClickException)
+
+    def test_duckdbs_own_message_is_kept_verbatim(self):
+        message = "Invalid Input Error: Geoparquet metadata does not have a columns object"
+        assert cli_error_for(duckdb.InvalidInputException(message)).format_message() == message
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            duckdb.InvalidInputException("Invalid Input Error: no columns"),
+            duckdb.IOException("IO Error: No files found that match the pattern"),
+            duckdb.BinderException("Binder Error: Referenced column not found"),
+            duckdb.ConversionException("Conversion Error: could not convert"),
+            duckdb.Error("some error"),
+        ],
+    )
+    def test_every_duckdb_error_is_covered_not_just_the_reproductions(self, exc):
+        """The trigger is any input DuckDB refuses, not one particular block."""
+        assert isinstance(cli_error_for(exc), click.ClickException)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [ValueError("bad value"), TypeError("bad type"), RuntimeError("boom")],
+    )
+    def test_a_non_duckdb_error_is_not_claimed(self, exc):
+        """``None`` means "not mine" -- the caller re-raises with its traceback."""
+        assert cli_error_for(exc) is None
+
+    def test_the_spill_hint_still_wins_over_the_generic_translation(self):
+        """An out-of-spill-space failure is a ``duckdb.Error`` too, and it keeps
+        the ``TMPDIR`` line the generic translation would have dropped."""
+        exc = duckdb.OutOfMemoryException(
+            "Out of Memory Error: failed to offload data block of size 256.0 KiB.\n"
+            "This limit was set by the 'max_temp_directory_size' setting."
+        )
+        message = cli_error_for(exc).format_message()
+        assert "TMPDIR" in message
+        assert "failed to offload data block" in message
+
+
+# =============================================================================
+# The boundary the translation is installed on
+# =============================================================================
+
+
+class TestTheRootGroupIsTheBoundary:
+    def test_the_real_cli_group_uses_it(self):
+        assert isinstance(cli, ErrorBoundaryGroup)
+
+    def test_a_duckdb_error_reaches_the_user_as_an_error_line(self):
+        result = CliRunner().invoke(
+            _group_raising(
+                duckdb.InvalidInputException(
+                    "Invalid Input Error: Geoparquet metadata does not have a columns object"
+                )
+            ),
+            ["boom"],
+        )
+
+        assert result.exit_code == 1
+        assert not isinstance(result.exception, duckdb.Error)
+        assert "Error: Invalid Input Error: Geoparquet metadata" in result.output
+        assert "Traceback" not in result.output
+
+    def test_the_original_exception_stays_in_the_cause_chain(self):
+        original = duckdb.IOException("IO Error: nope")
+        result = CliRunner().invoke(_group_raising(original), ["boom"], standalone_mode=False)
+        assert result.exception.__cause__ is original
+
+    def test_a_non_duckdb_error_still_propagates_untouched(self):
+        result = CliRunner().invoke(_group_raising(RuntimeError("a real bug")), ["boom"])
+        assert isinstance(result.exception, RuntimeError)
+
+    def test_the_traceback_is_still_available_at_debug_level(self, caplog):
+        """Nothing is lost: a gpio bug that surfaces as a DuckDB error is still
+        debuggable, it just is not shouted at a user who cannot act on it."""
+        with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
+            CliRunner().invoke(
+                _group_raising(duckdb.BinderException("Binder Error: oops")), ["boom"]
+            )
+
+        assert any(record.exc_info for record in caplog.records)
+
+
+# =============================================================================
+# The four commands the issue reproduces on, end to end
+# =============================================================================
+
+#: #983 reported these four. ``inspect head`` and ``convert geoparquet`` are the
+#: two that already behaved, and are here as the parity the fix matches.
+REPORTED = [
+    ("check optimization", ["check", "optimization", "{in}"]),
+    ("add bbox", ["add", "bbox", "{in}", "{out}"]),
+    ("sort hilbert", ["sort", "hilbert", "{in}", "{out}"]),
+    ("add quadkey", ["add", "quadkey", "{in}", "{out}"]),
+]
+
+ALREADY_CLEAN = [
+    ("inspect head", ["inspect", "head", "{in}"]),
+    ("convert geoparquet", ["convert", "geoparquet", "{in}", "{out}"]),
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "argv"), REPORTED + ALREADY_CLEAN, ids=[n for n, _ in REPORTED + ALREADY_CLEAN]
+)
+def test_a_rejected_file_gets_an_error_line_and_exit_one(name, argv, rejected_file, tmp_path):
+    args = [
+        a.format(**{"in": rejected_file, "out": str(tmp_path / f"{name}.parquet")}) for a in argv
+    ]
+
+    result = CliRunner().invoke(cli, args)
+
+    assert result.exit_code == 1, result.output
+    assert not isinstance(result.exception, duckdb.Error), result.exception
+    assert "Error: " in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_cli_error_boundary.py
+++ b/tests/test_cli_error_boundary.py
@@ -1,27 +1,12 @@
 """A DuckDB-rejected input gets an error line, not a traceback (#983).
 
-The ``geo`` key on an input file is arbitrary JSON written by somebody else's
-tool, and DuckDB's Parquet reader refuses several shapes of it outright --
-``{"version": "1.1.0"}`` with no ``columns``, a non-string ``version``, a column
-entry with no ``encoding``. That refusal is a property of the *input*, not a
-gpio bug, and DuckDB's message ("Geoparquet metadata does not have a columns
-object") says exactly what is wrong with the file.
-
-``gpio inspect head`` and ``gpio convert geoparquet`` already answered such a
-file with ``Error: <duckdb's message>`` and exit 1. Eleven other commands
-answered it with a raw Python traceback, because the handling lived in per-site
-``except`` blocks rather than at the boundary every command passes through.
-
-The fix is the boundary: the root group converts a DuckDB failure that nobody
-underneath owned into a ``ClickException``. One funnel, so a command added
-tomorrow inherits it.
-
-The catch is deliberately *not* ``duckdb.Error``. gpio authors every SQL string
-it runs, so a query that will not parse or bind is a bug in something we
-generated, and answering it with the same ``Error:`` line used for a bad input
-would tell a user their data is broken when the broken thing is ours. Both
-directions are pinned below: the input-caused failures become an error line, and
-the gpio-caused ones keep their traceback.
+The root group converts a DuckDB failure that no gpio frame owned into gpio's
+error line. Which failures those are, and why the set is narrower than
+``duckdb.Error``, is reasoned once on
+:data:`geoparquet_io.core.duckdb_utils.INPUT_FILE_DUCKDB_ERRORS`; this file
+pins the behaviour in both directions -- input-caused failures become an error
+line, gpio-caused ones keep their traceback -- and pins the ``--verbose``
+promise that makes hiding a traceback recoverable.
 """
 
 from __future__ import annotations
@@ -38,9 +23,10 @@ import pyarrow.parquet as pq
 import pytest
 from click.testing import CliRunner
 
-from geoparquet_io.cli.decorators import ErrorBoundaryGroup
-from geoparquet_io.cli.exception_handler import INPUT_FILE_DUCKDB_ERRORS, cli_error_for
+from geoparquet_io.cli.decorators import ErrorBoundaryGroup, verbose_option
+from geoparquet_io.cli.exception_handler import cli_error_for
 from geoparquet_io.cli.main import cli
+from geoparquet_io.core.duckdb_utils import INPUT_FILE_DUCKDB_ERRORS
 
 # One WKB point (1.0, 2.0), little-endian.
 POINT_WKB = struct.pack("<BI2d", 1, 1, 1.0, 2.0)
@@ -58,6 +44,15 @@ def rejected_file(tmp_path):
     path = tmp_path / "rejected.parquet"
     pq.write_table(table, path)
     return str(path)
+
+
+@pytest.fixture
+def restore_log_level():
+    """``configure_verbose`` is one-way and the logger is a module global."""
+    package_logger = logging.getLogger("geoparquet_io")
+    before = package_logger.level
+    yield
+    package_logger.setLevel(before)
 
 
 def _group_raising(exc: BaseException):
@@ -93,16 +88,15 @@ class TestCliErrorFor:
         [
             duckdb.InvalidInputException("Invalid Input Error: no columns"),
             duckdb.IOException("IO Error: No files found that match the pattern"),
-            duckdb.HTTPException("HTTP Error: 404"),
-            duckdb.ConversionException("Conversion Error: could not convert"),
+            duckdb.HTTPException("HTTP Error: 403 Forbidden"),
         ],
     )
     def test_every_input_caused_failure_is_covered_not_just_the_reproductions(self, exc):
         """The trigger is any input DuckDB refuses, not one particular block.
 
-        ``HTTPException`` is in the list because it hangs below ``IOException``:
-        a remote URL that will not fetch is a property of the path the user
-        named, and ``isinstance`` picks it up without a separate entry.
+        ``HTTPException`` is covered because it hangs below ``IOException``: a
+        remote URL that will not fetch is a property of the path the user named,
+        and ``isinstance`` picks it up without a separate entry.
         """
         assert isinstance(cli_error_for(exc), click.ClickException)
 
@@ -150,6 +144,20 @@ class TestCliErrorFor:
 
         assert cli_error_for(raised.value) is None
 
+    def test_the_tuple_cannot_be_collapsed_to_a_shared_base_class(self):
+        """Why the entries are enumerated instead of named by an ancestor.
+
+        A tripwire on duckdb's own class tree rather than on gpio's code: if
+        duckdb ever reorganises so that an ancestor *does* split along this
+        line, the enumeration can be replaced -- and until then, any base class
+        wide enough to include ``InvalidInputException`` is wide enough to
+        include the three classes that are its opposite.
+        """
+        assert issubclass(duckdb.InvalidInputException, duckdb.ProgrammingError)
+        for gpio_authored in (duckdb.ParserException, duckdb.BinderException):
+            assert issubclass(gpio_authored, duckdb.ProgrammingError)
+            assert not issubclass(gpio_authored, INPUT_FILE_DUCKDB_ERRORS)
+
     def test_the_spill_hint_still_wins_over_the_generic_translation(self):
         """An out-of-spill-space failure is a ``duckdb.Error`` too, and it keeps
         the ``TMPDIR`` line the generic translation would have dropped."""
@@ -160,6 +168,101 @@ class TestCliErrorFor:
         message = cli_error_for(exc).format_message()
         assert "TMPDIR" in message
         assert "failed to offload data block" in message
+
+
+class TestAnUnpublishedExtensionIsNotABadInputFile:
+    """A 404 from the extension registry hangs below ``IOException`` (#778).
+
+    Without asking first, ``INSTALL geography FROM community`` failing because
+    the registry has no build for this platform would be answered with the line
+    gpio uses for "your input file is unreachable" -- and lose the guidance
+    ``_UNPUBLISHED_EXTENSION_HINTS`` exists to give. Three ``INSTALL`` sites are
+    unwrapped (``core/duckdb_utils._install_and_load_extension``,
+    ``core/extract_bigquery``, ``core/partition/admin_hierarchical``), so their
+    failures arrive here raw.
+    """
+
+    NOT_PUBLISHED = (
+        'HTTP Error: Failed to download extension "geography" at URL '
+        '"https://community-extensions.duckdb.org/v1.5.5/osx_arm64/geography.duckdb_extension.gz" '
+        "(HTTP 404)"
+    )
+
+    def test_the_404_is_named_as_the_registry_not_the_input(self):
+        message = cli_error_for(duckdb.HTTPException(self.NOT_PUBLISHED)).format_message()
+        assert "not your input file" in message
+        assert "not published for this one" in message
+
+    def test_the_extension_specific_hint_survives(self):
+        message = cli_error_for(duckdb.HTTPException(self.NOT_PUBLISHED)).format_message()
+        assert "gpio add a5" in message
+
+    def test_a_remote_input_file_that_404s_is_still_a_bad_input_file(self):
+        """The guard that keeps the check from over-claiming.
+
+        ``is_unpublished_extension_error`` matches on "http 404" anywhere in the
+        message, and a remote *input* that is simply not there 404s too. Naming
+        an extension is what separates the two, so a missing file keeps the
+        plain error line and gets no advice about the extension registry.
+        """
+        missing = duckdb.HTTPException(
+            "HTTP Error: HTTP GET error on 'https://host/missing.parquet' (HTTP 404)"
+        )
+        error = cli_error_for(missing)
+
+        assert error is not None
+        assert "community-extensions" not in error.format_message()
+        assert error.format_message().endswith("(HTTP 404)")
+
+    def test_an_offline_download_failure_is_not_blamed_on_the_registry(self):
+        """#778's own distinction: only the 404 means "no build exists"."""
+        offline = duckdb.IOException(
+            'IO Error: Failed to download extension "geography" at URL '
+            '"https://community-extensions.duckdb.org/..." '
+            "(ERROR Could not establish connection)"
+        )
+        message = cli_error_for(offline).format_message()
+        assert "not published" not in message
+
+
+class TestTheMessageIsSanitized:
+    """DuckDB's message carries text gpio did not author (#983 review).
+
+    Pre-existing at every other site that prints one -- ``cli_error_for`` is
+    where it can be fixed once, because it is the single funnel.
+    """
+
+    def test_a_presigned_signature_does_not_reach_the_error_line(self):
+        exc = duckdb.HTTPException(
+            "HTTP GET error on 'https://bucket.s3.amazonaws.com/data/x.parquet"
+            "?X-Amz-Credential=AKIAEXAMPLE&X-Amz-Signature=deadbeefsecret' (HTTP 403)"
+        )
+        message = cli_error_for(exc).format_message()
+
+        assert "deadbeefsecret" not in message
+        assert "X-Amz-Credential" not in message
+        assert "x.parquet" in message, "the filename is what makes the message useful"
+
+    def test_a_url_without_a_query_string_is_left_readable(self):
+        exc = duckdb.IOException("IO Error: No files found for 'https://host/a.parquet'")
+        assert "https://host/a.parquet" in cli_error_for(exc).format_message()
+
+    def test_an_input_cannot_author_the_error_line_with_ansi_escapes(self):
+        """A value the *file* chose is quoted back verbatim by DuckDB. With the
+        escapes intact it could rewind the line and print an ``Error:`` of its
+        own choosing."""
+        exc = duckdb.InvalidInputException(
+            "Invalid Input Error: bad value '\x1b[2K\rError: everything is fine\x1b[0m'"
+        )
+        message = cli_error_for(exc).format_message()
+
+        assert "\x1b" not in message
+        assert "\r" not in message
+        assert "[2K" not in message, "the escape has to go whole, not just its introducer"
+
+    def test_a_tab_or_newline_is_not_stripped(self):
+        exc = duckdb.InvalidInputException("Invalid Input Error: a\n\tb")
+        assert cli_error_for(exc).format_message() == "Invalid Input Error: a\n\tb"
 
 
 # =============================================================================
@@ -212,66 +315,52 @@ class TestTheRootGroupIsTheBoundary:
         assert isinstance(result.exception, duckdb.ParserException)
         assert not isinstance(result.exception, click.ClickException)
 
-    def test_the_traceback_is_still_available_at_debug_level(self, caplog):
-        """Nothing is lost: the hidden traceback is logged, not dropped."""
-        with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
-            CliRunner().invoke(
-                _group_raising(duckdb.InvalidInputException("Invalid Input Error: oops")), ["boom"]
-            )
 
-        assert any(record.exc_info for record in caplog.records)
+class TestVerboseRestoresTheHiddenTraceback:
+    """Hiding a traceback is only acceptable if it is recoverable.
 
-
-class TestInnerHandlersStillRunFirst:
-    """The boundary is outermost, so it never preempts a recovery (#988).
-
-    ``convert`` identifies DuckDB's curved-geometry refusal by matching
-    "Unsupported geometry type in WKB" on the exception, linearizes the source
-    and writes again. That error is an ``InvalidInputException``, which is
-    exactly what ``INPUT_FILE_DUCKDB_ERRORS`` claims -- so if the boundary ran
-    anywhere but last, it would convert the error into a ``ClickException`` and
-    the retry would never happen. It runs last because it lives on
-    ``Group.invoke``, and these pin that rather than trusting it.
+    It was not, on four of the eleven commands, until ``--verbose`` stopped
+    depending on the failing path having reached a core function first. See
+    :func:`geoparquet_io.cli.decorators.enable_verbose_logging`.
     """
 
-    #: The real string ``_is_linearizable_curve_error`` matches on, and the real
-    #: class DuckDB raises with it -- both measured against the curved FileGDB
-    #: fixture, not invented here.
-    CURVE_REFUSAL = "Conversion Error: Unsupported geometry type in WKB"
+    #: The four that were measured *not* to restore it before the flag's own
+    #: callback raised the level (their paths fail before any
+    #: ``configure_verbose`` call), plus one that did, so a regression in either
+    #: direction shows up.
+    COMMANDS = [
+        ("add bbox", ["add", "bbox", "{in}", "{out}"]),
+        ("sort hilbert", ["sort", "hilbert", "{in}", "{out}"]),
+        ("extract geoparquet", ["extract", "geoparquet", "{in}", "{out}"]),
+        ("add geometry-metrics", ["add", "geometry-metrics", "{in}", "{out}"]),
+        ("check optimization", ["check", "optimization", "{in}"]),
+    ]
 
-    def test_the_curve_refusal_is_a_class_the_boundary_would_otherwise_claim(self):
-        """Without this being true, the tests below would prove nothing."""
-        exc = duckdb.InvalidInputException(self.CURVE_REFUSAL)
-        assert isinstance(exc, INPUT_FILE_DUCKDB_ERRORS)
-        assert cli_error_for(exc) is not None
+    @pytest.mark.usefixtures("restore_log_level")
+    @pytest.mark.parametrize(("name", "argv"), COMMANDS, ids=[n for n, _ in COMMANDS])
+    def test_verbose_prints_the_traceback_the_error_line_replaced(
+        self, name, argv, rejected_file, tmp_path
+    ):
+        args = [
+            a.format(**{"in": rejected_file, "out": str(tmp_path / f"{name}-v.parquet")})
+            for a in argv
+        ]
 
-    def test_an_inner_handler_recovers_before_the_boundary_sees_it(self):
-        """A command that catches and recovers still succeeds, untouched."""
-        attempts = []
+        quiet = CliRunner().invoke(cli, args)
+        verbose = CliRunner().invoke(cli, [*args, "--verbose"])
 
-        @click.group(cls=ErrorBoundaryGroup)
-        def root():
-            pass
+        assert quiet.exit_code == 1 and "Traceback" not in quiet.output
+        assert verbose.exit_code == 1, verbose.output
+        assert "Traceback (most recent call last)" in verbose.output, verbose.output
+        assert "InvalidInputException" in verbose.output
 
-        @root.command()
-        def convert():
-            try:
-                attempts.append("first")
-                raise duckdb.InvalidInputException(TestInnerHandlersStillRunFirst.CURVE_REFUSAL)
-            except duckdb.Error as e:
-                if "Unsupported geometry type in WKB" not in str(e):
-                    raise
-                attempts.append("linearized retry")
-
-        result = CliRunner().invoke(root, ["convert"])
-
-        assert result.exit_code == 0, result.output
-        assert attempts == ["first", "linearized retry"]
-
-    def test_the_inner_handler_sees_the_raw_exception_not_a_click_exception(self):
-        """The retry matches on the message and the DuckDB class. Both have to
-        arrive intact -- a reshaped exception would silently stop matching and
-        the fallback would turn into a hard failure."""
+    @pytest.mark.usefixtures("restore_log_level")
+    def test_the_flag_raises_the_level_before_the_command_body_runs(self):
+        """The mechanism, without a failure in the way: by the time any gpio
+        code runs, DEBUG is already on. Nothing inside the command is asked to
+        arrange it, which is exactly what the four commands above could not do.
+        """
+        logging.getLogger("geoparquet_io").setLevel(logging.INFO)
         seen = {}
 
         @click.group(cls=ErrorBoundaryGroup)
@@ -279,17 +368,47 @@ class TestInnerHandlersStillRunFirst:
             pass
 
         @root.command()
-        def convert():
-            try:
-                raise duckdb.InvalidInputException(TestInnerHandlersStillRunFirst.CURVE_REFUSAL)
-            except Exception as e:
-                seen["type"] = type(e)
-                seen["message"] = str(e)
+        @verbose_option
+        def noisy(verbose):
+            seen["level"] = logging.getLogger("geoparquet_io").level
 
-        CliRunner().invoke(root, ["convert"])
+        CliRunner().invoke(root, ["noisy", "--verbose"])
 
-        assert seen["type"] is duckdb.InvalidInputException
-        assert "Unsupported geometry type in WKB" in seen["message"]
+        assert seen["level"] == logging.DEBUG
+
+    def test_verbose_is_a_per_command_flag(self, rejected_file):
+        """Where it goes, pinned so the docs and the PR cannot drift from it:
+        the root group has no ``--verbose``, so before the subcommand it is a
+        usage error, not a quiet no-op."""
+        result = CliRunner().invoke(cli, ["--verbose", "check", "optimization", rejected_file])
+
+        assert result.exit_code == 2
+        assert "No such option" in result.output and "--verbose" in result.output
+
+
+class TestInnerHandlersStillRunFirst:
+    """The boundary is outermost, so it never preempts a recovery (#988).
+
+    ``convert`` identifies DuckDB's curved-geometry refusal by matching
+    "Unsupported geometry type in WKB" on the exception, linearizes the source
+    and writes again. That refusal is an ``InvalidInputException``, which is
+    exactly what ``INPUT_FILE_DUCKDB_ERRORS`` claims -- so if the boundary ran
+    anywhere but last, it would convert the error into a ``ClickException`` and
+    the retry would never happen.
+    """
+
+    #: Measured, all of it, against ``tests/data/curved_geometry_test.gdb``:
+    #: ``ST_AsWKB(geom)`` over ``ST_Read`` on that fixture raises
+    #: ``duckdb.InvalidInputException`` with exactly this message. The substring
+    #: ``_is_linearizable_curve_error`` matches on is the tail of it; the
+    #: "Invalid Input Error:" prefix is DuckDB's, not this test's.
+    CURVE_REFUSAL = "Invalid Input Error: Unsupported geometry type in WKB"
+
+    def test_the_curve_refusal_is_a_class_the_boundary_would_otherwise_claim(self):
+        """Without this being true, the test below would prove nothing."""
+        exc = duckdb.InvalidInputException(self.CURVE_REFUSAL)
+        assert isinstance(exc, INPUT_FILE_DUCKDB_ERRORS)
+        assert cli_error_for(exc) is not None
 
     def test_the_real_curved_filegdb_still_converts_through_the_boundary(self, tmp_path):
         """End to end on #988's own fixture, through the real ``cli``.
@@ -332,38 +451,6 @@ class TestInnerHandlersStillRunFirst:
         assert "Traceback" not in result.output
 
 
-class TestTheLineTheTupleDraws:
-    """Guards on ``INPUT_FILE_DUCKDB_ERRORS`` itself.
-
-    The first version of this fix caught ``duckdb.Error``, which is every DuckDB
-    failure there is -- its only direct subclass is ``DatabaseError`` and
-    everything hangs below that. These pin the narrowing so it cannot be widened
-    back without a failing test.
-    """
-
-    def test_it_is_not_the_base_class_in_disguise(self):
-        assert duckdb.Error not in INPUT_FILE_DUCKDB_ERRORS
-        assert duckdb.DatabaseError not in INPUT_FILE_DUCKDB_ERRORS
-
-    @pytest.mark.parametrize(
-        "gpio_authored",
-        [duckdb.ParserException, duckdb.BinderException, duckdb.CatalogException],
-    )
-    def test_gpio_authored_sql_failures_are_excluded(self, gpio_authored):
-        assert not issubclass(gpio_authored, INPUT_FILE_DUCKDB_ERRORS)
-
-    def test_the_tuple_cannot_be_collapsed_to_a_shared_base_class(self):
-        """Why the entries are enumerated instead of named by an ancestor.
-
-        Measured against duckdb 1.5.5: ``InvalidInputException`` shares
-        ``ProgrammingError`` with the three classes above, so any base class
-        wide enough to include the first is wide enough to include the others.
-        """
-        assert issubclass(duckdb.InvalidInputException, duckdb.ProgrammingError)
-        for gpio_authored in (duckdb.ParserException, duckdb.BinderException):
-            assert issubclass(gpio_authored, duckdb.ProgrammingError)
-
-
 # =============================================================================
 # The four commands the issue reproduces on, end to end
 # =============================================================================
@@ -387,6 +474,15 @@ ALREADY_CLEAN = [
     ("name", "argv"), REPORTED + ALREADY_CLEAN, ids=[n for n, _ in REPORTED + ALREADY_CLEAN]
 )
 def test_a_rejected_file_gets_an_error_line_and_exit_one(name, argv, rejected_file, tmp_path):
+    """Both halves in one pass: what the user sees, and what it was underneath.
+
+    The class matters because the fix only keeps #983 fixed if the exception
+    these four really raise is in ``INPUT_FILE_DUCKDB_ERRORS`` -- so a future
+    narrowing that excluded one of them fails loudly here rather than quietly
+    restoring a traceback. ``standalone_mode=False`` is what leaves the
+    ``ClickException`` itself in reach; under the default Click has already
+    turned it into the ``SystemExit`` that carries exit code 1.
+    """
     args = [
         a.format(**{"in": rejected_file, "out": str(tmp_path / f"{name}.parquet")}) for a in argv
     ]
@@ -398,28 +494,7 @@ def test_a_rejected_file_gets_an_error_line_and_exit_one(name, argv, rejected_fi
     assert "Error: " in result.output
     assert "Traceback" not in result.output
 
-
-@pytest.mark.parametrize(("name", "argv"), REPORTED, ids=[n for n, _ in REPORTED])
-def test_each_reported_command_fails_with_an_error_the_narrowed_tuple_admits(
-    name, argv, rejected_file, tmp_path
-):
-    """The narrowing keeps #983 fixed *because* of what DuckDB actually raises.
-
-    The four reproductions are only covered if their underlying class is in
-    ``INPUT_FILE_DUCKDB_ERRORS``. That is checked here against the exception the
-    boundary wrapped, so a future narrowing that excluded one of them would fail
-    loudly rather than quietly restoring a traceback.
-    """
-    args = [
-        a.format(**{"in": rejected_file, "out": str(tmp_path / f"{name}-cause.parquet")})
-        for a in argv
-    ]
-
-    # standalone_mode=False so the ClickException itself surfaces; under the
-    # default, Click has already turned it into the SystemExit that carries
-    # exit code 1, and the cause chain is one frame further down.
-    result = CliRunner().invoke(cli, args, standalone_mode=False)
-    cause = result.exception.__cause__
-
-    assert isinstance(cause, duckdb.InvalidInputException), f"{name}: {cause!r}"
-    assert isinstance(cause, INPUT_FILE_DUCKDB_ERRORS)
+    if (name, argv) in REPORTED:
+        cause = CliRunner().invoke(cli, args, standalone_mode=False).exception.__cause__
+        assert isinstance(cause, duckdb.InvalidInputException), f"{name}: {cause!r}"
+        assert isinstance(cause, INPUT_FILE_DUCKDB_ERRORS)

--- a/tests/test_cli_error_boundary.py
+++ b/tests/test_cli_error_boundary.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+import pathlib
 import struct
 
 import click
@@ -219,6 +220,116 @@ class TestTheRootGroupIsTheBoundary:
             )
 
         assert any(record.exc_info for record in caplog.records)
+
+
+class TestInnerHandlersStillRunFirst:
+    """The boundary is outermost, so it never preempts a recovery (#988).
+
+    ``convert`` identifies DuckDB's curved-geometry refusal by matching
+    "Unsupported geometry type in WKB" on the exception, linearizes the source
+    and writes again. That error is an ``InvalidInputException``, which is
+    exactly what ``INPUT_FILE_DUCKDB_ERRORS`` claims -- so if the boundary ran
+    anywhere but last, it would convert the error into a ``ClickException`` and
+    the retry would never happen. It runs last because it lives on
+    ``Group.invoke``, and these pin that rather than trusting it.
+    """
+
+    #: The real string ``_is_linearizable_curve_error`` matches on, and the real
+    #: class DuckDB raises with it -- both measured against the curved FileGDB
+    #: fixture, not invented here.
+    CURVE_REFUSAL = "Conversion Error: Unsupported geometry type in WKB"
+
+    def test_the_curve_refusal_is_a_class_the_boundary_would_otherwise_claim(self):
+        """Without this being true, the tests below would prove nothing."""
+        exc = duckdb.InvalidInputException(self.CURVE_REFUSAL)
+        assert isinstance(exc, INPUT_FILE_DUCKDB_ERRORS)
+        assert cli_error_for(exc) is not None
+
+    def test_an_inner_handler_recovers_before_the_boundary_sees_it(self):
+        """A command that catches and recovers still succeeds, untouched."""
+        attempts = []
+
+        @click.group(cls=ErrorBoundaryGroup)
+        def root():
+            pass
+
+        @root.command()
+        def convert():
+            try:
+                attempts.append("first")
+                raise duckdb.InvalidInputException(TestInnerHandlersStillRunFirst.CURVE_REFUSAL)
+            except duckdb.Error as e:
+                if "Unsupported geometry type in WKB" not in str(e):
+                    raise
+                attempts.append("linearized retry")
+
+        result = CliRunner().invoke(root, ["convert"])
+
+        assert result.exit_code == 0, result.output
+        assert attempts == ["first", "linearized retry"]
+
+    def test_the_inner_handler_sees_the_raw_exception_not_a_click_exception(self):
+        """The retry matches on the message and the DuckDB class. Both have to
+        arrive intact -- a reshaped exception would silently stop matching and
+        the fallback would turn into a hard failure."""
+        seen = {}
+
+        @click.group(cls=ErrorBoundaryGroup)
+        def root():
+            pass
+
+        @root.command()
+        def convert():
+            try:
+                raise duckdb.InvalidInputException(TestInnerHandlersStillRunFirst.CURVE_REFUSAL)
+            except Exception as e:
+                seen["type"] = type(e)
+                seen["message"] = str(e)
+
+        CliRunner().invoke(root, ["convert"])
+
+        assert seen["type"] is duckdb.InvalidInputException
+        assert "Unsupported geometry type in WKB" in seen["message"]
+
+    def test_the_real_curved_filegdb_still_converts_through_the_boundary(self, tmp_path):
+        """End to end on #988's own fixture, through the real ``cli``.
+
+        ``--skip-hilbert`` removes the bounds pass, so the curve refusal happens
+        on the write and only the retry can rescue it. Exit 0 here means the
+        boundary let the recovery run; a regression would show up as exit 1 with
+        DuckDB's message on a file that used to convert.
+        """
+        gdb = pathlib.Path(__file__).parent / "data" / "curved_geometry_test.gdb"
+        if not gdb.exists():  # pragma: no cover - fixture ships with the repo
+            pytest.skip("curved FileGDB fixture not present")
+
+        out = tmp_path / "curved.parquet"
+        result = CliRunner().invoke(cli, ["convert", str(gdb), str(out), "--skip-hilbert"])
+
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+
+    def test_a_refusal_the_inner_handler_declines_still_becomes_an_error_line(self):
+        """The other half of the contract: what the recovery re-raises (a
+        Parquet input, or ``--no-linearize-curves``) is still input-caused, so
+        it gets the error line rather than a traceback."""
+
+        @click.group(cls=ErrorBoundaryGroup)
+        def root():
+            pass
+
+        @root.command()
+        def convert():
+            try:
+                raise duckdb.InvalidInputException(TestInnerHandlersStillRunFirst.CURVE_REFUSAL)
+            except duckdb.Error:
+                raise  # --no-linearize-curves: the fallback is off
+
+        result = CliRunner().invoke(root, ["convert"])
+
+        assert result.exit_code == 1
+        assert "Unsupported geometry type in WKB" in result.output
+        assert "Traceback" not in result.output
 
 
 class TestTheLineTheTupleDraws:

--- a/tests/test_cli_error_boundary.py
+++ b/tests/test_cli_error_boundary.py
@@ -12,9 +12,16 @@ file with ``Error: <duckdb's message>`` and exit 1. Eleven other commands
 answered it with a raw Python traceback, because the handling lived in per-site
 ``except`` blocks rather than at the boundary every command passes through.
 
-The fix is the boundary: the root group converts a ``duckdb.Error`` that nobody
+The fix is the boundary: the root group converts a DuckDB failure that nobody
 underneath owned into a ``ClickException``. One funnel, so a command added
 tomorrow inherits it.
+
+The catch is deliberately *not* ``duckdb.Error``. gpio authors every SQL string
+it runs, so a query that will not parse or bind is a bug in something we
+generated, and answering it with the same ``Error:`` line used for a bad input
+would tell a user their data is broken when the broken thing is ours. Both
+directions are pinned below: the input-caused failures become an error line, and
+the gpio-caused ones keep their traceback.
 """
 
 from __future__ import annotations
@@ -31,7 +38,7 @@ import pytest
 from click.testing import CliRunner
 
 from geoparquet_io.cli.decorators import ErrorBoundaryGroup
-from geoparquet_io.cli.exception_handler import cli_error_for
+from geoparquet_io.cli.exception_handler import INPUT_FILE_DUCKDB_ERRORS, cli_error_for
 from geoparquet_io.cli.main import cli
 
 # One WKB point (1.0, 2.0), little-endian.
@@ -85,13 +92,17 @@ class TestCliErrorFor:
         [
             duckdb.InvalidInputException("Invalid Input Error: no columns"),
             duckdb.IOException("IO Error: No files found that match the pattern"),
-            duckdb.BinderException("Binder Error: Referenced column not found"),
+            duckdb.HTTPException("HTTP Error: 404"),
             duckdb.ConversionException("Conversion Error: could not convert"),
-            duckdb.Error("some error"),
         ],
     )
-    def test_every_duckdb_error_is_covered_not_just_the_reproductions(self, exc):
-        """The trigger is any input DuckDB refuses, not one particular block."""
+    def test_every_input_caused_failure_is_covered_not_just_the_reproductions(self, exc):
+        """The trigger is any input DuckDB refuses, not one particular block.
+
+        ``HTTPException`` is in the list because it hangs below ``IOException``:
+        a remote URL that will not fetch is a property of the path the user
+        named, and ``isinstance`` picks it up without a separate entry.
+        """
         assert isinstance(cli_error_for(exc), click.ClickException)
 
     @pytest.mark.parametrize(
@@ -101,6 +112,42 @@ class TestCliErrorFor:
     def test_a_non_duckdb_error_is_not_claimed(self, exc):
         """``None`` means "not mine" -- the caller re-raises with its traceback."""
         assert cli_error_for(exc) is None
+
+    @pytest.mark.parametrize(
+        ("sql", "expected"),
+        [
+            ("SELECT 1 +", duckdb.ParserException),
+            ("SELECT nonexistent_col FROM range(1)", duckdb.BinderException),
+            ("SELECT st_nosuchfunc(1)", duckdb.CatalogException),
+            ("SELECT o'brien FROM range(1)", duckdb.ParserException),
+        ],
+    )
+    def test_a_query_gpio_got_wrong_keeps_its_traceback(self, sql, expected):
+        """The negative direction, and the reason the tuple is not ``duckdb.Error``.
+
+        gpio authors every SQL string it runs, so a query that will not parse or
+        bind is never news about the user's file -- it is a bug in something we
+        generated, which is the defect class behind #700, #718 and #944. Raised
+        by really executing the bad SQL rather than by constructing the
+        exception, so the class is DuckDB's answer and not this test's guess.
+        """
+        with pytest.raises(expected) as raised:
+            duckdb.connect().execute(sql)
+
+        assert cli_error_for(raised.value) is None
+
+    def test_the_unquoted_identifier_defect_is_not_reported_as_a_bad_file(self):
+        """The concrete misattribution the narrowing prevents.
+
+        A name with an apostrophe that reached the SQL unquoted is #718's exact
+        shape. Answering it with ``Error:`` -- the line gpio uses to say "your
+        file is bad" -- would send the user looking at their data for a bug that
+        is ours.
+        """
+        with pytest.raises(duckdb.Error) as raised:
+            duckdb.connect().execute("SELECT * FROM range(1) WHERE 'o'brien' = 1")
+
+        assert cli_error_for(raised.value) is None
 
     def test_the_spill_hint_still_wins_over_the_generic_translation(self):
         """An out-of-spill-space failure is a ``duckdb.Error`` too, and it keeps
@@ -147,15 +194,63 @@ class TestTheRootGroupIsTheBoundary:
         result = CliRunner().invoke(_group_raising(RuntimeError("a real bug")), ["boom"])
         assert isinstance(result.exception, RuntimeError)
 
+    def test_a_command_whose_sql_will_not_parse_still_propagates(self):
+        """End to end, through the real boundary: a gpio-authored query that
+        DuckDB rejects must not come out looking like a bad input file."""
+
+        @click.group(cls=ErrorBoundaryGroup)
+        def root():
+            pass
+
+        @root.command()
+        def boom():
+            duckdb.connect().execute("SELECT 1 +")
+
+        result = CliRunner().invoke(root, ["boom"])
+
+        assert isinstance(result.exception, duckdb.ParserException)
+        assert not isinstance(result.exception, click.ClickException)
+
     def test_the_traceback_is_still_available_at_debug_level(self, caplog):
-        """Nothing is lost: a gpio bug that surfaces as a DuckDB error is still
-        debuggable, it just is not shouted at a user who cannot act on it."""
+        """Nothing is lost: the hidden traceback is logged, not dropped."""
         with caplog.at_level(logging.DEBUG, logger="geoparquet_io"):
             CliRunner().invoke(
-                _group_raising(duckdb.BinderException("Binder Error: oops")), ["boom"]
+                _group_raising(duckdb.InvalidInputException("Invalid Input Error: oops")), ["boom"]
             )
 
         assert any(record.exc_info for record in caplog.records)
+
+
+class TestTheLineTheTupleDraws:
+    """Guards on ``INPUT_FILE_DUCKDB_ERRORS`` itself.
+
+    The first version of this fix caught ``duckdb.Error``, which is every DuckDB
+    failure there is -- its only direct subclass is ``DatabaseError`` and
+    everything hangs below that. These pin the narrowing so it cannot be widened
+    back without a failing test.
+    """
+
+    def test_it_is_not_the_base_class_in_disguise(self):
+        assert duckdb.Error not in INPUT_FILE_DUCKDB_ERRORS
+        assert duckdb.DatabaseError not in INPUT_FILE_DUCKDB_ERRORS
+
+    @pytest.mark.parametrize(
+        "gpio_authored",
+        [duckdb.ParserException, duckdb.BinderException, duckdb.CatalogException],
+    )
+    def test_gpio_authored_sql_failures_are_excluded(self, gpio_authored):
+        assert not issubclass(gpio_authored, INPUT_FILE_DUCKDB_ERRORS)
+
+    def test_the_tuple_cannot_be_collapsed_to_a_shared_base_class(self):
+        """Why the entries are enumerated instead of named by an ancestor.
+
+        Measured against duckdb 1.5.5: ``InvalidInputException`` shares
+        ``ProgrammingError`` with the three classes above, so any base class
+        wide enough to include the first is wide enough to include the others.
+        """
+        assert issubclass(duckdb.InvalidInputException, duckdb.ProgrammingError)
+        for gpio_authored in (duckdb.ParserException, duckdb.BinderException):
+            assert issubclass(gpio_authored, duckdb.ProgrammingError)
 
 
 # =============================================================================
@@ -191,3 +286,29 @@ def test_a_rejected_file_gets_an_error_line_and_exit_one(name, argv, rejected_fi
     assert not isinstance(result.exception, duckdb.Error), result.exception
     assert "Error: " in result.output
     assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(("name", "argv"), REPORTED, ids=[n for n, _ in REPORTED])
+def test_each_reported_command_fails_with_an_error_the_narrowed_tuple_admits(
+    name, argv, rejected_file, tmp_path
+):
+    """The narrowing keeps #983 fixed *because* of what DuckDB actually raises.
+
+    The four reproductions are only covered if their underlying class is in
+    ``INPUT_FILE_DUCKDB_ERRORS``. That is checked here against the exception the
+    boundary wrapped, so a future narrowing that excluded one of them would fail
+    loudly rather than quietly restoring a traceback.
+    """
+    args = [
+        a.format(**{"in": rejected_file, "out": str(tmp_path / f"{name}-cause.parquet")})
+        for a in argv
+    ]
+
+    # standalone_mode=False so the ClickException itself surfaces; under the
+    # default, Click has already turned it into the SystemExit that carries
+    # exit code 1, and the cause chain is one frame further down.
+    result = CliRunner().invoke(cli, args, standalone_mode=False)
+    cause = result.exception.__cause__
+
+    assert isinstance(cause, duckdb.InvalidInputException), f"{name}: {cause!r}"
+    assert isinstance(cause, INPUT_FILE_DUCKDB_ERRORS)

--- a/tests/test_malformed_geo_metadata.py
+++ b/tests/test_malformed_geo_metadata.py
@@ -2222,13 +2222,29 @@ KNOWN_UNGUARDED: dict[str, set[str]] = {
 
 #: One column name only: the sweep's job is breadth across *commands*, and the
 #: `geometry`-versus-`geom` axis is covered per reader above.
-SWEEP_SHAPES = [(case, block) for col, case, block in MALFORMED_BLOCKS if col == "geometry"] + [
-    (f"version_is_{case}", _version_block(bad)) for case, bad in NON_STRING_VERSIONS[2:]
-]
+#:
+#: `no_columns_key` is #983's reproduction and is not one of `MALFORMED_BLOCKS`:
+#: nothing about it is malformed as far as *gpio* is concerned -- valid JSON, a
+#: string version, no key of a shape any guard here objects to. It is DuckDB's
+#: Parquet reader that refuses it, which is the whole point of the second
+#: assertion below.
+SWEEP_SHAPES = (
+    [("no_columns_key", {"version": "1.1.0"})]
+    + [(case, block) for col, case, block in MALFORMED_BLOCKS if col == "geometry"]
+    + [(f"version_is_{case}", _version_block(bad)) for case, bad in NON_STRING_VERSIONS[2:]]
+)
 
 
 @pytest.mark.parametrize(("case", "block"), SWEEP_SHAPES, ids=[c for c, _ in SWEEP_SHAPES])
-def test_no_command_dies_with_a_raw_type_error_on_a_malformed_block(case, block, tmp_path):
+def test_no_command_dies_with_a_raw_exception_on_a_malformed_block(case, block, tmp_path):
+    """Two ways the same file can end in a traceback, caught in one pass.
+
+    A raw ``TypeError``/``AttributeError`` is gpio indexing into a block it did
+    not check (#883, #979). A raw ``duckdb.Error`` is the layer underneath:
+    DuckDB's Parquet reader refuses the block outright, and eleven commands let
+    that refusal out as a traceback because the translation to an error line
+    lived in per-site ``except`` blocks instead of at the CLI boundary (#983).
+    """
     from click.testing import CliRunner
 
     from geoparquet_io.cli.main import cli
@@ -2237,6 +2253,7 @@ def test_no_command_dies_with_a_raw_type_error_on_a_malformed_block(case, block,
     src = _file_with_geo(tmp_path, f"sweep_{case}", block)
 
     crashed: dict[str, str] = {}
+    leaked_from_duckdb: dict[str, str] = {}
     for i, (name, argv) in enumerate(SWEEP_COMMANDS):
         args = [
             arg.format(
@@ -2253,5 +2270,8 @@ def test_no_command_dies_with_a_raw_type_error_on_a_malformed_block(case, block,
         exc = CliRunner().invoke(cli, args).exception
         if isinstance(exc, (TypeError, AttributeError)):
             crashed[name] = f"{type(exc).__name__}: {exc}"
+        if isinstance(exc, duckdb.Error):
+            leaked_from_duckdb[name] = f"{type(exc).__name__}: {exc}"
 
     assert set(crashed) == KNOWN_UNGUARDED.get(case, set()), crashed
+    assert leaked_from_duckdb == {}

--- a/tests/test_spill_strategy.py
+++ b/tests/test_spill_strategy.py
@@ -540,9 +540,9 @@ class TestTheCliNamesTmpdir:
     """The hint has to reach the user, on every command, not just the ones with a decorator."""
 
     def test_the_group_replaces_an_out_of_spill_space_message(self):
-        from geoparquet_io.cli.decorators import SpillAwareGroup
+        from geoparquet_io.cli.decorators import ErrorBoundaryGroup
 
-        @click.group(cls=SpillAwareGroup)
+        @click.group(cls=ErrorBoundaryGroup)
         def root():
             pass
 
@@ -560,10 +560,13 @@ class TestTheCliNamesTmpdir:
         # The original text is kept: it names the sizes involved.
         assert "failed to offload data block" in result.output
 
-    def test_other_errors_pass_through_untouched(self):
-        from geoparquet_io.cli.decorators import SpillAwareGroup
+    def test_another_duckdb_error_keeps_its_own_message(self):
+        """The spill hint is added to the one failure it explains and to nothing
+        else. Another DuckDB error still becomes an error line (#983) -- it just
+        does not grow a ``TMPDIR`` paragraph that has nothing to do with it."""
+        from geoparquet_io.cli.decorators import ErrorBoundaryGroup
 
-        @click.group(cls=SpillAwareGroup)
+        @click.group(cls=ErrorBoundaryGroup)
         def root():
             pass
 
@@ -573,13 +576,14 @@ class TestTheCliNamesTmpdir:
 
         result = CliRunner().invoke(root, ["boom"])
 
-        assert isinstance(result.exception, duckdb.IOException)
+        assert "IO Error: No files found that match the pattern" in result.output
+        assert "TMPDIR" not in result.output
 
     def test_the_real_cli_group_uses_it(self):
-        from geoparquet_io.cli.decorators import SpillAwareGroup
+        from geoparquet_io.cli.decorators import ErrorBoundaryGroup
         from geoparquet_io.cli.main import cli
 
-        assert isinstance(cli, SpillAwareGroup)
+        assert isinstance(cli, ErrorBoundaryGroup)
 
 
 def test_the_reaper_pattern_is_not_hand_written_twice():


### PR DESCRIPTION
Fixes #983.

## What changed

A GeoParquet file whose `geo` block DuckDB's Parquet reader refuses now gets
`Error: <DuckDB's message>` and exit 1 from every command, instead of a raw
Python traceback from most of them.

The block on an input file is arbitrary JSON written by somebody else's tool, so
DuckDB refusing it is news about the *file*, not a gpio bug — and DuckDB's
message ("Geoparquet metadata does not have a columns object") already says
exactly what is wrong. Only the traceback around it was wrong.

## Why this shape

`gpio inspect head` and `gpio convert geoparquet` already answered such a file
cleanly, because `cli/commands/inspect.py` and `core/convert.py` each carry
their own `except` block. Eleven commands never reach one of those. Adding
eleven more would have left the twelfth command, written next month, uncovered.

The root group is already the single funnel every subcommand passes through —
`SpillAwareGroup` was installed there for exactly that reason when DuckDB's
out-of-spill-space message needed a `TMPDIR` line (#752). So the fix widens that
boundary rather than adding a new one:

- `core/duckdb_utils.py` gains `INPUT_FILE_DUCKDB_ERRORS` and
  `is_input_file_duckdb_error()`, beside `spill_space_hint`. That is the whole
  taxonomy — "is this DuckDB error news about the user's file, or a bug in
  something we generated?" — and it lives in `core/` so `api/` can reach the
  same verdict; `api/` may not import `cli/`.
- `cli/exception_handler.py` gains `cli_error_for()`, which decides nothing
  itself. It asks three questions that already have answers in `core/` — spill
  shortage, unpublished community extension, input-caused DuckDB failure — in
  that order, most specific first, then wraps. Everything else returns `None`.
- `SpillAwareGroup` becomes `ErrorBoundaryGroup`, since naming it after one of
  the failures it now handles would be misleading.
- `None` means "not mine": the exception is re-raised untouched, traceback and
  all. The traceback that *is* hidden is logged at DEBUG rather than dropped.

Exit code is unchanged at 1, which is what `inspect head` and
`convert geoparquet` already produced — confirmed by running them, not assumed.

## `--verbose` really does restore the hidden traceback now

It did not, on four of the eleven commands, and the comment in
`cli/decorators.py` promised that it did. Measured on the `{"version":"1.1.0"}`
file, `--verbose` **after** the subcommand, looking at stdout+stderr together:

| Command | before this commit | after |
|---|---|---|
| `check optimization` | traceback | traceback |
| `check all` | traceback | traceback |
| `check compression` | traceback | traceback |
| `check row-group` | traceback | traceback |
| `check spatial` | traceback | traceback |
| `add quadkey` | traceback | traceback |
| `sort str` | traceback | traceback |
| `add bbox` | **nothing** | traceback |
| `sort hilbert` | **nothing** | traceback |
| `extract geoparquet` | **nothing** | traceback |
| `add geometry-metrics` | **nothing** | traceback |

7 of 11, now 11 of 11. Two measurement details account for every reading anyone
got, including "0 of 6":

- **Position matters.** The root group has no `--verbose`; it is a per-command
  flag. `gpio --verbose check optimization file.parquet` is a usage error and
  exits 2, printing no traceback for any command. Pinned by a test, because it
  is a real trap.
- **Stream matters.** The log handler writes to stdout on a TTY and to stderr
  when stdout is piped, so `gpio ... --verbose | grep Traceback` finds nothing
  on any of the eleven.

**Root cause.** `configure_verbose()` in `core/logging_config.py` is
deliberately one-way, and is called from ~60 nested *core* functions. On a path
that fails before reaching one, the package logger is still at INFO when
`Group.invoke` emits its DEBUG record, so the record is dropped. Measured
directly: the logger's level at the boundary was DEBUG on exactly the seven
commands that printed the traceback and INFO on the four that did not.
`core/hilbert_order.py` never calls it at all.

**Fix.** `--verbose` now raises the level as *the flag is parsed*, via an eager
Click option callback (`decorators.enable_verbose_logging`), applied to
`verbose_option` and to `check.py`'s six inline declarations. An option callback
runs inside `make_context` for the subcommand — after the root group's
`setup_cli_logging(verbose=False)` and before the command body — which is the
only point early enough to be unconditional. 58 of 59 leaf commands carry the
flag (`gpio skills` is the exception, and touches no DuckDB).

Pinned by real `CliRunner().invoke(cli, [...], "--verbose")` runs on the four
commands that were broken plus one that was not, asserting
`"Traceback (most recent call last)"` in the output — not by a synthetic group
under `caplog.at_level(DEBUG)`, which passed while the real path dropped the
record.

This matters because gpio's own bugs surface as `InvalidInputException` too —
measured: `Could not create projection: EPSG:4326 -> EPSG:999999`,
`Expected geometry type at position '0'`, `Values were not provided for the
following prepared statement parameters`. With the traceback unrecoverable, a
gpio bug on those commands printed one line and nothing else.

## Which DuckDB failures, and which deliberately not

**This is narrower than `duckdb.Error`, on purpose.** gpio authors every SQL
string it runs, so a query that will not parse or bind is never news about the
user's file — it is a bug in something we generated, the defect class behind
#700, #718 and #944. Answering those with `Error: Parser Error: ...` would use
the line gpio reserves for "your input is bad" to report gpio's own bugs,
sending a user to inspect data that is fine.

DuckDB's hierarchy gives no base class that splits along this line. Measured
against duckdb 1.5.5, `duckdb.Error`'s only direct subclass is `DatabaseError`,
and `InvalidInputException` — the one #983 is about — sits under
`ProgrammingError` beside `ParserException`, `BinderException` and
`CatalogException`, its exact opposite. So the set is enumerated:

| Caught (input-caused) | Falls through, traceback intact (gpio-caused) |
|---|---|
| `InvalidInputException` — the file's bytes/metadata are unreadable | `ParserException` — SQL gpio generated will not parse |
| `IOException` (and `HTTPException` below it) — missing, unreachable, unreadable | `BinderException` — a column gpio referenced does not exist |
| | `CatalogException` — a function gpio called does not exist |

Measured, not assumed:

```
#983 geo block DuckDB refuses    -> InvalidInputException
gpio SQL bug: syntax             -> ParserException
gpio SQL bug: unknown column     -> BinderException
gpio SQL bug: unknown func       -> CatalogException
gpio SQL bug: unquoted ident     -> ParserException
missing file                     -> IOException
unreadable remote                -> IOException
```

All four of #983's reproductions raise `InvalidInputException`, so they stay
fixed — pinned by a test that reads the wrapped exception's cause rather than
assuming it. The negative direction is pinned too, by really executing malformed
SQL so the class is DuckDB's answer and not the test's guess.

The classes are checked on the outermost exception only, while `spill_space_hint`
and `is_unpublished_extension_error` walk the `__cause__` chain. That asymmetry
is deliberate and documented: those two match on *text*, which survives being
re-raised inside a wrapper, so they have to look down the chain to find it. This
matches on *class*, and a class that a gpio frame has already wrapped is no
longer unowned — the wrapper is gpio saying what it thinks happened, and its
class is the answer to use.

### `ConversionException` was dropped

It was in the tuple in the first version of this branch. It is not any more, and
that is a decision rather than an oversight:

- **No reproduction reaches an unowned boundary with one.** Every other member
  has a measured one; this had none.
- **The live conversion site is already owned, with a better message.**
  `core/convert.py` answers a CSV whose sniffed type breaks on a later row with
  `Error: Conversion failed: Conversion Error: CSV Error on Line: 30002 ...` —
  measured on a 30,001-row CSV — and never reaches the boundary.
- **The one refusal known to carry "Conversion Error" in its text is not one.**
  #988's curved WKB is raised as `InvalidInputException` (measured against
  `tests/data/curved_geometry_test.gdb`: the full message is
  `Invalid Input Error: Unsupported geometry type in WKB`), so it is covered by
  the first entry anyway.
- **Membership has to be decidable.** gpio writes every `CAST` it runs, so
  whether such a failure is the data's fault or gpio's choice of target type is
  not decidable from the exception. Adding it back needs a reproduction of one
  reaching the boundary unowned.

### An unpublished extension is not a bad input file

`INSTALL geography FROM community` failing with an HTTP 404 arrives as
`HTTPException`, which hangs below `IOException` — so without asking first, it
would read as "your input file is unreachable" and lose #778's guidance. Three
`INSTALL` sites are unwrapped (`core/duckdb_utils._install_and_load_extension`,
`core/extract_bigquery`, `core/partition/admin_hierarchical`), so their failures
arrive here raw. `core/exceptions.unpublished_extension_hint()` — same shape as
`spill_space_hint` — is asked in the same place, and names the registry rather
than the file.

It requires the message to name an extension, not just carry a 404: a remote
*input* that is simply not there 404s too, and still gets the plain error line.
Pinned both ways.

### The message is sanitized

`core/exceptions.sanitize_url_for_logging` is applied at ~25 sites because
presigned URLs carry credentials in the query string; the boundary applied none
of it, and `IOException`/`HTTPException` carry the full URL:
`HTTP GET error on 'https://bucket/x.parquet?X-Amz-Signature=...'`. Pre-existing
and byte-identical to `main` on the checked paths — not a regression — but the
boundary is the single funnel, which is this PR's own argument for where such
things live.

`core/exceptions.sanitize_error_message()` now runs on every message
`cli_error_for` builds. It redacts each URL in the text through the existing
helper, and strips ANSI escapes and control characters (tab and newline
excepted): DuckDB quotes offending values back verbatim, so a hostile file could
otherwise author a clean `Error:` line of its own with `\r` and `\x1b[2K`.

## The real count is eleven, not four

#983 found four commands while verifying something else. The sweep in
`tests/test_malformed_geo_metadata.py` (from #984) already runs every malformed
`geo` shape against 26 commands, so it gained a second assertion in the same
pass — no new harness, no extra runtime — plus the `{"version": "1.1.0"}` shape
from the issue, which is not *malformed* by gpio's standards and so was not in
the existing shape list.

On a clean `origin/main` it reports eleven commands leaking a `duckdb.Error`:

```
add bbox, add geometry-metrics, add quadkey, check all, check compression,
check optimization, check row-group, check spatial, extract geoparquet,
sort hilbert, sort str
```

across 13 of the 15 input shapes swept. The four in the issue are a subset.
Re-measured on a clean `origin/main` worktree after #988 landed: **identical**
— same eleven commands, same thirteen shapes. With the boundary in place the
count is **zero**, and the sweep's assertion is the wider `duckdb.Error`, so it
would also catch a malformed block driving gpio into generating bad SQL.

## Interaction with #988

#988 landed while this branch was open. It identifies DuckDB's curved-WKB
refusal by matching `"Unsupported geometry type in WKB"` on the exception,
linearizes the source and writes again. That refusal measures as an
`InvalidInputException` — exactly what this boundary claims — so if the boundary
ran anywhere but last, it would convert the error and the retry would never
fire.

It runs last, because it lives on `Group.invoke` and inner handlers are strictly
inside it. Two tests pin that on real code rather than on Python's exception
semantics: #988's real curved FileGDB still converts under `--skip-hilbert`
through the real `cli` and exits 0, and a refusal the handler *declines* still
becomes an error line. All of #988's own tests pass unchanged; `convert` never
appeared in the leak list at all (it carried its own handlers all along).

## Known, reasoned costs

- **gpio's own scratch files.** An `IOException` on a file gpio itself minted —
  partition staging, an `add <index>` intermediate — is now reported with the
  same line as one on the user's input, because the class is all the exception
  says. No live case could be constructed: apostrophe paths and
  glob-metacharacter paths behave identically with and without the boundary. The
  message still names the path that failed. Noted in `ErrorBoundaryGroup`'s
  docstring rather than guarded against.
- **`gpio process` is already wider than this policy.** `cli/commands/process.py`
  `_aggregate_error` catches `duckdb.Error` broadly, so Parser/Binder errors
  there already become error lines. Pre-existing, and arguably right for that
  one command: `--where` is *user-authored* SQL, so a binder error genuinely is
  news about the user's input (#612). Named here, not changed.

## Verification

The four reproductions from the issue, on a clean `origin/main` worktree with
the issue's one-row file:

```
$ gpio check optimization file.parquet
  File ".../core/duckdb_metadata.py", line 515, in get_file_metadata
    result = connection.execute(f"""
_duckdb.InvalidInputException: Invalid Input Error: Geoparquet metadata does not have a columns object

$ gpio add bbox file.parquet out.parquet
  File ".../core/common.py", line 3909, in add_computed_column
    total_count = con.execute(f"SELECT COUNT(*) FROM {sql_path(input_path)}").fetchone()[0]
_duckdb.InvalidInputException: Invalid Input Error: Geoparquet metadata does not have a columns object

$ gpio sort hilbert file.parquet out.parquet
  File ".../core/hilbert_order.py", line 541, in _hilbert_order_file_based
    empty_count_result = con.execute(f"""
_duckdb.InvalidInputException: Invalid Input Error: Geoparquet metadata does not have a columns object

$ gpio add quadkey file.parquet out.parquet
  File ".../core/write_strategies/duckdb_kv.py", line 737, in _write_plain_parquet_from_query
    con.execute(copy_query)
_duckdb.InvalidInputException: Invalid Input Error: Geoparquet metadata does not have a columns object
```

and on this branch, all four:

```
Error: Invalid Input Error: Geoparquet metadata does not have a columns object   (exit 1)
```

with no traceback in stderr — and the traceback back in full under `--verbose`.

Rebased on `origin/main` after #987 and #988 landed; clean rebase, no conflicts.

- `uv run pytest -n auto -m "not slow and not network and not meta"` —
  **7637 passed**, 76 skipped, 7 xfailed. One run of the same command failed
  `test_add_bbox_to_sort_hilbert`; it passes serially, and subprocess pipe tests
  are a known parallel-load flake on this tree.
- `uv run pytest -m meta` — **205 passed**.
- `uv run pre-commit run --all-files` and `--hook-stage pre-push` — all passed,
  `menard-check`, `vulture`, `xenon`, `import-linter` and `mypy` included.
- diff-cover against `origin/main`: **100%** (58 changed lines, 0 missing).

### On the `cli_surface.json` diff

One line, and it is only the root group's recorded class name
(`SpillAwareGroup` → `ErrorBoundaryGroup`). No command, group or option is
added, removed or changed — the `--verbose` callbacks are not part of the
recorded surface. Re-recorded with `GPIO_UPDATE_SNAPSHOT=1`.

*Authored by Claude (AI); every reproduction, exception class and `--verbose`
row above was measured by running it, not inferred.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CLI commands now show clear error messages instead of raw Python tracebacks for invalid GeoParquet metadata and input-related database errors.
  - Error messages now provide more relevant guidance for insufficient temporary storage and unavailable extensions.
  - Sensitive URL signatures, terminal formatting codes, and unsafe control characters are removed from displayed errors.
  - Unrelated errors continue to surface for troubleshooting.

- **Improvements**
  - `--verbose` now enables detailed debug logging immediately, restoring traceback details when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->