### PR TITLE
fix(check): keep a file's CRS, native geo type and bbox covering through --fix

### DIFF
--- a/geoparquet_io/core/check_fixes.py
+++ b/geoparquet_io/core/check_fixes.py
@@ -54,6 +54,34 @@ from geoparquet_io.core.remote import (
 # already snapped to a whole 2,048-row writer vector, so what gpio asks for is
 # what lands. It is also exactly what `gpio sort` writes since #967, which is
 # what #795 meant by fix_spatial_order inheriting the sort default.
+#
+# Every rewrite below also hands the write facade the file it is rewriting --
+# both `input_file=` and that file's own metadata. A remedial command is held to
+# a stricter standard than an ordinary one: whatever `--fix` writes is the file
+# gpio's own checks are run against next, so a fix that loses a fact is a fix
+# that makes the report worse. Two were lost by withholding the input:
+#
+# * `input_file=` is the witness `resolve_output_geoparquet_version` and
+#   `resolve_input_crs` both answer from. Without it a native-geo-only input --
+#   Parquet GEOMETRY logical type, no `geo` key -- was rewritten as 1.1 WKB, and
+#   since that logical type is the *only* place such a file keeps its CRS, the
+#   CRS went with it. `check spec` then scored the output `✗ coordinates outside
+#   valid range for CRS`: EPSG:5070 metres read as degrees, because an absent
+#   `crs` means OGC:CRS84 (#1001).
+# * `original_metadata` used to be read only for a 1.x output, on the reasoning
+#   that 2.0 regenerates its `geo` block anyway. DuckDB does regenerate it, and
+#   what it generates carries no `covering` -- so `check all --fix` on a 2.0
+#   file with a bbox column discarded the covering and then complained that the
+#   bbox column was not declared in one (#1003). Since #738/#772 the carried
+#   block is what `_geo_block_to_carry_on_fast_path` substitutes for DuckDB's,
+#   and these two rewrites keep every row of their input, so it still describes
+#   the output exactly.
+#
+# The witness must be the file whose *rows* the write reads. Under
+# `check all --fix` that is the previous step's scratch file rather than the
+# user's input: the fixes chain, and naming the original while reading a
+# rewrite is how a wrong CRS comes to be asserted rather than omitted (see
+# `resolve_output_geoparquet_version`).
 
 
 def fix_compression(
@@ -100,10 +128,11 @@ def fix_compression(
 
     raw_url = resolve_file_url(parquet_file, verbose)
 
-    # Get original metadata (only needed for v1.x)
-    original_metadata = None
-    if geoparquet_version in (None, "1.0", "1.1"):
-        original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
+    # Both halves of what the input has to say about itself, at every version.
+    # See the module docstring: the `geo` block carries a 2.0 input's `covering`
+    # (#1003) and the file is the witness the facade resolves version and CRS
+    # from (#1001).
+    original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
 
     # Read and rewrite with ZSTD compression
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
@@ -123,6 +152,10 @@ def fix_compression(
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            # The rows come from `parquet_file` -- which under `check all --fix`
+            # is the previous fix's scratch file, not the user's input, and the
+            # witness has to be the file actually read (#1001).
+            input_file=parquet_file,
         )
 
         # If we used a temp file for in-place operation, move/upload it to final location
@@ -266,6 +299,11 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
             verbose=verbose,
             profile=profile,
             geoparquet_version=gp_version,
+            # The witness for the CRS. `gp_version` above answers the version
+            # question from the same file, but a native-geo-only input keeps its
+            # CRS only in the Parquet logical type, so without this the rewrite
+            # restates whatever DuckDB read and declares nothing (#1001).
+            input_file=parquet_file,
         )
 
         return {"fix_applied": f"Removed bbox column '{bbox_column_name}'", "success": True}
@@ -423,10 +461,9 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
 
     raw_url = resolve_file_url(parquet_file, verbose)
 
-    # Get original metadata (only needed for v1.x)
-    original_metadata = None
-    if geoparquet_version in (None, "1.0", "1.1"):
-        original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
+    # Both halves of what the input has to say about itself, at every version --
+    # see fix_compression above.
+    original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
 
     # Read and rewrite with optimal row groups
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
@@ -445,6 +482,7 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
             verbose=verbose,
             profile=profile,
             geoparquet_version=geoparquet_version,
+            input_file=parquet_file,
         )
 
         return {"fix_applied": "Optimized row groups", "success": True}

--- a/tests/native_geo_probes.py
+++ b/tests/native_geo_probes.py
@@ -183,7 +183,7 @@ def conus_wkb(*projections: str) -> list[tuple]:
         con.close()
 
 
-def write_native_geo_only(path, rows, columns) -> Path:
+def write_native_geo_only(path, rows, columns, compression="zstd", **write_options) -> Path:
     """Write a Parquet file with native geo logical types and **no** ``geo`` key.
 
     Written through pyarrow rather than DuckDB because that is the only way to
@@ -194,6 +194,12 @@ def write_native_geo_only(path, rows, columns) -> Path:
     is no ``geo`` block to answer either.
 
     ``columns`` maps a column name to ``(row index, geoarrow type)``.
+
+    ``compression`` and ``write_options`` (``row_group_size``, ...) go straight
+    to ``pq.write_table``. They are what a ``gpio check --fix`` test needs: a fix
+    only rewrites a file it finds something wrong with, so an input written
+    SNAPPY or in 5-row groups is how those tests get a rewrite to measure at all
+    (#1001).
     """
     arrays = {
         "id": pa.array([row[0] for row in rows], type=pa.int64()),
@@ -203,7 +209,7 @@ def write_native_geo_only(path, rows, columns) -> Path:
         arrays[name] = pa.ExtensionArray.from_storage(
             geo_type, pa.array([bytes(row[index]) for row in rows], type=pa.binary())
         )
-    pq.write_table(pa.table(arrays), str(path), compression="zstd")
+    pq.write_table(pa.table(arrays), str(path), compression=compression, **write_options)
     return path
 
 

--- a/tests/test_check_fix_preserves_native_geo.py
+++ b/tests/test_check_fix_preserves_native_geo.py
@@ -32,6 +32,7 @@ Refs: https://github.com/geoparquet/geoparquet-io/issues/997
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pyarrow.parquet as pq
@@ -62,6 +63,32 @@ def _covering(path) -> dict | None:
     """One column's declared ``covering``, read off the ``geo`` block."""
     columns = (geo_block(path) or {}).get("columns") or {}
     return (columns.get("geometry") or {}).get("covering")
+
+
+def _rewrite_geo_block(path, block: dict) -> None:
+    table = pq.read_table(str(path))
+    metadata = dict(table.schema.metadata or {})
+    metadata[b"geo"] = json.dumps(block).encode("utf-8")
+    pq.write_table(table.replace_schema_metadata(metadata), str(path), compression="zstd")
+
+
+def _strip_covering(path) -> None:
+    """Rewrite ``path`` with its primary column's ``covering`` removed from the block."""
+    block = geo_block(path)
+    block["columns"]["geometry"].pop("covering", None)
+    _rewrite_geo_block(path, block)
+
+
+def _declare_geo_block(path, *, crs_epsg: int) -> None:
+    """Give a ``geo``-less file a 2.0 block naming ``crs_epsg`` and no covering."""
+    column = {
+        "encoding": "WKB",
+        "geometry_types": ["Polygon"],
+        "crs": json.loads(projjson(crs_epsg)),
+    }
+    _rewrite_geo_block(
+        path, {"version": "2.0.0", "primary_column": "geometry", "columns": {"geometry": column}}
+    )
 
 
 def _geometry_compression(path) -> str:
@@ -189,16 +216,21 @@ def test_check_all_fix_leaves_a_native_geo_only_file_native_geo_only(native_geo_
 def test_removing_a_bbox_column_keeps_the_crs_it_is_removed_from(projected_conus, tmp_path):
     """The third rewrite, ``check_fixes.fix_bbox_removal``.
 
-    Measured on ``origin/main`` before the fix and it already passed: the output
-    is ``parquet-geo-only``, whose only CRS slot is the Parquet logical type, and
-    DuckDB restates that from the column it read. So this is a guard rather than
-    a reproduction -- the site is given the same witness as the other two because
-    the facade asks every rewrite for one, and nothing should be able to take the
-    CRS away here without a test noticing.
+    ``add bbox`` writes native 2.0 -- a ``geo`` block *and* a Parquet logical
+    type, both naming EPSG:5070 -- and declares the column in a ``covering``,
+    which ``check bbox`` calls optimal and leaves alone. Strip the covering and
+    the column is *undeclared*, which is the 2.0 shape ``--fix`` removes it from.
+
+    A guard rather than a reproduction: it passes with or without the witness,
+    because DuckDB reads the CRS off the logical type and restates it in both
+    places. The test below is the one the witness is load-bearing for.
     """
-    with_bbox = tmp_path / "pgo_with_bbox.parquet"
-    _run_cli("add", "bbox", projected_conus, with_bbox, "--geoparquet-version", "parquet-geo-only")
+    with_bbox = tmp_path / "v2_with_bbox.parquet"
+    _run_cli("add", "bbox", projected_conus, with_bbox)
     assert "bbox" in pq.read_schema(str(with_bbox)).names
+    assert (geo_version(with_bbox) or "").startswith("2.0")
+    _strip_covering(with_bbox)
+    assert _covering(with_bbox) is None
     fixed = tmp_path / "removed.parquet"
 
     _run_cli("check", "bbox", with_bbox, "--fix", "--fix-output", fixed)
@@ -207,7 +239,43 @@ def test_removing_a_bbox_column_keeps_the_crs_it_is_removed_from(projected_conus
     # *leaves*, so a bbox struct shows up as xmin/ymin/xmax/ymax and the column
     # name this asserts on never appears at all.
     assert "bbox" not in pq.read_schema(str(fixed)).names, "the fix did not run"
-    assert geo_block(fixed) is None
+    assert (geo_version(fixed) or "").startswith("2.0")
+    assert logical_geo_types(fixed)["geometry"] == ("Geometry", EPSG_5070)
+    assert geo_block_crs_id(fixed) == EPSG_5070
+    assert spec_problems(fixed) == []
+
+
+def test_removing_a_bbox_column_keeps_a_crs_only_the_geo_block_states(tmp_path, _conus_5070_rows):
+    """The input the witness at ``fix_bbox_removal`` exists for.
+
+    A 2.0 file whose ``geo`` block says EPSG:5070 while its Parquet logical type
+    carries no CRS at all. ``check spec`` fails it on ``v2_crs_consistency`` --
+    but it is a file people have, and the rewrite that removes its undeclared
+    bbox column does not carry the block (``original_metadata=None``), so the
+    output's ``crs`` has exactly one source: the witness. Measured with the
+    ``input_file=`` removed, the output said **nothing** in both places -- 5070
+    metres labelled OGC:CRS84, ``coordinates outside valid range for CRS`` --
+    the #945 shape, a fix that mislabels the data it was asked to repair.
+    """
+    import geoarrow.pyarrow as ga
+
+    no_crs = write_native_geo_only(
+        tmp_path / "no_crs.parquet", _conus_5070_rows, {"geometry": (2, ga.wkb())}
+    )
+    with_bbox = tmp_path / "block_says_5070.parquet"
+    _run_cli("add", "bbox", no_crs, with_bbox)
+    assert "bbox" in pq.read_schema(str(with_bbox)).names
+    _declare_geo_block(with_bbox, crs_epsg=5070)
+    assert geo_block_crs_id(with_bbox) == EPSG_5070
+    assert logical_geo_types(with_bbox) == {"geometry": ("Geometry", None)}
+    assert _covering(with_bbox) is None, "a declared bbox is 'optimal' and never removed"
+    fixed = tmp_path / "removed.parquet"
+
+    _run_cli("check", "bbox", with_bbox, "--fix", "--fix-output", fixed)
+
+    assert "bbox" not in pq.read_schema(str(fixed)).names, "the fix did not run"
+    assert (geo_version(fixed) or "").startswith("2.0")
+    assert geo_block_crs_id(fixed) == EPSG_5070
     assert logical_geo_types(fixed)["geometry"] == ("Geometry", EPSG_5070)
     assert spec_problems(fixed) == []
 

--- a/tests/test_check_fix_preserves_native_geo.py
+++ b/tests/test_check_fix_preserves_native_geo.py
@@ -1,0 +1,289 @@
+"""``gpio check --fix`` must not leave the file worse than it found it.
+
+``check --fix`` is remedial: whatever it writes is the file gpio itself will
+check next. Three of its rewrites called ``write_parquet_with_metadata`` without
+``input_file=``, so the write facade (#990) had no witness for the two questions
+a rewrite has to answer about a *native-geo-only* input -- which version, and
+which CRS -- and one of them also withheld the input's own ``geo`` block from a
+2.0 rewrite. Two symptoms, one deferral:
+
+* **#1001.** ``gpio check compression --fix`` and ``gpio check row-group --fix``
+  on a native-geo-only EPSG:5070 file wrote 1.1 WKB and dropped the CRS with the
+  logical type it lived in. The output then failed ``check spec`` with
+  ``coordinates outside valid range for CRS`` -- projected metres read as
+  degrees, because an absent ``crs`` means ``OGC:CRS84``.
+* **#1003.** ``gpio add bbox`` writes native 2.0 with a ``covering`` since #997.
+  ``check all --fix`` over that output discarded the covering and then complained
+  about the file it had just written::
+
+      ⚠️  Some issues remain after fixes:
+         - Bbox column 'bbox' is not declared in the 'covering' metadata
+
+Every end-to-end assertion below reads the ``geo`` block and the Parquet logical
+type **separately** and then asks ``gpio check spec`` whether they agree.
+``crs_utils.source_crs_string`` reads the first, falls back to the second and
+returns whichever answered, so it is structurally incapable of seeing the two
+disagree -- which is how #993 first shipped green with the bug still in it.
+
+Refs: https://github.com/geoparquet/geoparquet-io/issues/1001
+Refs: https://github.com/geoparquet/geoparquet-io/issues/1003
+Refs: https://github.com/geoparquet/geoparquet-io/issues/997
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from tests.native_geo_probes import (
+    EPSG_5070,
+    conus_wkb,
+    geo_block,
+    geo_block_crs_id,
+    geo_version,
+    logical_geo_types,
+    projjson,
+    spec_problems,
+    write_native_geo_only,
+)
+
+
+def _run_cli(*args) -> str:
+    result = CliRunner().invoke(cli, [str(a) for a in args])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def _covering(path) -> dict | None:
+    """One column's declared ``covering``, read off the ``geo`` block."""
+    columns = (geo_block(path) or {}).get("columns") or {}
+    return (columns.get("geometry") or {}).get("covering")
+
+
+def _geometry_compression(path) -> str:
+    """The codec the geometry column is stored with, from the footer."""
+    metadata = pq.ParquetFile(str(path)).metadata
+    schema = pq.ParquetFile(str(path)).schema
+    index = next(i for i in range(len(schema)) if schema.column(i).name == "geometry")
+    return metadata.row_group(0).column(index).compression
+
+
+# ---------------------------------------------------------------------------
+# Fixtures. `projected_conus` (conftest) is the clean native-geo-only EPSG:5070
+# input; these are the same 200 polygons written so that `check --fix` has
+# something to repair, because a fix that never runs proves nothing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _conus_5070_rows():
+    return conus_wkb("ST_Transform(cell, 'EPSG:4326', 'EPSG:5070', always_xy := true)")
+
+
+@pytest.fixture
+def native_geo_snappy(tmp_path, _conus_5070_rows) -> Path:
+    """Native-geo-only EPSG:5070, SNAPPY: ``check compression --fix`` has work."""
+    import geoarrow.pyarrow as ga
+
+    return write_native_geo_only(
+        tmp_path / "pgo_snappy.parquet",
+        _conus_5070_rows,
+        {"geometry": (2, ga.wkb().with_crs(projjson(5070)))},
+        compression="snappy",
+    )
+
+
+@pytest.fixture
+def native_geo_tiny_row_groups(tmp_path, _conus_5070_rows) -> Path:
+    """Native-geo-only EPSG:5070 in 5-row groups: ``check row-group --fix`` has work."""
+    import geoarrow.pyarrow as ga
+
+    return write_native_geo_only(
+        tmp_path / "pgo_tiny_groups.parquet",
+        _conus_5070_rows,
+        {"geometry": (2, ga.wkb().with_crs(projjson(5070)))},
+        row_group_size=5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1001: the version and the CRS both survive a --fix rewrite
+# ---------------------------------------------------------------------------
+
+
+def test_the_fixtures_are_clean_native_geo_only_epsg_5070_files(
+    native_geo_snappy, native_geo_tiny_row_groups
+):
+    """Non-vacuity: "the output has no failures" only means something if the input had none."""
+    for fixture in (native_geo_snappy, native_geo_tiny_row_groups):
+        assert geo_block(fixture) is None
+        assert logical_geo_types(fixture) == {"geometry": ("Geometry", EPSG_5070)}
+        assert spec_problems(fixture) == []
+
+
+def test_check_compression_fix_keeps_the_native_type_and_the_crs(native_geo_snappy):
+    """#1001, through the compression fix (``check_fixes.fix_compression``)."""
+    _run_cli("check", "compression", native_geo_snappy, "--fix")
+
+    assert _geometry_compression(native_geo_snappy) == "ZSTD", "the fix did not run"
+    assert (geo_version(native_geo_snappy) or "").startswith("2.0")
+    assert logical_geo_types(native_geo_snappy)["geometry"] == ("Geometry", EPSG_5070)
+    assert geo_block_crs_id(native_geo_snappy) == EPSG_5070
+    assert spec_problems(native_geo_snappy) == []
+
+
+def test_check_row_group_fix_keeps_the_native_type_and_the_crs(native_geo_tiny_row_groups):
+    """#1001, through the row-group fix (``check_fixes.fix_row_groups``)."""
+    before = pq.ParquetFile(str(native_geo_tiny_row_groups)).metadata.num_row_groups
+    assert before > 1, "fixture does not have row groups to merge"
+
+    _run_cli("check", "row-group", native_geo_tiny_row_groups, "--fix")
+
+    after = pq.ParquetFile(str(native_geo_tiny_row_groups)).metadata.num_row_groups
+    assert after == 1, "the fix did not run"
+    assert (geo_version(native_geo_tiny_row_groups) or "").startswith("2.0")
+    assert logical_geo_types(native_geo_tiny_row_groups)["geometry"] == ("Geometry", EPSG_5070)
+    assert geo_block_crs_id(native_geo_tiny_row_groups) == EPSG_5070
+    assert spec_problems(native_geo_tiny_row_groups) == []
+
+
+def test_an_explicit_version_still_wins_and_still_states_the_crs(native_geo_snappy, tmp_path):
+    """The witness informs auto mode; it does not override a caller who asked.
+
+    1.1 has nowhere but the ``geo`` block to record a CRS, so this is also the
+    case where the witness is the only thing standing between EPSG:5070 and a
+    file that declares no CRS at all -- the quieter half of #993, one command on.
+    """
+    from geoparquet_io.core.check_fixes import fix_compression
+
+    out = tmp_path / "explicit_1_1.parquet"
+
+    fix_compression(str(native_geo_snappy), str(out), geoparquet_version="1.1")
+
+    assert (geo_version(out) or "").startswith("1.1")
+    assert logical_geo_types(out) == {}, "1.1 forbids a native Parquet geo type"
+    assert geo_block_crs_id(out) == EPSG_5070
+    assert spec_problems(out) == []
+
+
+def test_check_all_fix_leaves_a_native_geo_only_file_native_geo_only(native_geo_snappy):
+    """The control for ``check all``, which names the version from its own checks.
+
+    ``get_geoparquet_version_from_check_results`` answers ``parquet-geo-only``
+    here, and an explicit answer wins, so the output keeps no ``geo`` key at all
+    -- with its CRS still in the logical type, which is the only place that file
+    shape has to put one.
+    """
+    _run_cli("check", "all", native_geo_snappy, "--fix")
+
+    assert _geometry_compression(native_geo_snappy) == "ZSTD", "the fix did not run"
+    assert geo_block(native_geo_snappy) is None
+    assert logical_geo_types(native_geo_snappy)["geometry"] == ("Geometry", EPSG_5070)
+    assert spec_problems(native_geo_snappy) == []
+
+
+def test_removing_a_bbox_column_keeps_the_crs_it_is_removed_from(projected_conus, tmp_path):
+    """The third rewrite, ``check_fixes.fix_bbox_removal``.
+
+    Measured on ``origin/main`` before the fix and it already passed: the output
+    is ``parquet-geo-only``, whose only CRS slot is the Parquet logical type, and
+    DuckDB restates that from the column it read. So this is a guard rather than
+    a reproduction -- the site is given the same witness as the other two because
+    the facade asks every rewrite for one, and nothing should be able to take the
+    CRS away here without a test noticing.
+    """
+    with_bbox = tmp_path / "pgo_with_bbox.parquet"
+    _run_cli("add", "bbox", projected_conus, with_bbox, "--geoparquet-version", "parquet-geo-only")
+    assert "bbox" in pq.read_schema(str(with_bbox)).names
+    fixed = tmp_path / "removed.parquet"
+
+    _run_cli("check", "bbox", with_bbox, "--fix", "--fix-output", fixed)
+
+    # `read_schema` and not `ParquetFile.schema`: the latter lists Parquet
+    # *leaves*, so a bbox struct shows up as xmin/ymin/xmax/ymax and the column
+    # name this asserts on never appears at all.
+    assert "bbox" not in pq.read_schema(str(fixed)).names, "the fix did not run"
+    assert geo_block(fixed) is None
+    assert logical_geo_types(fixed)["geometry"] == ("Geometry", EPSG_5070)
+    assert spec_problems(fixed) == []
+
+
+# ---------------------------------------------------------------------------
+# #1003: the composition `add bbox` -> `check all --fix`
+# ---------------------------------------------------------------------------
+
+
+def test_add_bbox_then_check_all_fix_keeps_the_covering(projected_conus, tmp_path):
+    """The composition #1003 asks for, end to end.
+
+    ``add bbox`` writes native 2.0 with a ``covering``; ``check all --fix`` then
+    rewrites the file for compression. Before this it wrote a 2.0 block built
+    from nothing -- no covering -- and its own bbox check then failed the file:
+    ``Bbox column 'bbox' is not declared in the 'covering' metadata``.
+    """
+    with_bbox = tmp_path / "with_bbox.parquet"
+    _run_cli("add", "bbox", projected_conus, with_bbox, "--compression", "snappy")
+
+    declared = _covering(with_bbox)
+    assert declared, "`add bbox` did not declare a covering -- nothing to lose"
+    assert (geo_version(with_bbox) or "").startswith("2.0")
+
+    output = _run_cli("check", "all", with_bbox, "--fix")
+
+    assert _geometry_compression(with_bbox) == "ZSTD", "the fix did not run"
+    assert _covering(with_bbox) == declared
+    assert "Some issues remain after fixes" not in output
+    assert (geo_version(with_bbox) or "").startswith("2.0")
+    assert logical_geo_types(with_bbox)["geometry"] == ("Geometry", EPSG_5070)
+    assert geo_block_crs_id(with_bbox) == EPSG_5070
+    assert spec_problems(with_bbox) == []
+
+
+def test_the_bbox_column_the_fix_leaves_behind_is_still_declared(projected_conus, tmp_path):
+    """The symptom as the user meets it: gpio's own bbox check, run again.
+
+    ``check spec`` is not the only oracle #1003 named -- ``check bbox`` is the
+    check that printed the complaint, so it gets asked directly.
+    """
+    with_bbox = tmp_path / "with_bbox.parquet"
+    _run_cli("add", "bbox", projected_conus, with_bbox, "--compression", "snappy")
+    _run_cli("check", "all", with_bbox, "--fix")
+
+    output = _run_cli("check", "bbox", with_bbox)
+
+    assert "not declared in 'covering'" not in output
+    assert "Bbox covering column 'bbox' declared" in output
+
+
+def test_a_1_1_input_keeps_its_version_and_its_covering(projected_conus, tmp_path):
+    """The control: a 1.x file is repaired as 1.1, not upgraded behind the user.
+
+    A fix that quietly upgrades the file a user asked gpio to *repair* is a
+    defect of the same family as losing its CRS.
+    """
+    one_one = tmp_path / "v1_1.parquet"
+    _run_cli(
+        "convert",
+        "geoparquet",
+        projected_conus,
+        one_one,
+        "--geoparquet-version",
+        "1.1",
+        "--compression",
+        "snappy",
+    )
+    declared = _covering(one_one)
+    assert declared, "fixture has no covering to preserve"
+
+    _run_cli("check", "all", one_one, "--fix")
+
+    assert _geometry_compression(one_one) == "ZSTD", "the fix did not run"
+    assert (geo_version(one_one) or "").startswith("1.1")
+    assert logical_geo_types(one_one) == {}, "a 1.1 output must not carry a native geo type"
+    assert _covering(one_one) == declared
+    assert geo_block_crs_id(one_one) == EPSG_5070
+    assert spec_problems(one_one) == []


### PR DESCRIPTION
## What changed

`gpio check --fix` is remedial: whatever it writes is the file gpio's own checks
are run against next. Three of its rewrites called
`write_parquet_with_metadata` without `input_file=`, so the write facade (#990)
had no witness for the two questions a rewrite has to answer about its input —
which GeoParquet version, and which CRS. Two of those three also withheld the
input's own `geo` block from a 2.0 rewrite, on a premise that stopped being true
in #738/#772.

One deferral, two symptoms, both closed here.

### #1001 — the version and the CRS

`check compression --fix` and `check row-group --fix` pass no version, so the
facade resolves auto mode. Without a witness it read the carried `geo` key, a
native-geo-only input has none, and the write landed on the 1.1 default: DuckDB
re-encoded the geometry column as plain WKB and the Parquet `GEOMETRY` logical
type went with it — taking the CRS, which for that file shape is the *only*
place a CRS is stored.

Measured on `origin/main` (7a62082), a clean native-geo-only EPSG:5070 file of
200 CONUS polygons, written SNAPPY so the fix has work to do. The `geo` block
and the Parquet logical type are read **separately**, because
`crs_utils.source_crs_string` falls back between them and cannot see them
disagree:

```
$ gpio check compression pgo_snappy.parquet --fix          # origin/main
  before:  geo version = None
           geo-block crs id = <no geo key>
           logical crs id   = {'authority': 'EPSG', 'code': 5070}
           check spec failures (0)
  after:   geo version = 1.1.0
           geo-block crs id = <no crs key -- resolves as OGC:CRS84>
           logical crs id   = <no native geo type>
           check spec failures (1):
             x coordinates_valid_for_crs_geometry: coordinates outside valid
               range for CRS (200 checked)
```

EPSG:5070 metres read as degrees, because an absent `crs` means `OGC:CRS84`.
`check row-group --fix` produced the identical loss. With this branch:

```
$ gpio check compression pgo_snappy.parquet --fix          # this branch
  after:   geo version = 2.0.0
           geo-block crs id = {'authority': 'EPSG', 'code': 5070}
           logical crs id   = {'authority': 'EPSG', 'code': 5070}
           check spec failures (0)
```

### #1003 — the bbox covering

`add bbox` writes native 2.0 with a `covering` since #997. `check all --fix`
over that output rebuilt the `geo` block from nothing — DuckDB's generated block
carries `version`, `primary_column`, `encoding`, `geometry_types` and `bbox`,
and no `covering` — and gpio's own bbox check then failed the file gpio had just
written:

```
$ gpio add bbox base_5070.parquet cf3.parquet --compression snappy
  covering = {'bbox': {'xmin': ['bbox','xmin'], ...}}   ver = 2.0.0
$ gpio check all cf3.parquet --fix                         # origin/main
  ⚠️  Some issues remain after fixes:
     - Bbox column 'bbox' is not declared in the 'covering' metadata,
       so no reader can use it
  covering = None                                        ver = 2.0.0
```

On this branch the covering is byte-identical across the fix, the warning is
gone, and both CRS readings still agree:

```
$ gpio check all cf3.parquet --fix                         # this branch
  covering = {'bbox': {'xmin': ['bbox','xmin'], ...}}   ver = 2.0.0
  geo-block crs id = {'authority': 'EPSG', 'code': 5070}
  logical crs id   = {'authority': 'EPSG', 'code': 5070}
  check spec failures (0)
```

As #1003 says, this half is **pre-existing on 2.0 inputs and not introduced by
#997** — verified on the clean worktree above, where the covering is lost on
`origin/main` too. What #997 changed is that `add bbox` now *produces* a 2.0
file by default, which routes users into it.

## The fix

`input_file=` at all three sites, plus the input's metadata at the two that were
withholding it:

| site | change |
|---|---|
| `check_fixes.py:115` `fix_compression` | `input_file=parquet_file`; read `original_metadata` at every version |
| `check_fixes.py:258` `fix_bbox_removal` | `input_file=parquet_file` |
| `check_fixes.py:437` `fix_row_groups` | `input_file=parquet_file`; read `original_metadata` at every version |

No version or CRS logic at the call sites — the facade owns both, and an
explicit `geoparquet_version` still wins over the witness (pinned by
`test_an_explicit_version_still_wins_and_still_states_the_crs`).

**`input_file=` is `parquet_file`, not the user's file, and that matters.**
Under `check all --fix` the fixes chain, and `parquet_file` is the previous
step's scratch file — which is the file whose *rows* this write reads, which is
what `resolve_output_geoparquet_version`'s docstring contract asks for. Naming
the user's original while reading a scratch rewrite is the failure mode that
docstring warns about.

**Why `original_metadata` had to come too.** `input_file=` alone fixes #1001 and
leaves #1003 exactly as it was — measured, on this branch's own history. The
guard read the input's metadata only for a 1.x output, on the reasoning that a
2.0 write regenerates its `geo` block anyway. DuckDB does regenerate it, and
since #738/#772 the block that actually reaches the file is the input's own,
substituted by `_geo_block_to_carry_on_fast_path` — which is handed
`original_metadata` and returns `None` without it. Both of these rewrites keep
every row of their input, so the carried stats still describe the output
exactly. `fix_bbox_removal` keeps its deliberate `original_metadata=None`: its
output no longer has the column the covering points at.

`fix_bbox_removal`'s `input_file=` has a narrower symptom than the other two,
and the first version of this PR misdescribed it as having none. On the shapes
`add bbox` produces the witness is not load-bearing: DuckDB reads the CRS off the
logical type and restates it in both places with or without one (an adversarial
review proved this by deleting the line — the test I had called a pin stayed
green). The shape it *is* load-bearing for is a 2.0 file whose `geo` block names
EPSG:5070 while its Parquet logical type carries no CRS — `check spec` fails it
on `v2_crs_consistency`, but people have such files, and its undeclared bbox
column is exactly what `check bbox --fix` removes. That rewrite does not carry
the block (`original_metadata=None`), so the output's `crs` has one source. With
the witness deleted, measured on this branch:

```
input : geo crs EPSG:5070 | logical <no crs>
output: geo crs <none -- OGC:CRS84> | logical <none -- OGC:CRS84>
        ✗ coordinates_valid_for_crs_geometry: coordinates outside valid range for CRS (200 checked)
```

5070 metres labelled as degrees, by the command asked to repair the file — the
#945 shape. `test_removing_a_bbox_column_keeps_a_crs_only_the_geo_block_states`
builds that input and fails without the line; the earlier `parquet-geo-only`
test is kept as a guard and its docstring now says that is all it is.

**A behaviour change worth naming.** With the witness in place, `check --fix`
resolves a file whose two CRS sources *disagree* the way every other rewrite
does — `geo` block first (`extract_crs_from_parquet`) — and writes the winner
into both places. On `main` the fix path let the logical type win, silently. Both
answers erase the `check spec` finding that flagged the input; #1008 (landing
right behind this one) adds the warning that names both CRSs and the winner
whenever that happens, so `check --fix` will say so rather than doing it
quietly. Also declared: sidecar keys (`fiboa`, `collection`) and `epoch` now
survive `check compression --fix` and `check row-group --fix` on a 2.0 file
(they were dropped with the block), a covering on a non-conventionally-named
bbox column survives too, and a GEOGRAPHY input comes out 2.0 with
`edges: spherical` instead of 1.1 WKB with the edge declaration gone. `check bbox
--fix` still drops sidecars and `epoch` — #1015.

## Tests

`tests/test_check_fix_preserves_native_geo.py`, 10 tests. Every end-to-end
assertion reads the `geo` block and the Parquet logical type separately and then
asks `check spec` whether they agree — the oracle #997 needed, since
`source_crs_string` falls back between the two and is structurally incapable of
reporting a disagreement, which is how #993 first shipped green with the bug in
it. `tests/native_geo_probes.py` gains a `compression`/`**write_options`
passthrough on its fixture builder, because a `--fix` test needs an input with
something actually wrong with it or the rewrite never runs.

- the two #1001 reproductions (`check compression --fix`, `check row-group --fix`),
  each asserting the fix ran before asserting what survived it
- the #1003 composition `add bbox` → `check all --fix`: the covering is
  unchanged, `Some issues remain after fixes` is absent, and `check bbox` on the
  output no longer prints `not declared in 'covering'`
- controls: an explicit `--geoparquet-version 1.1` still wins (and still states
  the CRS, the quieter #993 loss); a 1.1 input stays 1.1 with its covering and
  never gains a native geo type — a fix that upgrades a file the user asked it
  to *repair* is a defect of the same family; `check all --fix` on a
  native-geo-only file still leaves it native-geo-only
- non-vacuity: the fixtures are asserted clean (zero `check spec` failures)
  before anything runs
- the `fix_bbox_removal` witness, on the one input shape it decides: a 2.0 file
  whose CRS lives only in its `geo` block, proven load-bearing by deleting the
  line

Fixes #1001. Closes #1003.

On the fixture: `tests/data/fields_pgo_5070_snappy.parquet` is labelled EPSG:5070
but its coordinates are over Europe, so `check spec` scores it `coordinates
outside valid range for CRS` whatever the command did. These tests build on the
`projected_conus` shape #997 added instead — 200 polygons really inside 5070's
area of use — so "clean" can mean *zero* failures rather than "the same one
failure as before", and the assertion stays able to see a new failure appear.

## Verification

- `uv run pytest -n auto -m "not slow and not network and not meta"` — **7705
  passed**, 76 skipped, 3 xfailed
- `uv run pytest -m meta` — 205 passed
- `pre-commit run --all-files` and `--hook-stage pre-push` — all hooks pass
  (xenon, import-linter, deptry, vulture, mypy, menard-check, fast-tests)
- `diff-cover coverage.xml --compare-branch origin/main --fail-under=90` —
  **100%** (2 measured changed lines, 0 missing); total project coverage 89%
- `cli_surface.json` unchanged; no CLI surface, API or docs change

One transient: `tests/test_pipe_integration.py` timed out on two multi-process
pipe chains during an early run on this branch. Reproduced on a throwaway
detached `origin/main` worktree, where a *different* test in that same file
timed out the same way — a 60 s cap on shell pipelines under machine load, not
this change. The final full run above includes that file, green.

---

*This pull request was written by Claude (AI). A human has reviewed the
reproductions and the measurements above.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

