### PR TITLE
fix(write): warn on disagreeing CRS sources, and keep a streamed geometry field typed

### DIFF
--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -309,6 +309,14 @@ Validates file structure and metadata against the GeoParquet specification:
   carried through verbatim, `native_crs_format` warns with the literal, and
   `v2_crs_consistency` compares it as-is, so it fails closed and names the value
   it could not read rather than reading it as the default.
+- **A `v2_crs_consistency` failure does not survive a rewrite** — every gpio
+  command that rewrites the file answers "which CRS?" from the `geo` block
+  first, falling back to the Parquet logical type. When the two disagree, the
+  `geo` block wins and its answer is written into *both* places, so the output
+  passes this check over coordinates that were never transformed. gpio warns
+  when it does this, naming both CRSs and which one it used, but the warning is
+  the only trace: fix whichever half is wrong on the **input**, before the
+  rewrite.
 - **Datum-aware epoch validation** — a coordinate `epoch` on a datum ensemble
   (e.g. EPSG:4326, or the OGC:CRS84 default when `crs` is omitted) fails; on a
   specific static frame (e.g. GDA2020) it warns; on a dynamic frame (e.g. ITRF)

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -309,14 +309,15 @@ Validates file structure and metadata against the GeoParquet specification:
   carried through verbatim, `native_crs_format` warns with the literal, and
   `v2_crs_consistency` compares it as-is, so it fails closed and names the value
   it could not read rather than reading it as the default.
-- **A `v2_crs_consistency` failure does not survive a rewrite** — every gpio
-  command that rewrites the file answers "which CRS?" from the `geo` block
-  first, falling back to the Parquet logical type. When the two disagree, the
-  `geo` block wins and its answer is written into *both* places, so the output
-  passes this check over coordinates that were never transformed. gpio warns
-  when it does this, naming both CRSs and which one it used, but the warning is
-  the only trace: fix whichever half is wrong on the **input**, before the
-  rewrite.
+- **A `v2_crs_consistency` failure does not survive a rewrite** — a gpio
+  command that rewrites the file as GeoParquet (`add`, `sort`, `partition`,
+  `convert geoparquet`, `check --fix`) answers "which CRS?" for the primary
+  column from the `geo` block first, falling back to the Parquet logical type.
+  When the two disagree, the `geo` block wins and its answer is written into
+  *both* places, so the output passes this check over coordinates that were
+  never transformed. gpio warns when it does this, naming both CRSs and which
+  one it used, but the warning is the only trace: fix whichever half is wrong
+  on the **input**, before the rewrite.
 - **Datum-aware epoch validation** — a coordinate `epoch` on a datum ensemble
   (e.g. EPSG:4326, or the OGC:CRS84 default when `crs` is omitted) fails; on a
   specific static frame (e.g. GDA2020) it warns; on a dynamic frame (e.g. ITRF)

--- a/geoparquet_io/cli/commands/convert.py
+++ b/geoparquet_io/cli/commands/convert.py
@@ -314,6 +314,12 @@ def _convert_streaming(
     import tempfile
     import uuid
 
+    # Registers the GeoArrow extension types process-wide, so the `pq.read_table`
+    # below materialises a Parquet GEOMETRY/GEOGRAPHY column as `geoarrow.wkb`
+    # rather than plain `binary` and the stream describes its geometry as one.
+    # The registration is global, which is why it happens here rather than being
+    # relied on -- see `constants._fix_vecorel_schema` (#1006, #993).
+    import geoarrow.pyarrow  # noqa: F401
     import pyarrow.parquet as pq
 
     from geoparquet_io.core.streaming import write_arrow_stream

--- a/geoparquet_io/cli/commands/convert.py
+++ b/geoparquet_io/cli/commands/convert.py
@@ -353,8 +353,16 @@ def _convert_streaming(
             memory_limit=memory_limit,
         )
 
-        # Read and stream to stdout
-        table = pq.read_table(temp_path)
+        # Read and stream to stdout. Through `ParquetFile` so the file handle is
+        # closed here, before the `unlink` below, rather than whenever the
+        # reader `pq.read_table` creates internally is collected: with the
+        # extension types registered the table it returns is reachable through
+        # Python-side objects that outlive this frame's refcount drop, and
+        # Windows refuses to delete a file that still has a reader open
+        # (WinError 32). POSIX unlinks an open file happily, so only the Windows
+        # legs saw it.
+        with pq.ParquetFile(temp_path) as reader:
+            table = reader.read()
         write_arrow_stream(table)
     finally:
         if temp_path.exists():

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -653,13 +653,15 @@ def extract_crs_from_table(table, geometry_column: str | None = None):
     return None
 
 
-def _crs_from_geo_block(parquet_file) -> dict | str | None:
-    """The CRS the file's ``geo`` block states for its primary column, or ``None``.
+def _crs_from_geo_block(parquet_file) -> tuple[dict | str | None, str | None]:
+    """``(crs, primary column)`` as the file's ``geo`` block states them.
 
-    ``None`` for a missing block, an undescribed column, the default CRS and an
-    explicit ``crs: null`` alike -- all of them mean "this source does not name a
-    CRS to write". The null case warns on its way through, because an unknown CRS
-    is not an absent one.
+    The CRS is ``None`` for a missing block, an undescribed column, the default
+    CRS and an explicit ``crs: null`` alike -- all of them mean "this source does
+    not name a CRS to write". The null case warns on its way through, because an
+    unknown CRS is not an absent one. The column comes back alongside so the
+    caller can hold the logical type of *that* column against it, not whichever
+    geometry column happens to come first in the schema.
 
     A write-path reader, so a malformed carried block goes through
     :func:`sanitize_geo_metadata` rather than being indexed as-is (#887).
@@ -671,22 +673,25 @@ def _crs_from_geo_block(parquet_file) -> dict | str | None:
 
     geo_meta = sanitize_geo_metadata(get_geo_metadata(parquet_file))
     if not geo_meta:
-        return None
+        return None, None
     primary_col = _primary_column_of_file(geo_meta, parquet_file)
     columns = geo_meta.get("columns", {})
     if primary_col not in columns:
-        return None
+        return None, primary_col
     if crs_is_explicitly_null(columns[primary_col]):
         warn_null_crs_once(str(parquet_file))
     crs = columns[primary_col].get("crs")
-    return crs if crs and not is_default_crs(crs) else None
+    return (crs if crs and not is_default_crs(crs) else None), primary_col
 
 
-def _crs_from_native_geo_type(parquet_file) -> dict | str | None:
-    """The CRS inside the first Parquet GEOMETRY/GEOGRAPHY logical type, or ``None``.
+def _crs_from_native_geo_type(parquet_file, column: str | None = None) -> dict | str | None:
+    """The CRS inside a Parquet GEOMETRY/GEOGRAPHY logical type, or ``None``.
 
-    The only place a *native-geo-only* file records its CRS, and the second
-    opinion on every file that also has a ``geo`` block.
+    With ``column`` it reads that one column -- the second opinion on a file
+    whose ``geo`` block has already named its primary. Without it, the first
+    geometry column that names a non-default CRS: the only place a
+    *native-geo-only* file records its CRS, where no block says which column is
+    primary.
     """
     from geoparquet_io.core.duckdb_metadata import (
         get_schema_info,
@@ -695,6 +700,8 @@ def _crs_from_native_geo_type(parquet_file) -> dict | str | None:
     )
 
     for col in get_schema_info(parquet_file):
+        if column is not None and col.get("name") != column:
+            continue
         logical_type = col.get("logical_type") or ""
         if not logical_type.startswith(("GeometryType(", "GeographyType(")):
             continue
@@ -730,11 +737,14 @@ def _crs_sources_disagree(geo_block_crs, native_crs) -> bool:
 @lru_cache(maxsize=256)
 def _emit_crs_disagreement_warning(key: str, winner: str, loser: str) -> None:
     """Emit the two-sources-disagree warning exactly once per ``key`` (LRU-bounded)."""
+    # Says what was read and which half won, not what the caller will write with
+    # it: `convert reproject` transforms the coordinates and states its target
+    # CRS, the GDAL writers do not write a `geo` block at all, so a sentence
+    # about "the output" would be false for them.
     warn(
         f"{key}: the geo metadata says the CRS is {winner} but the Parquet geometry "
         f"logical type says {loser}. Using {winner}, per the documented preference "
-        "for the geo metadata -- an output written from this input will state "
-        f"{winner} in both places, with coordinates that were never transformed. "
+        "for the geo metadata; the coordinates themselves are read as-is. "
         "Run `gpio check spec` on the input and fix whichever half is wrong."
     )
 
@@ -777,8 +787,15 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
     footer either way, and ``gpio check spec`` reads both halves of every file
     regardless.
     """
-    geo_block_crs = _crs_from_geo_block(parquet_file)
-    native_crs = _crs_from_native_geo_type(parquet_file)
+    geo_block_crs, primary_col = _crs_from_geo_block(parquet_file)
+    # Compare like with like: the block's answer is about its primary column,
+    # so the logical type it is held against has to be that column's. A valid
+    # file with a second geometry column in another CRS ahead of the primary in
+    # schema order is otherwise accused of contradicting itself, and a primary
+    # that really does disagree is masked by a non-primary that happens to agree.
+    native_crs = _crs_from_native_geo_type(
+        parquet_file, column=primary_col if geo_block_crs is not None else None
+    )
 
     if geo_block_crs is not None:
         if _crs_sources_disagree(geo_block_crs, native_crs):

--- a/geoparquet_io/core/crs_utils.py
+++ b/geoparquet_io/core/crs_utils.py
@@ -653,6 +653,97 @@ def extract_crs_from_table(table, geometry_column: str | None = None):
     return None
 
 
+def _crs_from_geo_block(parquet_file) -> dict | str | None:
+    """The CRS the file's ``geo`` block states for its primary column, or ``None``.
+
+    ``None`` for a missing block, an undescribed column, the default CRS and an
+    explicit ``crs: null`` alike -- all of them mean "this source does not name a
+    CRS to write". The null case warns on its way through, because an unknown CRS
+    is not an absent one.
+
+    A write-path reader, so a malformed carried block goes through
+    :func:`sanitize_geo_metadata` rather than being indexed as-is (#887).
+    ``get_geo_metadata`` itself stays unsanitized -- ``gpio check`` reads through
+    it and has to see the file as it really is.
+    """
+    from geoparquet_io.core.duckdb_metadata import get_geo_metadata
+    from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
+
+    geo_meta = sanitize_geo_metadata(get_geo_metadata(parquet_file))
+    if not geo_meta:
+        return None
+    primary_col = _primary_column_of_file(geo_meta, parquet_file)
+    columns = geo_meta.get("columns", {})
+    if primary_col not in columns:
+        return None
+    if crs_is_explicitly_null(columns[primary_col]):
+        warn_null_crs_once(str(parquet_file))
+    crs = columns[primary_col].get("crs")
+    return crs if crs and not is_default_crs(crs) else None
+
+
+def _crs_from_native_geo_type(parquet_file) -> dict | str | None:
+    """The CRS inside the first Parquet GEOMETRY/GEOGRAPHY logical type, or ``None``.
+
+    The only place a *native-geo-only* file records its CRS, and the second
+    opinion on every file that also has a ``geo`` block.
+    """
+    from geoparquet_io.core.duckdb_metadata import (
+        get_schema_info,
+        parse_geometry_logical_type,
+        resolve_crs_reference,
+    )
+
+    for col in get_schema_info(parquet_file):
+        logical_type = col.get("logical_type") or ""
+        if not logical_type.startswith(("GeometryType(", "GeographyType(")):
+            continue
+        parsed = parse_geometry_logical_type(logical_type)
+        if not (parsed and "crs" in parsed):
+            continue
+        crs = resolve_crs_reference(parquet_file, parsed["crs"])
+        if crs and not is_default_crs(crs):
+            return crs
+    return None
+
+
+def _crs_sources_disagree(geo_block_crs, native_crs) -> bool:
+    """True only when both sources name a CRS and the two are demonstrably different.
+
+    Deliberately conservative: it reports a disagreement only when *both* sides
+    resolve to an authority identifier and those identifiers differ. A warning on
+    the write path that cries wolf is worse than one that is occasionally quiet,
+    and two PROJJSON objects with no ``id`` can be textually different renderings
+    of the same CRS (different pyproj versions spell the same datum out
+    differently), which is not something to tell a user their file is broken over.
+
+    Not ``validate._crs_equals``: that resolves the CRS84-vs-absent and
+    explicit-null cases, which the callers here have already filtered out, and
+    reaching for it would pull the 2800-line validator onto a read path that runs
+    for every rewrite.
+    """
+    left = crs_string_for_transform(geo_block_crs)
+    right = crs_string_for_transform(native_crs)
+    return bool(left and right and left != right)
+
+
+@lru_cache(maxsize=256)
+def _emit_crs_disagreement_warning(key: str, winner: str, loser: str) -> None:
+    """Emit the two-sources-disagree warning exactly once per ``key`` (LRU-bounded)."""
+    warn(
+        f"{key}: the geo metadata says the CRS is {winner} but the Parquet geometry "
+        f"logical type says {loser}. Using {winner}, per the documented preference "
+        "for the geo metadata -- an output written from this input will state "
+        f"{winner} in both places, with coordinates that were never transformed. "
+        "Run `gpio check spec` on the input and fix whichever half is wrong."
+    )
+
+
+def reset_crs_disagreement_warnings() -> None:
+    """Clear the disagreement warn-once dedup cache. Intended for tests."""
+    _emit_crs_disagreement_warning.cache_clear()
+
+
 def extract_crs_from_parquet(parquet_file, verbose=False):
     """
     Extract CRS (as PROJJSON dict) from a Parquet file.
@@ -666,48 +757,44 @@ def extract_crs_from_parquet(parquet_file, verbose=False):
     1. GeoParquet metadata (columns.<geom_col>.crs)
     2. Parquet native geo type (from schema logical_type)
 
-    A write-path reader: ``convert``, ``reproject``, the format writers and
-    ``process aggregate`` all turn this answer into a transform or an output
-    file, so a malformed carried block goes through
-    :func:`sanitize_geo_metadata` rather than being indexed as-is (#887).
-    ``get_geo_metadata`` itself stays unsanitized -- ``gpio check`` reads
-    through it and has to see the file as it really is.
+    **Both are read, not just the first that answers**, so that a file naming two
+    *different* CRSs is reported rather than resolved in silence. This is where
+    the preference order lives -- :func:`parquet_writer.resolve_input_crs` and
+    every other caller receives one answer and is structurally unable to see that
+    there were two -- so it is where the warning has to be.
+
+    Since #993 that preference decides what a rewrite *writes*: the winner lands
+    in the output's ``geo`` block and, via ``ST_SetCRS``, in its Parquet logical
+    type too. The input contradicted itself and ``gpio check spec`` said so; the
+    output agrees with itself and comes back clean, over coordinates that never
+    moved. Laundering a detectable inconsistency into a clean-looking assertion
+    is the one outcome worth a warning line, and #883's rule already says an
+    overridden metadata key gets named in one.
+
+    The second read costs a schema fetch on files that would previously have
+    stopped at the ``geo`` block -- pyarrow for a local file, the same
+    ``parquet_schema`` DuckDB already runs for a remote one. It is bounded by the
+    footer either way, and ``gpio check spec`` reads both halves of every file
+    regardless.
     """
-    from geoparquet_io.core.duckdb_metadata import (
-        get_geo_metadata,
-        get_schema_info,
-        parse_geometry_logical_type,
-        resolve_crs_reference,
-    )
-    from geoparquet_io.core.geo_metadata import sanitize_geo_metadata
+    geo_block_crs = _crs_from_geo_block(parquet_file)
+    native_crs = _crs_from_native_geo_type(parquet_file)
 
-    geo_meta = sanitize_geo_metadata(get_geo_metadata(parquet_file))
-    if geo_meta:
-        primary_col = _primary_column_of_file(geo_meta, parquet_file)
-        columns = geo_meta.get("columns", {})
-        if primary_col in columns:
-            if crs_is_explicitly_null(columns[primary_col]):
-                warn_null_crs_once(str(parquet_file))
-            crs = columns[primary_col].get("crs")
-            if crs and not is_default_crs(crs):
-                if verbose:
-                    debug(f"Found CRS in GeoParquet metadata: {_format_crs_display(crs)}")
-                return crs
+    if geo_block_crs is not None:
+        if _crs_sources_disagree(geo_block_crs, native_crs):
+            _emit_crs_disagreement_warning(
+                str(parquet_file),
+                _format_crs_display(geo_block_crs),
+                _format_crs_display(native_crs),
+            )
+        if verbose:
+            debug(f"Found CRS in GeoParquet metadata: {_format_crs_display(geo_block_crs)}")
+        return geo_block_crs
 
-    schema_info = get_schema_info(parquet_file)
-    for col in schema_info:
-        logical_type = col.get("logical_type") or ""
-        if logical_type and (
-            logical_type.startswith("GeometryType(") or logical_type.startswith("GeographyType(")
-        ):
-            parsed = parse_geometry_logical_type(logical_type)
-            if parsed and "crs" in parsed:
-                raw_crs = parsed["crs"]
-                crs = resolve_crs_reference(parquet_file, raw_crs)
-                if crs and not is_default_crs(crs):
-                    if verbose:
-                        debug(f"Found CRS in Parquet geo type: {_format_crs_display(crs)}")
-                    return crs
+    if native_crs is not None:
+        if verbose:
+            debug(f"Found CRS in Parquet geo type: {_format_crs_display(native_crs)}")
+        return native_crs
 
     return None
 

--- a/geoparquet_io/core/streaming.py
+++ b/geoparquet_io/core/streaming.py
@@ -334,6 +334,14 @@ def read_stdin_to_temp_file(verbose: bool = False) -> str:
     import tempfile
     import uuid
 
+    # Registers the GeoArrow extension types process-wide, so a geometry column
+    # arriving on the stream as `geoarrow.wkb` is written to the scratch file
+    # with its Parquet GEOMETRY/GEOGRAPHY logical type -- and the CRS inside it --
+    # rather than demoted to plain `binary`. That scratch file is the witness the
+    # write facade then reads the output's version and CRS from (#993), so it has
+    # to be lossless with respect to the stream. The registration is global, which
+    # is why it happens here rather than being relied on (#1006).
+    import geoarrow.pyarrow  # noqa: F401
     import pyarrow.parquet as pq
 
     from geoparquet_io.core.geo_metadata import (

--- a/tests/native_geo_probes.py
+++ b/tests/native_geo_probes.py
@@ -90,6 +90,26 @@ def logical_geo_types(path) -> dict[str, tuple[str, dict | None]]:
     return native
 
 
+def native_geo_edges(path, column: str = "geometry") -> tuple[str | None, str | None]:
+    """``(GEOMETRY|GEOGRAPHY, edge type)`` for one column, read from both carriers.
+
+    The Parquet logical type names the family, but the edge interpolation that
+    separates a *spherical* GEOGRAPHY from a planar one is not in
+    ``logical_type.to_json()`` -- it is the ``algorithm`` property, which pyarrow
+    surfaces on the GeoArrow extension type it materialises the column as. So the
+    family comes from :func:`logical_geo_types` and the edges from the Arrow
+    field, and a rewrite that quietly replanned spherical edges as straight lines
+    over the same bytes changes the second half of the pair.
+
+    Requires ``geoarrow.pyarrow`` to have been imported in this process; without
+    it the column is plain ``binary`` and the edge type reads ``None``.
+    """
+    described = logical_geo_types(path).get(column)
+    field = pq.read_table(str(path)).schema.field(column)
+    edges = getattr(field.type, "edge_type", None)
+    return (described[0] if described else None, None if edges is None else str(edges))
+
+
 def logical_crs_id(path, column: str = "geometry"):
     """The CRS inside one column's Parquet logical type, or a reason there is none."""
     described = logical_geo_types(path).get(column)

--- a/tests/native_geo_probes.py
+++ b/tests/native_geo_probes.py
@@ -105,7 +105,7 @@ def native_geo_edges(path, column: str = "geometry") -> tuple[str | None, str | 
     it the column is plain ``binary`` and the edge type reads ``None``.
     """
     described = logical_geo_types(path).get(column)
-    field = pq.read_table(str(path)).schema.field(column)
+    field = pq.read_schema(str(path)).field(column)
     edges = getattr(field.type, "edge_type", None)
     return (described[0] if described else None, None if edges is None else str(edges))
 

--- a/tests/test_add_preserves_native_geo.py
+++ b/tests/test_add_preserves_native_geo.py
@@ -51,6 +51,7 @@ from tests.native_geo_probes import (
     geo_block_crs_id,
     geo_version,
     logical_geo_types,
+    native_geo_edges,
     projjson,
     spec_problems,
     write_native_geo_only,
@@ -252,6 +253,48 @@ def test_the_geography_fixture_really_is_spherical(spherical_geography):
     """Non-vacuity for the xfail below."""
     assert logical_geo_types(spherical_geography)["geometry"][0] == "Geography"
     assert spec_problems(spherical_geography) == []
+
+
+def test_the_vecorel_rewrite_round_trips_a_geography_unchanged(spherical_geography, tmp_path):
+    """The measurement #993 deleted ~100 lines of hand-rolled mapping on.
+
+    That branch carried a ``_geography_edge_type`` mapper because a pyarrow
+    rewrite was assumed to lose a GEOGRAPHY's edge interpolation. It does not --
+    once ``geoarrow.pyarrow`` has registered the extension types,
+    ``_fix_vecorel_schema``'s read -> cast -> write carries the family *and* the
+    edges through untouched, which is why the mapper went. The claim was
+    verified and then pinned by nothing, leaving the only GEOGRAPHY coverage in
+    the tree an ``xfail(strict)`` about a different path (#999). This is the pin
+    (#1006).
+
+    The pair matters, not just the family: a GEOGRAPHY whose edges came back
+    planar would still read ``"Geography"`` while describing different shapes
+    over the same bytes.
+
+    In-process on purpose, and it is the one thing here that can be: what is
+    pinned is the round-trip *given* registered extension types, not the
+    registration itself. Deleting ``_fix_vecorel_schema``'s own import leaves
+    this green, because this module's fixtures already did it -- which is why
+    ``test_geometry_metrics_keeps_the_native_type_from_a_fresh_process`` exists
+    and runs in a subprocess.
+    """
+    from geoparquet_io.core.constants import _fix_vecorel_schema
+
+    # A copy, because the rewrite replaces the file in place and the fixture is
+    # module-scoped.
+    subject = tmp_path / "geography.parquet"
+    subject.write_bytes(Path(spherical_geography).read_bytes())
+
+    before = native_geo_edges(subject)
+    assert before == ("Geography", "EdgeType.SPHERICAL"), "fixture is not a spherical GEOGRAPHY"
+
+    # ``id`` has no nulls and is nullable, so the rewrite is actually taken --
+    # `_fix_vecorel_schema` returns early when no field needs changing, and an
+    # early return would round-trip the geometry column vacuously.
+    _fix_vecorel_schema(str(subject), ["id"])
+
+    assert native_geo_edges(subject) == before
+    assert spec_problems(subject) == []
 
 
 @pytest.mark.xfail(

--- a/tests/test_crs_source_disagreement.py
+++ b/tests/test_crs_source_disagreement.py
@@ -207,6 +207,92 @@ def test_a_crs_less_file_does_not_warn(tmp_path, _native_rows, caplog):
 
 
 # ---------------------------------------------------------------------------
+# Two geometry columns: the comparison is about the primary one
+# ---------------------------------------------------------------------------
+
+
+def _two_column_file(tmp_path: Path, *, block_primary_epsg: int) -> Path:
+    """``aux`` (EPSG:5070) ahead of the primary ``geometry`` (EPSG:3857) in schema order.
+
+    Both logical types carry their CRS; the ``geo`` block describes ``aux``
+    truthfully and says ``block_primary_epsg`` for ``geometry``. Passing 3857
+    makes a valid file; anything else makes the *primary* column disagree while
+    the non-primary one still agrees.
+    """
+    import geoarrow.pyarrow as ga
+
+    rows = conus_wkb(
+        "ST_Transform(cell, 'EPSG:4326', 'EPSG:5070', always_xy := true)",
+        "ST_Transform(cell, 'EPSG:4326', 'EPSG:3857', always_xy := true)",
+    )
+    path = write_native_geo_only(
+        tmp_path / "two_columns.parquet",
+        rows,
+        {
+            "aux": (2, ga.wkb().with_crs(projjson(5070))),
+            "geometry": (3, ga.wkb().with_crs(projjson(3857))),
+        },
+    )
+    table = pq.read_table(str(path))
+    block = {
+        "version": "2.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "aux": {
+                "encoding": "WKB",
+                "geometry_types": ["Polygon"],
+                "crs": json.loads(projjson(5070)),
+            },
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Polygon"],
+                "crs": json.loads(projjson(block_primary_epsg)),
+            },
+        },
+    }
+    metadata = dict(table.schema.metadata or {})
+    metadata[b"geo"] = json.dumps(block).encode("utf-8")
+    pq.write_table(table.replace_schema_metadata(metadata), str(path), compression="zstd")
+    return path
+
+
+def test_a_valid_second_geometry_column_ahead_of_the_primary_does_not_warn(tmp_path, caplog):
+    """Both columns agree with themselves; only the schema order is unusual.
+
+    Comparing the block's *primary* CRS against the *first* logical type in the
+    schema accuses a valid file of contradicting itself and sends the user to
+    ``gpio check spec``, which finds nothing.
+    """
+    path = _two_column_file(tmp_path, block_primary_epsg=3857)
+    assert spec_problems(path) == [], "the fixture itself must be a valid file"
+
+    with caplog.at_level(logging.WARNING):
+        resolved = extract_crs_from_parquet(str(path))
+
+    assert (resolved or {}).get("id") == EPSG_3857
+    assert caplog.records == []
+
+
+def test_the_disagreement_is_judged_on_the_primary_column(tmp_path, caplog):
+    """The block misdescribes the primary column while the earlier ``aux`` is fine.
+
+    Matching the block's primary CRS against ``aux``'s logical type -- the first
+    one in the schema -- would find EPSG:5070 on both sides and stay silent over
+    a real disagreement.
+    """
+    path = _two_column_file(tmp_path, block_primary_epsg=5070)
+
+    with caplog.at_level(logging.WARNING):
+        resolved = extract_crs_from_parquet(str(path))
+
+    assert (resolved or {}).get("id") == EPSG_5070, "the documented preference must not change"
+    warnings = _disagreement_warnings(caplog.records)
+    assert len(warnings) == 1, caplog.records
+    assert "Using EPSG:5070" in warnings[0]
+    assert "logical type says EPSG:3857" in warnings[0]
+
+
+# ---------------------------------------------------------------------------
 # The write path the issue was filed about
 # ---------------------------------------------------------------------------
 

--- a/tests/test_crs_source_disagreement.py
+++ b/tests/test_crs_source_disagreement.py
@@ -1,0 +1,230 @@
+"""A file that states two different CRSs must not be resolved silently.
+
+A GeoParquet 2.0 file says what its coordinates are in twice -- the ``geo``
+block's ``columns.<name>.crs`` and the Parquet ``GEOMETRY``/``GEOGRAPHY``
+logical type. ``crs_utils.extract_crs_from_parquet`` prefers the first and falls
+back to the second, and since #993 every rewrite answers the output's CRS
+through it (``parquet_writer.resolve_input_crs``).
+
+When the two sources *disagree*, that preference is load-bearing in a way it was
+never asked to be. The input is self-contradictory and ``gpio check spec`` says
+so; the output is written with the winner's answer in **both** places and comes
+back clean. The coordinates never moved, so a loud, detectable inconsistency
+becomes a silent, clean-looking assertion -- gpio launders the contradiction
+rather than reporting it. Picking a winner is defensible; doing it with no
+signal is not, and the repo's rule (#883) is that an overridden metadata key
+gets named in a warning.
+
+Refs: https://github.com/geoparquet/geoparquet-io/issues/1004
+Refs: https://github.com/geoparquet/geoparquet-io/issues/993
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core.crs_utils import extract_crs_from_parquet, reset_crs_disagreement_warnings
+from tests.native_geo_probes import (
+    conus_wkb,
+    geo_block_crs_id,
+    logical_crs_id,
+    projjson,
+    spec_problems,
+    write_native_geo_only,
+)
+
+EPSG_5070 = {"authority": "EPSG", "code": 5070}
+EPSG_3857 = {"authority": "EPSG", "code": 3857}
+
+
+def _with_geo_block(path: Path, crs_epsg: int | None) -> Path:
+    """Add a ``geo`` block to a native-geo file, naming ``crs_epsg`` (or no CRS)."""
+    table = pq.read_table(str(path))
+    column: dict = {"encoding": "WKB", "geometry_types": ["Polygon"]}
+    if crs_epsg is not None:
+        column["crs"] = json.loads(projjson(crs_epsg))
+    block = {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": column}}
+    metadata = dict(table.schema.metadata or {})
+    metadata[b"geo"] = json.dumps(block).encode("utf-8")
+    pq.write_table(table.replace_schema_metadata(metadata), str(path), compression="zstd")
+    return path
+
+
+@pytest.fixture(scope="module")
+def _native_rows():
+    return conus_wkb("ST_Transform(cell, 'EPSG:4326', 'EPSG:5070', always_xy := true)")
+
+
+def _native_file(tmp_path: Path, name: str, logical_epsg: int, rows) -> Path:
+    import geoarrow.pyarrow as ga
+
+    return write_native_geo_only(
+        tmp_path / name, rows, {"geometry": (2, ga.wkb().with_crs(projjson(logical_epsg)))}
+    )
+
+
+@pytest.fixture
+def disagreeing(tmp_path, _native_rows) -> Path:
+    """``geo`` block says EPSG:3857; the Parquet logical type says EPSG:5070."""
+    return _with_geo_block(_native_file(tmp_path, "disagree.parquet", 5070, _native_rows), 3857)
+
+
+@pytest.fixture
+def agreeing(tmp_path, _native_rows) -> Path:
+    """Both sources say EPSG:5070."""
+    return _with_geo_block(_native_file(tmp_path, "agree.parquet", 5070, _native_rows), 5070)
+
+
+@pytest.fixture
+def logical_type_only(tmp_path, _native_rows) -> Path:
+    """Only the Parquet logical type answers -- there is no ``geo`` block."""
+    return _native_file(tmp_path, "pgo.parquet", 5070, _native_rows)
+
+
+@pytest.fixture
+def geo_block_only(tmp_path, _native_rows) -> Path:
+    """Only the ``geo`` block answers; the logical type declares no CRS."""
+    import geoarrow.pyarrow as ga
+
+    path = write_native_geo_only(
+        tmp_path / "block_only.parquet", _native_rows, {"geometry": (2, ga.wkb())}
+    )
+    return _with_geo_block(path, 5070)
+
+
+def _disagreement_warnings(records) -> list[str]:
+    return [r.message for r in records if "EPSG:3857" in r.message and "EPSG:5070" in r.message]
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warning_cache():
+    """The warning is deduped per file; every test starts from an empty cache."""
+    reset_crs_disagreement_warnings()
+    yield
+    reset_crs_disagreement_warnings()
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the fixture really does contradict itself, and gpio can see it
+# ---------------------------------------------------------------------------
+
+
+def test_the_fixture_really_states_two_different_crss(disagreeing):
+    assert geo_block_crs_id(disagreeing) == EPSG_3857
+    assert logical_crs_id(disagreeing) == EPSG_5070
+    assert any("CRS in geo metadata must match" in p for p in spec_problems(disagreeing)), (
+        "`check spec` does not report the fixture as inconsistent; "
+        "the warning under test would have nothing to be louder than"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The warning
+# ---------------------------------------------------------------------------
+
+
+def test_disagreeing_sources_warn_naming_both_and_the_winner(disagreeing, caplog):
+    with caplog.at_level(logging.WARNING):
+        resolved = extract_crs_from_parquet(str(disagreeing))
+
+    assert (resolved or {}).get("id") == EPSG_3857, "the documented preference must not change"
+
+    warnings = _disagreement_warnings(caplog.records)
+    assert len(warnings) == 1, caplog.records
+    message = warnings[0]
+    assert "EPSG:3857" in message and "EPSG:5070" in message
+    assert str(disagreeing) in message
+    # Which one won has to be readable off the line, not inferred from the order
+    # the two CRSs happen to appear in.
+    assert "Using EPSG:3857" in message
+
+
+def test_the_warning_is_emitted_once_per_file(disagreeing, caplog):
+    """Several commands read the same input through this function in one run."""
+    with caplog.at_level(logging.WARNING):
+        extract_crs_from_parquet(str(disagreeing))
+        extract_crs_from_parquet(str(disagreeing))
+
+    assert len(_disagreement_warnings(caplog.records)) == 1
+
+
+def test_two_distinct_disagreeing_files_each_warn(disagreeing, tmp_path, _native_rows, caplog):
+    """The dedup key must not be so broad that a second bad file goes unreported."""
+    second = _with_geo_block(_native_file(tmp_path, "second.parquet", 5070, _native_rows), 3857)
+
+    with caplog.at_level(logging.WARNING):
+        extract_crs_from_parquet(str(disagreeing))
+        extract_crs_from_parquet(str(second))
+
+    assert len(_disagreement_warnings(caplog.records)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Silence everywhere else
+# ---------------------------------------------------------------------------
+
+
+def test_agreeing_sources_do_not_warn(agreeing, caplog):
+    with caplog.at_level(logging.WARNING):
+        resolved = extract_crs_from_parquet(str(agreeing))
+
+    assert (resolved or {}).get("id") == EPSG_5070
+    assert caplog.records == []
+
+
+def test_a_logical_type_only_file_does_not_warn(logical_type_only, caplog):
+    with caplog.at_level(logging.WARNING):
+        resolved = extract_crs_from_parquet(str(logical_type_only))
+
+    assert (resolved or {}).get("id") == EPSG_5070
+    assert caplog.records == []
+
+
+def test_a_geo_block_only_file_does_not_warn(geo_block_only, caplog):
+    with caplog.at_level(logging.WARNING):
+        resolved = extract_crs_from_parquet(str(geo_block_only))
+
+    assert (resolved or {}).get("id") == EPSG_5070
+    assert caplog.records == []
+
+
+def test_a_crs_less_file_does_not_warn(tmp_path, _native_rows, caplog):
+    """Neither source answers: nothing to disagree about, and nothing to say."""
+    import geoarrow.pyarrow as ga
+
+    path = write_native_geo_only(
+        tmp_path / "none.parquet", _native_rows, {"geometry": (2, ga.wkb())}
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert extract_crs_from_parquet(str(path)) is None
+    assert caplog.records == []
+
+
+# ---------------------------------------------------------------------------
+# The write path the issue was filed about
+# ---------------------------------------------------------------------------
+
+
+def test_a_rewrite_of_a_disagreeing_input_says_so(disagreeing, tmp_path, caplog):
+    """``gpio add bbox`` writes the winner into both places; it must say which.
+
+    This is the shape #1004 describes: the output is internally consistent and
+    ``check spec`` passes it, while the coordinates are exactly the ones that
+    were ambiguous on the way in.
+    """
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+
+    out = tmp_path / "bbox.parquet"
+    with caplog.at_level(logging.WARNING):
+        result = CliRunner().invoke(cli, ["add", "bbox", str(disagreeing), str(out)])
+    assert result.exit_code == 0, result.output
+
+    assert _disagreement_warnings(caplog.records), "the rewrite resolved the conflict in silence"

--- a/tests/test_stream_preserves_native_geo.py
+++ b/tests/test_stream_preserves_native_geo.py
@@ -23,10 +23,12 @@ defect (#1006). It stops being lossless for a consumer that reads the Arrow
 field type rather than the KV, and it is one import away from being the #993
 defect again if anything downstream starts trusting the schema.
 
-**Every test here runs in a subprocess, and has to.** This module's own imports
-register the extension types process-wide, so an in-process test of a
-process-global registration is green whatever the code under test does -- which
-is exactly how #993's first version shipped with the bug in it.
+**Every test of the registration here runs in a subprocess, and has to.** This
+module's own imports register the extension types process-wide, so an
+in-process test of a process-global registration is green whatever the code
+under test does -- which is exactly how #993's first version shipped with the
+bug in it. The one in-process test is about handle discipline, not the
+registration, and says so.
 
 Refs: https://github.com/geoparquet/geoparquet-io/issues/1006
 Refs: https://github.com/geoparquet/geoparquet-io/issues/993
@@ -129,6 +131,75 @@ def test_convert_to_stdout_keeps_the_geo_key(projected_conus):
     table = ipc.RecordBatchStreamReader(pa.BufferReader(payload)).read_all()
     geo = json.loads((table.schema.metadata or {})[b"geo"].decode("utf-8"))
     assert geo["columns"]["geometry"]["crs"]["id"] == EPSG_5070
+
+
+def test_convert_to_stdout_closes_the_scratch_file_before_deleting_it(projected_conus, monkeypatch):
+    """The handle-closed invariant behind a Windows-only failure, asserted on every OS.
+
+    With the extension types registered, the table ``pq.read_table`` returned
+    kept its reader reachable past the frame, and ``temp_path.unlink()`` in the
+    ``finally`` raised ``PermissionError: [WinError 32]`` on all three Windows
+    legs -- POSIX unlinks an open file, so nothing else saw it. The rule (see
+    ``windows-os-replace-open-handle``) is that a handle on a file the code
+    later deletes is closed first.
+
+    The leaked reader is not observable from POSIX -- no descriptor stays open,
+    the difference is in how Windows treats a reader the collector has not yet
+    reached -- so what can be pinned on every OS is the discipline that keeps
+    the invariant: the scratch file is read through a ``ParquetFile`` that is
+    closed before the stream is written, and never through ``pq.read_table``,
+    whose reader is closed whenever it is collected. In-process on purpose: it
+    is about handle discipline, not the registration.
+    """
+    import pyarrow.parquet as pq
+    from click.testing import CliRunner
+
+    from geoparquet_io.cli.main import cli
+    from geoparquet_io.core import streaming
+
+    events: list[tuple[str, str]] = []
+    real_parquet_file = pq.ParquetFile
+    real_read_table = pq.read_table
+
+    def recording_read_table(source, *args, **kwargs):
+        events.append(("read_table", str(source)))
+        return real_read_table(source, *args, **kwargs)
+
+    monkeypatch.setattr(pq, "read_table", recording_read_table)
+
+    class RecordingParquetFile(real_parquet_file):
+        """Records which file each closed reader was on: the conversion itself
+        opens and closes readers on the *input*, which are not the point."""
+
+        def __init__(self, source, *args, **kwargs):
+            self._recorded_source = str(source)
+            super().__init__(source, *args, **kwargs)
+
+        def close(self, *args, **kwargs):
+            events.append(("closed", self._recorded_source))
+            return super().close(*args, **kwargs)
+
+    monkeypatch.setattr(pq, "ParquetFile", RecordingParquetFile)
+    monkeypatch.setattr(
+        streaming, "write_arrow_stream", lambda table: events.append(("streamed", ""))
+    )
+
+    result = CliRunner().invoke(cli, ["convert", "geoparquet", str(projected_conus), "-"])
+
+    assert result.exit_code == 0, result.output
+    scratch_read_table = [s for kind, s in events if kind == "read_table" and "gpio_convert_" in s]
+    assert not scratch_read_table, (
+        "the scratch file was read through pq.read_table, whose reader is closed "
+        f"at the collector's leisure -- after the unlink, on Windows: {scratch_read_table}"
+    )
+    streamed_at = events.index(("streamed", ""))
+    scratch_closed_at = [
+        i
+        for i, (kind, source) in enumerate(events)
+        if kind == "closed" and "gpio_convert_" in source
+    ]
+    assert scratch_closed_at, f"the scratch file was never read through a closable reader: {events}"
+    assert scratch_closed_at[0] < streamed_at, events
 
 
 def test_read_stdin_to_temp_file_keeps_the_native_logical_type(stream_of):

--- a/tests/test_stream_preserves_native_geo.py
+++ b/tests/test_stream_preserves_native_geo.py
@@ -1,0 +1,165 @@
+"""The streaming path must not demote a native geometry column to plain binary.
+
+Two sites on the pipe path are a plain-pyarrow read or write of a table that
+carries a Parquet ``GEOMETRY``/``GEOGRAPHY`` column:
+
+* ``cli/commands/convert.py`` -- ``gpio convert geoparquet in.parquet -`` writes
+  its result to a scratch file, reads it back with ``pq.read_table`` and puts
+  that table on stdout as an Arrow IPC stream.
+* ``core/streaming.read_stdin_to_temp_file`` -- the other end of the same pipe,
+  materialising an incoming IPC stream to a scratch Parquet file with
+  ``pq.write_table``.
+
+Whether either keeps the geometry column's type depends on nothing in the data
+and everything in the *process*: importing ``geoarrow.pyarrow`` registers the
+extension types that make pyarrow materialise a Parquet ``GEOMETRY`` column as
+``geoarrow.wkb`` and write it back as one, and that registration is global.
+Without it the column round-trips as plain ``binary`` -- the logical type, and
+the CRS stored inside it, gone from the Arrow schema.
+
+End to end this is lossless anyway, because the ``geo`` key travels alongside
+and carries the CRS, which is why it is a latent shape rather than a live
+defect (#1006). It stops being lossless for a consumer that reads the Arrow
+field type rather than the KV, and it is one import away from being the #993
+defect again if anything downstream starts trusting the schema.
+
+**Every test here runs in a subprocess, and has to.** This module's own imports
+register the extension types process-wide, so an in-process test of a
+process-global registration is green whatever the code under test does -- which
+is exactly how #993's first version shipped with the bug in it.
+
+Refs: https://github.com/geoparquet/geoparquet-io/issues/1006
+Refs: https://github.com/geoparquet/geoparquet-io/issues/993
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.ipc as ipc
+import pyarrow.parquet as pq
+import pytest
+
+from tests.native_geo_probes import EPSG_5070
+
+#: A wedge cap rather than a performance budget, matching
+#: ``tests/test_add_preserves_native_geo.py``: each of these pays a cold
+#: interpreter's full CLI import (pyarrow, geoarrow, duckdb) with no warm
+#: process to share it.
+_SUBPROCESS_TIMEOUT = 300
+
+
+def _run_cli_in_a_fresh_process(*args) -> bytes:
+    """Run one gpio command in a subprocess and return its raw stdout.
+
+    Raw bytes, not text: what this module measures is an Arrow IPC stream.
+    """
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from geoparquet_io.cli.main import cli; cli()",
+            *(str(a) for a in args),
+        ],
+        capture_output=True,
+        timeout=_SUBPROCESS_TIMEOUT,
+    )
+    assert completed.returncode == 0, completed.stderr.decode("utf-8", "replace")
+    return completed.stdout
+
+
+def _geometry_field_of_stream(payload: bytes) -> pa.Field:
+    """The ``geometry`` field of an Arrow IPC stream, as its producer described it."""
+    return ipc.RecordBatchStreamReader(pa.BufferReader(payload)).read_all().schema.field("geometry")
+
+
+def _is_geoarrow(field: pa.Field) -> bool:
+    """Did the producer describe this field as a geometry, by either carrier?
+
+    Read in a process that *has* registered the extension types, a field the
+    producer emitted as ``geoarrow.wkb`` comes back as an extension type; read
+    in one that has not, the same field is plain ``binary`` carrying
+    ``ARROW:extension:name``. Both are the producer saying "geometry", and this
+    accepts either so the assertion is about the producer rather than about
+    this process's own imports.
+    """
+    if getattr(field.type, "extension_name", None):
+        return True
+    metadata = field.metadata or {}
+    return b"ARROW:extension:name" in metadata
+
+
+@pytest.fixture(scope="module")
+def stream_of(projected_conus, tmp_path_factory) -> Path:
+    """The EPSG:5070 fixture as an Arrow IPC stream file, geometry typed.
+
+    Built here rather than by a gpio command on purpose: the consumer test below
+    has to be handed a stream that is known-good, or a failure could not be told
+    apart from the producer's.
+    """
+    table = pq.read_table(str(projected_conus))
+    assert table.schema.field("geometry").type.extension_name == "geoarrow.wkb", (
+        "fixture stream is not geometry-typed; the consumer test would be vacuous"
+    )
+
+    path = tmp_path_factory.mktemp("stream") / "conus.arrows"
+    with path.open("wb") as handle:
+        writer = ipc.RecordBatchStreamWriter(handle, table.schema)
+        writer.write_table(table)
+        writer.close()
+    return path
+
+
+def test_convert_to_stdout_keeps_the_geometry_field_typed(projected_conus):
+    """``gpio convert geoparquet in -`` must not put plain binary on the pipe."""
+    payload = _run_cli_in_a_fresh_process("convert", "geoparquet", projected_conus, "-")
+
+    field = _geometry_field_of_stream(payload)
+    assert _is_geoarrow(field), f"geometry streamed as {field.type}, not a geometry type"
+
+
+def test_convert_to_stdout_keeps_the_geo_key(projected_conus):
+    """The control: the KV carrier is what makes this latent rather than lossy."""
+    payload = _run_cli_in_a_fresh_process("convert", "geoparquet", projected_conus, "-")
+
+    table = ipc.RecordBatchStreamReader(pa.BufferReader(payload)).read_all()
+    geo = json.loads((table.schema.metadata or {})[b"geo"].decode("utf-8"))
+    assert geo["columns"]["geometry"]["crs"]["id"] == EPSG_5070
+
+
+def test_read_stdin_to_temp_file_keeps_the_native_logical_type(stream_of):
+    """The scratch Parquet file a piped-into command reads must stay native.
+
+    ``read_stdin_to_temp_file`` is what every ``gpio <cmd> -`` runs first, and
+    its output is the file the command then treats as the user's input -- the
+    witness ``write_parquet_with_metadata`` reads the version and the CRS from
+    (#993). A scratch file that has dropped the Parquet ``GEOMETRY`` logical
+    type is a witness that has forgotten half of what it is asked.
+    """
+    driver = (
+        "import json;"
+        "import pyarrow.parquet as pq;"
+        "from geoparquet_io.core.streaming import read_stdin_to_temp_file;"
+        "schema = pq.ParquetFile(read_stdin_to_temp_file()).schema;"
+        "print(json.dumps({schema.column(i).name: "
+        "json.loads(schema.column(i).logical_type.to_json()) for i in range(len(schema))}))"
+    )
+    with stream_of.open("rb") as handle:
+        completed = subprocess.run(
+            [sys.executable, "-c", driver],
+            stdin=handle,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+    assert completed.returncode == 0, completed.stderr
+
+    described = json.loads(completed.stdout)["geometry"]
+    assert described.get("Type") == "Geometry", (
+        f"geometry written to the scratch file as {described}, not a Parquet GEOMETRY"
+    )
+    assert json.loads(described["crs"])["id"] == EPSG_5070


### PR DESCRIPTION
Two follow-ups to #997, both found by an adversarial review of it. Neither is a
live data-loss defect; both are places where gpio knew something and did not say
it.

## #1004 — two CRS sources, one silent winner

`extract_crs_from_parquet` prefers the `geo` block's CRS over the Parquet
`GEOMETRY` logical type's, and since #997 that preference decides what a rewrite
**writes**: the winner lands in the output's `geo` block and, via `ST_SetCRS`, in
its logical type too.

| input (geo block / logical type) | main | this branch |
|---|---|---|
| EPSG:3857 / EPSG:5070 | EPSG:3857 / EPSG:3857, `check spec` clean, silent | same output, plus a warning naming both |

The coordinates never moved. A loud, detectable inconsistency — `✗ CRS in geo
metadata must match CRS in Parquet schema` on the input — became a silent,
clean-looking assertion on the output. Choosing a winner is defensible and
documented; doing it with no signal is not, and #883's rule is that an
overridden metadata key gets named in a warning.

```
WARNING  /tmp/disagree.parquet: the geo metadata says the CRS is EPSG:3857 but
the Parquet geometry logical type says EPSG:5070. Using EPSG:3857, per the
documented preference for the geo metadata -- an output written from this input
will state EPSG:3857 in both places, with coordinates that were never
transformed. Run `gpio check spec` on the input and fix whichever half is wrong.
```

### Why the warning is in `extract_crs_from_parquet`, not `resolve_input_crs`

The issue offered both. `extract_crs_from_parquet` is the one place that can see
the problem: it is where the preference order lives, and it is the only frame in
which both sources exist. `resolve_input_crs` calls it and receives *one* value —
structurally unable to tell an answer from a choice between two, exactly the way
`source_crs_string` is unable to see the defect it certified green in #997's
first draft. Putting the warning at the delegating caller would mean reading the
schema a second time there to reconstruct what the callee already discarded.

It also covers the other four callers that launder the same contradiction the
same way — `convert`, `convert reproject`, the format writers and
`process aggregate` — rather than only the `add`/`sort`/`partition` rewrites that
reach it through `resolve_input_crs`.

Cost: the function now reads both sources instead of stopping at the first that
answers. That is one extra schema fetch on files whose `geo` block already
answered — pyarrow for a local file (`get_schema_info`'s fast path), the same
`parquet_schema` DuckDB already runs for a remote one, footer-bounded either way.
`gpio check spec` reads both halves of every file regardless.

The comparison is deliberately conservative — both sides must resolve to an
authority identifier and those identifiers must differ. Two PROJJSON objects with
no `id` can be different renderings of the same CRS, and a write-path warning
that cries wolf is worse than one that is occasionally quiet. Deduped per file
through the LRU the null-CRS warning already uses, so several commands reading
one input in a run produce one line.

The resolved value is unchanged: `assert (resolved or {}).get("id") == EPSG_3857`
is in the test, so the documented preference is pinned, not altered.

## #1006 — two plain-pyarrow stream sites demote the geometry field to binary

pyarrow round-trips a Parquet `GEOMETRY`/`GEOGRAPHY` logical type only if
`geoarrow.pyarrow` has been imported *somewhere in the process* — that import is
a global extension registration. #997 fixed `constants._fix_vecorel_schema` this
way; a sweep found two more sites of the same shape on the streaming path:

- `cli/commands/convert.py` — `gpio convert geoparquet in.parquet -` reads its
  scratch file back with `pq.read_table` and puts that table on stdout.
- `core/streaming.read_stdin_to_temp_file` — writes the incoming IPC stream to
  the scratch Parquet file that `write_parquet_with_metadata` then reads the
  output's version and CRS from (#997).

Both demoted the Arrow field to plain `binary`:

```
$ gpio convert geoparquet base_5070.parquet - | <pyarrow ipc>
field types: [('id','int64'), ('grp','string'), ('geometry','binary')]
kv keys: ['geo']   geo crs: EPSG:5070
```

Not a live CRS-loss defect — the `geo` KV survives and the round-trip is lossless
end to end — but a consumer reading the Arrow field type rather than the KV sees
`binary`, and both are one import away from being #997's defect again. Same
one-line lazy import at both sites; eight other `core/` modules already do this.

### Pinned in a subprocess, and sabotage-proven

No in-process test can see a process-global dependency: the test module's own
imports have already done the registering, which is exactly why #997's first
version was green with the bug in it. `tests/test_stream_preserves_native_geo.py`
runs every assertion in a fresh interpreter. Each import was then deleted on its
own:

| sabotage | result |
|---|---|
| remove `convert.py`'s import | `test_convert_to_stdout_keeps_the_geometry_field_typed` fails (`geometry streamed as binary`); other 2 pass |
| remove `streaming.py`'s import | `test_read_stdin_to_temp_file_keeps_the_native_logical_type` fails (`{'Type': 'None'}`); other 2 pass |
| both restored | 3 passed |

The consumer test is fed a stream built in-process from the fixture and asserted
geometry-typed before use, so a failure cannot be the producer's.

### The GEOGRAPHY claim #997 made and nothing pinned

#997's body claims pyarrow round-trips a GEOGRAPHY column's edge type once the
extension types are registered, and deleted a hand-rolled `_geography_edge_type`
mapper on that basis. Verified then, asserted nowhere — the only GEOGRAPHY test
in the tree is the `xfail(strict)` for #999.

`test_the_vecorel_rewrite_round_trips_a_geography_unchanged` measures the pair on
a spherical fixture through `_fix_vecorel_schema`:

```
before: ('Geography', 'EdgeType.SPHERICAL')
after : ('Geography', 'EdgeType.SPHERICAL')     spec_problems == []
```

The pair, not just the family: a GEOGRAPHY whose edges came back planar would
still read `"Geography"` while describing different shapes over the same bytes.
The edge type is not in `logical_type.to_json()` (which says only
`{"Type": "Geography"}`), so the new `native_geo_edges` probe reads the family off
the Parquet schema and the edges off the Arrow extension type. The rewrite is
forced to actually happen — `_fix_vecorel_schema` returns early when no field
needs changing, which would round-trip the geometry vacuously.

This one is in-process on purpose and its docstring says so: what it pins is the
round-trip *given* registered types, not the registration. Deleting
`_fix_vecorel_schema`'s own import leaves it green — confirmed — which is what
`test_geometry_metrics_keeps_the_native_type_from_a_fresh_process` is for.

## Verification

| | |
|---|---|
| fast suite | 7709 passed, 76 skipped, 3 xfailed (203s) |
| `-m meta` | 205 passed |
| docs lane | 236 passed, 224 skipped |
| `pre-commit --all-files` | 20 hooks, all pass |
| `--hook-stage pre-push` | 27 hooks, all pass |
| diff-cover vs `origin/main` | **100%** — 50 lines, 0 missing |
| `tests/data/cli_surface.json` | unchanged |

`core/check_fixes.py` is untouched (concurrent work on #1001/#1003).

<details>
<summary>One pre-existing hook failure, proven pre-existing and since resolved</summary>

Mid-branch, `menard-check` reported 4 stale doc targets against
`cli/commands/convert.py`, all attributed to symbols added by #995
(`enable_verbose_logging`, `ErrorBoundaryGroup`) and #990. Reproduced on a clean
detached `origin/main` worktree by appending a bare comment to that file and
staging it — identical 4 targets, no code of this branch involved. It passes on
the committed branch. Not in CI either way.
</details>

---

Written with Claude Code. Every measurement above was run; the sabotage table is
transcribed from the runs, not predicted.

## Review addendum (a5b3ff2)

An adversarial review of this branch found one real defect and three things the body oversold; the commit fixes them.

**The comparison was between two different columns.** `_crs_from_geo_block` reads the *primary* column; `_crs_from_native_geo_type` returned the *first* geometry column in schema order with a non-default CRS. A valid GeoParquet 2.0 file with `aux` (EPSG:5070, correct in both carriers) ahead of the primary `geometry` (EPSG:3857, correct in both carriers) was accused of contradicting itself and sent to `gpio check spec`, which passes it 56/56. The mirror case stayed silent over a real disagreement: a block that misdescribes the primary while `aux` agrees with its own logical type found 5070 on both sides. The block reader now returns its primary column and the logical-type reader is held to that column. The native-geo-only fallback (no block, so no primary) and every resolved value are unchanged. Two tests pin both directions.

**The message predicted the output, and was wrong for `convert reproject`** ("an output written from this input will state EPSG:3857 in both places, with coordinates that were never transformed" — reproject transforms them and states the target CRS; the GDAL writers write no `geo` block). It now says what was read and which half won.

**The docs said "every gpio command that rewrites the file" warns.** `convert geojson`/`csv` never reach the reader, and `check --fix` only does once #1009 lands (its three rewrites had no `input_file=` witness, so on `main` the *logical type* wins there, silently). The sentence now names the GeoParquet-writing commands; #1009 merges ahead of this one.

**Not fixed here, ticketed:**
- #1013 — on a remote input the second read is a second DuckDB connection + httpfs load + footer fetch, not "the same `parquet_schema` DuckDB already runs": 576 ms → 1238 ms per call against a localhost server; `add h3` calls it twice, `partition quadkey --auto` three times.
- #1014 — the conservative rule also drops a one-sided-`id` disagreement (block `EPSG:3857`, logical type a full PROJJSON of 5070 with `id` stripped), and an explicit `EPSG:4326` block silently *loses* to an `EPSG:5070` logical type because `is_default_crs` folds 4326 into "nothing to write" — pre-existing on `main`, surfaced by this warning.

Also declared, since the body's list of callers undersold it: the warning fires on `convert flatgeobuf`/`geopackage`/`shapefile` (via `_get_srs_parameter`), `add geometry-metrics`, `partition *`, and — after #1009 — `check --fix`, once per file per process, on stderr; `check spec`/`check all`/`inspect` do not warn and `check spec` still reports the finding.

## Windows (second addendum)

All three Windows legs failed the two new `convert … -` stream tests:

```
convert.py:361, in _convert_streaming
    temp_path.unlink()
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
```

`_convert_streaming` converts to a scratch Parquet file, reads it back with `pq.read_table`, streams the table and unlinks the scratch file in a `finally`. With `geoarrow.pyarrow` registered (this PR) the table returned for a native GEOMETRY column is reachable through Python-side extension objects that outlive the frame, so the reader `read_table` created is still open at the `unlink`. POSIX deletes an open file; Windows refuses. `tests/test_convert_stdin_guard.py` runs the same command on Windows and passes because its fixture is 1.x WKB — no extension array is built, nothing holds the reader. The `windows-os-replace-open-handle` class, in a new outfit.

Fixed by reading the scratch file through `pq.ParquetFile` in a `with` block, so the handle closes before the delete. The leaked reader is not observable from POSIX (no descriptor stays open — measured), so the regression test pins the discipline rather than the platform error: the scratch file is read through a `ParquetFile` closed before the stream is written, never through `pq.read_table`. With `read_table` put back it fails on macOS too.

`test_cli_error_boundary::…test_a_duckdb_error_reaches_the_user_as_an_error_line` also failed on the Windows legs here; it fails on `main`'s own runs of `7a62082` and passed on #1009's — a Windows flake in the error boundary, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

Closes #1006
Closes #1004


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preserved native `GEOMETRY` and `GEOGRAPHY` types, edge information, and CRS metadata during streaming, conversion, and file rewrites.
  - Added CRS conflict detection when metadata sources disagree. The `geo` block is used as the authoritative source, with the selected CRS written consistently and a warning identifying the conflict.

- **Documentation**
  - Added guidance explaining CRS conflict warnings and how to correct inconsistent input metadata.

- **Bug Fixes**
  - Prevented native geometry columns from being converted to plain binary during streamed or rewritten workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
