### PR TITLE
fix(check): stop --fix rewriting a file with a DuckDB COPY that overwrites its own input

### DIFF
--- a/geoparquet_io/core/check_fixes.py
+++ b/geoparquet_io/core/check_fixes.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import tempfile
+from contextlib import contextmanager
 
 import duckdb
 
@@ -84,6 +85,95 @@ from geoparquet_io.core.remote import (
 # `resolve_output_geoparquet_version`).
 
 
+@contextmanager
+def _staged_output(output_file, profile):
+    """The path a rewrite writes to, put over *output_file* once it is closed.
+
+    A ``COPY`` whose destination already exists is not a plain write: DuckDB
+    writes ``tmp_<name>`` beside it and then *moves* that onto the destination.
+    Every ``--fix`` here defaults to rewriting the file in place, so the file
+    DuckDB moved over was the file the same statement was reading, and nothing
+    but the scheduler ordered the release of the scan handle against the move.
+    POSIX does not care. Windows refuses to rename over a path any handle still
+    holds open, so the command died with ``IO Error: Could not move file: Access
+    is denied.`` -- in some runs of the same commit and not others, which is
+    what an intermittent windows-latest failure with no local reproduction looks
+    like (#1032).
+
+    Staging beside the output and swapping afterwards moves the rename out of
+    DuckDB's hands and to a point where the connection is closed and every
+    PyArrow reader the write opened on the input -- the ``get_parquet_metadata``
+    read and the ``input_file=`` witness that #1009 made unconditional -- is
+    gone. ``add_bbox_metadata`` and ``fix_spatial_ordering`` already work this
+    way; this is the same pattern for the other three.
+
+    A destination that does not exist yet needs none of it: there is no file to
+    move over. So does a remote one, which ``write_parquet_with_metadata``
+    already routes through its own local staging and upload.
+    """
+    if is_remote_url(output_file) or not os.path.exists(output_file):
+        yield output_file
+        return
+
+    staging = _staging_path_beside(output_file)
+    moved = False
+    try:
+        yield staging
+        _move_temp_output_into_place(staging, output_file, profile)
+        moved = True
+    finally:
+        # Only ever discard the rewrite when it did NOT reach the destination
+        # -- the original is still in place, and under `--no-backup` there is
+        # no .bak to fall back on (#959).
+        if not moved and os.path.exists(staging):
+            os.remove(staging)
+
+
+def _rewrite_through_staging(
+    parquet_file,
+    output_file,
+    query,
+    *,
+    verbose,
+    profile,
+    geoparquet_version=None,
+    original_metadata=None,
+):
+    """Run *query* over *parquet_file* and leave the result at *output_file*.
+
+    The one rewrite the three ``COPY``-based fixes share: staged output, one
+    DuckDB connection closed before the swap, and the input named as the write
+    facade's witness.
+    """
+    with _staged_output(output_file, profile) as destination:
+        con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
+        try:
+            write_parquet_with_metadata(
+                con=con,
+                query=query,
+                output_file=destination,
+                original_metadata=original_metadata,
+                compression="ZSTD",
+                compression_level=15,
+                row_group_rows=DEFAULT_ROW_GROUP_ROWS,
+                verbose=verbose,
+                profile=profile,
+                geoparquet_version=geoparquet_version,
+                # The rows come from `parquet_file` -- which under
+                # `check all --fix` is the previous fix's scratch file, not the
+                # user's input, and the witness has to be the file actually
+                # read (#1001).
+                input_file=parquet_file,
+            )
+        except duckdb.IOException as e:
+            if is_remote_url(parquet_file):
+                hints = get_remote_error_hint(str(e), parquet_file)
+                raise RemoteAccessError(parquet_file, f"{hints}\n\nOriginal error: {str(e)}") from e
+            raise
+        finally:
+            con.close()
+
+
 def fix_compression(
     parquet_file, output_file, verbose=False, profile=None, geoparquet_version=None
 ):
@@ -102,29 +192,8 @@ def fix_compression(
     if verbose:
         debug("Applying ZSTD compression...")
 
-    # Handle in-place operations: use temp file if input == output
-    import tempfile
-    from pathlib import Path
-
-    actual_output = output_file
-    temp_output_file = None
-    is_inplace = parquet_file == output_file
-    is_remote_output = is_remote_url(output_file)
-
-    if is_inplace:
-        # In-place operation: write to temp file first, then move/upload
-        fd, temp_output_file = tempfile.mkstemp(suffix=".parquet")
-        os.close(fd)
-        os.unlink(temp_output_file)
-        actual_output = temp_output_file
-    elif output_file and not is_remote_output and Path(output_file).exists():
-        # Different local files: safe to delete output
-        Path(output_file).unlink()
-
     # Setup AWS profile if needed
-    setup_aws_profile_if_needed(
-        profile, parquet_file, actual_output if not is_remote_output else output_file
-    )
+    setup_aws_profile_if_needed(profile, parquet_file, output_file)
 
     raw_url = resolve_file_url(parquet_file, verbose)
 
@@ -134,57 +203,18 @@ def fix_compression(
     # from (#1001).
     original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
 
-    # Read and rewrite with ZSTD compression
-    con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
+    # Preserve row order from input file (important after Hilbert sorting)
+    _rewrite_through_staging(
+        parquet_file,
+        output_file,
+        f"SELECT * FROM read_parquet({sql_path(raw_url)}, hive_partitioning=false)",
+        verbose=verbose,
+        profile=profile,
+        geoparquet_version=geoparquet_version,
+        original_metadata=original_metadata,
+    )
 
-    try:
-        # Preserve row order from input file (important after Hilbert sorting)
-        query = f"SELECT * FROM read_parquet({sql_path(raw_url)}, hive_partitioning=false)"
-
-        write_parquet_with_metadata(
-            con=con,
-            query=query,
-            output_file=actual_output,
-            original_metadata=original_metadata,
-            compression="ZSTD",
-            compression_level=15,
-            row_group_rows=DEFAULT_ROW_GROUP_ROWS,
-            verbose=verbose,
-            profile=profile,
-            geoparquet_version=geoparquet_version,
-            # The rows come from `parquet_file` -- which under `check all --fix`
-            # is the previous fix's scratch file, not the user's input, and the
-            # witness has to be the file actually read (#1001).
-            input_file=parquet_file,
-        )
-
-        # If we used a temp file for in-place operation, move/upload it to final location
-        if temp_output_file:
-            if is_remote_output:
-                # Remote output: upload temp file
-                with remote_write_context(output_file, profile=profile) as remote_path:
-                    import shutil
-
-                    shutil.copy2(temp_output_file, remote_path)
-                # Clean up temp file
-                Path(temp_output_file).unlink()
-            else:
-                # Local output: move temp file
-                import shutil
-
-                if Path(output_file).exists():
-                    Path(output_file).unlink()
-                shutil.move(actual_output, output_file)
-
-        return {"fix_applied": "Re-compressed with ZSTD", "success": True}
-    except duckdb.IOException as e:
-        con.close()
-        if is_remote_url(parquet_file):
-            hints = get_remote_error_hint(str(e), parquet_file)
-            raise RemoteAccessError(parquet_file, f"{hints}\n\nOriginal error: {str(e)}") from e
-        raise
-    finally:
-        con.close()
+    return {"fix_applied": "Re-compressed with ZSTD", "success": True}
 
 
 def fix_bbox_column(parquet_file, output_file, verbose=False, profile=None):
@@ -278,43 +308,27 @@ def fix_bbox_removal(parquet_file, output_file, bbox_column_name, verbose=False,
     else:
         gp_version = "1.1"  # Fallback, shouldn't happen for removal
 
-    con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
+    # Select all columns EXCEPT the bbox column. The column name is read from
+    # the file's own schema (see ``_detect_bbox_column_from_table``), so it is
+    # attacker-controlled and must be quoted as an identifier -- a bare
+    # interpolation lets a crafted column name inject arbitrary SQL into the
+    # projection (#918).
+    #
+    # `original_metadata=None`: don't preserve old metadata with bbox covering.
+    # The CRS still survives, from `input_file` -- `gp_version` above answers
+    # the version question from the same file, but a native-geo-only input keeps
+    # its CRS only in the Parquet logical type, so without the witness the
+    # rewrite restates whatever DuckDB read and declares nothing (#1001).
+    _rewrite_through_staging(
+        parquet_file,
+        output_file,
+        f"SELECT * EXCLUDE ({quote_identifier(bbox_column_name)}) FROM {sql_path(raw_url)}",
+        verbose=verbose,
+        profile=profile,
+        geoparquet_version=gp_version,
+    )
 
-    try:
-        # Select all columns EXCEPT the bbox column. The column name is read from
-        # the file's own schema (see ``_detect_bbox_column_from_table``), so it is
-        # attacker-controlled and must be quoted as an identifier -- a bare
-        # interpolation lets a crafted column name inject arbitrary SQL into the
-        # projection (#918).
-        query = f"SELECT * EXCLUDE ({quote_identifier(bbox_column_name)}) FROM {sql_path(raw_url)}"
-
-        write_parquet_with_metadata(
-            con=con,
-            query=query,
-            output_file=output_file,
-            original_metadata=None,  # Don't preserve old metadata with bbox covering
-            compression="ZSTD",
-            compression_level=15,
-            row_group_rows=DEFAULT_ROW_GROUP_ROWS,
-            verbose=verbose,
-            profile=profile,
-            geoparquet_version=gp_version,
-            # The witness for the CRS. `gp_version` above answers the version
-            # question from the same file, but a native-geo-only input keeps its
-            # CRS only in the Parquet logical type, so without this the rewrite
-            # restates whatever DuckDB read and declares nothing (#1001).
-            input_file=parquet_file,
-        )
-
-        return {"fix_applied": f"Removed bbox column '{bbox_column_name}'", "success": True}
-    except duckdb.IOException as e:
-        con.close()
-        if is_remote_url(parquet_file):
-            hints = get_remote_error_hint(str(e), parquet_file)
-            raise RemoteAccessError(parquet_file, f"{hints}\n\nOriginal error: {str(e)}") from e
-        raise
-    finally:
-        con.close()
+    return {"fix_applied": f"Removed bbox column '{bbox_column_name}'", "success": True}
 
 
 def fix_bbox_all(
@@ -466,34 +480,17 @@ def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geopa
     original_metadata, _ = get_parquet_metadata(parquet_file, verbose)
 
     # Read and rewrite with optimal row groups
-    con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
+    _rewrite_through_staging(
+        parquet_file,
+        output_file,
+        f"SELECT * FROM {sql_path(raw_url)}",
+        verbose=verbose,
+        profile=profile,
+        geoparquet_version=geoparquet_version,
+        original_metadata=original_metadata,
+    )
 
-    try:
-        query = f"SELECT * FROM {sql_path(raw_url)}"
-
-        write_parquet_with_metadata(
-            con=con,
-            query=query,
-            output_file=output_file,
-            original_metadata=original_metadata,
-            compression="ZSTD",
-            compression_level=15,
-            row_group_rows=DEFAULT_ROW_GROUP_ROWS,
-            verbose=verbose,
-            profile=profile,
-            geoparquet_version=geoparquet_version,
-            input_file=parquet_file,
-        )
-
-        return {"fix_applied": "Optimized row groups", "success": True}
-    except duckdb.IOException as e:
-        con.close()
-        if is_remote_url(parquet_file):
-            hints = get_remote_error_hint(str(e), parquet_file)
-            raise RemoteAccessError(parquet_file, f"{hints}\n\nOriginal error: {str(e)}") from e
-        raise
-    finally:
-        con.close()
+    return {"fix_applied": "Optimized row groups", "success": True}
 
 
 def get_geoparquet_version_from_check_results(check_results):

--- a/geoparquet_io/core/check_fixes.py
+++ b/geoparquet_io/core/check_fixes.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
+import contextlib
 import os
 import shutil
 import tempfile
+from collections.abc import Iterator
 from contextlib import contextmanager
 
 import duckdb
@@ -20,7 +22,7 @@ from geoparquet_io.core.duckdb_utils import (
     sql_path,
 )
 from geoparquet_io.core.exceptions import GeoParquetError, RemoteAccessError
-from geoparquet_io.core.file_utils import is_same_file_path, resolve_file_url
+from geoparquet_io.core.file_utils import resolve_file_url
 from geoparquet_io.core.hilbert_order import hilbert_order
 from geoparquet_io.core.logging_config import debug, info, progress
 from geoparquet_io.core.parquet_writer import DEFAULT_ROW_GROUP_ROWS
@@ -28,7 +30,6 @@ from geoparquet_io.core.remote import (
     get_remote_error_hint,
     is_remote_url,
     needs_httpfs,
-    remote_write_context,
     setup_aws_profile_if_needed,
 )
 
@@ -86,7 +87,7 @@ from geoparquet_io.core.remote import (
 
 
 @contextmanager
-def _staged_output(output_file, profile):
+def _staged_output(output_file: str) -> Iterator[str]:
     """The path a rewrite writes to, put over *output_file* once it is closed.
 
     A ``COPY`` whose destination already exists is not a plain write: DuckDB
@@ -95,57 +96,64 @@ def _staged_output(output_file, profile):
     DuckDB moved over was the file the same statement was reading, and nothing
     but the scheduler ordered the release of the scan handle against the move.
     POSIX does not care. Windows refuses to rename over a path any handle still
-    holds open, so the command died with ``IO Error: Could not move file: Access
-    is denied.`` -- in some runs of the same commit and not others, which is
-    what an intermittent windows-latest failure with no local reproduction looks
-    like (#1032).
+    holds open: ``IO Error: Could not move file: Access is denied.``, in some
+    runs of the same commit and not others (#1032).
 
-    Staging beside the output and swapping afterwards moves the rename out of
-    DuckDB's hands and to a point where the connection is closed and every
-    PyArrow reader the write opened on the input -- the ``get_parquet_metadata``
-    read and the ``input_file=`` witness that #1009 made unconditional -- is
-    gone. ``add_bbox_metadata`` and ``fix_spatial_ordering`` already work this
-    way; this is the same pattern for the other three.
+    So the rule here is *any existing local destination* is staged -- not only
+    one that is the input. That is stronger than the ``is_same_file_path`` test
+    the rest of the module asks, on purpose: the hazard is DuckDB moving over an
+    existing file, whichever file it is, and it cannot be defeated by two
+    spellings of one path. The swap is gpio's own ``os.replace()``, after the
+    caller has closed its connection and every reader the write opened.
 
-    A destination that does not exist yet needs none of it: there is no file to
-    move over. So does a remote one, which ``write_parquet_with_metadata``
-    already routes through its own local staging and upload.
+    A destination that does not exist yet needs none of it. Neither does a
+    remote one: ``write_parquet_with_metadata`` stages a remote output locally
+    and uploads it, and there is no file on this machine to rename over.
     """
     if is_remote_url(output_file) or not os.path.exists(output_file):
         yield output_file
         return
 
     staging = _staging_path_beside(output_file)
-    moved = False
     try:
         yield staging
-        _move_temp_output_into_place(staging, output_file, profile)
-        moved = True
+        # The rewrite takes the original's mode: DuckDB created the staging
+        # file from the umask, and a 0600 file should not come out 0644.
+        with contextlib.suppress(OSError):
+            shutil.copymode(output_file, staging)
+        # os.replace() is atomic on POSIX and Windows for two paths on one
+        # filesystem, which _staging_path_beside() guarantees. The destination
+        # is never unlinked or truncated first, so a failure here leaves the
+        # original intact (#959).
+        os.replace(staging, output_file)
     finally:
-        # Only ever discard the rewrite when it did NOT reach the destination
-        # -- the original is still in place, and under `--no-backup` there is
-        # no .bak to fall back on (#959).
-        if not moved and os.path.exists(staging):
-            os.remove(staging)
+        # Gone after a successful replace. Still here after a failed write or a
+        # failed move -- and discarded either way: the untouched original is the
+        # good copy, and a dot-prefixed leftover in the user's data directory
+        # would be invisible to `ls` and accumulate. Cleanup must not mask the
+        # error that got us here.
+        if os.path.exists(staging):
+            with contextlib.suppress(OSError):
+                os.remove(staging)
 
 
 def _rewrite_through_staging(
-    parquet_file,
-    output_file,
-    query,
+    parquet_file: str,
+    output_file: str,
+    query: str,
     *,
-    verbose,
-    profile,
-    geoparquet_version=None,
-    original_metadata=None,
-):
+    verbose: bool,
+    profile: str | None,
+    geoparquet_version: str | None = None,
+    original_metadata: dict | None = None,
+) -> None:
     """Run *query* over *parquet_file* and leave the result at *output_file*.
 
     The one rewrite the three ``COPY``-based fixes share: staged output, one
     DuckDB connection closed before the swap, and the input named as the write
     facade's witness.
     """
-    with _staged_output(output_file, profile) as destination:
+    with _staged_output(output_file) as destination:
         con = get_duckdb_connection(load_spatial=True, load_httpfs=needs_httpfs(parquet_file))
         try:
             write_parquet_with_metadata(
@@ -380,24 +388,16 @@ def fix_spatial_ordering(parquet_file, output_file, verbose=False, profile=None)
     if verbose:
         debug("Applying Hilbert spatial ordering (this may take a while)...")
 
-    # An in-place fix has to be routed through a temp file: hilbert_order() reads
-    # the whole input while writing, so handle_output_overwrite() refuses an
-    # output that resolves to its own input, and `overwrite=True` does not lift
-    # that. This function was the only fix_* that handed the path straight
-    # through, which is why `check spatial --fix` alone could not repair a file
-    # in place; fix_compression() and fix_bbox_all() already route the same way
-    # (#941).
-    actual_output = output_file
-    temp_output_file = None
-    moved_into_place = False
-    if is_same_file_path(parquet_file, output_file):
-        temp_output_file = _staging_path_beside(output_file)
-        actual_output = temp_output_file
-
-    try:
+    # An in-place fix has to be routed through a staging file: hilbert_order()
+    # reads the whole input while writing, so handle_output_overwrite() refuses
+    # an output that resolves to its own input, and `overwrite=True` does not
+    # lift that (#941). Same staging as the three COPY-based fixes; a remote
+    # in-place fix is not staged, so hilbert_order's own refusal is what the
+    # user sees rather than a half-finished upload.
+    with _staged_output(output_file) as destination:
         hilbert_order(
             input_parquet=parquet_file,
-            output_parquet=actual_output,
+            output_parquet=destination,
             add_bbox_flag=False,  # bbox should already be added if needed
             verbose=verbose,
             compression="ZSTD",
@@ -406,17 +406,6 @@ def fix_spatial_ordering(parquet_file, output_file, verbose=False, profile=None)
             profile=profile,
             overwrite=True,  # check --fix manages file lifecycle
         )
-
-        if temp_output_file:
-            _move_temp_output_into_place(temp_output_file, output_file, profile)
-            moved_into_place = True
-    finally:
-        # Only ever discard the rewrite when it did NOT reach the destination.
-        # Deleting it unconditionally destroyed the only good copy of the data
-        # whenever the move failed -- ENOSPC, a read-only mount, a quota -- and
-        # under `--fix --no-backup` there is no .bak to fall back on (#959).
-        if temp_output_file and not moved_into_place and os.path.exists(temp_output_file):
-            os.remove(temp_output_file)
 
     return {"fix_applied": "Applied Hilbert spatial ordering", "success": True}
 
@@ -429,29 +418,16 @@ def _staging_path_beside(output_file):
     multi-GB in-place fix exhaust a tmpfs the destination would have
     accommodated, and degrades the move back into a copy+unlink -- which is what
     makes it non-atomic. Co-locating keeps ``os.replace()`` a rename. The dot
-    prefix keeps the in-flight file out of the ``*.parquet`` globs that walk a
-    partition directory.
+    prefix keeps the in-flight file out of ``glob.glob("*.parquet")`` and out
+    of a plain ``ls`` -- not out of ``pathlib.Path.glob``, which matches
+    dotfiles, so an orphan left by a hard kill is still visible to gpio's own
+    directory walks.
     """
     directory = None if is_remote_url(output_file) else (os.path.dirname(output_file) or ".")
     fd, temp_path = tempfile.mkstemp(dir=directory, prefix=".gpio-fix-", suffix=".parquet")
     os.close(fd)
     os.unlink(temp_path)
     return temp_path
-
-
-def _move_temp_output_into_place(temp_output_file, output_file, profile):
-    """Put a temp-file rewrite back over the path it was produced from."""
-    if is_remote_url(output_file):
-        with remote_write_context(output_file, profile=profile) as remote_path:
-            shutil.copy2(temp_output_file, remote_path)
-        os.remove(temp_output_file)
-        return
-
-    # os.replace() is atomic on POSIX and Windows for two paths on one
-    # filesystem, which _staging_path_beside() guarantees. The destination is
-    # never unlinked or truncated first, so a failure here leaves the original
-    # file intact and the rewrite still sitting in the temp file (#959).
-    os.replace(temp_output_file, output_file)
 
 
 def fix_row_groups(parquet_file, output_file, verbose=False, profile=None, geoparquet_version=None):

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -239,8 +239,12 @@ def get_parquet_metadata(parquet_file, verbose=False):
         # Create a simple object that mimics PyArrow schema for basic usage
         schema = _DuckDBSchemaWrapper(schema_info)
     else:
-        pf = pq.ParquetFile(file_to_check)
-        schema = pf.schema_arrow
+        # Closed before returning, not left to the collector. `check compression
+        # --fix` and `check row-group --fix` call this on the file they then
+        # rewrite in place, and Windows refuses to rename over a path this
+        # process still holds open (#1032).
+        with pq.ParquetFile(file_to_check) as pf:
+            schema = pf.schema_arrow
 
     if verbose and kv_metadata:
         debug("\nParquet metadata key-value pairs:")

--- a/geoparquet_io/core/duckdb_metadata.py
+++ b/geoparquet_io/core/duckdb_metadata.py
@@ -52,10 +52,12 @@ def _resolve_local_path(parquet_file: str) -> str:
 
 def _pyarrow_get_kv_metadata(parquet_file: str) -> dict[bytes, bytes]:
     """Get key-value metadata using PyArrow (fast path for local files)."""
-    pf = None
     try:
-        pf = pq.ParquetFile(parquet_file)
-        metadata = pf.metadata.metadata
+        # Closed on exit, not left to the collector: an in-place `check --fix`
+        # renames over this file next, and Windows refuses while a reader holds
+        # it (#1032).
+        with pq.ParquetFile(parquet_file) as pf:
+            metadata = pf.metadata.metadata
         return dict(metadata) if metadata else {}
     except Exception as e:
         error_msg = str(e)
@@ -66,17 +68,13 @@ def _pyarrow_get_kv_metadata(parquet_file: str) -> dict[bytes, bytes]:
                 f"Hint: Use 'gpio convert geoparquet' to convert other formats."
             ) from e
         raise GeoParquetError(f"Cannot read file: {parquet_file}\n{error_msg}") from e
-    finally:
-        # Explicitly delete ParquetFile to release file handle (Windows compatibility)
-        del pf
 
 
 def _pyarrow_get_geo_metadata(parquet_file: str) -> dict | None:
     """Get and parse 'geo' metadata using PyArrow (fast path for local files)."""
-    pf = None
     try:
-        pf = pq.ParquetFile(parquet_file)
-        metadata = pf.metadata.metadata
+        with pq.ParquetFile(parquet_file) as pf:
+            metadata = pf.metadata.metadata
         if metadata and b"geo" in metadata:
             return json.loads(metadata[b"geo"].decode("utf-8"))
         return None
@@ -93,9 +91,6 @@ def _pyarrow_get_geo_metadata(parquet_file: str) -> dict | None:
                 f"Hint: Use 'gpio convert' to convert other formats to GeoParquet."
             ) from e
         raise GeoParquetError(f"Cannot read file: {parquet_file}\n{error_msg}") from e
-    finally:
-        # Explicitly delete ParquetFile to release file handle (Windows compatibility)
-        del pf
 
 
 def _pyarrow_get_file_metadata(parquet_file: str) -> dict:
@@ -118,11 +113,10 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
     Returns list of dicts matching DuckDB's parquet_schema() format,
     or None if PyArrow cannot handle the file (e.g., unsupported CRS format).
     """
-    pf = None
     try:
-        pf = pq.ParquetFile(parquet_file)
-        schema = pf.schema_arrow
-        parquet_schema = pf.schema  # Physical Parquet schema
+        with pq.ParquetFile(parquet_file) as pf:
+            schema = pf.schema_arrow
+            parquet_schema = pf.schema  # Physical Parquet schema
         result = []
 
         # Build a map from column name to Parquet physical schema for logical type lookup
@@ -218,9 +212,6 @@ def _pyarrow_get_schema_info(parquet_file: str) -> list[dict] | None:
         raise GeoParquetError(f"Cannot read schema: {parquet_file}\n{str(e)}") from e
     except Exception as e:
         raise GeoParquetError(f"Cannot read schema: {parquet_file}\n{str(e)}") from e
-    finally:
-        # Explicitly delete ParquetFile to release file handle (Windows compatibility)
-        del pf
 
 
 def _format_geometry_type_crs(crs) -> str:

--- a/geoparquet_io/core/parquet_write.py
+++ b/geoparquet_io/core/parquet_write.py
@@ -319,8 +319,11 @@ def _plain_copy_to(
     if verbose:
         import pyarrow.parquet as pq
 
-        pf = pq.ParquetFile(output_path)
-        success(f"Wrote {pf.metadata.num_rows:,} rows to {output_path}")
+        # Closed before the caller moves or uploads this file: `--verbose` must
+        # not be the difference between a fix that lands and one that dies on
+        # `Could not move file: Access is denied` (#1023, #1032).
+        with pq.ParquetFile(output_path) as pf:
+            success(f"Wrote {pf.metadata.num_rows:,} rows to {output_path}")
 
 
 def _prune_metadata_to_output_columns(

--- a/tests/test_check_fix_inplace_handles.py
+++ b/tests/test_check_fix_inplace_handles.py
@@ -1,0 +1,296 @@
+"""``gpio check --fix`` must not rename a file anything still has open.
+
+An in-place ``--fix`` used to hand DuckDB its own input as the ``COPY`` target.
+DuckDB writes ``tmp_<name>`` beside an existing destination and then *moves* that
+onto it -- so the file being moved over was the file the same statement was
+reading, and the two events are ordered by nothing but the scheduler. POSIX does
+not care: a rename over an open file succeeds and the reader keeps its inode.
+Windows refuses, and the whole command dies with::
+
+    Error: IO Error: Could not move file: Access is denied.
+
+which is why ``test_geo_native_file_loses_its_bbox_column`` failed on
+``windows-latest, 3.11`` in some runs and passed in others, on the same commit.
+#1009 widened the window rather than opening it: it added an unconditional
+``get_parquet_metadata()`` read and an ``input_file=`` witness to those rewrites,
+both of which open the destination with PyArrow immediately before the ``COPY``.
+
+The tests below are the invariant, not the error -- there is no Windows runner
+here, and a test that waits for "Access is denied" would never fail on this
+machine. Both are checked on every platform:
+
+1. no ``COPY`` a fix issues writes to the file it is reading, and
+2. the swap that puts a rewrite over the user's file is gpio's own
+   ``os.replace()``, called when nothing in this process holds that path open --
+   no live ``pyarrow.parquet.ParquetFile``, no unclosed DuckDB connection that
+   has named it.
+
+Refs: https://github.com/geoparquet/geoparquet-io/issues/1032
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import weakref
+from dataclasses import dataclass, field
+from itertools import count
+from pathlib import Path
+
+import duckdb
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from geoparquet_io.cli.main import cli
+from geoparquet_io.core import check_fixes
+from geoparquet_io.core.exceptions import RemoteAccessError
+from geoparquet_io.core.file_utils import is_same_file_path
+
+# `COPY (...) TO '<path>' (...)`, with the SQL-literal doubling undone by the
+# caller. DuckDB is the only writer that moves a file gpio did not name.
+_COPY_TO = re.compile(r"\bCOPY\b.*?\bTO\b\s+'((?:[^']|'')*)'", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass
+class _Rename:
+    """One ``os.replace()``, and what still held its destination open."""
+
+    source: str
+    destination: str
+    holders: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _Probe:
+    copy_destinations: list[str] = field(default_factory=list)
+    renames: list[_Rename] = field(default_factory=list)
+
+    def swaps_onto(self, path) -> list[_Rename]:
+        return [r for r in self.renames if is_same_file_path(r.destination, str(path))]
+
+    def copies_onto(self, path) -> list[str]:
+        return [d for d in self.copy_destinations if is_same_file_path(d, str(path))]
+
+
+@pytest.fixture
+def fix_probe(monkeypatch):
+    """Watch every DuckDB ``COPY``, every ``os.replace()``, and every open handle.
+
+    Handles are tracked at the Python level rather than through the OS: a
+    ``ParquetFile`` is registered on construction and drops out of the weak
+    mapping the moment it is collected, and a DuckDB connection is remembered
+    against every path its SQL names until it is closed. That is what "open on
+    Windows" means here, and unlike an ``/proc``-style descriptor scan it reads
+    the same on macOS, Linux and Windows.
+    """
+    probe = _Probe()
+    live_readers: weakref.WeakValueDictionary[int, pq.ParquetFile] = weakref.WeakValueDictionary()
+    reader_paths: dict[int, str] = {}
+    connection_paths: dict[int, set[str]] = {}
+    ids = count()
+
+    def holders_of(path: str) -> list[str]:
+        held = [
+            f"pyarrow.ParquetFile({reader_paths[key]})"
+            for key in list(live_readers)
+            if key in reader_paths and is_same_file_path(reader_paths[key], path)
+        ]
+        held += [
+            f"open duckdb connection that read {path}"
+            for paths in connection_paths.values()
+            if any(is_same_file_path(seen, path) for seen in paths)
+        ]
+        return held
+
+    original_reader_init = pq.ParquetFile.__init__
+
+    def reader_init(self, source, *args, **kwargs):
+        original_reader_init(self, source, *args, **kwargs)
+        if isinstance(source, (str, os.PathLike)):
+            key = next(ids)
+            live_readers[key] = self
+            reader_paths[key] = str(source)
+
+    original_execute = duckdb.DuckDBPyConnection.execute
+    original_close = duckdb.DuckDBPyConnection.close
+
+    def execute(self, query, *args, **kwargs):
+        if isinstance(query, str):
+            destination = _COPY_TO.search(query)
+            if destination:
+                probe.copy_destinations.append(destination.group(1).replace("''", "'"))
+            connection_paths.setdefault(id(self), set()).update(
+                literal.replace("''", "'") for literal in re.findall(r"'((?:[^']|'')*)'", query)
+            )
+        return original_execute(self, query, *args, **kwargs)
+
+    def close(self):
+        connection_paths.pop(id(self), None)
+        return original_close(self)
+
+    original_replace = os.replace
+
+    def replace(src, dst, **kwargs):
+        probe.renames.append(_Rename(str(src), str(dst), holders_of(str(dst))))
+        return original_replace(src, dst, **kwargs)
+
+    monkeypatch.setattr(pq.ParquetFile, "__init__", reader_init)
+    monkeypatch.setattr(duckdb.DuckDBPyConnection, "execute", execute)
+    monkeypatch.setattr(duckdb.DuckDBPyConnection, "close", close)
+    monkeypatch.setattr(os, "replace", replace)
+    return probe
+
+
+# ---------------------------------------------------------------------------
+# Inputs: one per fix, each with exactly the defect its `--fix` repairs, so the
+# rewrite actually runs. A fix that no-ops proves nothing about its rename.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def undeclared_bbox_file(fields_geom_type_only_file, tmp_path):
+    """Native-geo-only with a bbox column: ``check bbox --fix`` removes it."""
+    target = tmp_path / "pgo_with_bbox.parquet"
+    shutil.copy(fields_geom_type_only_file, target)
+    return target
+
+
+@pytest.fixture
+def tiny_row_group_file(places_test_file, tmp_path):
+    """Five-row row groups: ``check row-group --fix`` merges them."""
+    target = tmp_path / "tiny_groups.parquet"
+    with pq.ParquetFile(places_test_file) as reader:
+        table = reader.read()
+    pq.write_table(table, target, row_group_size=5, compression="zstd")
+    return target
+
+
+@pytest.fixture
+def snappy_file(places_test_file, tmp_path):
+    """SNAPPY: ``check compression --fix`` re-compresses it."""
+    target = tmp_path / "snappy.parquet"
+    with pq.ParquetFile(places_test_file) as reader:
+        table = reader.read()
+    pq.write_table(table, target, compression="snappy")
+    return target
+
+
+IN_PLACE_FIXES = [
+    pytest.param("bbox", "undeclared_bbox_file", id="bbox"),
+    pytest.param("row-group", "tiny_row_group_file", id="row-group"),
+    pytest.param("compression", "snappy_file", id="compression"),
+]
+
+
+def _run_fix(subcommand: str, target) -> None:
+    result = CliRunner().invoke(cli, ["check", subcommand, str(target), "--fix"])
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize(("subcommand", "fixture_name"), IN_PLACE_FIXES)
+def test_an_in_place_fix_never_copies_over_the_file_it_is_reading(
+    subcommand, fixture_name, request, fix_probe
+):
+    """DuckDB's ``COPY`` must never be pointed at its own source.
+
+    This is the defect itself: ``COPY (SELECT ... FROM 'f.parquet') TO
+    'f.parquet'`` makes DuckDB move ``tmp_f.parquet`` onto the file its own scan
+    has open. gpio stages the rewrite beside the output instead and does the
+    swap itself, once everything is closed.
+    """
+    target = request.getfixturevalue(fixture_name)
+
+    _run_fix(subcommand, target)
+
+    assert fix_probe.copy_destinations, "no COPY ran -- the fix did not do any work"
+    assert fix_probe.copies_onto(target) == [], (
+        f"`check {subcommand} --fix` asked DuckDB to write over the file it reads"
+    )
+
+
+@pytest.mark.parametrize(("subcommand", "fixture_name"), IN_PLACE_FIXES)
+def test_an_in_place_fix_swaps_its_rewrite_in_with_nothing_holding_the_file_open(
+    subcommand, fixture_name, request, fix_probe
+):
+    """gpio owns the rename, and nothing holds the destination when it happens."""
+    target = request.getfixturevalue(fixture_name)
+
+    _run_fix(subcommand, target)
+
+    swaps = fix_probe.swaps_onto(target)
+    assert swaps, f"`check {subcommand} --fix` never renamed its rewrite over the user's file"
+    for swap in swaps:
+        assert swap.holders == [], (
+            f"`check {subcommand} --fix` renamed over {swap.destination} while "
+            f"{swap.holders} still held it open"
+        )
+
+
+@pytest.mark.parametrize(("subcommand", "fixture_name"), IN_PLACE_FIXES)
+def test_an_in_place_fix_still_repairs_the_file_and_leaves_a_backup(
+    subcommand, fixture_name, request
+):
+    """Non-vacuity: the staged rewrite is the file the user is left with."""
+    target = request.getfixturevalue(fixture_name)
+    before = target.read_bytes()
+
+    _run_fix(subcommand, target)
+
+    assert target.read_bytes() != before, "the fix left the file untouched"
+    backup = target.with_name(target.name + ".bak")
+    assert backup.exists() and backup.read_bytes() == before
+    assert list(target.parent.glob(".gpio-fix-*")) == [], "a staging file was left behind"
+
+
+# ---------------------------------------------------------------------------
+# What a failed rewrite leaves behind. Staging only helps if the file the user
+# already has survives the staging step going wrong.
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_rewrite_keeps_the_original_and_removes_the_staging_file(tmp_path, monkeypatch):
+    """The #959 rule, one function on: never discard a rewrite that landed, and
+    never leave one that did not.
+
+    The original is still the only copy of the data at this point -- under
+    ``--fix --no-backup`` there is no ``.bak`` -- so a staged write that raises
+    must leave it untouched and take its own scratch file with it.
+    """
+    target = tmp_path / "unchanged.parquet"
+    target.write_bytes(b"the original bytes")
+
+    def explode(**kwargs):
+        # Half a file, the way a write that runs out of disk leaves one.
+        Path(kwargs["output_file"]).write_bytes(b"half a parquet file")
+        raise duckdb.IOException("disk went away")
+
+    monkeypatch.setattr(check_fixes, "write_parquet_with_metadata", explode)
+
+    with pytest.raises(duckdb.IOException):
+        check_fixes._rewrite_through_staging(
+            str(target), str(target), "SELECT 1", verbose=False, profile=None
+        )
+
+    assert target.read_bytes() == b"the original bytes"
+    assert list(tmp_path.glob(".gpio-fix-*")) == [], "a staging file was left behind"
+
+
+def test_a_remote_rewrite_that_cannot_read_its_input_says_so(monkeypatch):
+    """A remote input keeps its credential/endpoint hint through the staging move."""
+
+    def explode(**kwargs):
+        raise duckdb.IOException("HTTP 403")
+
+    monkeypatch.setattr(check_fixes, "write_parquet_with_metadata", explode)
+    monkeypatch.setattr(check_fixes, "get_duckdb_connection", lambda **kwargs: duckdb.connect())
+
+    with pytest.raises(RemoteAccessError):
+        check_fixes._rewrite_through_staging(
+            "s3://bucket/in.parquet",
+            "s3://bucket/out.parquet",
+            "SELECT 1",
+            verbose=False,
+            profile=None,
+        )

--- a/tests/test_check_fix_inplace_handles.py
+++ b/tests/test_check_fix_inplace_handles.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 import os
 import re
 import shutil
-import weakref
 from dataclasses import dataclass, field
 from itertools import count
 from pathlib import Path
@@ -55,11 +54,16 @@ _COPY_TO = re.compile(r"\bCOPY\b.*?\bTO\b\s+'((?:[^']|'')*)'", re.IGNORECASE | r
 
 @dataclass
 class _Rename:
-    """One ``os.replace()``, and what still held its destination open."""
+    """One ``os.replace()``, and what still held either of its paths open.
+
+    Windows refuses ``MoveFileEx`` when *either* the source or the destination
+    has an open handle, so both are recorded.
+    """
 
     source: str
     destination: str
     holders: list[str] = field(default_factory=list)
+    source_holders: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -78,24 +82,27 @@ class _Probe:
 def fix_probe(monkeypatch):
     """Watch every DuckDB ``COPY``, every ``os.replace()``, and every open handle.
 
-    Handles are tracked at the Python level rather than through the OS: a
-    ``ParquetFile`` is registered on construction and drops out of the weak
-    mapping the moment it is collected, and a DuckDB connection is remembered
-    against every path its SQL names until it is closed. That is what "open on
-    Windows" means here, and unlike an ``/proc``-style descriptor scan it reads
-    the same on macOS, Linux and Windows.
+    Handles are tracked at the Python level rather than through the OS, and by
+    *discipline* rather than by liveness: a ``ParquetFile`` counts as a holder
+    from construction until its ``close()`` (which ``with`` calls), and a DuckDB
+    connection is remembered against every path its SQL names until it is
+    closed. Liveness would not do -- on CPython a reader bound to a local is
+    collected at function return whether or not anyone closed it, so a probe
+    keyed on liveness read the un-``with``ed reads in ``get_parquet_metadata``
+    and the pyarrow fast paths as already gone, and passed with them reverted.
+    That is what "open on Windows" means here, and unlike an ``/proc``-style
+    descriptor scan it reads the same on macOS, Linux and Windows.
     """
     probe = _Probe()
-    live_readers: weakref.WeakValueDictionary[int, pq.ParquetFile] = weakref.WeakValueDictionary()
-    reader_paths: dict[int, str] = {}
+    unclosed_readers: dict[int, str] = {}
     connection_paths: dict[int, set[str]] = {}
     ids = count()
 
     def holders_of(path: str) -> list[str]:
         held = [
-            f"pyarrow.ParquetFile({reader_paths[key]})"
-            for key in list(live_readers)
-            if key in reader_paths and is_same_file_path(reader_paths[key], path)
+            f"pyarrow.ParquetFile({seen}) never closed"
+            for seen in unclosed_readers.values()
+            if is_same_file_path(seen, path)
         ]
         held += [
             f"open duckdb connection that read {path}"
@@ -105,13 +112,17 @@ def fix_probe(monkeypatch):
         return held
 
     original_reader_init = pq.ParquetFile.__init__
+    original_reader_close = pq.ParquetFile.close
 
     def reader_init(self, source, *args, **kwargs):
         original_reader_init(self, source, *args, **kwargs)
         if isinstance(source, (str, os.PathLike)):
-            key = next(ids)
-            live_readers[key] = self
-            reader_paths[key] = str(source)
+            self._probe_key = next(ids)
+            unclosed_readers[self._probe_key] = str(source)
+
+    def reader_close(self, *args, **kwargs):
+        unclosed_readers.pop(getattr(self, "_probe_key", None), None)
+        return original_reader_close(self, *args, **kwargs)
 
     original_execute = duckdb.DuckDBPyConnection.execute
     original_close = duckdb.DuckDBPyConnection.close
@@ -133,10 +144,13 @@ def fix_probe(monkeypatch):
     original_replace = os.replace
 
     def replace(src, dst, **kwargs):
-        probe.renames.append(_Rename(str(src), str(dst), holders_of(str(dst))))
+        probe.renames.append(
+            _Rename(str(src), str(dst), holders_of(str(dst)), holders_of(str(src)))
+        )
         return original_replace(src, dst, **kwargs)
 
     monkeypatch.setattr(pq.ParquetFile, "__init__", reader_init)
+    monkeypatch.setattr(pq.ParquetFile, "close", reader_close)
     monkeypatch.setattr(duckdb.DuckDBPyConnection, "execute", execute)
     monkeypatch.setattr(duckdb.DuckDBPyConnection, "close", close)
     monkeypatch.setattr(os, "replace", replace)
@@ -226,6 +240,10 @@ def test_an_in_place_fix_swaps_its_rewrite_in_with_nothing_holding_the_file_open
             f"`check {subcommand} --fix` renamed over {swap.destination} while "
             f"{swap.holders} still held it open"
         )
+        assert swap.source_holders == [], (
+            f"`check {subcommand} --fix` renamed {swap.source} while "
+            f"{swap.source_holders} still held it open"
+        )
 
 
 @pytest.mark.parametrize(("subcommand", "fixture_name"), IN_PLACE_FIXES)
@@ -275,6 +293,62 @@ def test_a_failed_rewrite_keeps_the_original_and_removes_the_staging_file(tmp_pa
 
     assert target.read_bytes() == b"the original bytes"
     assert list(tmp_path.glob(".gpio-fix-*")) == [], "a staging file was left behind"
+
+
+def test_a_failed_move_keeps_the_original_and_discards_the_rewrite(tmp_path, monkeypatch):
+    """The other half of #959: the swap itself fails (ENOSPC, EXDEV, a quota).
+
+    The original was never unlinked, so it is intact and is the good copy. The
+    completed rewrite is discarded rather than left as a dot-prefixed orphan --
+    the user re-runs the fix; they do not go looking for a hidden file.
+    """
+    target = tmp_path / "precious.parquet"
+    target.write_bytes(b"the original bytes")
+
+    def write_something(**kwargs):
+        Path(kwargs["output_file"]).write_bytes(b"a complete rewrite")
+
+    def no_space(*_args, **_kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(check_fixes, "write_parquet_with_metadata", write_something)
+    monkeypatch.setattr(check_fixes, "get_duckdb_connection", lambda **kwargs: duckdb.connect())
+    monkeypatch.setattr(os, "replace", no_space)
+
+    with pytest.raises(OSError, match="No space left on device"):
+        check_fixes._rewrite_through_staging(
+            str(target), str(target), "SELECT 1", verbose=False, profile=None
+        )
+
+    assert target.read_bytes() == b"the original bytes"
+    assert list(tmp_path.glob(".gpio-fix-*")) == [], "a staging file was left behind"
+
+
+def test_a_remote_in_place_fix_is_handed_to_the_facade_unstaged(monkeypatch):
+    """``check row-group s3://b/k.parquet --fix --overwrite``: nothing to rename over here.
+
+    The facade stages a remote output locally and uploads it. Staging it a
+    second time on this machine and then trying to ``os.replace`` onto a URL is
+    how the first version of this fix's sibling (#1029) turned a working command
+    into a ``TypeError``.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr(
+        check_fixes,
+        "write_parquet_with_metadata",
+        lambda con, query, output_file, **kwargs: seen.append(output_file),
+    )
+    monkeypatch.setattr(check_fixes, "get_duckdb_connection", lambda **kwargs: duckdb.connect())
+
+    check_fixes._rewrite_through_staging(
+        "s3://bucket/key.parquet",
+        "s3://bucket/key.parquet",
+        "SELECT 1",
+        verbose=False,
+        profile=None,
+    )
+
+    assert seen == ["s3://bucket/key.parquet"]
 
 
 def test_a_remote_rewrite_that_cannot_read_its_input_says_so(monkeypatch):

--- a/tests/test_check_fixes_core.py
+++ b/tests/test_check_fixes_core.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
@@ -12,7 +11,6 @@ import pytest
 
 from geoparquet_io.core import check_fixes
 from geoparquet_io.core.check_fixes import (
-    _move_temp_output_into_place,
     fix_bbox_column,
     fix_bbox_metadata,
     fix_bbox_removal,
@@ -477,11 +475,11 @@ class TestFixSpatialOrdering:
     def test_a_failed_move_leaves_the_original_intact(self, places_test_file, temp_output_dir):
         """A move that fails must not take the only good copy of the data with it.
 
-        The whole destructive step lives in ``_move_temp_output_into_place``, so
-        if it raises, the ``finally`` must not go on to delete the rewrite *and*
-        leave the caller with nothing. Under ``--fix --no-backup`` there is no
-        ``.bak`` to fall back on, and a direct caller of this function has no
-        ``.bak`` concept at all.
+        The whole destructive step is the ``os.replace()`` inside
+        ``_staged_output``, so if it raises, the original -- never unlinked --
+        is exactly as it was. Under ``--fix --no-backup`` there is no ``.bak``
+        to fall back on, and a direct caller of this function has no ``.bak``
+        concept at all.
         """
         target = os.path.join(temp_output_dir, "precious.parquet")
         shutil.copy2(places_test_file, target)
@@ -495,77 +493,14 @@ class TestFixSpatialOrdering:
 
         with (
             mock.patch.object(check_fixes, "hilbert_order", side_effect=copy_into_place),
-            mock.patch.object(check_fixes, "_move_temp_output_into_place", side_effect=no_space),
+            mock.patch.object(os, "replace", side_effect=no_space),
             pytest.raises(OSError, match="No space left on device"),
         ):
             fix_spatial_ordering(target, target, verbose=False)
 
         assert os.path.exists(target), "the in-place fix destroyed the original file"
         assert Path(target).read_bytes() == original_bytes
-
-
-class TestMoveTempOutputIntoPlace:
-    """The temp-file rewrite lands on both local and remote destinations."""
-
-    def test_local_destination_is_replaced(self, tmp_path):
-        temp_file = tmp_path / "temp.parquet"
-        temp_file.write_bytes(b"new")
-        destination = tmp_path / "dest.parquet"
-        destination.write_bytes(b"old")
-
-        _move_temp_output_into_place(str(temp_file), str(destination), None)
-
-        assert destination.read_bytes() == b"new"
-        assert not temp_file.exists()
-
-    def test_a_failed_replace_does_not_destroy_the_destination(self, tmp_path):
-        """ENOSPC mid-move must leave the destination exactly as it was.
-
-        Unlinking the destination and *then* moving leaves a window in which an
-        ``OSError`` -- ENOSPC (likely precisely when fixing a large file in
-        place), a read-only mount, a quota, EXDEV -- destroys the original with
-        the rewrite still only in the temp file. ``os.replace()`` is atomic on
-        POSIX and Windows for two paths on one filesystem, which co-locating the
-        temp guarantees, so there is no such window.
-        """
-        temp_file = tmp_path / "temp.parquet"
-        temp_file.write_bytes(b"new")
-        destination = tmp_path / "dest.parquet"
-        destination.write_bytes(b"old")
-
-        def no_space(*_args, **_kwargs):
-            raise OSError(28, "No space left on device")
-
-        # Whichever primitive puts the rewrite back, a failure must be survivable.
-        with (
-            mock.patch("os.replace", side_effect=no_space),
-            mock.patch("shutil.move", side_effect=no_space),
-            pytest.raises(OSError, match="No space left on device"),
-        ):
-            _move_temp_output_into_place(str(temp_file), str(destination), None)
-
-        assert destination.exists(), "the destination was destroyed by a failed move"
-        assert destination.read_bytes() == b"old"
-        assert temp_file.read_bytes() == b"new"
-
-    def test_remote_destination_is_uploaded(self, tmp_path):
-        temp_file = tmp_path / "temp.parquet"
-        temp_file.write_bytes(b"new")
-        staged = tmp_path / "staged.parquet"
-
-        @contextmanager
-        def fake_remote_write_context(path, profile=None):
-            yield str(staged)
-
-        with (
-            mock.patch.object(check_fixes, "is_remote_url", return_value=True),
-            mock.patch.object(
-                check_fixes, "remote_write_context", side_effect=fake_remote_write_context
-            ),
-        ):
-            _move_temp_output_into_place(str(temp_file), "s3://bucket/dest.parquet", "myprofile")
-
-        assert staged.read_bytes() == b"new"
+        assert list(Path(temp_output_dir).glob(".gpio-fix-*")) == []
 
 
 class TestInPlaceFixOperations:


### PR DESCRIPTION
## What changed

`gpio check bbox --fix`, `check row-group --fix` and `check compression --fix` no longer ask DuckDB to write a file over the one it is reading. All three now stage the rewrite beside the output, close the connection, and do the rename themselves.

## Why

`check --fix` defaults to repairing the file in place, so `fix_bbox_removal` handed `write_parquet_with_metadata` an `output_file` that *is* its `parquet_file`:

```sql
COPY (SELECT * EXCLUDE ("bbox") FROM 'f.parquet') TO 'f.parquet' (...)
```

A DuckDB `COPY` whose destination already exists is not a plain write. Measured locally (macOS, DuckDB 1.5), polling open descriptors through one such statement:

```
 0.00ms  open: ['f.parquet']                    <- the scan
 5.74ms  open: ['f.parquet', 'tmp_f.parquet']   <- the writer
12.21ms  open: ['tmp_f.parquet']                <- scan handle released
39.97ms  tmp_f.parquet gone                     <- MoveFile onto f.parquet
```

DuckDB writes `tmp_<name>` beside the destination and then **moves** it on top — onto the file the same statement has open. POSIX renames over an open file happily. Windows refuses, and nothing but the scheduler orders those last two events, which is why

```
FAILED tests/test_check_cli_guards.py::TestBboxFixReporting::test_geo_native_file_loses_its_bbox_column
E   AssertionError:
E     Error: IO Error: Could not move file: Access is denied.
```

failed on `windows-latest, 3.11` for #1016 (run 34687636322) and #1010 while 3.12/3.13 of the same runs were green, and never reproduced here.

**#1009 did not open the window, it widened it.** It added an unconditional `get_parquet_metadata()` read and an `input_file=` witness (`resolve_output_geoparquet_version` → `detect_geoparquet_file_type`, `resolve_input_crs` → `extract_crs_from_parquet`) to these rewrites — every one of them a PyArrow open of the destination, immediately before the `COPY`. That is why it started showing up now.

The fix is the pattern `add_bbox_metadata()` and `fix_spatial_ordering()` already use, and the three `COPY`-based fixes now share one `_rewrite_through_staging()`. `fix_compression` loses its `$TMPDIR` staging (a cross-filesystem `shutil.move`, plus a `Path(output_file).unlink()` before the move — the same Windows hazard one function along) in favour of `_staging_path_beside()` + `os.replace()`.

Two handles are also closed deterministically rather than left to the collector: `get_parquet_metadata()`'s `ParquetFile` — which since #1009 is opened on the file two of these rewrites then replace — and the `--verbose` reader in `_plain_copy_to` (already noted in #1023).

## Verification

There is no Windows runner here, so the tests are the invariant rather than the error. `tests/test_check_fix_inplace_handles.py` asserts, for each of the three in-place fixes, that

1. no `COPY` the fix issues names a destination that is the file it reads, and
2. the swap that puts the rewrite over the user's file is gpio's own `os.replace()`, called when nothing in the process holds that path open — no live `pyarrow.parquet.ParquetFile`, no unclosed DuckDB connection that has named it.

Both are checked by watching `ParquetFile.__init__`, `DuckDBPyConnection.execute/close` and `os.replace`, which reads the same on every platform.

**Sabotage proof.** With `core/check_fixes.py` reverted to main and the tests kept, on macOS:

```
5 failed, 4 passed
FAILED ...::test_an_in_place_fix_never_copies_over_the_file_it_is_reading[bbox]
FAILED ...::test_an_in_place_fix_never_copies_over_the_file_it_is_reading[row-group]
FAILED ...::test_an_in_place_fix_swaps_its_rewrite_in_with_nothing_holding_the_file_open[bbox]
FAILED ...::test_an_in_place_fix_swaps_its_rewrite_in_with_nothing_holding_the_file_open[row-group]
FAILED ...::test_an_in_place_fix_swaps_its_rewrite_in_with_nothing_holding_the_file_open[compression]
```

`compression` already staged (#959), so only its rename assertion fails; the two that pointed `COPY` at their own input fail both. With the fix restored, 11 passed.

Everything else:

- fast suite: `7733 passed, 76 skipped, 3 xfailed` in 196s
- `-m meta`: `205 passed`
- `pre-commit run --all-files` and `--hook-stage pre-push`: all green (no `--no-verify`)
- diff-cover: **100%** of 36 changed lines
- `tests/data/cli_surface.json`: unchanged

## Review addendum

Six reviews in parallel (adversarial reproduction, Python quality, security, performance, architecture, simplicity), after a rebase onto `main` that moved the `_plain_copy_to` hunk into `core/parquet_write.py` where #1011 put it. Verdict: no S1/S2 — the fix does what it says on every path, measured. What changed in the review commit:

- **The probe read liveness, not closed-ness.** Two reviewers independently reverted the `with pq.ParquetFile` hunks in `common.py` and `parquet_write.py` and watched all 11 tests stay green: a reader bound to a local is refcount-collected at function return on CPython, so a `WeakValueDictionary` never saw it. The probe now counts a reader as a holder from construction until `close()` (which `with` calls), and records holders of the swap's *source* too — Windows refuses `MoveFileEx` on either path. Reverting `get_parquet_metadata`'s `with` now fails all three swap cases. That stricter probe flushed out the three pyarrow fast paths in `duckdb_metadata.py` (`del pf` in a `finally` — not a close), which are now `with` blocks.
- **`_staged_output` lost a dead parameter and gained the swap.** `profile` only fed `_move_temp_output_into_place`'s remote branch, unreachable from the early return one line up. The helper now does `os.replace` itself (after `shutil.copymode`, so a 0600 file does not come out 0644), removes the staging file on *any* failure without masking the error, and states its rule: any existing local destination is staged — stronger than `is_same_file_path`, on purpose.
- **`fix_spatial_ordering` routes through the same helper.** That removed the last caller of `_move_temp_output_into_place`, whose remote branch called `remote_write_context(output_file, profile=profile)` — a signature the function does not have (it takes no `profile`, yields a tuple, never uploads) — and the test that certified it with a mock of that same fake signature. `check spatial s3://… --fix --overwrite` goes from a `TypeError` after the sort to `hilbert_order`'s own refusal before it. Pre-existing since #959; one of the two things #1029's review had asked this PR be held to.
- Tests added for a failed `os.replace` (original intact, no orphan) and for a remote in-place rewrite reaching the facade unstaged (the other #1029 hold). Type hints on both helpers. `_staging_path_beside`'s docstring no longer claims the dot prefix hides the file from `pathlib.Path.glob`, which matches dotfiles.

**Undeclared in the first version, measured by the reviews:** `gpio check compression in.parquet --fix --fix-output ./in.parquet --no-backup` **deleted the user's file on `main`** (`is_inplace = parquet_file == output_file` was false for the alias, so the destination was unlinked and the `$TMPDIR` move then failed with "File not found") — fixed here because `_staged_output` keys on the destination existing, not on path equality. `check compression s3://… --fix --overwrite` went from `TypeError` to working. `check compression --fix --fix-output <other existing file>` no longer unlinks the destination before writing. Peak disk for an in-place fix moved from `$TMPDIR` to the destination's filesystem (3× the file at peak; a nearly-full data volume that used to succeed by staging elsewhere can now hit ENOSPC — original intact). `check all --fix` on a native-geo input stages once more than before (its bbox step writes to a scratch that `NamedTemporaryFile` pre-creates, so it "exists"). On `main` under load, a self-overwriting `COPY` on a 396 MB file failed its rename and left `f.parquet` as a **264 MB truncated partial** — the class this PR removes; the branch's runs swapped cleanly. The first version's "5 failed, 4 passed" sabotage arithmetic was 7/4 (reverting `check_fixes.py` also removes the helper the two helper-level tests import). Fast-suite count on the rebase: 7830 passed.

Follow-ups filed rather than folded in: the other eleven in-place staging implementations in `core/` and the caller-less `atomic_write` (promote the helper to `file_utils`, ratchet the rest), a negative guard in the facade, the `check all --fix` chain's unlink-then-move and raw `==` predicates, the staging-name TOCTOU (`USE_TMP_FILE false` on a kept reservation), the probe as a shared fixture — one issue; and `check <cmd> "*.parquet" --fix` fixing only the first match — another.

## Not fixed here

Four more unclosed-`ParquetFile` sites of the same shape in `write_strategies/duckdb_kv.py`, all `--verbose`-only "Wrote N rows" reads; two of them precede a `Path(local_path).unlink()` for a remote output, which Windows would also refuse. Left out to keep this diff to the race, and noted on #1032 alongside the `_plain_copy_to` one that #1023 already tracks.

`fix_bbox_all()` and `_apply_compression_fix()` still finish with `shutil.move`, which on Windows degrades to copy + unlink when the destination exists. Same family, different mechanism, and those paths are green on Windows today.

Closes #1032. Refs #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved in-place Parquet fixes for compression, bounding boxes, row groups, and spatial ordering.
  - Prevented file access and rename failures on Windows by ensuring files are closed before replacement.
  - Preserved original files when rewrites or replacements fail.
  - Improved remote rewrite error reporting and cleanup of temporary files.

- **Tests**
  - Added regression coverage for local and remote in-place fixes, failed rewrites, replacement failures, and temporary-file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->