### PR TITLE
fix(upload): report the files a directory upload actually sent, and exit non-zero when any is missing

### DIFF
--- a/docs/guide/upload.md
+++ b/docs/guide/upload.md
@@ -134,6 +134,38 @@ By default, directory uploads continue on errors. Use `--fail-fast` to stop on f
 gpio publish upload output/ s3://bucket/dataset/ --fail-fast
 ```
 
+Either way, the summary counts only the files that actually reached the store,
+and a directory upload that left anything out exits **1** — so `&&` and `set -e`
+stop the script instead of carrying on over an incomplete dataset:
+
+```
+==================================================
+✓ 2/10 file(s) uploaded successfully
+✗ 1 file(s) failed
+⊘ 7 file(s) not attempted (stopped on first error)
+```
+
+`--fail-fast` stops every file that has not started yet; uploads already in
+flight are allowed to finish, and are counted by whether they arrived. The three
+counts always add up to the total, so a retry knows exactly how much is missing.
+Partial and total failure both exit 1 — read the counts, not the exit code, to
+tell them apart.
+
+In Python the same failure raises `RemoteAccessError`:
+
+<!-- doctest: skip="needs cloud credentials" -->
+```python
+from pathlib import Path
+
+from geoparquet_io.core.exceptions import RemoteAccessError
+from geoparquet_io.core.upload import upload
+
+try:
+    upload(Path("output/"), "s3://bucket/dataset/", fail_fast=True)
+except RemoteAccessError as e:
+    print(f"upload incomplete: {e}")
+```
+
 ## Dry Run
 
 Preview what would be uploaded without actually uploading:

--- a/geoparquet_io/core/exceptions.py
+++ b/geoparquet_io/core/exceptions.py
@@ -39,9 +39,13 @@ def sanitize_url_for_logging(url: str) -> str:
     # Remove query string (may contain presigned credentials)
     if "?" in url:
         url = url.split("?")[0]
-    # Truncate very long paths but keep filename for debugging
+    # Truncate very long paths but keep filename for debugging. A directory
+    # URL ends in "/" and has no filename to keep: the elision would leave
+    # `s3://bucket/datasets/.../`, which names nothing a user can act on --
+    # the destination of a partial upload came out that way (#1025 review).
+    # The credentials, if any, were in the query string, already gone.
     parts = url.split("/")
-    if len(parts) > 5:
+    if len(parts) > 5 and parts[-1]:
         return "/".join(parts[:4]) + "/..." + "/" + parts[-1]
     return url
 

--- a/geoparquet_io/core/upload.py
+++ b/geoparquet_io/core/upload.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -729,6 +730,13 @@ def _print_upload_summary(counts: tuple[int, int, int], total_files: int) -> Non
         print(f"✗ {failed} file(s) failed")
     if not_attempted:
         print(f"⊘ {not_attempted} file(s) not attempted (stopped on first error)")
+    # The summary is the one thing here on stdout; everything else -- the
+    # per-file errors, and the `Error:` line the raise below becomes -- goes to
+    # stderr. Redirected to a log (`> log 2>&1`, the CI case this exists for),
+    # stdout is block-buffered and the summary would land *after* the error
+    # that tells the reader to look at it. Flush so the order on disk is the
+    # order it happened.
+    sys.stdout.flush()
 
 
 def _raise_if_upload_incomplete(

--- a/geoparquet_io/core/upload.py
+++ b/geoparquet_io/core/upload.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -14,7 +15,7 @@ from geoparquet_io.core.aws_credentials import (
     resolve_aws_credentials,
     resolve_aws_region,
 )
-from geoparquet_io.core.exceptions import InvalidParameterError
+from geoparquet_io.core.exceptions import InvalidParameterError, RemoteAccessError
 from geoparquet_io.core.logging_config import error, progress, success
 
 
@@ -384,10 +385,34 @@ def _upload_file_sync(store, source: Path, target_key: str, **kwargs) -> None:
     success(f"Upload complete ({speed_mbps:.2f} MB/s)")
 
 
+class _UploadNotAttempted(Exception):
+    """Marker for a file ``--fail-fast`` stopped before it was ever tried.
+
+    It rides in the error slot of a result tuple so a not-attempted file is
+    neither a success nor a failure when the summary is counted (#1019).
+    """
+
+
 def _upload_one_file(
-    store, file_path: Path, source: Path, prefix: str, **kwargs
+    store,
+    file_path: Path,
+    source: Path,
+    prefix: str,
+    stop_requested: threading.Event | None = None,
+    **kwargs,
 ) -> tuple[Path, Exception | None]:
-    """Upload a single file and return result tuple for parallel processing."""
+    """Upload a single file and return result tuple for parallel processing.
+
+    ``stop_requested`` is set only when ``--fail-fast`` is in force. Checking it
+    here is what makes the stop reliable: cancelling the queued futures from the
+    consumer loop races a worker that is already pulling the next file off the
+    queue, and loses often enough that the same failing run cancelled six files
+    on one machine and none on another. The first failure sets the flag before
+    it returns, so every file a worker picks up afterwards stops here instead.
+    """
+    if stop_requested is not None and stop_requested.is_set():
+        return file_path, _UploadNotAttempted()
+
     try:
         target_key = _build_target_key(file_path, source, prefix)
         file_size = file_path.stat().st_size
@@ -405,12 +430,15 @@ def _upload_one_file(
         return file_path, None
     except Exception as e:
         error(f"{file_path.name}: {e}")
+        if stop_requested is not None:
+            stop_requested.set()
         return file_path, e
 
 
 def _upload_directory_sync(
     store,
     source: Path,
+    destination: str,
     prefix: str,
     files: list[Path],
     max_files: int,
@@ -422,11 +450,16 @@ def _upload_directory_sync(
     Args:
         store: obstore ObjectStore instance
         source: Source directory path
+        destination: Object store URL the files are going to, named in the error
+            raised when some of them do not get there
         prefix: S3/GCS/Azure prefix for uploaded files
         files: List of files to upload
         max_files: Max number of concurrent file uploads (must be >= 1)
         fail_fast: Stop on first error if True
         **kwargs: Additional arguments passed to obs.put
+
+    Raises:
+        RemoteAccessError: If any file failed or was never attempted
     """
     # Ensure max_files is at least 1 to avoid ThreadPoolExecutor ValueError
     max_files = max(1, max_files)
@@ -435,22 +468,74 @@ def _upload_directory_sync(
     total_size_mb = total_size / (1024 * 1024)
     progress(f"Found {len(files)} file(s) to upload ({total_size_mb:.2f} MB total)")
 
-    results = []
+    stop_requested = threading.Event() if fail_fast else None
+    results: list[tuple[Path, Exception | None]] = []
+    cancelled: list[Path] = []
     with ThreadPoolExecutor(max_workers=max_files) as executor:
         futures = {
-            executor.submit(_upload_one_file, store, f, source, prefix, **kwargs): f for f in files
+            executor.submit(
+                _upload_one_file, store, f, source, prefix, stop_requested=stop_requested, **kwargs
+            ): f
+            for f in files
         }
+        pending = set(futures)
 
         for future in as_completed(futures):
+            pending.discard(future)
             result = future.result()
             results.append(result)
             if fail_fast and result[1] is not None:
-                # Cancel remaining futures on first error
-                for f in futures:
-                    f.cancel()
+                cancelled = _drain_remaining_uploads(futures, pending, results)
                 break
 
-    _print_upload_summary(results, len(files))
+    counts = _classify_upload_results(results, cancelled)
+    _print_upload_summary(counts, len(files))
+    _raise_if_upload_incomplete(destination, counts, len(files))
+
+
+def _drain_remaining_uploads(
+    futures: dict,
+    pending: set,
+    results: list[tuple[Path, Exception | None]],
+) -> list[Path]:
+    """End a ``--fail-fast`` run and return the files no worker ever saw.
+
+    ``Future.cancel()`` only takes a file still queued. An upload already in
+    flight cannot be called back -- its bytes are on their way -- so it is
+    waited on and appended to ``results``, and counted by whether it actually
+    reached the store. What comes back from here is only what was cancelled
+    outright, which the summary reports as not attempted rather than as
+    uploaded (#1019).
+    """
+    for future in pending:
+        future.cancel()
+
+    in_flight = [future for future in pending if not future.cancelled()]
+    results.extend(future.result() for future in in_flight)
+    return [futures[future] for future in pending if future.cancelled()]
+
+
+def _classify_upload_results(
+    results: list[tuple[Path, Exception | None]],
+    cancelled: list[Path],
+) -> tuple[int, int, int]:
+    """Split what happened into (uploaded, failed, not attempted).
+
+    A file is counted as uploaded only if it returned without an exception.
+    Files stopped by ``--fail-fast`` -- cancelled while queued, or turned back
+    at the start of their worker -- are their own category, because calling
+    them either uploaded or failed misreports the state of the bucket.
+    """
+    uploaded = failed = 0
+    not_attempted = len(cancelled)
+    for _path, err in results:
+        if err is None:
+            uploaded += 1
+        elif isinstance(err, _UploadNotAttempted):
+            not_attempted += 1
+        else:
+            failed += 1
+    return uploaded, failed, not_attempted
 
 
 def _upload_single_file(
@@ -497,7 +582,11 @@ def _upload_directory(
     s3_region: str | None = None,
     s3_use_ssl: bool = True,
 ) -> None:
-    """Upload a directory of files."""
+    """Upload a directory of files.
+
+    Raises:
+        RemoteAccessError: If any file failed or was never attempted
+    """
     files = list(source.rglob(pattern) if pattern else source.rglob("*"))
     files = [f for f in files if f.is_file()]
 
@@ -520,6 +609,7 @@ def _upload_directory(
     _upload_directory_sync(
         store=store,
         source=source,
+        destination=destination,
         prefix=prefix,
         files=files,
         max_files=max_files,
@@ -557,6 +647,11 @@ def upload(
         s3_endpoint: Custom S3-compatible endpoint (e.g., "minio.example.com:9000")
         s3_region: S3 region (default: us-east-1 when using custom endpoint)
         s3_use_ssl: Whether to use HTTPS for S3 endpoint (default: True)
+
+    Raises:
+        RemoteAccessError: If a directory upload left any file out of the
+            destination -- failed, or never attempted because ``fail_fast``
+            stopped the run. The summary printed first says how many of each.
 
     Examples:
         # Single file
@@ -619,15 +714,46 @@ def _build_target_key(file_path: Path, source: Path, prefix: str) -> str:
     return str(rel_path)
 
 
-def _print_upload_summary(results: list, total_files: int) -> None:
-    """Print summary of upload results."""
-    errors = [(path, err) for path, err in results if err is not None]
-    success_count = total_files - len(errors)
+def _print_upload_summary(counts: tuple[int, int, int], total_files: int) -> None:
+    """Print summary of upload results.
+
+    The uploaded count is counted from the files that actually returned without
+    an exception, never derived as ``total_files - errors``: deriving it
+    reported every file ``--fail-fast`` stopped as uploaded (#1019).
+    """
+    uploaded, failed, not_attempted = counts
 
     print(f"\n{'=' * 50}")
-    print(f"✓ {success_count}/{total_files} file(s) uploaded successfully")
-    if errors:
-        print(f"✗ {len(errors)} file(s) failed")
+    print(f"✓ {uploaded}/{total_files} file(s) uploaded successfully")
+    if failed:
+        print(f"✗ {failed} file(s) failed")
+    if not_attempted:
+        print(f"⊘ {not_attempted} file(s) not attempted (stopped on first error)")
+
+
+def _raise_if_upload_incomplete(
+    destination: str,
+    counts: tuple[int, int, int],
+    total_files: int,
+) -> None:
+    """Fail the run when any file did not reach the store.
+
+    Without this a directory upload printed its errors and still exited 0, so
+    ``gpio publish upload … && echo ok`` printed ``ok`` over a bucket missing
+    data (#1019). Partial and total failure raise alike: a caller branching on
+    ``$?`` needs "the dataset is not all there", and the summary above says how
+    much of it is there. Giving them separate exit codes would invent a
+    convention gpio does not have -- 1 is a failure and 2 is Click's usage
+    error, and nothing else is in use.
+    """
+    _uploaded, failed, not_attempted = counts
+    if not failed and not not_attempted:
+        return
+
+    reason = f"{failed} of {total_files} file(s) failed to upload"
+    if not_attempted:
+        reason += f"; {not_attempted} not attempted (stopped on first error)"
+    raise RemoteAccessError(destination, f"{reason}. See the errors above.")
 
 
 def _get_target_key(source: Path, prefix: str, is_dir_destination: bool) -> str:

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -3,7 +3,10 @@ Tests for upload functionality.
 """
 
 import importlib
+import itertools
 import os
+import re
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,6 +19,7 @@ cli = main_module.cli
 # `check_credentials` is patched where `gpio publish upload` resolves it, which is
 # the module that owns the command (Deep Review 3.2 moved it out of `cli.main`).
 publish_module = importlib.import_module("geoparquet_io.cli.commands.publish")
+upload_module = importlib.import_module("geoparquet_io.core.upload")
 from geoparquet_io.core.upload import (  # noqa: E402
     _check_azure_credentials,
     _check_gcs_credentials,
@@ -836,3 +840,165 @@ class TestCredentialValidationFunctions:
             assert "az login" in hint
             # "az login" alone is not enough for obstore -- the opt-in must be named.
             assert "AZURE_USE_AZURE_CLI=true" in hint
+
+
+class TestDirectoryUploadReportsWhatReachedTheStore:
+    """A directory upload must report the files that actually arrived (#1019).
+
+    Every test here drives the real ``gpio publish upload`` command with
+    ``obs.put`` replaced by a recording stub, then checks the printed summary
+    against the keys the stub actually received -- not against itself.
+    """
+
+    @staticmethod
+    def _make_files(tmp_path, count=10):
+        source = tmp_path / "dataset"
+        source.mkdir()
+        for i in range(count):
+            (source / f"part-{i:02d}.parquet").write_bytes(b"x" * 100)
+        return source
+
+    @staticmethod
+    def _run(source, fake_put, extra_args=()):
+        runner = CliRunner()
+        with (
+            patch.object(publish_module, "check_credentials", return_value=(True, "")),
+            patch.object(upload_module.obs, "put", fake_put),
+            patch.object(upload_module, "_setup_store_and_kwargs", lambda *a, **k: (object(), {})),
+        ):
+            return runner.invoke(
+                cli,
+                ["publish", "upload", str(source), "s3://example-bucket/out/", *extra_args],
+            )
+
+    @staticmethod
+    def _summary_counts(output):
+        """The three counts the summary claims: (uploaded, failed, not attempted)."""
+        uploaded = re.search(r"✓ (\d+)/(\d+) file\(s\) uploaded successfully", output)
+        failed = re.search(r"✗ (\d+) file\(s\) failed", output)
+        skipped = re.search(r"⊘ (\d+) file\(s\) not attempted", output)
+        assert uploaded, f"no summary line in output:\n{output}"
+        return (
+            int(uploaded.group(1)),
+            int(failed.group(1)) if failed else 0,
+            int(skipped.group(1)) if skipped else 0,
+        )
+
+    def test_fail_fast_does_not_count_stopped_files_as_uploaded(self, tmp_path):
+        """The success count is what arrived, not ``total - errors`` (#1019).
+
+        The very first file to reach the store fails, on a single worker, so
+        nothing else is ever tried. Before the fix this printed
+        ``9/10 file(s) uploaded successfully`` over an empty bucket.
+        """
+        source = self._make_files(tmp_path)
+        arrived = []
+        calls = itertools.count()
+        lock = threading.Lock()
+
+        def fake_put(store, key, path, **kwargs):
+            with lock:
+                nth = next(calls)
+            if nth == 0:
+                raise RuntimeError("AccessDenied: bucket is read-only")
+            arrived.append(Path(path).name)
+
+        result = self._run(source, fake_put, ["--fail-fast", "--max-files", "1"])
+
+        assert arrived == []
+        assert self._summary_counts(result.output) == (0, 1, 9)
+        assert "⊘ 9 file(s) not attempted (stopped on first error)" in result.output
+        assert result.exit_code == 1
+
+    def test_fail_fast_lets_in_flight_uploads_finish_and_counts_them(self, tmp_path):
+        """Cancellation reaches files that never started, never files in flight.
+
+        The gate makes every non-failing upload finish *after* the failure has
+        been signalled, so a file counted as uploaded here can only be one that
+        was in flight when ``--fail-fast`` tripped.
+        """
+        source = self._make_files(tmp_path)
+        started, arrived = [], []
+        calls = itertools.count()
+        lock = threading.Lock()
+        failure_landed = threading.Event()
+
+        def fake_put(store, key, path, **kwargs):
+            with lock:
+                nth = next(calls)
+                started.append(Path(path).name)
+            if nth == 1:
+                failure_landed.set()
+                raise RuntimeError("AccessDenied: bucket is read-only")
+            assert failure_landed.wait(timeout=30), "the failing upload never ran"
+            arrived.append(Path(path).name)
+
+        result = self._run(source, fake_put, ["--fail-fast", "--max-files", "2"])
+
+        # Two workers, so exactly two files were in flight when the failure
+        # landed; the survivor could only finish after it, and must be counted.
+        assert len(started) == 2
+        assert arrived == [started[0]]
+        assert self._summary_counts(result.output) == (1, 1, 8)
+        assert result.exit_code == 1
+
+    def test_continue_on_error_attempts_every_file_and_still_exits_non_zero(self, tmp_path):
+        """Without ``--fail-fast`` nothing is skipped, but errors must still fail."""
+        source = self._make_files(tmp_path)
+        arrived = []
+
+        def fake_put(store, key, path, **kwargs):
+            if Path(path).name == "part-00.parquet":
+                raise RuntimeError("AccessDenied: bucket is read-only")
+            arrived.append(Path(path).name)
+
+        result = self._run(source, fake_put, ["--max-files", "2"])
+
+        assert len(arrived) == 9
+        assert self._summary_counts(result.output) == (9, 1, 0)
+        assert "not attempted" not in result.output
+        assert result.exit_code == 1
+
+    def test_a_directory_upload_that_failed_entirely_exits_non_zero(self, tmp_path):
+        """Nothing reached the bucket, so ``cmd && echo ok`` must not print ok."""
+        source = self._make_files(tmp_path)
+        arrived = []
+
+        def fake_put(store, key, path, **kwargs):
+            raise RuntimeError("AccessDenied: bucket is read-only")
+
+        result = self._run(source, fake_put)
+
+        assert arrived == []
+        assert self._summary_counts(result.output) == (0, 10, 0)
+        assert "10 of 10 file(s) failed to upload" in result.output
+        assert result.exit_code == 1
+
+    def test_a_fully_successful_directory_upload_still_exits_zero(self, tmp_path):
+        """The happy path is unchanged: no failure lines, exit 0."""
+        source = self._make_files(tmp_path)
+        arrived = []
+
+        def fake_put(store, key, path, **kwargs):
+            arrived.append(Path(path).name)
+
+        result = self._run(source, fake_put, ["--max-files", "4"])
+
+        assert len(arrived) == 10
+        assert self._summary_counts(result.output) == (10, 0, 0)
+        assert "failed" not in result.output
+        assert result.exit_code == 0
+
+    def test_the_error_names_the_destination_and_the_counts(self, tmp_path):
+        """A script's operator needs to know where the gap is, and how big."""
+        source = self._make_files(tmp_path, count=4)
+
+        def fake_put(store, key, path, **kwargs):
+            if Path(path).name == "part-00.parquet":
+                raise RuntimeError("AccessDenied: bucket is read-only")
+
+        result = self._run(source, fake_put, ["--max-files", "2"])
+
+        assert "s3://example-bucket/out/" in result.output
+        assert "1 of 4 file(s) failed to upload" in result.output
+        assert result.exit_code == 1

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -859,7 +859,7 @@ class TestDirectoryUploadReportsWhatReachedTheStore:
         return source
 
     @staticmethod
-    def _run(source, fake_put, extra_args=()):
+    def _run(source, fake_put, extra_args=(), destination="s3://example-bucket/out/"):
         runner = CliRunner()
         with (
             patch.object(publish_module, "check_credentials", return_value=(True, "")),
@@ -868,7 +868,7 @@ class TestDirectoryUploadReportsWhatReachedTheStore:
         ):
             return runner.invoke(
                 cli,
-                ["publish", "upload", str(source), "s3://example-bucket/out/", *extra_args],
+                ["publish", "upload", str(source), destination, *extra_args],
             )
 
     @staticmethod
@@ -990,15 +990,87 @@ class TestDirectoryUploadReportsWhatReachedTheStore:
         assert result.exit_code == 0
 
     def test_the_error_names_the_destination_and_the_counts(self, tmp_path):
-        """A script's operator needs to know where the gap is, and how big."""
+        """A script's operator needs to know where the gap is, and how big.
+
+        A realistic prefix, several segments deep: the first version of this
+        error routed the destination through the presigned-URL sanitizer, which
+        keeps a *filename* and elides the path before it -- so a directory URL,
+        ending in ``/``, came out as ``s3://bucket/datasets/.../``. The fixture
+        it was tested with sat exactly at the threshold where nothing is elided.
+        """
         source = self._make_files(tmp_path, count=4)
+        destination = "s3://example-bucket/datasets/overture/2025-01/buildings/"
 
         def fake_put(store, key, path, **kwargs):
             if Path(path).name == "part-00.parquet":
                 raise RuntimeError("AccessDenied: bucket is read-only")
 
-        result = self._run(source, fake_put, ["--max-files", "2"])
+        result = self._run(source, fake_put, ["--max-files", "2"], destination=destination)
 
-        assert "s3://example-bucket/out/" in result.output
+        assert destination in result.output, result.output
+        assert "..." not in result.output.split("Error:")[-1]
         assert "1 of 4 file(s) failed to upload" in result.output
         assert result.exit_code == 1
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            # A directory URL keeps its whole path: there is no filename to elide to.
+            (
+                "s3://bucket/datasets/overture/2025-01/buildings/",
+                "s3://bucket/datasets/overture/2025-01/buildings/",
+            ),
+            # A file URL still elides the middle and keeps the filename.
+            ("s3://bucket/a/b/c/d/file.parquet", "s3://bucket/a/.../file.parquet"),
+            # And the query string -- where presigned credentials live -- always goes.
+            (
+                "s3://bucket/a/b/c/d/?X-Amz-Signature=secret",
+                "s3://bucket/a/b/c/d/",
+            ),
+        ],
+    )
+    def test_sanitizing_a_directory_url_keeps_its_path(self, url, expected):
+        from geoparquet_io.core.exceptions import sanitize_url_for_logging
+
+        assert sanitize_url_for_logging(url) == expected
+
+    def test_a_partition_to_a_remote_folder_exits_non_zero_when_a_file_is_missing(self, tmp_path):
+        """The raise reaches every directory writer, not only ``publish upload``.
+
+        ``gpio partition <scheme> in.parquet s3://…/`` writes locally and then
+        uploads the directory through the same ``_upload_directory_sync``. On
+        ``main`` a partial upload there printed ``Created N partition(s) in
+        s3://…`` and exited 0.
+        """
+        arrived = []
+
+        def fake_put(store, key, path, **kwargs):
+            if not arrived:
+                arrived.append(Path(path).name)
+                raise RuntimeError("AccessDenied: bucket is read-only")
+            arrived.append(Path(path).name)
+
+        runner = CliRunner()
+        with (
+            patch.object(upload_module.obs, "put", fake_put),
+            patch.object(upload_module, "_setup_store_and_kwargs", lambda *a, **k: (object(), {})),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "partition",
+                    "quadkey",
+                    "tests/data/buildings_test.parquet",
+                    "s3://example-bucket/datasets/buildings/",
+                    "--resolution",
+                    "8",
+                    "--partition-resolution",
+                    "3",
+                    "--force",
+                ],
+            )
+
+        assert arrived, "the partition never reached the upload"
+        assert result.exit_code != 0, result.output
+        assert "failed to upload" in result.output
+        assert "Created" not in result.output.split("Error:")[-1]


### PR DESCRIPTION
## What changed

`gpio publish upload <dir>` reported files it never sent as uploaded, and exited 0 when the upload had failed. Three fixes, in `geoparquet_io/core/upload.py`:

1. **Count, don't subtract.** `_print_upload_summary` derived `success_count = total_files - len(errors)`, so every file `--fail-fast` stopped landed in the success count. It now counts the files that actually returned without an exception, and reports the rest as their own category:

   ```
   ==================================================
   ✓ 2/10 file(s) uploaded successfully
   ✗ 1 file(s) failed
   ⊘ 7 file(s) not attempted (stopped on first error)
   ```

   The three counts always add to the total, so a retry knows exactly how much is missing.

2. **Exit non-zero when anything is missing.** `upload()` → `_upload_directory` → `_upload_directory_sync` all returned `None` and raised nothing, on both the fail-fast and the continue-on-error path. `_upload_directory_sync` now raises `RemoteAccessError` when any file failed or was skipped, which the existing `handle_geoparquet_errors` / `handle_core_exception` path turns into a `ClickException` — **exit 1**, the code this repo already uses for a failure. The Python API (`core.upload.upload`) raises the same exception, so `api/` gets the signal too.

3. **Make `--fail-fast` stop reliably, and report truthfully.** Cancelling the queued futures from the consumer loop races a worker that is already pulling the next file off the queue. It loses often: the issue's transcript cancelled 6 of 10 files, the same script on this machine cancelled 0 and uploaded all 10. The first failure now sets a flag every worker checks before it starts. Uploads **already in flight are allowed to finish** and are counted by whether they arrived — their bytes are on their way and cannot be recalled — and the summary says so. That means the *counts* are not deterministic above two workers (with the default four and a failure on the first file, the review measured uploaded = 1, 2 or 3 across 50 runs, depending on how many were in flight); what is deterministic is that the summary matches what reached the store — `uploaded == files the stub received` in 250 of 250 runs, and the three counts sum to the total in 250 of 250. The first version of this body said "deterministic" without that distinction.

**This raise reaches more than `publish upload`.** `_upload_directory_sync` is also what `remote.upload_if_remote(..., is_directory=True)` calls, which is how every `gpio partition <scheme> in.parquet s3://…/` (and `Table.partition_*` to a remote folder) uploads its output directory. On `main` a partial upload there printed `Created N partition(s) in s3://…` and exited **0**; now it prints the summary and the error and exits **1**. Same defect, same fix, declared here because the title says `fix(upload)` and a partition user reading the changelog would not otherwise learn their exit codes changed. One test covers it (`test_a_partition_to_a_remote_folder_exits_non_zero_when_a_file_is_missing`).

Two things the review found in the first version, fixed in the review commit: the error routed the destination through the presigned-URL sanitizer, whose "keep the filename, elide the middle" rule turned a directory URL into `s3://bucket/datasets/.../` for any prefix deeper than one segment (the sanitizer now leaves a trailing-slash URL's path alone — there is no filename to keep, and the credentials it strips live in the query string, which still goes); and the summary is printed with `print()` on stdout while everything else goes to stderr, so under `> log 2>&1` it landed *after* the `Error:` line that tells the reader to look at it — stdout is now flushed before the raise.

Still not done, on purpose: the summary and the error carry **counts, not keys**. Failed files are named on their own error lines as they happen; not-attempted files are not named at all. #1019's harm ("no local record of which keys are missing") is answered by the exit code and the counts, not by a manifest. Ctrl-C is likewise still unaccounted: the new stop flag is only set by an upload error, so SIGINT lets every in-flight and queued upload finish (`shutdown(wait=True)`) and prints no summary — pre-existing, and the flag is the piece that would fix it.

### Partial vs. total failure both exit 1

Deliberate. A caller branching on `$?` needs one fact — "the dataset is not all there" — and the summary above says how much of it is. `cli/exception_handler.py` has exactly two non-zero codes in play: 1 for a failure, 2 for Click's usage error. A third code for "partial" would be a convention gpio does not have, and `cmd && …` cannot see it anyway. This matches the #778 precedent in `cli/decorators.py:1148`, where a partial sub-partition run also raises a plain `ClickException`.

## Why

A script reading `$?` after `gpio publish upload` was told the data was there when it was not, and the summary a human reads said the same. Acting on "just re-upload the one that failed" left a silently incomplete dataset in the bucket, with no local record of which keys were missing.

## Verification

Reproduced first, through the real CLI, with `obs.put` stubbed to fail one file of ten and record what actually arrived — nothing else mocked.

**Before** (`--fail-fast --max-files 1`):

```
✓ 9/10 file(s) uploaded successfully
✗ 1 file(s) failed
exit code: 0
actually uploaded: 3 of 10
```

**After**, same script:

```
✓ 2/10 file(s) uploaded successfully
✗ 1 file(s) failed
⊘ 7 file(s) not attempted (stopped on first error)
Error: Remote access error for s3://example-bucket/out/: 1 of 10 file(s) failed to upload; 7 not attempted (stopped on first error). See the errors above.
exit code: 1
actually uploaded: 2 of 10
```

2 + 1 + 7 = 10, and the 2 match the stub's recorded arrivals. A total failure and a continue-on-error run (9 of 10 arrive) now exit 1 as well; a fully successful upload still exits 0.

Six new tests in `tests/test_upload.py` drive the real `gpio publish upload` with a recording stub and assert the printed counts against the keys the stub received, plus the exit code — not the summary against itself. `test_fail_fast_lets_in_flight_uploads_finish_and_counts_them` gates every non-failing upload behind the failure, so a file counted as uploaded there can only be one that was in flight when `--fail-fast` tripped. All six are deterministic: 20/20 repeat runs identical.

- fast suite: 7712 passed, 76 skipped, 3 xfailed
- `-m meta`: 205 passed
- `pre-commit --all-files` and `--hook-stage pre-push`: all green (xenon, import-linter, mypy, vulture, deptry included)
- diff-cover vs `origin/main`: **100%** (47 lines, 0 missing)
- `tests/data/cli_surface.json`: unchanged

The coverage run also showed 7 failures in `test_pipe_integration.py` / `test_journeys.py`; those are coverage-instrumentation artifacts on piped subprocesses, pass uninstrumented, and are untouched by this change.

Fixes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

