### PR TITLE
fix(extract): classify Carto failures by HTTP status, not by digits in your SQL

### DIFF
--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import quote, urlparse
 
+import duckdb
 import pyarrow as pa
 
 from geoparquet_io.core.column_selection import (
@@ -33,6 +34,7 @@ from geoparquet_io.core.duckdb_utils import (
     validate_where_clause,
     where_condition_fragment,
 )
+from geoparquet_io.core.exceptions import sanitize_error_message
 from geoparquet_io.core.geometry_repair import repair_arrow_table_geometry
 from geoparquet_io.core.logging_config import (
     configure_verbose,
@@ -52,6 +54,33 @@ DEFAULT_RETRY_DELAY = 2.0  # seconds
 # Cap how long that may take so a long --timeout is not paid a second time just
 # to learn a status code.
 STATUS_PROBE_TIMEOUT = 30.0  # seconds
+
+# How much of a 4xx response body the probe reads to explain the failure. Carto
+# answers a bad query with a short JSON error; the cap keeps a body that is
+# not short from becoming a download.
+PROBE_DETAIL_BYTES = 2048
+
+# The longest a server's Retry-After is honoured for, so a hostile or confused
+# header cannot park the client for an hour.
+MAX_RETRY_AFTER = 60.0  # seconds
+
+# Statuses that mean "try again": the server is asking for it (429), asked the
+# client to resend (408), or is itself failing (5xx).
+_RETRYABLE_STATUSES = {408, 429}
+
+# Failures that happened on this machine, not at the server: the query never
+# produced a response to classify, so there is nothing to probe for and no
+# retry that could help. Everything else that reaches the classifier is an
+# I/O failure whose status is worth asking about.
+_LOCAL_FAILURES: tuple[type[BaseException], ...] = (
+    duckdb.OutOfMemoryException,
+    duckdb.InterruptException,
+    duckdb.BinderException,
+    duckdb.CatalogException,
+    duckdb.ParserException,
+    duckdb.InvalidInputException,
+    MemoryError,
+)
 
 # Environment variable for API key
 CARTO_API_KEY_ENV = "CARTO_API_KEY"
@@ -83,12 +112,25 @@ class _CartoStatus(NamedTuple):
         code: The HTTP status the server answered with, or None when the
             request never got one. That absence -- connection refused, DNS
             failure, a timeout -- *is* the retryable class.
-        timed_out: Whether the request timed out, known from the exception
-            *type* rather than from any text in its message.
+        timed_out: Whether the request timed out. Known from the exception
+            *type* when the probe times out, and from the *clock* when the data
+            request does -- an attempt that ran for the whole ``--timeout``
+            before failing timed out whatever its message says, and is not
+            probed: the probe would re-run the query that was too heavy the
+            first time.
+        local: The failure happened on this machine -- out of memory, an
+            interrupt, a binder error -- before any response existed to
+            classify. Nothing to probe, nothing a retry would change.
+        detail: For a 4xx, the start of the server's own explanation
+            (``column "foo" does not exist``), sanitized. None otherwise.
+        retry_after: The server's ``Retry-After`` in seconds, when it sent one.
     """
 
     code: int | None
     timed_out: bool
+    local: bool = False
+    detail: str | None = None
+    retry_after: float | None = None
 
 
 def _validate_carto_url(url: str) -> str:
@@ -628,7 +670,12 @@ def _probe_request_status(full_url: str, timeout: float) -> _CartoStatus:
             timeout=min(timeout, STATUS_PROBE_TIMEOUT),
             follow_redirects=True,
         ) as response:
-            return _CartoStatus(response.status_code, False)
+            code = response.status_code
+            # A 4xx is the one class where the body is worth a bounded read:
+            # Carto puts the reason there ("column ... does not exist"), and a
+            # bare "HTTP 400" throws away the only thing the user can act on.
+            detail = _read_probe_detail(response) if 400 <= code < 500 and code != 429 else None
+            return _CartoStatus(code, False, detail=detail, retry_after=_retry_after(response))
     except httpx.TimeoutException:
         return _CartoStatus(None, True)
     except Exception as probe_error:  # noqa: BLE001 - any failure means "no status"
@@ -636,31 +683,100 @@ def _probe_request_status(full_url: str, timeout: float) -> _CartoStatus:
         return _CartoStatus(None, False)
 
 
-def _classify_fetch_failure(exc: BaseException, full_url: str, timeout: float) -> _CartoStatus:
+def _read_probe_detail(response) -> str | None:
+    """The first ``PROBE_DETAIL_BYTES`` of a 4xx body, made safe to print.
+
+    Carto's SQL API answers ``{"error": ["column \\"foo\\" does not exist"]}``;
+    the messages are unwrapped when the body is that shape, and the raw text is
+    used when it is anything else.
+    """
+    try:
+        chunk = next(response.iter_bytes(PROBE_DETAIL_BYTES), b"")
+    except Exception:  # noqa: BLE001 - the detail is a courtesy, never the verdict
+        return None
+    text = chunk.decode("utf-8", "replace").strip()
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        payload = None
+    if isinstance(payload, dict) and isinstance(payload.get("error"), list):
+        text = "; ".join(str(item) for item in payload["error"])
+    return sanitize_error_message(text) or None
+
+
+def _retry_after(response) -> float | None:
+    """A ``Retry-After`` given in seconds, capped; None when absent or a date."""
+    raw = response.headers.get("Retry-After")
+    if raw and raw.strip().isdigit():
+        return min(float(raw), MAX_RETRY_AFTER)
+    return None
+
+
+def _classify_fetch_failure(
+    exc: BaseException, full_url: str, timeout: float, elapsed: float = 0.0
+) -> _CartoStatus:
     """Decide what a failed fetch attempt was, without reading the message.
 
-    Prefers a status DuckDB itself reported (the CSV path goes through httpfs,
-    which has one); falls back to a direct probe for the ``ST_Read`` path, which
-    does not.
+    In order: a failure that happened here rather than at the server is local;
+    an attempt that ran out the whole ``timeout`` timed out, whatever the
+    message says, and is not probed (the probe would re-run the query that was
+    already too heavy); a status DuckDB itself reported is used as-is (the CSV
+    path goes through httpfs, which has one); and only the ``ST_Read`` path,
+    whose exception carries no status at all, is probed.
     """
+    if isinstance(exc, _LOCAL_FAILURES):
+        return _CartoStatus(None, False, local=True)
+    if elapsed >= timeout:
+        return _CartoStatus(None, True)
     code = _status_from_duckdb_error(exc)
     if code is not None:
         return _CartoStatus(code, False)
     return _probe_request_status(full_url, timeout)
 
 
-def _fatal_status_error(status: int | None, table_name: str) -> CartoError | None:
-    """Build the fatal error for an HTTP status, or None when it is retryable.
+def _is_retryable(status: _CartoStatus) -> bool:
+    """No status (refused, DNS, timed out), 408/429, or a 5xx: worth another go."""
+    if status.local:
+        return False
+    code = status.code
+    return code is None or code in _RETRYABLE_STATUSES or code >= 500
 
-    Retryable: no status at all, any success/redirect, 429, and every 5xx.
-    Fatal: the rest of 4xx, which no amount of retrying will change.
+
+def _fatal_status_error(
+    status: _CartoStatus, table_name: str, fmt: str, exc: BaseException
+) -> CartoError | None:
+    """Build the fatal error for a classified failure, or None when it is retryable.
+
+    Fatal, and said plainly: a 4xx other than 408/429 (no amount of retrying
+    changes a missing table or a bad key -- Carto's own explanation is quoted
+    when the probe could read it); a failure that happened on this machine; and
+    a server that answered 2xx/3xx to a request gpio could not then read, which
+    means the response, not the connection, is the problem -- retrying it three
+    times and reporting "Carto returned HTTP 200" helps nobody.
     """
-    if status is None or status < 400 or status == 429 or status >= 500:
+    if _is_retryable(status):
         return None
-    hint = _FATAL_STATUS_HINTS.get(status)
-    if hint is not None:
-        return CartoError(hint.format(table=table_name))
-    return CartoError(f"Carto request for table '{table_name}' failed with HTTP {status}.")
+    reason = sanitize_error_message(str(exc))
+    if status.local:
+        return CartoError(
+            f"Reading table '{table_name}' from Carto failed before any response could be "
+            f"classified -- this is a local failure, not a Carto one: {reason}"
+        )
+    if status.code is not None and status.code < 400:
+        return CartoError(
+            f"Carto answered HTTP {status.code} for table '{table_name}', but the response "
+            f"could not be read as {fmt}. Retrying would fetch the same response; the "
+            f"query or the format is the problem: {reason}"
+        )
+    hint = _FATAL_STATUS_HINTS.get(status.code)
+    message = (
+        hint.format(table=table_name)
+        if hint is not None
+        else f"Carto request for table '{table_name}' failed with HTTP {status.code}."
+    )
+    if status.detail:
+        message += f" Carto said: {status.detail}"
+    return CartoError(message)
 
 
 def _retry_warning(status: _CartoStatus, attempt: int, max_retries: int, delay: float) -> str:
@@ -720,6 +836,7 @@ def _fetch_with_retry(
     last_exception: Exception | None = None
 
     for attempt in range(max_retries):
+        started = time.monotonic()
         try:
             conn = get_duckdb_connection()
             conn.execute("SET allow_asterisks_in_http_paths = true")
@@ -734,15 +851,21 @@ def _fetch_with_retry(
             # Classify on the HTTP status the transport reported -- never on the
             # exception message, which embeds full_url and therefore the user's
             # own table name, WHERE clause and LIMIT (#1020).
-            status = _classify_fetch_failure(e, full_url, timeout)
+            status = _classify_fetch_failure(
+                e, full_url, timeout, elapsed=time.monotonic() - started
+            )
 
-            fatal = _fatal_status_error(status.code, table_name)
+            fatal = _fatal_status_error(status, table_name, fmt_param, e)
             if fatal is not None:
                 raise fatal from e
 
-            # Retryable: a 429/5xx, or no status at all (connection refused, DNS).
+            # Retryable: a 408/429/5xx, or no status at all (refused, DNS, timeout).
             if attempt < max_retries - 1:
                 delay = retry_delay * (2**attempt)  # Exponential backoff
+                if status.retry_after is not None:
+                    # The server said how long it wants; a 429 answered with more
+                    # requests on our own schedule is the wrong direction.
+                    delay = max(delay, status.retry_after)
                 warn(_retry_warning(status, attempt, max_retries, delay))
                 time.sleep(delay)
             elif status.timed_out:
@@ -752,9 +875,11 @@ def _fetch_with_retry(
                     "or increase --timeout."
                 ) from e
 
-    # All retries exhausted
+    # All retries exhausted. The DuckDB message names the URL it failed on, key
+    # and all; sanitized rather than echoed.
     raise CartoError(
-        f"Failed to fetch data from Carto after {max_retries} attempts: {last_exception}"
+        f"Failed to fetch data from Carto after {max_retries} attempts: "
+        f"{sanitize_error_message(str(last_exception))}"
     ) from last_exception
 
 

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -12,6 +12,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import NamedTuple
 from urllib.parse import quote, urlparse
 
 import pyarrow as pa
@@ -47,14 +48,47 @@ DEFAULT_TIMEOUT = 120  # seconds
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_DELAY = 2.0  # seconds
 
+# A failed fetch is diagnosed with one extra request (see _probe_request_status).
+# Cap how long that may take so a long --timeout is not paid a second time just
+# to learn a status code.
+STATUS_PROBE_TIMEOUT = 30.0  # seconds
+
 # Environment variable for API key
 CARTO_API_KEY_ENV = "CARTO_API_KEY"
+
+# The fatal HTTP statuses, and what each one means for a Carto extraction.
+# Keyed on the status the transport reported -- never on text found in an
+# exception message, which embeds the request URL and so the user's own SQL
+# (#1020).
+_FATAL_STATUS_HINTS = {
+    404: ("Table '{table}' not found. Check the table name and ensure it is publicly accessible."),
+    401: (
+        "Unauthorized access to table '{table}'. "
+        "Set CARTO_API_KEY environment variable or check permissions."
+    ),
+    403: "Access forbidden to table '{table}'. Check permissions.",
+}
 
 
 class CartoError(Exception):
     """Carto-specific error."""
 
     pass
+
+
+class _CartoStatus(NamedTuple):
+    """What the transport reported about one failed fetch attempt.
+
+    Args:
+        code: The HTTP status the server answered with, or None when the
+            request never got one. That absence -- connection refused, DNS
+            failure, a timeout -- *is* the retryable class.
+        timed_out: Whether the request timed out, known from the exception
+            *type* rather than from any text in its message.
+    """
+
+    code: int | None
+    timed_out: bool
 
 
 def _validate_carto_url(url: str) -> str:
@@ -547,6 +581,98 @@ def _create_empty_geoparquet_table(geoparquet_version: str | None = None) -> pa.
     return table.replace_schema_metadata(new_metadata)
 
 
+def _status_from_duckdb_error(exc: BaseException) -> int | None:
+    """Read the HTTP status off a DuckDB exception, when it carries a usable one.
+
+    ``duckdb.HTTPException`` exposes ``status_code``, but reports 0 whenever the
+    request produced no status of its own -- including, in practice, some auth
+    failures -- so 0 is read as "no status" rather than as a code. The
+    ``ST_Read`` path raises a plain ``IOException`` that carries no status at
+    all; :func:`_probe_request_status` is how that one gets a number.
+
+    Returns:
+        The status, or None when the exception does not carry a real one.
+    """
+    code = getattr(exc, "status_code", None)
+    if isinstance(code, int) and not isinstance(code, bool) and code > 0:
+        return code
+    return None
+
+
+def _probe_request_status(full_url: str, timeout: float) -> _CartoStatus:
+    """Ask the server what status this exact request gets.
+
+    ``ST_Read`` fetches through GDAL, which reports only ``IO Error: Could not
+    open GDAL dataset at: <url>`` no matter what the server said -- so the
+    status has to be asked for separately. One streamed GET reads the response
+    headers without pulling the body down.
+
+    This costs a request, but only on a failure, and the failures it has to tell
+    apart are the cheap ones: a missing table, a rejected key, a server already
+    erroring. The expensive case is a transient blip on a large query, where
+    Carto re-runs it to produce the headers; ``STATUS_PROBE_TIMEOUT`` bounds how
+    long that may take before the probe gives up and the failure stays
+    retryable.
+
+    Returns:
+        The status, or ``_CartoStatus(None, ...)`` when the request produced no
+        status. A probe that cannot answer must say so rather than guess: no
+        status means the retryable class.
+    """
+    import httpx
+
+    try:
+        with httpx.stream(
+            "GET",
+            full_url,
+            timeout=min(timeout, STATUS_PROBE_TIMEOUT),
+            follow_redirects=True,
+        ) as response:
+            return _CartoStatus(response.status_code, False)
+    except httpx.TimeoutException:
+        return _CartoStatus(None, True)
+    except Exception as probe_error:  # noqa: BLE001 - any failure means "no status"
+        debug(f"Status probe failed ({probe_error}); treating the failure as retryable")
+        return _CartoStatus(None, False)
+
+
+def _classify_fetch_failure(exc: BaseException, full_url: str, timeout: float) -> _CartoStatus:
+    """Decide what a failed fetch attempt was, without reading the message.
+
+    Prefers a status DuckDB itself reported (the CSV path goes through httpfs,
+    which has one); falls back to a direct probe for the ``ST_Read`` path, which
+    does not.
+    """
+    code = _status_from_duckdb_error(exc)
+    if code is not None:
+        return _CartoStatus(code, False)
+    return _probe_request_status(full_url, timeout)
+
+
+def _fatal_status_error(status: int | None, table_name: str) -> CartoError | None:
+    """Build the fatal error for an HTTP status, or None when it is retryable.
+
+    Retryable: no status at all, any success/redirect, 429, and every 5xx.
+    Fatal: the rest of 4xx, which no amount of retrying will change.
+    """
+    if status is None or status < 400 or status == 429 or status >= 500:
+        return None
+    hint = _FATAL_STATUS_HINTS.get(status)
+    if hint is not None:
+        return CartoError(hint.format(table=table_name))
+    return CartoError(f"Carto request for table '{table_name}' failed with HTTP {status}.")
+
+
+def _retry_warning(status: _CartoStatus, attempt: int, max_retries: int, delay: float) -> str:
+    """Word the retry warning from the classified status, not from the message."""
+    suffix = f"(attempt {attempt + 1}/{max_retries}), retrying in {delay:.1f}s..."
+    if status.timed_out:
+        return f"Request timed out {suffix}"
+    if status.code is None:
+        return f"Could not reach Carto {suffix}"
+    return f"Carto returned HTTP {status.code} {suffix}"
+
+
 def _fetch_with_retry(
     url: str,
     table_name: str,
@@ -604,50 +730,27 @@ def _fetch_with_retry(
 
         except Exception as e:
             last_exception = e
-            error_msg = str(e).lower()
 
-            # Non-retryable errors - fail immediately
-            if "404" in error_msg or "not found" in error_msg:
-                raise CartoError(
-                    f"Table '{table_name}' not found. Check the table name and ensure "
-                    f"it is publicly accessible."
-                ) from e
+            # Classify on the HTTP status the transport reported -- never on the
+            # exception message, which embeds full_url and therefore the user's
+            # own table name, WHERE clause and LIMIT (#1020).
+            status = _classify_fetch_failure(e, full_url, timeout)
 
-            if "401" in error_msg or "unauthorized" in error_msg:
-                raise CartoError(
-                    f"Unauthorized access to table '{table_name}'. "
-                    "Set CARTO_API_KEY environment variable or check permissions."
-                ) from e
+            fatal = _fatal_status_error(status.code, table_name)
+            if fatal is not None:
+                raise fatal from e
 
-            if "403" in error_msg or "forbidden" in error_msg:
-                raise CartoError(
-                    f"Access forbidden to table '{table_name}'. Check permissions."
-                ) from e
-
-            # Retryable errors
+            # Retryable: a 429/5xx, or no status at all (connection refused, DNS).
             if attempt < max_retries - 1:
                 delay = retry_delay * (2**attempt)  # Exponential backoff
-                if "timeout" in error_msg:
-                    warn(
-                        f"Request timed out (attempt {attempt + 1}/{max_retries}), retrying in {delay:.1f}s..."
-                    )
-                elif "connection" in error_msg or "network" in error_msg:
-                    warn(
-                        f"Connection error (attempt {attempt + 1}/{max_retries}), retrying in {delay:.1f}s..."
-                    )
-                else:
-                    warn(
-                        f"Request failed (attempt {attempt + 1}/{max_retries}): {e}, retrying in {delay:.1f}s..."
-                    )
+                warn(_retry_warning(status, attempt, max_retries, delay))
                 time.sleep(delay)
-            else:
-                # Final attempt failed
-                if "timeout" in error_msg:
-                    raise CartoError(
-                        f"Request timed out after {max_retries} attempts. "
-                        "The table may be too large. Try using --limit or --where to reduce the result set, "
-                        "or increase --timeout."
-                    ) from e
+            elif status.timed_out:
+                raise CartoError(
+                    f"Request timed out after {max_retries} attempts. "
+                    "The table may be too large. Try using --limit or --where to reduce the result set, "
+                    "or increase --timeout."
+                ) from e
 
     # All retries exhausted
     raise CartoError(

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -112,12 +112,11 @@ class _CartoStatus(NamedTuple):
         code: The HTTP status the server answered with, or None when the
             request never got one. That absence -- connection refused, DNS
             failure, a timeout -- *is* the retryable class.
-        timed_out: Whether the request timed out. Known from the exception
-            *type* when the probe times out, and from the *clock* when the data
-            request does -- an attempt that ran for the whole ``--timeout``
-            before failing timed out whatever its message says, and is not
-            probed: the probe would re-run the query that was too heavy the
-            first time.
+        timed_out: Whether the data request timed out, known from the *clock*:
+            an attempt that ran for the whole ``--timeout`` before failing timed
+            out whatever its message says, and is not probed -- the probe would
+            re-run the query that was too heavy the first time. A probe that
+            itself times out is "no status", never this.
         local: The failure happened on this machine -- out of memory, an
             interrupt, a binder error -- before any response existed to
             classify. Nothing to probe, nothing a retry would change.
@@ -676,9 +675,14 @@ def _probe_request_status(full_url: str, timeout: float) -> _CartoStatus:
             # bare "HTTP 400" throws away the only thing the user can act on.
             detail = _read_probe_detail(response) if 400 <= code < 500 and code != 429 else None
             return _CartoStatus(code, False, detail=detail, retry_after=_retry_after(response))
-    except httpx.TimeoutException:
-        return _CartoStatus(None, True)
     except Exception as probe_error:  # noqa: BLE001 - any failure means "no status"
+        # A probe that times out is a probe that could not answer -- no status,
+        # the retryable class. It is *not* evidence that the data request timed
+        # out: that verdict comes from the data request's own clock in
+        # `_classify_fetch_failure`. The first version read a probe timeout as
+        # one, and Windows runners, where a SYN to a closed loopback port is
+        # dropped rather than refused, reported "Request timed out ... try
+        # --limit" for a connection that was never made.
         debug(f"Status probe failed ({probe_error}); treating the failure as retryable")
         return _CartoStatus(None, False)
 

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -768,11 +768,14 @@ def _fatal_status_error(
             f"could not be read as {fmt}. Retrying would fetch the same response; the "
             f"query or the format is the problem: {reason}"
         )
-    hint = _FATAL_STATUS_HINTS.get(status.code)
+    code = status.code
+    if code is None:  # pragma: no cover - _is_retryable already answered for no status
+        return None
+    hint = _FATAL_STATUS_HINTS.get(code)
     message = (
         hint.format(table=table_name)
         if hint is not None
-        else f"Carto request for table '{table_name}' failed with HTTP {status.code}."
+        else f"Carto request for table '{table_name}' failed with HTTP {code}."
     )
     if status.detail:
         message += f" Carto said: {status.detail}"

--- a/geoparquet_io/core/carto.py
+++ b/geoparquet_io/core/carto.py
@@ -845,6 +845,10 @@ def _fetch_with_retry(
             conn.execute("SET allow_asterisks_in_http_paths = true")
             conn.execute(f"SET http_timeout = {int(timeout * 1000)}")  # milliseconds
 
+            # The clock that decides "timed out" starts at the request, not at
+            # the connection: loading the spatial extension on a cold macOS
+            # runner took longer than a 2 s --timeout and read as one.
+            started = time.monotonic()
             table = conn.execute(f"SELECT * FROM {read_expr}").arrow().read_all()
             return table
 

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -4,6 +4,7 @@ import http.server
 import json
 import tempfile
 import threading
+import time
 from pathlib import Path
 from unittest import mock
 from urllib.parse import quote
@@ -864,9 +865,13 @@ class TestCartoReadExpressionEscaping:
     URL that arrives from config or automation makes it an injection.
     """
 
-    # Passes _validate_carto_url (https scheme, /api/v2/sql suffix) and
-    # carries the one character the old spelling could not survive.
-    HOSTILE_URL = 'https://ex"ample.carto.com/api/v2/sql'
+    # Carries the one character the old spelling could not survive, on a
+    # loopback port that refuses instantly. The first version used
+    # `https://ex"ample.carto.com/...`: since #1020 a failed fetch probes the
+    # URL for its status, and that hostname resolves (wildcard DNS) -- two
+    # fast-suite tests were opening real TLS connections to Carto's load
+    # balancer, and would block for 30 s each wherever DNS is blackholed.
+    HOSTILE_URL = 'http://127.0.0.1:1/ex"ample/api/v2/sql'
 
     def _captured_read_sql(self, monkeypatch, fmt):
         """Run _fetch_with_retry against a connection that only records SQL."""
@@ -954,19 +959,22 @@ def status_http_server():
     Yields ``(base_url, state)``; set ``state["code"]`` to pick the status the
     next request gets. Loopback only, so this is not a ``network`` test.
     """
-    state = {"code": 404}
+    state = {"code": 404, "body": b'{"error": ["boom"]}', "headers": {}, "requests": []}
 
     class _Handler(http.server.BaseHTTPRequestHandler):
         def _respond(self, body=b""):
+            state["requests"].append(self.path)
             self.send_response(state["code"])
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
+            for name, value in state["headers"].items():
+                self.send_header(name, value)
             self.end_headers()
             if body:
                 self.wfile.write(body)
 
         def do_GET(self):  # noqa: N802 - http.server API
-            self._respond(b'{"error": ["boom"]}')
+            self._respond(state["body"])
 
         def do_HEAD(self):  # noqa: N802 - http.server API
             self._respond()
@@ -1009,7 +1017,13 @@ class TestStatusFromDuckdbError:
 
 
 class TestFatalStatusError:
-    """Which statuses are fatal, and which are the retryable class."""
+    """Which classified failures are fatal, and which are the retryable class."""
+
+    _EXC = RuntimeError("IO Error: Could not open GDAL dataset")
+
+    @staticmethod
+    def _status(code, **kwargs):
+        return carto_module._CartoStatus(code, False, **kwargs)
 
     @pytest.mark.parametrize(
         ("status", "expected"),
@@ -1022,15 +1036,55 @@ class TestFatalStatusError:
         ],
     )
     def test_client_errors_are_fatal(self, status, expected):
-        error = _fatal_status_error(status, "my_table")
+        error = _fatal_status_error(self._status(status), "my_table", "GeoJSON", self._EXC)
         assert error is not None
         assert expected in str(error)
         assert "my_table" in str(error)
 
-    @pytest.mark.parametrize("status", [None, 200, 429, 500, 502, 503, 504])
+    @pytest.mark.parametrize("status", [None, 408, 429, 500, 502, 503, 504])
     def test_transient_and_absent_statuses_are_retryable(self, status):
-        """No status at all -- connection refused, DNS -- is the retryable class."""
-        assert _fatal_status_error(status, "my_table") is None
+        """No status at all -- connection refused, DNS -- is the retryable class.
+
+        408 is the server asking the client to resend (RFC 9110); it sits with
+        429, not with the 4xx that no retry can change.
+        """
+        assert _fatal_status_error(self._status(status), "my_table", "GeoJSON", self._EXC) is None
+
+    def test_a_2xx_probe_means_the_response_not_the_server_is_the_problem(self):
+        """The server is fine and the parse failed: retrying fetches the same bytes.
+
+        The first version retried this three times, warning ``Carto returned
+        HTTP 200 ... retrying`` each time -- a sentence no user can act on.
+        """
+        error = _fatal_status_error(self._status(200), "my_table", "GeoJSON", self._EXC)
+        assert error is not None
+        assert "HTTP 200" in str(error)
+        assert "could not be read as GeoJSON" in str(error)
+        assert "GDAL dataset" in str(error), "the local error is the actionable part"
+
+    def test_a_4xx_quotes_cartos_own_explanation(self):
+        detail = 'column "foo" does not exist'
+        error = _fatal_status_error(
+            self._status(400, detail=detail), "my_table", "GeoJSON", self._EXC
+        )
+        assert error is not None
+        assert "HTTP 400" in str(error)
+        assert detail in str(error)
+
+    def test_a_local_failure_is_fatal_and_says_it_is_local(self):
+        status = carto_module._CartoStatus(None, False, local=True)
+        error = _fatal_status_error(status, "my_table", "csv", MemoryError("boom"))
+        assert error is not None
+        assert "local failure" in str(error)
+
+    def test_the_url_in_the_underlying_error_is_sanitized(self):
+        """DuckDB's text names the request URL, api_key and all."""
+        exc = RuntimeError(
+            "IO Error: Could not open GDAL dataset at: "
+            "https://x.carto.com/api/v2/sql?q=SELECT%201&api_key=SUPERSECRET"
+        )
+        error = _fatal_status_error(self._status(200), "t", "GeoJSON", exc)
+        assert "SUPERSECRET" not in str(error)
 
 
 class TestFailureClassificationIgnoresTheUsersSql:
@@ -1219,6 +1273,176 @@ class TestFailureClassificationUsesTheHttpStatus:
             )
 
         assert conn.attempts == 3
+
+    def test_the_probe_is_one_request_per_failed_attempt(self, monkeypatch, status_http_server):
+        """Cost claim, pinned: a retryable failure costs one probe per attempt, no more."""
+        base_url, state = status_http_server
+        state["code"] = 503
+        conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        with pytest.raises(CartoError):
+            _fetch_with_retry(
+                url=base_url,
+                table_name="t",
+                sql="SELECT 1",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 3
+        assert len(state["requests"]) == 3, state["requests"]
+
+    def test_a_400_quotes_cartos_explanation_and_fails_fast(self, monkeypatch, status_http_server):
+        """The most common *user* error: bad SQL. Carto says why; so must gpio."""
+        base_url, state = status_http_server
+        state["code"] = 400
+        state["body"] = b'{"error": ["column \\"foo\\" does not exist"]}'
+        conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        with pytest.raises(CartoError) as excinfo:
+            _fetch_with_retry(
+                url=base_url,
+                table_name="t",
+                sql="SELECT foo FROM t",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 1
+        assert "HTTP 400" in str(excinfo.value)
+        assert 'column "foo" does not exist' in str(excinfo.value)
+
+    def test_a_200_from_the_probe_is_fatal_not_retried(self, monkeypatch, status_http_server):
+        """The server is fine; the parse failed. Retrying fetches the same bytes."""
+        base_url, state = status_http_server
+        state["code"] = 200
+        state["body"] = b"this is not GeoJSON"
+        conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+        warnings: list[str] = []
+        monkeypatch.setattr(carto_module, "warn", warnings.append)
+
+        with pytest.raises(CartoError) as excinfo:
+            _fetch_with_retry(
+                url=base_url,
+                table_name="t",
+                sql="SELECT 1",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 1
+        assert "HTTP 200" in str(excinfo.value) and "could not be read" in str(excinfo.value)
+        assert warnings == [], "no 'Carto returned HTTP 200 ... retrying'"
+
+    def test_a_429_honours_retry_after(self, monkeypatch, status_http_server):
+        base_url, state = status_http_server
+        state["code"] = 429
+        state["headers"] = {"Retry-After": "3"}
+        conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+        slept: list[float] = []
+        monkeypatch.setattr(carto_module.time, "sleep", slept.append)
+
+        with pytest.raises(CartoError):
+            _fetch_with_retry(
+                url=base_url,
+                table_name="t",
+                sql="SELECT 1",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 3
+        assert slept == [3.0, 3.0], "the server's Retry-After beats the shorter backoff"
+
+    def test_a_data_request_that_ran_out_the_clock_is_a_timeout_and_is_not_probed(
+        self, monkeypatch
+    ):
+        """S2-1 of the review: the --limit hint was lost whenever the server answered headers.
+
+        Known from the clock, not the message: an attempt that ran for the whole
+        ``--timeout`` before failing timed out. And it is not probed -- the probe
+        would re-run the query that was too heavy the first time.
+        """
+
+        class _SlowConnection(_AttemptCountingConnection):
+            def execute(self, sql, *args, **kwargs):
+                if sql.lstrip().upper().startswith("SELECT"):
+                    time.sleep(0.05)
+                return super().execute(sql, *args, **kwargs)
+
+        conn = _SlowConnection(RuntimeError("IO Error: Connection timeout: HTTP GET took too long"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        def _no_probe(*args, **kwargs):  # pragma: no cover - must not be reached
+            raise AssertionError("a timed-out attempt must not re-run the query as a probe")
+
+        monkeypatch.setattr(carto_module, "_probe_request_status", _no_probe)
+
+        with pytest.raises(CartoError, match="timed out after 3 attempts.*--limit"):
+            _fetch_with_retry(
+                url="http://127.0.0.1:1/api/v2/sql",
+                table_name="t",
+                sql="SELECT * FROM t",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=0.01,
+            )
+
+        assert conn.attempts == 3
+
+    def test_a_local_failure_is_fatal_at_once_and_not_probed(self, monkeypatch):
+        """Out of memory on this machine is not a Carto problem and not retryable."""
+        import duckdb
+
+        conn = _AttemptCountingConnection(duckdb.OutOfMemoryException("Out of Memory Error"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        def _no_probe(*args, **kwargs):  # pragma: no cover - must not be reached
+            raise AssertionError("a local failure has no status to ask for")
+
+        monkeypatch.setattr(carto_module, "_probe_request_status", _no_probe)
+
+        with pytest.raises(CartoError, match="local failure"):
+            _fetch_with_retry(
+                url="http://127.0.0.1:1/api/v2/sql",
+                table_name="t",
+                sql="SELECT * FROM t",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 1
+
+    def test_the_exhausted_retries_message_does_not_leak_the_api_key(self, monkeypatch):
+        conn = _AttemptCountingConnection(
+            RuntimeError(
+                "IO Error: Could not open GDAL dataset at: "
+                "http://127.0.0.1:1/api/v2/sql?q=SELECT%201&format=GeoJSON&api_key=SUPERSECRET"
+            )
+        )
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        with pytest.raises(CartoError) as excinfo:
+            _fetch_with_retry(
+                url="http://127.0.0.1:1/api/v2/sql",
+                table_name="t",
+                sql="SELECT 1",
+                api_key="SUPERSECRET",
+                max_retries=2,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert "SUPERSECRET" not in str(excinfo.value)
 
     def test_a_probe_that_cannot_answer_is_retryable(self, monkeypatch):
         """An unusable URL breaks the probe itself; that means 'no status'."""

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -1,9 +1,12 @@
 """Tests for Carto SQL API extractor."""
 
+import http.server
 import json
 import tempfile
+import threading
 from pathlib import Path
 from unittest import mock
+from urllib.parse import quote
 
 import pytest
 from click.testing import CliRunner
@@ -18,7 +21,10 @@ from geoparquet_io.core.carto import (
     _create_empty_geoparquet_table,
     _detect_geometry_column,
     _detect_table_shape,
+    _fatal_status_error,
+    _fetch_with_retry,
     _geometry_column_from_fields,
+    _status_from_duckdb_error,
     _validate_carto_url,
     _validate_table_name,
     carto_to_table,
@@ -872,16 +878,22 @@ class TestCartoReadExpressionEscaping:
             def execute(self, sql, *args, **kwargs):
                 seen.append(sql)
                 if sql.lstrip().upper().startswith("SELECT"):
-                    # Non-retryable, so the helper gives up after one attempt.
-                    raise RuntimeError("404 not found")
+                    raise RuntimeError("the read failed; only the SQL matters here")
                 return self
 
         monkeypatch.setattr(
             carto_module, "get_duckdb_connection", lambda *a, **k: _RecordingConnection()
         )
+        # max_retries=1 keeps this to one attempt. The failure classification is
+        # not what is under test here, and since #1020 it no longer takes its cue
+        # from the exception message.
         with pytest.raises(CartoError):
             carto_module._fetch_with_retry(
-                url=self.HOSTILE_URL, table_name="t", sql="SELECT * FROM t", fmt=fmt
+                url=self.HOSTILE_URL,
+                table_name="t",
+                sql="SELECT * FROM t",
+                fmt=fmt,
+                max_retries=1,
             )
         return next(s for s in seen if s.lstrip().upper().startswith("SELECT"))
 
@@ -910,3 +922,312 @@ class TestCartoReadExpressionEscaping:
         finally:
             con.close()
         assert '"error":true' not in payload.replace(" ", ""), payload
+
+
+# =============================================================================
+# #1020: failures are classified by HTTP status, never by the exception message
+# =============================================================================
+
+
+class _AttemptCountingConnection:
+    """A DuckDB connection stand-in that counts fetches and fails them all.
+
+    Only the ``SELECT * FROM ST_Read(...)`` / ``read_csv_auto(...)`` statement
+    is counted; the ``SET`` statements around it are not attempts.
+    """
+
+    def __init__(self, error: Exception):
+        self.error = error
+        self.attempts = 0
+
+    def execute(self, sql, *args, **kwargs):
+        if sql.lstrip().upper().startswith("SELECT"):
+            self.attempts += 1
+            raise self.error
+        return self
+
+
+@pytest.fixture
+def status_http_server():
+    """Serve loopback HTTP with a caller-chosen status code.
+
+    Yields ``(base_url, state)``; set ``state["code"]`` to pick the status the
+    next request gets. Loopback only, so this is not a ``network`` test.
+    """
+    state = {"code": 404}
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def _respond(self, body=b""):
+            self.send_response(state["code"])
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+
+        def do_GET(self):  # noqa: N802 - http.server API
+            self._respond(b'{"error": ["boom"]}')
+
+        def do_HEAD(self):  # noqa: N802 - http.server API
+            self._respond()
+
+        def log_message(self, *args):  # pragma: no cover - silence stderr noise
+            pass
+
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{httpd.server_address[1]}/api/v2/sql", state
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+class TestStatusFromDuckdbError:
+    """``duckdb.HTTPException.status_code`` is used only when it is a real status."""
+
+    def test_a_plain_exception_carries_no_status(self):
+        assert _status_from_duckdb_error(RuntimeError("IO Error: 404 not found")) is None
+
+    def test_a_real_status_is_read(self):
+        exc = RuntimeError("boom")
+        exc.status_code = 503
+        assert _status_from_duckdb_error(exc) == 503
+
+    def test_zero_is_not_a_status(self):
+        """DuckDB reports status_code 0 when the request produced no status."""
+        exc = RuntimeError("boom")
+        exc.status_code = 0
+        assert _status_from_duckdb_error(exc) is None
+
+    def test_a_non_integer_status_is_ignored(self):
+        exc = RuntimeError("boom")
+        exc.status_code = "404"
+        assert _status_from_duckdb_error(exc) is None
+
+
+class TestFatalStatusError:
+    """Which statuses are fatal, and which are the retryable class."""
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (404, "not found"),
+            (401, "Unauthorized"),
+            (403, "forbidden"),
+            (400, "HTTP 400"),
+            (418, "HTTP 418"),
+        ],
+    )
+    def test_client_errors_are_fatal(self, status, expected):
+        error = _fatal_status_error(status, "my_table")
+        assert error is not None
+        assert expected in str(error)
+        assert "my_table" in str(error)
+
+    @pytest.mark.parametrize("status", [None, 200, 429, 500, 502, 503, 504])
+    def test_transient_and_absent_statuses_are_retryable(self, status):
+        """No status at all -- connection refused, DNS -- is the retryable class."""
+        assert _fatal_status_error(status, "my_table") is None
+
+
+class TestFailureClassificationIgnoresTheUsersSql:
+    """#1020: digits in the user's own SQL must not decide the verdict.
+
+    Every row here is the same underlying failure -- connection refused against
+    a dead port, the canonical retryable class -- and differs only in the SQL,
+    which the old classifier saw because the request URL is embedded in the
+    DuckDB exception message.
+    """
+
+    DEAD_URL = "http://127.0.0.1:1/api/v2/sql"
+
+    @pytest.mark.parametrize(
+        ("sql", "note"),
+        [
+            ("SELECT * FROM census_blocks LIMIT 10", "plain SQL, no magic digits"),
+            ("SELECT * FROM census_blocks LIMIT 404", "user typed --limit 404"),
+            ("SELECT * FROM parcels WHERE zone = '404'", "'404' inside a WHERE value"),
+            ("SELECT * FROM room_401_sensors LIMIT 10", "'401' inside the table name"),
+            ("SELECT * FROM logs WHERE msg = 'not found'", "the words, inside a WHERE value"),
+            ("SELECT * FROM unauthorized_events LIMIT 10", "'unauthorized' in the table name"),
+        ],
+    )
+    def test_the_sql_in_the_message_never_decides_the_verdict(self, monkeypatch, sql, note):
+        """The classifier's old input, verbatim, over the issue's whole table.
+
+        The exception carries the real ``ST_Read`` failure text, URL and all, so
+        the digits the old classifier matched on are present exactly as they
+        were. The port is still dead, so the status probe answers "no status" --
+        the retryable class -- for every row.
+        """
+        gdal_message = (
+            f"IO Error: Could not open GDAL dataset at: "
+            f"{self.DEAD_URL}?q={quote(sql)}&format=GeoJSON"
+        )
+        conn = _AttemptCountingConnection(RuntimeError(gdal_message))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        with pytest.raises(CartoError) as excinfo:
+            _fetch_with_retry(
+                url=self.DEAD_URL,
+                table_name="t",
+                sql=sql,
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=2,
+            )
+        message = str(excinfo.value)
+
+        assert conn.attempts == 3, f"{note}: retries were lost"
+        assert "Failed to fetch data from Carto after 3 attempts" in message, note
+        assert "not found" not in message, note
+        assert "Unauthorized" not in message, note
+        assert "forbidden" not in message, note
+
+    def test_a_real_dead_port_fetch_retries_end_to_end(self, monkeypatch):
+        """The issue's reproduction, with DuckDB and GDAL actually in the loop.
+
+        ``--limit 404`` used to cost every retry and report "Table 't' not
+        found" for what was only a connection failure.
+        """
+        real_get_conn = carto_module.get_duckdb_connection
+        seen = {"attempts": 0}
+
+        class _Counting:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def execute(self, sql_text, *args, **kwargs):
+                if sql_text.lstrip().upper().startswith("SELECT"):
+                    seen["attempts"] += 1
+                return self._inner.execute(sql_text, *args, **kwargs)
+
+        monkeypatch.setattr(
+            carto_module, "get_duckdb_connection", lambda *a, **k: _Counting(real_get_conn())
+        )
+
+        with pytest.raises(CartoError) as excinfo:
+            _fetch_with_retry(
+                url=self.DEAD_URL,
+                table_name="t",
+                sql="SELECT * FROM census_blocks LIMIT 404",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=2,
+            )
+
+        assert seen["attempts"] == 3
+        assert "Failed to fetch data from Carto after 3 attempts" in str(excinfo.value)
+        assert "not found" not in str(excinfo.value)
+
+
+class TestFailureClassificationUsesTheHttpStatus:
+    """A real server's status decides the verdict, against a mocked server."""
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [(404, "not found"), (401, "Unauthorized"), (403, "forbidden")],
+    )
+    def test_a_real_client_error_fails_fast_with_the_right_message(
+        self, monkeypatch, status_http_server, status, expected
+    ):
+        base_url, state = status_http_server
+        state["code"] = status
+        conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        with pytest.raises(CartoError) as excinfo:
+            _fetch_with_retry(
+                url=base_url,
+                table_name="my_table",
+                sql="SELECT * FROM my_table LIMIT 10",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 1, "a fatal status must not burn the retry budget"
+        assert expected in str(excinfo.value)
+
+    def test_a_real_503_retries_even_when_the_table_name_says_404(
+        self, monkeypatch, status_http_server
+    ):
+        """The inverse of the bug: a name full of digits must not fail fast."""
+        base_url, state = status_http_server
+        state["code"] = 503
+        conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        with pytest.raises(CartoError) as excinfo:
+            _fetch_with_retry(
+                url=base_url,
+                table_name="room_404_sensors",
+                sql="SELECT * FROM room_404_sensors LIMIT 404",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 3
+        assert "Failed to fetch data from Carto after 3 attempts" in str(excinfo.value)
+
+    def test_a_duckdb_http_status_is_used_without_a_probe(self, monkeypatch):
+        """When DuckDB itself reports the status, no extra request is issued."""
+        error = RuntimeError("HTTP Error: HTTP GET error")
+        error.status_code = 404
+        conn = _AttemptCountingConnection(error)
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+
+        def _no_probe(*args, **kwargs):  # pragma: no cover - must not be reached
+            raise AssertionError("the status was already known; no probe should be issued")
+
+        monkeypatch.setattr(carto_module, "_probe_request_status", _no_probe)
+
+        with pytest.raises(CartoError, match="not found"):
+            _fetch_with_retry(
+                url="http://127.0.0.1:1/api/v2/sql",
+                table_name="my_table",
+                sql="SELECT * FROM my_table",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 1
+
+    def test_a_timeout_is_retried_then_reported_as_a_timeout(self, monkeypatch):
+        """Timeouts keep their actionable hint, classified by type not by text."""
+        conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
+        monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
+        monkeypatch.setattr(
+            carto_module,
+            "_probe_request_status",
+            lambda *a, **k: carto_module._CartoStatus(None, True),
+        )
+
+        with pytest.raises(CartoError, match="timed out after 3 attempts"):
+            _fetch_with_retry(
+                url="http://127.0.0.1:1/api/v2/sql",
+                table_name="my_table",
+                sql="SELECT * FROM my_table",
+                max_retries=3,
+                retry_delay=0.01,
+                timeout=5,
+            )
+
+        assert conn.attempts == 3
+
+    def test_a_probe_that_cannot_answer_is_retryable(self, monkeypatch):
+        """An unusable URL breaks the probe itself; that means 'no status'."""
+        import httpx
+
+        def _boom(*args, **kwargs):
+            raise httpx.InvalidURL("not a URL httpx will accept")
+
+        monkeypatch.setattr(httpx, "stream", _boom)
+        assert carto_module._probe_request_status("http://x/", 1.0) == carto_module._CartoStatus(
+            None, False
+        )

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -1255,17 +1255,27 @@ class TestFailureClassificationUsesTheHttpStatus:
 
         assert conn.attempts == 1
 
-    def test_a_timeout_is_retried_then_reported_as_a_timeout(self, monkeypatch):
-        """Timeouts keep their actionable hint, classified by type not by text."""
+    def test_a_probe_that_times_out_is_no_status_not_a_timeout_verdict(self, monkeypatch):
+        """A probe that cannot answer in time says nothing about the data request.
+
+        The first version read it as "the request timed out" and printed the
+        ``--limit`` hint. On Windows runners a SYN to a closed loopback port is
+        dropped rather than refused, so every dead-port test there reported a
+        timeout for a connection that was never made.
+        """
+        import httpx
+
         conn = _AttemptCountingConnection(RuntimeError("IO Error: Could not open GDAL dataset"))
         monkeypatch.setattr(carto_module, "get_duckdb_connection", lambda *a, **k: conn)
-        monkeypatch.setattr(
-            carto_module,
-            "_probe_request_status",
-            lambda *a, **k: carto_module._CartoStatus(None, True),
-        )
 
-        with pytest.raises(CartoError, match="timed out after 3 attempts"):
+        def _slow(*args, **kwargs):
+            raise httpx.ConnectTimeout("took too long")
+
+        monkeypatch.setattr(httpx, "stream", _slow)
+        warnings: list[str] = []
+        monkeypatch.setattr(carto_module, "warn", warnings.append)
+
+        with pytest.raises(CartoError, match="Failed to fetch data from Carto after 3 attempts"):
             _fetch_with_retry(
                 url="http://127.0.0.1:1/api/v2/sql",
                 table_name="my_table",
@@ -1276,6 +1286,7 @@ class TestFailureClassificationUsesTheHttpStatus:
             )
 
         assert conn.attempts == 3
+        assert all(w.startswith("Could not reach Carto") for w in warnings), warnings
 
     def test_the_probe_is_one_request_per_failed_attempt(self, monkeypatch, status_http_server):
         """Cost claim, pinned: a retryable failure costs one probe per attempt, no more."""
@@ -1459,8 +1470,8 @@ class TestFailureClassificationUsesTheHttpStatus:
             None, False
         )
 
-    def test_a_probe_that_times_out_says_so_by_type(self, monkeypatch):
-        """The timeout verdict comes from httpx's exception type, not from text."""
+    def test_a_probe_that_times_out_reports_no_status(self, monkeypatch):
+        """httpx's timeout type means the *probe* could not answer -- no status."""
         import httpx
 
         def _slow(*args, **kwargs):
@@ -1468,7 +1479,7 @@ class TestFailureClassificationUsesTheHttpStatus:
 
         monkeypatch.setattr(httpx, "stream", _slow)
         assert carto_module._probe_request_status("http://x/", 1.0) == carto_module._CartoStatus(
-            None, True
+            None, False
         )
 
     def test_the_probe_is_bounded_below_a_long_data_timeout(self, monkeypatch):

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -1163,6 +1163,9 @@ class TestFailureClassificationIgnoresTheUsersSql:
             carto_module, "get_duckdb_connection", lambda *a, **k: _Counting(real_get_conn())
         )
 
+        # A refused loopback connection fails in milliseconds; the generous
+        # timeout keeps a slow GDAL on a cold runner from making the attempt
+        # look like it ran out the clock, which is a different verdict.
         with pytest.raises(CartoError) as excinfo:
             _fetch_with_retry(
                 url=self.DEAD_URL,
@@ -1170,7 +1173,7 @@ class TestFailureClassificationIgnoresTheUsersSql:
                 sql="SELECT * FROM census_blocks LIMIT 404",
                 max_retries=3,
                 retry_delay=0.01,
-                timeout=2,
+                timeout=30,
             )
 
         assert seen["attempts"] == 3

--- a/tests/test_carto.py
+++ b/tests/test_carto.py
@@ -1231,3 +1231,32 @@ class TestFailureClassificationUsesTheHttpStatus:
         assert carto_module._probe_request_status("http://x/", 1.0) == carto_module._CartoStatus(
             None, False
         )
+
+    def test_a_probe_that_times_out_says_so_by_type(self, monkeypatch):
+        """The timeout verdict comes from httpx's exception type, not from text."""
+        import httpx
+
+        def _slow(*args, **kwargs):
+            raise httpx.ConnectTimeout("took too long")
+
+        monkeypatch.setattr(httpx, "stream", _slow)
+        assert carto_module._probe_request_status("http://x/", 1.0) == carto_module._CartoStatus(
+            None, True
+        )
+
+    def test_the_probe_is_bounded_below_a_long_data_timeout(self, monkeypatch):
+        """A 120s --timeout must not be paid twice just to learn a status."""
+        import httpx
+
+        seen = {}
+
+        def _record(*args, **kwargs):
+            seen["timeout"] = kwargs["timeout"]
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(httpx, "stream", _record)
+        carto_module._probe_request_status("http://x/", 120.0)
+        assert seen["timeout"] == carto_module.STATUS_PROBE_TIMEOUT
+
+        carto_module._probe_request_status("http://x/", 2.0)
+        assert seen["timeout"] == 2.0


### PR DESCRIPTION
Fixes #1020. Refs #970, #975, #1018.

## What changed

`gpio extract carto`'s retry classifier decided whether a failure was fatal by
lower-casing the DuckDB exception message and looking for `"404"`, `"401"`,
`"403"`, `"not found"` and `"unauthorized"` anywhere in it. That message embeds
the request URL, and the request URL embeds `?q={quote(sql)}` — the user's own
table name, WHERE clause and LIMIT, with digits passing through un-encoded.

Classification now keys on the HTTP status the transport actually reported, and
never on the message:

- `duckdb.HTTPException.status_code` where DuckDB has one — the CSV/`read_csv_auto`
  path goes through httpfs, which does. `status_code == 0` is read as *no status*
  rather than as a code, because DuckDB reports 0 for some auth failures.
- Otherwise one streamed `httpx` GET that reads the response headers without
  pulling the body down. This is needed because the default GeoJSON path fetches
  through GDAL's `ST_Read`, which reports only `IO Error: Could not open GDAL
  dataset at: <url>` — the same text whatever the server said, with no status
  attached. `STATUS_PROBE_TIMEOUT` (30 s) bounds the probe so a long `--timeout`
  is not paid twice.
- Where no status exists at all — connection refused, DNS failure, timeout —
  that absence **is** the retryable class, whatever the message says.

4xx is fatal (404/401/403 keep their specific guidance; other 4xx report the
bare status), 429 and every 5xx retry. The timeout hint — "the table may be too
large, try `--limit`" — survives, now driven by `httpx.TimeoutException`, an
exception *type*, rather than by the word "timeout" appearing somewhere in the
text.

## Why

Measured against a dead local port, so that every attempt is connection-refused
— the canonical retryable class — with only the SQL varying. Each row run in a
fresh process (`max_retries=3`, `retry_delay=0.2`):

| SQL | before | after |
|---|---|---|
| `LIMIT 10` | 3 attempts, 5.45 s, correct generic error | 3 attempts, 5.45 s, correct generic error |
| `LIMIT 404` | **1 attempt**, 1.60 s, "Table 't' not found" | 3 attempts, 5.43 s, correct generic error |
| `WHERE zone = '404'` | **1 attempt**, 1.60 s, "Table 't' not found" | 3 attempts, 5.46 s, correct generic error |
| `FROM room_401_sensors` | **1 attempt**, 1.61 s, "Unauthorized… set CARTO_API_KEY" | 3 attempts, 5.43 s, correct generic error |

One underlying failure, four different verdicts, chosen by digits in the user's
query. Rows 2 and 3 lost every retry and reported a table lookup that never
happened; row 4 sent the user off to debug credentials for a network outage.

The inverse held too: `quote()` turns spaces into `%20`, so the word forms
`"not found"` / `"unauthorized"` could never match text that arrived via the URL
— the substring test both matched what was not a status and missed statuses
that were.

And against a loopback server returning real statuses, with `LIMIT 404` still in
the SQL:

| status | attempts | verdict |
|---|---|---|
| 404 | 1 | `Table 'my_table' not found.` |
| 401 | 1 | `Unauthorized access to table 'my_table'. Set CARTO_API_KEY…` |
| 403 | 1 | `Access forbidden to table 'my_table'.` |
| 429 | 3 | generic, retried in full |
| 503 | 3 | generic, retried in full |

## Verification

- Fast suite: 7738 passed, 76 skipped, 3 xfailed (213 s).
- `pytest -m meta`: 205 passed.
- `pre-commit run --all-files` and `--hook-stage pre-push`: all hooks pass
  (ruff, mypy, vulture, xenon, deptry, import-linter, menard-check, fast-tests).
  No `--no-verify` anywhere.
- diff-cover vs `origin/main`: **100 %** (47/47 changed lines).
- `core/carto.py` line coverage 78.7 % → **85.3 %**; `_fetch_with_retry`'s
  classification block, previously uncovered (#1018 WP-2), is now covered.
- `tests/data/cli_surface.json` unchanged — no CLI or Python API surface change.

## Tests

`tests/test_carto.py`, all offline (loopback only, no `network` marker — the first version's `TestCartoReadExpressionEscaping` used `https://ex"ample.carto.com/…`, which resolves via wildcard DNS, so two fast-suite tests were opening real TLS connections to Carto's load balancer once the probe existed; the review caught it and the URL is now a refused loopback port):

- The issue's whole table, parametrized, with the verbatim GDAL message as the
  classifier's input — plus two rows for the *word* forms (`WHERE msg = 'not
  found'`, `FROM unauthorized_events`). **Attempt counts are asserted**, not just
  the exception type.
- One end-to-end row with DuckDB and GDAL actually in the loop, against the dead
  port.
- A real 404, 401 and 403 via a loopback server: one attempt each, right message.
- A real 503 against a table named `room_404_sensors` queried with `LIMIT 404`:
  the full retry budget.
- Unit tests for `_status_from_duckdb_error` (0 and non-int are *not* statuses),
  `_fatal_status_error` (which statuses are fatal, which retryable), and the
  probe's timeout branch and its bound.

One pre-existing test in `TestCartoReadExpressionEscaping` relied on
`RuntimeError("404 not found")` being non-retryable to stop after one attempt;
it now passes `max_retries=1`, which is what it actually meant.

## Review addendum

An adversarial review against a loopback server that logs every request corrected four claims above and found three defects, all fixed in the review commit:

- **The `--limit` timeout hint did not survive.** It was driven only by the *probe* timing out. A data request that ran out the whole `--timeout` against a server that answers headers promptly — the normal shape of a too-heavy query — produced `Carto returned HTTP 200 … retrying` three times and a generic failure. The timeout is now read from the **clock**: an attempt that ran for the whole timeout before failing timed out, whatever its message says, and such an attempt is not probed (the probe would re-run the query that was too heavy). Test: `test_a_data_request_that_ran_out_the_clock_is_a_timeout_and_is_not_probed`.
- **A 2xx/3xx from the probe was retryable.** It means the server is fine and the *response* could not be read; retrying fetches the same bytes. Now fatal at once, quoting the local error. Test: `test_a_200_from_the_probe_is_fatal_not_retried`.
- **A 400 threw away Carto's explanation.** The probe already holds it; the first 2 KB of a 4xx body is read, `{"error": [...]}` unwrapped, sanitized and quoted — `Carto said: column "foo" does not exist`. So "one streamed GET that reads the headers without the body" above is now "…without the body, except up to 2 KB of a 4xx's".
- **The probe is one request per failed *attempt*, not one per failure** — up to `max_retries`. Pinned by `test_the_probe_is_one_request_per_failed_attempt`. Total request counts measured by the review, GeoJSON path, 3 retries: every *fatal* class fell (45 → 16 for 400/401/403/413/502, 9 → 4 for 404, because on `main` the GeoJSON path never detected those at all and burned the retry budget); the retryable classes rose by 3 (36 → 39). The CSV path probes too, for the statuses DuckDB reports as `status_code == 0` (400/401/403/413/502).
- **408 now retries** (RFC 9110: the client may resend); **`Retry-After` on a 429 is honoured**, capped at 60 s; a **local failure** (out of memory, an interrupt, a binder error) is fatal at once and not probed; the exhausted-retries message and the new fatal messages go through `sanitize_error_message`, since DuckDB's text names the URL with `api_key=` in it — the first version's retry warning printed that URL on every attempt; this one does not.
- **A probe that times out is "no status", not a timeout verdict.** The first version read `httpx.TimeoutException` from the *probe* as "the request timed out" and printed the `--limit` hint; the review called this the inverse of the lost-hint bug, and the Windows legs proved it — a SYN to a closed loopback port is dropped there rather than refused, so every dead-port test reported a timeout for a connection that was never made. The timeout verdict now comes only from the data request's clock.
- Worst-case wall time for a dead endpoint at defaults: `3 × (120 + 30) + 6 = 456 s`, up from 366 s — each failed attempt may pay the 30 s probe. And `ST_Read` does not honour `SET http_timeout` at all (measured: over two minutes against a server that accepts and never answers), so on the default GeoJSON path `STATUS_PROBE_TIMEOUT` is the only bound in the loop; tracked with the items below.

## Not in this PR

`core/arcgis.py` and `core/wfs.py` were checked for the same defect. **The
retry/fatal classification there is already status-based** — both go through
`httpx` and branch on `response.status_code` in an `httpx.HTTPStatusError`
handler (`core/http_retry.py:198-227`, `core/wfs.py:257-281`), with transport
failures caught by type (`TimeoutException`, `NetworkError`,
`RemoteProtocolError`). No substring classification of retryability exists in
either.

There is one adjacent, *lower*-severity instance worth filing separately:
`core/wfs.py:403`, in `_get_wfs_service()`, does `error_msg = str(e).lower()`
and branches on `"connection"` / `"timeout"` / `"xml"` / `"parse"` to word an
OWSLib capabilities failure. It only picks between three error *messages* — all
three are fatal, no retry budget is at stake — and the text it reads is
OWSLib's, not a URL carrying user SQL. Worth cleaning up, but a different bug
with a different blast radius; happy to have it filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4

