### PR TITLE
fix(add)!: keep native geo and the CRS when a gpio add subcommand rewrites a file

### DIFF
--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -15,6 +15,11 @@ The `add` commands enhance GeoParquet files with spatial indices, geometry metri
     the CRS is preserved either way, including when you ask for 1.1, which has
     nowhere but the `geo` block to record it.
 
+    A native 2.0 output needs a reader that understands the Parquet `GEOMETRY`
+    logical type — older pyarrow, geopandas and DuckDB builds may not open one.
+    `--geoparquet-version 1.1` is the escape hatch: it writes plain WKB, and
+    keeps the CRS in the `geo` block.
+
     It is the same rewrite behind `gpio sort quadkey` and
     `gpio partition quadkey/h3/s2/a5/kdtree`, which add their index column to a
     scratch file first, so those commands preserve the version and the CRS now

--- a/docs/guide/add.md
+++ b/docs/guide/add.md
@@ -2,6 +2,32 @@
 
 The `add` commands enhance GeoParquet files with spatial indices, geometry metrics, and administrative metadata.
 
+!!! note "The output keeps the input's GeoParquet version and CRS"
+    Every `add` command rewrites the whole file to append its column, and with
+    no `--geoparquet-version` that rewrite preserves what the input was: a 1.1
+    file stays 1.1, a 2.0 file stays 2.0, and a file that carries a native
+    Parquet `GEOMETRY` type with no `geo` key is written as native 2.0. Until
+    [#993](https://github.com/geoparquet/geoparquet-io/issues/993) that last
+    case was re-encoded as 1.1 WKB, which stripped the logical type **and the
+    CRS stored inside it** — an `EPSG:5070` file came back out declaring
+    nothing, which every reader resolves as `OGC:CRS84`. Pass
+    `--geoparquet-version` to ask for something other than the input's version;
+    the CRS is preserved either way, including when you ask for 1.1, which has
+    nowhere but the `geo` block to record it.
+
+    It is the same rewrite behind `gpio sort quadkey` and
+    `gpio partition quadkey/h3/s2/a5/kdtree`, which add their index column to a
+    scratch file first, so those commands preserve the version and the CRS now
+    too.
+
+    Two shapes are not fully covered yet, both pinned by failing-on-purpose
+    tests: a native `GEOGRAPHY` column comes back as a planar `GEOMETRY` while
+    the metadata still declares spherical edges
+    ([#999](https://github.com/geoparquet/geoparquet-io/issues/999)), and a
+    *secondary* geometry column keeps its own Parquet type but is left out of
+    `geo.columns` and loses its CRS
+    ([#1000](https://github.com/geoparquet/geoparquet-io/issues/1000)).
+
 !!! note "Coordinate Reference Systems"
     The grid-index commands (`h3`, `s2`, `a5`, `quadkey`) and `admin-divisions` are
     **CRS-aware**. If your input declares a projected CRS (e.g. EPSG:5070 or

--- a/geoparquet_io/core/add/admin_divisions.py
+++ b/geoparquet_io/core/add/admin_divisions.py
@@ -776,6 +776,11 @@ def _execute_per_level_joins(
                 profile=profile,
                 geoparquet_version=geoparquet_version,
                 extra_kv_metadata=extra_kv,
+                # Every level is `SELECT a.*` over the one before it, so the
+                # geometry column the last write emits is the input's own --
+                # the witness auto mode needs to keep a native-geo-only input
+                # native rather than rewriting it as 1.1 WKB (#993).
+                input_file=input_source,
                 memory_limit=memory_limit,
             )
         else:
@@ -986,6 +991,9 @@ def add_admin_divisions_multi(
                     profile=profile,
                     geoparquet_version=geoparquet_version,
                     extra_kv_metadata=extra_kv,
+                    # The join is `SELECT a.*` plus admin columns, so the
+                    # geometry reaching the output is the input's own (#993).
+                    input_file=input_path,
                     memory_limit=memory_limit,
                 )
 

--- a/geoparquet_io/core/add/country_codes.py
+++ b/geoparquet_io/core/add/country_codes.py
@@ -747,6 +747,9 @@ def add_country_codes(
             row_group_size_mb=row_group_size_mb,
             row_group_rows=row_group_rows,
             verbose=verbose,
+            # The join keeps the input's own geometry column, so the input is
+            # the witness auto mode resolves the output version from (#993).
+            input_file=input_path,
         )
 
         _print_results_summary(con, output_parquet)

--- a/geoparquet_io/core/add/geometry_metrics.py
+++ b/geoparquet_io/core/add/geometry_metrics.py
@@ -298,6 +298,11 @@ def _add_vecorel_metadata_to_file(
                 original_metadata=metadata,
                 extra_kv_metadata=extra_kv,
                 verbose=verbose,
+                # A whole-file rewrite to attach one sidecar key must not also
+                # change the geometry encoding. Without this witness auto mode
+                # read the carried `geo` key, which does not say whether the
+                # column is native, and the rewrite re-encoded it as WKB (#993).
+                input_file=parquet_file,
                 memory_limit=memory_limit,
             )
         finally:

--- a/geoparquet_io/core/add/kdtree.py
+++ b/geoparquet_io/core/add/kdtree.py
@@ -659,6 +659,10 @@ def add_kdtree_column(
         verbose=verbose,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        # The rows this write reads are the input's, so auto mode resolves the
+        # output version from the input file rather than from a `geo` key a
+        # native-geo-only input does not have (#993).
+        input_file=input_parquet,
         memory_limit=memory_limit,
     )
 

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -703,11 +703,8 @@ def _add_quadkey_file_based(
             profile=profile,
             geoparquet_version=geoparquet_version,
             custom_metadata=quadkey_metadata,
-            # The rows this write reads are the input's, so the input is the
-            # witness auto mode resolves the output version from. Without it a
-            # native-geo-only input was re-encoded as 1.1 WKB and lost the CRS
-            # its GEOMETRY logical type carried -- which `gpio sort quadkey`
-            # then read back as its data (#993).
+            # The precondition: this query is `SELECT *` plus the quadkey
+            # column, so the rows it writes are `input_parquet`'s own.
             input_file=input_parquet,
             memory_limit=memory_limit,
         )

--- a/geoparquet_io/core/add/quadkey.py
+++ b/geoparquet_io/core/add/quadkey.py
@@ -703,6 +703,12 @@ def _add_quadkey_file_based(
             profile=profile,
             geoparquet_version=geoparquet_version,
             custom_metadata=quadkey_metadata,
+            # The rows this write reads are the input's, so the input is the
+            # witness auto mode resolves the output version from. Without it a
+            # native-geo-only input was re-encoded as 1.1 WKB and lost the CRS
+            # its GEOMETRY logical type carried -- which `gpio sort quadkey`
+            # then read back as its data (#993).
+            input_file=input_parquet,
             memory_limit=memory_limit,
         )
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -75,6 +75,7 @@ from geoparquet_io.core.logging_config import (
 from geoparquet_io.core.parquet_writer import (
     ParquetWriteSettings,
     note_duckdb_copy_rounding,
+    resolve_input_crs,
     resolve_output_geoparquet_version,
     resolve_row_group_rows,
 )
@@ -2871,7 +2872,14 @@ def write_parquet_with_metadata(
         show_sql: Whether to print SQL statements before execution
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
-        input_crs: PROJJSON dict with CRS from input file
+        input_crs: PROJJSON dict naming the CRS the output declares. Set by a
+            write that changes the coordinates (reproject, convert --to-crs),
+            where the output's CRS is not a fact any reading of the input could
+            supply. Left None by every rewrite that keeps its input's
+            coordinates: the facade then resolves it from ``input_file``, so a
+            native-geo-only input's CRS — which lives only in the Parquet
+            GEOMETRY logical type — reaches the output's ``geo`` block too
+            (#993).
         write_strategy: Write strategy to use. Options:
             - "duckdb-kv" (default): Use DuckDB COPY TO with KV_METADATA
             - "in-memory": Load entire dataset into memory
@@ -2886,9 +2894,15 @@ def write_parquet_with_metadata(
         extra_kv_metadata: Additional Parquet file-level KV metadata as {key: json_string}.
             Written alongside the 'geo' key (e.g., for Vecorel collection metadata).
         input_file: Path to the input parquet file, when the write rewrites an
-            existing file. Enables full-fidelity non-planar edges preservation
-            (native GEOGRAPHY logical types are only visible in the file's
-            schema); without it, edges still fall back to original_metadata.
+            existing file. The witness the facade resolves the output's version
+            and CRS from, and what enables full-fidelity non-planar edges
+            preservation (native GEOMETRY/GEOGRAPHY logical types, and the CRS
+            stored inside them, are only visible in the file's schema); without
+            it, both fall back to original_metadata's ``geo`` key, which a
+            native-geo-only input does not have. Must be the file whose *rows*
+            this write reads, or one lossless with respect to it: naming the
+            user's file while reading a scratch rewrite that dropped the native
+            type is how a wrong CRS comes to be asserted rather than omitted.
         invalidate_derived_stats: When True, strip the carried per-column
             ``bbox`` and ``geometry_types`` from ``original_metadata`` before
             building output geo metadata. Set by callers that transform geometry
@@ -2970,12 +2984,19 @@ def write_parquet_with_metadata(
         con, query, original_metadata, geometry_column, verbose
     )
 
-    # The facade owns both of these: how many rows a row group gets, and which
-    # version auto mode resolves to. Every caller of this function -- 21 of them
-    # -- used to inherit whatever its writer defaulted to and whatever its own
-    # `geo` key happened to say, which is how `convert` came to write 122,880-row
-    # groups (#981) and how `sort`/`extract`/`partition` came to rewrite a
+    # The facade owns all three of these: how many rows a row group gets, which
+    # version auto mode resolves to, and which CRS the output describes its
+    # geometry with. Every caller of this function -- 21 of them -- used to
+    # inherit whatever its writer defaulted to and whatever its own `geo` key
+    # happened to say, which is how `convert` came to write 122,880-row groups
+    # (#981) and how `sort`/`extract`/`partition` came to rewrite a
     # native-geo-only input as 1.1 WKB while `convert` kept it native (#600).
+    #
+    # The version and the CRS are resolved from the same `input_file` witness,
+    # together, because they are the same question asked of the same file.
+    # Answering only the version made the output native 2.0 while leaving its
+    # `geo` block with no `crs` key -- EPSG:5070 in the Parquet GEOMETRY logical
+    # type, OGC:CRS84 in the geo block, one file disagreeing with itself (#993).
     row_group_rows = resolve_row_group_rows(row_group_rows, row_group_size_mb)
     geoparquet_version = resolve_output_geoparquet_version(
         geoparquet_version,
@@ -2983,6 +3004,7 @@ def write_parquet_with_metadata(
         original_metadata=original_metadata,
         verbose=verbose,
     )
+    input_crs = resolve_input_crs(input_crs, input_file=input_file, verbose=verbose)
 
     effective_version = geoparquet_version or "1.1"
 
@@ -3981,6 +4003,14 @@ TO {sql_path(output_parquet)}
         verbose=verbose,
         profile=profile,
         geoparquet_version=geoparquet_version,
+        # The query above is `SELECT *` plus one computed column, so the rows
+        # this write reads are the rows of `input_parquet` -- exactly the
+        # witness `resolve_output_geoparquet_version` asks for. Without it,
+        # auto mode saw only the carried `geo` key, which a native-geo-only
+        # input does not have, and every `gpio add` re-encoded such a file as
+        # 1.1 WKB, stripping the Parquet GEOMETRY logical type and the CRS
+        # stored in it (#993).
+        input_file=input_parquet,
         memory_limit=memory_limit,
     )
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -2873,9 +2873,10 @@ def write_parquet_with_metadata(
         profile: AWS profile name (S3 only, optional)
         geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
         input_crs: PROJJSON dict naming the CRS the output declares. Set by a
-            write that changes the coordinates (reproject, convert --to-crs),
-            where the output's CRS is not a fact any reading of the input could
-            supply. Left None by every rewrite that keeps its input's
+            write whose output CRS is not a reading of the input's: `gpio convert
+            reproject`, which transforms the coordinates, and `gpio convert`,
+            which names the CRS a non-Parquet source's geometry is in (`--crs`,
+            for CSV/TSV input). Left None by every rewrite that keeps its input's
             coordinates: the facade then resolves it from ``input_file``, so a
             native-geo-only input's CRS — which lives only in the Parquet
             GEOMETRY logical type — reaches the output's ``geo`` block too

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -3004,7 +3004,9 @@ def write_parquet_with_metadata(
         original_metadata=original_metadata,
         verbose=verbose,
     )
-    input_crs = resolve_input_crs(input_crs, input_file=input_file, verbose=verbose)
+    input_crs = resolve_input_crs(
+        input_crs, input_file=input_file, geometry_column=geometry_column, verbose=verbose
+    )
 
     effective_version = geoparquet_version or "1.1"
 
@@ -4003,13 +4005,8 @@ TO {sql_path(output_parquet)}
         verbose=verbose,
         profile=profile,
         geoparquet_version=geoparquet_version,
-        # The query above is `SELECT *` plus one computed column, so the rows
-        # this write reads are the rows of `input_parquet` -- exactly the
-        # witness `resolve_output_geoparquet_version` asks for. Without it,
-        # auto mode saw only the carried `geo` key, which a native-geo-only
-        # input does not have, and every `gpio add` re-encoded such a file as
-        # 1.1 WKB, stripping the Parquet GEOMETRY logical type and the CRS
-        # stored in it (#993).
+        # The precondition: the query above is `SELECT *` plus one computed
+        # column, so the rows this write reads are `input_parquet`'s own.
         input_file=input_parquet,
         memory_limit=memory_limit,
     )

--- a/geoparquet_io/core/constants.py
+++ b/geoparquet_io/core/constants.py
@@ -157,7 +157,27 @@ def _fix_vecorel_schema(parquet_file: str, non_nullable_columns: list[str]) -> N
 
     Preserves all existing Parquet metadata, compression, and row group structure.
     Processes one row group at a time to avoid loading the entire file into memory.
+
+    This is a pyarrow read/write of the whole file, so it has to preserve the
+    things pyarrow does not carry by default. A Parquet ``GEOMETRY``/``GEOGRAPHY``
+    logical type is one: plain pyarrow reads such a column as ``binary`` and
+    writes it back as ``binary``, dropping the logical type **and the CRS stored
+    inside it**, which for a native-geo-only file is the only place the CRS
+    lives. Importing ``geoarrow.pyarrow`` registers the extension types that make
+    pyarrow materialise those columns as ``geoarrow.wkb`` instead, so the read ->
+    cast -> write below round-trips the type, the CRS and a GEOGRAPHY's edge type
+    unchanged.
+
+    That import is a process-wide registration, which is why it has to happen
+    *here* rather than be relied on: before #993 this function's behaviour
+    depended on whether something else in the process had already imported it.
+    Measured on ``gpio add geometry-metrics`` over a native-geo-only EPSG:5070
+    input, the same code scored ``0 failed`` under pytest (whose fixtures import
+    ``geoarrow.pyarrow`` to write their files) and ``4 failed`` from a fresh CLI
+    process. ``tests/test_add_preserves_native_geo.py`` runs that command in a
+    subprocess for exactly that reason.
     """
+    import geoarrow.pyarrow  # noqa: F401  -- registers the extension types; see above
     import pyarrow as pa
     import pyarrow.parquet as pq
 

--- a/geoparquet_io/core/parquet_writer.py
+++ b/geoparquet_io/core/parquet_writer.py
@@ -12,23 +12,36 @@ identical CLI request wrote 49,152 (#971), ``convert geoparquet`` documenting
 ``convert`` downgrading a native-geo-only input to 1.1 WKB (#600).
 
 This module is the single owner of those shared decisions. It owns exactly
-three, because each one is a fact about the *output file* that no individual
+four, because each one is a fact about the *output file* that no individual
 write path is entitled to answer for itself:
 
 1. **How many rows go in a row group** -- :func:`resolve_row_group_rows`, and
    the constants it derives the default from.
 2. **Which GeoParquet version the output declares** when the caller did not ask
    for one -- :func:`resolve_output_geoparquet_version`.
-3. **Whether a ``geo`` key appears in the output's file-level metadata at all**
+3. **Which CRS the output declares** when the caller did not name one --
+   :func:`resolve_input_crs`.
+4. **Whether a ``geo`` key appears in the output's file-level metadata at all**
    -- :func:`apply_output_kv_metadata`.
+
+The third exists because it is the *same question as the second*, asked of the
+same witness. Both are "what did the input declare", and a rewrite that answers
+one from the input file and the other from the carried ``geo`` key produces a
+file that contradicts itself: native 2.0 with EPSG:5070 in the Parquet
+``GEOMETRY`` logical type and no ``crs`` key in the ``geo`` block, which
+GeoParquet resolves as ``OGC:CRS84`` (#993). Splitting the two answers between
+two owners is what made that possible, so they are answered together.
 
 It deliberately does **not** own the rest of the write. Compression validation
 (``common.validate_compression_settings``), the contents of the ``geo`` block
-(``write_strategies.base.build_geo_metadata``), CRS resolution
+(``write_strategies.base.build_geo_metadata``), the null-vs-default CRS rule
 (``crs_utils.apply_output_crs``), bbox coverings and geometry-type computation
 all already have a single owner each, and pulling them in here would turn a
 facade into a rewrite. The line is: this module decides what the paths were
-*disagreeing* about; the existing owners keep what they already own.
+*disagreeing* about; the existing owners keep what they already own. In
+particular :func:`resolve_input_crs` only *finds* the input's CRS; what a write
+does with it -- omit it when it is the default, strip a stale one, refuse to
+overwrite an explicit null -- stays with ``apply_output_crs``.
 """
 
 from __future__ import annotations
@@ -270,13 +283,16 @@ def resolve_output_geoparquet_version(
     ``input_file`` must be the file whose *rows* the write will read, or a file
     that is lossless with respect to it. Handing this the user's input while
     reading the data from a scratch rewrite that dropped the native type and
-    the CRS produces the worst of both: a native 2.0 output declaring the
+    the CRS produced the worst of both: a native 2.0 output declaring the
     default CRS over projected data, which reads as an assertion rather than an
     omission and which ``gpio check spec`` then blesses. ``gpio sort quadkey``
-    does exactly that today, and it is why the index-adding ``gpio partition``
-    drivers were left resolving from their scratch file rather than "fixed" the
-    same way. See ``partition/staging.py`` and the strict xfails in
-    ``tests/test_write_facade_version_owner.py``.
+    and the five index-adding ``gpio partition`` drivers did exactly that until
+    #993 made their scratch write pass the same witness, so the intermediate is
+    now lossless with respect to the user's file. See ``partition/staging.py``.
+
+    The same witness answers :func:`resolve_input_crs`, and it has to: this
+    function is what makes the output native, and a native output states its
+    CRS in two places that must agree.
 
     Returns ``None`` when nothing can be detected, leaving the caller's own
     default in charge.
@@ -298,12 +314,65 @@ def resolve_output_geoparquet_version(
     return _resolve_auto_version(extract_version_from_metadata(original_metadata))
 
 
+def resolve_input_crs(
+    input_crs: dict | None,
+    *,
+    input_file: str | None = None,
+    verbose: bool = False,
+) -> dict | None:
+    """Decide which CRS the output describes its geometry with. The third decision.
+
+    A caller that names a CRS always wins -- ``reproject`` and ``convert`` pass
+    the CRS they are transforming *to*, which is a fact about the output that no
+    reading of the input could supply. Everything else is a rewrite that keeps
+    its input's coordinates, and for those the input file is the witness, the
+    same one :func:`resolve_output_geoparquet_version` consults.
+
+    Without this, a rewrite answered the CRS question from whatever ``geo``
+    block it happened to carry. A native-geo-only input has none, so nothing
+    described the output's CRS at all -- while the version question, answered
+    from the file, made that output *native 2.0*. The two answers then landed in
+    two different places: EPSG:5070 in the Parquet ``GEOMETRY`` logical type
+    (DuckDB writes it there from the column it read) and nothing in the ``geo``
+    block, which GeoParquet reads as ``OGC:CRS84``. One file, two CRSs, and
+    ``gpio check spec`` printing ``✗ CRS in geo metadata must match CRS in
+    Parquet schema`` over it (#993).
+
+    It also repairs a quieter loss on the same inputs: an explicit
+    ``--geoparquet-version 1.1`` has nowhere but the ``geo`` block to put a CRS,
+    so before this the 1.1 rewrite of a native-geo-only file declared no CRS
+    anywhere.
+
+    ``extract_crs_from_parquet`` returns ``None`` for the default CRS and for an
+    explicit ``crs: null``, both of which mean "do not state a CRS here" -- so a
+    miss leaves ``input_crs`` ``None`` and ``apply_output_crs`` keeps its
+    existing behaviour of preserving whatever the carried block said. A file
+    that cannot be inspected (remote without credentials, a path that is not
+    Parquet) is a miss too, not an error: the write worked before this function
+    existed and must keep working.
+    """
+    if input_crs is not None:
+        return input_crs
+    if not input_file:
+        return None
+
+    from geoparquet_io.core.crs_utils import extract_crs_from_parquet
+    from geoparquet_io.core.logging_config import debug
+
+    try:
+        # RAW path: extract_crs_from_parquet escapes its own argument (#718).
+        return extract_crs_from_parquet(input_file, verbose=verbose)
+    except Exception as exc:  # pragma: no cover - defensive, see docstring
+        debug(f"CRS auto-detect failed for {input_file}: {exc}; leaving the CRS unstated")
+        return None
+
+
 def apply_output_kv_metadata(
     table: pa.Table,
     geoparquet_version: str | None,
     extra_kv_metadata: dict[str, str] | None = None,
 ) -> pa.Table:
-    """Decide the output's file-level KV metadata. The third decision.
+    """Decide the output's file-level KV metadata. The fourth decision.
 
     Two rules, and the version decides both:
 

--- a/geoparquet_io/core/parquet_writer.py
+++ b/geoparquet_io/core/parquet_writer.py
@@ -42,6 +42,17 @@ facade into a rewrite. The line is: this module decides what the paths were
 particular :func:`resolve_input_crs` only *finds* the input's CRS; what a write
 does with it -- omit it when it is the default, strip a stale one, refuse to
 overwrite an explicit null -- stays with ``apply_output_crs``.
+
+"Only finds" is not "only informs one place", though: a non-``None`` answer
+where the write previously had ``None`` moves three things at once.
+``apply_output_crs`` writes an explicit ``crs`` into the ``geo`` block,
+``crs_utils._wrap_query_with_crs`` wraps the query in ``ST_SetCRS`` so DuckDB
+stamps the CRS into the Parquet ``GEOMETRY`` logical type (``common._plain_copy_to``
+and both ``write_strategies/duckdb_kv`` writers), and
+``geoarrow_encoding`` attaches it to the Arrow extension type it emits. The
+``ST_SetCRS`` wrap is the load-bearing one: without it DuckDB restates whatever
+the column it read carried, which is how ``gpio sort quadkey`` stamped
+``OGC:CRS84`` onto EPSG:5070 data.
 """
 
 from __future__ import annotations
@@ -318,11 +329,19 @@ def resolve_input_crs(
     input_crs: dict | None,
     *,
     input_file: str | None = None,
+    geometry_column: str | None = None,
     verbose: bool = False,
 ) -> dict | None:
     """Decide which CRS the output describes its geometry with. The third decision.
 
-    A caller that names a CRS always wins -- ``reproject`` and ``convert`` pass
+    An output with no geometry column describes no geometry, so the question has
+    no subject and the answer is ``None`` -- before any witness is consulted, and
+    whatever the caller named. A column projection can drop the geometry column
+    (``gpio extract geoparquet --exclude-cols geometry``), and answering anyway
+    handed ``crs_utils._wrap_query_with_crs`` a CRS with no column to
+    ``ST_SetCRS``, which raises rather than writes.
+
+    A caller that names a CRS otherwise wins -- ``reproject`` and ``convert`` pass
     the CRS they are transforming *to*, which is a fact about the output that no
     reading of the input could supply. Everything else is a rewrite that keeps
     its input's coordinates, and for those the input file is the witness, the
@@ -351,6 +370,8 @@ def resolve_input_crs(
     Parquet) is a miss too, not an error: the write worked before this function
     existed and must keep working.
     """
+    if not geometry_column:
+        return None
     if input_crs is not None:
         return input_crs
     if not input_file:

--- a/geoparquet_io/core/parquet_writer.py
+++ b/geoparquet_io/core/parquet_writer.py
@@ -341,9 +341,11 @@ def resolve_input_crs(
     handed ``crs_utils._wrap_query_with_crs`` a CRS with no column to
     ``ST_SetCRS``, which raises rather than writes.
 
-    A caller that names a CRS otherwise wins -- ``reproject`` and ``convert`` pass
-    the CRS they are transforming *to*, which is a fact about the output that no
-    reading of the input could supply. Everything else is a rewrite that keeps
+    A caller that names a CRS otherwise wins -- ``gpio convert reproject`` passes
+    the CRS it is transforming *to*, and ``gpio convert`` the one a non-Parquet
+    source's geometry is in (``--crs``, for CSV/TSV input). Both are facts about
+    the output that no reading of the input could supply. Everything else is a
+    rewrite that keeps
     its input's coordinates, and for those the input file is the witness, the
     same one :func:`resolve_output_geoparquet_version` consults.
 

--- a/geoparquet_io/core/partition/staging.py
+++ b/geoparquet_io/core/partition/staging.py
@@ -58,15 +58,20 @@ class PartitionWriteOptions:
     ``test_write_facade_version_owner.py`` checks every construction site obeys
     this, because an invariant with an exempt site is a comment.
 
-    "The real input" means the file the *user* named. Only ``partition string``
-    and ``partition admin`` hand that file to the resolver; the index-adding
-    drivers (quadkey, h3, s2, a5, kdtree) resolve from the scratch file their
-    ``add <index>`` step wrote, which is already a 1.1 WKB rewrite -- so they do
-    not yet deliver #600. Pointing them at the user's file would fix the version
-    and import ``sort quadkey``'s wrong-CRS defect, because the *data* would
-    still come from a scratch file that lost the CRS; the scratch write is the
-    thing to fix. Both gaps are pinned ``xfail(strict=True)`` in
-    ``test_write_facade_version_owner.py``.
+    "The real input" means the file whose rows the partition write will read.
+    ``partition string`` and ``partition admin`` hand the resolver the file the
+    user named; the index-adding drivers (quadkey, h3, s2, a5, kdtree) hand it
+    the scratch file their ``add <index>`` step wrote, and that is correct
+    *because* the scratch write is now lossless: it carries the same
+    ``input_file`` witness, so it preserves the user's version, native geometry
+    type and CRS (#993). Until it did, resolving here from the scratch file
+    called every input native-geo-only and the five drivers wrote 1.1 WKB, while
+    pointing them at the user's file instead would have fixed the version and
+    imported ``sort quadkey``'s wrong-CRS defect -- the *data* still coming from
+    a scratch file that had lost the CRS. Fixing the scratch write is what made
+    both correct at once. ``test_write_facade_version_owner.py`` measures every
+    driver's output against the user's file, in the ``geo`` block and the Parquet
+    logical type separately.
     """
 
     geoparquet_version: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,6 +389,34 @@ def fields_geom_type_only_5070_file(test_data_dir):
     return str(test_data_dir / "fields_pgo_5070_snappy.parquet")
 
 
+@pytest.fixture(scope="session")
+def projected_conus(tmp_path_factory):
+    """A clean native-geo-only EPSG:5070 file: 200 polygons spread over CONUS.
+
+    Three things at once, which no committed fixture is:
+
+    * **Native geo with no ``geo`` key**, the input class the write facade has to
+      answer the version *and* the CRS question about from the schema alone.
+    * **Not CRS84.** A file in the default CRS cannot tell a path that keeps the
+      CRS from one that loses it, because an absent ``crs`` already means CRS84.
+    * **Really inside EPSG:5070's area of use.** ``fields_pgo_5070_snappy.parquet``
+      is labelled 5070 but its coordinates are over Europe, so ``check spec``
+      scores it ``✗ coordinates outside valid range for CRS`` whatever the
+      command under test did -- and "clean" has to mean *zero* failures, or the
+      assertion stops being able to see a new failure appear (#993).
+    """
+    import geoarrow.pyarrow as ga
+
+    from tests.native_geo_probes import conus_wkb, projjson, write_native_geo_only
+
+    rows = conus_wkb("ST_Transform(cell, 'EPSG:4326', 'EPSG:5070', always_xy := true)")
+    return write_native_geo_only(
+        tmp_path_factory.mktemp("projected_conus") / "pgo.parquet",
+        rows,
+        {"geometry": (2, ga.wkb().with_crs(projjson(5070)))},
+    )
+
+
 @pytest.fixture
 def austria_bbox_covering_file(test_data_dir):
     """Return path to the austria_bbox_covering.parquet test file.

--- a/tests/native_geo_probes.py
+++ b/tests/native_geo_probes.py
@@ -1,0 +1,209 @@
+"""Readers and fixture builders for native-geo-only GeoParquet files.
+
+A GeoParquet 2.0 file states its CRS in **two** places -- the ``geo`` block's
+``columns.<name>.crs`` and the Parquet ``GEOMETRY``/``GEOGRAPHY`` logical type --
+and the interesting failure is the two disagreeing. ``crs_utils.source_crs_string``
+reads the first, falls back to the second and returns whichever answered, so it
+reports *an* answer for a file that holds two: structurally incapable of seeing
+the defect. #993 shipped green under exactly that oracle.
+
+Everything here therefore comes in pairs. :func:`geo_block_crs_id` reads the
+``geo`` block and only the ``geo`` block; :func:`logical_crs_id` reads the
+Parquet schema and only the Parquet schema; :func:`spec_failures` asks gpio's
+own validator whether what they say adds up.
+
+Refs: https://github.com/geoparquet/geoparquet-io/issues/993
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+#: Authority identifiers the fixtures below declare, as PROJJSON ``id`` objects.
+EPSG_5070 = {"authority": "EPSG", "code": 5070}
+EPSG_3857 = {"authority": "EPSG", "code": 3857}
+
+
+# ---------------------------------------------------------------------------
+# Reader 1: the `geo` block, and only the `geo` block
+# ---------------------------------------------------------------------------
+
+
+def geo_block(path) -> dict | None:
+    """The file-level ``geo`` key, or None when there is none."""
+    metadata = pq.ParquetFile(str(path)).metadata.metadata or {}
+    if b"geo" not in metadata:
+        return None
+    return json.loads(metadata[b"geo"].decode("utf-8"))
+
+
+def geo_version(path) -> str | None:
+    return (geo_block(path) or {}).get("version")
+
+
+def geo_block_crs_id(path, column: str = "geometry"):
+    """One column's CRS as the ``geo`` block states it, and nothing else.
+
+    Returns the PROJJSON ``id`` object, or a string naming why there is none --
+    a marker rather than ``None``, so a missing ``crs`` key cannot be mistaken
+    for a deliberate ``crs: null`` and neither can slip past an ``is not None``.
+    """
+    block = geo_block(path)
+    if block is None:
+        return "<no geo key>"
+    col_meta = (block.get("columns") or {}).get(column)
+    if col_meta is None:
+        return "<column not described>"
+    if "crs" not in col_meta:
+        # GeoParquet's default: an absent `crs` means OGC:CRS84.
+        return "<no crs key -- resolves as OGC:CRS84>"
+    if col_meta["crs"] is None:
+        return "<crs: null -- unknown>"
+    return (col_meta["crs"] or {}).get("id")
+
+
+# ---------------------------------------------------------------------------
+# Reader 2: the Parquet schema, and only the Parquet schema
+# ---------------------------------------------------------------------------
+
+
+def logical_geo_types(path) -> dict[str, tuple[str, dict | None]]:
+    """``{column: (GEOMETRY|GEOGRAPHY, crs id)}`` read straight off the schema.
+
+    Never through the ``geo`` block: the input class this exists for has no
+    ``geo`` block, and its CRS lives only here.
+    """
+    schema = pq.ParquetFile(str(path)).schema
+    native: dict[str, tuple[str, dict | None]] = {}
+    for index in range(len(schema)):
+        column = schema.column(index)
+        described = json.loads(column.logical_type.to_json())
+        if described.get("Type") not in ("Geometry", "Geography"):
+            continue
+        raw_crs = described.get("crs")
+        crs = json.loads(raw_crs) if raw_crs else None
+        native[column.name] = (described["Type"], (crs or {}).get("id"))
+    return native
+
+
+def logical_crs_id(path, column: str = "geometry"):
+    """The CRS inside one column's Parquet logical type, or a reason there is none."""
+    described = logical_geo_types(path).get(column)
+    if described is None:
+        return "<no native geo type>"
+    return described[1] if described[1] is not None else "<no crs -- resolves as OGC:CRS84>"
+
+
+# ---------------------------------------------------------------------------
+# The arbiter: gpio's own validator
+# ---------------------------------------------------------------------------
+
+
+def spec_report(path) -> dict:
+    """``gpio check spec --json`` on one file."""
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    result = CliRunner().invoke(cli, ["check", "spec", "--json", str(path)])
+    # `check spec` exits non-zero when the file fails, which is the thing under
+    # test, so only a crash (no parseable report) is an error here.
+    payload = result.output[result.output.index("{") :]
+    return json.loads(payload)
+
+
+def spec_problems(path, status: str = "failed") -> list[str]:
+    """The messages of every ``check spec`` check with ``status``."""
+    return [
+        f"{check['name']}: {check['message']}"
+        for check in spec_report(path)["checks"]
+        if check["status"] == status
+    ]
+
+
+def spec_failures(path) -> list[str]:
+    return spec_problems(path, "failed")
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+#: 200 small polygons on a grid across the lower 48, as lon/lat degrees.
+#:
+#: Spread matters twice over. ``tests/data/fields_pgo_5070_snappy.parquet`` is
+#: labelled EPSG:5070 but its coordinates are over Europe, so ``check spec``
+#: scores it ``✗ coordinates outside valid range for CRS`` whatever the command
+#: under test did. "Clean" has to mean *zero* failures rather than "the same one
+#: failure as before", or the assertion stops being able to see a new failure
+#: appear.
+_CONUS_GRID = """
+    SELECT i, -122.0 + (i % 20) * 2.6 AS lon, 26.0 + (i // 20) * 2.1 AS lat
+    FROM range(200) t(i)
+"""
+
+
+def conus_wkb(*projections: str) -> list[tuple]:
+    """``id``, ``grp`` and one WKB column per projection, over the same 200 cells.
+
+    ``projections`` are SQL expressions over a ``cell`` GEOMETRY in lon/lat.
+    ``grp`` is the low-cardinality column ``gpio partition string`` needs.
+    """
+    from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+
+    con = get_duckdb_connection(load_spatial=True)
+    try:
+        selected = ", ".join(f"ST_AsWKB({expr})::BLOB" for expr in projections)
+        return con.execute(
+            f"""
+            SELECT i AS id, 'g' || (i % 3) AS grp, {selected}
+            FROM (
+                SELECT i, ST_MakeEnvelope(lon, lat, lon + 0.4, lat + 0.3) AS cell
+                FROM ({_CONUS_GRID})
+            )
+            ORDER BY i
+            """
+        ).fetchall()
+    finally:
+        con.close()
+
+
+def write_native_geo_only(path, rows, columns) -> Path:
+    """Write a Parquet file with native geo logical types and **no** ``geo`` key.
+
+    Written through pyarrow rather than DuckDB because that is the only way to
+    get this shape on purpose: a Parquet ``GEOMETRY``/``GEOGRAPHY`` logical type
+    carrying the CRS, with nothing in the file-level metadata repeating it. It is
+    exactly the shape the write facade had no witness for -- the version question
+    and the CRS question both have to be answered from the schema, because there
+    is no ``geo`` block to answer either.
+
+    ``columns`` maps a column name to ``(row index, geoarrow type)``.
+    """
+    arrays = {
+        "id": pa.array([row[0] for row in rows], type=pa.int64()),
+        "grp": pa.array([row[1] for row in rows]),
+    }
+    for name, (index, geo_type) in columns.items():
+        arrays[name] = pa.ExtensionArray.from_storage(
+            geo_type, pa.array([bytes(row[index]) for row in rows], type=pa.binary())
+        )
+    pq.write_table(pa.table(arrays), str(path), compression="zstd")
+    return path
+
+
+def projjson(epsg: int) -> str:
+    """Full PROJJSON for an EPSG code.
+
+    Not a hand-written ``{"id": ...}`` stub: GeoParquet requires a ``type``
+    member, and a stub makes ``check spec`` report the *fixture* rather than the
+    command under test.
+    """
+    from pyproj import CRS
+
+    return json.dumps(CRS.from_epsg(epsg).to_json_dict())

--- a/tests/native_geo_probes.py
+++ b/tests/native_geo_probes.py
@@ -9,7 +9,7 @@ the defect. #993 shipped green under exactly that oracle.
 
 Everything here therefore comes in pairs. :func:`geo_block_crs_id` reads the
 ``geo`` block and only the ``geo`` block; :func:`logical_crs_id` reads the
-Parquet schema and only the Parquet schema; :func:`spec_failures` asks gpio's
+Parquet schema and only the Parquet schema; :func:`spec_problems` asks gpio's
 own validator whether what they say adds up.
 
 Refs: https://github.com/geoparquet/geoparquet-io/issues/993
@@ -111,9 +111,23 @@ def spec_report(path) -> dict:
 
     result = CliRunner().invoke(cli, ["check", "spec", "--json", str(path)])
     # `check spec` exits non-zero when the file fails, which is the thing under
-    # test, so only a crash (no parseable report) is an error here.
-    payload = result.output[result.output.index("{") :]
-    return json.loads(payload)
+    # test, so a failing report is not an error here. A crash before the report
+    # is, and it has to say so: slicing from the first `{` raised `ValueError:
+    # substring not found` when there was no report at all, and sliced from the
+    # wrong place when a log line printed ahead of it happened to contain one.
+    # So try each `{` in turn and take the first that decodes.
+    decoder = json.JSONDecoder()
+    for start, char in enumerate(result.output):
+        if char != "{":
+            continue
+        try:
+            return decoder.raw_decode(result.output, start)[0]
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(
+        f"`check spec --json` emitted no JSON report for {path} "
+        f"(exit {result.exit_code}): {result.output or result.exception!r}"
+    )
 
 
 def spec_problems(path, status: str = "failed") -> list[str]:
@@ -123,10 +137,6 @@ def spec_problems(path, status: str = "failed") -> list[str]:
         for check in spec_report(path)["checks"]
         if check["status"] == status
     ]
-
-
-def spec_failures(path) -> list[str]:
-    return spec_problems(path, "failed")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_add_preserves_native_geo.py
+++ b/tests/test_add_preserves_native_geo.py
@@ -48,13 +48,13 @@ from tests.native_geo_probes import (
     EPSG_5070,
     conus_wkb,
     geo_block,
+    geo_block_crs_id,
     geo_version,
     logical_geo_types,
     projjson,
     spec_problems,
     write_native_geo_only,
 )
-from tests.native_geo_probes import geo_block_crs_id as _geo_block_crs_id
 
 
 def _run_cli(*args) -> None:
@@ -83,6 +83,12 @@ def _run_cli_in_a_fresh_process(*args) -> None:
         ],
         capture_output=True,
         text=True,
+        # A wedge cap, not a performance budget, and deliberately not the 30 s
+        # most subprocess tests here use: this one pays a cold interpreter's
+        # full CLI import (pyarrow, geoarrow, duckdb) with no warm process to
+        # share it. 0.8 s idle, and over 30 s under `-n auto` with coverage on
+        # 12 workers -- measured, after a 30 s cap turned that into a failure.
+        timeout=300,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
@@ -144,13 +150,13 @@ def two_native_geometry_columns(tmp_path_factory) -> Path:
 #: ``admin-divisions`` because it needs a boundary dataset to join against
 #: (covered by the network lane).
 ROW_REWRITING_ADD_COMMANDS = [
-    pytest.param("bbox", (), id="bbox"),
-    pytest.param("quadkey", (), id="quadkey"),
-    pytest.param("h3", (), id="h3"),
-    pytest.param("s2", (), id="s2"),
-    pytest.param("a5", (), id="a5"),
-    pytest.param("kdtree", (), id="kdtree"),
-    pytest.param("geometry-metrics", (), id="geometry-metrics"),
+    "bbox",
+    "quadkey",
+    "h3",
+    "s2",
+    "a5",
+    "kdtree",
+    "geometry-metrics",
 ]
 
 
@@ -165,10 +171,8 @@ def test_the_fixture_is_a_clean_native_geo_only_epsg_5070_file(projected_conus):
     assert spec_problems(projected_conus) == []
 
 
-@pytest.mark.parametrize(("subcommand", "extra_args"), ROW_REWRITING_ADD_COMMANDS)
-def test_add_keeps_the_file_describing_itself_consistently(
-    subcommand, extra_args, projected_conus, tmp_path
-):
+@pytest.mark.parametrize("subcommand", ROW_REWRITING_ADD_COMMANDS)
+def test_add_keeps_the_file_describing_itself_consistently(subcommand, projected_conus, tmp_path):
     """One run, four facts: version, encoding, CRS *in the geo block*, agreement.
 
     The fourth is what the old oracle could not see. The third is what makes the
@@ -177,18 +181,16 @@ def test_add_keeps_the_file_describing_itself_consistently(
     """
     out = tmp_path / f"{subcommand}.parquet"
 
-    _run_cli("add", subcommand, projected_conus, out, *extra_args)
+    _run_cli("add", subcommand, projected_conus, out)
 
     assert (geo_version(out) or "").startswith("2.0")
     assert logical_geo_types(out)["geometry"] == ("Geometry", EPSG_5070)
-    assert _geo_block_crs_id(out) == EPSG_5070
+    assert geo_block_crs_id(out) == EPSG_5070
     assert spec_problems(out) == []
 
 
-@pytest.mark.parametrize(("subcommand", "extra_args"), ROW_REWRITING_ADD_COMMANDS)
-def test_add_states_the_crs_even_when_asked_for_1_1(
-    subcommand, extra_args, projected_conus, tmp_path
-):
+@pytest.mark.parametrize("subcommand", ROW_REWRITING_ADD_COMMANDS)
+def test_add_states_the_crs_even_when_asked_for_1_1(subcommand, projected_conus, tmp_path):
     """An explicit version still wins -- and still has to say which CRS it is.
 
     1.1 has nowhere but the ``geo`` block to put a CRS, so a 1.1 rewrite of a
@@ -199,11 +201,11 @@ def test_add_states_the_crs_even_when_asked_for_1_1(
     """
     out = tmp_path / f"{subcommand}.parquet"
 
-    _run_cli("add", subcommand, projected_conus, out, *extra_args, "--geoparquet-version", "1.1")
+    _run_cli("add", subcommand, projected_conus, out, "--geoparquet-version", "1.1")
 
     assert (geo_version(out) or "").startswith("1.1")
     assert logical_geo_types(out) == {}, "1.1 forbids a native Parquet geo type"
-    assert _geo_block_crs_id(out) == EPSG_5070
+    assert geo_block_crs_id(out) == EPSG_5070
     assert spec_problems(out) == []
 
 
@@ -225,7 +227,7 @@ def test_geometry_metrics_keeps_the_native_type_from_a_fresh_process(projected_c
 
     assert (geo_version(out) or "").startswith("2.0")
     assert logical_geo_types(out)["geometry"] == ("Geometry", EPSG_5070)
-    assert _geo_block_crs_id(out) == EPSG_5070
+    assert geo_block_crs_id(out) == EPSG_5070
     assert spec_problems(out) == []
 
 
@@ -301,7 +303,7 @@ def test_add_attaches_the_witness_crs_to_the_primary_column_only(
 
     _run_cli("add", "bbox", two_native_geometry_columns, out)
 
-    assert _geo_block_crs_id(out) == EPSG_5070
+    assert geo_block_crs_id(out) == EPSG_5070
     assert logical_geo_types(out)["geometry"] == ("Geometry", EPSG_5070)
     assert logical_geo_types(out)["centroid"][1] != EPSG_5070
 

--- a/tests/test_add_preserves_native_geo.py
+++ b/tests/test_add_preserves_native_geo.py
@@ -1,0 +1,335 @@
+"""``gpio add *`` must not downgrade -- or contradict -- the file it rewrites.
+
+Every ``gpio add`` subcommand rewrites its whole input to append one column.
+That rewrite went through ``write_parquet_with_metadata`` without ``input_file=``,
+so the write facade (#990) had no witness to answer either of the two questions
+a rewrite of a *native-geo-only* file has to answer:
+
+* **Which version?** Auto mode read the carried ``geo`` key, and a
+  native-geo-only input has no ``geo`` key. It landed on the 1.1 default, DuckDB
+  re-encoded the geometry column as plain WKB, and the Parquet ``GEOMETRY``
+  logical type went with it.
+* **Which CRS?** A native-geo-only file stores its CRS *only* inside that
+  logical type, so ``input_crs`` was ``None`` and nothing described the output's
+  CRS at all.
+
+The two answers have to come from the same witness, and this is why. Passing
+``input_file=`` alone fixes the version and leaves the CRS unanswered: the
+output is then native 2.0 with the CRS in the Parquet logical type and **no**
+``crs`` key in the ``geo`` block -- which GeoParquet resolves as ``OGC:CRS84``.
+The file contradicts itself, and ``gpio check spec`` says so::
+
+    ✗ CRS in geo metadata must match CRS in Parquet schema
+        Metadata: OGC:CRS84 (default), Schema: NAD83 / Conus Albers (EPSG:5070)
+
+So every end-to-end assertion here reads the ``geo`` block and the Parquet
+logical type **separately**, and then asks ``gpio check spec`` whether they
+agree. Reading the CRS through ``crs_utils.source_crs_string`` -- which consults
+the ``geo`` block, falls back to the logical type, and returns the first answer
+it finds -- is structurally incapable of reporting a disagreement between them,
+and an oracle that cannot see the defect certified it green.
+
+Refs: https://github.com/geoparquet/geoparquet-io/issues/993
+Refs: https://github.com/geoparquet/geoparquet-io/issues/600
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from tests.native_geo_probes import (
+    EPSG_3857,
+    EPSG_5070,
+    conus_wkb,
+    geo_block,
+    geo_version,
+    logical_geo_types,
+    projjson,
+    spec_problems,
+    write_native_geo_only,
+)
+from tests.native_geo_probes import geo_block_crs_id as _geo_block_crs_id
+
+
+def _run_cli(*args) -> None:
+    result = CliRunner().invoke(cli, [str(a) for a in args])
+    assert result.exit_code == 0, result.output
+
+
+def _run_cli_in_a_fresh_process(*args) -> None:
+    """Run one gpio command in a subprocess, importing nothing this module did.
+
+    In-process is the wrong oracle for anything that depends on ``pyarrow``'s
+    *global* extension-type registry. The fixtures below import
+    ``geoarrow.pyarrow`` to write their files, and that import silently changes
+    how every later pyarrow read in the process materialises a Parquet
+    ``GEOMETRY`` column -- plain ``binary`` without it, ``geoarrow.wkb`` with it.
+    A pyarrow rewrite that loses the logical type therefore passes under pytest
+    and fails for the user. Measured, on ``add geometry-metrics`` over the
+    EPSG:5070 fixture: 0 failures in-process, 4 from a fresh CLI.
+    """
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from geoparquet_io.cli.main import cli; cli()",
+            *(str(a) for a in args),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+# ---------------------------------------------------------------------------
+# Fixtures. The EPSG:5070 one is `projected_conus`, shared via conftest with
+# tests/test_write_facade_version_owner.py -- the same input, measured on both
+# sides of the scratch-file write.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def spherical_geography(tmp_path_factory) -> Path:
+    """A native-geo-only file whose geometry column is a GEOGRAPHY.
+
+    A GEOGRAPHY column's edges follow the sphere. Anything that rebuilds it as a
+    plain GEOMETRY leaves the same bytes describing straight lines between the
+    same vertices -- different shapes, with nothing in the file saying so.
+    """
+    import geoarrow.pyarrow as ga
+    import geoarrow.types as gt
+
+    return write_native_geo_only(
+        tmp_path_factory.mktemp("geography") / "pgo.parquet",
+        conus_wkb("cell"),
+        {"geometry": (2, ga.wkb().with_edge_type(gt.EdgeType.SPHERICAL))},
+    )
+
+
+@pytest.fixture(scope="module")
+def two_native_geometry_columns(tmp_path_factory) -> Path:
+    """``geometry`` in EPSG:5070 and ``centroid`` in EPSG:3857, both native.
+
+    Two columns with *different* CRSs, so a write that applies one column's CRS
+    to both -- or drops one of them -- is visible rather than a no-op.
+    """
+    import geoarrow.pyarrow as ga
+
+    rows = conus_wkb(
+        "ST_Transform(cell, 'EPSG:4326', 'EPSG:5070', always_xy := true)",
+        "ST_Transform(ST_Centroid(cell), 'EPSG:4326', 'EPSG:3857', always_xy := true)",
+    )
+    return write_native_geo_only(
+        tmp_path_factory.mktemp("two_geo") / "pgo.parquet",
+        rows,
+        {
+            "geometry": (2, ga.wkb().with_crs(projjson(5070))),
+            "centroid": (3, ga.wkb().with_crs(projjson(3857))),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Every `add` subcommand that rewrites its input's rows
+# ---------------------------------------------------------------------------
+
+
+#: ``bbox-metadata`` is excluded because it writes metadata only, and
+#: ``admin-divisions`` because it needs a boundary dataset to join against
+#: (covered by the network lane).
+ROW_REWRITING_ADD_COMMANDS = [
+    pytest.param("bbox", (), id="bbox"),
+    pytest.param("quadkey", (), id="quadkey"),
+    pytest.param("h3", (), id="h3"),
+    pytest.param("s2", (), id="s2"),
+    pytest.param("a5", (), id="a5"),
+    pytest.param("kdtree", (), id="kdtree"),
+    pytest.param("geometry-metrics", (), id="geometry-metrics"),
+]
+
+
+def test_the_fixture_is_a_clean_native_geo_only_epsg_5070_file(projected_conus):
+    """Non-vacuity, and the baseline every "clean" below is measured against.
+
+    If the input already failed ``check spec``, "the output has no failures"
+    would be an assertion about the fixture rather than about the command.
+    """
+    assert geo_block(projected_conus) is None
+    assert logical_geo_types(projected_conus) == {"geometry": ("Geometry", EPSG_5070)}
+    assert spec_problems(projected_conus) == []
+
+
+@pytest.mark.parametrize(("subcommand", "extra_args"), ROW_REWRITING_ADD_COMMANDS)
+def test_add_keeps_the_file_describing_itself_consistently(
+    subcommand, extra_args, projected_conus, tmp_path
+):
+    """One run, four facts: version, encoding, CRS *in the geo block*, agreement.
+
+    The fourth is what the old oracle could not see. The third is what makes the
+    fourth non-vacuous: a file can only contradict itself once both halves have
+    said something.
+    """
+    out = tmp_path / f"{subcommand}.parquet"
+
+    _run_cli("add", subcommand, projected_conus, out, *extra_args)
+
+    assert (geo_version(out) or "").startswith("2.0")
+    assert logical_geo_types(out)["geometry"] == ("Geometry", EPSG_5070)
+    assert _geo_block_crs_id(out) == EPSG_5070
+    assert spec_problems(out) == []
+
+
+@pytest.mark.parametrize(("subcommand", "extra_args"), ROW_REWRITING_ADD_COMMANDS)
+def test_add_states_the_crs_even_when_asked_for_1_1(
+    subcommand, extra_args, projected_conus, tmp_path
+):
+    """An explicit version still wins -- and still has to say which CRS it is.
+
+    1.1 has nowhere but the ``geo`` block to put a CRS, so a 1.1 rewrite of a
+    native-geo-only input is the case where the witness is the *only* thing
+    standing between EPSG:5070 and a file that declares nothing. This was
+    silently lossy for every ``add`` subcommand before #993, and no version
+    assertion could have caught it.
+    """
+    out = tmp_path / f"{subcommand}.parquet"
+
+    _run_cli("add", subcommand, projected_conus, out, *extra_args, "--geoparquet-version", "1.1")
+
+    assert (geo_version(out) or "").startswith("1.1")
+    assert logical_geo_types(out) == {}, "1.1 forbids a native Parquet geo type"
+    assert _geo_block_crs_id(out) == EPSG_5070
+    assert spec_problems(out) == []
+
+
+def test_geometry_metrics_keeps_the_native_type_from_a_fresh_process(projected_conus, tmp_path):
+    """The one ``add`` subcommand that ends in a pyarrow rewrite of the whole file.
+
+    ``add geometry-metrics`` runs ``constants._fix_vecorel_schema`` last, and
+    pyarrow only re-emits a Parquet ``GEOMETRY`` logical type if
+    ``geoarrow.pyarrow`` has registered its extension types in *that* process.
+    Every other test in this file is blind to that, because the fixtures imported
+    ``geoarrow.pyarrow`` to write their files. Run from a fresh interpreter the
+    same command scored ``4 failed`` -- the native type gone, the CRS left in the
+    ``geo`` block with nothing in the schema to match it -- which is why
+    ``_fix_vecorel_schema`` now does the registering itself.
+    """
+    out = tmp_path / "geometry-metrics.parquet"
+
+    _run_cli_in_a_fresh_process("add", "geometry-metrics", projected_conus, out)
+
+    assert (geo_version(out) or "").startswith("2.0")
+    assert logical_geo_types(out)["geometry"] == ("Geometry", EPSG_5070)
+    assert _geo_block_crs_id(out) == EPSG_5070
+    assert spec_problems(out) == []
+
+
+def test_add_on_a_1_1_input_still_writes_1_1(tmp_path):
+    """The control: auto mode preserves, it does not upgrade a 1.1 input to 2.0."""
+    one_one = Path(__file__).parent / "data" / "austria_bbox_covering.parquet"
+    assert (geo_version(one_one) or "").startswith("1."), "fixture is not a 1.x input"
+    out = tmp_path / "bbox.parquet"
+
+    _run_cli("add", "bbox", one_one, out)
+
+    assert (geo_version(out) or "").startswith("1.1")
+    assert logical_geo_types(out) == {}
+
+
+# ---------------------------------------------------------------------------
+# The two inputs the witness does not reach, measured rather than assumed
+# ---------------------------------------------------------------------------
+
+
+def test_the_geography_fixture_really_is_spherical(spherical_geography):
+    """Non-vacuity for the xfail below."""
+    assert logical_geo_types(spherical_geography)["geometry"][0] == "Geography"
+    assert spec_problems(spherical_geography) == []
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "`add bbox` on a native GEOGRAPHY input writes a planar Parquet GEOMETRY "
+        "logical type, while the `geo` block it builds declares "
+        '`"edges": "spherical"` -- so `check spec` warns that the two halves of '
+        "the output describe different shapes over the same bytes. It is still an "
+        "improvement on main, which wrote 1.1 WKB and dropped the `edges` "
+        "declaration outright, silently replanning the edges with nothing in the "
+        "file saying so. The witness #993 adds carries the CRS, not the edge type: "
+        "DuckDB reads a GEOGRAPHY column as a planar GEOMETRY and the write has "
+        "nothing left to restate it from, so closing this means teaching the "
+        "write path to round-trip the edge type (#999). Delete this marker then."
+    ),
+)
+def test_add_keeps_a_geography_column_spherical(spherical_geography, tmp_path):
+    """Measured, not assumed: the output must not silently replan the edges."""
+    out = tmp_path / "bbox.parquet"
+
+    _run_cli("add", "bbox", spherical_geography, out)
+
+    assert logical_geo_types(out)["geometry"][0] == "Geography"
+    assert spec_problems(out) == []
+    assert spec_problems(out, status="warning") == []
+
+
+def test_the_two_column_fixture_really_declares_two_crss(two_native_geometry_columns):
+    """Non-vacuity for the two below."""
+    assert logical_geo_types(two_native_geometry_columns) == {
+        "geometry": ("Geometry", EPSG_5070),
+        "centroid": ("Geometry", EPSG_3857),
+    }
+    assert spec_problems(two_native_geometry_columns) == []
+
+
+def test_add_attaches_the_witness_crs_to_the_primary_column_only(
+    two_native_geometry_columns, tmp_path
+):
+    """The half that does work: a per-file witness must not become a per-file CRS.
+
+    ``resolve_input_crs`` answers for the file, and ``apply_output_crs`` applies
+    that answer to the primary column alone. A secondary column in a *different*
+    CRS is what makes the difference observable: EPSG:5070 must not land on
+    ``centroid``.
+    """
+    out = tmp_path / "bbox.parquet"
+
+    _run_cli("add", "bbox", two_native_geometry_columns, out)
+
+    assert _geo_block_crs_id(out) == EPSG_5070
+    assert logical_geo_types(out)["geometry"] == ("Geometry", EPSG_5070)
+    assert logical_geo_types(out)["centroid"][1] != EPSG_5070
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "A secondary native geometry column survives the rewrite with its logical "
+        "type but loses its own CRS, and nothing adds it to `geo.columns`, which "
+        "GeoParquet 2.0 requires for every geometry column in the file: "
+        "`✗ geometry columns not described in geo metadata: ['centroid']`. The "
+        "caller is what is missing -- `add *` passes no `geometry_info`, so "
+        "`build_geo_metadata` is never told there is a secondary column and no "
+        "witness is read for it. That is a per-column change affecting every write "
+        "path, not the per-file witness #993 adds, and it is filed as #1000 next to "
+        "#952/#953. Main is worse here (a 1.1 file still carrying a native "
+        "`centroid` type, two failures); this narrows it to one. Delete this "
+        "marker then."
+    ),
+)
+def test_add_describes_and_keeps_every_native_geometry_column(
+    two_native_geometry_columns, tmp_path
+):
+    """Measured, not assumed: 2.0 requires every geometry column to be described."""
+    out = tmp_path / "bbox.parquet"
+
+    _run_cli("add", "bbox", two_native_geometry_columns, out)
+
+    assert sorted((geo_block(out) or {}).get("columns", {})) == ["centroid", "geometry"]
+    assert logical_geo_types(out)["centroid"] == ("Geometry", EPSG_3857)
+    assert spec_problems(out) == []

--- a/tests/test_write_facade_version_owner.py
+++ b/tests/test_write_facade_version_owner.py
@@ -1,9 +1,9 @@
-"""One owner for the auto-version decision -- and what still is not covered.
+"""One owner for the auto-version decision -- and the CRS that travels with it.
 
 ``tests/test_write_facade_contract.py`` pins the contracts the facade turned
 green. This file pins the three things review found *around* them, each a case
-where something other than the facade still answers the facade's own question,
-or where the facade's answer reaches an output the input never described.
+where something other than the facade answered the facade's own question, or
+where the facade's answer reached an output the input never described.
 
 * **A stale second owner.** ``hilbert_order._resolve_output_version`` decides
   which version ``gpio sort hilbert`` and ``gpio sort str`` *say* they are
@@ -13,23 +13,34 @@ or where the facade's answer reaches an output the input never described.
   side, and the exact input class the facade exists to fix.
 * **A version resolved from a lossy intermediate.** ``gpio sort quadkey`` and
   the five index-adding ``gpio partition`` drivers rewrite their input into a
-  scratch file first (to add the index column), and that scratch write does not
+  scratch file first (to add the index column), and that scratch write did not
   preserve native geo or the input's CRS. Resolving the *version* from the
   user's real file while reading the *data* from the scratch file is how
-  ``sort quadkey`` came to stamp ``OGC:CRS84`` on an EPSG:5070 input.
-* **A behaviour claimed wholesale.** Only ``partition string`` and
-  ``partition admin`` read the user's file directly, so only they deliver the
-  #600 fix; the index-adding drivers still write 1.1 WKB.
+  ``sort quadkey`` came to stamp ``OGC:CRS84`` on an EPSG:5070 input. #993 made
+  the scratch write pass the same witness, so the intermediate is now lossless
+  and the two markers here were deleted with their assertions unchanged.
+* **A behaviour claimed wholesale.** Before #993 only ``partition string`` and
+  ``partition admin`` read the user's file directly, so only they delivered the
+  #600 fix.
 
-The gaps are marked ``xfail(strict=True)`` rather than left untested or
+The gaps were marked ``xfail(strict=True)`` rather than left untested or
 asserted as correct: strict mode means whoever fixes the underlying scratch-file
 write has to come here and delete the marker, which is the signal. Certifying
 them green -- which the contract file's ``crs=<null>`` fixture does by
 omission -- is what let ``gpio check spec`` print
 ``✓ valid inline PROJJSON CRS`` over the wrong CRS.
 
+The two assertions the markers guarded are kept exactly as they were written,
+so the deletion means what it is supposed to mean. They are *not* the evidence,
+though: ``source_crs_string`` reads the ``geo`` block, falls back to the Parquet
+logical type and returns the first answer, so it cannot report the two
+disagreeing -- which is a file's own way of being wrong. The tests below them
+add that oracle, reading each source separately and then asking
+``gpio check spec`` whether they agree.
+
 Refs: https://github.com/geoparquet/geoparquet-io/issues/600
 Refs: https://github.com/geoparquet/geoparquet-io/issues/738
+Refs: https://github.com/geoparquet/geoparquet-io/issues/993
 """
 
 from __future__ import annotations
@@ -44,6 +55,8 @@ from click.testing import CliRunner
 from geoparquet_io.cli.main import cli
 from geoparquet_io.core.crs_utils import source_crs_string
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
+from tests.native_geo_probes import EPSG_5070, logical_crs_id, spec_failures
+from tests.native_geo_probes import geo_block_crs_id as _geo_block_crs_id
 
 #: A native-geo-only input whose CRS is *not* the default. The distinction the
 #: contract file's DuckDB-written fixture cannot make: it carries ``crs=<null>``,
@@ -197,18 +210,6 @@ def test_auto_mode_keeps_the_input_crs_while_upgrading_to_native_2_0(command, ex
     assert source_crs_string(str(out), False) == PROJECTED_CRS
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "sort quadkey resolves the version from the user's file but reads the data "
-        "from the scratch file `add quadkey` wrote, and that write drops the native "
-        "GEOMETRY type and the CRS with it. The output is therefore native 2.0 "
-        "declaring OGC:CRS84 over EPSG:5070 data -- a wrong CRS asserted where "
-        "before it was merely absent, which `gpio check spec` blesses. Fixing it "
-        "means making the index-adding scratch write preserve the input's version "
-        "and CRS (the other half of #600); delete this marker then."
-    ),
-)
 def test_sort_quadkey_keeps_the_input_crs(tmp_path):
     """Same assertion as the four above, on the one path with an intermediate."""
     out = tmp_path / "quadkey.parquet"
@@ -216,6 +217,26 @@ def test_sort_quadkey_keeps_the_input_crs(tmp_path):
     _run_cli("sort", "quadkey", PROJECTED_PGO, out)
 
     assert source_crs_string(str(out), False) == PROJECTED_CRS
+
+
+def test_sort_quadkey_does_not_leave_the_two_crs_sources_disagreeing(projected_conus, tmp_path):
+    """What the assertion above cannot see, and why it needed a second test.
+
+    ``source_crs_string`` returns the ``geo`` block's answer when there is one
+    and the Parquet logical type's otherwise, so it reports *an* answer for a
+    file that holds two. Passing ``input_file=`` alone made this exact output
+    native 2.0 with EPSG:5070 in the logical type and no ``crs`` key in the
+    ``geo`` block -- ``source_crs_string`` still said EPSG:5070, and
+    ``gpio check spec`` said ``✗ CRS in geo metadata must match CRS in Parquet
+    schema``.
+    """
+    out = tmp_path / "quadkey.parquet"
+
+    _run_cli("sort", "quadkey", projected_conus, out)
+
+    assert _geo_block_crs_id(out) == EPSG_5070
+    assert logical_crs_id(out) == EPSG_5070
+    assert spec_failures(out) == []
 
 
 # ---------------------------------------------------------------------------
@@ -275,23 +296,35 @@ def test_partition_string_delivers_native_2_0(native_geo_only, tmp_path):
 
 
 @pytest.mark.parametrize("driver", ["quadkey", "h3", "s2", "a5", "kdtree"])
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "The index-adding partition drivers hand `partition_by_column` the scratch "
-        "file their `add <index>` step wrote, not the user's input, so the facade "
-        "resolves auto mode from a file that is already a 1.1 WKB rewrite. "
-        "Resolving from the user's file instead would fix the version and import "
-        "`sort quadkey`'s wrong-CRS defect (see test_sort_quadkey_keeps_the_input_crs) "
-        "onto five more commands, so the scratch write is the thing to fix. Until "
-        "then `gpio partition <index>` does not deliver #600."
-    ),
-)
 def test_index_partition_drivers_deliver_native_2_0(driver, native_geo_only, tmp_path):
-    """Pins the gap the PR body must not claim as fixed."""
+    """The five drivers that reach ``partition_by_column`` through a scratch file."""
     out_dir = tmp_path / driver
     extra = ["--auto"] if driver != "kdtree" else []
 
     _run_cli("partition", driver, native_geo_only, out_dir, "--force", *extra)
 
     assert _partition_versions(out_dir) == {("2.0.0", True)}
+
+
+@pytest.mark.parametrize("driver", ["quadkey", "h3", "s2", "a5", "kdtree"])
+def test_index_partition_drivers_keep_a_projected_crs_in_both_places(
+    driver, projected_conus, tmp_path
+):
+    """The version half is not the whole fix, and this fixture is what shows it.
+
+    ``native_geo_only`` above is written in lon/lat, where an absent ``crs``
+    already means the right thing -- so a driver that loses the CRS and one that
+    keeps it produce the same file and ``{("2.0.0", True)}`` passes either way.
+    Every part file here has to name EPSG:5070 in both places and survive
+    ``check spec``.
+    """
+    out_dir = tmp_path / driver
+    extra = ["--auto"] if driver != "kdtree" else []
+
+    _run_cli("partition", driver, projected_conus, out_dir, "--force", *extra)
+
+    parts = sorted(Path(out_dir).rglob("*.parquet"))
+    assert parts, "partition wrote no files"
+    assert [_geo_block_crs_id(part) for part in parts] == [EPSG_5070] * len(parts)
+    assert [logical_crs_id(part) for part in parts] == [EPSG_5070] * len(parts)
+    assert [spec_failures(part) for part in parts] == [[]] * len(parts)

--- a/tests/test_write_facade_version_owner.py
+++ b/tests/test_write_facade_version_owner.py
@@ -55,8 +55,7 @@ from click.testing import CliRunner
 from geoparquet_io.cli.main import cli
 from geoparquet_io.core.crs_utils import source_crs_string
 from geoparquet_io.core.duckdb_utils import get_duckdb_connection, sql_path
-from tests.native_geo_probes import EPSG_5070, logical_crs_id, spec_failures
-from tests.native_geo_probes import geo_block_crs_id as _geo_block_crs_id
+from tests.native_geo_probes import EPSG_5070, geo_block_crs_id, logical_crs_id, spec_problems
 
 #: A native-geo-only input whose CRS is *not* the default. The distinction the
 #: contract file's DuckDB-written fixture cannot make: it carries ``crs=<null>``,
@@ -234,9 +233,9 @@ def test_sort_quadkey_does_not_leave_the_two_crs_sources_disagreeing(projected_c
 
     _run_cli("sort", "quadkey", projected_conus, out)
 
-    assert _geo_block_crs_id(out) == EPSG_5070
+    assert geo_block_crs_id(out) == EPSG_5070
     assert logical_crs_id(out) == EPSG_5070
-    assert spec_failures(out) == []
+    assert spec_problems(out) == []
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +324,60 @@ def test_index_partition_drivers_keep_a_projected_crs_in_both_places(
 
     parts = sorted(Path(out_dir).rglob("*.parquet"))
     assert parts, "partition wrote no files"
-    assert [_geo_block_crs_id(part) for part in parts] == [EPSG_5070] * len(parts)
+    assert [geo_block_crs_id(part) for part in parts] == [EPSG_5070] * len(parts)
     assert [logical_crs_id(part) for part in parts] == [EPSG_5070] * len(parts)
-    assert [spec_failures(part) for part in parts] == [[]] * len(parts)
+    assert [spec_problems(part) for part in parts] == [[]] * len(parts)
+
+
+# ---------------------------------------------------------------------------
+# A CRS the output has nothing to attach to
+# ---------------------------------------------------------------------------
+
+
+#: Both input shapes that reach the plain-COPY fast path with a CRS to resolve:
+#: a native-geo-only file whose CRS lives only in the Parquet logical type, and
+#: a 2.0 file that also has a ``geo`` block. Neither is in the default CRS, so
+#: the facade has a non-``None`` answer to give in both cases.
+PROJECTED_INPUTS = [
+    pytest.param(PROJECTED_PGO, id="native-geo-only"),
+    pytest.param(Path(__file__).parent / "data" / "fields_gpq2_5070_brotli.parquet", id="gpq2"),
+]
+
+
+@pytest.mark.parametrize("source", PROJECTED_INPUTS)
+def test_a_projection_that_drops_the_geometry_column_still_writes(source, tmp_path):
+    """The output declares no CRS because it has no geometry to declare one for.
+
+    The facade answers "which CRS does the output describe its geometry with",
+    and a projection that drops the geometry column leaves that question with no
+    subject. Answering it anyway handed ``_wrap_query_with_crs`` a CRS and no
+    column to ``ST_SetCRS``, which raised ``ValueError: geometry_column is
+    required when input_crs is specified`` out of a command that worked before
+    #993 -- a traceback, not even an error line.
+    """
+    out = tmp_path / "attributes.parquet"
+
+    _run_cli("extract", "geoparquet", source, out, "--exclude-cols", "geometry")
+
+    schema = pq.ParquetFile(str(out)).schema_arrow
+    assert "geometry" not in schema.names
+    assert "id" in schema.names
+    assert pq.ParquetFile(str(out)).metadata.num_rows == 100
+
+
+def test_the_facade_states_no_crs_for_an_output_with_no_geometry_column():
+    """The gate, at the one place that owns the decision.
+
+    Stated here as well as through the CLI above because it is the whole rule:
+    the witness is only consulted for an output that has somewhere to put the
+    answer, and an explicitly named CRS gets the same treatment -- there is no
+    column for ``apply_output_crs`` to write it onto either.
+    """
+    from geoparquet_io.core.parquet_writer import resolve_input_crs
+
+    assert resolve_input_crs(None, input_file=str(PROJECTED_PGO), geometry_column=None) is None
+    assert resolve_input_crs({"id": EPSG_5070}, geometry_column=None) is None
+    assert (
+        resolve_input_crs(None, input_file=str(PROJECTED_PGO), geometry_column="geometry")
+        is not None
+    )


### PR DESCRIPTION
## What changed

Every `gpio add` subcommand rewrites its whole input to append one column, and
none of them passed `input_file=` to `write_parquet_with_metadata`. The write
facade (#990) therefore had no witness to answer either of the two questions a
rewrite of a **native-geo-only** file has to answer:

- **Which version?** Auto mode read the carried `geo` key, and a native-geo-only
  input has none. It landed on the 1.1 default, DuckDB re-encoded the geometry
  column as plain WKB, and the Parquet `GEOMETRY` logical type went with it.
- **Which CRS?** That logical type is the *only* place a native-geo-only file
  stores its CRS, so `input_crs` was `None` and nothing described the output's
  CRS at all. `EPSG:5070` in, nothing declared out — which every reader resolves
  as `OGC:CRS84`.

Two commands read that downgraded scratch file rather than the user's, so the
loss reached them too, and both were pinned `xfail(strict=True)` in
`tests/test_write_facade_version_owner.py`: `gpio sort quadkey` and
`gpio partition quadkey/h3/s2/a5/kdtree`.

### The two answers have to come from the same witness

The first draft of this PR passed `input_file=` at the seven `add`-family sites
and stopped there. That fixes the version and leaves the CRS unanswered — which
is **worse than the bug it replaces**, because the output is then native 2.0
with EPSG:5070 in the Parquet logical type and no `crs` key in the `geo` block.
One file, two CRSs, and gpio's own checker saying so:

```
✗ CRS in geo metadata must match CRS in Parquet schema
    Metadata: OGC:CRS84 (default), Schema: NAD83 / Conus Albers (EPSG:5070)
```

So the facade gains a third resolver, `parquet_writer.resolve_input_crs`,
reading the CRS from the same `input_file` witness the version already came
from, applied next to it in `write_parquet_with_metadata`. Not at seven call
sites: splitting one question between many answerers is the defect class #990
exists to end.

It also repairs a quieter loss on the same inputs. `--geoparquet-version 1.1` on
a native-geo-only file has nowhere but the `geo` block to record a CRS, and
before this it recorded none — a silent downgrade to CRS84 that no version
assertion could have caught.

The facade still does **not** own what `crs_utils.apply_output_crs` owns: the
null-vs-default rule, stripping a stale value, omitting the default. This only
*finds* the input's CRS. An explicit `input_crs` always wins — `gpio convert
reproject` passes the CRS it transforms *to*, and `gpio convert` the one a
non-Parquet source's geometry is in (`--crs`, for CSV/TSV input) — so those
paths are untouched (measured below).

"Only finds" is not "only informs one place", though, and the facade docstring
now says so: a non-`None` answer where the write previously had `None` moves
three things at once — `apply_output_crs` writes an explicit `crs` into the
`geo` block, `_wrap_query_with_crs` wraps the query in `ST_SetCRS` so DuckDB
stamps the CRS into the Parquet logical type, and `geoarrow_encoding` attaches
it to the Arrow extension type. The `ST_SetCRS` wrap is the load-bearing one:
without it DuckDB restates whatever the column it read carried, which is how
`sort quadkey` came to stamp `OGC:CRS84` on EPSG:5070 data.

### An output with no geometry column declares no CRS

Review found the one case where the facade's answer reaches an output that has
nowhere to put it. A column projection can drop the geometry column entirely,
and the resolver then answered a question with no subject:

```
$ gpio extract geoparquet tests/data/fields_pgo_5070_snappy.parquet out.parquet --exclude-cols geometry
ValueError: geometry_column is required when input_crs is specified — cannot apply CRS without a geometry column
   rc=1
```

`_wrap_query_with_crs` got a CRS and no column to `ST_SetCRS`. A traceback, not
even an error line, out of a command that worked before this branch. It needed
all three of: an output resolving to 2.0/native (so the plain-`COPY` fast path
is taken), an input with a non-default CRS, and a projection that drops the
geometry column — which is why a 1.1 input, taking the rewrite-strategy path,
never showed it.

The gate is in `resolve_input_crs`, before any witness is consulted and whatever
the caller named: the one place that owns the decision is the one place that
knows the answer can be `None`. Both of review's triggers now exit 0 —
`--exclude-cols geometry` on the native-geo-only fixture, and
`--exclude-cols geometry,bbox` on a 2.0 input with a `geo` block — each writing
the seven attribute columns and 100 rows, with no `geo` key.

### The Vecorel schema fix, measured rather than assumed

`constants._fix_vecorel_schema`, which `add geometry-metrics` runs last, is a
pyarrow read/write of the whole file. Plain pyarrow reads a Parquet `GEOMETRY`
column as `binary` and writes it back as `binary`, so with the fix above in
place it would turn a native 2.0 file into a 2.0 file with no native geo type.

This turns out to depend on nothing in the file and everything in the process:
`geoarrow.pyarrow`'s import registers the extension types that make pyarrow
materialise those columns as `geoarrow.wkb`, and that registration is global. The
same code, same input:

| | `check spec` on `add geometry-metrics` output |
|---|---|
| under pytest (fixtures import `geoarrow.pyarrow`) | 34 passed, **0 failed** |
| from a fresh CLI process | 26 passed, **4 failed** |

The fix is therefore one line — `_fix_vecorel_schema` imports `geoarrow.pyarrow`
itself — and `tests/test_add_preserves_native_geo.py` runs that one command in a
**subprocess**, because no in-process test can see this class of defect.
Re-verified as load-bearing by deleting that one line: exactly the subprocess
test fails (`KeyError: 'geometry'` — the native type gone), while its
in-process sibling over the same command stays green.

An earlier draft carried ~100 lines for this instead: a `native_geo_types_in_file`
helper that parsed each column's logical type out of JSON, a `_geography_edge_type`
mapper, and a `_conform_to_schema` that duplicated `disk_rewrite._conform_row_group`.
Review found four defects in it, and the measurement dissolved all four along with
the code they were in — pyarrow already round-trips the logical type, the CRS *and*
a GEOGRAPHY's edge type once its extension types are registered. What review found,
and where it went:

| finding | severity | disposition |
|---|---|---|
| `json.loads` on a CRS that is `EPSG:32633` or `srid:...` rather than PROJJSON would raise | **latent, not CLI-reachable** — no gpio write path emits a non-PROJJSON CRS into a logical type, so no command could reach it | code deleted |
| `_geography_edge_type("planar")` returned `PLANAR`, against its own docstring's guarantee that every GEOGRAPHY algorithm is non-planar | would have silently replanned a GEOGRAPHY's edges | code deleted; pyarrow preserves the edge type, verified on a spherical fixture |
| `_conform_to_schema` duplicated `disk_rewrite._conform_row_group` | duplication | code deleted |
| the helper lived in a module named `constants` while importing from `write_strategies` | layering | code deleted |

No separate PR was opened for it: there is nothing left to review that this
does not contain.

## Measured, per command

`gpio check spec --json` on the output of every command, plus the `geo` block's
`crs` and the Parquet logical type's `crs` read **separately** — because
`crs_utils.source_crs_string` reads the first, falls back to the second, and
returns whichever answered. It reports *an* answer for a file that holds two,
which is exactly how the first draft of this PR passed its own tests.

Input: 200 polygons spread across the lower 48, EPSG:5070 in the Parquet
`GEOMETRY` logical type, **no** `geo` key, `6 passed / 0 failed`. Built inside
5070's real area of use on purpose: `tests/data/fields_pgo_5070_snappy.parquet`
is labelled 5070 but its coordinates are over Europe, so it always scores one
`✗ coordinates outside valid range for CRS` and "clean" could never mean zero.

`before` is `origin/main` in a clean worktree; `after` is this branch rebased
onto it.

| command | `geo` block | Parquet logical type | `check spec` |
|---|---|---|---|
| **before** | | | |
| `add bbox` | 1.1.0, no `crs` key | WKB, no native type | 27p / **1F** |
| `add quadkey` / `h3` / `s2` / `a5` / `kdtree` / `geometry-metrics` | 1.1.0, no `crs` key | WKB, no native type | 23p / **1F** each |
| `add bbox-metadata` (on `add bbox`'s output) | 1.1.0, no `crs` key | WKB, no native type | 27p / **1F** |
| `partition quadkey` / `h3` / `s2` / `a5` / `kdtree` | 1.1.0, no `crs` key | WKB, no native type | 23p / **1F** (every part file) |
| `sort quadkey` | 2.0.0, no `crs` key | `Geometry`, **`OGC:CRS84`** | 33p / **1F** |
| **after** | | | |
| `add bbox` | 2.0.0, **EPSG:5070** | `Geometry`, **EPSG:5070** | 38p / **0F** |
| `add quadkey` / `h3` / `s2` / `a5` / `kdtree` / `geometry-metrics` | 2.0.0, **EPSG:5070** | `Geometry`, **EPSG:5070** | 34p / **0F** each |
| `add bbox-metadata` (on `add bbox`'s output) | 2.0.0, **EPSG:5070** | `Geometry`, **EPSG:5070** | 38p / **0F** |
| `partition quadkey` / `h3` / `s2` / `a5` / `kdtree` | 2.0.0, **EPSG:5070** | `Geometry`, **EPSG:5070** | 34p / **0F** (all 13 part files) |
| `sort quadkey` | 2.0.0, **EPSG:5070** | `Geometry`, **EPSG:5070** | 34p / **0F** |

The single `1F` on every `before` row is `coordinates outside valid range for
CRS`: the downgrade left EPSG:5070 metres in a file claiming CRS84. It is the
defect, not fixture noise — the input scores zero failures, and so does every
`after` row.

`sort quadkey`'s `before` row is the one worth reading twice. It is already
native 2.0, and it **asserts** `OGC:CRS84` inside the logical type over
EPSG:5070 data — a wrong CRS stated where the others merely omit one, which
`gpio check spec` then blesses with `✓ column "geometry" has valid inline
PROJJSON CRS`.

### What else the user sees change

**Files get bigger by a fixed amount.** The full EPSG:5070 PROJJSON (2,477
bytes) is now written into the `geo` block *and* the Parquet logical type, and
for `geometry-metrics` into `ARROW:schema` as well. On the same 200-row,
18,437-byte input:

| command | before | after | delta |
|---|---|---|---|
| `add bbox` | 18,989 | 23,460 | +4,471 |
| `sort quadkey` | 14,300 | 20,318 | +6,018 |
| `add geometry-metrics` | 14,491 | 25,814 | +11,323 |

It is a **constant, not a ratio** — metadata, not data. On a 200-row fixture
that reads as +24% to +78%; on a real file it is noise. Row groups are
unchanged: this does not touch `resolve_row_group_rows`, and the #990 row-group
concern does not apply.

**A `crs: null` input now prints a warning it did not print before.** The
resolver reaches `extract_crs_from_parquet`, which calls `warn_null_crs_once`,
so `gpio add *` on a file with an explicit `"crs": null` now says:

```
Input has an explicit null CRS (unknown). An explicit null CRS means the CRS is
*unknown* (not the OGC:CRS84 default). If the coordinates are really lon/lat
WGS84, run `gpio convert reproject <input> <output> --assume-crs84` to set the
default.
```

`main` was silent. This is an improvement — the information was always true and
never surfaced — but it is new output on a breaking-change PR, so it is declared
rather than discovered. The written `crs: null` is unchanged either way.

### Controls, unchanged before and after

`partition string`, `sort hilbert`, `sort column`, `sort str`,
`extract geoparquet`, `convert geoparquet` — all `2.0.0, EPSG:5070` in both
places, `34 passed / 0 failed`, on both sides. The paths that already read the
user's file directly do not move, and neither does the one that passes its own
`input_crs`.

`add admin-divisions` is not in the table: it needs a boundary dataset to join
against and belongs to the network lane. Its two write sites, and the
`add/country_codes.py` join it is built on (reached by `admin-divisions` and by
`gpio benchmark`), take the same `input_file=` change as the rest.

## Two defects this does not fix, pinned rather than left unmeasured

Both are now exercised end-to-end through the real command, with
`xfail(strict=True)` — so whoever fixes them has to come back and delete a
marker.

**#999 — a native `GEOGRAPHY` column comes back planar.** `add bbox` on a
spherical input writes a planar `Geometry` logical type while the `geo` block it
builds declares `"edges": "spherical"`, and `check spec` warns. Still better
than `main`, which wrote 1.1 WKB and dropped the `edges` declaration **outright**
— silently replanning the edges with nothing in the file saying so. The witness
here carries the CRS, not the edge type: DuckDB reads a GEOGRAPHY column as a
planar GEOMETRY, so the write has nothing left to restate it from.

**#1000 — a secondary geometry column is left undescribed.** Two native columns
(`geometry` EPSG:5070, `centroid` EPSG:3857) through `add bbox`: `centroid` keeps
its logical type, loses its own CRS, and never appears in `geo.columns`, which
2.0 requires. `main` scores this input **2 failures** (it wrote a 1.1 file that
still carried a native `centroid` type); this narrows it to 1. Its sibling test
`test_add_attaches_the_witness_crs_to_the_primary_column_only` **passes** and
pins the half that is right — a per-file witness must not become a per-file CRS
stamped onto every column. Sits next to #952 and #953.

## Also found, out of scope by this repo's separate-PRs rule

`core/check_fixes.py:115`, `:258` and `:437` call `write_parquet_with_metadata`
without `input_file=`, so `gpio check --fix` has the identical defect on the
identical inputs. Not bolted onto this branch: it is a different command with its
own before/after measurement to take. Review found a second `check --fix` defect
next to it — it drops a bbox covering on a 2.0 input, which this PR newly routes
users into by making more outputs 2.0 — filed with it.

## Docs

`docs/guide/add.md` gains the note that `add` preserves the input's version and
CRS, that `sort quadkey` and the five index `partition` drivers inherit it, and
that the two shapes above are not covered yet. It also states the reader
contract this change implies: a native 2.0 output needs a reader that
understands the Parquet `GEOMETRY` logical type — older pyarrow, geopandas and
DuckDB builds may not open one — and `--geoparquet-version 1.1` is the escape
hatch, writing plain WKB with the CRS in the `geo` block.

## Tests

`tests/test_add_preserves_native_geo.py` is rewritten around the oracle the first
draft lacked. Every end-to-end assertion reads the `geo` block and the Parquet
logical type separately and then asks `gpio check spec` whether they agree —
one test, four asserts, per subcommand, rather than three pipeline runs each. The
readers and fixture builders live in `tests/native_geo_probes.py` so
`test_write_facade_version_owner.py` measures its side of the scratch write
against the same input.

The six `xfail(strict=True)` markers in `test_write_facade_version_owner.py` are
deleted **with their assertions unchanged**, which is what the markers were for.
Those assertions go through `source_crs_string`, so they are not the evidence:
two new tests beside them read both sources separately and require `check spec`
to be clean, for `sort quadkey` and for every part file of all five index
partition drivers, on a projected fixture (the file's own `native_geo_only`
fixture is lon/lat, where an absent `crs` already means the right thing and a
CRS assertion cannot fail).

Three more from review: the dropped-geometry case above, through the CLI on both
input shapes and directly against `resolve_input_crs`. `spec_report` now tries
each `{` in turn rather than slicing from the first, so a `check spec` that
crashes before emitting JSON says so instead of raising `ValueError: substring
not found`. The subprocess probe gets a wedge cap of 300 s — deliberately not
the 30 s the repo's other subprocess tests use, because this one pays a cold
interpreter's full CLI import: 0.8 s idle, and over 30 s under `-n auto` with
coverage on 12 workers, measured after a 30 s cap turned that into a failure.

## Verification

- `uv run pytest -q -n auto -m "not slow and not network and not meta" --cov=geoparquet_io --cov-report=xml --cov-fail-under=0` — **7700 passed, 76 skipped, 3 xfailed** in 199s
- `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` — **100%**, 12 changed lines, 0 missing
- `uv run pytest -q -m meta` — **205 passed**
- `uv run pre-commit run --all-files` and `--hook-stage pre-push` — all green (ruff, codespell, duckdb-antipatterns, mypy, vulture, xenon, import-linter, deptry, menard-check, doc-sync)
- `uv run lint-imports` — 4 contracts kept, 0 broken
- `uv run pytest docs/guide -n 4 -m "not network"` — **236 passed, 224 skipped**
- `tests/data/cli_surface.json` unchanged

Refs #600. Closes #993.

Deferred from review, each with its own issue rather than riding along:

- **#1003** — `add bbox` → `check --fix` drops the covering on a native 2.0 file. Pre-existing in `check_fixes` (the three `write_parquet_with_metadata` calls there pass no `input_file=`); this PR newly routes users into it by making `add bbox` produce 2.0.
- **#1004** — when the `geo` block and the Parquet logical type disagree on the CRS, the resolver picks the block and writes it into both, silently. The input is already invalid, but a loud inconsistency becomes a clean-looking assertion; it should warn.
- **#1005** — the partition path is the one exemption from "version and CRS from one witness, together": `staging.py` passes neither, and the AST invariant asserts only that the version is pre-resolved, not that the CRS came from the same file.
- **#1006** — two streaming sites (`cli/commands/convert.py`, `core/streaming.py`) have the same latent `geoarrow.pyarrow` registration dependency fixed here for `_fix_vecorel_schema`; lossless end to end today, same shape. Plus a regression test for the GEOGRAPHY edge-type round-trip this PR relies on but does not pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rewriting GeoParquet files now preserves native geometry encoding, CRS, and format version across column additions, sorting, and spatial partitioning.
  * Inputs using native Parquet `GEOMETRY` types retain their metadata and remain valid after processing.
  * CRS information is preserved for projected datasets, including EPSG:5070.
  * Added support for explicitly writing GeoParquet 1.1 when compatibility with older readers is required.

* **Documentation**
  * Documented file-rewrite behavior, metadata preservation, supported format versions, and compatibility options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->