### PR TITLE
chore(core): remove unused calculate_row_group_size

### DIFF
--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -379,43 +379,6 @@ def parse_size_string(size_str):
     return int(value * multiplier)
 
 
-def calculate_row_group_size(
-    total_rows, file_size_bytes, target_row_group_size_mb=None, target_row_group_rows=None
-):
-    """
-    Calculate optimal row group size for parquet file.
-
-    Args:
-        total_rows: Total number of rows in the file
-        file_size_bytes: Current file size in bytes
-        target_row_group_size_mb: Target size per row group in MB
-        target_row_group_rows: Exact number of rows per row group
-
-    Returns:
-        int: Number of rows per row group
-    """
-    if target_row_group_rows:
-        # Use exact row count if specified
-        return min(target_row_group_rows, total_rows)
-
-    if not target_row_group_size_mb:
-        target_row_group_size_mb = 130  # Default 130MB
-
-    # Convert target size to bytes
-    target_bytes = target_row_group_size_mb * 1024 * 1024
-
-    # Calculate average bytes per row
-    if total_rows > 0 and file_size_bytes > 0:
-        bytes_per_row = file_size_bytes / total_rows
-        # Calculate number of rows that would fit in target size
-        rows_per_group = int(target_bytes / bytes_per_row)
-        # Ensure at least 1 row per group but not more than total rows
-        return max(1, min(rows_per_group, total_rows))
-    else:
-        # Default to all rows in one group if we can't calculate
-        return max(1, total_rows)
-
-
 def validate_compression_settings(compression, compression_level, verbose=False):
     """
     Validate and normalize compression settings.

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -4,7 +4,6 @@ import pytest
 
 from geoparquet_io.core.common import (
     _get_geometry_type_name,
-    calculate_row_group_size,
     check_bbox_structure,
     detect_geoparquet_file_type,
     format_size,
@@ -967,40 +966,6 @@ class TestValidateProjjson:
 
     def test_rejects_dict_without_expected_keys(self):
         assert _validate_projjson({"name": "'; DROP TABLE foo; --"}) is False
-
-
-class TestCalculateRowGroupSize:
-    """Tests for calculate_row_group_size function."""
-
-    def test_with_exact_row_count(self):
-        """Test that exact row count is used when specified."""
-
-        # If target_row_group_rows is specified, use it
-        result = calculate_row_group_size(1000, 1024 * 1024, target_row_group_rows=500)
-        assert result == 500
-
-    def test_with_target_mb_size(self):
-        """Test calculating row groups based on target MB size."""
-
-        # 1000 rows, 1MB total = 1KB per row
-        # Target 10MB = should get 10240 rows, but capped at 1000
-        result = calculate_row_group_size(1000, 1024 * 1024, target_row_group_size_mb=10)
-        assert result == 1000
-
-    def test_default_row_group_size(self):
-        """Test default row group size calculation (130MB)."""
-
-        # 10000 rows, 10MB total = 1KB per row
-        # Default 130MB target = 133120 rows, but capped at 10000
-        result = calculate_row_group_size(10000, 10 * 1024 * 1024)
-        assert result == 10000
-
-    def test_minimum_one_row(self):
-        """Test that result is at least 1 row."""
-
-        # Even with tiny target, should return at least 1
-        result = calculate_row_group_size(1000, 1024 * 1024 * 1024, target_row_group_size_mb=0.001)
-        assert result >= 1
 
 
 class TestIsPartitionPath:


### PR DESCRIPTION
## My comments
Came across this piece of unused code while investigating a fever dream of auto-computing optimal row group sizes per file, and my mother said that cleaning up was often quite as productive as adding something new.

## Summary
- Remove `calculate_row_group_size` from `core/common.py`. No
  production callers, only its own unit test.
- Remove the matching test class from `tests/test_common_utils.py`.

## Why
gpio converts a `--row-group-size-mb` target to a row count in one
place: `write_strategies/row_group_sizing.py` calls
`common._estimate_row_size`, and both DuckDB write strategies and the
plain Arrow write path use it. `calculate_row_group_size` did the same
conversion differently - bytes-per-row from the existing file's
on-disk compressed size rather than the in-memory table - and nothing
called it. Its output does not match what any write path produces.

No behavior change: no write path called this function.

## Test plan
- `uv run pytest tests/test_common_utils.py` - 135 passed
- `uv run pytest -k "row_group or common_utils or disk_rewrite"` - 382
  passed, 1 skipped
- Full fast suite (`-m "not slow and not network and not meta"`) -
  7661 passed, 76 skipped, 7 xfailed
- `grep -rn calculate_row_group_size .` - no references
- `vulture` - nothing flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the row-group size calculation utility and its related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->