### PR TITLE
fix(test): clear the package logger before each test so --verbose cannot leak into the next

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ duckdb.connect = _thread_limited_connect
 # ---------------------------------------------------------------------------
 import functools  # noqa: E402
 import json  # noqa: E402
+import logging  # noqa: E402
 import os  # noqa: E402
 import shutil  # noqa: E402
 import tempfile  # noqa: E402
@@ -64,6 +65,54 @@ try:
 except ImportError:  # pragma: no cover - click < 8.2
     UNSET = object()
     CLICK_HAS_UNSET = False
+
+
+# ---------------------------------------------------------------------------
+# The package logger is process-global; a test must hand it back
+# ---------------------------------------------------------------------------
+# ``--verbose`` raises the ``geoparquet_io`` logger to DEBUG as the flag is
+# parsed (``cli.decorators.enable_verbose_logging``, #995), and
+# ``core.logging_config.configure_verbose`` is deliberately one-way -- nothing
+# lowers the level again. That is correct for a CLI, which runs one command per
+# process, and it is why the fix for this belongs here rather than in the CLI.
+#
+# Under pytest one process runs hundreds of tests, so the first ``--verbose``
+# invocation (or the first core call made with ``verbose=True``) turns DEBUG on
+# for every later test on that xdist worker. Any test that asserts on the
+# *absence* of debug output then fails depending on the schedule -- which is how
+# ``test_cli_error_boundary.py`` started failing on Windows only, with a
+# traceback that ``ErrorBoundaryGroup.invoke`` logs at DEBUG with ``exc_info``.
+#
+# The state to put back is read off ``core/logging_config.py``: ``level``,
+# ``handlers`` (``setup_cli_logging`` clears the list in place and installs its
+# own; ``_bootstrap_default_handler`` may append a ``NullHandler``) and
+# ``propagate``. There is no module-level verbosity flag -- the logger's level
+# *is* the state -- and nothing mutates a handler that was already attached, so
+# restoring the same handler objects restores their levels and formatters too.
+
+PACKAGE_LOGGER_NAME = "geoparquet_io"
+
+
+@contextmanager
+def pristine_package_logging():
+    """Hand the ``geoparquet_io`` logger back exactly as it was found."""
+    package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+    level = package_logger.level
+    handlers = list(package_logger.handlers)
+    propagate = package_logger.propagate
+    try:
+        yield
+    finally:
+        package_logger.setLevel(level)
+        package_logger.handlers[:] = handlers
+        package_logger.propagate = propagate
+
+
+@pytest.fixture(autouse=True)
+def _isolate_package_logging():
+    """Snapshot/restore the package logger around every test in the suite."""
+    with pristine_package_logging():
+        yield
 
 
 def walk_cli_commands(cmd, path: tuple[str, ...] = ()):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ except ImportError:  # pragma: no cover - click < 8.2
 
 
 # ---------------------------------------------------------------------------
-# The package logger is process-global; a test must hand it back
+# The package logger is process-global; a test must start from a known state
 # ---------------------------------------------------------------------------
 # ``--verbose`` raises the ``geoparquet_io`` logger to DEBUG as the flag is
 # parsed (``cli.decorators.enable_verbose_logging``, #995), and
@@ -80,38 +80,95 @@ except ImportError:  # pragma: no cover - click < 8.2
 # invocation (or the first core call made with ``verbose=True``) turns DEBUG on
 # for every later test on that xdist worker. Any test that asserts on the
 # *absence* of debug output then fails depending on the schedule -- which is how
-# ``test_cli_error_boundary.py`` started failing on Windows only, with a
-# traceback that ``ErrorBoundaryGroup.invoke`` logs at DEBUG with ``exc_info``.
+# ``test_cli_error_boundary.py`` started failing, with a traceback that
+# ``ErrorBoundaryGroup.invoke`` logs at DEBUG with ``exc_info``. Windows was
+# never special; ``-n auto`` just drew the losing order there first.
 #
-# The state to put back is read off ``core/logging_config.py``: ``level``,
-# ``handlers`` (``setup_cli_logging`` clears the list in place and installs its
-# own; ``_bootstrap_default_handler`` may append a ``NullHandler``) and
-# ``propagate``. There is no module-level verbosity flag -- the logger's level
-# *is* the state -- and nothing mutates a handler that was already attached, so
-# restoring the same handler objects restores their levels and formatters too.
+# Restoring a *snapshot* is not enough, and was itself a bug (#1016): a
+# function-scoped fixture is set up only after every higher-scoped one, so a
+# module-scoped fixture that runs ``--verbose`` -- ``test_add.py``'s
+# ``bbox_optioned_run`` and ``_h3_optioned_invocation`` both do -- has already
+# raised the level by the time the snapshot is taken. Restoring that snapshot
+# then re-applies the poison after every later test, turning an intermittent
+# leak into a permanent one for the rest of the worker.
+#
+# So this sets a *known* state instead of putting back whatever it found:
+# every ``geoparquet_io`` logger goes back to what a freshly imported process
+# has -- level ``NOTSET``, no handlers, ``propagate`` True -- before the test
+# body runs and again after it. Nothing that happened earlier in the process
+# can survive that, whether it came from a previous test, a higher-scoped
+# fixture, or import time.
+#
+# The pieces are read off ``core/logging_config.py``: ``setup_cli_logging``
+# assigns the level, clears ``handlers`` in place and installs its own, and sets
+# ``propagate``; ``configure_verbose`` raises the level and may add a handler
+# through ``_bootstrap_default_handler``. There is no module-level verbosity
+# flag -- the logger's level *is* the state -- and every handler those install
+# is created fresh, so dropping them cannot lose configuration that belongs to
+# somebody else.
+#
+# ``NOTSET`` (rather than a fixed level) is what a fresh process has, and 13
+# tests use a bare ``caplog.at_level(...)`` that sets the *root* level and
+# relies on the package logger inheriting from it. That inheritance is also the
+# one way a poisoned root could still enable DEBUG here, so the root level is
+# clamped out of DEBUG too -- unless the run explicitly asked for a log level,
+# which is a developer debugging and must be honoured.
 
 PACKAGE_LOGGER_NAME = "geoparquet_io"
 
 
+def _reset_package_loggers() -> None:
+    """Return every ``geoparquet_io`` logger to its freshly-imported state."""
+    prefix = PACKAGE_LOGGER_NAME + "."
+    names = [
+        name
+        for name in list(logging.Logger.manager.loggerDict)
+        if name == PACKAGE_LOGGER_NAME or name.startswith(prefix)
+    ]
+    # `geoparquet_io` itself may not be in loggerDict yet; getLogger creates it.
+    for name in [PACKAGE_LOGGER_NAME, *names]:
+        child = logging.getLogger(name)
+        child.setLevel(logging.NOTSET)
+        child.handlers[:] = []
+        child.propagate = True
+
+
 @contextmanager
-def pristine_package_logging():
-    """Hand the ``geoparquet_io`` logger back exactly as it was found."""
-    package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
-    level = package_logger.level
-    handlers = list(package_logger.handlers)
-    propagate = package_logger.propagate
+def pristine_package_logging(*, guard_root: bool = True):
+    """Run the body with gpio's loggers in a known-clean state, and leave it so.
+
+    ``guard_root`` clamps the root logger out of DEBUG for the duration, so the
+    package loggers -- which sit at ``NOTSET`` and inherit -- cannot be switched
+    on by a root level somebody else left behind. The root's own level is put
+    back afterwards; it belongs to pytest, not to us.
+    """
+    root = logging.getLogger()
+    root_level = root.level
+    _reset_package_loggers()
+    if guard_root and root.getEffectiveLevel() < logging.WARNING:
+        root.setLevel(logging.WARNING)
     try:
         yield
     finally:
-        package_logger.setLevel(level)
-        package_logger.handlers[:] = handlers
-        package_logger.propagate = propagate
+        _reset_package_loggers()
+        root.setLevel(root_level)
+
+
+def _has_explicit_log_level(config) -> bool:
+    """True when the run asked for a log level (``--log-level``/``log_cli_level``)."""
+    for name in ("log_level", "log_cli_level"):
+        try:
+            if config.getoption(name, None) or config.getini(name):
+                return True
+        except (ValueError, KeyError):  # pragma: no cover - plugin not registered
+            continue
+    return False
 
 
 @pytest.fixture(autouse=True)
-def _isolate_package_logging():
-    """Snapshot/restore the package logger around every test in the suite."""
-    with pristine_package_logging():
+def _isolate_package_logging(pytestconfig):
+    """Give every test in the suite a known-clean ``geoparquet_io`` logger."""
+    with pristine_package_logging(guard_root=not _has_explicit_log_level(pytestconfig)):
         yield
 
 

--- a/tests/test_cli_error_boundary.py
+++ b/tests/test_cli_error_boundary.py
@@ -47,12 +47,15 @@ def rejected_file(tmp_path):
 
 
 # ``configure_verbose`` is one-way and the logger is a module global, so a
-# ``--verbose`` test used to hand DEBUG to whatever ran next. This file's own
-# local fixture only covered the tests below; ``tests/conftest.py`` now snapshots
-# the logger -- level, handlers and ``propagate`` -- around *every* test, because
-# the test this leak actually broke was ``test_a_duckdb_error_reaches_the_user_as
-# _an_error_line`` in this file, poisoned from another module on the same xdist
-# worker. See ``tests/test_logging_state_isolation.py``.
+# ``--verbose`` test hands DEBUG to whatever runs next. This file's own local
+# fixture only covered the tests below, and the tests it could not save are the
+# two that build their own ``ErrorBoundaryGroup`` -- ``cli`` resets the level on
+# every invocation through ``setup_cli_logging``, a throwaway group does not.
+# ``tests/conftest.py`` now puts every ``geoparquet_io`` logger back to a
+# known-clean state around *every* test in the suite, which is what it takes:
+# the poison arrived from ``test_add.py``'s module-scoped ``--verbose`` fixtures
+# on the same xdist worker, before any function-scoped fixture could look.
+# See ``tests/test_logging_state_isolation.py``.
 
 
 def _group_raising(exc: BaseException):

--- a/tests/test_cli_error_boundary.py
+++ b/tests/test_cli_error_boundary.py
@@ -46,13 +46,13 @@ def rejected_file(tmp_path):
     return str(path)
 
 
-@pytest.fixture
-def restore_log_level():
-    """``configure_verbose`` is one-way and the logger is a module global."""
-    package_logger = logging.getLogger("geoparquet_io")
-    before = package_logger.level
-    yield
-    package_logger.setLevel(before)
+# ``configure_verbose`` is one-way and the logger is a module global, so a
+# ``--verbose`` test used to hand DEBUG to whatever ran next. This file's own
+# local fixture only covered the tests below; ``tests/conftest.py`` now snapshots
+# the logger -- level, handlers and ``propagate`` -- around *every* test, because
+# the test this leak actually broke was ``test_a_duckdb_error_reaches_the_user_as
+# _an_error_line`` in this file, poisoned from another module on the same xdist
+# worker. See ``tests/test_logging_state_isolation.py``.
 
 
 def _group_raising(exc: BaseException):
@@ -336,7 +336,6 @@ class TestVerboseRestoresTheHiddenTraceback:
         ("check optimization", ["check", "optimization", "{in}"]),
     ]
 
-    @pytest.mark.usefixtures("restore_log_level")
     @pytest.mark.parametrize(("name", "argv"), COMMANDS, ids=[n for n, _ in COMMANDS])
     def test_verbose_prints_the_traceback_the_error_line_replaced(
         self, name, argv, rejected_file, tmp_path
@@ -354,7 +353,6 @@ class TestVerboseRestoresTheHiddenTraceback:
         assert "Traceback (most recent call last)" in verbose.output, verbose.output
         assert "InvalidInputException" in verbose.output
 
-    @pytest.mark.usefixtures("restore_log_level")
     def test_the_flag_raises_the_level_before_the_command_body_runs(self):
         """The mechanism, without a failure in the way: by the time any gpio
         code runs, DEBUG is already on. Nothing inside the command is asked to

--- a/tests/test_logging_state_isolation.py
+++ b/tests/test_logging_state_isolation.py
@@ -1,26 +1,36 @@
-"""One test must not leave the package logger raised for the next one.
+"""Every test must start from a known-clean ``geoparquet_io`` logger.
 
-``--verbose`` raises the ``geoparquet_io`` logger to DEBUG as the flag is parsed
+``--verbose`` raises that logger to DEBUG as the flag is parsed
 (:func:`geoparquet_io.cli.decorators.enable_verbose_logging`, #995) and
 :func:`~geoparquet_io.core.logging_config.configure_verbose` is deliberately
-one-way, so nothing ever lowers it again. That is right for a CLI -- one command
-per process -- and wrong under pytest, where a whole file of tests shares one
-xdist worker process: the first ``--verbose`` invocation, or the first core call
-made with ``verbose=True``, leaves DEBUG on for every test that follows it on
-that worker.
+one-way, so nothing lowers it again. That is right for a CLI -- one command per
+process -- and wrong under pytest, where a whole file of tests shares one xdist
+worker process: the first ``--verbose`` invocation, or the first core call made
+with ``verbose=True``, leaves DEBUG on for every test that follows it on that
+worker.
 
-The victim is any test that asserts on the *absence* of debug output. The one
-that actually went red on ``main`` is
-``tests/test_cli_error_boundary.py::TestTheRootGroupIsTheBoundary::test_a_duckdb_error_reaches_the_user_as_an_error_line``:
+The victim is any test that asserts on the *absence* of debug output.
 ``ErrorBoundaryGroup.invoke`` logs "Converted a low-level failure to an error
-line" at DEBUG with ``exc_info``, so a leaked DEBUG level puts a traceback in
-``result.output`` and the test's ``assert "Traceback" not in result.output``
-fails -- on Windows first, only because ``-n auto`` happened to schedule the
-tests in the poisoning order there.
+line" at DEBUG with ``exc_info``, so a leaked DEBUG level -- together with a
+leaked stream handler -- puts a traceback in ``result.output`` and
+``tests/test_cli_error_boundary.py`` fails on ``assert "Traceback" not in
+result.output``.
 
-The CLI behaviour is correct and is not what these tests pin. What they pin is
-the test harness: ``tests/conftest.py`` snapshots the package logger around
-every test, so no test can inherit another's level or handlers.
+Two shapes of that leak are pinned below, because the first fix only handled
+one of them:
+
+* **Left behind by an earlier test**, which a snapshot/restore fixture catches.
+* **Already in place before the fixture can look** -- a module- or
+  session-scoped fixture is set up *before* any function-scoped one, so
+  ``test_add.py``'s ``bbox_optioned_run`` (a module-scoped fixture that runs
+  ``gpio add bbox --verbose``) had raised the level before the snapshot was
+  taken. Putting that snapshot back after every test made the poison permanent
+  for the rest of the worker rather than fixing it (#1016).
+
+So ``tests/conftest.py`` sets a known state rather than restoring what it
+found. These tests pin that distinction: a restore-only fixture fails
+:class:`TestAPoisonedWorkerStillStartsClean`, which is poisoned from a
+module-scoped fixture exactly as ``test_add.py`` poisons a real worker.
 """
 
 from __future__ import annotations
@@ -31,123 +41,249 @@ import subprocess
 import sys
 from pathlib import Path
 
+import click
+import duckdb
 import pytest
+from click.testing import CliRunner
 
+from geoparquet_io.cli.decorators import ErrorBoundaryGroup
 from geoparquet_io.core.logging_config import configure_verbose, setup_cli_logging
 from tests.conftest import pristine_package_logging
 
 PACKAGE_LOGGER = logging.getLogger("geoparquet_io")
+ROOT_LOGGER = logging.getLogger()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-class TestTheGuardPutsBackWhatConfigureVerboseChanges:
-    """The three pieces of global state the logging entry points mutate.
+def _boundary_result():
+    """Invoke a throwaway ``ErrorBoundaryGroup`` that fails the way #983 did.
 
-    Read off ``core/logging_config.py`` rather than guessed: ``setup_cli_logging``
-    assigns ``logger.setLevel``, ``logger.handlers.clear()`` +
-    ``addHandler``, and ``logger.propagate``; ``configure_verbose`` raises the
-    level and, through ``_bootstrap_default_handler``, may add a handler. No
-    module-level flag records verbosity -- the logger's own level *is* the
-    state -- and nothing mutates a handler that was already attached, so putting
-    back the same handler objects puts back their levels and formatters too.
+    A throwaway group rather than the real ``cli`` on purpose: ``cli``'s own
+    callback calls ``setup_cli_logging``, which resets the level on every
+    invocation and hides the leak. The two tests that actually went red are the
+    two that build their own group, and this is why.
     """
 
-    def test_a_raised_level_is_put_back(self):
-        before = PACKAGE_LOGGER.level
+    @click.group(cls=ErrorBoundaryGroup)
+    def root():
+        pass
+
+    @root.command()
+    def boom():
+        raise duckdb.InvalidInputException(
+            "Invalid Input Error: Geoparquet metadata does not have a columns object"
+        )
+
+    return CliRunner().invoke(root, ["boom"])
+
+
+# =============================================================================
+# The guard itself
+# =============================================================================
+
+
+class TestTheGuardSetsAKnownState:
+    """What it puts in place, and why those are the pieces.
+
+    Read off ``core/logging_config.py`` rather than guessed: ``setup_cli_logging``
+    assigns the level, clears ``handlers`` in place and installs its own, and
+    sets ``propagate``; ``configure_verbose`` raises the level and may add a
+    handler through ``_bootstrap_default_handler``. No module-level flag records
+    verbosity -- the logger's level *is* the state.
+    """
+
+    def test_a_raised_level_is_gone_on_entry_not_merely_on_exit(self):
+        """The difference from a snapshot: entering cleans, it does not record.
+
+        This is the whole bug in #1016. A fixture that only restores hands back
+        whatever a module-scoped fixture already did.
+        """
+        configure_verbose(True)
+        assert PACKAGE_LOGGER.level == logging.DEBUG
 
         with pristine_package_logging():
-            setup_cli_logging(verbose=False)
-            configure_verbose(True)
-            assert PACKAGE_LOGGER.level == logging.DEBUG
+            assert PACKAGE_LOGGER.level == logging.NOTSET
 
-        assert PACKAGE_LOGGER.level == before
-
-    def test_replaced_handlers_are_put_back_as_the_same_objects(self):
-        before = list(PACKAGE_LOGGER.handlers)
+    def test_handlers_are_gone_on_entry(self):
+        setup_cli_logging(verbose=True)
+        assert PACKAGE_LOGGER.handlers
 
         with pristine_package_logging():
-            setup_cli_logging(verbose=True)
-            assert PACKAGE_LOGGER.handlers != before
+            assert PACKAGE_LOGGER.handlers == []
 
-        assert PACKAGE_LOGGER.handlers == before
-
-    def test_propagate_is_put_back(self):
-        before = PACKAGE_LOGGER.propagate
+    def test_a_child_logger_is_cleaned_too(self):
+        """``get_logger(__name__)`` hands out children, and the record that
+        broke the boundary tests is logged on ``geoparquet_io.cli.decorators``."""
+        child = logging.getLogger("geoparquet_io.cli.decorators")
+        child.setLevel(logging.DEBUG)
+        child.propagate = False
 
         with pristine_package_logging():
-            PACKAGE_LOGGER.propagate = not before
+            assert child.level == logging.NOTSET
+            assert child.propagate is True
 
-        assert PACKAGE_LOGGER.propagate is before
+    def test_a_root_level_that_would_switch_debug_back_on_is_clamped(self):
+        """The package loggers sit at ``NOTSET``, so they inherit from the root.
 
-    def test_the_guard_puts_state_back_even_when_the_body_raises(self):
-        before = PACKAGE_LOGGER.level
+        A root left at DEBUG would re-enable every gpio debug record through
+        that inheritance, which is the one way a snapshot of *our* loggers can
+        still be wrong.
+        """
+        ROOT_LOGGER.setLevel(logging.DEBUG)
+        try:
+            with pristine_package_logging():
+                assert PACKAGE_LOGGER.getEffectiveLevel() > logging.DEBUG
+        finally:
+            ROOT_LOGGER.setLevel(logging.WARNING)
 
+    def test_the_root_level_is_handed_back(self):
+        """The root belongs to pytest, not to us."""
+        before = ROOT_LOGGER.level
+        with pristine_package_logging():
+            pass
+        assert ROOT_LOGGER.level == before
+
+    def test_an_explicit_log_level_is_not_clamped_away(self):
+        """``--log-level=DEBUG`` is a developer asking for output, not a leak."""
+        ROOT_LOGGER.setLevel(logging.DEBUG)
+        try:
+            with pristine_package_logging(guard_root=False):
+                assert ROOT_LOGGER.level == logging.DEBUG
+        finally:
+            ROOT_LOGGER.setLevel(logging.WARNING)
+
+    def test_the_guard_cleans_up_even_when_the_body_raises(self):
         with pytest.raises(RuntimeError), pristine_package_logging():
-            configure_verbose(True)
-            raise RuntimeError("a failing test still has to hand the logger back")
+            setup_cli_logging(verbose=True)
+            raise RuntimeError("a failing test still has to leave the logger clean")
 
-        assert PACKAGE_LOGGER.level == before
+        assert PACKAGE_LOGGER.level == logging.NOTSET
+        assert PACKAGE_LOGGER.handlers == []
+
+
+# =============================================================================
+# The leak, in the shape that reached CI
+# =============================================================================
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _poison_before_any_test_in_this_module():
+    """Poison the loggers from a *module-scoped* fixture, as ``test_add.py`` does.
+
+    Module-scoped setup runs before every function-scoped fixture, so this is
+    in place before the autouse guard in ``tests/conftest.py`` gets to look --
+    the exact ordering that made #1016's snapshot/restore fixture re-apply the
+    poison after every test instead of clearing it. Both the package logger
+    (DEBUG plus a live stream handler, which is what ``gpio ... --verbose``
+    leaves) and the root logger are poisoned, so neither route is left untested.
+
+    Undone afterwards so the poisoning cannot escape this module if the guard
+    under test is ever removed.
+    """
+    root_level = ROOT_LOGGER.level
+    setup_cli_logging(verbose=True, use_colors=False)  # DEBUG + a stream handler
+    ROOT_LOGGER.setLevel(logging.DEBUG)
+    yield
+    PACKAGE_LOGGER.setLevel(logging.NOTSET)
+    PACKAGE_LOGGER.handlers[:] = []
+    PACKAGE_LOGGER.propagate = True
+    ROOT_LOGGER.setLevel(root_level)
+
+
+class TestAPoisonedWorkerStillStartsClean:
+    """Every test in this module runs on a worker poisoned before it started."""
+
+    def test_the_level_did_not_survive_into_this_test(self):
+        assert PACKAGE_LOGGER.level == logging.NOTSET
+        assert PACKAGE_LOGGER.getEffectiveLevel() > logging.DEBUG
+
+    def test_the_stream_handler_did_not_survive_into_this_test(self):
+        assert PACKAGE_LOGGER.handlers == []
+
+    def test_the_boundary_still_answers_with_an_error_line_and_no_traceback(self):
+        """The failure from CI run 34683461451, reproduced by construction.
+
+        With a snapshot/restore guard this fails with
+        ``assert 'Traceback' not in 'Converted a low-level failure to an error
+        line\\nTraceback (most recent call last): ...'`` -- the boundary's own
+        DEBUG record, in a test that never passed ``--verbose``.
+        """
+        result = _boundary_result()
+
+        assert result.exit_code == 1
+        assert "Error: Invalid Input Error: Geoparquet metadata" in result.output
+        assert "Traceback" not in result.output
 
 
 def test_this_test_did_not_inherit_a_raised_level():
-    """The invariant the autouse fixture buys, asserted from inside a test.
-
-    Nothing in this process can have left DEBUG set, whatever ran before and on
-    whichever worker, because every test hands the level back.
-    """
+    """The invariant the autouse guard buys, asserted from inside a test."""
     assert PACKAGE_LOGGER.level != logging.DEBUG
+    assert PACKAGE_LOGGER.getEffectiveLevel() > logging.DEBUG
+
+
+# =============================================================================
+# The same thing end to end, in the order that failed
+# =============================================================================
 
 
 @pytest.mark.integration
-def test_the_poisoning_order_no_longer_fails_the_error_boundary_test():
-    """The measured reproduction, pinned in the order that used to fail.
+def test_the_poisoning_orders_no_longer_fail_the_error_boundary_tests():
+    """Both measured orders, run for real in a subprocess.
 
-    Two things have to be true at once for the boundary test to see a
-    traceback, which is why it took an unlucky schedule to surface:
+    ``tests/test_add.py`` before ``tests/test_cli_error_boundary.py`` is the CI
+    failure itself: two module-scoped ``--verbose`` fixtures in ``test_add.py``
+    poison the worker, and the two boundary tests that build their own group --
+    rather than invoking ``cli``, whose callback resets the level -- go red. The
+    three-node order is the minimal form of the same leak.
 
-    1. a stream handler is attached to the package logger -- any invocation of
-       the real ``cli`` does that, via ``setup_cli_logging``; and
-    2. the level is DEBUG -- any ``--verbose`` invocation does that, and never
-       undoes it.
-
-    Neither test below is unusual; ``test_verbose_option_adds_flag`` is a
-    four-line decorator test. Run in this order on ``main`` the third test fails
-    with ``assert 'Traceback' not in ...``. A subprocess is what makes the order
-    deterministic: under ``-n auto`` the scheduler, not this file, decides which
-    tests share a worker.
+    A subprocess is what makes the order deterministic: under ``-n auto`` the
+    scheduler, not this file, decides which tests share a worker.
     """
-    order = [
-        "tests/test_cli_error_boundary.py::test_a_rejected_file_gets_an_error_line_and_exit_one[inspect head]",
-        "tests/test_decorators.py::TestVerboseOption::test_verbose_option_adds_flag",
-        "tests/test_cli_error_boundary.py::TestTheRootGroupIsTheBoundary"
-        "::test_a_duckdb_error_reaches_the_user_as_an_error_line",
+    boundary = "tests/test_cli_error_boundary.py"
+    orders = [
+        # `TestAddBboxCLI` is the smallest real poisoner: its module-scoped
+        # `bbox_optioned_run` runs `gpio add bbox --verbose`, which leaves DEBUG
+        # and a live stream handler behind before any function-scoped fixture runs.
+        [
+            "tests/test_add.py::TestAddBboxCLI",
+            f"{boundary}::TestTheRootGroupIsTheBoundary"
+            "::test_a_duckdb_error_reaches_the_user_as_an_error_line",
+            f"{boundary}::TestInnerHandlersStillRunFirst"
+            "::test_a_refusal_the_inner_handler_declines_still_becomes_an_error_line",
+        ],
+        [
+            "tests/test_cli_error_boundary.py::test_a_rejected_file_gets_an_error_line_and_exit_one[inspect head]",
+            "tests/test_decorators.py::TestVerboseOption::test_verbose_option_adds_flag",
+            "tests/test_cli_error_boundary.py::TestTheRootGroupIsTheBoundary"
+            "::test_a_duckdb_error_reaches_the_user_as_an_error_line",
+        ],
     ]
     # The child must not inherit the parent run's coverage hooks, xdist worker
     # identity or extra flags -- CI supplies --cov and -n auto to the outer run.
     dropped = ("COV_CORE", "PYTEST_XDIST", "PYTEST_ADDOPTS", "PYTEST_CURRENT_TEST")
     env = {k: v for k, v in os.environ.items() if not k.startswith(dropped)}
 
-    run = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            "-p",
-            "no:cacheprovider",
-            "-n",
-            "0",
-            "-q",
-            "--no-header",
-            "-p",
-            "no:randomly",
-            *order,
-        ],
-        cwd=REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
-
-    assert run.returncode == 0, run.stdout + run.stderr
+    for order in orders:
+        run = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:cacheprovider",
+                "-p",
+                "no:randomly",
+                "-n",
+                "0",
+                "-q",
+                "--no-header",
+                *order,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+        assert run.returncode == 0, f"{order}\n{run.stdout}{run.stderr}"

--- a/tests/test_logging_state_isolation.py
+++ b/tests/test_logging_state_isolation.py
@@ -1,0 +1,153 @@
+"""One test must not leave the package logger raised for the next one.
+
+``--verbose`` raises the ``geoparquet_io`` logger to DEBUG as the flag is parsed
+(:func:`geoparquet_io.cli.decorators.enable_verbose_logging`, #995) and
+:func:`~geoparquet_io.core.logging_config.configure_verbose` is deliberately
+one-way, so nothing ever lowers it again. That is right for a CLI -- one command
+per process -- and wrong under pytest, where a whole file of tests shares one
+xdist worker process: the first ``--verbose`` invocation, or the first core call
+made with ``verbose=True``, leaves DEBUG on for every test that follows it on
+that worker.
+
+The victim is any test that asserts on the *absence* of debug output. The one
+that actually went red on ``main`` is
+``tests/test_cli_error_boundary.py::TestTheRootGroupIsTheBoundary::test_a_duckdb_error_reaches_the_user_as_an_error_line``:
+``ErrorBoundaryGroup.invoke`` logs "Converted a low-level failure to an error
+line" at DEBUG with ``exc_info``, so a leaked DEBUG level puts a traceback in
+``result.output`` and the test's ``assert "Traceback" not in result.output``
+fails -- on Windows first, only because ``-n auto`` happened to schedule the
+tests in the poisoning order there.
+
+The CLI behaviour is correct and is not what these tests pin. What they pin is
+the test harness: ``tests/conftest.py`` snapshots the package logger around
+every test, so no test can inherit another's level or handlers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from geoparquet_io.core.logging_config import configure_verbose, setup_cli_logging
+from tests.conftest import pristine_package_logging
+
+PACKAGE_LOGGER = logging.getLogger("geoparquet_io")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestTheGuardPutsBackWhatConfigureVerboseChanges:
+    """The three pieces of global state the logging entry points mutate.
+
+    Read off ``core/logging_config.py`` rather than guessed: ``setup_cli_logging``
+    assigns ``logger.setLevel``, ``logger.handlers.clear()`` +
+    ``addHandler``, and ``logger.propagate``; ``configure_verbose`` raises the
+    level and, through ``_bootstrap_default_handler``, may add a handler. No
+    module-level flag records verbosity -- the logger's own level *is* the
+    state -- and nothing mutates a handler that was already attached, so putting
+    back the same handler objects puts back their levels and formatters too.
+    """
+
+    def test_a_raised_level_is_put_back(self):
+        before = PACKAGE_LOGGER.level
+
+        with pristine_package_logging():
+            setup_cli_logging(verbose=False)
+            configure_verbose(True)
+            assert PACKAGE_LOGGER.level == logging.DEBUG
+
+        assert PACKAGE_LOGGER.level == before
+
+    def test_replaced_handlers_are_put_back_as_the_same_objects(self):
+        before = list(PACKAGE_LOGGER.handlers)
+
+        with pristine_package_logging():
+            setup_cli_logging(verbose=True)
+            assert PACKAGE_LOGGER.handlers != before
+
+        assert PACKAGE_LOGGER.handlers == before
+
+    def test_propagate_is_put_back(self):
+        before = PACKAGE_LOGGER.propagate
+
+        with pristine_package_logging():
+            PACKAGE_LOGGER.propagate = not before
+
+        assert PACKAGE_LOGGER.propagate is before
+
+    def test_the_guard_puts_state_back_even_when_the_body_raises(self):
+        before = PACKAGE_LOGGER.level
+
+        with pytest.raises(RuntimeError), pristine_package_logging():
+            configure_verbose(True)
+            raise RuntimeError("a failing test still has to hand the logger back")
+
+        assert PACKAGE_LOGGER.level == before
+
+
+def test_this_test_did_not_inherit_a_raised_level():
+    """The invariant the autouse fixture buys, asserted from inside a test.
+
+    Nothing in this process can have left DEBUG set, whatever ran before and on
+    whichever worker, because every test hands the level back.
+    """
+    assert PACKAGE_LOGGER.level != logging.DEBUG
+
+
+@pytest.mark.integration
+def test_the_poisoning_order_no_longer_fails_the_error_boundary_test():
+    """The measured reproduction, pinned in the order that used to fail.
+
+    Two things have to be true at once for the boundary test to see a
+    traceback, which is why it took an unlucky schedule to surface:
+
+    1. a stream handler is attached to the package logger -- any invocation of
+       the real ``cli`` does that, via ``setup_cli_logging``; and
+    2. the level is DEBUG -- any ``--verbose`` invocation does that, and never
+       undoes it.
+
+    Neither test below is unusual; ``test_verbose_option_adds_flag`` is a
+    four-line decorator test. Run in this order on ``main`` the third test fails
+    with ``assert 'Traceback' not in ...``. A subprocess is what makes the order
+    deterministic: under ``-n auto`` the scheduler, not this file, decides which
+    tests share a worker.
+    """
+    order = [
+        "tests/test_cli_error_boundary.py::test_a_rejected_file_gets_an_error_line_and_exit_one[inspect head]",
+        "tests/test_decorators.py::TestVerboseOption::test_verbose_option_adds_flag",
+        "tests/test_cli_error_boundary.py::TestTheRootGroupIsTheBoundary"
+        "::test_a_duckdb_error_reaches_the_user_as_an_error_line",
+    ]
+    # The child must not inherit the parent run's coverage hooks, xdist worker
+    # identity or extra flags -- CI supplies --cov and -n auto to the outer run.
+    dropped = ("COV_CORE", "PYTEST_XDIST", "PYTEST_ADDOPTS", "PYTEST_CURRENT_TEST")
+    env = {k: v for k, v in os.environ.items() if not k.startswith(dropped)}
+
+    run = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "0",
+            "-q",
+            "--no-header",
+            "-p",
+            "no:randomly",
+            *order,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr

--- a/tests/test_write_memory_forwarding.py
+++ b/tests/test_write_memory_forwarding.py
@@ -730,7 +730,16 @@ class TestStdoutStreamingIgnoresMemoryLimit:
         self, places_test_file, capsys
     ):
         from geoparquet_io.core.duckdb_utils import get_duckdb_connection
+        from geoparquet_io.core.logging_config import setup_cli_logging
         from geoparquet_io.core.stream_io import write_output
+
+        # The warning reaches stderr only through the CLI stream handler, and
+        # this test calls a core function rather than the CLI -- so it has to
+        # install that handler itself. It used to inherit one another test left
+        # on the process-global package logger, which made it pass or fail on
+        # the xdist schedule; `tests/conftest.py` now hands the logger back
+        # after every test, so the dependency has to be stated here.
+        setup_cli_logging(verbose=False, use_colors=False)
 
         con = get_duckdb_connection(load_spatial=True, load_httpfs=False)
         try:


### PR DESCRIPTION
## What changed

`tests/conftest.py` gains an autouse fixture that puts every `geoparquet_io`
logger into a **known-clean state before each test and again after it** — level
`NOTSET`, no handlers, `propagate` True, exactly what a freshly imported process
has. No source file changes; `gpio`'s logging behaviour is exactly as `main` has
it.

## Why

`main` is red on `test (windows-latest, 3.12)` (runs 34679874571, 34677582883),
and #1008 and #1009 fail the same way:

```
tests/test_cli_error_boundary.py::TestTheRootGroupIsTheBoundary::test_a_duckdb_error_reaches_the_user_as_an_error_line
assert "Traceback" not in result.output
E   assert 'Traceback' not in 'Converted a low-level failure to an error line\nTraceback ...'
```

`Converted a low-level failure to an error line` is `ErrorBoundaryGroup.invoke`'s
own DEBUG record, logged with `exc_info` — in a test that never passes
`--verbose`.

#995 made `--verbose` raise the package logger to DEBUG in an eager Click
callback, as the flag is *parsed* (`cli/decorators.py::enable_verbose_logging`),
and `core/logging_config.configure_verbose` is deliberately one-way: it never
lowers the level again. Both are correct — a CLI runs one command per process.
Under pytest a worker process runs hundreds of tests, so the first `--verbose`
invocation (or the first core call made with `verbose=True`) turns DEBUG on for
everything `-n auto` schedules after it on that worker. **~100 tests across ~30
files leave DEBUG set**, measured with a `pytest_runtest_call` probe.

Two things must be true at once for the boundary test to see a traceback:

1. a stream handler is attached to the package logger — `setup_cli_logging`
   attaches one; and
2. the level is DEBUG — any `--verbose` run does that, and nothing undoes it.

Windows is not special. The order reproduces exactly on macOS:

```
$ uv run pytest -p no:randomly -n 0 tests/test_add.py tests/test_cli_error_boundary.py
FAILED …TestTheRootGroupIsTheBoundary::test_a_duckdb_error_reaches_the_user_as_an_error_line
FAILED …TestInnerHandlersStillRunFirst::test_a_refusal_the_inner_handler_declines_still_becomes_an_error_line
2 failed, 93 passed
```

### Why restoring a snapshot was not enough — and made it worse

The first push snapshotted the logger and put the snapshot back after each test.
A function-scoped fixture is set up only **after every higher-scoped one**, and
`tests/test_add.py` has two *module-scoped* fixtures that run `--verbose`
(`bbox_optioned_run`, `_h3_optioned_invocation`). They had already raised the
level and attached a stream handler before the snapshot was taken, so the
snapshot *was* the poison — and restoring it after every later test made the
poison permanent for the rest of the worker instead of fixing it.

Probed state transitions, `test_add.py` then `test_cli_error_boundary.py`:

```
[SNAP] TestAddBboxCLI::test_adds_a_bbox_struct_keeping_every_row_and_column
       at-setup-start=('NOTSET', [], 'WARNING')
       after-setup =('INFO',   ['DynamicStreamHandler'], 'WARNING')
[SNAP] TestAddBboxCLI::test_bbox_name_option_reaches_core      <- module fixture runs --verbose
       at-setup-start=('INFO',  ['DynamicStreamHandler'], 'WARNING')
       after-setup =('DEBUG', ['DynamicStreamHandler'], 'WARNING')   <- snapshot taken here
```

From that point every test on the worker was *restored* to
`DEBUG + DynamicStreamHandler`. That also explains why CI showed **two**
failures where `main` showed one: the two that fail are exactly the two that
build their own `ErrorBoundaryGroup`. Every other test in that file invokes the
real `cli`, whose callback calls `setup_cli_logging` on each invocation and
resets the level — so they are immune either way.

## The fix, by construction

The guard sets a known state rather than recording one, so nothing from earlier
in the process can survive — previous test, higher-scoped fixture, or import
time. Enumerating every mutation in `core/logging_config.py`:

| line | what it touches |
|---|---|
| 170–175 `setup_cli_logging` | `geoparquet_io` level, handlers (cleared in place), propagate |
| 204/208 `verbose_logging` | `geoparquet_io` level |
| 231/237 `_bootstrap_default_handler` | `geoparquet_io` handler + level; only **reads** the root's handler list |
| 258/261 `configure_verbose` | `geoparquet_io` level |
| 191 `get_logger(name)` | only *obtains* `geoparquet_io.*` children; never configures them |

So a gpio DEBUG record can be switched on through exactly four channels, and all
four are closed: the package logger's own level/handlers/propagate; any
`geoparquet_io.*` child's (only a test's `caplog` can set those — and the record
that breaks these tests is logged on `geoparquet_io.cli.decorators`); the root
level, via `NOTSET` inheritance, which is clamped out of DEBUG and handed
straight back; and the root's handlers, which can only receive a record that was
already emitted. `NOTSET` rather than a fixed level because 13 tests use a bare
`caplog.at_level(...)` that sets the *root* level and relies on inheritance. An
explicit `--log-level`/`log_cli_level` is honoured rather than clamped.

Cost measured at **20.3 µs per test — 157 ms across the whole suite**.

## Verification

`tests/test_logging_state_isolation.py` poisons the loggers from a
**module-scoped** fixture — the same ordering `test_add.py` creates — and from
the root logger, then asserts a boundary invocation prints no traceback. Swapped
back to the old snapshot/restore guard, **9 of its 12 tests fail**, including:

```
TestAPoisonedWorkerStillStartsClean::test_the_boundary_still_answers_with_an_error_line_and_no_traceback
E   assert 'Traceback' not in 'Converted a...mns object\n'
```

and its end-to-end subprocess check reports `2 failed, 4 passed` — the two CI
failures exactly.

- `uv run pytest -n auto -m "not slow and not network and not meta"` — **7708
  passed, 76 skipped, 3 xfailed**, twice (189.4s, 188.9s), unchanged from the
  195s baseline
- `pytest -p no:randomly -n 0 tests/test_add.py tests/test_cli_error_boundary.py`
  — 95 passed, 1 skipped (was 2 failed)
- `uv run pytest -m meta` — 205 passed
- `pre-commit run --all-files` and `--hook-stage pre-push` — all hooks pass
- `tests/data/cli_surface.json` unchanged; no file under `geoparquet_io/`
  changed, so there are no source lines for diff-cover to gate

## Also fixed, same defect

`TestStdoutStreamingIgnoresMemoryLimit::test_write_output_to_stdout_warns_that_memory_limit_is_ignored`
is the leak running the other way: it calls a core function directly and asserts
the warning reaches `capsys`'s stderr, which only happens through the CLI stream
handler — one it was silently inheriting. It passes on `main` today and fails
there in isolation, so it was already a latent schedule-dependent flake; it now
installs its own handler with `setup_cli_logging`.

The other `assert "Traceback" not in result.output` sites (`test_add.py`,
`test_extract_cli_layer.py`, `test_add_partition_cli_guards.py`,
`test_partition_input.py`, `test_upload.py`) either invoke the real `cli` or run
a subcommand group that carries no `exc_info` logging; `test_pipe_integration.py`
asserts on a subprocess's stderr. The only other `exc_info` sites in the package
are two `logger.debug` calls in `api/table.py`'s stats fallback, which no test
asserts against — and which the guard now covers anyway.

`test_cli_error_boundary.py`'s local `restore_log_level` fixture is removed: it
only covered that file's own `--verbose` tests, and the poison came from another
module on the same worker before it could look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4
