### PR TITLE
fix(check): stage an in-place row-group or bbox-removal fix beside the file

### DIFF
--- a/geoparquet_io/core/check_fixes.py
+++ b/geoparquet_io/core/check_fixes.py
@@ -278,13 +278,14 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
     else:
         gp_version = "1.1"  # Fallback, shouldn't happen for removal
 
-    # In place: stage beside the destination and move once the connection is
-    # closed, or DuckDB renames its `.tmp` over a file it is still reading --
-    # `Could not move file: Access is denied` on Windows. See fix_row_groups.
+    # Local in-place: stage beside the destination and move once the connection
+    # is closed, or DuckDB renames its `tmp_<basename>` over a file it is still
+    # reading -- `Could not move file: Access is denied` on Windows. See
+    # fix_row_groups for the remote case.
     actual_output = output_file
     temp_output_file = None
     moved_into_place = False
-    if is_same_file_path(parquet_file, output_file):
+    if is_same_file_path(parquet_file, output_file) and not is_remote_url(output_file):
         temp_output_file = _staging_path_beside(output_file)
         actual_output = temp_output_file
 
@@ -315,20 +316,17 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
             # restates whatever DuckDB read and declares nothing (#1001).
             input_file=parquet_file,
         )
-    except duckdb.IOException as e:
         con.close()
+        if temp_output_file:
+            _move_temp_output_into_place(temp_output_file, output_file, profile)
+            moved_into_place = True
+    except duckdb.IOException as e:
         if is_remote_url(parquet_file):
             hints = get_remote_error_hint(str(e), parquet_file)
             raise RemoteAccessError(parquet_file, f"{hints}\n\nOriginal error: {str(e)}") from e
         raise
     finally:
         con.close()
-
-    try:
-        if temp_output_file:
-            _move_temp_output_into_place(temp_output_file, output_file, profile)
-            moved_into_place = True
-    finally:
         if temp_output_file and not moved_into_place and os.path.exists(temp_output_file):
             os.remove(temp_output_file)
 
@@ -483,17 +481,19 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
     # see fix_compression above.
     original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
 
-    # An in-place fix is staged beside the destination and moved over it once
-    # the connection is closed. Handed the input path as its output, DuckDB's
-    # COPY finds the destination in place, writes `<file>.tmp` and renames it
-    # over a file it is still reading -- fine on POSIX, and on Windows
-    # `IO Error: Could not move file: Access is denied`, intermittently, as
-    # the .bak sits there with nothing to restore from. Same routing as
-    # fix_compression and fix_spatial_ordering (#941, #959).
+    # A local in-place fix is staged beside the destination and moved over it
+    # once the connection is closed. Handed the input path as its output,
+    # DuckDB's COPY finds the destination in place, writes `tmp_<basename>` next
+    # to it and renames that over a file it is still reading -- fine on POSIX,
+    # and on Windows `IO Error: Could not move file: Access is denied`,
+    # intermittently, as the .bak sits there with nothing to restore from.
+    # Same routing as fix_spatial_ordering (#941, #959). A remote in-place fix
+    # is not staged: the write facade already stages a remote output locally
+    # and uploads it, and there is no destination on this machine to rename over.
     actual_output = output_file
     temp_output_file = None
     moved_into_place = False
-    if is_same_file_path(parquet_file, output_file):
+    if is_same_file_path(parquet_file, output_file) and not is_remote_url(output_file):
         temp_output_file = _staging_path_beside(output_file)
         actual_output = temp_output_file
 
@@ -516,24 +516,23 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
             geoparquet_version=geoparquet_version,
             input_file=parquet_file,
         )
+        # Closed before the move: the connection is the last reader of the file
+        # the staging copy is about to replace.
+        con.close()
+        if temp_output_file:
+            _move_temp_output_into_place(temp_output_file, output_file, profile)
+            moved_into_place = True
     except duckdb.IOException as e:
         if is_remote_url(parquet_file):
             hints = get_remote_error_hint(str(e), parquet_file)
             raise RemoteAccessError(parquet_file, f"{hints}\n\nOriginal error: {str(e)}") from e
         raise
     finally:
-        # Closed before the move below: the connection is the last reader of
-        # the file the staging copy is about to replace.
         con.close()
-
-    try:
-        if temp_output_file:
-            _move_temp_output_into_place(temp_output_file, output_file, profile)
-            moved_into_place = True
-    finally:
-        # Only ever discard the rewrite when it did NOT reach the destination
-        # (#959): a failed move leaves the original intact and the rewrite in
-        # the staging file for the user to recover.
+        # The staging file is discarded on any failure -- of the write or of the
+        # move -- and only then: the original was never touched, so it is the
+        # good copy (#959), and a rewrite left behind under a dot-prefixed name
+        # would sit invisibly in the user's data directory.
         if temp_output_file and not moved_into_place and os.path.exists(temp_output_file):
             os.remove(temp_output_file)
 

--- a/geoparquet_io/core/check_fixes.py
+++ b/geoparquet_io/core/check_fixes.py
@@ -278,6 +278,16 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
     else:
         gp_version = "1.1"  # Fallback, shouldn't happen for removal
 
+    # In place: stage beside the destination and move once the connection is
+    # closed, or DuckDB renames its `.tmp` over a file it is still reading --
+    # `Could not move file: Access is denied` on Windows. See fix_row_groups.
+    actual_output = output_file
+    temp_output_file = None
+    moved_into_place = False
+    if is_same_file_path(parquet_file, output_file):
+        temp_output_file = _staging_path_beside(output_file)
+        actual_output = temp_output_file
+
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
 
     try:
@@ -291,7 +301,7 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
         write_parquet_with_metadata(
             con=con,
             query=query,
-            output_file=output_file,
+            output_file=actual_output,
             original_metadata=None,  # Don't preserve old metadata with bbox covering
             compression="ZSTD",
             compression_level=15,
@@ -305,8 +315,6 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
             # restates whatever DuckDB read and declares nothing (#1001).
             input_file=parquet_file,
         )
-
-        return {"fix_applied": f"Removed bbox column '{bbox_column_name}'", "success": True}
     except duckdb.IOException as e:
         con.close()
         if is_remote_url(parquet_file):
@@ -315,6 +323,16 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
         raise
     finally:
         con.close()
+
+    try:
+        if temp_output_file:
+            _move_temp_output_into_place(temp_output_file, output_file, profile)
+            moved_into_place = True
+    finally:
+        if temp_output_file and not moved_into_place and os.path.exists(temp_output_file):
+            os.remove(temp_output_file)
+
+    return {"fix_applied": f"Removed bbox column '{bbox_column_name}'", "success": True}
 
 
 def fix_bbox_all(
@@ -465,6 +483,20 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
     # see fix_compression above.
     original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
 
+    # An in-place fix is staged beside the destination and moved over it once
+    # the connection is closed. Handed the input path as its output, DuckDB's
+    # COPY finds the destination in place, writes `<file>.tmp` and renames it
+    # over a file it is still reading -- fine on POSIX, and on Windows
+    # `IO Error: Could not move file: Access is denied`, intermittently, as
+    # the .bak sits there with nothing to restore from. Same routing as
+    # fix_compression and fix_spatial_ordering (#941, #959).
+    actual_output = output_file
+    temp_output_file = None
+    moved_into_place = False
+    if is_same_file_path(parquet_file, output_file):
+        temp_output_file = _staging_path_beside(output_file)
+        actual_output = temp_output_file
+
     # Read and rewrite with optimal row groups
     con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
 
@@ -474,7 +506,7 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
         write_parquet_with_metadata(
             con=con,
             query=query,
-            output_file=output_file,
+            output_file=actual_output,
             original_metadata=original_metadata,
             compression="ZSTD",
             compression_level=15,
@@ -484,16 +516,28 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
             geoparquet_version=geoparquet_version,
             input_file=parquet_file,
         )
-
-        return {"fix_applied": "Optimized row groups", "success": True}
     except duckdb.IOException as e:
-        con.close()
         if is_remote_url(parquet_file):
             hints = get_remote_error_hint(str(e), parquet_file)
             raise RemoteAccessError(parquet_file, f"{hints}\n\nOriginal error: {str(e)}") from e
         raise
     finally:
+        # Closed before the move below: the connection is the last reader of
+        # the file the staging copy is about to replace.
         con.close()
+
+    try:
+        if temp_output_file:
+            _move_temp_output_into_place(temp_output_file, output_file, profile)
+            moved_into_place = True
+    finally:
+        # Only ever discard the rewrite when it did NOT reach the destination
+        # (#959): a failed move leaves the original intact and the rewrite in
+        # the staging file for the user to recover.
+        if temp_output_file and not moved_into_place and os.path.exists(temp_output_file):
+            os.remove(temp_output_file)
+
+    return {"fix_applied": "Optimized row groups", "success": True}
 
 
 def get_geoparquet_version_from_check_results(check_results):

--- a/tests/test_check_fix_in_place_staging.py
+++ b/tests/test_check_fix_in_place_staging.py
@@ -3,8 +3,8 @@
 ``fix_row_groups`` and ``fix_bbox_removal`` handed ``output_file`` straight to
 ``write_parquet_with_metadata``. For an in-place fix that is the input path, so
 DuckDB's ``COPY`` -- finding the destination already there -- writes
-``<file>.tmp`` and renames it over the original while the original still has a
-reader on it. POSIX allows that; Windows does not::
+``tmp_<basename>`` beside it and renames that over the original while the
+original still has a reader on it. POSIX allows that; Windows does not::
 
     ✓ Created backup: ...\\pgo_tiny_groups.parquet.bak
     Error: IO Error: Could not move file: Access is denied.
@@ -33,7 +33,12 @@ from geoparquet_io.core import check_fixes
 
 @pytest.fixture
 def local_copy(tmp_path) -> Path:
-    src = Path("tests/data/fields_pgo_5070_snappy.parquet")
+    """A parquet-geo-only file *with* a ``bbox`` column, so both fixers have work.
+
+    ``fix_bbox_removal`` really does ``SELECT * EXCLUDE (bbox)``; a fixture
+    without the column would pass the recorder below and fail the real fixer.
+    """
+    src = Path("tests/data/fields_pgo_crs84_bbox_snappy.parquet")
     dst = tmp_path / "in_place.parquet"
     shutil.copy2(src, dst)
     return dst
@@ -86,6 +91,81 @@ def test_an_in_place_fix_writes_beside_the_file_and_moves_it_into_place(
     assert sorted(p.name for p in local_copy.parent.iterdir()) == before, (
         "an in-place fix leaves exactly the files it found"
     )
+
+
+def test_the_real_fixers_work_in_place_end_to_end(local_copy):
+    """No recorder: the two fixers, on a real file, leave one file and a result."""
+    before = sorted(p.name for p in local_copy.parent.iterdir())
+
+    check_fixes.fix_bbox_removal(str(local_copy), str(local_copy), "bbox")
+    assert "bbox" not in pq.read_schema(str(local_copy)).names
+    check_fixes.fix_row_groups(str(local_copy), str(local_copy))
+
+    assert pq.ParquetFile(str(local_copy)).metadata.num_rows > 0
+    assert sorted(p.name for p in local_copy.parent.iterdir()) == before
+
+
+@pytest.mark.parametrize(
+    "fixer",
+    [
+        pytest.param(
+            lambda path: check_fixes.fix_row_groups(str(path), str(path)),
+            id="fix_row_groups",
+        ),
+        pytest.param(
+            lambda path: check_fixes.fix_bbox_removal(str(path), str(path), "bbox"),
+            id="fix_bbox_removal",
+        ),
+    ],
+)
+def test_a_failed_write_leaves_neither_a_staging_file_nor_a_changed_original(
+    fixer, local_copy, monkeypatch
+):
+    """A writer that dies after creating the staging file must not leave it.
+
+    A dot-prefixed staging file is invisible to ``ls`` and to the ``*.parquet``
+    globs that walk a partition directory, so a fix that keeps failing would
+    accumulate multi-GB orphans nobody can see. The original is the good copy
+    and is untouched.
+    """
+    before = {p.name: p.stat().st_size for p in local_copy.parent.iterdir()}
+
+    def dying_write(con, query, output_file, **kwargs):
+        Path(output_file).write_bytes(b"half a file")
+        raise RuntimeError("the writer died mid-way")
+
+    monkeypatch.setattr(check_fixes, "write_parquet_with_metadata", dying_write)
+
+    with pytest.raises(RuntimeError, match="died"):
+        fixer(local_copy)
+
+    assert {p.name: p.stat().st_size for p in local_copy.parent.iterdir()} == before
+
+
+def test_a_remote_in_place_fix_is_not_staged_locally(monkeypatch):
+    """``check row-group s3://b/k.parquet --fix --overwrite`` worked on ``main``.
+
+    The write facade stages a *remote* output itself and uploads it; there is no
+    destination on this machine to rename over, so the local staging path is
+    skipped and the facade is handed the remote URL as before. The first
+    version of this fix routed the remote case through
+    ``_move_temp_output_into_place``, whose remote branch calls
+    ``remote_write_context`` with a signature it does not have.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr(check_fixes, "get_parquet_metadata", lambda *a, **k: ({}, None))
+    monkeypatch.setattr(check_fixes, "setup_aws_profile_if_needed", lambda *a, **k: None)
+    monkeypatch.setattr(check_fixes, "resolve_file_url", lambda path, verbose=False: path)
+    monkeypatch.setattr(
+        check_fixes,
+        "write_parquet_with_metadata",
+        lambda con, query, output_file, **kwargs: seen.append(output_file),
+    )
+
+    result = check_fixes.fix_row_groups("s3://bucket/key.parquet", "s3://bucket/key.parquet")
+
+    assert result["success"] is True
+    assert seen == ["s3://bucket/key.parquet"]
 
 
 def test_a_fix_to_a_different_path_still_writes_there_directly(local_copy, tmp_path, monkeypatch):

--- a/tests/test_check_fix_in_place_staging.py
+++ b/tests/test_check_fix_in_place_staging.py
@@ -1,0 +1,100 @@
+"""An in-place ``check --fix`` never asks DuckDB to write over the file it is reading.
+
+``fix_row_groups`` and ``fix_bbox_removal`` handed ``output_file`` straight to
+``write_parquet_with_metadata``. For an in-place fix that is the input path, so
+DuckDB's ``COPY`` -- finding the destination already there -- writes
+``<file>.tmp`` and renames it over the original while the original still has a
+reader on it. POSIX allows that; Windows does not::
+
+    ✓ Created backup: ...\\pgo_tiny_groups.parquet.bak
+    Error: IO Error: Could not move file: Access is denied.
+
+Intermittent, because it depends on which reader the collector has released by
+the time DuckDB renames -- which is why it slipped through #1009's own Windows
+legs and then failed two of ``main``'s. ``fix_compression`` and
+``fix_spatial_ordering`` already route an in-place rewrite through a staging
+file beside the destination and ``os.replace`` it after the connection is
+closed (#941, #959); these two now do the same.
+
+The invariant is asserted directly -- the path DuckDB is asked to write is never
+the path being read -- rather than the platform error, so it fails on every OS.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from geoparquet_io.core import check_fixes
+
+
+@pytest.fixture
+def local_copy(tmp_path) -> Path:
+    src = Path("tests/data/fields_pgo_5070_snappy.parquet")
+    dst = tmp_path / "in_place.parquet"
+    shutil.copy2(src, dst)
+    return dst
+
+
+def _recording_writer(seen: list[str]):
+    """Stand in for ``write_parquet_with_metadata``: record where it was asked to write,
+    and put a real Parquet file there so the move that follows has something to move."""
+
+    def fake_write(con, query, output_file, **kwargs):
+        seen.append(output_file)
+        source = kwargs["input_file"]
+        pq.write_table(pq.read_table(source), output_file, compression="zstd")
+
+    return fake_write
+
+
+@pytest.mark.parametrize(
+    "fixer",
+    [
+        pytest.param(
+            lambda path: check_fixes.fix_row_groups(str(path), str(path)),
+            id="fix_row_groups",
+        ),
+        pytest.param(
+            lambda path: check_fixes.fix_bbox_removal(str(path), str(path), "bbox"),
+            id="fix_bbox_removal",
+        ),
+    ],
+)
+def test_an_in_place_fix_writes_beside_the_file_and_moves_it_into_place(
+    fixer, local_copy, monkeypatch
+):
+    seen: list[str] = []
+    monkeypatch.setattr(check_fixes, "write_parquet_with_metadata", _recording_writer(seen))
+    before = sorted(p.name for p in local_copy.parent.iterdir())
+
+    result = fixer(local_copy)
+
+    assert result["success"] is True
+    assert seen, "the fixer never wrote anything"
+    written = Path(seen[0])
+    assert written.resolve() != local_copy.resolve(), (
+        "DuckDB was asked to write over the file it is reading -- on Windows that is "
+        "`IO Error: Could not move file: Access is denied`"
+    )
+    assert written.parent == local_copy.parent, "staging must be beside the destination"
+    assert not written.exists(), "the staging file must not be left behind"
+    assert local_copy.exists() and pq.ParquetFile(str(local_copy)).metadata.num_rows > 0
+    assert sorted(p.name for p in local_copy.parent.iterdir()) == before, (
+        "an in-place fix leaves exactly the files it found"
+    )
+
+
+def test_a_fix_to_a_different_path_still_writes_there_directly(local_copy, tmp_path, monkeypatch):
+    """Not in place: no staging, the output path is used as given."""
+    seen: list[str] = []
+    monkeypatch.setattr(check_fixes, "write_parquet_with_metadata", _recording_writer(seen))
+    out = tmp_path / "elsewhere.parquet"
+
+    check_fixes.fix_row_groups(str(local_copy), str(out))
+
+    assert seen == [str(out)]
+    assert out.exists()


### PR DESCRIPTION
## What changed

`gpio check row-group --fix` and `gpio check bbox --fix` (the bbox-*removal* branch, for 2.0 / parquet-geo-only files), run **in place**, asked DuckDB to write over the file it was reading. `fix_row_groups` and `fix_bbox_removal` passed `output_file` — the input path — straight to `write_parquet_with_metadata`, so DuckDB's `COPY` found the destination already there, wrote `tmp_<basename>` beside it, and renamed that over the original while a reader was still open on it. POSIX permits that; Windows does not:

```
✓ Created backup: C:\...\pgo_tiny_groups.parquet.bak
Error: IO Error: Could not move file: Access is denied.
```

Both now do what `fix_spatial_ordering` already did (#941, #959): stage a **local** in-place rewrite beside the destination (`_staging_path_beside`, same filesystem so the move stays a rename), **close the connection**, then `os.replace` it into place. On any failure — of the write or of the move — the staging file is removed and the original, never touched, is the good copy. A **remote** in-place fix (`check row-group s3://… --fix --overwrite`) is not staged: the write facade already stages a remote output locally and uploads it, and there is no destination on this machine to rename over.

**Review addendum.** The adversarial review of the first version found: (S1) the remote in-place case was routed through `_move_temp_output_into_place`, whose remote branch calls `remote_write_context(..., profile=)` — a signature it does not have — so `check row-group s3://… --fix --overwrite` went from working on `main` to a raw `TypeError` with nothing uploaded; the remote case is now not staged at all. (S2) only the move sat inside the `try`, so a writer that died after creating the staging file left a dot-prefixed orphan `ls` cannot see; the write and the move now share one `try`/`finally`, matching `fix_spatial_ordering`, and a test kills the writer mid-way and asserts the directory is byte-for-byte what it was. (S3) the first version's comment said a failed move "keeps the rewrite for the user to recover" — it never did, and should not; corrected. (S3) the `fix_bbox_removal` test case used a fixture with no `bbox` column, which only the recorder let pass; it now uses `fields_pgo_crs84_bbox_snappy.parquet`, and an end-to-end test runs both real fixers in place. (S4) DuckDB's temp is `tmp_<basename>`, not `<file>.tmp`. The reviewer also measured, with `lsof` at the moment of the move, **0 open handles** on the destination for both fixers — the window is closed, not narrowed.

Not this PR's, ticketed separately: `fix_compression` decides "in place" by raw string equality (`parquet_file == output_file`), stages in `$TMPDIR`, and unlinks-then-moves inside the `try` before `con.close()` — the exact shape #959 removed elsewhere; `check compression in.parquet --fix --fix-output ./in.parquet --no-backup` deletes the user's file outright.

## Why now

This surfaced after #1009 landed. Its tests (`test_check_fix_preserves_native_geo.py::test_check_row_group_fix_keeps_the_native_type_and_the_crs`, and `test_check_cli_guards.py::test_geo_native_file_loses_its_bbox_column`) failed on `main`'s Windows 3.13 and 3.12 legs respectively at `fc15c04`, and again on #1010's Windows 3.11 leg — while passing on #1009's own run. Intermittent, because whether the rename is refused depends on which reader the collector has released by the time DuckDB moves the file. #1009 put three more reads of the input (`get_parquet_metadata`, the version witness, the CRS witness) immediately in front of the rewrite, which is what turned a latent shape into a two-legs-in-three failure. The bug is the routing, not the reads: an in-place rewrite should never target the path it reads from, whatever is open.

## Tests

`tests/test_check_fix_in_place_staging.py` asserts the invariant, not the platform error, so it fails on every OS: with `write_parquet_with_metadata` replaced by a recorder that writes a real file where it is told, both fixers must (a) be asked to write a path other than the input, (b) beside it, (c) leave no staging file behind, (d) leave the directory with exactly the files it had, and (e) a non-in-place call still writes straight to the output path. Both in-place cases fail on `main`.

## Verification

- `uv run pytest -q -n 4 -m "not slow and not network and not meta"` — see the gate line in the last commit's CI
- `diff-cover --compare-branch=origin/main --fail-under=90`, `pytest -m meta`, `lint-imports`, `pre-commit run --all-files` and `--hook-stage pre-push` — all green locally
- Reproduced the failure path from the two `main` Windows logs (run 34684922042, jobs 103530139112 / 103530139338) and #1010's (run 34687791917, job 103537728532); it cannot be reproduced on POSIX, which is why the test pins the invariant.

Refs #1009, #941, #959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyXqfoa834LVqdKyUWxrS
