### PR TITLE
test: turn on branch coverage, re-base the floor to 85, drop three dead blocks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,17 +188,17 @@ jobs:
           # this is that instrumenting nine jobs to discard the result is waste
           # and obscures where the gate lives, not a matrix speedup.
           #
-          # The reporting job passes every flag explicitly because `addopts` no
-          # longer carries them: the 85% floor is enforced HERE.
-          #
-          # Branch coverage is NOT a flag here: [tool.coverage.run] branch = true
-          # in pyproject.toml turns it on for every consumer (local runs, this
-          # job, coverage.xml for diff-cover), so the floor below measures the
-          # combined line+branch figure. Keep the number in step with
-          # [tool.coverage.report] fail_under; tests/test_coverage_job.py pins it.
+          # The reporting job passes the coverage flags explicitly because
+          # `addopts` no longer carries them. The floor itself is NOT a flag:
+          # pytest-cov reads [tool.coverage.report] fail_under from pyproject.toml
+          # when no --cov-fail-under is given, so the number lives in one place
+          # and this leg enforces it. tests/test_coverage_job.py asserts that no
+          # --cov-fail-under= creeps back in here to override it. Likewise branch
+          # coverage comes from [tool.coverage.run] branch = true, so the floor is
+          # the combined line+branch figure.
           COV_ARGS: >-
             ${{ env.COVERAGE_JOB == 'true'
-            && '--cov=geoparquet_io --cov-report=term-missing --cov-report=xml --cov-fail-under=85'
+            && '--cov=geoparquet_io --cov-report=term-missing --cov-report=xml'
             || '--no-cov' }}
         run: |
           # word-splitting intended: COV_ARGS is a flag list (or --no-cov)
@@ -231,8 +231,11 @@ jobs:
         # tests that run on every PR, not only in the post-merge slow suite.
         run: |
           git fetch origin "$BASE_REF"
+          # --branch-coverage: diff-cover ignores the condition-coverage data
+          # coverage.xml carries unless asked, so without it a new `if` whose
+          # else-arm never ran still reads as 100% covered on its changed lines.
           uv run diff-cover coverage.xml \
-            --compare-branch "origin/$BASE_REF" --fail-under=90
+            --compare-branch "origin/$BASE_REF" --fail-under=90 --branch-coverage
 
   notebooks:
     runs-on: ubuntu-latest
@@ -418,8 +421,8 @@ jobs:
         env:
           # Only ubuntu uploads slow-suite coverage to Codecov (step below);
           # macOS and Windows discarded theirs. --cov-fail-under=0 stays on the
-          # reporting job because the slow suite alone never reaches the 80%
-          # floor that [tool.coverage.report] would otherwise apply.
+          # reporting job because the slow suite alone never reaches the floor
+          # that [tool.coverage.report] would otherwise apply.
           COV_ARGS: >-
             ${{ matrix.os == 'ubuntu-latest'
             && '--cov=geoparquet_io --cov-report=xml --cov-report=term-missing --cov-fail-under=0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
       # diff-cover gate); when each re-derived `os == ... && python-version ==
       # ...` for itself, moving the baseline (drop 3.11, add 3.14) would have
       # turned all four false at once — no coverage measured, nothing uploaded,
-      # and BOTH the 80% floor and the 90% diff-cover gate silently gone with
+      # and BOTH the 85% floor and the 90% diff-cover gate silently gone with
       # every check green. Change the baseline HERE and everything follows.
       # (Deliberately not a `matrix.coverage` flag added via `include:`: an
       # include-contributed key is appended to the generated job name, so the
@@ -189,10 +189,16 @@ jobs:
           # and obscures where the gate lives, not a matrix speedup.
           #
           # The reporting job passes every flag explicitly because `addopts` no
-          # longer carries them: the 80% floor is enforced HERE.
+          # longer carries them: the 85% floor is enforced HERE.
+          #
+          # Branch coverage is NOT a flag here: [tool.coverage.run] branch = true
+          # in pyproject.toml turns it on for every consumer (local runs, this
+          # job, coverage.xml for diff-cover), so the floor below measures the
+          # combined line+branch figure. Keep the number in step with
+          # [tool.coverage.report] fail_under; tests/test_coverage_job.py pins it.
           COV_ARGS: >-
             ${{ env.COVERAGE_JOB == 'true'
-            && '--cov=geoparquet_io --cov-report=term-missing --cov-report=xml --cov-fail-under=80'
+            && '--cov=geoparquet_io --cov-report=term-missing --cov-report=xml --cov-fail-under=85'
             || '--no-cov' }}
         run: |
           # word-splitting intended: COV_ARGS is a flag list (or --no-cov)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,19 +176,23 @@ uv run pytest --cov=geoparquet_io --cov-report=term-missing --cov-fail-under=0  
 ```
 
 `--cov-fail-under=0` is needed on partial runs: `[tool.coverage.report].fail_under`
-re-arms the 85% floor whenever you opt into `--cov`, and a subset never clears it.
+re-arms the floor whenever you opt into `--cov`, and a subset never clears it.
 
 Local runs are uninstrumented: `addopts` carries no `--cov`, so a single-file run
-is fast and a partial run can't fail a whole-suite gate. The 85% floor (a trailing ratchet: measured full-fast-suite coverage minus two points) and the 90%
-diff-cover gate on changed lines are enforced in CI (the ubuntu/3.11 job in
-`.github/workflows/tests.yml`), which passes the coverage flags explicitly.
+is fast and a partial run can't fail a whole-suite gate. The coverage floor (a
+trailing ratchet: measured full-fast-suite coverage minus two points, rounded
+down) and the 90% diff-cover gate on changed lines are enforced in CI (the
+ubuntu/3.11 job in `.github/workflows/tests.yml`). The floor's number lives in
+**one** place, `[tool.coverage.report] fail_under` in `pyproject.toml`, which
+pytest-cov reads on that leg; `tests/test_coverage_job.py` asserts nothing
+overrides it.
 
 `[tool.coverage.run] branch = true`, so the floor measures the **combined**
-line+branch figure — 87.069% on 2026-09-12, several points under the line-only
-figure (89.4%). When you raise the floor, re-measure the combined number; don't
-convert from a line percentage. Three places must move together:
-`[tool.coverage.report] fail_under`, `COV_ARGS` in `.github/workflows/tests.yml`,
-and `FLOOR` in `tests/test_coverage_job.py`.
+line+branch figure, several points under the line-only figure (the dated
+measurement is in the `fail_under` comment). When you raise the floor,
+re-measure the combined number; don't convert from a line percentage. The
+diff-cover gate is passed `--branch-coverage`, so a partial branch on a changed
+line counts as uncovered there too.
 
 The `meta` lane (codespell, commitizen, doc-sync, mutmut, mypy,
 validate-claude-md, security tool checks) is excluded from the fast suite and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,12 +176,19 @@ uv run pytest --cov=geoparquet_io --cov-report=term-missing --cov-fail-under=0  
 ```
 
 `--cov-fail-under=0` is needed on partial runs: `[tool.coverage.report].fail_under`
-re-arms the 80% floor whenever you opt into `--cov`, and a subset never clears it.
+re-arms the 85% floor whenever you opt into `--cov`, and a subset never clears it.
 
 Local runs are uninstrumented: `addopts` carries no `--cov`, so a single-file run
-is fast and a partial run can't fail a whole-suite gate. The 80% floor (a trailing ratchet: measured full-fast-suite coverage minus two points) and the 90%
+is fast and a partial run can't fail a whole-suite gate. The 85% floor (a trailing ratchet: measured full-fast-suite coverage minus two points) and the 90%
 diff-cover gate on changed lines are enforced in CI (the ubuntu/3.11 job in
 `.github/workflows/tests.yml`), which passes the coverage flags explicitly.
+
+`[tool.coverage.run] branch = true`, so the floor measures the **combined**
+line+branch figure — 87.069% on 2026-09-12, several points under the line-only
+figure (89.4%). When you raise the floor, re-measure the combined number; don't
+convert from a line percentage. Three places must move together:
+`[tool.coverage.report] fail_under`, `COV_ARGS` in `.github/workflows/tests.yml`,
+and `FLOOR` in `tests/test_coverage_job.py`.
 
 The `meta` lane (codespell, commitizen, doc-sync, mutmut, mypy,
 validate-claude-md, security tool checks) is excluded from the fast suite and

--- a/context/shared/adr/0005-test-fixture-strategy.md
+++ b/context/shared/adr/0005-test-fixture-strategy.md
@@ -56,7 +56,7 @@ uv run pytest -n auto
 ### Neutral
 - The `tests/data/` directory currently contains ~30 fixture files totaling approximately 1.5MB.
 - Some test modules create temporary fixtures in pytest's `tmp_path` for tests that modify data, ensuring test isolation.
-- Coverage requirement is 80% minimum (enforced via `--cov-fail-under=80`; a trailing ratchet two points under the measured full-fast-suite number), with a higher target for new code.
+- Coverage requirement is 85% minimum (enforced via `--cov-fail-under=85`; a trailing ratchet two points under the measured full-fast-suite number, which is the combined line+branch figure since `branch = true`), with a higher target for new code.
 
 ## Alternatives Considered
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,7 +111,7 @@ CI runs four test tiers:
 
 Coverage gates (both enforced in CI):
 
-- Global floor: 80% total coverage.
+- Global floor: `[tool.coverage.report] fail_under` in `pyproject.toml` (85 at the time of writing), measured as combined line+branch coverage.
 - **Changed lines: 90%** — `diff-cover` checks that the lines your PR touches
   are covered *by fast tests*. New code ships with tests that run on every PR,
   not only in the post-merge slow suite.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -78,8 +78,11 @@ partial run can never clear a whole-suite floor, so the default invocation used 
 exit 1 on a gate that measured nothing. Both gates below still run in CI.
 
 Add `--cov-fail-under=0` when you opt in on a subset: `[tool.coverage.report]`
-sets `fail_under = 80`, so coverage re-arms the floor on any `--cov` run even
+sets `fail_under = 85`, so coverage re-arms the floor on any `--cov` run even
 though `addopts` no longer requests one.
+
+Branch coverage is on (`[tool.coverage.run] branch = true`), so that floor is
+measured against the combined line+branch figure, not the line figure.
 
 CI runs four test tiers:
 

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -41,10 +41,7 @@ from geoparquet_io.core.arrow_geo_metadata import (
 from geoparquet_io.core.arrow_geo_metadata import _DIMENSION_SUFFIXES as _DIMENSION_SUFFIXES
 from geoparquet_io.core.arrow_geo_metadata import _GEOMETRY_TYPE_CODES as _GEOMETRY_TYPE_CODES
 from geoparquet_io.core.arrow_geo_metadata import (
-    _apply_geoparquet_metadata,
-    _detect_version_from_table,
-    _normalize_arrow_large_types,
-    _write_table_with_settings,
+    _apply_geoparquet_metadata as _apply_geoparquet_metadata,
 )
 from geoparquet_io.core.arrow_geo_metadata import (
     _canonicalize_wkb_columns as _canonicalize_wkb_columns,
@@ -54,9 +51,15 @@ from geoparquet_io.core.arrow_geo_metadata import _compute_geometry_types as _co
 from geoparquet_io.core.arrow_geo_metadata import (
     _detect_bbox_column_from_table as _detect_bbox_column_from_table,
 )
+from geoparquet_io.core.arrow_geo_metadata import (
+    _detect_version_from_table,
+)
 from geoparquet_io.core.arrow_geo_metadata import _estimate_row_size as _estimate_row_size
 from geoparquet_io.core.arrow_geo_metadata import (
     _get_geometry_type_name as _get_geometry_type_name,
+)
+from geoparquet_io.core.arrow_geo_metadata import (
+    _normalize_arrow_large_types as _normalize_arrow_large_types,
 )
 from geoparquet_io.core.arrow_geo_metadata import (
     _parse_geo_metadata_quietly as _parse_geo_metadata_quietly,
@@ -70,6 +73,9 @@ from geoparquet_io.core.arrow_geo_metadata import (
 from geoparquet_io.core.arrow_geo_metadata import (
     _strip_geoarrow_to_plain_wkb as _strip_geoarrow_to_plain_wkb,
 )
+from geoparquet_io.core.arrow_geo_metadata import (
+    _write_table_with_settings as _write_table_with_settings,
+)
 from geoparquet_io.core.arrow_types import _cast_table_to_schema as _cast_table_to_schema
 from geoparquet_io.core.arrow_types import _compute_unified_schema as _compute_unified_schema
 from geoparquet_io.core.arrow_types import _promote_numeric_type as _promote_numeric_type
@@ -79,14 +85,15 @@ from geoparquet_io.core.bbox_structure import (
 )
 from geoparquet_io.core.bbox_structure import check_bbox_structure
 from geoparquet_io.core.bbox_structure import get_bbox_advice as get_bbox_advice
-from geoparquet_io.core.compression import validate_compression_settings
+from geoparquet_io.core.compression import (
+    validate_compression_settings as validate_compression_settings,
+)
 
 # Internal imports - used by functions in this module
 from geoparquet_io.core.duckdb_utils import (
     _DuckDBSchemaWrapper,
     _get_query_column_type,
     _get_query_columns,
-    _wrap_query_with_wkb_conversion,
     get_duckdb_connection,
     load_community_extension,
     quote_identifier,
@@ -124,7 +131,6 @@ from geoparquet_io.core.geo_metadata_repair import (
     _rewrite_file_with_geo_metadata as _rewrite_file_with_geo_metadata,
 )
 from geoparquet_io.core.geometry_detection import (
-    _detect_geometry_from_query,
     find_primary_geometry_column,
 )
 from geoparquet_io.core.logging_config import (
@@ -180,12 +186,9 @@ from geoparquet_io.core.remote import (
     _sanitize_url_for_logging,
     is_remote_url,
     needs_httpfs,
-    remote_write_context,
-    upload_if_remote,
 )
 from geoparquet_io.core.sizing import format_size as format_size
 from geoparquet_io.core.sizing import parse_size_string as parse_size_string
-from geoparquet_io.core.streaming import extract_version_from_metadata
 
 
 def should_skip_bbox(geoparquet_version):
@@ -492,140 +495,6 @@ def resolve_geoparquet_version_from_table(table, verbose: bool = False) -> str |
     the same version the CLI would for the same input file (todo 043).
     """
     return _resolve_auto_version(_detect_version_from_table(table, verbose))
-
-
-def write_geoparquet_via_arrow(
-    con,
-    query: str,
-    output_file: str,
-    geometry_column: str | None = None,
-    original_metadata: dict | None = None,
-    compression: str = "ZSTD",
-    compression_level: int = 15,
-    row_group_size_mb: int | None = None,
-    row_group_rows: int | None = None,
-    custom_metadata: dict | None = None,
-    verbose: bool = False,
-    show_sql: bool = False,
-    profile: str | None = None,
-    geoparquet_version: str | None = None,
-    input_crs: dict | None = None,
-) -> None:
-    """
-    Write a GeoParquet file using Arrow as the internal transfer format.
-
-    This is more efficient than the COPY-then-rewrite approach because it:
-    1. Fetches query results directly as an Arrow Table
-    2. Applies GeoParquet metadata in memory
-    3. Writes once to disk
-
-    Args:
-        con: DuckDB connection with spatial extension loaded
-        query: SQL SELECT query to execute
-        output_file: Path to output file (local or remote URL)
-        geometry_column: Name of geometry column (auto-detected if None)
-        original_metadata: Original metadata from source file for preservation
-        compression: Compression type (ZSTD, GZIP, BROTLI, LZ4, SNAPPY, UNCOMPRESSED)
-        compression_level: Compression level (varies by format)
-        row_group_size_mb: Target row group size in MB
-        row_group_rows: Exact number of rows per row group
-        custom_metadata: Optional dict with custom metadata (e.g., H3 covering info)
-        verbose: Whether to print verbose output
-        show_sql: Whether to print SQL statements before execution
-        profile: AWS profile name (S3 only, optional)
-        geoparquet_version: GeoParquet version to write (1.0, 1.1, 2.0, parquet-geo-only)
-        input_crs: PROJJSON dict with CRS from input file
-    """
-    # Detect geometry column if not provided
-    if geometry_column is None:
-        geometry_column = _detect_geometry_from_query(con, query, original_metadata, verbose)
-
-    # Auto-detect GeoParquet version from input metadata if not explicitly provided
-    if geoparquet_version is None:
-        geoparquet_version = extract_version_from_metadata(original_metadata)
-
-    # Check if geometry column actually exists in the query result
-    query_columns = _get_query_columns(con, query)
-    has_geometry = geometry_column in query_columns
-
-    # No AWS_PROFILE env mutation here: the write target inside this block is a
-    # local (temp) file, and the upload at the end is credentialed by passing
-    # profile= straight through to upload().
-    with remote_write_context(output_file, is_directory=False, verbose=verbose) as (
-        actual_output,
-        is_remote,
-    ):
-        # Validate compression settings
-        compression, compression_level, compression_desc = validate_compression_settings(
-            compression, compression_level, verbose
-        )
-
-        if verbose:
-            debug(f"Writing output with {compression_desc} compression (Arrow path)...")
-            if geoparquet_version:
-                debug(f"Using GeoParquet version: {geoparquet_version}")
-
-        # Wrap query with WKB conversion only if geometry column exists
-        if has_geometry:
-            final_query = _wrap_query_with_wkb_conversion(query, geometry_column, con)
-        else:
-            final_query = query
-            if verbose:
-                debug(
-                    f"Geometry column '{geometry_column}' not in query - writing as regular Parquet"
-                )
-
-        if show_sql:
-            info("\n-- Arrow query (with WKB conversion):" if has_geometry else "\n-- Arrow query:")
-            progress(final_query)
-
-        # Fetch as Arrow table
-        if verbose:
-            debug("Fetching query results as Arrow table...")
-
-        result = con.execute(final_query)
-        table = result.arrow().read_all()
-
-        # Normalize large_string/large_binary back to string/binary for Parquet compatibility
-        table = _normalize_arrow_large_types(table)
-
-        if verbose:
-            debug(f"Fetched {table.num_rows:,} rows, {len(table.column_names)} columns")
-
-        # Apply GeoParquet metadata only if geometry column exists
-        if has_geometry:
-            table = _apply_geoparquet_metadata(
-                table,
-                geometry_column=geometry_column,
-                geoparquet_version=geoparquet_version,
-                original_metadata=original_metadata,
-                input_crs=input_crs,
-                custom_metadata=custom_metadata,
-                verbose=verbose,
-            )
-
-        # Write to disk
-        _write_table_with_settings(
-            table,
-            actual_output,
-            compression=compression,
-            compression_level=compression_level,
-            row_group_rows=row_group_rows,
-            row_group_size_mb=row_group_size_mb,
-            geoparquet_version=geoparquet_version,
-            geometry_column=geometry_column,
-            verbose=verbose,
-        )
-
-        # Upload to remote if needed
-        if is_remote:
-            upload_if_remote(
-                actual_output,
-                output_file,
-                profile=profile,
-                is_directory=False,
-                verbose=verbose,
-            )
 
 
 def _build_bounds_query(parquet_path, bbox_info, geometry_column, verbose):

--- a/geoparquet_io/core/common.py
+++ b/geoparquet_io/core/common.py
@@ -51,9 +51,7 @@ from geoparquet_io.core.arrow_geo_metadata import _compute_geometry_types as _co
 from geoparquet_io.core.arrow_geo_metadata import (
     _detect_bbox_column_from_table as _detect_bbox_column_from_table,
 )
-from geoparquet_io.core.arrow_geo_metadata import (
-    _detect_version_from_table,
-)
+from geoparquet_io.core.arrow_geo_metadata import _detect_version_from_table
 from geoparquet_io.core.arrow_geo_metadata import _estimate_row_size as _estimate_row_size
 from geoparquet_io.core.arrow_geo_metadata import (
     _get_geometry_type_name as _get_geometry_type_name,
@@ -130,9 +128,7 @@ from geoparquet_io.core.geo_metadata_repair import (
 from geoparquet_io.core.geo_metadata_repair import (
     _rewrite_file_with_geo_metadata as _rewrite_file_with_geo_metadata,
 )
-from geoparquet_io.core.geometry_detection import (
-    find_primary_geometry_column,
-)
+from geoparquet_io.core.geometry_detection import find_primary_geometry_column
 from geoparquet_io.core.logging_config import (
     configure_verbose,
     debug,

--- a/geoparquet_io/core/partition/admin_hierarchical.py
+++ b/geoparquet_io/core/partition/admin_hierarchical.py
@@ -305,15 +305,6 @@ def _setup_admin_join_connection(dataset, get_duckdb_connection):
     return con
 
 
-def _setup_duckdb_extensions(con):
-    """Load required DuckDB extensions."""
-    con.execute("INSTALL spatial;")
-    con.execute("LOAD spatial;")
-    con.execute("SET geometry_always_xy = true;")
-    con.execute("INSTALL httpfs;")
-    con.execute("LOAD httpfs;")
-
-
 def _build_admin_select_for_partitioning(levels, boundary_columns, dataset=None, vecorel=False):
     """Build admin SELECT clause for partitioning.
 

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -3833,7 +3833,11 @@ def _run_parquet_geo_only_checks(
         return checks
 
     for geom_col in geo_columns.keys():
-        # Parquet native geo type checks
+        # Parquet native geo type checks. Spec validation asks for native
+        # GeospatialStatistics; whether a bbox *column*'s row-group min/max
+        # exist is a best-practice question, answered by `check optimization`'s
+        # geo_bbox_stats, not a spec check (a `_check_row_group_bbox_statistics`
+        # was written for it once, never registered, and removed in #1038).
         checks.append(_check_native_geo_type_present(schema_info, geom_col))
         checks.append(_check_geography_edges_valid(schema_info, geom_col))
         checks.append(_check_native_geo_statistics(parquet_file, geom_col))

--- a/geoparquet_io/core/validate.py
+++ b/geoparquet_io/core/validate.py
@@ -2291,66 +2291,6 @@ def _execute_bounds_query(con, raw_url: str, geom_col: str, limit_clause: str):
 # =============================================================================
 
 
-def _check_row_group_bbox_statistics(parquet_file: str, geom_col: str) -> ValidationCheck:
-    """Check that file has bbox column with row group statistics for spatial filtering."""
-    from geoparquet_io.core.duckdb_metadata import (
-        get_bbox_from_row_group_stats,
-        has_bbox_column,
-    )
-    from geoparquet_io.core.remote import is_remote_url
-
-    try:
-        # For remote files, skip (DuckDB can handle but may be slow)
-        if is_remote_url(parquet_file):
-            return ValidationCheck(
-                name=f"row_group_bbox_stats_{geom_col}",
-                status=CheckStatus.SKIPPED,
-                message="row group statistics check skipped for remote files",
-                category="parquet_geo_types",
-            )
-
-        # Check if file has a bbox column
-        has_bbox, bbox_col_name = has_bbox_column(parquet_file)
-
-        if not has_bbox:
-            return ValidationCheck(
-                name=f"row_group_bbox_stats_{geom_col}",
-                status=CheckStatus.WARNING,
-                message="no bbox column found for spatial filtering",
-                details="A bbox struct column (xmin/ymin/xmax/ymax) enables efficient spatial "
-                "filtering. Use 'gpio add bbox' to add one.",
-                category="parquet_geo_types",
-            )
-
-        # Check if bbox column has valid statistics
-        bbox = get_bbox_from_row_group_stats(parquet_file, bbox_col_name)
-
-        if bbox:
-            return ValidationCheck(
-                name=f"row_group_bbox_stats_{geom_col}",
-                status=CheckStatus.PASSED,
-                message=f'bbox column "{bbox_col_name}" has row group statistics',
-                category="parquet_geo_types",
-            )
-        else:
-            return ValidationCheck(
-                name=f"row_group_bbox_stats_{geom_col}",
-                status=CheckStatus.WARNING,
-                message=f'bbox column "{bbox_col_name}" missing row group statistics',
-                details="Row group statistics enable efficient spatial filtering. "
-                "Re-write the file with a tool that generates statistics.",
-                category="parquet_geo_types",
-            )
-
-    except Exception as e:
-        return ValidationCheck(
-            name=f"row_group_bbox_stats_{geom_col}",
-            status=CheckStatus.SKIPPED,
-            message=f"could not check row group statistics: {e}",
-            category="parquet_geo_types",
-        )
-
-
 def _is_bbox_valid(geo_bbox: dict) -> bool:
     """Check if bbox values are reasonable (not garbage from parsing errors).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -419,12 +419,12 @@ check-filenames = true
 
 [tool.coverage.run]
 source = ["geoparquet_io"]
-# Branch coverage on: the line figure hid an 8.7-point gap (88.6% line vs 79.9%
-# branch, 1,195 partial branches - an `if` whose body ran and whose fall-through
-# never did). With this on, the 90% diff-cover gate stops accepting a new
-# conditional with only one arm exercised. Note it also changes what
-# [tool.coverage.report] fail_under measures: coverage.py then compares the
-# *combined* line+branch figure, which is several points below the line figure.
+# Branch coverage on: the line figure hid partial branches -- an `if` whose body
+# ran and whose fall-through never did. Two consumers see the difference: the
+# fail_under floor below now measures the COMBINED line+branch figure, and the
+# diff-cover gate in tests.yml counts a partial branch on a changed line as
+# uncovered -- but only because it is passed --branch-coverage; without that
+# flag diff-cover ignores the condition data coverage.xml carries.
 branch = true
 omit = [
     "geoparquet_io/__init__.py",
@@ -435,13 +435,20 @@ omit = [
 # number (87.069% on 2026-09-12, `-m "not slow and not network and not meta"`),
 # so it catches real regressions without flaking on run-to-run noise. When the
 # measured number moves up, raise the floor to follow it (measured minus two,
-# rounded down); never lower it to admit a regression. The same value is repeated
-# in the CI COV_ARGS (.github/workflows/tests.yml) and pinned by
-# tests/test_coverage_job.py.
+# rounded down); never lower it to admit a regression. This is the ONE place the
+# number lives: pytest-cov reads it on the CI coverage leg because COV_ARGS
+# passes no --cov-fail-under, and tests/test_coverage_job.py asserts that stays
+# so (and that branch = true stays on, since turning it off would silently
+# turn this into a looser line-only floor).
 #
 # That measured number is the COMBINED line+branch figure, because
-# [tool.coverage.run] branch = true. It is not the line figure (89.4% on the same
-# run) - re-measure, don't convert, when you next move this.
+# [tool.coverage.run] branch = true. It is several points under the line figure
+# - re-measure, don't convert, when you next move this.
+#
+# pytest-cov rounds the total to a whole number before comparing, so the exit
+# status enforces "> 84.5", while its summary line compares unrounded; between
+# 84.5 and 85.0 the log says FAIL and the job passes. Cosmetic, but read the
+# exit status, not the line.
 fail_under = 85
 show_missing = true
 skip_covered = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,15 +145,15 @@ python_classes = "Test*"
 python_functions = "test_*"
 # Coverage flags deliberately absent: a plain `uv run pytest` should be fast and
 # green. Instrumenting every run (including every spawned subprocess) cost 39-49%
-# on single-file dev runs, and a partial run can never clear the 80% floor, so the
+# on single-file dev runs, and a partial run can never clear the 85% floor, so the
 # default local invocation always exited 1 on a gate that measured nothing.
 # The floor is enforced where it is meaningful — the ubuntu/3.11 job in
 # .github/workflows/tests.yml passes --cov=geoparquet_io --cov-report=term-missing
-# --cov-report=xml --cov-fail-under=80 over the whole fast suite, and feeds
+# --cov-report=xml --cov-fail-under=85 over the whole fast suite, and feeds
 # Codecov plus the 90% diff-cover gate. Locally, opt in with:
 #   uv run pytest --cov=geoparquet_io --cov-report=term-missing --cov-fail-under=0
 # (--cov-fail-under=0 is required on a subset: [tool.coverage.report].fail_under
-# re-arms the 80% floor on any --cov run, which a partial run can never clear.)
+# re-arms the 85% floor on any --cov run, which a partial run can never clear.)
 addopts = [
     "-v",
     "--tb=short",
@@ -419,19 +419,30 @@ check-filenames = true
 
 [tool.coverage.run]
 source = ["geoparquet_io"]
-branch = false
+# Branch coverage on: the line figure hid an 8.7-point gap (88.6% line vs 79.9%
+# branch, 1,195 partial branches - an `if` whose body ran and whose fall-through
+# never did). With this on, the 90% diff-cover gate stops accepting a new
+# conditional with only one arm exercised. Note it also changes what
+# [tool.coverage.report] fail_under measures: coverage.py then compares the
+# *combined* line+branch figure, which is several points below the line figure.
+branch = true
 omit = [
     "geoparquet_io/__init__.py",
 ]
 
 [tool.coverage.report]
 # Trailing ratchet: the floor sits two points under the measured full-fast-suite
-# number (82.8% on 2026-09, `-m "not slow and not network and not meta"`), so it
-# catches real regressions without flaking on run-to-run noise. When the measured
-# number moves up, raise the floor to follow it (measured minus two, rounded
-# down); never lower it to admit a regression. The same value is repeated in the
-# CI COV_ARGS (.github/workflows/tests.yml) and pinned by tests/test_coverage_job.py.
-fail_under = 80
+# number (87.069% on 2026-09-12, `-m "not slow and not network and not meta"`),
+# so it catches real regressions without flaking on run-to-run noise. When the
+# measured number moves up, raise the floor to follow it (measured minus two,
+# rounded down); never lower it to admit a regression. The same value is repeated
+# in the CI COV_ARGS (.github/workflows/tests.yml) and pinned by
+# tests/test_coverage_job.py.
+#
+# That measured number is the COMBINED line+branch figure, because
+# [tool.coverage.run] branch = true. It is not the line figure (89.4% on the same
+# run) - re-measure, don't convert, when you next move this.
+fail_under = 85
 show_missing = true
 skip_covered = false
 exclude_lines = [

--- a/tests/README.md
+++ b/tests/README.md
@@ -69,7 +69,7 @@ pytest tests/test_check.py::TestCheckCommands::test_check_all_places
 
 ## Coverage
 
-Current test coverage is approximately 83% (the CI floor is 80%), covering:
+Current fast-suite coverage is about 87% combined line+branch (the CI floor is `[tool.coverage.report] fail_under` in `pyproject.toml`), covering:
 - CLI command interfaces
 - Core functionality for all major operations
 - Error handling for invalid inputs

--- a/tests/test_coverage_job.py
+++ b/tests/test_coverage_job.py
@@ -2,7 +2,7 @@
 
 Exactly one matrix combination reports coverage: it is the only job that
 measures lines at all, the only one that uploads to Codecov, the only one that
-enforces the 80% floor, and the only one that runs the 90% diff-cover gate.
+enforces the 85% floor, and the only one that runs the 90% diff-cover gate.
 
 Four separate places key off that decision (checkout depth, the pytest flag
 list, the Codecov upload, the diff-cover gate). While each re-derived
@@ -22,6 +22,14 @@ import pytest
 import yaml
 
 PROJECT_ROOT = Path(__file__).parent.parent
+
+# The coverage floor, repeated in three places that must agree: this pin,
+# `[tool.coverage.report] fail_under` in pyproject.toml, and `--cov-fail-under`
+# inside COV_ARGS in tests.yml. It is a trailing ratchet — the measured
+# full-fast-suite number minus two, rounded down — and since
+# `[tool.coverage.run] branch = true` that measured number is the COMBINED
+# line+branch figure (87.069% on 2026-09-12), not the line figure.
+FLOOR = 85
 
 # The job-level env var that decides which matrix leg reports coverage.
 COVERAGE_FLAG = "COVERAGE_JOB"
@@ -128,7 +136,7 @@ class TestCoverageLegIsSingleSourced:
         assert selected in combos, (
             f"{COVERAGE_FLAG} points at {selected}, which is not one of the "
             f"{len(combos)} combinations this matrix actually schedules "
-            f"({combos}). No job would measure coverage, so the 80% floor and "
+            f"({combos}). No job would measure coverage, so the {FLOOR}% floor and "
             "the 90% diff-cover gate would both vanish with all checks green."
         )
 
@@ -204,7 +212,7 @@ class TestCoverageLegStillEnforcesTheGates:
         """`addopts` no longer carries coverage, so these flags are the gate."""
         step = _step_by_name(test_job, "Run fast tests")
         cov_args = step["env"]["COV_ARGS"]
-        for flag in ("--cov=geoparquet_io", "--cov-report=xml", "--cov-fail-under=80"):
+        for flag in ("--cov=geoparquet_io", "--cov-report=xml", f"--cov-fail-under={FLOOR}"):
             assert flag in cov_args, (
                 f"{flag} missing from COV_ARGS. Coverage flags are no longer in "
                 "pyproject `addopts`, so this env var is the only thing enforcing "

--- a/tests/test_coverage_job.py
+++ b/tests/test_coverage_job.py
@@ -2,7 +2,7 @@
 
 Exactly one matrix combination reports coverage: it is the only job that
 measures lines at all, the only one that uploads to Codecov, the only one that
-enforces the 85% floor, and the only one that runs the 90% diff-cover gate.
+enforces the coverage floor, and the only one that runs the 90% diff-cover gate.
 
 Four separate places key off that decision (checkout depth, the pytest flag
 list, the Codecov upload, the diff-cover gate). While each re-derived
@@ -15,21 +15,19 @@ and these tests keep it that way.
 
 import itertools
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 
-PROJECT_ROOT = Path(__file__).parent.parent
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
-# The coverage floor, repeated in three places that must agree: this pin,
-# `[tool.coverage.report] fail_under` in pyproject.toml, and `--cov-fail-under`
-# inside COV_ARGS in tests.yml. It is a trailing ratchet — the measured
-# full-fast-suite number minus two, rounded down — and since
-# `[tool.coverage.run] branch = true` that measured number is the COMBINED
-# line+branch figure (87.069% on 2026-09-12), not the line figure.
-FLOOR = 85
+PROJECT_ROOT = Path(__file__).parent.parent
 
 # The job-level env var that decides which matrix leg reports coverage.
 COVERAGE_FLAG = "COVERAGE_JOB"
@@ -136,7 +134,7 @@ class TestCoverageLegIsSingleSourced:
         assert selected in combos, (
             f"{COVERAGE_FLAG} points at {selected}, which is not one of the "
             f"{len(combos)} combinations this matrix actually schedules "
-            f"({combos}). No job would measure coverage, so the {FLOOR}% floor and "
+            f"({combos}). No job would measure coverage, so the coverage floor and "
             "the 90% diff-cover gate would both vanish with all checks green."
         )
 
@@ -205,19 +203,61 @@ class TestCoverageLegIsSingleSourced:
             )
 
 
+@pytest.fixture()
+def coverage_config() -> dict[str, Any]:
+    """`[tool.coverage]` from pyproject.toml -- the one place the floor lives."""
+    with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
+        return tomllib.load(f)["tool"]["coverage"]
+
+
 class TestCoverageLegStillEnforcesTheGates:
     """The one leg that measures coverage still carries every gate."""
 
-    def test_coverage_leg_passes_the_floor_and_reports(self, test_job: dict[str, Any]):
-        """`addopts` no longer carries coverage, so these flags are the gate."""
+    def test_coverage_leg_measures_and_reports(self, test_job: dict[str, Any]):
+        """`addopts` no longer carries coverage, so these flags are what measures."""
         step = _step_by_name(test_job, "Run fast tests")
         cov_args = step["env"]["COV_ARGS"]
-        for flag in ("--cov=geoparquet_io", "--cov-report=xml", f"--cov-fail-under={FLOOR}"):
+        for flag in ("--cov=geoparquet_io", "--cov-report=xml"):
             assert flag in cov_args, (
                 f"{flag} missing from COV_ARGS. Coverage flags are no longer in "
-                "pyproject `addopts`, so this env var is the only thing enforcing "
-                "the floor and producing coverage.xml for Codecov/diff-cover."
+                "pyproject `addopts`, so this env var is the only thing measuring "
+                "coverage and producing coverage.xml for Codecov/diff-cover."
             )
+
+    def test_the_floor_is_read_from_pyproject_and_nothing_overrides_it(
+        self, test_job: dict[str, Any], coverage_config: dict[str, Any]
+    ):
+        """One number, in `[tool.coverage.report] fail_under`.
+
+        pytest-cov falls back to that value when no `--cov-fail-under` is given,
+        so a second copy in COV_ARGS would not be a cross-check: an explicit
+        flag silently wins, and the pyproject value -- the one every local
+        `--cov` run and every prose mention cites -- becomes a lie the moment
+        the two drift. The first version of this floor lived in three places and
+        two prose sites were missed in the very PR that moved it.
+        """
+        floor = coverage_config["report"]["fail_under"]
+        assert isinstance(floor, int) and 80 <= floor < 100, (
+            f"[tool.coverage.report] fail_under = {floor!r}: expected the trailing-ratchet "
+            "floor, an integer two points under the measured combined figure"
+        )
+        fast_cov_args = _step_by_name(test_job, "Run fast tests")["env"]["COV_ARGS"]
+        assert "--cov-fail-under" not in fast_cov_args, (
+            "COV_ARGS on the fast-test leg carries --cov-fail-under, which overrides "
+            "[tool.coverage.report] fail_under. Delete it: the floor has one home."
+        )
+
+    def test_branch_coverage_stays_on(self, coverage_config: dict[str, Any]):
+        """`branch = true` is what makes the floor a combined figure.
+
+        Turning it off does not fail any check: `fail_under` quietly becomes a
+        line-only floor that the same tree clears with several points to spare.
+        """
+        assert coverage_config["run"].get("branch") is True, (
+            "[tool.coverage.run] branch must stay true: the fail_under floor was "
+            "measured as a combined line+branch figure, and a line-only comparison "
+            "against it is a looser gate wearing the same number."
+        )
 
     def test_non_coverage_legs_opt_out_explicitly(self, test_job: dict[str, Any]):
         """The other legs must pass --no-cov, not an empty string."""
@@ -229,3 +269,16 @@ class TestCoverageLegStillEnforcesTheGates:
     def test_diff_cover_threshold_unchanged(self, test_job: dict[str, Any]):
         step = _step_by_name(test_job, "Diff coverage gate")
         assert "--fail-under=90" in step["run"], "diff-cover must gate changed lines at 90%"
+
+    def test_diff_cover_counts_partial_branches(self, test_job: dict[str, Any]):
+        """diff-cover ignores coverage.xml's branch data unless asked.
+
+        Without `--branch-coverage`, a new `if` whose else-arm never ran is 100%
+        covered on its changed lines; the flag is what turns `branch = true`
+        into a changed-lines gate rather than only a floor metric.
+        """
+        step = _step_by_name(test_job, "Diff coverage gate")
+        assert "--branch-coverage" in step["run"], (
+            "diff-cover must be passed --branch-coverage, or partial branches on "
+            "changed lines pass the 90% gate as if fully covered"
+        )


### PR DESCRIPTION
Step 1 of the execution order in #1018 — the part that needs no new tests. Three
things, deliberately in one PR because the third is only correct in light of the
first two.

## 1. Three dead blocks deleted (52 statements, zero callers)

Each was proved dead by a grep across `geoparquet_io/`, `tests/` and `docs/`
that returns exactly one hit: the `def` line itself.

| block | proof |
|---|---|
| `core/common.py` `write_geoparquet_via_arrow` (126 lines) | 1 hit repo-wide. Absent from every `__all__`; `core/common.py` is a re-export shim after the 3.4 split and this function was *not* part of the split, so it would have survived the refactor as a stale duplicate of `core/write_strategies/arrow_memory.py`. |
| `core/validate.py` `_check_row_group_bbox_statistics` (60 lines) | 1 hit repo-wide. Registered in neither `_run_geoparquet_checks` nor `_run_parquet_geo_only_checks`; the check id it returns, `row_group_bbox_stats_<col>`, appears nowhere else in the tree, so no test could have been asserting on it either. |
| `core/partition/admin_hierarchical.py` `_setup_duckdb_extensions` (7 lines) | 1 hit repo-wide. Its sole caller was swapped for `get_duckdb_connection(load_spatial=True, load_httpfs=True)` in `2f3e74a` (2026-04-22); `_setup_admin_join_connection` directly above it is what survived. (The first version of this row named a `_get_partition_connection` that does not exist.) |

One consequence worth reviewing: `write_geoparquet_via_arrow` was the last
in-module user of four names that `common.py` imports and **other modules import
back out of it** — `_apply_geoparquet_metadata`, `_normalize_arrow_large_types`,
`_write_table_with_settings` (all consumed by
`core/write_strategies/arrow_memory.py` and four test modules) and
`validate_compression_settings` (consumed by `core/reproject.py`). Ruff's
`--fix` removes those as unused the moment the function goes, which breaks the
import chain at `geoparquet_io/__init__.py`. They are restored under the
`import X as X` explicit-re-export form that the module docstring already
prescribes for precisely this case, which is also how ruff and vulture tell a
compatibility shim from a live import.

`vulture` has no whitelist file in this repo (`[tool.vulture]` sets
`min_confidence = 80`, above the 60% it scores unused functions at), so there
was nothing to prune. It passes at pre-push.

## 2. `[tool.coverage.run] branch = true`

The measured gap the flag closes: 88.6% line vs 79.9% branch, **1,195 partial
branches** — an `if` whose body ran and whose fall-through never did.

Two consumers see the difference. The `fail_under` floor becomes a combined
line+branch figure (§3). And the 90% diff-cover gate on changed lines stops
accepting a new conditional with only its true arm exercised — **but only
because the review commit passes `--branch-coverage` to diff-cover.** The first
version of this body said "no CI flag is needed"; that was true of `branch =
true` itself (it is read from `[tool.coverage.run]` by every consumer) and false
of the gate: diff-cover 10.5.1 ignores the `condition-coverage` data
`coverage.xml` carries unless asked. Reproduced by the review: an `if` with only
its true arm exercised read 100% on its changed lines without the flag and 80%
with it. This is a genuinely stricter gate for every PR from here; this PR's own
diff clears it, and the first few after it will say whether 90% needs revisiting.

## 3. The floor, re-based and moved in all three places

Turning branch coverage on **changes what `fail_under` measures**: coverage.py
compares the combined line+branch figure, not the line figure. So the floor is
re-measured rather than converted.

```
uv run pytest -n 4 -m "not slow and not network and not meta" \
  --cov=geoparquet_io --cov-branch --cov-report=term --cov-fail-under=0
```

| | |
|---|---|
| fast suite | 7,822 passed, 76 skipped, 3 xfailed, 214 s |
| statements | 24,940 · 2,646 missed |
| branches | 9,314 · 1,175 partial |
| **combined** | **87.069%** |
| line-only, for reference | 89.4% |

Trailing ratchet — measured minus two, rounded down — so **`fail_under = 85`**.
(#1018 estimated 84 from a measurement two weeks and ~30 PRs ago; the tree has
gained coverage since, and the dead-code deletion above adds a little more.)

**One home for the number.** The first version moved it in three machine-read
places and about eleven prose ones — and missed three of the prose ones
(`docs/contributing.md:114`, the slow-job comment in `tests.yml`,
`tests/README.md`), which is the empirical case against three copies. pytest-cov
reads `[tool.coverage.report] fail_under` when no `--cov-fail-under` is given;
the repo already relies on that in the other direction (the slow job passes
`--cov-fail-under=0` *because* pyproject would otherwise re-arm the floor). So
the CLI copy in `COV_ARGS` was never a cross-check — an explicit flag silently
wins — and it is gone. After the review commit:

- `[tool.coverage.report] fail_under = 85` is the only place the number lives,
  with the comment's stale *"82.8% on 2026-09"* replaced by the measured
  87.069% and today's date, and a note that it is the combined figure and must
  be re-measured, not converted.
- `COV_ARGS` carries no `--cov-fail-under`; the leg enforces pyproject's value.
- `tests/test_coverage_job.py` carries no number. It reads `fail_under` from
  pyproject and asserts three invariants, each sabotage-proven to fail alone:
  the value is a sane integer; `COV_ARGS` on the fast leg has no
  `--cov-fail-under` to override it; `[tool.coverage.run] branch` is `true`
  (turning it off would quietly make the same 85 a line-only floor this tree
  clears by four points). Plus one for `--branch-coverage` on the diff-cover
  step. 14 tests, was 11.

Prose now states the *rule* and points at `pyproject.toml` rather than
repeating the number: `CLAUDE.md`, `docs/contributing.md` (both sites),
`tests/README.md`, `context/shared/adr/0005-test-fixture-strategy.md`, and the
comments in `pyproject.toml` and `tests.yml`. The dated measurement appears once,
in the `fail_under` comment.

## Verification

- **The floor passes with margin.** Full fast suite under the new config:
  `Required test coverage of 85.0% reached. Total coverage: 87.07%` — 2.07 points
  of headroom. It is a ratchet, not an aspiration.
- Fast suite: 7,822 passed / 76 skipped / 3 xfailed.
- `-m meta`: 205 passed (`test_coverage_job.py` is not in that lane — run
  separately, 11 passed).
- `pre-commit run --all-files`: all hooks pass.
- `pre-commit run --all-files --hook-stage pre-push`: all pass, **`vulture`
  included** — as do `mypy`, `import-linter`, `deptry` and `xenon`.
- `tests/data/cli_surface.json` unchanged; no CLI surface is touched.
- **diff-cover:** `geoparquet_io/core/common.py (100%)`, 4 lines (the restored
  re-exports), 0 missing — under `--branch-coverage`, as CI now runs it.

## Review addendum

Six reviews in parallel (adversarial reproduction, Python quality, security,
performance, architecture, simplicity). Every measurement above reproduced to
the decimal; the deletions were proven dead both statically and dynamically — a
373-check-id A/B of `gpio check spec --json` over every `tests/data` fixture and
the 73-file `geoparquet-testing` corpus, `main` vs branch, in auto and
`parquet-geo-only` modes: **0 differences**, and `row_group_bbox_stats_*` never
emitted on `main` either. `git log -S` shows the check was registered and
unregistered on the same day in 2025-12 (`41ea4e7` → `766b987`), replaced by
`_check_native_geo_statistics`; a comment at the registration site now records
that bbox-column row-group stats are `check optimization`'s `geo_bbox_stats`,
not a spec check, so it is not re-written. CI legs: the floor is enforced only
on ubuntu/3.11, where the corpus submodule is checked out and ~45 more tests
run than locally — so CI's figure is ≥ the local 87.07%. The combined 85 floor
can only ever pass with less than 80% line coverage at ≥98.4% branch coverage
(today's is 80.9%), so it is stricter in every plausible state of the tree.

Undeclared in the first version: five more names left `common.py`'s import
block with the dead function (`_wrap_query_with_wkb_conversion`,
`_detect_geometry_from_query`, `remote_write_context`, `upload_if_remote`,
`extract_version_from_metadata`) — none reached through `common` by any module,
test or `mock.patch` string, so nothing breaks, but the shim surface shrank by
five, not zero. `write_geoparquet_via_arrow` was a public-looking name on an
importable module; `core/` is internal per CLAUDE.md, so `test:` stands.

Follow-ups filed, not folded in: a `scripts/coverage_floor.py` that measures
the combined figure and rewrites `fail_under` (the ratchet is documented but
not mechanical, and the previous one left a stale comment); an ADR for
coverage policy so 0005 stops being edited at every ratchet; repointing the
live consumers of the four restored shims (`write_strategies/arrow_memory.py`,
`reproject.py`) at their homes so the shims can go.

One caveat on the runs above: on a loaded machine under `-n auto` with coverage
instrumentation, the subprocess-driven tests (`tests/e2e/test_journeys.py`,
`tests/test_pipe_integration.py`) hit `subprocess.TimeoutExpired` — the known
cold-parallel-run flake, not a regression. All 104 of them pass serially in 47 s,
and the whole suite is green at `-n 4`. Coverage totals were byte-identical
across a run with those timeouts and a run without, because the coverage in
question is in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WA1fsYKLbc2hwmD1qWY4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Increased the enforced test coverage threshold from 80% to 85%.
  - Enabled branch coverage so the threshold reflects combined line and branch coverage.

- **Documentation**
  - Updated contributor guidance and architecture documentation to reflect the new coverage standard and measurement method.

- **Validation**
  - Removed legacy row-group bounding-box statistics checks; native Parquet geospatial statistics validation remains in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
